### PR TITLE
Initial preparation upgrade to ITK5

### DIFF
--- a/Common/CostFunctions/itkParzenWindowHistogramImageToImageMetric.hxx
+++ b/Common/CostFunctions/itkParzenWindowHistogramImageToImageMetric.hxx
@@ -430,7 +430,7 @@ ParzenWindowHistogramImageToImageMetric< TFixedImage, TMovingImage >
 
   /** The ParzenIndex is the lowest bin number that is affected by a
    * pixel and computed as:
-   * ParzenIndex = vcl_floor( ParzenTerm + ParzenTermToIndexOffset )
+   * ParzenIndex = std::floor( ParzenTerm + ParzenTermToIndexOffset )
    * where ParzenTermToIndexOffset = 1/2, 0, -1/2, or -1.
    */
   this->m_FixedParzenTermToIndexOffset
@@ -576,10 +576,10 @@ ParzenWindowHistogramImageToImageMetric< TFixedImage, TMovingImage >
 
   /** The lowest bin numbers affected by this pixel: */
   const OffsetValueType fixedImageParzenWindowIndex
-    = static_cast< OffsetValueType >( vcl_floor(
+    = static_cast< OffsetValueType >( std::floor(
     fixedImageParzenWindowTerm + this->m_FixedParzenTermToIndexOffset ) );
   const OffsetValueType movingImageParzenWindowIndex
-    = static_cast< OffsetValueType >( vcl_floor(
+    = static_cast< OffsetValueType >( std::floor(
     movingImageParzenWindowTerm + this->m_MovingParzenTermToIndexOffset ) );
 
   /** The Parzen values. */
@@ -856,7 +856,7 @@ ParzenWindowHistogramImageToImageMetric< TFixedImage, TMovingImage >
 
   /** The lowest bin numbers affected by this pixel: */
   const OffsetValueType fixedImageParzenWindowIndex
-    = static_cast< OffsetValueType >( vcl_floor(
+    = static_cast< OffsetValueType >( std::floor(
     fixedImageParzenWindowTerm + this->m_FixedParzenTermToIndexOffset ) );
   this->EvaluateParzenValues(
     fixedImageParzenWindowTerm, fixedImageParzenWindowIndex,
@@ -868,7 +868,7 @@ ParzenWindowHistogramImageToImageMetric< TFixedImage, TMovingImage >
     const double movingImageParzenWindowTerm
       = movingImageValue / this->m_MovingImageBinSize - this->m_MovingImageNormalizedMin;
     const OffsetValueType movingImageParzenWindowIndex
-      = static_cast< OffsetValueType >( vcl_floor(
+      = static_cast< OffsetValueType >( std::floor(
       movingImageParzenWindowTerm + this->m_MovingParzenTermToIndexOffset ) );
     this->EvaluateParzenValues(
       movingImageParzenWindowTerm, movingImageParzenWindowIndex,
@@ -945,7 +945,7 @@ ParzenWindowHistogramImageToImageMetric< TFixedImage, TMovingImage >
       const double movParzenWindowTermRight
         = movr / this->m_MovingImageBinSize - this->m_MovingImageNormalizedMin;
       const OffsetValueType movParzenWindowIndexRight
-        = static_cast< OffsetValueType >( vcl_floor(
+        = static_cast< OffsetValueType >( std::floor(
         movParzenWindowTermRight + this->m_MovingParzenTermToIndexOffset ) );
       this->EvaluateParzenValues(
         movParzenWindowTermRight, movParzenWindowIndexRight,
@@ -980,7 +980,7 @@ ParzenWindowHistogramImageToImageMetric< TFixedImage, TMovingImage >
       const double movParzenWindowTermLeft
         = movl / this->m_MovingImageBinSize - this->m_MovingImageNormalizedMin;
       const OffsetValueType movParzenWindowIndexLeft
-        = static_cast< OffsetValueType >( vcl_floor(
+        = static_cast< OffsetValueType >( std::floor(
         movParzenWindowTermLeft + this->m_MovingParzenTermToIndexOffset ) );
       this->EvaluateParzenValues(
         movParzenWindowTermLeft, movParzenWindowIndexLeft,

--- a/Common/CostFunctions/itkScaledSingleValuedCostFunction.cxx
+++ b/Common/CostFunctions/itkScaledSingleValuedCostFunction.cxx
@@ -217,7 +217,7 @@ ScaledSingleValuedCostFunction
   this->m_Scales.SetSize( squaredScales.GetSize() );
   for( unsigned int i = 0; i < squaredScales.Size(); ++i )
   {
-    this->m_Scales[ i ] = vcl_sqrt( squaredScales[ i ] );
+    this->m_Scales[ i ] = std::sqrt( squaredScales[ i ] );
   }
   this->Modified();
 

--- a/Common/ImageSamplers/itkImageGridSampler.hxx
+++ b/Common/ImageSamplers/itkImageGridSampler.hxx
@@ -261,7 +261,7 @@ ImageGridSampler< TInputImage >
   /** Compute the grid spacing. */
   const double indimd      = static_cast< double >( InputImageDimension );
   int          gridspacing = static_cast< int >(  // no unsigned int version of rnd, max
-    Math::Round< double >( vcl_pow( fraction, 1.0 / indimd ) ) );
+    Math::Round< double >( std::pow( fraction, 1.0 / indimd ) ) );
   gridspacing = vnl_math_max( 1, gridspacing );
 
   /** Set gridspacings for all dimensions

--- a/Common/ImageSamplers/itkImageSamplerBase.hxx
+++ b/Common/ImageSamplers/itkImageSamplerBase.hxx
@@ -383,7 +383,7 @@ ImageSamplerBase< TInputImage >
       maxIndex[ i ] = static_cast< IndexValueType >(
         vcl_ceil( bbIndex->GetMaximum()[ i ] ) );
       minIndex[ i ] = static_cast< IndexValueType >(
-        vcl_floor( bbIndex->GetMinimum()[ i ] ) );
+        std::floor( bbIndex->GetMinimum()[ i ] ) );
       size[ i ] = maxIndex[ i ] - minIndex[ i ] + 1;
     }
     boundingBoxRegion.SetIndex( minIndex );

--- a/Common/LineSearchOptimizers/itkMoreThuenteLineSearchOptimizer.cxx
+++ b/Common/LineSearchOptimizers/itkMoreThuenteLineSearchOptimizer.cxx
@@ -20,7 +20,7 @@
 #define __itkMoreThuenteLineSearchOptimizer_cxx
 
 #include "itkMoreThuenteLineSearchOptimizer.h"
-#include "vcl_limits.h"
+#include <limits>
 #include "vnl/vnl_math.h"
 
 namespace itk

--- a/Common/LineSearchOptimizers/itkMoreThuenteLineSearchOptimizer.cxx
+++ b/Common/LineSearchOptimizers/itkMoreThuenteLineSearchOptimizer.cxx
@@ -730,7 +730,7 @@ MoreThuenteLineSearchOptimizer
       vnl_math_max( vnl_math_abs( theta ), vnl_math_abs( dx ) ),
       vnl_math_abs( dp ) );
     d__1  = theta / s;
-    gamma = s * vcl_sqrt( d__1 * d__1 - dx / s * ( dp / s ) );
+    gamma = s * std::sqrt( d__1 * d__1 - dx / s * ( dp / s ) );
     if( stp < stx )
     {
       gamma = -gamma;
@@ -766,7 +766,7 @@ MoreThuenteLineSearchOptimizer
       vnl_math_max( vnl_math_abs( theta ), vnl_math_abs( dx ) ),
       vnl_math_abs( dp ) );
     d__1  = theta / s;
-    gamma = s * vcl_sqrt( d__1 * d__1 - dx / s * ( dp / s ) );
+    gamma = s * std::sqrt( d__1 * d__1 - dx / s * ( dp / s ) );
     if( stp > stx )
     {
       gamma = -gamma;
@@ -810,7 +810,7 @@ MoreThuenteLineSearchOptimizer
 
     d__1  = theta / s;
     d__1  = d__1 * d__1 - dx / s * ( dp / s );
-    gamma = s * vcl_sqrt( vnl_math_max( 0., d__1 ) );
+    gamma = s * std::sqrt( vnl_math_max( 0., d__1 ) );
     if( stp > stx )
     {
       gamma = -gamma;
@@ -871,7 +871,7 @@ MoreThuenteLineSearchOptimizer
         vnl_math_max( vnl_math_abs( theta ), vnl_math_abs( dy ) ),
         vnl_math_abs( dp ) );
       d__1  = theta / s;
-      gamma = s * vcl_sqrt( d__1 * d__1 - dy / s * ( dp / s ) );
+      gamma = s * std::sqrt( d__1 * d__1 - dy / s * ( dp / s ) );
       if( stp > sty )
       {
         gamma = -gamma;

--- a/Common/Transforms/itkAdvancedBSplineDeformableTransform.hxx
+++ b/Common/Transforms/itkAdvancedBSplineDeformableTransform.hxx
@@ -171,7 +171,7 @@ AdvancedBSplineDeformableTransform< TScalarType, NDimensions, VSplineOrder >
     // when spline order is even.
     // The valid interval for evaluation is [start+offset, last-offset)
     // when spline order is odd.
-    // Where offset = vcl_floor(spline / 2 ).
+    // Where offset = std::floor(spline / 2 ).
     // Note that the last pixel is not included in the valid region
     // with odd spline orders.
     // For backward compatibility m_ValidRegion is still created.

--- a/Common/Transforms/itkAdvancedEuler3DTransform.hxx
+++ b/Common/Transforms/itkAdvancedEuler3DTransform.hxx
@@ -177,44 +177,44 @@ AdvancedEuler3DTransform< TScalarType >
   if( m_ComputeZYX )
   {
     m_AngleY = -asin( this->GetMatrix()[ 2 ][ 0 ] );
-    double C = vcl_cos( m_AngleY );
-    if( vcl_fabs( C ) > 0.00005 )
+    double C = std::cos( m_AngleY );
+    if( std::fabs( C ) > 0.00005 )
     {
       double x = this->GetMatrix()[ 2 ][ 2 ] / C;
       double y = this->GetMatrix()[ 2 ][ 1 ] / C;
-      m_AngleX = vcl_atan2( y, x );
+      m_AngleX = std::atan2( y, x );
       x        = this->GetMatrix()[ 0 ][ 0 ] / C;
       y        = this->GetMatrix()[ 1 ][ 0 ] / C;
-      m_AngleZ = vcl_atan2( y, x );
+      m_AngleZ = std::atan2( y, x );
     }
     else
     {
       m_AngleX = 0;
       double x = this->GetMatrix()[ 1 ][ 1 ];
       double y = -this->GetMatrix()[ 0 ][ 1 ];
-      m_AngleZ = vcl_atan2( y, x );
+      m_AngleZ = std::atan2( y, x );
     }
   }
   else
   {
-    m_AngleX = vcl_asin( this->GetMatrix()[ 2 ][ 1 ] );
-    double A = vcl_cos( m_AngleX );
-    if( vcl_fabs( A ) > 0.00005 )
+    m_AngleX = std::asin( this->GetMatrix()[ 2 ][ 1 ] );
+    double A = std::cos( m_AngleX );
+    if( std::fabs( A ) > 0.00005 )
     {
       double x = this->GetMatrix()[ 2 ][ 2 ] / A;
       double y = -this->GetMatrix()[ 2 ][ 0 ] / A;
-      m_AngleY = vcl_atan2( y, x );
+      m_AngleY = std::atan2( y, x );
 
       x        = this->GetMatrix()[ 1 ][ 1 ] / A;
       y        = -this->GetMatrix()[ 0 ][ 1 ] / A;
-      m_AngleZ = vcl_atan2( y, x );
+      m_AngleZ = std::atan2( y, x );
     }
     else
     {
       m_AngleZ = 0;
       double x = this->GetMatrix()[ 0 ][ 0 ];
       double y = this->GetMatrix()[ 1 ][ 0 ];
-      m_AngleY = vcl_atan2( y, x );
+      m_AngleY = std::atan2( y, x );
     }
   }
   this->ComputeMatrix();
@@ -228,12 +228,12 @@ AdvancedEuler3DTransform< TScalarType >
 ::ComputeMatrix( void )
 {
   // need to check if angles are in the right order
-  const double cx = vcl_cos( m_AngleX );
-  const double sx = vcl_sin( m_AngleX );
-  const double cy = vcl_cos( m_AngleY );
-  const double sy = vcl_sin( m_AngleY );
-  const double cz = vcl_cos( m_AngleZ );
-  const double sz = vcl_sin( m_AngleZ );
+  const double cx = std::cos( m_AngleX );
+  const double sx = std::sin( m_AngleX );
+  const double cy = std::cos( m_AngleY );
+  const double sy = std::sin( m_AngleY );
+  const double cz = std::cos( m_AngleZ );
+  const double sz = std::sin( m_AngleZ );
 
   Matrix< TScalarType, 3, 3 > RotationX;
   RotationX[ 0 ][ 0 ] = 1; RotationX[ 0 ][ 1 ] = 0; RotationX[ 0 ][ 2 ] = 0;
@@ -317,20 +317,20 @@ AdvancedEuler3DTransform< TScalarType >
   /** The Jacobian of spatial Jacobian is constant over inputspace, so is precomputed */
   JacobianOfSpatialJacobianType & jsj = this->m_JacobianOfSpatialJacobian;
   jsj.resize( ParametersDimension );
-  const double cx = vcl_cos( m_AngleX );
-  const double sx = vcl_sin( m_AngleX );
-  const double cy = vcl_cos( m_AngleY );
-  const double sy = vcl_sin( m_AngleY );
-  const double cz = vcl_cos( m_AngleZ );
-  const double sz = vcl_sin( m_AngleZ );
+  const double cx = std::cos( m_AngleX );
+  const double sx = std::sin( m_AngleX );
+  const double cy = std::cos( m_AngleY );
+  const double sy = std::sin( m_AngleY );
+  const double cz = std::cos( m_AngleZ );
+  const double sz = std::sin( m_AngleZ );
 
   /** derivatives: */
-  const double cxd = -vcl_sin( m_AngleX );
-  const double sxd = vcl_cos( m_AngleX );
-  const double cyd = -vcl_sin( m_AngleY );
-  const double syd = vcl_cos( m_AngleY );
-  const double czd = -vcl_sin( m_AngleZ );
-  const double szd = vcl_cos( m_AngleZ );
+  const double cxd = -std::sin( m_AngleX );
+  const double sxd = std::cos( m_AngleX );
+  const double cyd = -std::sin( m_AngleY );
+  const double syd = std::cos( m_AngleY );
+  const double czd = -std::sin( m_AngleZ );
+  const double szd = std::cos( m_AngleZ );
 
   /** rotation matrices */
   Matrix< TScalarType, 3, 3 > RotationX;

--- a/Common/Transforms/itkAdvancedRigid2DTransform.hxx
+++ b/Common/Transforms/itkAdvancedRigid2DTransform.hxx
@@ -222,8 +222,8 @@ void
 AdvancedRigid2DTransform< TScalarType >
 ::ComputeMatrix( void )
 {
-  const double ca = vcl_cos( m_Angle );
-  const double sa = vcl_sin( m_Angle );
+  const double ca = std::cos( m_Angle );
+  const double sa = std::sin( m_Angle );
 
   MatrixType rotationMatrix;
   rotationMatrix[ 0 ][ 0 ] = ca; rotationMatrix[ 0 ][ 1 ] = -sa;
@@ -300,8 +300,8 @@ AdvancedRigid2DTransform< TScalarType >::GetJacobian( const InputPointType & p,
   j.Fill( 0.0 );
 
   // Some helper variables
-  const double ca = vcl_cos( this->GetAngle() );
-  const double sa = vcl_sin( this->GetAngle() );
+  const double ca = std::cos( this->GetAngle() );
+  const double sa = std::sin( this->GetAngle() );
   const double cx = this->GetCenter()[ 0 ];
   const double cy = this->GetCenter()[ 1 ];
 
@@ -328,8 +328,8 @@ AdvancedRigid2DTransform< TScalarType >
 ::PrecomputeJacobianOfSpatialJacobian( void )
 {
   /** The Jacobian of spatial Jacobian remains constant, so is precomputed */
-  const double                    ca  = vcl_cos( m_Angle );
-  const double                    sa  = vcl_sin( m_Angle );
+  const double                    ca  = std::cos( m_Angle );
+  const double                    sa  = std::sin( m_Angle );
   JacobianOfSpatialJacobianType & jsj = this->m_JacobianOfSpatialJacobian;
   jsj.resize( ParametersDimension );
   if( ParametersDimension > 1 )

--- a/Common/Transforms/itkAdvancedSimilarity2DTransform.hxx
+++ b/Common/Transforms/itkAdvancedSimilarity2DTransform.hxx
@@ -137,8 +137,8 @@ AdvancedSimilarity2DTransform< TScalarType >
 {
   const double angle = this->GetAngle();
 
-  const double cc = vcl_cos( angle );
-  const double ss = vcl_sin( angle );
+  const double cc = std::cos( angle );
+  const double ss = std::sin( angle );
 
   const double ca = cc * m_Scale;
   const double sa = ss * m_Scale;
@@ -159,7 +159,7 @@ void
 AdvancedSimilarity2DTransform< TScalarType >
 ::ComputeMatrixParameters( void )
 {
-  m_Scale = vcl_sqrt( vnl_math_sqr( this->GetMatrix()[ 0 ][ 0 ] )
+  m_Scale = std::sqrt( vnl_math_sqr( this->GetMatrix()[ 0 ][ 0 ] )
     + vnl_math_sqr( this->GetMatrix()[ 0 ][ 1 ] ) );
 
   this->SetVarAngle( vcl_acos( this->GetMatrix()[ 0 ][ 0 ] / m_Scale ) );
@@ -169,7 +169,7 @@ AdvancedSimilarity2DTransform< TScalarType >
     this->SetVarAngle( -this->GetAngle() );
   }
 
-  if( ( this->GetMatrix()[ 1 ][ 0 ] / m_Scale ) - vcl_sin( this->GetAngle() ) > 0.000001 )
+  if( ( this->GetMatrix()[ 1 ][ 0 ] / m_Scale ) - std::sin( this->GetAngle() ) > 0.000001 )
   {
     std::cout << "Bad Rotation Matrix" << std::endl;
   }
@@ -193,8 +193,8 @@ AdvancedSimilarity2DTransform< TScalarType >::GetJacobian( const InputPointType 
 
   // Some helper variables
   const double         angle  = this->GetAngle();
-  const double         ca     = vcl_cos( angle );
-  const double         sa     = vcl_sin( angle );
+  const double         ca     = std::cos( angle );
+  const double         sa     = std::sin( angle );
   const InputPointType center = this->GetCenter();
   const double         cx     = center[ 0 ];
   const double         cy     = center[ 1 ];
@@ -303,8 +303,8 @@ AdvancedSimilarity2DTransform< TScalarType >
 {
   /** The Jacobian of spatial Jacobian remains constant, so is precomputed */
   const double                    angle = this->GetAngle();
-  double                          ca    = vcl_cos( angle );
-  double                          sa    = vcl_sin( angle );
+  double                          ca    = std::cos( angle );
+  double                          sa    = std::sin( angle );
   JacobianOfSpatialJacobianType & jsj   = this->m_JacobianOfSpatialJacobian;
   jsj.resize( ParametersDimension );
   if( ParametersDimension > 1 )

--- a/Common/Transforms/itkAdvancedSimilarity3DTransform.hxx
+++ b/Common/Transforms/itkAdvancedSimilarity3DTransform.hxx
@@ -147,7 +147,7 @@ AdvancedSimilarity3DTransform< TScalarType >
   axis[ 2 ] = parameters[ 2 ];
   if( norm > 0 )
   {
-    norm = vcl_sqrt( norm );
+    norm = std::sqrt( norm );
   }
 
   double epsilon = 1e-10;
@@ -184,7 +184,7 @@ AdvancedSimilarity3DTransform< TScalarType >
 //
 // Parameters are ordered as:
 //
-// p[0:2] = right part of the versor (axis times vcl_sin(t/2))
+// p[0:2] = right part of the versor (axis times std::sin(t/2))
 // p[3:5} = translation components
 // p[6:6} = scaling factor (isotropic)
 //
@@ -346,7 +346,7 @@ AdvancedSimilarity3DTransform< TScalarType >
   {
     jsj[ par ].Fill( 0.0 );
   }
-  if( vcl_abs( this->m_Scale ) > 0 )
+  if( std::abs( this->m_Scale ) > 0 )
   {
     jsj[ 6 ] = this->GetMatrix().GetVnlMatrix() / this->m_Scale;
   }

--- a/Common/Transforms/itkAdvancedVersorRigid3DTransform.hxx
+++ b/Common/Transforms/itkAdvancedVersorRigid3DTransform.hxx
@@ -81,7 +81,7 @@ AdvancedVersorRigid3DTransform< TScalarType >
   axis[ 2 ] = parameters[ 2 ];
   if( norm > 0 )
   {
-    norm = vcl_sqrt( norm );
+    norm = std::sqrt( norm );
   }
 
   double epsilon = 1e-10;
@@ -117,7 +117,7 @@ AdvancedVersorRigid3DTransform< TScalarType >
 //
 // Parameters are ordered as:
 //
-// p[0:2] = right part of the versor (axis times vcl_sin(t/2))
+// p[0:2] = right part of the versor (axis times std::sin(t/2))
 // p[3:5} = translation components
 //
 

--- a/Common/Transforms/itkAdvancedVersorTransform.h
+++ b/Common/Transforms/itkAdvancedVersorTransform.h
@@ -132,7 +132,7 @@ public:
    * There are 3 parameters. They represent the components
    * of the right part of the versor. This can be seen
    * as the components of the vector parallel to the rotation
-   * axis and multiplied by vcl_sin( angle / 2 ). */
+   * axis and multiplied by std::sin( angle / 2 ). */
   void SetParameters( const ParametersType & parameters );
 
   /** Get the Transformation Parameters. */

--- a/Common/Transforms/itkBSplineInterpolationWeightFunctionBase.hxx
+++ b/Common/Transforms/itkBSplineInterpolationWeightFunctionBase.hxx
@@ -144,7 +144,7 @@ BSplineInterpolationWeightFunctionBase< TCoordRep, VSpaceDimension, VSplineOrder
   for( unsigned int i = 0; i < SpaceDimension; ++i )
   {
     startIndex[ i ] = static_cast< typename IndexType::IndexValueType >(
-      vcl_floor( cindex[ i ]
+      std::floor( cindex[ i ]
       - static_cast< double >( this->m_SupportSize[ i ] - 2.0 ) / 2.0 ) );
   }
 

--- a/Common/itkAdvancedRayCastInterpolateImageFunction.hxx
+++ b/Common/itkAdvancedRayCastInterpolateImageFunction.hxx
@@ -150,7 +150,7 @@ public:
 
     if( m_ValidRay )
     {
-      return vcl_sqrt( m_VoxelIncrement[ 0 ] * spacing[ 0 ] * m_VoxelIncrement[ 0 ] * spacing[ 0 ]
+      return std::sqrt( m_VoxelIncrement[ 0 ] * spacing[ 0 ] * m_VoxelIncrement[ 0 ] * spacing[ 0 ]
         + m_VoxelIncrement[ 1 ] * spacing[ 1 ] * m_VoxelIncrement[ 1 ] * spacing[ 1 ]
         + m_VoxelIncrement[ 2 ] * spacing[ 2 ] * m_VoxelIncrement[ 2 ] * spacing[ 2 ] );
     }
@@ -481,10 +481,10 @@ RayCastHelper< TInputImage, TCoordRep >
       + C * m_BoundingCorner[ c1 ][ 2 ] );
 
     // initialise plane value and normalise
-    m_BoundingPlane[ j ][ 0 ] = A / vcl_sqrt( A * A + B * B + C * C );
-    m_BoundingPlane[ j ][ 1 ] = B / vcl_sqrt( A * A + B * B + C * C );
-    m_BoundingPlane[ j ][ 2 ] = C / vcl_sqrt( A * A + B * B + C * C );
-    m_BoundingPlane[ j ][ 3 ] = D / vcl_sqrt( A * A + B * B + C * C );
+    m_BoundingPlane[ j ][ 0 ] = A / std::sqrt( A * A + B * B + C * C );
+    m_BoundingPlane[ j ][ 1 ] = B / std::sqrt( A * A + B * B + C * C );
+    m_BoundingPlane[ j ][ 2 ] = C / std::sqrt( A * A + B * B + C * C );
+    m_BoundingPlane[ j ][ 3 ] = D / std::sqrt( A * A + B * B + C * C );
 
     if( ( A * A + B * B + C * C ) == 0 )
     {
@@ -824,9 +824,9 @@ RayCastHelper< TInputImage, TCoordRep >
 
   // Calculate the number of voxels in each direction
 
-  xNum = vcl_fabs( this->m_RayVoxelStartPosition[ 0 ] - this->m_RayVoxelEndPosition[ 0 ] );
-  yNum = vcl_fabs( this->m_RayVoxelStartPosition[ 1 ] - this->m_RayVoxelEndPosition[ 1 ] );
-  zNum = vcl_fabs( this->m_RayVoxelStartPosition[ 2 ] - this->m_RayVoxelEndPosition[ 2 ] );
+  xNum = std::fabs( this->m_RayVoxelStartPosition[ 0 ] - this->m_RayVoxelEndPosition[ 0 ] );
+  yNum = std::fabs( this->m_RayVoxelStartPosition[ 1 ] - this->m_RayVoxelEndPosition[ 1 ] );
+  zNum = std::fabs( this->m_RayVoxelStartPosition[ 2 ] - this->m_RayVoxelEndPosition[ 2 ] );
 
   // The direction iterated in is that with the greatest number of voxels
   // ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
@@ -1035,9 +1035,9 @@ RayCastHelper< TInputImage, TCoordRep >
     startOK = false;
     endOK   = false;
 
-    Istart[ 0 ] = (int)vcl_floor( m_RayVoxelStartPosition[ 0 ] );
-    Istart[ 1 ] = (int)vcl_floor( m_RayVoxelStartPosition[ 1 ] );
-    Istart[ 2 ] = (int)vcl_floor( m_RayVoxelStartPosition[ 2 ] );
+    Istart[ 0 ] = (int)std::floor( m_RayVoxelStartPosition[ 0 ] );
+    Istart[ 1 ] = (int)std::floor( m_RayVoxelStartPosition[ 1 ] );
+    Istart[ 2 ] = (int)std::floor( m_RayVoxelStartPosition[ 2 ] );
 
     if( ( Istart[ 0 ] >= 0 ) && ( Istart[ 0 ] + Idirn[ 0 ] < m_NumberOfVoxelsInX )
       && ( Istart[ 1 ] >= 0 ) && ( Istart[ 1 ] + Idirn[ 1 ] < m_NumberOfVoxelsInY )
@@ -1055,13 +1055,13 @@ RayCastHelper< TInputImage, TCoordRep >
       m_TotalRayVoxelPlanes--;
     }
 
-    Istart[ 0 ] = (int)vcl_floor( m_RayVoxelStartPosition[ 0 ]
+    Istart[ 0 ] = (int)std::floor( m_RayVoxelStartPosition[ 0 ]
       + m_TotalRayVoxelPlanes * m_VoxelIncrement[ 0 ] );
 
-    Istart[ 1 ] = (int)vcl_floor( m_RayVoxelStartPosition[ 1 ]
+    Istart[ 1 ] = (int)std::floor( m_RayVoxelStartPosition[ 1 ]
       + m_TotalRayVoxelPlanes * m_VoxelIncrement[ 1 ] );
 
-    Istart[ 2 ] = (int)vcl_floor( m_RayVoxelStartPosition[ 2 ]
+    Istart[ 2 ] = (int)std::floor( m_RayVoxelStartPosition[ 2 ]
       + m_TotalRayVoxelPlanes * m_VoxelIncrement[ 2 ] );
 
     if( ( Istart[ 0 ] >= 0 ) && ( Istart[ 0 ] + Idirn[ 0 ] < m_NumberOfVoxelsInX )
@@ -1339,20 +1339,20 @@ RayCastHelper< TInputImage, TCoordRep >
   {
     case TRANSVERSE_IN_X:
     {
-      y = m_Position3Dvox[ 1 ] - vcl_floor( m_Position3Dvox[ 1 ] );
-      z = m_Position3Dvox[ 2 ] - vcl_floor( m_Position3Dvox[ 2 ] );
+      y = m_Position3Dvox[ 1 ] - std::floor( m_Position3Dvox[ 1 ] );
+      z = m_Position3Dvox[ 2 ] - std::floor( m_Position3Dvox[ 2 ] );
       break;
     }
     case TRANSVERSE_IN_Y:
     {
-      y = m_Position3Dvox[ 0 ] - vcl_floor( m_Position3Dvox[ 0 ] );
-      z = m_Position3Dvox[ 2 ] - vcl_floor( m_Position3Dvox[ 2 ] );
+      y = m_Position3Dvox[ 0 ] - std::floor( m_Position3Dvox[ 0 ] );
+      z = m_Position3Dvox[ 2 ] - std::floor( m_Position3Dvox[ 2 ] );
       break;
     }
     case TRANSVERSE_IN_Z:
     {
-      y = m_Position3Dvox[ 0 ] - vcl_floor( m_Position3Dvox[ 0 ] );
-      z = m_Position3Dvox[ 1 ] - vcl_floor( m_Position3Dvox[ 1 ] );
+      y = m_Position3Dvox[ 0 ] - std::floor( m_Position3Dvox[ 0 ] );
+      z = m_Position3Dvox[ 1 ] - std::floor( m_Position3Dvox[ 1 ] );
       break;
     }
     default:
@@ -1379,7 +1379,7 @@ void
 RayCastHelper< TInputImage, TCoordRep >
 ::IncrementIntensities( double increment )
 {
-  short inc = (short)vcl_floor( increment + 0.5 );
+  short inc = (short)std::floor( increment + 0.5 );
 
   if( !m_ValidRay )
   {

--- a/Common/itkComputeDisplacementDistribution.hxx
+++ b/Common/itkComputeDisplacementDistribution.hxx
@@ -179,7 +179,7 @@ ComputeDisplacementDistribution< TFixedImage, TTransform >
   Jgg.Fill( 0.0 );
   std::vector< double > JGG_k;
   double                globalDeformation = 0.0;
-  const double          sqrt2             = vcl_sqrt( static_cast< double >( 2.0 ) );
+  const double          sqrt2             = std::sqrt( static_cast< double >( 2.0 ) );
   JacobianType          jacjjacj( outdim, outdim );
 
   samplenr = 0;
@@ -244,7 +244,7 @@ ComputeDisplacementDistribution< TFixedImage, TTransform >
       sigma += vnl_math_sqr( JGG_k[ i ] - mean_JGG );
     }
     sigma /= ( nrofsamples - 1 ); // unbiased estimation
-    jacg   = mean_JGG + 2.0 * vcl_sqrt( sigma );
+    jacg   = mean_JGG + 2.0 * std::sqrt( sigma );
   }
 
 } // end ComputeSingleThreaded()
@@ -391,7 +391,7 @@ ComputeDisplacementDistribution< TFixedImage, TTransform >
   /** Temporaries. */
   //std::vector< double > JGG_k; not here so only mean + 2 sigma is supported
   DerivativeType Jgg( outdim ); Jgg.Fill( 0.0 );
-  const double   sqrt2 = vcl_sqrt( static_cast< double >( 2.0 ) );
+  const double   sqrt2 = std::sqrt( static_cast< double >( 2.0 ) );
   JacobianType   jacjjacj( outdim, outdim );
   double         maxJJ                 = 0.0;
   double         jggMagnitude          = 0.0;
@@ -498,7 +498,7 @@ ComputeDisplacementDistribution< TFixedImage, TTransform >
   const double meanDisplacement = displacement / this->m_NumberOfPixelsCounted;
   const double sigma            = displacementSquared / this->m_NumberOfPixelsCounted - vnl_math_sqr( meanDisplacement );
 
-  jacg = meanDisplacement + 2.0 * vcl_sqrt( sigma );
+  jacg = meanDisplacement + 2.0 * std::sqrt( sigma );
 
 } // end AfterThreadedCompute()
 
@@ -619,7 +619,7 @@ ComputeDisplacementDistribution< TFixedImage, TTransform >
       sigma += vnl_math_sqr( JGG_k[ i ] - mean_JGG );
     }
     sigma /= ( nrofsamples - 1 ); // unbiased estimation
-    jacg   = mean_JGG + 2.0 * vcl_sqrt( sigma );
+    jacg   = mean_JGG + 2.0 * std::sqrt( sigma );
   }
 } // end ComputeUsingSearchDirection()
 

--- a/Common/itkComputeJacobianTerms.hxx
+++ b/Common/itkComputeJacobianTerms.hxx
@@ -179,7 +179,7 @@ ComputeJacobianTerms< TFixedImage, TTransform >
       for( unsigned int j = i; j < sizejacind; ++j )
       {
         const int jacindj = static_cast< int >( jacind[ j ] );
-        difHist[ static_cast< unsigned int >( vcl_abs( jacindj - jacindi ) ) ]++;
+        difHist[ static_cast< unsigned int >( std::abs( jacindj - jacindi ) ) ]++;
       }
     }
   }
@@ -265,7 +265,7 @@ ComputeJacobianTerms< TFixedImage, TTransform >
             if( q >= p )
             {
               const double tempval = jactjac( pi, qi ) / n;
-              if( vcl_abs( tempval ) > 1e-14 )
+              if( std::abs( tempval ) > 1e-14 )
               {
                 const unsigned int bandindex = bandcovMap[ q - p ];
                 if( bandindex < bandcovsize )
@@ -303,7 +303,7 @@ ComputeJacobianTerms< TFixedImage, TTransform >
       if( q >= p )
       {
         const double tempval = jactjac( pi, qi ) / n;
-        if( vcl_abs( tempval ) > 1e-14 )
+        if( std::abs( tempval ) > 1e-14 )
         {
           const unsigned int bandindex = bandcovMap[ q - p ];
           if( bandindex < bandcovsize )
@@ -327,7 +327,7 @@ ComputeJacobianTerms< TFixedImage, TTransform >
     for( unsigned int b = 0; b < bandcovsize; ++b )
     {
       const double tempval = bandcov( p, b );
-      if( vcl_abs( tempval ) > 1e-14 )
+      if( std::abs( tempval ) > 1e-14 )
       {
         const unsigned int q = p + bandcovMap2[ b ];
         cov( p, q ) = tempval;
@@ -392,7 +392,7 @@ ComputeJacobianTerms< TFixedImage, TTransform >
    */
   maxJJ  = 0.0;
   maxJCJ = 0.0;
-  const double sqrt2 = vcl_sqrt( static_cast< double >( 2.0 ) );
+  const double sqrt2 = std::sqrt( static_cast< double >( 2.0 ) );
 
   JacobianType                       jacjjacj( outdim, outdim );
   JacobianType                       jacjcov( outdim, sizejacind );

--- a/Common/itkMultiOrderBSplineDecompositionImageFilter.hxx
+++ b/Common/itkMultiOrderBSplineDecompositionImageFilter.hxx
@@ -187,7 +187,7 @@ MultiOrderBSplineDecompositionImageFilter< TInputImage, TOutputImage >
   {
     case 3:
       m_NumberOfPoles    = 1;
-      m_SplinePoles[ 0 ] = vcl_sqrt( 3.0 ) - 2.0;
+      m_SplinePoles[ 0 ] = std::sqrt( 3.0 ) - 2.0;
       break;
     case 0:
       m_NumberOfPoles = 0;
@@ -197,18 +197,18 @@ MultiOrderBSplineDecompositionImageFilter< TInputImage, TOutputImage >
       break;
     case 2:
       m_NumberOfPoles    = 1;
-      m_SplinePoles[ 0 ] = vcl_sqrt( 8.0 ) - 3.0;
+      m_SplinePoles[ 0 ] = std::sqrt( 8.0 ) - 3.0;
       break;
     case 4:
       m_NumberOfPoles    = 2;
-      m_SplinePoles[ 0 ] = vcl_sqrt( 664.0 - vcl_sqrt( 438976.0 ) ) + vcl_sqrt( 304.0 ) - 19.0;
-      m_SplinePoles[ 1 ] = vcl_sqrt( 664.0 + vcl_sqrt( 438976.0 ) ) - vcl_sqrt( 304.0 ) - 19.0;
+      m_SplinePoles[ 0 ] = std::sqrt( 664.0 - std::sqrt( 438976.0 ) ) + std::sqrt( 304.0 ) - 19.0;
+      m_SplinePoles[ 1 ] = std::sqrt( 664.0 + std::sqrt( 438976.0 ) ) - std::sqrt( 304.0 ) - 19.0;
       break;
     case 5:
       m_NumberOfPoles    = 2;
-      m_SplinePoles[ 0 ] = vcl_sqrt( 135.0 / 2.0 - vcl_sqrt( 17745.0 / 4.0 ) ) + vcl_sqrt( 105.0 / 4.0 )
+      m_SplinePoles[ 0 ] = std::sqrt( 135.0 / 2.0 - std::sqrt( 17745.0 / 4.0 ) ) + std::sqrt( 105.0 / 4.0 )
         - 13.0 / 2.0;
-      m_SplinePoles[ 1 ] = vcl_sqrt( 135.0 / 2.0 + vcl_sqrt( 17745.0 / 4.0 ) ) - vcl_sqrt( 105.0 / 4.0 )
+      m_SplinePoles[ 1 ] = std::sqrt( 135.0 / 2.0 + std::sqrt( 17745.0 / 4.0 ) ) - std::sqrt( 105.0 / 4.0 )
         - 13.0 / 2.0;
       break;
     default:
@@ -238,7 +238,7 @@ MultiOrderBSplineDecompositionImageFilter< TInputImage, TOutputImage >
   zn      = z;
   if( m_Tolerance > 0.0 )
   {
-    horizon = (long)vcl_ceil( vcl_log( m_Tolerance ) / vcl_log( vcl_fabs( z ) ) );
+    horizon = (long)vcl_ceil( std::log( m_Tolerance ) / std::log( std::fabs( z ) ) );
   }
   if( horizon < m_DataLength[ m_IteratorDirection ] )
   {
@@ -255,7 +255,7 @@ MultiOrderBSplineDecompositionImageFilter< TInputImage, TOutputImage >
   {
     /* full loop */
     iz   = 1.0 / z;
-    z2n  = vcl_pow( z, (double)( m_DataLength[ m_IteratorDirection ] - 1L ) );
+    z2n  = std::pow( z, (double)( m_DataLength[ m_IteratorDirection ] - 1L ) );
     sum  = m_Scratch[ 0 ] + z2n * m_Scratch[ m_DataLength[ m_IteratorDirection ] - 1L ];
     z2n *= z2n * iz;
     for( unsigned int n = 1; n <= ( m_DataLength[ m_IteratorDirection ] - 2 ); n++ )

--- a/Common/itkMultiResolutionImageRegistrationMethod2.hxx
+++ b/Common/itkMultiResolutionImageRegistrationMethod2.hxx
@@ -262,7 +262,7 @@ MultiResolutionImageRegistrationMethod2< TFixedImage, TMovingImage >
     {
       start[ dim ] = static_cast< IndexValueType >( vcl_ceil( startcindex[ dim ] ) );
       size[ dim ]  = vnl_math_max( NumericTraits< SizeValueType >::One, static_cast< SizeValueType >(
-          static_cast< SizeValueType >( vcl_floor( endcindex[ dim ] ) ) - start[ dim ] + 1 ) );
+          static_cast< SizeValueType >( std::floor( endcindex[ dim ] ) ) - start[ dim ] + 1 ) );
     }
 
     this->m_FixedImageRegionPyramid[ level ].SetSize( size );

--- a/Common/itkReducedDimensionBSplineInterpolateImageFunction.hxx
+++ b/Common/itkReducedDimensionBSplineInterpolateImageFunction.hxx
@@ -523,7 +523,7 @@ ReducedDimensionBSplineInterpolateImageFunction< TImageType, TCoordRep, TCoeffic
   {
     if( splineOrder & 1 )     // Use this index calculation for odd splineOrder
     {
-      indx = (long)vcl_floor( (float)x[ n ] ) - splineOrder / 2;
+      indx = (long)std::floor( (float)x[ n ] ) - splineOrder / 2;
       for( unsigned int k = 0; k <= splineOrder; k++ )
       {
         evaluateIndex[ n ][ k ] = indx++;
@@ -531,7 +531,7 @@ ReducedDimensionBSplineInterpolateImageFunction< TImageType, TCoordRep, TCoeffic
     }
     else                       // Use this index calculation for even splineOrder
     {
-      indx = (long)vcl_floor( (float)( x[ n ] + 0.5 ) ) - splineOrder / 2;
+      indx = (long)std::floor( (float)( x[ n ] + 0.5 ) ) - splineOrder / 2;
       for( unsigned int k = 0; k <= splineOrder; k++ )
       {
         evaluateIndex[ n ][ k ] = indx++;

--- a/Components/Metrics/AdvancedMattesMutualInformation/elxAdvancedMattesMutualInformationMetric.hxx
+++ b/Components/Metrics/AdvancedMattesMutualInformation/elxAdvancedMattesMutualInformationMetric.hxx
@@ -183,7 +183,7 @@ AdvancedMattesMutualInformationMetric< TElastix >
 ::Compute_c( unsigned long k ) const
 {
   return static_cast< double >(
-    this->m_Param_c / vcl_pow( k + 1, this->m_Param_gamma ) );
+    this->m_Param_c / std::pow( k + 1, this->m_Param_gamma ) );
 
 } // end Compute_c()
 

--- a/Components/Metrics/AdvancedMattesMutualInformation/itkParzenWindowMutualInformationImageToImageMetric.hxx
+++ b/Components/Metrics/AdvancedMattesMutualInformation/itkParzenWindowMutualInformationImageToImageMetric.hxx
@@ -122,7 +122,7 @@ ParzenWindowMutualInformationImageToImageMetric< TFixedImage, TMovingImage >
       /** Check for non-zero bin contribution. */
       if( jointPDFValue > 1e-16 && fixPDFmovPDF > 1e-16 )
       {
-        MI += jointPDFValue * vcl_log( jointPDFValue / fixPDFmovPDF );
+        MI += jointPDFValue * std::log( jointPDFValue / fixPDFmovPDF );
       }
       ++movingPDFit;
       ++jointPDFit;
@@ -215,7 +215,7 @@ ParzenWindowMutualInformationImageToImageMetric< TFixedImage, TMovingImage >
       if( jointPDFValue > 1e-16 && fixPDFmovPDF > 1e-16 )
       {
         derivit = derivbegin;
-        const double pRatio      = vcl_log( jointPDFValue / fixPDFmovPDF );
+        const double pRatio      = std::log( jointPDFValue / fixPDFmovPDF );
         const double pRatioAlpha = this->m_Alpha * pRatio;
         MI += jointPDFValue * pRatio;
         while( derivit != derivend )
@@ -712,7 +712,7 @@ ParzenWindowMutualInformationImageToImageMetric< TFixedImage, TMovingImage >
     double       logFixedPDFValue = 0.0;
     if( fixedPDFValue > 1e-16 )
     {
-      logFixedPDFValue = vcl_log( fixedPDFValue );
+      logFixedPDFValue = std::log( fixedPDFValue );
     }
     movingPDFit = movingPDFbegin;
     movingIndex = 0;
@@ -725,7 +725,7 @@ ParzenWindowMutualInformationImageToImageMetric< TFixedImage, TMovingImage >
       /** Check for non-zero bin contribution. */
       if( jointPDFValue > 1e-16 && movingPDFValue > 1e-16 )
       {
-        const PDFValueType pRatio = vcl_log( jointPDFValue / movingPDFValue );
+        const PDFValueType pRatio = std::log( jointPDFValue / movingPDFValue );
         this->m_PRatioArray[ fixedIndex ][ movingIndex ] = static_cast< PRatioType >(
           this->m_Alpha * pRatio );
 
@@ -791,10 +791,10 @@ ParzenWindowMutualInformationImageToImageMetric< TFixedImage, TMovingImage >
 
   /** The lowest bin numbers affected by this pixel: */
   const int fixedParzenWindowIndex
-    = static_cast< int >( vcl_floor(
+    = static_cast< int >( std::floor(
     fixedImageParzenWindowTerm + this->m_FixedParzenTermToIndexOffset ) );
   const int movingParzenWindowIndex
-    = static_cast< int >( vcl_floor(
+    = static_cast< int >( std::floor(
     movingImageParzenWindowTerm + this->m_MovingParzenTermToIndexOffset ) );
 
   /** Compute the fixed Parzen values. */
@@ -950,7 +950,7 @@ ParzenWindowMutualInformationImageToImageMetric< TFixedImage, TMovingImage >
       /** Check for non-zero bin contribution and update the mutual information value. */
       if( jointPDFValue > 1e-16 && fixPDFmovPDFAlpha > 1e-16 )
       {
-        MI += this->m_Alpha * jointPDFValue * vcl_log( jointPDFValue / fixPDFmovPDFAlpha );
+        MI += this->m_Alpha * jointPDFValue * std::log( jointPDFValue / fixPDFmovPDFAlpha );
       }
 
       /** Update the derivative. */
@@ -980,7 +980,7 @@ ParzenWindowMutualInformationImageToImageMetric< TFixedImage, TMovingImage >
         if( perturbedJointPDFRightValue > 1e-16 && perturbedfixPDFmovPDFAlphaRight > 1e-16 )
         {
           contrib += perturbedAlphaRightValue * perturbedJointPDFRightValue
-            * vcl_log( perturbedJointPDFRightValue / perturbedfixPDFmovPDFAlphaRight );
+            * std::log( perturbedJointPDFRightValue / perturbedfixPDFmovPDFAlphaRight );
         }
 
         /** For clarity, get some values and give them a name. */
@@ -999,7 +999,7 @@ ParzenWindowMutualInformationImageToImageMetric< TFixedImage, TMovingImage >
         if( perturbedJointPDFLeftValue > 1e-16 && perturbedfixPDFmovPDFAlphaLeft > 1e-16 )
         {
           contrib -= perturbedAlphaLeftValue * perturbedJointPDFLeftValue
-            * vcl_log( perturbedJointPDFLeftValue / perturbedfixPDFmovPDFAlphaLeft );
+            * std::log( perturbedJointPDFLeftValue / perturbedfixPDFmovPDFAlphaLeft );
         }
 
         /** Update the derivative component. */

--- a/Components/Metrics/AdvancedNormalizedCorrelation/itkAdvancedNormalizedCorrelationImageToImageMetric.hxx
+++ b/Components/Metrics/AdvancedNormalizedCorrelation/itkAdvancedNormalizedCorrelationImageToImageMetric.hxx
@@ -280,7 +280,7 @@ AdvancedNormalizedCorrelationImageToImageMetric< TFixedImage, TMovingImage >
   }
 
   /** The denominator of the NC. */
-  const RealType denom = -1.0 * vcl_sqrt( sff * smm );
+  const RealType denom = -1.0 * std::sqrt( sff * smm );
 
   /** Calculate the measure value. */
   if( this->m_NumberOfPixelsCounted > 0 && denom < -1e-14 )
@@ -458,7 +458,7 @@ AdvancedNormalizedCorrelationImageToImageMetric< TFixedImage, TMovingImage >
   }
 
   /** The denominator of the value and the derivative. */
-  const RealType denom = -1.0 * vcl_sqrt( sff * smm );
+  const RealType denom = -1.0 * std::sqrt( sff * smm );
 
   /** Calculate the value and the derivative. */
   if( this->m_NumberOfPixelsCounted > 0 && denom < -1e-14 )
@@ -709,7 +709,7 @@ AdvancedNormalizedCorrelationImageToImageMetric< TFixedImage, TMovingImage >
   }
 
   /** The denominator of the value and the derivative. */
-  const RealType denom = -1.0 * vcl_sqrt( sff * smm );
+  const RealType denom = -1.0 * std::sqrt( sff * smm );
 
   /** Check for sufficiently large denominator. */
   if( denom > -1e-14 )

--- a/Components/Metrics/KNNGraphAlphaMutualInformation/itkKNNGraphAlphaMutualInformationImageToImageMetric.hxx
+++ b/Components/Metrics/KNNGraphAlphaMutualInformation/itkKNNGraphAlphaMutualInformationImageToImageMetric.hxx
@@ -425,11 +425,11 @@ KNNGraphAlphaMutualInformationImageToImageMetric< TFixedImage, TMovingImage >
      *
     for ( unsigned int j = 0; j < K; j++ )
     {
-    enumerator = vcl_sqrt( distsJ[ j ] );
-    denominator = vcl_sqrt( vcl_sqrt( distsF[ j ] ) * vcl_sqrt( distsM[ j ] ) );
+    enumerator = std::sqrt( distsJ[ j ] );
+    denominator = std::sqrt( std::sqrt( distsF[ j ] ) * std::sqrt( distsM[ j ] ) );
     if ( denominator > 1e-14 )
     {
-    contribution += vcl_pow( enumerator / denominator, twoGamma );
+    contribution += std::pow( enumerator / denominator, twoGamma );
     }
     }*/
 
@@ -446,18 +446,18 @@ KNNGraphAlphaMutualInformationImageToImageMetric< TFixedImage, TMovingImage >
     /** Loop over the neighbours. */
     for( unsigned int p = 0; p < k; p++ )
     {
-      Gamma_F += vcl_sqrt( distances_F[ p ] );
-      Gamma_M += vcl_sqrt( distances_M[ p ] );
-      Gamma_J += vcl_sqrt( distances_J[ p ] );
+      Gamma_F += std::sqrt( distances_F[ p ] );
+      Gamma_M += std::sqrt( distances_M[ p ] );
+      Gamma_J += std::sqrt( distances_J[ p ] );
     } // end loop over the k neighbours
 
     /** Calculate the contribution of this query point. */
-    H = vcl_sqrt( Gamma_F * Gamma_M );
+    H = std::sqrt( Gamma_F * Gamma_M );
     if( H > this->m_AvoidDivisionBy )
     {
       /** Compute some sums. */
       G     = Gamma_J / H;
-      sumG += vcl_pow( G, twoGamma );
+      sumG += std::pow( G, twoGamma );
     }
   } // end looping over all query points
 
@@ -470,8 +470,8 @@ KNNGraphAlphaMutualInformationImageToImageMetric< TFixedImage, TMovingImage >
   {
     /** Compute the measure. */
     n       = static_cast< double >( this->m_NumberOfPixelsCounted );
-    number  = vcl_pow( n, this->m_Alpha );
-    measure = vcl_log( sumG / number ) / ( this->m_Alpha - 1.0 );
+    number  = std::pow( n, this->m_Alpha );
+    measure = std::log( sumG / number ) / ( this->m_Alpha - 1.0 );
   }
 
   /** Return the negative alpha - mutual information. */
@@ -670,9 +670,9 @@ KNNGraphAlphaMutualInformationImageToImageMetric< TFixedImage, TMovingImage >
       listSampleMoving->GetMeasurementVector( indices_J[ p ], z_J_ip );
 
       /** Get the distances. */
-      distance_F = vcl_sqrt( distances_F[ p ] );
-      distance_M = vcl_sqrt( distances_M[ p ] );
-      distance_J = vcl_sqrt( distances_J[ p ] );
+      distance_F = std::sqrt( distances_F[ p ] );
+      distance_M = std::sqrt( distances_M[ p ] );
+      distance_J = std::sqrt( distances_J[ p ] );
 
       /** Compute Gamma's. */
       Gamma_F += distance_F;
@@ -702,15 +702,15 @@ KNNGraphAlphaMutualInformationImageToImageMetric< TFixedImage, TMovingImage >
     } // end loop over the k neighbours
 
     /** Compute contributions. */
-    H = vcl_sqrt( Gamma_F * Gamma_M );
+    H = std::sqrt( Gamma_F * Gamma_M );
     if( H > this->m_AvoidDivisionBy )
     {
       /** Compute some sums. */
       G     = Gamma_J / H;
-      sumG += vcl_pow( G, twoGamma );
+      sumG += std::pow( G, twoGamma );
 
       /** Compute the contribution to the derivative. */
-      Gpow          = vcl_pow( G, twoGamma - 1.0 );
+      Gpow          = std::pow( G, twoGamma - 1.0 );
       contribution += ( Gpow / H ) * ( dGamma_J - ( 0.5 * Gamma_J / Gamma_M ) * dGamma_M );
     }
 
@@ -726,8 +726,8 @@ KNNGraphAlphaMutualInformationImageToImageMetric< TFixedImage, TMovingImage >
   {
     /** Compute the measure. */
     n       = static_cast< double >( this->m_NumberOfPixelsCounted );
-    number  = vcl_pow( n, this->m_Alpha );
-    measure = vcl_log( sumG / number ) / ( this->m_Alpha - 1.0 );
+    number  = std::pow( n, this->m_Alpha );
+    measure = std::log( sumG / number ) / ( this->m_Alpha - 1.0 );
 
     /** Compute the derivative (-2.0 * d = -jointSize). */
     derivative = ( static_cast< AccumulateType >( jointSize ) / sumG ) * contribution;

--- a/Components/Metrics/NormalizedMutualInformation/itkParzenWindowNormalizedMutualInformationImageToImageMetric.hxx
+++ b/Components/Metrics/NormalizedMutualInformation/itkParzenWindowNormalizedMutualInformationImageToImageMetric.hxx
@@ -67,7 +67,7 @@ ParzenWindowNormalizedMutualInformationImageToImageMetric< TFixedImage, TMovingI
   {
     if( ( *PDFit ) > 1e-16 )
     {
-      ( *PDFit ) = vcl_log( *PDFit );
+      ( *PDFit ) = std::log( *PDFit );
     }
     else
     {
@@ -120,7 +120,7 @@ ParzenWindowNormalizedMutualInformationImageToImageMetric< TFixedImage, TMovingI
       /** check for non-zero bin contribution */
       if( jointPDFValue > 1e-16 )
       {
-        sumden -= jointPDFValue * vcl_log( jointPDFValue );
+        sumden -= jointPDFValue * std::log( jointPDFValue );
       }
       ++movingPDFconstit;
       ++jointPDFconstit;
@@ -257,7 +257,7 @@ ParzenWindowNormalizedMutualInformationImageToImageMetric< TFixedImage, TMovingI
       const double jointPDFValue          = jointPDFconstit.Get();
       if( jointPDFValue > 1e-16 )
       {
-        const double pRatio = ( nMI * vcl_log( jointPDFValue )
+        const double pRatio = ( nMI * std::log( jointPDFValue )
           - logFixedImagePDFValue - logMovingImagePDFValue ) / jointEntropy;
         const double pRatioAlpha = this->m_Alpha * pRatio;
         /** check for non-zero bin contribution */

--- a/Components/Metrics/RigidityPenalty/itkTransformRigidityPenaltyTerm.hxx
+++ b/Components/Metrics/RigidityPenalty/itkTransformRigidityPenaltyTerm.hxx
@@ -672,17 +672,17 @@ TransformRigidityPenaltyTerm< TFixedImage, TScalarType >
       {
         this->m_OrthonormalityConditionValue
           += it_RCI.Get() * (
-          vcl_pow(
+          std::pow(
           +( 1.0 + mu1_A ) * ( 1.0 + mu1_A )
           + mu2_A * mu2_A
           - 1.0,
           2.0 )
-          + vcl_pow(
+          + std::pow(
           +mu1_B * mu1_B
           + ( 1.0 + mu2_B ) * ( 1.0 + mu2_B )
           - 1.0,
           2.0 )
-          + vcl_pow(
+          + std::pow(
           +( 1.0 + mu1_A ) * mu1_B
           + mu2_A * ( 1.0 + mu2_B ),
           2.0 )
@@ -692,34 +692,34 @@ TransformRigidityPenaltyTerm< TFixedImage, TScalarType >
       {
         this->m_OrthonormalityConditionValue
           += it_RCI.Get() * (
-          vcl_pow(
+          std::pow(
           +( 1.0 + mu1_A ) * ( 1.0 + mu1_A )
           + mu2_A * mu2_A
           + mu3_A * mu3_A
           - 1.0,
           2.0 )
-          + vcl_pow(
+          + std::pow(
           +( 1.0 + mu1_A ) * mu1_B
           + mu2_A * ( 1.0 + mu2_B )
           + mu3_A * mu3_B,
           2.0 )
-          + vcl_pow(
+          + std::pow(
           +( 1.0 + mu1_A ) * mu1_C
           + mu2_A * mu2_C
           + mu3_A * ( 1.0 + mu3_C ),
           2.0 )
-          + vcl_pow(
+          + std::pow(
           +mu1_B * mu1_B
           + ( 1.0 + mu2_B ) * ( 1.0 + mu2_B )
           + mu3_B * mu3_B
           - 1.0,
           2.0 )
-          + vcl_pow(
+          + std::pow(
           +mu1_B * mu1_C
           + ( 1.0 + mu2_B ) * mu2_C
           + mu3_B * ( 1.0 + mu3_C ),
           2.0 )
-          + vcl_pow(
+          + std::pow(
           +mu1_C * mu1_C
           + mu2_C * mu2_C
           + ( 1.0 + mu3_C ) * ( 1.0 + mu3_C )
@@ -771,7 +771,7 @@ TransformRigidityPenaltyTerm< TFixedImage, TScalarType >
       {
         this->m_PropernessConditionValue
           += it_RCI.Get() * (
-          vcl_pow(
+          std::pow(
           +( 1.0 + mu1_A ) * ( 1.0 + mu2_B )
           - mu2_A * mu1_B
           - 1.0,
@@ -782,7 +782,7 @@ TransformRigidityPenaltyTerm< TFixedImage, TScalarType >
       {
         this->m_PropernessConditionValue
           += it_RCI.Get() * (
-          vcl_pow(
+          std::pow(
           -mu1_C * ( 1.0 + mu2_B ) * mu3_A
           + mu1_B * mu2_C * mu3_A
           + mu1_C * mu2_A * mu3_B
@@ -1214,17 +1214,17 @@ TransformRigidityPenaltyTerm< TFixedImage, TScalarType >
         /** Calculate the value of the orthonormality condition. */
         this->m_OrthonormalityConditionValue
           += it_RCI.Get() * (
-          vcl_pow(
+          std::pow(
           +( 1.0 + mu1_A ) * ( 1.0 + mu1_A )
           + mu2_A * mu2_A
           - 1.0,
           2.0 )
-          + vcl_pow(
+          + std::pow(
           +mu1_B * mu1_B
           + ( 1.0 + mu2_B ) * ( 1.0 + mu2_B )
           - 1.0,
           2.0 )
-          + vcl_pow(
+          + std::pow(
           +( 1.0 + mu1_A ) * mu1_B
           + mu2_A * ( 1.0 + mu2_B ),
           2.0 )
@@ -1268,34 +1268,34 @@ TransformRigidityPenaltyTerm< TFixedImage, TScalarType >
         /** Calculate the value of the orthonormality condition. */
         this->m_OrthonormalityConditionValue
           += it_RCI.Get() * (
-          vcl_pow(
+          std::pow(
           +( 1.0 + mu1_A ) * ( 1.0 + mu1_A )
           + mu2_A * mu2_A
           + mu3_A * mu3_A
           - 1.0,
           2.0 )
-          + vcl_pow(
+          + std::pow(
           +( 1.0 + mu1_A ) * mu1_B
           + mu2_A * ( 1.0 + mu2_B )
           + mu3_A * mu3_B,
           2.0 )
-          + vcl_pow(
+          + std::pow(
           +( 1.0 + mu1_A ) * mu1_C
           + mu2_A * mu2_C
           + mu3_A * ( 1.0 + mu3_C ),
           2.0 )
-          + vcl_pow(
+          + std::pow(
           +mu1_B * mu1_B
           + ( 1.0 + mu2_B ) * ( 1.0 + mu2_B )
           + mu3_B * mu3_B
           - 1.0,
           2.0 )
-          + vcl_pow(
+          + std::pow(
           +mu1_B * mu1_C
           + ( 1.0 + mu2_B ) * mu2_C
           + mu3_B * ( 1.0 + mu3_C ),
           2.0 )
-          + vcl_pow(
+          + std::pow(
           +mu1_C * mu1_C
           + mu2_C * mu2_C
           + ( 1.0 + mu3_C ) * ( 1.0 + mu3_C )
@@ -1470,7 +1470,7 @@ TransformRigidityPenaltyTerm< TFixedImage, TScalarType >
         /** Calculate the value of the properness condition. */
         this->m_PropernessConditionValue
           += it_RCI.Get() * (
-          vcl_pow(
+          std::pow(
           +( 1.0 + mu1_A ) * ( 1.0 + mu2_B )
           - mu2_A * mu1_B
           - 1.0,
@@ -1507,7 +1507,7 @@ TransformRigidityPenaltyTerm< TFixedImage, TScalarType >
         /** Calculate the value of the properness condition. */
         this->m_PropernessConditionValue
           += it_RCI.Get() * (
-          vcl_pow(
+          std::pow(
           -mu1_C * ( 1.0 + mu2_B ) * mu3_A
           + mu1_B * mu2_C * mu3_A
           + mu1_C * mu2_A * mu3_B
@@ -2131,9 +2131,9 @@ TransformRigidityPenaltyTerm< TFixedImage, TScalarType >
   } // end while
 
   /** Set the gradient magnitudes of the several terms. */
-  this->m_LinearityConditionGradientMagnitude      = vcl_sqrt( gradMagLC );
-  this->m_OrthonormalityConditionGradientMagnitude = vcl_sqrt( gradMagOC );
-  this->m_PropernessConditionGradientMagnitude     = vcl_sqrt( gradMagPC );
+  this->m_LinearityConditionGradientMagnitude      = std::sqrt( gradMagLC );
+  this->m_OrthonormalityConditionGradientMagnitude = std::sqrt( gradMagOC );
+  this->m_PropernessConditionGradientMagnitude     = std::sqrt( gradMagPC );
 
   /** Rearrange to create a derivative. */
   unsigned int j = 0;

--- a/Components/Optimizers/AdaptiveStochasticGradientDescent/elxAdaptiveStochasticGradientDescent.hxx
+++ b/Components/Optimizers/AdaptiveStochasticGradientDescent/elxAdaptiveStochasticGradientDescent.hxx
@@ -635,7 +635,7 @@ AdaptiveStochasticGradientDescent< TElastix >
   double       ee           = 0.0;
   if( maxJJ > 1e-14 )
   {
-    sigma4 = sigma4factor * delta / vcl_sqrt( maxJJ );
+    sigma4 = sigma4factor * delta / std::sqrt( maxJJ );
   }
   this->SampleGradients(
     this->GetScaledCurrentPosition(), sigma4, gg, ee );
@@ -652,11 +652,11 @@ AdaptiveStochasticGradientDescent< TElastix >
    */
   if( gg > 1e-14 && TrC > 1e-14 )
   {
-    sigma1 = vcl_sqrt( gg / TrC );
+    sigma1 = std::sqrt( gg / TrC );
   }
   if( ee > 1e-14 && TrC > 1e-14 )
   {
-    sigma3 = vcl_sqrt( ee / TrC );
+    sigma3 = std::sqrt( ee / TrC );
   }
 
   const double alpha = 1.0;
@@ -664,14 +664,14 @@ AdaptiveStochasticGradientDescent< TElastix >
   double       a_max = 0.0;
   if( sigma1 > 1e-14 && maxJCJ > 1e-14 )
   {
-    a_max = A * delta / sigma1 / vcl_sqrt( maxJCJ );
+    a_max = A * delta / sigma1 / std::sqrt( maxJCJ );
   }
   const double noisefactor = sigma1 * sigma1
     / ( sigma1 * sigma1 + sigma3 * sigma3 + 1e-14 );
   const double a = a_max * noisefactor;
 
   const double omega = vnl_math_max( 1e-14,
-    this->m_SigmoidScaleFactor * sigma3 * sigma3 * vcl_sqrt( TrCC ) );
+    this->m_SigmoidScaleFactor * sigma3 * sigma3 * std::sqrt( TrCC ) );
   const double fmax = 1.0;
   const double fmin = -0.99 + 0.98 * noisefactor;
 
@@ -786,19 +786,19 @@ AdaptiveStochasticGradientDescent< TElastix >
     timer5.Start();
     if( maxJJ > 1e-14 )
     {
-      sigma4 = sigma4factor * delta / vcl_sqrt( maxJJ );
+      sigma4 = sigma4factor * delta / std::sqrt( maxJJ );
     }
     this->SampleGradients( this->GetScaledCurrentPosition(), sigma4, gg, ee );
 
     double noisefactor = gg / ( gg + ee );
-    a =  delta * vcl_pow( A + 1.0, alpha ) / jacg * noisefactor;
+    a =  delta * std::pow( A + 1.0, alpha ) / jacg * noisefactor;
     timer5.Stop();
     elxout << "  Computing the noise compensation took "
            << this->ConvertSecondsToDHMS( timer5.GetMean(), 6 ) << std::endl;
   }
   else
   {
-    a = delta * vcl_pow( A + 1.0, alpha ) / jacg;
+    a = delta * std::pow( A + 1.0, alpha ) / jacg;
   }
 
   /** Set parameters in superclass. */

--- a/Components/Optimizers/AdaptiveStochasticGradientDescent/itkAdaptiveStochasticGradientDescentOptimizer.cxx
+++ b/Components/Optimizers/AdaptiveStochasticGradientDescent/itkAdaptiveStochasticGradientDescentOptimizer.cxx
@@ -61,7 +61,7 @@ AdaptiveStochasticGradientDescentOptimizer
       sigmoid.SetOutputMinimum( this->GetSigmoidMin() );
       sigmoid.SetAlpha( this->GetSigmoidScale() );
       const double beta = this->GetSigmoidScale()
-        * vcl_log( -this->GetSigmoidMax() / this->GetSigmoidMin() );
+        * std::log( -this->GetSigmoidMax() / this->GetSigmoidMin() );
       sigmoid.SetBeta( beta );
 
       /** Formula (2) in Cruz */

--- a/Components/Optimizers/ConjugateGradient/itkGenericConjugateGradientOptimizer.cxx
+++ b/Components/Optimizers/ConjugateGradient/itkGenericConjugateGradientOptimizer.cxx
@@ -31,6 +31,7 @@ namespace itk
 
 GenericConjugateGradientOptimizer::GenericConjugateGradientOptimizer()
 {
+  vcl_abs(0);
   itkDebugMacro( "Constructor" );
 
   this->m_CurrentValue                          = NumericTraits< MeasureType >::Zero;
@@ -199,10 +200,10 @@ GenericConjugateGradientOptimizer::ResumeOptimization()
 
     /** Check for convergence
      * \todo: move this code to TestConvergence() */
-    if( 2.0 * vcl_abs( this->GetCurrentValue() - previousValue ) <=
+    if( 2.0 * std::abs( this->GetCurrentValue() - previousValue ) <=
       this->GetValueTolerance()
-      * ( vcl_abs( this->GetCurrentValue() )
-      + vcl_abs( previousValue ) + TINY_NUMBER ) )
+      * ( std::abs( this->GetCurrentValue() )
+      + std::abs( previousValue ) + TINY_NUMBER ) )
     {
       if( limitCount < this->GetMaxNrOfItWithoutImprovement() )
       {

--- a/Components/Optimizers/FiniteDifferenceGradientDescent/itkFiniteDifferenceGradientDescentOptimizer.cxx
+++ b/Components/Optimizers/FiniteDifferenceGradientDescent/itkFiniteDifferenceGradientDescentOptimizer.cxx
@@ -201,7 +201,7 @@ FiniteDifferenceGradientDescentOptimizer
 
     /** Save the gradient magnitude;
      * only for interested users... */
-    this->m_GradientMagnitude = vcl_sqrt( sumOfSquaredGradients );
+    this->m_GradientMagnitude = std::sqrt( sumOfSquaredGradients );
 
     this->AdvanceOneStep();
 
@@ -281,7 +281,7 @@ FiniteDifferenceGradientDescentOptimizer
 ::Compute_a( unsigned long k ) const
 {
   return static_cast< double >(
-    this->m_Param_a / vcl_pow( this->m_Param_A + k + 1, this->m_Param_alpha ) );
+    this->m_Param_a / std::pow( this->m_Param_A + k + 1, this->m_Param_alpha ) );
 
 } // end Compute_a
 
@@ -298,7 +298,7 @@ FiniteDifferenceGradientDescentOptimizer
 ::Compute_c( unsigned long k ) const
 {
   return static_cast< double >(
-    this->m_Param_c / vcl_pow( k + 1, this->m_Param_gamma ) );
+    this->m_Param_c / std::pow( k + 1, this->m_Param_gamma ) );
 
 } // end Compute_c
 

--- a/Components/Optimizers/Powell/elxPowell.hxx
+++ b/Components/Optimizers/Powell/elxPowell.hxx
@@ -68,13 +68,13 @@ Powell< TElastix >
   this->SetValueTolerance( valueTolerance );
 
   /** Set the MaximumStepLength.*/
-  double maxStepLength = 16.0 / vcl_pow( 2.0, static_cast< int >( level ) );
+  double maxStepLength = 16.0 / std::pow( 2.0, static_cast< int >( level ) );
   this->m_Configuration->ReadParameter( maxStepLength,
     "MaximumStepLength", this->GetComponentLabel(), level, 0 );
   this->SetStepLength( maxStepLength );
 
   /** Set the MinimumStepLength.*/
-  double stepTolerance = 0.5 / vcl_pow( 2.0, static_cast< int >( level ) );
+  double stepTolerance = 0.5 / std::pow( 2.0, static_cast< int >( level ) );
   this->m_Configuration->ReadParameter( stepTolerance,
     "StepTolerance", this->GetComponentLabel(), level, 0 );
   this->SetStepTolerance( stepTolerance );

--- a/Components/Optimizers/RegularStepGradientDescent/elxRegularStepGradientDescent.hxx
+++ b/Components/Optimizers/RegularStepGradientDescent/elxRegularStepGradientDescent.hxx
@@ -68,13 +68,13 @@ RegularStepGradientDescent< TElastix >
   this->SetGradientMagnitudeTolerance( minGradientMagnitude );
 
   /** Set the MaximumStepLength.*/
-  double maxStepLength = 16.0 / vcl_pow( 2.0, static_cast< int >( level ) );
+  double maxStepLength = 16.0 / std::pow( 2.0, static_cast< int >( level ) );
   this->m_Configuration->ReadParameter( maxStepLength,
     "MaximumStepLength", this->GetComponentLabel(), level, 0 );
   this->SetMaximumStepLength( maxStepLength );
 
   /** Set the MinimumStepLength.*/
-  double minStepLength = 0.5 / vcl_pow( 2.0, static_cast< int >( level ) );
+  double minStepLength = 0.5 / std::pow( 2.0, static_cast< int >( level ) );
   this->m_Configuration->ReadParameter( minStepLength,
     "MinimumStepLength", this->GetComponentLabel(), level, 0 );
   this->SetMinimumStepLength( minStepLength );

--- a/Components/Optimizers/StandardGradientDescent/itkStandardGradientDescentOptimizer.cxx
+++ b/Components/Optimizers/StandardGradientDescent/itkStandardGradientDescentOptimizer.cxx
@@ -88,7 +88,7 @@ StandardGradientDescentOptimizer
 ::Compute_a( double k ) const
 {
   return static_cast< double >(
-    this->m_Param_a / vcl_pow( this->m_Param_A + k + 1.0, this->m_Param_alpha ) );
+    this->m_Param_a / std::pow( this->m_Param_A + k + 1.0, this->m_Param_alpha ) );
 
 } // end Compute_a()
 

--- a/Components/Registrations/MultiMetricMultiResolutionRegistration/itkMultiMetricMultiResolutionImageRegistrationMethod.hxx
+++ b/Components/Registrations/MultiMetricMultiResolutionRegistration/itkMultiMetricMultiResolutionImageRegistrationMethod.hxx
@@ -305,7 +305,7 @@ MultiMetricMultiResolutionImageRegistrationMethod< TFixedImage, TMovingImage >
         {
           start[ dim ] = static_cast< IndexValueType >( vcl_ceil( startcindex[ dim ] ) );
           size[ dim ]  = vnl_math_max( NumericTraits< SizeValueType >::One, static_cast< SizeValueType >(
-            static_cast< SizeValueType >( vcl_floor( endcindex[ dim ] ) ) - start[ dim ] + 1 ) );
+            static_cast< SizeValueType >( std::floor( endcindex[ dim ] ) ) - start[ dim ] + 1 ) );
         }
 
         this->m_FixedImageRegionPyramids[ i ][ level ].SetSize( size );

--- a/Components/Registrations/MultiResolutionRegistrationWithFeatures/itkMultiInputMultiResolutionImageRegistrationMethodBase.hxx
+++ b/Components/Registrations/MultiResolutionRegistrationWithFeatures/itkMultiInputMultiResolutionImageRegistrationMethodBase.hxx
@@ -441,7 +441,7 @@ MultiInputMultiResolutionImageRegistrationMethodBase< TFixedImage, TMovingImage 
         {
           start[ dim ] = static_cast< IndexValueType >( vcl_ceil( startcindex[ dim ] ) );
           size[ dim ]  = static_cast< SizeValueType >(
-            static_cast< SizeValueType >( vcl_floor( endcindex[ dim ] ) ) - start[ dim ] + 1 );
+            static_cast< SizeValueType >( std::floor( endcindex[ dim ] ) ) - start[ dim ] + 1 );
         }
 
         this->m_FixedImageRegionPyramids[ i ][ level ].SetSize( size );

--- a/Components/Transforms/SplineKernelTransform/itkThinPlateR2LogRSplineKernelTransform2.hxx
+++ b/Components/Transforms/SplineKernelTransform/itkThinPlateR2LogRSplineKernelTransform2.hxx
@@ -46,7 +46,7 @@ ThinPlateR2LogRSplineKernelTransform2< TScalarType, NDimensions >::ComputeG( con
   const TScalarType r = x.GetNorm();
   GMatrix.fill( NumericTraits< TScalarType >::ZeroValue() );
   const TScalarType          R2logR
-    = ( r > 1e-8 ) ? r * r * vcl_log( r ) : NumericTraits< TScalarType >::Zero;
+    = ( r > 1e-8 ) ? r * r * std::log( r ) : NumericTraits< TScalarType >::Zero;
 
   GMatrix.fill_diagonal( R2logR );
 }
@@ -66,7 +66,7 @@ ThinPlateR2LogRSplineKernelTransform2< TScalarType, NDimensions >::ComputeDeform
     InputVectorType            position = thisPoint - sp->Value();
     const TScalarType          r        = position.GetNorm();
     const TScalarType          R2logR
-      = ( r > 1e-8 ) ? r * r * vcl_log( r ) : NumericTraits< TScalarType >::Zero;
+      = ( r > 1e-8 ) ? r * r * std::log( r ) : NumericTraits< TScalarType >::Zero;
     for( unsigned int odim = 0; odim < NDimensions; odim++ )
     {
       result[ odim ] += R2logR * this->m_DMatrix( odim, lnd );

--- a/Core/ComponentBaseClasses/elxOptimizerBase.hxx
+++ b/Core/ComponentBaseClasses/elxOptimizerBase.hxx
@@ -170,7 +170,7 @@ OptimizerBase< TElastix >
   {
     const double x = static_cast< double >( i ) / nrofpar * 2.0
       * vnl_math::pi * frequency;
-    scales[ i ] = vcl_pow( amplitude, vcl_sin( x ) );
+    scales[ i ] = std::pow( amplitude, std::sin( x ) );
   }
   this->GetAsITKBaseType()->SetScales( scales );
 

--- a/Core/Main/elastix.cxx
+++ b/Core/Main/elastix.cxx
@@ -73,11 +73,11 @@ main( int argc, char ** argv )
   /** Some declarations and initializations. */
   ElastixMainVectorType elastices;
 
-  ObjectPointer              transform            = 0;
-  DataObjectContainerPointer fixedImageContainer  = 0;
-  DataObjectContainerPointer movingImageContainer = 0;
-  DataObjectContainerPointer fixedMaskContainer   = 0;
-  DataObjectContainerPointer movingMaskContainer  = 0;
+  ObjectPointer              transform;
+  DataObjectContainerPointer fixedImageContainer;
+  DataObjectContainerPointer movingImageContainer;
+  DataObjectContainerPointer fixedMaskContainer;
+  DataObjectContainerPointer movingMaskContainer;
   FlatDirectionCosinesType   fixedImageOriginalDirection;
   int                        returndummy        = 0;
   unsigned long              nrOfParameterFiles = 0;

--- a/Testing/elxTransformParametersCompare.cxx
+++ b/Testing/elxTransformParametersCompare.cxx
@@ -202,7 +202,7 @@ main( int argc, char ** argv )
       baselineNorm += vnl_math_sqr( parametersBaseline[ i ] );
       diffNorm     += vnl_math_sqr( parametersBaseline[ i ] - parametersTest[ i ] );
     }
-    diffNormNormalized = vcl_sqrt( diffNorm ) / vcl_sqrt( baselineNorm );
+    diffNormNormalized = std::sqrt( diffNorm ) / std::sqrt( baselineNorm );
   }
   else
   {
@@ -274,7 +274,7 @@ main( int argc, char ** argv )
         unsigned int j = index + i * numberParPerDim;
         diffNormTmp += vnl_math_sqr( parametersBaseline[ j ] - parametersTest[ j ] );
       }
-      diffNormTmp = vcl_sqrt( diffNormTmp );
+      diffNormTmp = std::sqrt( diffNormTmp );
       it.Set( diffNormTmp );
 
       /** Compare. */
@@ -301,7 +301,7 @@ main( int argc, char ** argv )
     } // end while
 
     /** Final normalized norm. */
-    diffNormNormalized = vcl_sqrt( diffNorm ) / vcl_sqrt( baselineNorm );
+    diffNormNormalized = std::sqrt( diffNorm ) / std::sqrt( baselineNorm );
 
     /** Create name for difference image. */
     std::string diffImageFileName
@@ -336,7 +336,7 @@ main( int argc, char ** argv )
             << "    ---------------------\n"
             << "       || baseline ||\n";
   std::cerr << "Computed difference: "
-            << vcl_sqrt( diffNorm ) << " / " << vcl_sqrt( baselineNorm ) << " = "
+            << std::sqrt( diffNorm ) << " / " << std::sqrt( baselineNorm ) << " = "
             << diffNormNormalized << std::endl;
   std::cerr << "Allowed  difference: " << allowedTolerance << std::endl;
 

--- a/Testing/itkAdvancedBSplineDeformableTransformTest.cxx
+++ b/Testing/itkAdvancedBSplineDeformableTransformTest.cxx
@@ -338,7 +338,7 @@ main( int argc, char * argv[] )
   {
     differenceNorm += ( opp1[ i ] - opp2[ i ] ) * ( opp1[ i ] - opp2[ i ] );
   }
-  if( vcl_sqrt( differenceNorm ) > 1e-10 )
+  if( std::sqrt( differenceNorm ) > 1e-10 )
   {
     std::cerr << "ERROR: Advanced B-spline TransformPoint() returning incorrect result." << std::endl;
     return 1;
@@ -360,7 +360,7 @@ main( int argc, char * argv[] )
     }
   }
   //if ( jacobianDifferenceMatrix.frobenius_norm() > 1e-10 )
-  if( vcl_sqrt( jacDiff ) > 1e-10 )
+  if( std::sqrt( jacDiff ) > 1e-10 )
   {
     std::cerr << "ERROR: Advanced B-spline GetJacobian() returning incorrect result." << std::endl;
     return 1;
@@ -400,18 +400,18 @@ main( int argc, char * argv[] )
   //      for( unsigned int k = 0; k < Dimension; k++ ) {
   //        jshDiff += vnl_math_sqr( jacobianOfSpatialHessian1[mu][i][j][k] - jacobianOfSpatialHessian2[mu][i][j][k] );
   //      } } } }
-  //if ( vcl_sqrt( shDiff ) > 1e-8 )
+  //if ( std::sqrt( shDiff ) > 1e-8 )
   //{
   //  std::cerr << "ERROR: Advanced B-spline GetJacobianOfSpatialHessian_opt() "
   //    << "returning incorrect spatial Hessian result: MSD = "
-  //    << vcl_sqrt( shDiff ) << std::endl;
+  //    << std::sqrt( shDiff ) << std::endl;
   //  return 1;
   //}
-  //if ( vcl_sqrt( jshDiff ) > 1e-8 )
+  //if ( std::sqrt( jshDiff ) > 1e-8 )
   //{
   //  std::cerr << "ERROR: Advanced B-spline GetJacobianOfSpatialHessian_opt() "
   //    << "returning incorrect Jacobian of spatial Hessian result: MSD = "
-  //    << vcl_sqrt( jshDiff ) << std::endl;
+  //    << std::sqrt( jshDiff ) << std::endl;
   //  return 1;
   //}
 

--- a/Testing/itkAdvancedRecursiveBSplineTransformTest.cxx
+++ b/Testing/itkAdvancedRecursiveBSplineTransformTest.cxx
@@ -249,7 +249,7 @@ main( int argc, char * argv[] )
   TransformType::ParameterIndexArrayType          indices;
   RecursiveTransformType::ParameterIndexArrayType indices2;
 
-  const unsigned int dummyNum = vcl_pow( static_cast< double >( SplineOrder + 1 ), static_cast< double >( Dimension ) );
+  const unsigned int dummyNum = std::pow( static_cast< double >( SplineOrder + 1 ), static_cast< double >( Dimension ) );
   weights.SetSize( dummyNum );
   indices.SetSize( dummyNum );
   weights2.SetSize( dummyNum );
@@ -394,7 +394,7 @@ main( int argc, char * argv[] )
       differenceNorm1 += ( opp1[ j ] - opp2[ j ] ) * ( opp1[ j ] - opp2[ j ] );
     }
   }
-  differenceNorm1 = vcl_sqrt( differenceNorm1 ) / N;
+  differenceNorm1 = std::sqrt( differenceNorm1 ) / N;
 
   std::cerr << "\n" << std::endl;
   std::cerr << "Recursive B-spline TransformPoint() MSD with ITK: " << differenceNorm1 << std::endl;

--- a/Testing/itkBSplineInterpolationDerivativeWeightFunctionTest.cxx
+++ b/Testing/itkBSplineInterpolationDerivativeWeightFunctionTest.cxx
@@ -120,7 +120,7 @@ main( int argc, char * argv[] )
   {
     error += vnl_math_sqr( foWeights[ i ] - trueFOWeights[ i ] );
   }
-  error = vcl_sqrt( error );
+  error = std::sqrt( error );
 
   /** TEST: Compare the two qualitatively. */
   if( error > distance )
@@ -173,7 +173,7 @@ main( int argc, char * argv[] )
   }
 
   if( foWeightFunction->GetNumberOfWeights()
-    != static_cast< unsigned long >( vcl_pow(
+    != static_cast< unsigned long >( std::pow(
     static_cast< float >( SplineOrder + 1 ), 2.0f ) ) )
   {
     std::cerr << "ERROR: wrong number of weights was computed." << std::endl;

--- a/Testing/itkBSplineInterpolationSODerivativeWeightFunctionTest.cxx
+++ b/Testing/itkBSplineInterpolationSODerivativeWeightFunctionTest.cxx
@@ -123,7 +123,7 @@ main( int argc, char * argv[] )
   {
     error += vnl_math_sqr( soWeights[ i ] - trueSOWeights[ i ] );
   }
-  error = vcl_sqrt( error );
+  error = std::sqrt( error );
 
   /** TEST: Compare the two qualitatively. */
   if( error > distance )
@@ -212,7 +212,7 @@ main( int argc, char * argv[] )
   {
     error += vnl_math_sqr( soWeights[ i ] - trueSOWeights[ i ] );
   }
-  error = vcl_sqrt( error );
+  error = std::sqrt( error );
 
   /** TEST: Compare the two qualitatively. */
   if( error > distance )
@@ -265,7 +265,7 @@ main( int argc, char * argv[] )
   }
 
   if( soWeightFunction->GetNumberOfWeights()
-    != static_cast< unsigned long >( vcl_pow(
+    != static_cast< unsigned long >( std::pow(
     static_cast< float >( SplineOrder + 1 ), 2.0f ) ) )
   {
     std::cerr << "ERROR: wrong number of weights was computed." << std::endl;

--- a/Testing/itkBSplineInterpolationWeightFunctionTest.cxx
+++ b/Testing/itkBSplineInterpolationWeightFunctionTest.cxx
@@ -92,7 +92,7 @@ main( int argc, char * argv[] )
   {
     error += vnl_math_sqr( weights2D[ i ] - weights2_2D[ i ] );
   }
-  error = vcl_sqrt( error );
+  error = std::sqrt( error );
 
   /** TEST: Compare the two qualitatively. */
   if( error > distance )
@@ -191,7 +191,7 @@ main( int argc, char * argv[] )
   {
     error += vnl_math_sqr( weights3D[ i ] - weights2_3D[ i ] );
   }
-  error = vcl_sqrt( error );
+  error = std::sqrt( error );
 
   /** TEST: Compare the two qualitatively. */
   if( error > distance )
@@ -280,7 +280,7 @@ main( int argc, char * argv[] )
   }
 
   if( weight2Function2D->GetNumberOfWeights()
-    != static_cast< unsigned long >( vcl_pow(
+    != static_cast< unsigned long >( std::pow(
     static_cast< float >( SplineOrder + 1 ), 2.0f ) ) )
   {
     std::cerr << "ERROR: wrong number of weights was computed." << std::endl;


### PR DESCRIPTION
Initial preparation upgrade to ITK5:

- Replaced vcl (VXL) macro calls by direct calls to std functions
- Fix error w/ ITK5, trying to initialize itk::SmartPointer by zero
- Replaced `#include "vcl_limits.h"` by `#include <limits> `

These changes should not yet break ITK4 compatibility.
