### PR TITLE
ENH: add support of AppVeyor

### DIFF
--- a/appveyor.yml
+++ b/appveyor.yml
@@ -1,0 +1,25 @@
+branches:
+ only:
+ - add-appveyor
+os:
+  - Visual Studio 2013
+shallow_clone: false
+skip_tags: true
+clone_folder: c:\elastix-source
+configuration:
+  - Release
+platform:
+  - x64
+environment:
+  ELASTIX_SOURCE_DIR: c:\elastix-source
+  ELASTIX_BUILD_DIR: c:\elastix-build
+  ITK_URL: https://github.com/InsightSoftwareConsortium/ITK
+  ITK_SOURCE_DIR: c:\ITK-source
+  ITK_BUILD_DIR: c:\ITK-build
+cache:
+  - '%ITK_SOURCE_DIR%'
+  - '%ITK_BUILD_DIR%'
+build_script:
+  - cmd: git clone %ITK_URL% %ITK_SOURCE_DIR% && cd %ITK_SOURCE_DIR% && git checkout v4.11.1
+  - cmd: mkdir -p %ITK_BUILD_DIR% && cd %ITK_BUILD_DIR% && cmake -G "Visual Studio 12 2013 Win64" -DBUILD_EXAMPLES=OFF -DBUILD_TESTING:BOOL=OFF -DITK_BUILD_DEFAULT_MODULES:BOOL=OFF -DITKGroup_IO:BOOL=ON -DModule_ITKDistanceMap:BOOL=ON -DModule_ITKImageFusion:BOOL=ON -DModule_ITKLabelMap:BOOL:=ON -DModule_ITKMathematicalMorphology:BOOL=ON -DModule_ITKOptimizers:BOOL=ON -DModule_ITKOptimizersv4:BOOL=ON -DModule_ITKRegistrationCommon:BOOL=ON -DModule_ITKVideoIO:BOOL=ON-DCMAKE_BUILD_TYPE=Release %ITK_SOURCE_DIR% && cmake --build . --config Release -- /m
+  - cmd: mkdir -p %ELASTIX_BUILD_DIR% && cd %ELASTIX_BUILD_DIR% && cmake -G "Visual Studio 12 2013 Win64" -DITK_DIR=%ITK_BUILD_DIR% -DCMAKE_BUILD_TYPE=Release %ELASTIX_SOURCE_DIR% && cmake --build . --config Release -- /m && ctest -j4 -VV -C Release


### PR DESCRIPTION
Follow up on discussion in #6.

Numerous tests are failing on AppVeyor right now - see https://ci.appveyor.com/project/fedorov/elastix/build/1.0.8:

```
[00:50:41] 74% tests passed, 41 tests failed out of 157
[00:50:41] 
[00:50:41] Total Test time (real) = 626.55 sec
[00:50:41] 
[00:50:41] The following tests FAILED:
[00:50:41] 	 20 - elastix_run_example_COMPARE_IM (Failed)
[00:50:41] 	 23 - elastix_run_3DCT_lung.example_COMPARE_OVERLAP (Failed)
[00:50:41] 	 27 - elastix_run_3DCT_lung.NC.translation.ASGD.001_COMPARE_OVERLAP (Failed)
[00:50:41] 	 31 - elastix_run_3DCT_lung.NC.euler.ASGD.001_COMPARE_OVERLAP (Failed)
[00:50:41] 	 35 - elastix_run_3DCT_lung.NC.affine.ASGD.001_COMPARE_OVERLAP (Failed)
[00:50:41] 	 39 - elastix_run_3DCT_lung.NC.bspline_r.ASGD.001a_COMPARE_OVERLAP (Failed)
[00:50:41] 	 43 - elastix_run_3DCT_lung.SSD.bspline.ASGD.001_COMPARE_OVERLAP (Failed)
[00:50:41] 	 47 - elastix_run_3DCT_lung.MI.bspline.ASGD.001_COMPARE_OVERLAP (Failed)
[00:50:41] 	 49 - elastix_run_3DCT_lung.MI.bspline.ASGD.001_COMPARE_TP (Failed)
[00:50:41] 	 51 - elastix_run_3DCT_lung.NMI.bspline.ASGD.001_COMPARE_OVERLAP (Failed)
[00:50:41] 	 54 - elastix_run_3DCT_lung.Kappa.bspline.ASGD.001_OUTPUT (Failed)
[00:50:41] 	 55 - elastix_run_3DCT_lung.Kappa.bspline.ASGD.001_COMPARE_OVERLAP (Failed)
[00:50:41] 	 56 - elastix_run_3DCT_lung.Kappa.bspline.ASGD.001_COMPARE_LANDMARKS (Failed)
[00:50:41] 	 58 - elastix_run_3DCT_lung.NC.bspline.ASGD.002_COMPARE_OVERLAP (Failed)
[00:50:41] 	 62 - elastix_run_3DCT_lung.NC.bspline.ASGD.003_COMPARE_OVERLAP (Failed)
[00:50:41] 	 66 - elastix_run_3DCT_lung.NC.bspline.ASGD.004_COMPARE_OVERLAP (Failed)
[00:50:41] 	 70 - elastix_run_3DCT_lung.NC.bspline.ASGD.004b_COMPARE_OVERLAP (Failed)
[00:50:41] 	 74 - elastix_run_3DCT_lung.NC.bspline.SGD.001_COMPARE_OVERLAP (Failed)
[00:50:41] 	 78 - elastix_run_3DCT_lung.NC.bspline.QN.001_COMPARE_OVERLAP (Failed)
[00:50:41] 	 82 - elastix_run_3DCT_lung.MI.bspline.SGD.001_COMPARE_OVERLAP (Failed)
[00:50:41] 	 86 - elastix_run_3DCT_lung.MI.bspline.SGD.002_COMPARE_OVERLAP (Failed)
[00:50:41] 	 90 - elastix_run_3DCT_lung.MI.bspline.SGD.003_COMPARE_OVERLAP (Failed)
[00:50:41] 	 94 - elastix_run_3DCT_lung.MI.bspline.SGD.004_COMPARE_OVERLAP (Failed)
[00:50:41] 	 98 - elastix_run_3DCT_lung.SSD.bspline.ASGD.002_COMPARE_OVERLAP (Failed)
[00:50:41] 	101 - elastix_run_3DCT_lung.SSD.bspline.ASGD.003_OUTPUT (Failed)
[00:50:41] 	102 - elastix_run_3DCT_lung.SSD.bspline.ASGD.003_COMPARE_OVERLAP (Failed)
[00:50:41] 	103 - elastix_run_3DCT_lung.SSD.bspline.ASGD.003_COMPARE_LANDMARKS (Failed)
[00:50:41] 	104 - elastix_run_3DCT_lung.SSD.bspline.ASGD.003_COMPARE_TP (Failed)
[00:50:41] 	106 - elastix_run_3DCT_lung.SSD.bspline.ASGD.001-Threads1_COMPARE_OVERLAP (Failed)
[00:50:41] 	110 - elastix_run_3DCT_lung.SSD.bspline.ASGD.001-Threads2_COMPARE_OVERLAP (Failed)
[00:50:41] 	114 - elastix_run_3DCT_lung.SSD.bspline.ASGD.001-Threads4_COMPARE_OVERLAP (Failed)
[00:50:41] 	118 - elastix_run_3DCT_lung.NC.bspline.ASGD.001a-Threads1_COMPARE_OVERLAP (Failed)
[00:50:41] 	122 - elastix_run_3DCT_lung.NC.bspline.ASGD.001a-Threads2_COMPARE_OVERLAP (Failed)
[00:50:41] 	126 - elastix_run_3DCT_lung.NC.bspline.ASGD.001a-Threads4_COMPARE_OVERLAP (Failed)
[00:50:41] 	130 - elastix_run_3DCT_lung.MI.bspline.SGD.001-Threads1_COMPARE_OVERLAP (Failed)
[00:50:41] 	134 - elastix_run_3DCT_lung.MI.bspline.SGD.001-Threads2_COMPARE_OVERLAP (Failed)
[00:50:41] 	138 - elastix_run_3DCT_lung.MI.bspline.SGD.001-Threads4_COMPARE_OVERLAP (Failed)
[00:50:41] 	142 - elastix_run_3DCT_lung.NC.bspline.ASGD.001a_COMPARE_OVERLAP (Failed)
[00:50:41] 	146 - elastix_run_3DCT_lung.NC.bspline.ASGD.001b_COMPARE_OVERLAP (Failed)
[00:50:41] 	150 - elastix_run_3DCT_lung.NC.bspline.ASGD.001c_COMPARE_OVERLAP (Failed)
[00:50:41] 	154 - elastix_run_3DCT_lung.NC.bspline.ASGD.001d_COMPARE_OVERLAP (Failed)
[00:50:41] Errors while running CTest
```

I do not know if this is the same behavior folks observe on regular Windows builds or not (cc: @lassoan).

Once integrated, maintainers of https://github.com/SuperElastix/elastix should set up AppVeyor CI using their credentials.

Note that ITK source and build are currently cached.

Hope this helps!