### PR TITLE
COMP: Added compilation defines to use vnl_math legacy macro's with ITK5

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -26,18 +26,6 @@ string( SUBSTRING ${ELASTIX_VERSION} 26 3 ELASTIX_VERSION )
 string( REGEX MATCH "[0-9]+" ELASTIX_VERSION_MAJOR "${ELASTIX_VERSION}" )
 string( REGEX REPLACE "([0-9]+)\\." "" ELASTIX_VERSION_MINOR "${ELASTIX_VERSION}" )
 
-if ( ELASTIX_VNL_CONFIG_LEGACY_METHODS )
-  add_definitions(
-    -Dvnl_math_abs=vnl_math::abs
-    -Dvnl_math_max=vnl_math::max
-    -Dvnl_math_min=vnl_math::min 
-    -Dvnl_math_rnd=vnl_math::rnd
-    -Dvnl_math_sgn0=vnl_math::sgn0
-    -Dvnl_math_sgn=vnl_math::sgn
-    -Dvnl_math_sqr=vnl_math::sqr
-   )
- endif()
-
 #---------------------------------------------------------------------
 include( CTest )
 
@@ -75,6 +63,22 @@ endif()
 # Find ITK.
 find_package( ITK REQUIRED )
 include( ${ITK_USE_FILE} )
+
+if ( NOT ITK_VERSION VERSION_LESS "5.0.0" )
+  # Workaround to still allow using those vnl_math legacy macro's with ITK >= 5,
+  # as defined in "ITK\Modules\ThirdParty\VNL\src\vxl\vcl\vcl_legacy_aliases.h",
+  # with ITK5.
+  add_definitions(
+    -Dvnl_math_abs=vnl_math::abs
+    -Dvnl_math_max=vnl_math::max
+    -Dvnl_math_min=vnl_math::min 
+    -Dvnl_math_rnd=vnl_math::rnd
+    -Dvnl_math_sgn0=vnl_math::sgn0
+    -Dvnl_math_sgn=vnl_math::sgn
+    -Dvnl_math_sqr=vnl_math::sqr
+   )
+endif()
+
 
 #---------------------------------------------------------------------
 # Add the CMake dir as an additional module path,


### PR DESCRIPTION
Added command-line compilation defines to use `vnl_math` macro's for `abs`, `max`, `min`, `rnd`, etc., when ITK >= 5.

These macro's are also defined in "vxl\vcl\vcl_legacy_aliases.h"