### PR TITLE
BUG: Clean up xout before rethrow

### DIFF
--- a/Common/xout/xoutmain.cxx
+++ b/Common/xout/xoutmain.cxx
@@ -37,6 +37,10 @@ set_xout( xoutbase_type * arg )
   local_xout = arg;
 }
 
+bool xout_valid() {
+  return local_xout != 0;
+}
+
 
 } // end namespace
 

--- a/Common/xout/xoutmain.h
+++ b/Common/xout/xoutmain.h
@@ -41,6 +41,8 @@ xoutbase_type & get_xout( void );
 
 void set_xout( xoutbase_type * arg );
 
+bool xout_valid();
+
 } // end namespace xoutlibrary
 
 #endif // end #ifndef __xoutmain_h

--- a/Core/Kernel/elxElastixTemplate.hxx
+++ b/Core/Kernel/elxElastixTemplate.hxx
@@ -317,6 +317,9 @@ ElastixTemplate< TFixedImage, TMovingImage >
     err_str += "\n\nError occurred during actual registration.";
     excp.SetDescription( err_str );
 
+    /** Clean up before returning - very important for exception safety of the xout global static object */
+    this->AfterRegistrationBase();
+
     /** Pass the exception to a higher level. */
     throw excp;
   }

--- a/Core/Kernel/elxElastixTemplate.hxx
+++ b/Core/Kernel/elxElastixTemplate.hxx
@@ -318,7 +318,10 @@ ElastixTemplate< TFixedImage, TMovingImage >
     excp.SetDescription( err_str );
 
     /** Clean up before returning - very important for exception safety of the xout global static object */
-    this->AfterRegistrationBase();
+    if( xoutlibrary::xout_valid() )
+    {
+      xoutlibrary::xout.RemoveTargetCell("iteration");
+    }
 
     /** Pass the exception to a higher level. */
     throw excp;


### PR DESCRIPTION
Elastix did not call AfterRegistrationBase before throwing exception and consequently did not clean up xout. This resulted in undefined behaviour and more or less random segfaults if the ElastixFilter was called again after an exception was thrown. This would happen _even_ if the filter was completely destroyed and a new filter was instantiated because xout is a global static object. This possibly fixes SuperElastix/SimpleElastix#123 and an issue previously reported by @coertmetz.

The PR needs more testing and thorough review before merge. In addition, we should review exception handling elsewhere - e.g. for transformix. 

NOTE: This does not change the fact that elastix is not thread safe which might still be an issue (also reported by @coertmetz). The logger will most likely have to be completely refactored into a member variable on e.g. ElastixMain for the library interface to become thread safe. 