### PR TITLE
ITK5 drops support 0 as smart pointer (part 3)

### DIFF
--- a/Common/itkMultiResolutionImageRegistrationMethod2.hxx
+++ b/Common/itkMultiResolutionImageRegistrationMethod2.hxx
@@ -484,15 +484,11 @@ DataObject::Pointer
 MultiResolutionImageRegistrationMethod2< TFixedImage, TMovingImage >
 ::MakeOutput( unsigned int output )
 {
-  switch( output )
+  if (output > 0)
   {
-    case 0:
-      return static_cast< DataObject * >( TransformOutputType::New().GetPointer() );
-      break;
-    default:
-      itkExceptionMacro( "MakeOutput request for an output number larger than the expected number of outputs" );
-      return 0;
+    itkExceptionMacro("MakeOutput request for an output number larger than the expected number of outputs.");
   }
+  return TransformOutputType::New().GetPointer();
 }
 
 

--- a/Components/Metrics/BendingEnergyPenalty/itkTransformBendingEnergyPenaltyTerm.hxx
+++ b/Components/Metrics/BendingEnergyPenalty/itkTransformBendingEnergyPenaltyTerm.hxx
@@ -191,7 +191,7 @@ TransformBendingEnergyPenaltyTerm< TFixedImage, TScalarType >
   // TODO: This is only required once! and not every iteration.
 
   /** Check if this transform is a B-spline transform. */
-  typename BSplineOrder3TransformType::Pointer dummy = 0;
+  typename BSplineOrder3TransformType::Pointer dummy; // default-constructed (null)
   bool transformIsBSpline = this->CheckForBSplineTransform2( dummy );
 
   /** Call non-thread-safe stuff, such as:
@@ -426,7 +426,7 @@ TransformBendingEnergyPenaltyTerm< TFixedImage, TScalarType >
   // TODO: This is only required once! and not every iteration.
 
   /** Check if this transform is a B-spline transform. */
-  typename BSplineOrder3TransformType::Pointer dummy = 0;
+  typename BSplineOrder3TransformType::Pointer dummy; // default-constructed (null)
   bool transformIsBSpline = this->CheckForBSplineTransform2( dummy );
 
   /** Get a handle to the pre-allocated derivative for the current thread.

--- a/Components/Metrics/CorrespondingPointsEuclideanDistanceMetric/elxCorrespondingPointsEuclideanDistanceMetric.hxx
+++ b/Components/Metrics/CorrespondingPointsEuclideanDistanceMetric/elxCorrespondingPointsEuclideanDistanceMetric.hxx
@@ -109,7 +109,7 @@ CorrespondingPointsEuclideanDistanceMetric< TElastix >
 {
   /** Read and set the fixed pointset. */
   std::string fixedName = this->GetConfiguration()->GetCommandLineArgument( "-fp" );
-  typename PointSetType::Pointer fixedPointSet      = 0;
+  typename PointSetType::Pointer fixedPointSet; // default-constructed (null)
   const typename ImageType::ConstPointer fixedImage = this->GetElastix()->GetFixedImage();
   const unsigned int nrOfFixedPoints = this->ReadLandmarks(
     fixedName, fixedPointSet, fixedImage );
@@ -117,7 +117,7 @@ CorrespondingPointsEuclideanDistanceMetric< TElastix >
 
   /** Read and set the moving pointset. */
   std::string movingName = this->GetConfiguration()->GetCommandLineArgument( "-mp" );
-  typename PointSetType::Pointer movingPointSet      = 0;
+  typename PointSetType::Pointer movingPointSet; // default-constructed (null)
   const typename ImageType::ConstPointer movingImage = this->GetElastix()->GetMovingImage();
   const unsigned int nrOfMovingPoints = this->ReadLandmarks(
     movingName, movingPointSet, movingImage );

--- a/Components/Metrics/DistancePreservingRigidityPenalty/itkDistancePreservingRigidityPenaltyTerm.hxx
+++ b/Components/Metrics/DistancePreservingRigidityPenalty/itkDistancePreservingRigidityPenaltyTerm.hxx
@@ -64,7 +64,7 @@ DistancePreservingRigidityPenaltyTerm< TFixedImage, TScalarType >
   this->Superclass::Initialize();
 
   /** Check if this transform is a B-spline transform. */
-  typename BSplineTransformType::Pointer localBSplineTransform = 0;
+  typename BSplineTransformType::Pointer localBSplineTransform; // default-constructed (null)
   bool transformIsBSpline = this->CheckForBSplineTransform2( localBSplineTransform );
   if( transformIsBSpline )
   {

--- a/Components/Metrics/RigidityPenalty/itkTransformRigidityPenaltyTerm.hxx
+++ b/Components/Metrics/RigidityPenalty/itkTransformRigidityPenaltyTerm.hxx
@@ -128,7 +128,7 @@ TransformRigidityPenaltyTerm< TFixedImage, TScalarType >
   this->Superclass::Initialize();
 
   /** Check if this transform is a B-spline transform. */
-  typename BSplineTransformType::Pointer localBSplineTransform = 0;
+  typename BSplineTransformType::Pointer localBSplineTransform; // default-constructed (null)
   bool transformIsBSpline = this->CheckForBSplineTransform2( localBSplineTransform );
   if( transformIsBSpline ) { this->SetBSplineTransform( localBSplineTransform ); }
 

--- a/Components/Optimizers/AdaptiveStochasticGradientDescent/elxAdaptiveStochasticGradientDescent.hxx
+++ b/Components/Optimizers/AdaptiveStochasticGradientDescent/elxAdaptiveStochasticGradientDescent.hxx
@@ -823,9 +823,11 @@ AdaptiveStochasticGradientDescent< TElastix >
 
   /** Variables for sampler support. Each metric may have a sampler. */
   std::vector< bool >                                useRandomSampleRegionVec( M, false );
-  std::vector< ImageRandomSamplerBasePointer >       randomSamplerVec( M, 0 );
-  std::vector< ImageRandomCoordinateSamplerPointer > randomCoordinateSamplerVec( M, 0 );
-  std::vector< ImageGridSamplerPointer >             gridSamplerVec( M, 0 );
+
+  // Note that std::vector will properly initialize its M elements to null (by default).
+  std::vector< ImageRandomSamplerBasePointer >       randomSamplerVec( M );
+  std::vector< ImageRandomCoordinateSamplerPointer > randomCoordinateSamplerVec( M );
+  std::vector< ImageGridSamplerPointer >             gridSamplerVec( M );
 
   /** If new samples every iteration, get each sampler, and check if it is
    * a kind of random sampler. If yes, prepare an additional grid sampler

--- a/Components/Transforms/AdvancedAffineTransform/itkCenteredTransformInitializer2.hxx
+++ b/Components/Transforms/AdvancedAffineTransform/itkCenteredTransformInitializer2.hxx
@@ -98,14 +98,14 @@ CenteredTransformInitializer2< TTransform, TFixedImage, TMovingImage >
   if( m_UseMoments )
   {
     // Convert the masks to spatial objects
-    typename FixedMaskSpatialObjectType::Pointer fixedMaskAsSpatialObject = 0;
+    typename FixedMaskSpatialObjectType::Pointer fixedMaskAsSpatialObject; // default-constructed (null)
     if( this->m_FixedImageMask )
     {
       fixedMaskAsSpatialObject = FixedMaskSpatialObjectType::New();
       fixedMaskAsSpatialObject->SetImage( this->m_FixedImageMask );
     }
 
-    typename MovingMaskSpatialObjectType::Pointer movingMaskAsSpatialObject = 0;
+    typename MovingMaskSpatialObjectType::Pointer movingMaskAsSpatialObject;  // default-constructed (null)
     if( this->m_MovingImageMask )
     {
       movingMaskAsSpatialObject = MovingMaskSpatialObjectType::New();

--- a/Components/Transforms/DeformationFieldTransform/elxDeformationFieldTransform.hxx
+++ b/Components/Transforms/DeformationFieldTransform/elxDeformationFieldTransform.hxx
@@ -128,7 +128,7 @@ DeformationFieldTransform< TElastix >::ReadFromFile( void )
   typedef itk::VectorLinearInterpolateImageFunction<
     DeformationFieldType, CoordRepType >  LinInterpolatorType;
 
-  typename InterpolatorType::Pointer interpolator = 0;
+  typename InterpolatorType::Pointer interpolator; // default-constructed (null)
   unsigned int interpolationOrder = 0;
   this->m_Configuration->ReadParameter( interpolationOrder,
     "DeformationFieldInterpolationOrder", 0 );

--- a/Components/Transforms/SplineKernelTransform/elxSplineKernelTransform.hxx
+++ b/Components/Transforms/SplineKernelTransform/elxSplineKernelTransform.hxx
@@ -243,7 +243,7 @@ SplineKernelTransform< TElastix >
   {
     fp = ipp;                 // backwards compatibility, added in elastix 4.5
   }
-  PointSetPointer landmarkPointSet = 0;
+  PointSetPointer landmarkPointSet; // default-constructed (null)
   this->ReadLandmarkFile( fp, landmarkPointSet, true );
 
   /** Set the fp as source landmarks. */
@@ -279,7 +279,7 @@ SplineKernelTransform< TElastix >
          << this->GetComponentLabel()
          << ":" << this->elxGetClassName() << "." << std::endl;
 
-  PointSetPointer landmarkPointSet = 0;
+  PointSetPointer landmarkPointSet;
   this->ReadLandmarkFile( mp, landmarkPointSet, false );
 
   /** Set the mp as target landmarks. */

--- a/Components/Transforms/TranslationTransform/itkTranslationTransformInitializer.hxx
+++ b/Components/Transforms/TranslationTransform/itkTranslationTransformInitializer.hxx
@@ -82,14 +82,14 @@ TranslationTransformInitializer< TTransform, TFixedImage, TMovingImage >
   if( this->m_UseMoments )
   {
     // Convert the masks to spatial objects
-    typename FixedMaskSpatialObjectType::Pointer fixedMaskAsSpatialObject = 0;
+    typename FixedMaskSpatialObjectType::Pointer fixedMaskAsSpatialObject; // default-constructed (null)
     if( this->m_FixedMask )
     {
       fixedMaskAsSpatialObject = FixedMaskSpatialObjectType::New();
       fixedMaskAsSpatialObject->SetImage( this->m_FixedMask );
     }
 
-    typename MovingMaskSpatialObjectType::Pointer movingMaskAsSpatialObject = 0;
+    typename MovingMaskSpatialObjectType::Pointer movingMaskAsSpatialObject; // default-constructed (null)
     if( this->m_MovingMask )
     {
       movingMaskAsSpatialObject = MovingMaskSpatialObjectType::New();

--- a/Core/ComponentBaseClasses/elxTransformBase.hxx
+++ b/Core/ComponentBaseClasses/elxTransformBase.hxx
@@ -565,12 +565,11 @@ TransformBase< TElastix >
     initialTransformName, "Transform", 0 );
 
   /** Create an InitialTransform. */
-  ObjectType::Pointer initialTransform;
-
   PtrToCreator testcreator = 0;
   testcreator = this->GetElastix()->GetComponentDatabase()
     ->GetCreator( initialTransformName, this->m_Elastix->GetDBIndex() );
-  initialTransform = testcreator ? testcreator() : NULL;
+  // Note that ObjectType::Pointer() yields a default-constructed SmartPointer (null).
+  ObjectType::Pointer initialTransform = testcreator ? testcreator() : ObjectType::Pointer();
 
   Self * elx_initialTransform = dynamic_cast< Self * >(
     initialTransform.GetPointer() );
@@ -627,12 +626,12 @@ TransformBase< TElastix >
     initialTransformName, "Transform", 0 );
 
   /** Create an InitialTransform. */
-  ObjectType::Pointer initialTransform;
-
   PtrToCreator testcreator = 0;
   testcreator = this->GetElastix()->GetComponentDatabase()
     ->GetCreator( initialTransformName, this->m_Elastix->GetDBIndex() );
-  initialTransform = testcreator ? testcreator() : NULL;
+
+  // Note that ObjectType::Pointer() yields a default-constructed SmartPointer (null).
+  ObjectType::Pointer initialTransform = testcreator ? testcreator() : ObjectType::Pointer();
 
   Self * elx_initialTransform = dynamic_cast< Self * >(
     initialTransform.GetPointer() );

--- a/Core/Main/elastix.cxx
+++ b/Core/Main/elastix.cxx
@@ -73,11 +73,13 @@ main( int argc, char ** argv )
   /** Some declarations and initializations. */
   ElastixMainVectorType elastices;
 
+  // Note that the following pointers are "smart", so they are defaulted-constructed to null.
   ObjectPointer              transform;
   DataObjectContainerPointer fixedImageContainer;
   DataObjectContainerPointer movingImageContainer;
   DataObjectContainerPointer fixedMaskContainer;
   DataObjectContainerPointer movingMaskContainer;
+
   FlatDirectionCosinesType   fixedImageOriginalDirection;
   int                        returndummy        = 0;
   unsigned long              nrOfParameterFiles = 0;


### PR DESCRIPTION
Three more commits regarding the use of 0 (zero) as smart pointer null value, which is no longer supported by ITK 5 (current ITK git master branch).

Follow-up to #94 and #99