### PR TITLE
ITK5 thread workaround

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -77,6 +77,8 @@ if ( NOT ITK_VERSION VERSION_LESS "5.0.0" )
     -Dvnl_math_sgn=vnl_math::sgn
     -Dvnl_math_sqr=vnl_math::sqr
    )
+  # Workaround to still allow #include "itkMultiThreader.h" with ITK >= 5.
+  include_directories( ${CMAKE_CURRENT_SOURCE_DIR}/Common/ITK5Workaround )
 endif()
 
 

--- a/Common/CostFunctions/itkAdvancedImageToImageMetric.h
+++ b/Common/CostFunctions/itkAdvancedImageToImageMetric.h
@@ -370,6 +370,14 @@ protected:
   MovingImageLimiterOutputType m_MovingImageMinLimit;
   MovingImageLimiterOutputType m_MovingImageMaxLimit;
 
+#if ITK_VERSION_MAJOR >= 5
+  /** \note This is a workaround for ITK5, which renamed NumberOfThreads to NumberOfWorkUnits. */
+  ThreadIdType GetNumberOfThreads() const
+  {
+    return Superclass::GetNumberOfWorkUnits();
+  }
+#endif
+
   /** Multi-threaded metric computation. */
 
   /** Multi-threaded version of GetValue(). */

--- a/Common/CostFunctions/itkAdvancedImageToImageMetric.hxx
+++ b/Common/CostFunctions/itkAdvancedImageToImageMetric.hxx
@@ -139,7 +139,13 @@ void
 AdvancedImageToImageMetric< TFixedImage, TMovingImage >
 ::SetNumberOfThreads( ThreadIdType numberOfThreads )
 {
+#if ITK_VERSION_MAJOR >= 5
+  // Note: This is a workaround for ITK5, which renamed NumberOfThreads
+  // to NumberOfWorkUnits
+  Superclass::SetNumberOfWorkUnits( numberOfThreads );
+#else
   Superclass::SetNumberOfThreads( numberOfThreads );
+#endif
 
 #ifdef ELASTIX_USE_OPENMP
   const int nthreads = static_cast< int >( Self::GetNumberOfThreads() );

--- a/Common/CostFunctions/itkAdvancedImageToImageMetric.hxx
+++ b/Common/CostFunctions/itkAdvancedImageToImageMetric.hxx
@@ -87,8 +87,13 @@ AdvancedImageToImageMetric< TFixedImage, TMovingImage >
   /** Threading related variables. */
   this->m_UseMetricSingleThreaded = true;
   this->m_UseMultiThread = false;
+
+#if ITK_VERSION_MAJOR < 5
+  // Note: This `#if` is a workaround for ITK5, which no longer supports calling
+  // `threader->SetUseThreadPool(false)`. ITK5 does not use thread pools by default. 
   this->m_Threader->SetUseThreadPool( false ); // setting to true makes elastix hang
                                                // at a WaitForSingleMethodThread()
+#endif
 
   /** OpenMP related. Switch to on when available */
 #ifdef ELASTIX_USE_OPENMP

--- a/Common/ITK5Workaround/itkMultiThreader.h
+++ b/Common/ITK5Workaround/itkMultiThreader.h
@@ -1,0 +1,36 @@
+/*=========================================================================
+ *
+ *  Copyright UMC Utrecht and contributors
+ *
+ *  Licensed under the Apache License, Version 2.0 (the "License");
+ *  you may not use this file except in compliance with the License.
+ *  You may obtain a copy of the License at
+ *
+ *        http://www.apache.org/licenses/LICENSE-2.0.txt
+ *
+ *  Unless required by applicable law or agreed to in writing, software
+ *  distributed under the License is distributed on an "AS IS" BASIS,
+ *  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *  See the License for the specific language governing permissions and
+ *  limitations under the License.
+ *
+ *=========================================================================*/
+
+#ifndef elxITK5Workaround_itkMultiThreader_h
+#define elxITK5Workaround_itkMultiThreader_h
+
+// This header file provides a workaround to still allow doing
+// #include "itkMultiThreader.h" with ITK >= 5.
+
+#include "itkPlatformMultiThreader.h"
+
+using itk::ITK_THREAD_RETURN_TYPE;
+
+const ITK_THREAD_RETURN_TYPE ITK_THREAD_RETURN_VALUE = ITK_THREAD_RETURN_DEFAULT_VALUE;
+
+namespace itk
+{
+  typedef PlatformMultiThreader MultiThreader;
+}
+
+#endif

--- a/Common/Transforms/itkAdvancedImageMomentsCalculator.hxx
+++ b/Common/Transforms/itkAdvancedImageMomentsCalculator.hxx
@@ -67,7 +67,12 @@ AdvancedImageMomentsCalculator< TImage >::AdvancedImageMomentsCalculator(void)
   /** Threading related variables. */
   this->m_UseMultiThread = true;
   this->m_Threader = ThreaderType::New();
+
+#if ITK_VERSION_MAJOR < 5
+  // Note: This `#if` is a workaround for ITK5, which no longer supports calling
+  // `threader->SetUseThreadPool(false)`. ITK5 does not use thread pools by default. 
   this->m_Threader->SetUseThreadPool(false);
+#endif
 
   /** Initialize the m_ThreaderParameters. */
   this->m_ThreaderParameters.st_Self = this;

--- a/Common/itkComputeDisplacementDistribution.hxx
+++ b/Common/itkComputeDisplacementDistribution.hxx
@@ -53,7 +53,12 @@ ComputeDisplacementDistribution< TFixedImage, TTransform >
   /** Threading related variables. */
   this->m_UseMultiThread = true;
   this->m_Threader       = ThreaderType::New();
+
+#if ITK_VERSION_MAJOR < 5
+  // Note: This `#if` is a workaround for ITK5, which no longer supports calling
+  // `threader->SetUseThreadPool(false)`. ITK5 does not use thread pools by default. 
   this->m_Threader->SetUseThreadPool( false );
+#endif
 
   /** Initialize the m_ThreaderParameters. */
   this->m_ThreaderParameters.st_Self = this;


### PR DESCRIPTION
This pull request allows compilation with both ITK4 _and_ ITK5 (latest from git master branch at https://github.com/InsightSoftwareConsortium/ITK/commit/dc26af240c732b2e74f8bcd0464066e8b189b2e1):

- COMP: Avoided m_Threader->SetUseThreadPool(false) with ITK5 
- COMP: Workaround ITK5, renaming NumberOfThreads into NumberOfWorkUnits 
- COMP: Workaround ITK5, renaming MultiThreader to PlatformMultiThreader 