### PR TITLE
ENH: TransformixFilter exposes deformation field object

### DIFF
--- a/Core/ComponentBaseClasses/elxTransformBase.h
+++ b/Core/ComponentBaseClasses/elxTransformBase.h
@@ -298,15 +298,18 @@ public:
   /** Function to transform coordinates from fixed to moving image, given as VTK file. */
   virtual void TransformPointsSomePointsVTK( const std::string filename ) const;
 
+  /** Deprecation note: The plan is to split all Compute* and TransformPoints* functions 
+   *  into Generate* and Write* functions, since that would facilitate a proper library 
+   *  interface. To keep everything functional during the transition period we need to 
+   *  keep the orignal Compute* and TransformPoints* functions and let them just call 
+   *  Generate* and Write*. These functions should be considered marked deprecated.
+
   /** Function to transform all coordinates from fixed to moving image. */
-  /** Legacy note: the function formerly called TransformPointsAllPoints was split into 
-      GenerateDeformationFieldImage for generating and WriteDeformationFieldImage for 
-      writing to disk*/
   typename DeformationFieldImageType::Pointer GenerateDeformationFieldImage( void ) const;
 
   void WriteDeformationFieldImage( typename DeformationFieldImageType::Pointer ) const;
 
-  /** Function to transform all coordinates from fixed to moving image. */
+  /** Legacy function that calls GenerateDeformationFieldImage and WriteDeformationFieldImage. */
   virtual void TransformPointsAllPoints(void) const;
 
   /** Function to compute the determinant of the spatial Jacobian. */

--- a/Core/ComponentBaseClasses/elxTransformBase.h
+++ b/Core/ComponentBaseClasses/elxTransformBase.h
@@ -192,6 +192,12 @@ public:
   typedef typename ITKBaseType::InputPointType  InputPointType;
   typedef typename ITKBaseType::OutputPointType OutputPointType;
 
+  /** Typedef's for TransformPointsAllPoints. */
+  typedef itk::Vector<
+    float, FixedImageDimension >                      VectorPixelType;
+  typedef itk::Image<
+    VectorPixelType, FixedImageDimension >            DeformationFieldImageType;
+
   /** Typedefs needed for AutomaticScalesEstimation function */
   typedef typename RegistrationType::ITKBaseType      ITKRegistrationType;
   typedef typename ITKRegistrationType::OptimizerType OptimizerType;
@@ -293,7 +299,15 @@ public:
   virtual void TransformPointsSomePointsVTK( const std::string filename ) const;
 
   /** Function to transform all coordinates from fixed to moving image. */
-  virtual void TransformPointsAllPoints( void ) const;
+  /** Legacy note: the function formerly called TransformPointsAllPoints was split into 
+      GenerateDeformationFieldImage for generating and WriteDeformationFieldImage for 
+      writing to disk*/
+  typename DeformationFieldImageType::Pointer GenerateDeformationFieldImage( void ) const;
+
+  void WriteDeformationFieldImage( typename DeformationFieldImageType::Pointer ) const;
+
+  /** Function to transform all coordinates from fixed to moving image. */
+  virtual void TransformPointsAllPoints(void) const;
 
   /** Function to compute the determinant of the spatial Jacobian. */
   virtual void ComputeDeterminantOfSpatialJacobian( void ) const;

--- a/Core/Kernel/elxElastixBase.h
+++ b/Core/Kernel/elxElastixBase.h
@@ -252,6 +252,10 @@ public:
   elxGetObjectMacro( ResultImageContainer, DataObjectContainerType );
   elxSetObjectMacro( ResultImageContainer, DataObjectContainerType );
 
+  /** Set/Get the result image container. */
+  elxGetObjectMacro( ResultDeformationFieldContainer, DataObjectContainerType );
+  elxSetObjectMacro( ResultDeformationFieldContainer, DataObjectContainerType );
+
   /** Set/Get The Image FileName containers.
    * Normally, these are filled in the BeforeAllBase function.
    */
@@ -288,6 +292,7 @@ public:
   elxGetNumberOfMacro( FixedMaskFileName );
   elxGetNumberOfMacro( MovingMaskFileName );
   elxGetNumberOfMacro( ResultImage );
+  elxGetNumberOfMacro( ResultDeformationField );
 
   /** Set/Get the initial transform
    * The type is ObjectType, but the pointer should actually point
@@ -524,6 +529,9 @@ private:
 
   /** The result image container. These are stored as pointers to itk::DataObject. */
   DataObjectContainerPointer m_ResultImageContainer;
+
+  /** The result deformation field container. These are stored as pointers to itk::DataObject. */
+  DataObjectContainerPointer m_ResultDeformationFieldContainer;
 
   /** The image and mask FileNameContainers. */
   FileNameContainerPointer m_FixedImageFileNameContainer;

--- a/Core/Kernel/elxElastixMain.h
+++ b/Core/Kernel/elxElastixMain.h
@@ -183,8 +183,8 @@ public:
   itkSetObjectMacro( ResultImageContainer, DataObjectContainerType );
   itkGetObjectMacro( ResultImageContainer, DataObjectContainerType );
 
-  itkSetObjectMacro(ResultDeformationFieldContainer, DataObjectContainerType);
-  itkGetObjectMacro(ResultDeformationFieldContainer, DataObjectContainerType);
+  itkSetObjectMacro( ResultDeformationFieldContainer, DataObjectContainerType );
+  itkGetObjectMacro( ResultDeformationFieldContainer, DataObjectContainerType );
 
   /** Set/Get the configuration object. */
   itkSetObjectMacro( Configuration, ConfigurationType );

--- a/Core/Kernel/elxElastixMain.h
+++ b/Core/Kernel/elxElastixMain.h
@@ -183,6 +183,9 @@ public:
   itkSetObjectMacro( ResultImageContainer, DataObjectContainerType );
   itkGetObjectMacro( ResultImageContainer, DataObjectContainerType );
 
+  itkSetObjectMacro(ResultDeformationFieldContainer, DataObjectContainerType);
+  itkGetObjectMacro(ResultDeformationFieldContainer, DataObjectContainerType);
+
   /** Set/Get the configuration object. */
   itkSetObjectMacro( Configuration, ConfigurationType );
   itkGetObjectMacro( Configuration, ConfigurationType );
@@ -323,6 +326,7 @@ protected:
   DataObjectContainerPointer m_FixedMaskContainer;
   DataObjectContainerPointer m_MovingMaskContainer;
   DataObjectContainerPointer m_ResultImageContainer;
+  DataObjectContainerPointer m_ResultDeformationFieldContainer;
 
   /** A transform that is the result of registration. */
   ObjectPointer m_FinalTransform;

--- a/Core/Kernel/elxElastixTemplate.h
+++ b/Core/Kernel/elxElastixTemplate.h
@@ -151,6 +151,9 @@ public:
   /** Result image */
   typedef itk::DataObject ResultImageType;
 
+  /** Result deformation field */
+  typedef itk::DataObject ResultDeformationFieldType;
+
   /** For using the Dimensions. */
   itkStaticConstMacro( Dimension,       unsigned int, FixedImageType::ImageDimension );
   itkStaticConstMacro( FixedDimension,  unsigned int, FixedImageType::ImageDimension );
@@ -273,6 +276,17 @@ public:
   virtual ResultImageType * GetResultImage( unsigned int idx ) const;
 
   virtual int SetResultImage( DataObjectPointer result_image );
+
+  
+  virtual ResultDeformationFieldType * GetResultDeformationField( void ) const
+  {
+    return this->GetResultDeformationField( 0 );
+  }
+
+
+  virtual ResultDeformationFieldType * GetResultDeformationField( unsigned int idx ) const;
+
+  virtual int SetResultDeformationField( DataObjectPointer result_deformationfield );
 
   /** Main functions:
    * Run() for registration, and ApplyTransform() for just

--- a/Core/Kernel/elxElastixTemplate.hxx
+++ b/Core/Kernel/elxElastixTemplate.hxx
@@ -178,6 +178,39 @@ ElastixTemplate< TFixedImage, TMovingImage >
 
 
 /**
+* ********************** GetResultDeformationField *************************
+*/
+
+template< class TFixedImage, class TMovingImage >
+typename ElastixTemplate< TFixedImage, TMovingImage >::ResultDeformationFieldType
+* ElastixTemplate< TFixedImage, TMovingImage >
+::GetResultDeformationField( unsigned int idx ) const
+{
+  if (idx < this->GetNumberOfResultDeformationFields() )
+  {
+    return dynamic_cast< ResultDeformationFieldType * >(
+      this->GetResultDeformationFieldContainer()->ElementAt( idx ).GetPointer() );
+  }
+
+  return 0;
+
+} // end GetResultDeformationField()
+
+/**
+* ********************** SetResultDeformationField *************************
+*/
+
+template< class TFixedImage, class TMovingImage >
+int
+ElastixTemplate< TFixedImage, TMovingImage >
+::SetResultDeformationField( DataObjectPointer result_deformationfield )
+{
+  this->SetResultDeformationFieldContainer(
+    MultipleDataObjectFiller::GenerateImageContainer( result_deformationfield ) );
+  return 0;
+} // end SetResultDeformationField()
+
+/**
  * **************************** Run *****************************
  */
 

--- a/Core/Kernel/elxTransformixMain.cxx
+++ b/Core/Kernel/elxTransformixMain.cxx
@@ -157,6 +157,8 @@ TransformixMain::Run( void )
     this->GetElastixBase()->GetMovingImageContainer() );
   this->SetResultImageContainer(
     this->GetElastixBase()->GetResultImageContainer() );
+  this->SetResultDeformationFieldContainer(
+    this->GetElastixBase()->GetResultDeformationFieldContainer() );
 
   return errorCode;
 

--- a/Core/Main/elxTransformixFilter.h
+++ b/Core/Main/elxTransformixFilter.h
@@ -55,6 +55,7 @@ public:
   typedef TransformixMainType::ArgumentMapType ArgumentMapType;
   typedef ArgumentMapType::value_type          ArgumentMapEntryType;
 
+  typedef itk::ProcessObject::DataObjectPointer           DataObjectPointer;
   typedef itk::ProcessObject::DataObjectIdentifierType    DataObjectIdentifierType;
   typedef TransformixMainType::DataObjectContainerType    DataObjectContainerType;
   typedef TransformixMainType::DataObjectContainerPointer DataObjectContainerPointer;
@@ -65,6 +66,8 @@ public:
   typedef ParameterObjectType::ParameterValueVectorType ParameterValueVectorType;
   typedef typename ParameterObjectType::Pointer         ParameterObjectPointer;
   typedef typename ParameterObjectType::ConstPointer    ParameterObjectConstPointer;
+
+  typedef typename itk::Image< itk::Vector< float, TMovingImage::ImageDimension >, TMovingImage::ImageDimension > OutputDeformationFieldType;
 
   typedef typename TMovingImage::Pointer      InputImagePointer;
   typedef typename TMovingImage::ConstPointer InputImageConstPointer;
@@ -103,6 +106,10 @@ public:
 
   const ParameterObjectType * GetTransformParameterObject( void ) const;
 
+  OutputDeformationFieldType * GetOutputDeformationField(void);
+  
+  const OutputDeformationFieldType * GetOutputDeformationField(void) const;
+
   /** Set/Get/Remove output directory. */
   itkSetMacro( OutputDirectory, std::string );
   itkGetConstMacro( OutputDirectory, std::string );
@@ -123,6 +130,9 @@ public:
   itkSetMacro( LogToFile, bool );
   itkGetConstMacro( LogToFile, bool );
   itkBooleanMacro( LogToFile );
+
+  /** To support outputs of different types (i.e. ResultImage and ResultDeformationField) MakeOutput from itk::ImageSource< TOutputImage > needs to be overridden */
+  virtual DataObjectPointer MakeOutput(const DataObjectIdentifierType & key) ITK_OVERRIDE;
 
 protected:
 

--- a/Core/Main/elxTransformixFilter.h
+++ b/Core/Main/elxTransformixFilter.h
@@ -67,7 +67,8 @@ public:
   typedef typename ParameterObjectType::Pointer         ParameterObjectPointer;
   typedef typename ParameterObjectType::ConstPointer    ParameterObjectConstPointer;
 
-  typedef typename itk::Image< itk::Vector< float, TMovingImage::ImageDimension >, TMovingImage::ImageDimension > OutputDeformationFieldType;
+  typedef typename itk::Image< itk::Vector< float, TMovingImage::ImageDimension >, 
+                         TMovingImage::ImageDimension > OutputDeformationFieldType;
 
   typedef typename TMovingImage::Pointer      InputImagePointer;
   typedef typename TMovingImage::ConstPointer InputImageConstPointer;
@@ -106,9 +107,9 @@ public:
 
   const ParameterObjectType * GetTransformParameterObject( void ) const;
 
-  OutputDeformationFieldType * GetOutputDeformationField(void);
+  OutputDeformationFieldType * GetOutputDeformationField( void );
   
-  const OutputDeformationFieldType * GetOutputDeformationField(void) const;
+  const OutputDeformationFieldType * GetOutputDeformationField( void ) const;
 
   /** Set/Get/Remove output directory. */
   itkSetMacro( OutputDirectory, std::string );
@@ -132,7 +133,7 @@ public:
   itkBooleanMacro( LogToFile );
 
   /** To support outputs of different types (i.e. ResultImage and ResultDeformationField) MakeOutput from itk::ImageSource< TOutputImage > needs to be overridden */
-  virtual DataObjectPointer MakeOutput(const DataObjectIdentifierType & key) ITK_OVERRIDE;
+  virtual DataObjectPointer MakeOutput( const DataObjectIdentifierType & key ) ITK_OVERRIDE;
 
 protected:
 

--- a/Core/Main/elxTransformixFilter.hxx
+++ b/Core/Main/elxTransformixFilter.hxx
@@ -31,6 +31,7 @@ TransformixFilter< TMovingImage >
 {
   this->SetPrimaryInputName( "InputImage" );
   this->SetPrimaryOutputName( "ResultImage" );
+  this->SetOutput( "ResultDeformationField", this->MakeOutput( "ResultDeformationField" ) );
 
   this->AddRequiredInputName( "TransformParameterObject" );
 
@@ -220,9 +221,9 @@ TransformixFilter< TMovingImage >
   }
   // Optionally, save result deformation field
   DataObjectContainerPointer resultDeformationFieldContainer = transformix->GetResultDeformationFieldContainer();
-  if (resultDeformationFieldContainer.IsNotNull() && resultDeformationFieldContainer->Size() > 0)
+  if ( resultDeformationFieldContainer.IsNotNull() && resultDeformationFieldContainer->Size() > 0 )
   {
-    this->GraftOutput("ResultDeformationField", resultDeformationFieldContainer->ElementAt(0));
+    this->GraftOutput( "ResultDeformationField", resultDeformationFieldContainer->ElementAt( 0 ) );
   }
 } // end GenerateData()
 
@@ -233,13 +234,13 @@ TransformixFilter< TMovingImage >
 template< typename TMovingImage >
 typename TransformixFilter< TMovingImage >::DataObjectPointer
 TransformixFilter< TMovingImage >
-::MakeOutput(const DataObjectIdentifierType & key)
+::MakeOutput( const DataObjectIdentifierType & key )
 {
-  if (key == "ResultImage")
+  if ( key == "ResultImage" )
   {
     return TMovingImage::New().GetPointer();
   }
-  else if (key == "ResultDeformationField")
+  else if ( key == "ResultDeformationField" )
   {
     return OutputDeformationFieldType::New().GetPointer();
   }
@@ -248,7 +249,7 @@ TransformixFilter< TMovingImage >
     // Primary and all other outputs default to ResultImage.
     return TMovingImage::New().GetPointer();
   }
-}
+} // end MakeOutput()
 
 /**
  * ********************* SetInput *********************
@@ -337,7 +338,8 @@ TransformixFilter< TMovingImage >
 ::GetOutputDeformationField()
 {
 
-  return itkDynamicCastInDebugMode< OutputDeformationFieldType * >(this->ProcessObject::GetOutput("ResultDeformationField"));
+  return itkDynamicCastInDebugMode< OutputDeformationFieldType * >(
+    this->itk::ProcessObject::GetOutput( "ResultDeformationField" ) );
 }
 
 /**
@@ -349,7 +351,8 @@ TransformixFilter< TMovingImage >
 ::GetOutputDeformationField() const
 {
 
-  return itkDynamicCastInDebugMode< const OutputDeformationFieldType * >(this->ProcessObject::GetOutput("ResultDeformationField"));
+  return itkDynamicCastInDebugMode< const OutputDeformationFieldType * >(
+    this->itk::ProcessObject::GetOutput( "ResultDeformationField" ) );
 }
 
 

--- a/Core/Main/elxTransformixFilter.hxx
+++ b/Core/Main/elxTransformixFilter.hxx
@@ -218,8 +218,37 @@ TransformixFilter< TMovingImage >
   {
     this->GraftOutput( "ResultImage", resultImageContainer->ElementAt( 0 ) );
   }
+  // Optionally, save result deformation field
+  DataObjectContainerPointer resultDeformationFieldContainer = transformix->GetResultDeformationFieldContainer();
+  if (resultDeformationFieldContainer.IsNotNull() && resultDeformationFieldContainer->Size() > 0)
+  {
+    this->GraftOutput("ResultDeformationField", resultDeformationFieldContainer->ElementAt(0));
+  }
 } // end GenerateData()
 
+
+/**
+*
+*/
+template< typename TMovingImage >
+typename TransformixFilter< TMovingImage >::DataObjectPointer
+TransformixFilter< TMovingImage >
+::MakeOutput(const DataObjectIdentifierType & key)
+{
+  if (key == "ResultImage")
+  {
+    return TMovingImage::New().GetPointer();
+  }
+  else if (key == "ResultDeformationField")
+  {
+    return OutputDeformationFieldType::New().GetPointer();
+  }
+  else
+  {
+    // Primary and all other outputs default to ResultImage.
+    return TMovingImage::New().GetPointer();
+  }
+}
 
 /**
  * ********************* SetInput *********************
@@ -297,6 +326,31 @@ TransformixFilter< TMovingImage >
 {
   return dynamic_cast< const ParameterObjectType * >( this->GetInput( "TransformParameterObject" ) );
 } // end GetTransformParameterObject()
+
+
+/**
+*  ********************* GetOutputDeformationField *********************
+*/
+template< typename TMovingImage >
+typename TransformixFilter< TMovingImage >::OutputDeformationFieldType *
+TransformixFilter< TMovingImage >
+::GetOutputDeformationField()
+{
+
+  return itkDynamicCastInDebugMode< OutputDeformationFieldType * >(this->ProcessObject::GetOutput("ResultDeformationField"));
+}
+
+/**
+*  ********************* GetOutputDeformationField *********************
+*/
+template< typename TMovingImage >
+const typename TransformixFilter< TMovingImage >::OutputDeformationFieldType *
+TransformixFilter< TMovingImage >
+::GetOutputDeformationField() const
+{
+
+  return itkDynamicCastInDebugMode< const OutputDeformationFieldType * >(this->ProcessObject::GetOutput("ResultDeformationField"));
+}
 
 
 /**

--- a/Core/Main/elxTransformixFilter.hxx
+++ b/Core/Main/elxTransformixFilter.hxx
@@ -229,7 +229,7 @@ TransformixFilter< TMovingImage >
 
 
 /**
-*
+* ********************* MakeOutput *********************
 */
 template< typename TMovingImage >
 typename TransformixFilter< TMovingImage >::DataObjectPointer
@@ -252,7 +252,7 @@ TransformixFilter< TMovingImage >
 } // end MakeOutput()
 
 /**
- * ********************* SetInput *********************
+ * ********************* SetMovingImage *********************
  */
 
 template< typename TMovingImage >
@@ -261,11 +261,11 @@ TransformixFilter< TMovingImage >
 ::SetMovingImage( TMovingImage * inputImage )
 {
   this->SetInput( "InputImage", inputImage );
-} // end SetInput()
+} // end SetMovingImage()
 
 
 /**
- * ********************* GetInput *********************
+ * ********************* GetMovingImage *********************
  */
 
 template< typename TMovingImage >
@@ -274,11 +274,11 @@ TransformixFilter< TMovingImage >
 ::GetMovingImage( void )
 {
   return itkDynamicCastInDebugMode< TMovingImage * >( this->GetInput( "InputImage" ) );
-} // end GetInput()
+} // end GetMovingImage()
 
 
 /**
- * ********************* RemoveInput *********************
+ * ********************* RemoveMovingImage *********************
  */
 
 template< typename TMovingImage >
@@ -287,7 +287,7 @@ TransformixFilter< TMovingImage >
 ::RemoveMovingImage( void )
 {
   this->RemoveInput( "InputImage" );
-} // end RemoveInput
+} // end RemoveMovingImage
 
 
 /**
@@ -340,7 +340,7 @@ TransformixFilter< TMovingImage >
 
   return itkDynamicCastInDebugMode< OutputDeformationFieldType * >(
     this->itk::ProcessObject::GetOutput( "ResultDeformationField" ) );
-}
+} // end GetOutputDeformationField
 
 /**
 *  ********************* GetOutputDeformationField *********************
@@ -353,7 +353,7 @@ TransformixFilter< TMovingImage >
 
   return itkDynamicCastInDebugMode< const OutputDeformationFieldType * >(
     this->itk::ProcessObject::GetOutput( "ResultDeformationField" ) );
-}
+} // end GetOutputDeformationField
 
 
 /**


### PR DESCRIPTION
Previously, when tranformix was asked to give deformation field it was written to disk directly (deformation.mhd), even when called from the library interface. Current pull request lets transformix pass its deformation field via memory.