### PR TITLE
COMP: Fix elxElastixMain ITK5 errors, trying to use 0 for SmartPointer

### DIFF
--- a/Core/Kernel/elxElastixMain.cxx
+++ b/Core/Kernel/elxElastixMain.cxx
@@ -161,8 +161,9 @@ ElastixMain::ElastixMain()
  * ****************** Initialization of static members *********
  */
 
-ElastixMain::ComponentDatabasePointer ElastixMain::s_CDB             = 0;
-ElastixMain::ComponentLoaderPointer   ElastixMain::s_ComponentLoader = 0;
+// Both s_CDB and s_ComponentLoader are defaulted-constructed to null.
+ElastixMain::ComponentDatabasePointer ElastixMain::s_CDB;
+ElastixMain::ComponentLoaderPointer   ElastixMain::s_ComponentLoader;
 
 /**
  * ********************** Destructor ****************************
@@ -811,9 +812,11 @@ ElastixMain::CreateComponent(
 {
   /** A pointer to the New() function. */
   PtrToCreator  testcreator = 0;
-  ObjectPointer testpointer = 0;
   testcreator = this->s_CDB->GetCreator( name,  this->m_DBIndex );
-  testpointer = testcreator ? testcreator() : NULL;
+
+  // Note that ObjectPointer() yields a default-constructed SmartPointer (null).
+  ObjectPointer testpointer = testcreator ? testcreator() : ObjectPointer();
+
   if( testpointer.IsNull() )
   {
     itkExceptionMacro( << "The following component could not be created: " << name );


### PR DESCRIPTION
Fixes compilation errors when using ITK 5 (from ITK git master branch):

    elxElastixMain.cxx(164): error C2440: 'initializing': cannot convert from 'int' to 'itk::SmartPointer<elastix::ComponentDatabase::Self>'
    elxElastixMain.cxx(165): error C2440: 'initializing': cannot convert from 'int' to 'itk::SmartPointer<elastix::ComponentLoader::Self>'
    elxElastixMain.cxx(814): error C2440: 'initializing': cannot convert from 'int' to 'itk::SmartPointer<itk::Object::Self>'
    elxElastixMain.cxx(816): error C2446: ':': no conversion from 'int' to 'elastix::ComponentDatabase::ObjectPointer'

Follow-up to revision 49421b181302c75e22158e282254c30b44631b55 (2019-01-08), "COMP: Fix error w/ ITK5, trying to initialize itk::SmartPointer by zero"