### PR TITLE
COMP: Removed incorrect paths to KNN (elastix issue #22)

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -209,8 +209,6 @@ set( elxCommon_INCLUDE_DIRECTORIES
   ${elastix_SOURCE_DIR}/Common
   ${elastix_SOURCE_DIR}/Common/CostFunctions
   ${elastix_SOURCE_DIR}/Common/ImageSamplers
-  ${elastix_SOURCE_DIR}/Common/KNN
-  ${elastix_SOURCE_DIR}/Common/KNN/ann_1.1/include
   ${elastix_SOURCE_DIR}/Common/LineSearchOptimizers
   ${elastix_SOURCE_DIR}/Common/ParameterFileParser
   ${elastix_SOURCE_DIR}/Common/Transforms


### PR DESCRIPTION
Removed incorrect paths to KNN from elxCommon_INCLUDE_DIRECTORIES, as minimal fix to elastix issue #22 (Incorrect paths to KNN in elxCommon_INCLUDE_DIRECTORIES)