### PR TITLE
COMP: Replaced vcl_ceil (VXL) macro calls by direct calls to std::ceil

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -26,6 +26,18 @@ string( SUBSTRING ${ELASTIX_VERSION} 26 3 ELASTIX_VERSION )
 string( REGEX MATCH "[0-9]+" ELASTIX_VERSION_MAJOR "${ELASTIX_VERSION}" )
 string( REGEX REPLACE "([0-9]+)\\." "" ELASTIX_VERSION_MINOR "${ELASTIX_VERSION}" )
 
+if ( ELASTIX_VNL_CONFIG_LEGACY_METHODS )
+  add_definitions(
+    -Dvnl_math_abs=vnl_math::abs
+    -Dvnl_math_max=vnl_math::max
+    -Dvnl_math_min=vnl_math::min 
+    -Dvnl_math_rnd=vnl_math::rnd
+    -Dvnl_math_sgn0=vnl_math::sgn0
+    -Dvnl_math_sgn=vnl_math::sgn
+    -Dvnl_math_sqr=vnl_math::sqr
+   )
+ endif()
+
 #---------------------------------------------------------------------
 include( CTest )
 

--- a/Common/CostFunctions/itkAdvancedImageToImageMetric.hxx
+++ b/Common/CostFunctions/itkAdvancedImageToImageMetric.hxx
@@ -959,7 +959,7 @@ AdvancedImageToImageMetric< TFixedImage, TMovingImage >
 
   const unsigned int numPar  = temp->st_Metric->GetNumberOfParameters();
   const unsigned int subSize = static_cast< unsigned int >(
-    vcl_ceil( static_cast< double >( numPar )
+    std::ceil( static_cast< double >( numPar )
     / static_cast< double >( nrOfThreads ) ) );
   const unsigned int jmin = threadID * subSize;
   unsigned int       jmax = ( threadID + 1 ) * subSize;

--- a/Common/CostFunctions/itkParzenWindowHistogramImageToImageMetric.hxx
+++ b/Common/CostFunctions/itkParzenWindowHistogramImageToImageMetric.hxx
@@ -1167,7 +1167,7 @@ ParzenWindowHistogramImageToImageMetric< TFixedImage, TMovingImage >
 
   /** Get the samples for this thread. */
   const unsigned long nrOfSamplesPerThreads
-    = static_cast< unsigned long >( vcl_ceil( static_cast< double >( sampleContainerSize )
+    = static_cast< unsigned long >( std::ceil( static_cast< double >( sampleContainerSize )
     / static_cast< double >( this->m_NumberOfThreads ) ) );
 
   unsigned long pos_begin = nrOfSamplesPerThreads * threadId;

--- a/Common/ImageSamplers/itkImageSamplerBase.hxx
+++ b/Common/ImageSamplers/itkImageSamplerBase.hxx
@@ -381,7 +381,7 @@ ImageSamplerBase< TInputImage >
       /** apply ceil/floor for max/min resp. to be sure that
       * the bounding box is not too small */
       maxIndex[ i ] = static_cast< IndexValueType >(
-        vcl_ceil( bbIndex->GetMaximum()[ i ] ) );
+        std::ceil( bbIndex->GetMaximum()[ i ] ) );
       minIndex[ i ] = static_cast< IndexValueType >(
         std::floor( bbIndex->GetMinimum()[ i ] ) );
       size[ i ] = maxIndex[ i ] - minIndex[ i ] + 1;

--- a/Common/Transforms/itkAdvancedImageMomentsCalculator.hxx
+++ b/Common/Transforms/itkAdvancedImageMomentsCalculator.hxx
@@ -395,7 +395,7 @@ AdvancedImageMomentsCalculator< TImage >
 
 /** Get the samples for this thread. */
   const unsigned long nrOfSamplesPerThreads
-    = static_cast<unsigned long>(vcl_ceil(static_cast<double>(sampleContainerSize)
+    = static_cast<unsigned long>(std::ceil(static_cast<double>(sampleContainerSize)
       / static_cast<double>(numberOfThreads)));
 
   unsigned long pos_begin = nrOfSamplesPerThreads * threadId;

--- a/Common/Transforms/itkCyclicGridScheduleComputer.hxx
+++ b/Common/Transforms/itkCyclicGridScheduleComputer.hxx
@@ -97,7 +97,7 @@ CyclicGridScheduleComputer< TTransformScalarType, VImageDimension >
       {
         /** Compute the grid size without the extra grid points at the edges. */
         bareGridSize = static_cast< unsigned int >(
-          vcl_ceil( size[ dim ] * imageSpacing[ dim ] / gridSpacing ) );
+          std::ceil( size[ dim ] * imageSpacing[ dim ] / gridSpacing ) );
       }
 
       this->m_GridSpacings[ res ][ dim ] = gridSpacing;

--- a/Common/Transforms/itkGridScheduleComputer.hxx
+++ b/Common/Transforms/itkGridScheduleComputer.hxx
@@ -151,7 +151,7 @@ GridScheduleComputer< TTransformScalarType, VImageDimension >
 
       /** Compute the grid size without the extra grid points at the edges. */
       const unsigned int bareGridSize = static_cast< unsigned int >(
-        vcl_ceil( size[ dim ] * imageSpacing[ dim ] / gridSpacing ) );
+        std::ceil( size[ dim ] * imageSpacing[ dim ] / gridSpacing ) );
 
       /** The number of B-spline grid nodes is the bareGridSize plus the
        * B-spline order more grid nodes. */

--- a/Common/itkComputeDisplacementDistribution.hxx
+++ b/Common/itkComputeDisplacementDistribution.hxx
@@ -371,7 +371,7 @@ ComputeDisplacementDistribution< TFixedImage, TTransform >
 
   /** Get the samples for this thread. */
   const unsigned long nrOfSamplesPerThreads
-    = static_cast< unsigned long >( vcl_ceil( static_cast< double >( sampleContainerSize )
+    = static_cast< unsigned long >( std::ceil( static_cast< double >( sampleContainerSize )
     / static_cast< double >( numberOfThreads ) ) );
 
   unsigned long pos_begin = nrOfSamplesPerThreads * threadId;

--- a/Common/itkMultiOrderBSplineDecompositionImageFilter.hxx
+++ b/Common/itkMultiOrderBSplineDecompositionImageFilter.hxx
@@ -238,7 +238,7 @@ MultiOrderBSplineDecompositionImageFilter< TInputImage, TOutputImage >
   zn      = z;
   if( m_Tolerance > 0.0 )
   {
-    horizon = (long)vcl_ceil( std::log( m_Tolerance ) / std::log( std::fabs( z ) ) );
+    horizon = (long)std::ceil( std::log( m_Tolerance ) / std::log( std::fabs( z ) ) );
   }
   if( horizon < m_DataLength[ m_IteratorDirection ] )
   {

--- a/Common/itkMultiResolutionImageRegistrationMethod2.hxx
+++ b/Common/itkMultiResolutionImageRegistrationMethod2.hxx
@@ -260,7 +260,7 @@ MultiResolutionImageRegistrationMethod2< TFixedImage, TMovingImage >
     fixedImageAtLevel->TransformPhysicalPointToContinuousIndex( inputEndPoint, endcindex );
     for( unsigned int dim = 0; dim < TFixedImage::ImageDimension; dim++ )
     {
-      start[ dim ] = static_cast< IndexValueType >( vcl_ceil( startcindex[ dim ] ) );
+      start[ dim ] = static_cast< IndexValueType >( std::ceil( startcindex[ dim ] ) );
       size[ dim ]  = vnl_math_max( NumericTraits< SizeValueType >::One, static_cast< SizeValueType >(
           static_cast< SizeValueType >( std::floor( endcindex[ dim ] ) ) - start[ dim ] + 1 ) );
     }

--- a/Components/Metrics/AdvancedMattesMutualInformation/itkParzenWindowMutualInformationImageToImageMetric.hxx
+++ b/Components/Metrics/AdvancedMattesMutualInformation/itkParzenWindowMutualInformationImageToImageMetric.hxx
@@ -470,7 +470,7 @@ ParzenWindowMutualInformationImageToImageMetric< TFixedImage, TMovingImage >
 
   /** Get the samples for this thread. */
   const unsigned long nrOfSamplesPerThreads
-    = static_cast< unsigned long >( vcl_ceil( static_cast< double >( sampleContainerSize )
+    = static_cast< unsigned long >( std::ceil( static_cast< double >( sampleContainerSize )
     / static_cast< double >( this->m_NumberOfThreads ) ) );
 
   unsigned long pos_begin = nrOfSamplesPerThreads * threadId;

--- a/Components/Metrics/AdvancedMeanSquares/itkAdvancedMeanSquaresImageToImageMetric.hxx
+++ b/Components/Metrics/AdvancedMeanSquares/itkAdvancedMeanSquaresImageToImageMetric.hxx
@@ -325,7 +325,7 @@ AdvancedMeanSquaresImageToImageMetric< TFixedImage, TMovingImage >
 
   /** Get the samples for this thread. */
   const unsigned long nrOfSamplesPerThreads
-    = static_cast< unsigned long >( vcl_ceil( static_cast< double >( sampleContainerSize )
+    = static_cast< unsigned long >( std::ceil( static_cast< double >( sampleContainerSize )
     / static_cast< double >( this->m_NumberOfThreads ) ) );
 
   unsigned long pos_begin = nrOfSamplesPerThreads * threadId;
@@ -654,7 +654,7 @@ AdvancedMeanSquaresImageToImageMetric< TFixedImage, TMovingImage >
 
   /** Get the samples for this thread. */
   const unsigned long nrOfSamplesPerThreads
-    = static_cast< unsigned long >( vcl_ceil( static_cast< double >( sampleContainerSize )
+    = static_cast< unsigned long >( std::ceil( static_cast< double >( sampleContainerSize )
     / static_cast< double >( this->m_NumberOfThreads ) ) );
 
   unsigned long pos_begin = nrOfSamplesPerThreads * threadId;

--- a/Components/Metrics/AdvancedNormalizedCorrelation/itkAdvancedNormalizedCorrelationImageToImageMetric.hxx
+++ b/Components/Metrics/AdvancedNormalizedCorrelation/itkAdvancedNormalizedCorrelationImageToImageMetric.hxx
@@ -550,7 +550,7 @@ AdvancedNormalizedCorrelationImageToImageMetric< TFixedImage, TMovingImage >
 
   /** Get the samples for this thread. */
   const unsigned long nrOfSamplesPerThreads
-    = static_cast< unsigned long >( vcl_ceil( static_cast< double >( sampleContainerSize )
+    = static_cast< unsigned long >( std::ceil( static_cast< double >( sampleContainerSize )
     / static_cast< double >( this->m_NumberOfThreads ) ) );
 
   unsigned long pos_begin = nrOfSamplesPerThreads * threadId;
@@ -837,7 +837,7 @@ AdvancedNormalizedCorrelationImageToImageMetric< TFixedImage, TMovingImage >
 
   const unsigned int numPar  = temp->st_Metric->GetNumberOfParameters();
   const unsigned int subSize = static_cast< unsigned int >(
-    vcl_ceil( static_cast< double >( numPar ) / static_cast< double >( nrOfThreads ) ) );
+    std::ceil( static_cast< double >( numPar ) / static_cast< double >( nrOfThreads ) ) );
   unsigned int jmin = threadId * subSize;
   unsigned int jmax = ( threadId + 1 ) * subSize;
   jmax = ( jmax > numPar ) ? numPar : jmax;

--- a/Components/Metrics/BendingEnergyPenalty/itkTransformBendingEnergyPenaltyTerm.hxx
+++ b/Components/Metrics/BendingEnergyPenalty/itkTransformBendingEnergyPenaltyTerm.hxx
@@ -442,7 +442,7 @@ TransformBendingEnergyPenaltyTerm< TFixedImage, TScalarType >
 
   /** Get the samples for this thread. */
   const unsigned long nrOfSamplesPerThreads
-    = static_cast< unsigned long >( vcl_ceil( static_cast< double >( sampleContainerSize )
+    = static_cast< unsigned long >( std::ceil( static_cast< double >( sampleContainerSize )
     / static_cast< double >( this->m_NumberOfThreads ) ) );
 
   unsigned long pos_begin = nrOfSamplesPerThreads * threadId;

--- a/Components/Metrics/PCAMetric/itkPCAMetric_F_multithreaded.hxx
+++ b/Components/Metrics/PCAMetric/itkPCAMetric_F_multithreaded.hxx
@@ -744,7 +744,7 @@ PCAMetric< TFixedImage, TMovingImage >
 
   /** Get the samples for this thread. */
   const unsigned long nrOfSamplesPerThreads
-    = static_cast< unsigned long >( vcl_ceil( static_cast< double >( sampleContainerSize )
+    = static_cast< unsigned long >( std::ceil( static_cast< double >( sampleContainerSize )
     / static_cast< double >( this->m_NumberOfThreads ) ) );
   unsigned long pos_begin = nrOfSamplesPerThreads * threadId;
   unsigned long pos_end   = nrOfSamplesPerThreads * ( threadId + 1 );

--- a/Components/Metrics/SumSquaredTissueVolumeDifferenceMetric/itkSumSquaredTissueVolumeDifferenceImageToImageMetric.hxx
+++ b/Components/Metrics/SumSquaredTissueVolumeDifferenceMetric/itkSumSquaredTissueVolumeDifferenceImageToImageMetric.hxx
@@ -217,7 +217,7 @@ void SumSquaredTissueVolumeDifferenceImageToImageMetric<TFixedImage,TMovingImage
 
   /** Get the samples for this thread. */
   const unsigned long nSamplesPerThread
-    = static_cast<unsigned long>( vcl_ceil( static_cast<double>( sampleContainerSize )
+    = static_cast<unsigned long>( std::ceil( static_cast<double>( sampleContainerSize )
     / static_cast<double>( this->m_NumberOfThreads ) ) );
 
   unsigned long pos_begin = nSamplesPerThread * threadId;
@@ -544,7 +544,7 @@ SumSquaredTissueVolumeDifferenceImageToImageMetric<TFixedImage, TMovingImage>
 
   /** Get the samples for this thread. */
   const unsigned long nSamplesPerThread
-    = static_cast<unsigned long>(vcl_ceil(static_cast<double>( sampleContainerSize )
+    = static_cast<unsigned long>(std::ceil(static_cast<double>( sampleContainerSize )
       / static_cast<double>( this->m_NumberOfThreads ) ) );
 
   unsigned long pos_begin = nSamplesPerThread * threadId;

--- a/Components/Optimizers/AdaptiveStochasticGradientDescent/elxAdaptiveStochasticGradientDescent.hxx
+++ b/Components/Optimizers/AdaptiveStochasticGradientDescent/elxAdaptiveStochasticGradientDescent.hxx
@@ -615,7 +615,7 @@ AdaptiveStochasticGradientDescent< TElastix >
     if( TrCC > 1e-14 && TrC > 1e-14 )
     {
       this->m_NumberOfGradientMeasurements = static_cast< unsigned int >(
-        vcl_ceil( 8.0 * TrCC / TrC / TrC / ( K - 1 ) / ( K - 1 ) ) );
+        std::ceil( 8.0 * TrCC / TrC / TrC / ( K - 1 ) / ( K - 1 ) ) );
     }
     else
     {

--- a/Components/Registrations/MultiMetricMultiResolutionRegistration/itkMultiMetricMultiResolutionImageRegistrationMethod.hxx
+++ b/Components/Registrations/MultiMetricMultiResolutionRegistration/itkMultiMetricMultiResolutionImageRegistrationMethod.hxx
@@ -303,7 +303,7 @@ MultiMetricMultiResolutionImageRegistrationMethod< TFixedImage, TMovingImage >
           inputEndPoint, endcindex );
         for( unsigned int dim = 0; dim < TFixedImage::ImageDimension; dim++ )
         {
-          start[ dim ] = static_cast< IndexValueType >( vcl_ceil( startcindex[ dim ] ) );
+          start[ dim ] = static_cast< IndexValueType >( std::ceil( startcindex[ dim ] ) );
           size[ dim ]  = vnl_math_max( NumericTraits< SizeValueType >::One, static_cast< SizeValueType >(
             static_cast< SizeValueType >( std::floor( endcindex[ dim ] ) ) - start[ dim ] + 1 ) );
         }

--- a/Components/Registrations/MultiResolutionRegistrationWithFeatures/itkMultiInputMultiResolutionImageRegistrationMethodBase.hxx
+++ b/Components/Registrations/MultiResolutionRegistrationWithFeatures/itkMultiInputMultiResolutionImageRegistrationMethodBase.hxx
@@ -439,7 +439,7 @@ MultiInputMultiResolutionImageRegistrationMethodBase< TFixedImage, TMovingImage 
         fixedImageAtLevel->TransformPhysicalPointToContinuousIndex( inputEndPoint, endcindex );
         for( unsigned int dim = 0; dim < TFixedImage::ImageDimension; dim++ )
         {
-          start[ dim ] = static_cast< IndexValueType >( vcl_ceil( startcindex[ dim ] ) );
+          start[ dim ] = static_cast< IndexValueType >( std::ceil( startcindex[ dim ] ) );
           size[ dim ]  = static_cast< SizeValueType >(
             static_cast< SizeValueType >( std::floor( endcindex[ dim ] ) ) - start[ dim ] + 1 );
         }

--- a/Testing/itkAccumulateDerivativesParallellizationTest.cxx
+++ b/Testing/itkAccumulateDerivativesParallellizationTest.cxx
@@ -157,7 +157,7 @@ public:
 
     const unsigned int numPar  = temp->st_Metric->m_NumberOfParameters;
     const unsigned int subSize = static_cast< unsigned int >(
-      vcl_ceil( static_cast< double >( numPar )
+      std::ceil( static_cast< double >( numPar )
       / static_cast< double >( nrOfThreads ) ) );
     const unsigned int jmin = threadID * subSize;
     unsigned int       jmax = ( threadID + 1 ) * subSize;

--- a/Testing/itkAdvanceOneStepParallellizationTest.cxx
+++ b/Testing/itkAdvanceOneStepParallellizationTest.cxx
@@ -191,7 +191,7 @@ public:
     /** Compute the range for this thread. */
     const unsigned int spaceDimension = m_NumberOfParameters;
     const unsigned int subSize        = static_cast< unsigned int >(
-      vcl_ceil( static_cast< double >( spaceDimension )
+      std::ceil( static_cast< double >( spaceDimension )
       / static_cast< double >( this->m_Threader->GetNumberOfThreads() ) ) );
     const unsigned int jmin = threadId * subSize;
     unsigned int       jmax = ( threadId + 1 ) * subSize;
@@ -217,7 +217,7 @@ public:
     /** Compute the range for this thread. */
     const unsigned int spaceDimension = m_NumberOfParameters;
     const unsigned int subSize        = static_cast< unsigned int >(
-      vcl_ceil( static_cast< double >( spaceDimension )
+      std::ceil( static_cast< double >( spaceDimension )
       / static_cast< double >( this->m_Threader->GetNumberOfThreads() ) ) );
     const unsigned int jmin = threadId * subSize;
     unsigned int       jmax = ( threadId + 1 ) * subSize;


### PR DESCRIPTION
Replaced calls to the obsolete `vcl_ceil` macro from "ITK\Modules\ThirdParty\VNL\src\vxl\vcl\vcl_legacy_aliases.h" (in ITK5) by direct calls to `std::ceil`.

Fixes many "error C3861: identifier not found" messages, when using ITK5.

Follow-up to: 4e0a41732ad1654e9b801b698e2cf93ab772e9e1 (14 January 2019), "COMP: Replaced vcl_ceil (VXL) macro calls by direct calls to std::ceil"