### PR TITLE
BUG: Removed accidentally added vcl_abs(0)

### DIFF
--- a/Components/Optimizers/ConjugateGradient/itkGenericConjugateGradientOptimizer.cxx
+++ b/Components/Optimizers/ConjugateGradient/itkGenericConjugateGradientOptimizer.cxx
@@ -31,7 +31,6 @@ namespace itk
 
 GenericConjugateGradientOptimizer::GenericConjugateGradientOptimizer()
 {
-  vcl_abs(0);
   itkDebugMacro( "Constructor" );
 
   this->m_CurrentValue                          = NumericTraits< MeasureType >::Zero;


### PR DESCRIPTION
Removed the `vcl_abs(0)` call that I accidentally added with

    Revision: d975c0d070246fe3f5b3a91db0570cc4061ff9af
    Date: 2019-01-08 4:44:57 PM
    COMP: Replaced vcl (VXL) macro calls by direct calls to std functions