### PR TITLE
COMP: Replace vcl numeric_limits, acos, exp, atan by directly using std

### DIFF
--- a/Common/CostFunctions/itkExponentialLimiterFunction.hxx
+++ b/Common/CostFunctions/itkExponentialLimiterFunction.hxx
@@ -63,7 +63,7 @@ ExponentialLimiterFunction< TInput, NDimension >
   if( diffU > 1e-10 )
   {
     return static_cast< OutputType >(
-      this->m_UTminUB * vcl_exp( this->m_UTminUBinv * diffU ) + this->m_UpperBound );
+      this->m_UTminUB * std::exp( this->m_UTminUBinv * diffU ) + this->m_UpperBound );
   }
 
   /** Apply a soft limit if the input is smaller than the LowerThreshold */
@@ -71,7 +71,7 @@ ExponentialLimiterFunction< TInput, NDimension >
   if( diffL < -1e-10 )
   {
     return static_cast< OutputType >(
-      this->m_LTminLB * vcl_exp( this->m_LTminLBinv * diffL ) + this->m_LowerBound );
+      this->m_LTminLB * std::exp( this->m_LTminLBinv * diffL ) + this->m_LowerBound );
   }
 
   /** Leave the value as it is */
@@ -92,7 +92,7 @@ ExponentialLimiterFunction< TInput, NDimension >
   const double diffU = static_cast< double >( input - this->m_UpperThreshold );
   if( diffU > 1e-10 )
   {
-    const double temp           = this->m_UTminUB * vcl_exp( this->m_UTminUBinv * diffU );
+    const double temp           = this->m_UTminUB * std::exp( this->m_UTminUBinv * diffU );
     const double gradientfactor = this->m_UTminUBinv * temp;
     for( unsigned int i = 0; i < Dimension; ++i )
     {
@@ -105,7 +105,7 @@ ExponentialLimiterFunction< TInput, NDimension >
   const double diffL = static_cast< double >( input - this->m_LowerThreshold );
   if( diffL < -1e-10 )
   {
-    const double temp           = this->m_LTminLB * vcl_exp( this->m_LTminLBinv * diffL );
+    const double temp           = this->m_LTminLB * std::exp( this->m_LTminLBinv * diffL );
     const double gradientfactor = this->m_LTminLBinv * temp;
     for( unsigned int i = 0; i < Dimension; ++i )
     {

--- a/Common/Transforms/itkAdvancedRigid2DTransform.hxx
+++ b/Common/Transforms/itkAdvancedRigid2DTransform.hxx
@@ -127,7 +127,7 @@ AdvancedRigid2DTransform< TScalarType >
   vnl_matrix< TScalarType > r( 2, 2 );
   r = svd.U() * svd.V().transpose();
 
-  m_Angle = vcl_acos( r[ 0 ][ 0 ] );
+  m_Angle = std::acos( r[ 0 ][ 0 ] );
 
   if( r[ 1 ][ 0 ] < 0.0 )
   {
@@ -211,7 +211,7 @@ void
 AdvancedRigid2DTransform< TScalarType >
 ::SetAngleInDegrees( TScalarType angle )
 {
-  const TScalarType angleInRadians = angle * vcl_atan( 1.0 ) / 45.0;
+  const TScalarType angleInRadians = angle * std::atan( 1.0 ) / 45.0;
   this->SetAngle( angleInRadians );
 }
 

--- a/Common/Transforms/itkAdvancedSimilarity2DTransform.hxx
+++ b/Common/Transforms/itkAdvancedSimilarity2DTransform.hxx
@@ -162,7 +162,7 @@ AdvancedSimilarity2DTransform< TScalarType >
   m_Scale = std::sqrt( vnl_math_sqr( this->GetMatrix()[ 0 ][ 0 ] )
     + vnl_math_sqr( this->GetMatrix()[ 0 ][ 1 ] ) );
 
-  this->SetVarAngle( vcl_acos( this->GetMatrix()[ 0 ][ 0 ] / m_Scale ) );
+  this->SetVarAngle( std::acos( this->GetMatrix()[ 0 ][ 0 ] / m_Scale ) );
 
   if( this->GetMatrix()[ 1 ][ 0 ] < 0.0 )
   {

--- a/Components/Metrics/CorrespondingPointsEuclideanDistanceMetric/itkCorrespondingPointsEuclideanDistancePointMetric.hxx
+++ b/Components/Metrics/CorrespondingPointsEuclideanDistanceMetric/itkCorrespondingPointsEuclideanDistancePointMetric.hxx
@@ -220,7 +220,7 @@ CorrespondingPointsEuclideanDistancePointMetric< TFixedPointSet, TMovingPointSet
       measure += distance;
 
       /** Calculate the contributions to the derivatives with respect to each parameter. */
-      if( distance > vcl_numeric_limits< MeasureType >::epsilon() )
+      if( distance > std::numeric_limits< MeasureType >::epsilon() )
       {
         VnlVectorType diff_2 = diffPoint / distance;
         if( nzji.size() == this->GetNumberOfParameters() )


### PR DESCRIPTION
Replaced uses of vcl versions of `numeric_limits`, `acos`, `exp`, and `atan` by using `std` directly. Fixes compile errors when trying to use ITK 5 (from the ITK git master branch).

Follow-up to d975c0d070246fe3f5b3a91db0570cc4061ff9af (8 January, 2019)