### PR TITLE
STYLE: Avoid direct access to itk::ImageToImageMetric::m_NumberOfThreads

### DIFF
--- a/Common/CostFunctions/itkAdvancedImageToImageMetric.hxx
+++ b/Common/CostFunctions/itkAdvancedImageToImageMetric.hxx
@@ -94,7 +94,7 @@ AdvancedImageToImageMetric< TFixedImage, TMovingImage >
 #ifdef ELASTIX_USE_OPENMP
   this->m_UseOpenMP = true;
 
-  const int nthreads = static_cast< int >( this->m_NumberOfThreads );
+  const int nthreads = static_cast< int >( Self::GetNumberOfThreads() );
   omp_set_num_threads( nthreads );
 #else
   this->m_UseOpenMP = false;
@@ -137,7 +137,7 @@ AdvancedImageToImageMetric< TFixedImage, TMovingImage >
   Superclass::SetNumberOfThreads( numberOfThreads );
 
 #ifdef ELASTIX_USE_OPENMP
-  const int nthreads = static_cast< int >( this->m_NumberOfThreads );
+  const int nthreads = static_cast< int >( Self::GetNumberOfThreads() );
   omp_set_num_threads( nthreads );
 #endif
 } // end SetNumberOfThreads()
@@ -188,6 +188,8 @@ void
 AdvancedImageToImageMetric< TFixedImage, TMovingImage >
 ::InitializeThreadingParameters( void ) const
 {
+  const ThreadIdType numberOfThreads = Self::GetNumberOfThreads();
+
   /** Resize and initialize the threading related parameters.
    * The SetSize() functions do not resize the data when this is not
    * needed, which saves valuable re-allocation time.
@@ -199,23 +201,23 @@ AdvancedImageToImageMetric< TFixedImage, TMovingImage >
    */
 
   /** Only resize the array of structs when needed. */
-  if( this->m_GetValuePerThreadVariablesSize != this->m_NumberOfThreads )
+  if( this->m_GetValuePerThreadVariablesSize != numberOfThreads )
   {
     delete[] this->m_GetValuePerThreadVariables;
-    this->m_GetValuePerThreadVariables     = new AlignedGetValuePerThreadStruct[ this->m_NumberOfThreads ];
-    this->m_GetValuePerThreadVariablesSize = this->m_NumberOfThreads;
+    this->m_GetValuePerThreadVariables     = new AlignedGetValuePerThreadStruct[ numberOfThreads ];
+    this->m_GetValuePerThreadVariablesSize = numberOfThreads;
   }
 
   /** Only resize the array of structs when needed. */
-  if( this->m_GetValueAndDerivativePerThreadVariablesSize != this->m_NumberOfThreads )
+  if( this->m_GetValueAndDerivativePerThreadVariablesSize != numberOfThreads )
   {
     delete[] this->m_GetValueAndDerivativePerThreadVariables;
-    this->m_GetValueAndDerivativePerThreadVariables     = new AlignedGetValueAndDerivativePerThreadStruct[ this->m_NumberOfThreads ];
-    this->m_GetValueAndDerivativePerThreadVariablesSize = this->m_NumberOfThreads;
+    this->m_GetValueAndDerivativePerThreadVariables     = new AlignedGetValueAndDerivativePerThreadStruct[ numberOfThreads ];
+    this->m_GetValueAndDerivativePerThreadVariablesSize = numberOfThreads;
   }
 
   /** Some initialization. */
-  for( ThreadIdType i = 0; i < this->m_NumberOfThreads; ++i )
+  for( ThreadIdType i = 0; i < numberOfThreads; ++i )
   {
     this->m_GetValuePerThreadVariables[ i ].st_NumberOfPixelsCounted = NumericTraits< SizeValueType >::Zero;
     this->m_GetValuePerThreadVariables[ i ].st_Value                 = NumericTraits< MeasureType >::Zero;

--- a/Components/Metrics/AdvancedMattesMutualInformation/itkParzenWindowMutualInformationImageToImageMetric.hxx
+++ b/Components/Metrics/AdvancedMattesMutualInformation/itkParzenWindowMutualInformationImageToImageMetric.hxx
@@ -471,7 +471,7 @@ ParzenWindowMutualInformationImageToImageMetric< TFixedImage, TMovingImage >
   /** Get the samples for this thread. */
   const unsigned long nrOfSamplesPerThreads
     = static_cast< unsigned long >( std::ceil( static_cast< double >( sampleContainerSize )
-    / static_cast< double >( this->m_NumberOfThreads ) ) );
+    / static_cast< double >( Self::GetNumberOfThreads() ) ) );
 
   unsigned long pos_begin = nrOfSamplesPerThreads * threadId;
   unsigned long pos_end   = nrOfSamplesPerThreads * ( threadId + 1 );
@@ -594,12 +594,14 @@ void
 ParzenWindowMutualInformationImageToImageMetric< TFixedImage, TMovingImage >
 ::AfterThreadedComputeDerivativeLowMemory( DerivativeType & derivative ) const
 {
+  const ThreadIdType numberOfThreads = Self::GetNumberOfThreads();
+
   /** Accumulate derivatives. */
   // compute single-threadedly
   if( !this->m_UseMultiThread && false ) // force multi-threaded
   {
     derivative = this->m_GetValueAndDerivativePerThreadVariables[ 0 ].st_Derivative;
-    for( ThreadIdType i = 1; i < this->m_NumberOfThreads; ++i )
+    for( ThreadIdType i = 1; i < numberOfThreads; ++i )
     {
       derivative += this->m_GetValueAndDerivativePerThreadVariables[ i ].st_Derivative;
     }
@@ -614,7 +616,7 @@ ParzenWindowMutualInformationImageToImageMetric< TFixedImage, TMovingImage >
     for( int j = 0; j < spaceDimension; ++j )
     {
       DerivativeValueType sum = this->m_GetValueAndDerivativePerThreadVariables[ 0 ].st_Derivative[ j ];
-      for( ThreadIdType i = 1; i < this->m_NumberOfThreads; ++i )
+      for( ThreadIdType i = 1; i < numberOfThreads; ++i )
       {
         sum += this->m_GetValueAndDerivativePerThreadVariables[ i ].st_Derivative[ j ];
       }

--- a/Components/Metrics/AdvancedMeanSquares/itkAdvancedMeanSquaresImageToImageMetric.hxx
+++ b/Components/Metrics/AdvancedMeanSquares/itkAdvancedMeanSquaresImageToImageMetric.hxx
@@ -326,7 +326,7 @@ AdvancedMeanSquaresImageToImageMetric< TFixedImage, TMovingImage >
   /** Get the samples for this thread. */
   const unsigned long nrOfSamplesPerThreads
     = static_cast< unsigned long >( std::ceil( static_cast< double >( sampleContainerSize )
-    / static_cast< double >( this->m_NumberOfThreads ) ) );
+    / static_cast< double >( Self::GetNumberOfThreads() ) ) );
 
   unsigned long pos_begin = nrOfSamplesPerThreads * threadId;
   unsigned long pos_end   = nrOfSamplesPerThreads * ( threadId + 1 );
@@ -403,9 +403,11 @@ void
 AdvancedMeanSquaresImageToImageMetric< TFixedImage, TMovingImage >
 ::AfterThreadedGetValue( MeasureType & value ) const
 {
+  const ThreadIdType numberOfThreads = Self::GetNumberOfThreads();
+
   /** Accumulate the number of pixels. */
   this->m_NumberOfPixelsCounted = this->m_GetValueAndDerivativePerThreadVariables[ 0 ].st_NumberOfPixelsCounted;
-  for( ThreadIdType i = 1; i < this->m_NumberOfThreads; ++i )
+  for( ThreadIdType i = 1; i < numberOfThreads; ++i )
   {
     this->m_NumberOfPixelsCounted += this->m_GetValueAndDerivativePerThreadVariables[ i ].st_NumberOfPixelsCounted;
 
@@ -424,7 +426,7 @@ AdvancedMeanSquaresImageToImageMetric< TFixedImage, TMovingImage >
 
   /** Accumulate values. */
   value = NumericTraits< MeasureType >::Zero;
-  for( ThreadIdType i = 0; i < this->m_NumberOfThreads; ++i )
+  for( ThreadIdType i = 0; i < numberOfThreads; ++i )
   {
     value += this->m_GetValueAndDerivativePerThreadVariables[ i ].st_Value;
 
@@ -655,7 +657,7 @@ AdvancedMeanSquaresImageToImageMetric< TFixedImage, TMovingImage >
   /** Get the samples for this thread. */
   const unsigned long nrOfSamplesPerThreads
     = static_cast< unsigned long >( std::ceil( static_cast< double >( sampleContainerSize )
-    / static_cast< double >( this->m_NumberOfThreads ) ) );
+    / static_cast< double >( Self::GetNumberOfThreads() ) ) );
 
   unsigned long pos_begin = nrOfSamplesPerThreads * threadId;
   unsigned long pos_end   = nrOfSamplesPerThreads * ( threadId + 1 );
@@ -749,9 +751,11 @@ AdvancedMeanSquaresImageToImageMetric< TFixedImage, TMovingImage >
 ::AfterThreadedGetValueAndDerivative(
   MeasureType & value, DerivativeType & derivative ) const
 {
+  const ThreadIdType numberOfThreads = Self::GetNumberOfThreads();
+
   /** Accumulate the number of pixels. */
   this->m_NumberOfPixelsCounted = this->m_GetValueAndDerivativePerThreadVariables[ 0 ].st_NumberOfPixelsCounted;
-  for( ThreadIdType i = 1; i < this->m_NumberOfThreads; ++i )
+  for( ThreadIdType i = 1; i < numberOfThreads; ++i )
   {
     this->m_NumberOfPixelsCounted += this->m_GetValueAndDerivativePerThreadVariables[ i ].st_NumberOfPixelsCounted;
 
@@ -770,7 +774,7 @@ AdvancedMeanSquaresImageToImageMetric< TFixedImage, TMovingImage >
 
   /** Accumulate values. */
   value = NumericTraits< MeasureType >::Zero;
-  for( ThreadIdType i = 0; i < this->m_NumberOfThreads; ++i )
+  for( ThreadIdType i = 0; i < numberOfThreads; ++i )
   {
     value += this->m_GetValueAndDerivativePerThreadVariables[ i ].st_Value;
 
@@ -784,7 +788,7 @@ AdvancedMeanSquaresImageToImageMetric< TFixedImage, TMovingImage >
   if( !this->m_UseMultiThread && false ) // force multi-threaded
   {
     derivative = this->m_GetValueAndDerivativePerThreadVariables[ 0 ].st_Derivative * normal_sum;
-    for( ThreadIdType i = 1; i < this->m_NumberOfThreads; i++ )
+    for( ThreadIdType i = 1; i < numberOfThreads; i++ )
     {
       derivative += this->m_GetValueAndDerivativePerThreadVariables[ i ].st_Derivative * normal_sum;
     }
@@ -809,7 +813,7 @@ AdvancedMeanSquaresImageToImageMetric< TFixedImage, TMovingImage >
     for( int j = 0; j < spaceDimension; ++j )
     {
       DerivativeValueType tmp = NumericTraits< DerivativeValueType >::Zero;
-      for( ThreadIdType i = 0; i < this->m_NumberOfThreads; ++i )
+      for( ThreadIdType i = 0; i < numberOfThreads; ++i )
       {
         tmp += this->m_GetValueAndDerivativePerThreadVariables[ i ].st_Derivative[ j ];
       }

--- a/Components/Metrics/AdvancedNormalizedCorrelation/itkAdvancedNormalizedCorrelationImageToImageMetric.hxx
+++ b/Components/Metrics/AdvancedNormalizedCorrelation/itkAdvancedNormalizedCorrelationImageToImageMetric.hxx
@@ -69,6 +69,8 @@ void
 AdvancedNormalizedCorrelationImageToImageMetric< TFixedImage, TMovingImage >
 ::InitializeThreadingParameters( void ) const
 {
+  const ThreadIdType numberOfThreads = Self::GetNumberOfThreads();
+
   /** Resize and initialize the threading related parameters.
    * The SetSize() functions do not resize the data when this is not
    * needed, which saves valuable re-allocation time.
@@ -77,19 +79,18 @@ AdvancedNormalizedCorrelationImageToImageMetric< TFixedImage, TMovingImage >
    */
 
   /** Only resize the array of structs when needed. */
-  if( this->m_CorrelationGetValueAndDerivativePerThreadVariablesSize != this->m_NumberOfThreads )
+  if( this->m_CorrelationGetValueAndDerivativePerThreadVariablesSize != numberOfThreads )
   {
     delete[] this->m_CorrelationGetValueAndDerivativePerThreadVariables;
     this->m_CorrelationGetValueAndDerivativePerThreadVariables
-      = new AlignedCorrelationGetValueAndDerivativePerThreadStruct[ this->
-      m_NumberOfThreads ];
-    this->m_CorrelationGetValueAndDerivativePerThreadVariablesSize = this->m_NumberOfThreads;
+      = new AlignedCorrelationGetValueAndDerivativePerThreadStruct[ numberOfThreads ];
+    this->m_CorrelationGetValueAndDerivativePerThreadVariablesSize = numberOfThreads;
   }
 
   /** Some initialization. */
   const AccumulateType      zero1 = NumericTraits< AccumulateType >::Zero;
   const DerivativeValueType zero2 = NumericTraits< DerivativeValueType >::Zero;
-  for( ThreadIdType i = 0; i < this->m_NumberOfThreads; ++i )
+  for( ThreadIdType i = 0; i < numberOfThreads; ++i )
   {
     this->m_CorrelationGetValueAndDerivativePerThreadVariables[ i ].st_NumberOfPixelsCounted = NumericTraits< SizeValueType >::Zero;
     this->m_CorrelationGetValueAndDerivativePerThreadVariables[ i ].st_Sff                   = zero1;
@@ -551,7 +552,7 @@ AdvancedNormalizedCorrelationImageToImageMetric< TFixedImage, TMovingImage >
   /** Get the samples for this thread. */
   const unsigned long nrOfSamplesPerThreads
     = static_cast< unsigned long >( std::ceil( static_cast< double >( sampleContainerSize )
-    / static_cast< double >( this->m_NumberOfThreads ) ) );
+    / static_cast< double >( Self::GetNumberOfThreads() ) ) );
 
   unsigned long pos_begin = nrOfSamplesPerThreads * threadId;
   unsigned long pos_end   = nrOfSamplesPerThreads * ( threadId + 1 );
@@ -659,10 +660,12 @@ AdvancedNormalizedCorrelationImageToImageMetric< TFixedImage, TMovingImage >
 ::AfterThreadedGetValueAndDerivative(
   MeasureType & value, DerivativeType & derivative ) const
 {
+  const ThreadIdType numberOfThreads = Self::GetNumberOfThreads();
+
   /** Accumulate the number of pixels. */
   this->m_NumberOfPixelsCounted
     = this->m_CorrelationGetValueAndDerivativePerThreadVariables[ 0 ].st_NumberOfPixelsCounted;
-  for( ThreadIdType i = 1; i < this->m_NumberOfThreads; ++i )
+  for( ThreadIdType i = 1; i < numberOfThreads; ++i )
   {
     this->m_NumberOfPixelsCounted
       += this->m_CorrelationGetValueAndDerivativePerThreadVariables[ i ].st_NumberOfPixelsCounted;
@@ -683,7 +686,7 @@ AdvancedNormalizedCorrelationImageToImageMetric< TFixedImage, TMovingImage >
   AccumulateType       sfm  = this->m_CorrelationGetValueAndDerivativePerThreadVariables[ 0 ].st_Sfm;
   AccumulateType       sf   = this->m_CorrelationGetValueAndDerivativePerThreadVariables[ 0 ].st_Sf;
   AccumulateType       sm   = this->m_CorrelationGetValueAndDerivativePerThreadVariables[ 0 ].st_Sm;
-  for( ThreadIdType i = 1; i < this->m_NumberOfThreads; ++i )
+  for( ThreadIdType i = 1; i < numberOfThreads; ++i )
   {
     sff += this->m_CorrelationGetValueAndDerivativePerThreadVariables[ i ].st_Sff;
     smm += this->m_CorrelationGetValueAndDerivativePerThreadVariables[ i ].st_Smm;
@@ -730,7 +733,7 @@ AdvancedNormalizedCorrelationImageToImageMetric< TFixedImage, TMovingImage >
     DerivativeType & derivativeM  = this->m_CorrelationGetValueAndDerivativePerThreadVariables[ 0 ].st_DerivativeM;
     DerivativeType & differential = this->m_CorrelationGetValueAndDerivativePerThreadVariables[ 0 ].st_Differential;
 
-    for( ThreadIdType i = 1; i < this->m_NumberOfThreads; ++i )
+    for( ThreadIdType i = 1; i < numberOfThreads; ++i )
     {
       derivativeF  += this->m_CorrelationGetValueAndDerivativePerThreadVariables[ i ].st_DerivativeF;
       derivativeM  += this->m_CorrelationGetValueAndDerivativePerThreadVariables[ i ].st_DerivativeM;
@@ -792,7 +795,7 @@ AdvancedNormalizedCorrelationImageToImageMetric< TFixedImage, TMovingImage >
       DerivativeValueType differential
         = this->m_CorrelationGetValueAndDerivativePerThreadVariables[ 0 ].st_Differential[ j ];
 
-      for( ThreadIdType i = 1; i < this->m_NumberOfThreads; ++i )
+      for( ThreadIdType i = 1; i < numberOfThreads; ++i )
       {
         derivativeF  += this->m_CorrelationGetValueAndDerivativePerThreadVariables[ i ].st_DerivativeF[ j ];
         derivativeM  += this->m_CorrelationGetValueAndDerivativePerThreadVariables[ i ].st_DerivativeM[ j ];

--- a/Components/Metrics/SumSquaredTissueVolumeDifferenceMetric/itkSumSquaredTissueVolumeDifferenceImageToImageMetric.hxx
+++ b/Components/Metrics/SumSquaredTissueVolumeDifferenceMetric/itkSumSquaredTissueVolumeDifferenceImageToImageMetric.hxx
@@ -218,7 +218,7 @@ void SumSquaredTissueVolumeDifferenceImageToImageMetric<TFixedImage,TMovingImage
   /** Get the samples for this thread. */
   const unsigned long nSamplesPerThread
     = static_cast<unsigned long>( std::ceil( static_cast<double>( sampleContainerSize )
-    / static_cast<double>( this->m_NumberOfThreads ) ) );
+    / static_cast<double>( Self::GetNumberOfThreads() ) ) );
 
   unsigned long pos_begin = nSamplesPerThread * threadId;
   unsigned long pos_end = nSamplesPerThread * (threadId + 1);
@@ -295,9 +295,11 @@ template <class TFixedImage, class TMovingImage>
 void SumSquaredTissueVolumeDifferenceImageToImageMetric<TFixedImage,TMovingImage>
 ::AfterThreadedGetValue( MeasureType & value ) const
 {
+  const ThreadIdType numberOfThreads = Self::GetNumberOfThreads();
+
   /** Accumulate the number of pixels. */
   this->m_NumberOfPixelsCounted = this->m_GetValueAndDerivativePerThreadVariables[ 0 ].st_NumberOfPixelsCounted;
-  for( ThreadIdType i = 1; i < this->m_NumberOfThreads; ++i )
+  for( ThreadIdType i = 1; i < numberOfThreads; ++i )
   {
     this->m_NumberOfPixelsCounted += this->m_GetValueAndDerivativePerThreadVariables[ i ].st_NumberOfPixelsCounted;
 
@@ -312,7 +314,7 @@ void SumSquaredTissueVolumeDifferenceImageToImageMetric<TFixedImage,TMovingImage
 
   /** Accumulate values. */
   value = NumericTraits< MeasureType >::Zero;
-  for( ThreadIdType i = 0; i < this->m_NumberOfThreads; ++i )
+  for( ThreadIdType i = 0; i < numberOfThreads; ++i )
   {
     value += this->m_GetValueAndDerivativePerThreadVariables[ i ].st_Value;
 
@@ -545,7 +547,7 @@ SumSquaredTissueVolumeDifferenceImageToImageMetric<TFixedImage, TMovingImage>
   /** Get the samples for this thread. */
   const unsigned long nSamplesPerThread
     = static_cast<unsigned long>(std::ceil(static_cast<double>( sampleContainerSize )
-      / static_cast<double>( this->m_NumberOfThreads ) ) );
+      / static_cast<double>( Self::GetNumberOfThreads() ) ) );
 
   unsigned long pos_begin = nSamplesPerThread * threadId;
   unsigned long pos_end = nSamplesPerThread * (threadId + 1);
@@ -648,9 +650,11 @@ SumSquaredTissueVolumeDifferenceImageToImageMetric<TFixedImage, TMovingImage>
   MeasureType & value,
   DerivativeType & derivative ) const
 {
+  const ThreadIdType numberOfThreads = Self::GetNumberOfThreads();
+
   /** Accumulate the number of pixels. */
   this->m_NumberOfPixelsCounted = this->m_GetValueAndDerivativePerThreadVariables[0].st_NumberOfPixelsCounted;
-  for( ThreadIdType i = 1; i < this->m_NumberOfThreads; ++i )
+  for( ThreadIdType i = 1; i < numberOfThreads; ++i )
   {
     this->m_NumberOfPixelsCounted += this->m_GetValueAndDerivativePerThreadVariables[i].st_NumberOfPixelsCounted;
 
@@ -664,7 +668,7 @@ SumSquaredTissueVolumeDifferenceImageToImageMetric<TFixedImage, TMovingImage>
 
   /** Accumulate values. */
   value = NumericTraits< MeasureType >::Zero;
-  for( ThreadIdType i = 0; i < this->m_NumberOfThreads; ++i )
+  for( ThreadIdType i = 0; i < numberOfThreads; ++i )
   {
     value += this->m_GetValueAndDerivativePerThreadVariables[i].st_Value;
 
@@ -679,7 +683,7 @@ SumSquaredTissueVolumeDifferenceImageToImageMetric<TFixedImage, TMovingImage>
   if( !this->m_UseMultiThread && false ) // force multi-threaded as in AdvancedMeanSquares
   {
     derivative = this->m_GetValueAndDerivativePerThreadVariables[ 0 ].st_Derivative;
-    for( ThreadIdType i = 1; i < this->m_NumberOfThreads; ++i )
+    for( ThreadIdType i = 1; i < numberOfThreads; ++i )
     {
       derivative += this->m_GetValueAndDerivativePerThreadVariables[ i ].st_Derivative;
     }
@@ -708,7 +712,7 @@ SumSquaredTissueVolumeDifferenceImageToImageMetric<TFixedImage, TMovingImage>
     for( int j = 0; j < spaceDimension; ++j )
     {
       DerivativeValueType tmp = NumericTraits< DerivativeValueType >::Zero;
-      for( ThreadIdType i = 0; i < this->m_NumberOfThreads; ++i )
+      for( ThreadIdType i = 0; i < numberOfThreads; ++i )
       {
         tmp += this->m_GetValueAndDerivativePerThreadVariables[ i ].st_Derivative[ j ];
       }


### PR DESCRIPTION
This commit replaces all direct access to the protected `itk::ImageToImageMetric` data member `m_NumberOfThreads` by calls to its `GetNumberOfThreads()` member function.

Doing so clarifies that elastix does not modify `itk::ImageToImageMetric::m_NumberOfThreads` directly. It is also a style improvement, because it reduces the dependency on the `itk::ImageToImageMetric` implementation.