### PR TITLE
Fix installing as library

### DIFF
--- a/Core/CMakeLists.txt
+++ b/Core/CMakeLists.txt
@@ -242,8 +242,8 @@ install( FILES
   ${elastix_BINARY_DIR}/elxInstallComponentFunctionCalls.h
   ${elastix_BINARY_DIR}/elxInstallComponentFunctionDeclarations.h
   ${elastix_BINARY_DIR}/elxSupportedImageTypes.h
-  ${elastix_BINARY_DIR}/ITKIOFactoryRegistration/itkImageIOFactoryRegisterManager.h
-  ${elastix_BINARY_DIR}/ITKIOFactoryRegistration/itkTransformIOFactoryRegisterManager.h
+  ${elastix_BINARY_DIR}/ITKFactoryRegistration/itkImageIOFactoryRegisterManager.h
+  ${elastix_BINARY_DIR}/ITKFactoryRegistration/itkTransformIOFactoryRegisterManager.h
   DESTINATION ${ELASTIX_INCLUDE_DIR} )
 
 #---------------------------------------------------------------------


### PR DESCRIPTION
When installing elastix compiled as library I got this error:

CMake Error at src/Core/cmake_install.cmake:93 (file):
  file INSTALL cannot find
  ".../src/ITKIOFactoryRegistration/itkImageIOFactoryRegisterManager.h".
Call Stack (most recent call first):
  src/cmake_install.cmake:44 (include)
  cmake_install.cmake:42 (include)

It is because ITKIOFactoryRegistration does not exits.
The actual folder name is ITKFactoryRegistration (without "IO").