### PR TITLE
elastixlib supports user-supplied initial transform

### DIFF
--- a/src/Core/Main/elastixlib.cxx
+++ b/src/Core/Main/elastixlib.cxx
@@ -48,7 +48,8 @@ namespace elastix
 
 ELASTIX::ELASTIX() :
   m_ResultImage( 0 )
-{} // end Constructor
+{
+} // end Constructor
 
 
 /**
@@ -135,7 +136,8 @@ ELASTIX::RegisterImages(
   bool performLogging,
   bool performCout,
   ImagePointer fixedMask,
-  ImagePointer movingMask )
+  ImagePointer movingMask,
+  ObjectPointer transform)
 {
   /** Some typedef's. */
   typedef elx::ElastixMain                            ElastixMainType;
@@ -159,7 +161,7 @@ ELASTIX::RegisterImages(
   /** Some declarations and initialisations. */
   ElastixMainVectorType elastices;
 
-  ObjectPointer              transform            = 0;
+  //ObjectPointer              transform = 0;
   DataObjectContainerPointer fixedImageContainer  = 0;
   DataObjectContainerPointer movingImageContainer = 0;
   DataObjectContainerPointer fixedMaskContainer   = 0;

--- a/src/Core/Main/elastixlib.h
+++ b/src/Core/Main/elastixlib.h
@@ -24,6 +24,8 @@
 #include <itkDataObject.h>
 #include "itkParameterFileParser.h"
 #include "elxMacro.h"
+#include "elxElastixMain.h"
+
 
 /********************************************************************************
  *                          *
@@ -46,6 +48,9 @@ public:
   typedef itk::ParameterFileParser::ParameterValuesType             ParameterValuesType;
   typedef itk::ParameterFileParser::ParameterMapType                ParameterMapType;
   typedef std::vector< itk::ParameterFileParser::ParameterMapType > ParameterMapListType;
+
+  //typedefs for ObjectPointer
+  typedef elastix::ElastixMain::ObjectPointer              ObjectPointer;
 
   /**
    *  Constructor and destructor
@@ -94,7 +99,8 @@ public:
     bool performLogging,
     bool performCout,
     ImagePointer fixedMask = 0,
-    ImagePointer movingMask = 0 );
+    ImagePointer movingMask = 0,
+    ObjectPointer transform = 0);
 
   /** Getter for result image. */
   ImagePointer GetResultImage( void );


### PR DESCRIPTION
elastixlib supports user-supplied initial transform using additional input: RegisterImages( ..., ObjectPointer transform);

It was tested with AdvancedAffineTransformElastix as input:
        error = _elastix->RegisterImages(
            static_cast<typename itk::DataObject::Pointer> (_fixedImage),
            static_cast<typename itk::DataObject::Pointer> (_movingImage),
            _elastixPreAlignParametersVector, /*_elastixParameters*/
            _outputPath,
            _logToFile,
            _logToConsole,
            0,    // Optional, fixed image mask
            0,    // Optional, floating image mask
            static_cast<typename elastix::ElastixMain::ObjectPointer> (_initialTransform));  // Optional, initial transform
