### PR TITLE
Initial commits to support ITK5 with USE_ALL_COMPONENTS

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -76,6 +76,8 @@ if ( NOT ITK_VERSION VERSION_LESS "5.0.0" )
     -Dvnl_math_sgn0=vnl_math::sgn0
     -Dvnl_math_sgn=vnl_math::sgn
     -Dvnl_math_sqr=vnl_math::sqr
+     # Note: std::cbrt was introduced with C++11
+     -Dvnl_math_cuberoot=std::cbrt
    )
   # Workaround to still allow #include "itkMultiThreader.h" with ITK >= 5.
   include_directories( ${CMAKE_CURRENT_SOURCE_DIR}/Common/ITK5Workaround )

--- a/Components/Metrics/MissingStructurePenalty/elxMissingStructurePenalty.hxx
+++ b/Components/Metrics/MissingStructurePenalty/elxMissingStructurePenalty.hxx
@@ -145,7 +145,7 @@ MissingStructurePenalty< TElastix >
     std::ostringstream fmeshArgument( "-fmesh", std::ios_base::ate );
     fmeshArgument << ch << metricNumber;
     std::string fixedMeshName = this->GetConfiguration()->GetCommandLineArgument( fmeshArgument.str() );
-    typename MeshType::Pointer fixedMesh = 0;
+    typename MeshType::Pointer fixedMesh; // default-constructed (null)
     if( itksys::SystemTools::GetFilenameLastExtension( fixedMeshName ) == ".txt" )
     {
       this->ReadTransformixPoints( fixedMeshName, fixedMesh );

--- a/Components/Metrics/MissingStructurePenalty/itkMissingStructurePenalty.hxx
+++ b/Components/Metrics/MissingStructurePenalty/itkMissingStructurePenalty.hxx
@@ -19,6 +19,7 @@
 #define __itkMissingStructurePenalty_hxx
 
 #include "itkMissingStructurePenalty.h"
+#include <cmath>
 
 namespace itk
 {
@@ -302,7 +303,7 @@ MissingVolumeMeshPenalty< TFixedPointSet, TMovingPointSet >
       }
 
       sumSignedVolume +=  signedVolume;
-      sumAbsVolume    += vcl_abs( signedVolume );
+      sumAbsVolume    += std::abs( signedVolume );
     }
 
     /** Create iterators. */

--- a/Components/Metrics/PatternIntensity/itkPatternIntensityImageToImageMetric.hxx
+++ b/Components/Metrics/PatternIntensity/itkPatternIntensityImageToImageMetric.hxx
@@ -22,6 +22,7 @@
 #include "itkImageRegionConstIteratorWithIndex.h"
 #include "itkNumericTraits.h"
 
+#include <cmath>
 #include <iostream>
 #include <iomanip>
 #include <stdio.h>
@@ -107,7 +108,7 @@ PatternIntensityImageToImageMetric< TFixedImage, TMovingImage >
   /* to rescale the similarity measure between 0-1;*/
   MeasureType tmpmeasure = this->GetValue( this->m_Transform->GetParameters() );
 
-  while( ( vcl_fabs( tmpmeasure ) / this->m_Rescalingfactor ) > 1 )
+  while( ( std::fabs( tmpmeasure ) / this->m_Rescalingfactor ) > 1 )
   {
     this->m_Rescalingfactor *= 10;
   }

--- a/Components/Metrics/PolydataDummyPenalty/elxPolydataDummyPenalty.hxx
+++ b/Components/Metrics/PolydataDummyPenalty/elxPolydataDummyPenalty.hxx
@@ -132,7 +132,7 @@ PolydataDummyPenalty< TElastix >
     std::ostringstream fmeshArgument( "-fmesh", std::ios_base::ate );
     fmeshArgument << ch << metricNumber;
     std::string fixedMeshName = this->GetConfiguration()->GetCommandLineArgument( fmeshArgument.str() );
-    typename MeshType::Pointer fixedMesh = 0;
+    typename MeshType::Pointer fixedMesh; // default-constructed (null)
     if( itksys::SystemTools::GetFilenameLastExtension( fixedMeshName ) == ".txt" )
     {
       this->ReadTransformixPoints( fixedMeshName, fixedMesh );

--- a/Components/Metrics/StatisticalShapePenalty/elxStatisticalShapePenalty.hxx
+++ b/Components/Metrics/StatisticalShapePenalty/elxStatisticalShapePenalty.hxx
@@ -28,6 +28,7 @@
 #include "itkTransformMeshFilter.h"
 #include <itkMesh.h>
 
+#include <fstream>
 #include <typeinfo>
 
 namespace elastix
@@ -85,7 +86,7 @@ StatisticalShapePenalty< TElastix >
 
   /** Read meanVector filename. */
   std::string                  meanVectorName = this->GetConfiguration()->GetCommandLineArgument( "-mean" );
-  vcl_ifstream                 datafile;
+  std::ifstream                 datafile;
   vnl_vector< double > * const meanVector = new vnl_vector< double >();
   datafile.open( meanVectorName.c_str() );
   if( datafile.is_open() )

--- a/Components/Metrics/StatisticalShapePenalty/elxStatisticalShapePenalty.hxx
+++ b/Components/Metrics/StatisticalShapePenalty/elxStatisticalShapePenalty.hxx
@@ -73,7 +73,7 @@ StatisticalShapePenalty< TElastix >
 
   /** Read and set the fixed pointset. */
   std::string fixedName = this->GetConfiguration()->GetCommandLineArgument( "-fp" );
-  typename PointSetType::Pointer fixedPointSet      = 0;
+  typename PointSetType::Pointer fixedPointSet; // default-constructed (null)
   const typename ImageType::ConstPointer fixedImage = this->GetElastix()->GetFixedImage();
   const unsigned int nrOfFixedPoints = this->ReadShape(
     fixedName, fixedPointSet, fixedImage );

--- a/Components/Metrics/StatisticalShapePenalty/itkStatisticalShapePointPenalty.hxx
+++ b/Components/Metrics/StatisticalShapePenalty/itkStatisticalShapePointPenalty.hxx
@@ -19,6 +19,7 @@
 #define __itkStatisticalShapePointPenalty_hxx
 
 #include "itkStatisticalShapePointPenalty.h"
+#include <cmath>
 
 namespace itk
 {
@@ -976,8 +977,8 @@ StatisticalShapePointPenalty< TFixedPointSet, TMovingPointSet >
 {
   if( this->m_CutOffValue > 0.0 )
   {
-    value = vcl_log( vcl_exp( this->m_CutOffSharpness * value )
-      + vcl_exp( this->m_CutOffSharpness * this->m_CutOffValue ) )
+    value = std::log( std::exp( this->m_CutOffSharpness * value )
+      + std::exp( this->m_CutOffSharpness * this->m_CutOffValue ) )
       / this->m_CutOffSharpness;
   }
 } // end CalculateCutOffValue()
@@ -996,7 +997,7 @@ StatisticalShapePointPenalty< TFixedPointSet, TMovingPointSet >
 {
   if( this->m_CutOffValue > 0.0 )
   {
-    derivativeElement *= 1.0 / ( 1.0 + vcl_exp( this->m_CutOffSharpness
+    derivativeElement *= 1.0 / ( 1.0 + std::exp( this->m_CutOffSharpness
       * ( this->m_CutOffValue - value ) ) );
   }
 } // end CalculateCutOffDerivative()

--- a/Components/Optimizers/CMAEvolutionStrategy/itkCMAEvolutionStrategyOptimizer.cxx
+++ b/Components/Optimizers/CMAEvolutionStrategy/itkCMAEvolutionStrategyOptimizer.cxx
@@ -23,6 +23,7 @@
 #include "itkSymmetricEigenAnalysis.h"
 #include "vnl/vnl_math.h"
 #include <algorithm>
+#include <cmath>
 #include "itkCommand.h"
 #include "itkEventObject.h"
 #include "itkExceptionObject.h"
@@ -293,7 +294,7 @@ CMAEvolutionStrategyOptimizer::InitializeConstants( void )
   if( this->m_PopulationSize == 0 )
   {
     this->m_PopulationSize = 4 + static_cast< unsigned int >(
-      vcl_floor( 3.0 * vcl_log( static_cast< double >( numberOfParameters ) ) ) );
+      std::floor( 3.0 * std::log( static_cast< double >( numberOfParameters ) ) ) );
   }
 
   /** m_NumberOfParents (if not provided by the user) */
@@ -323,11 +324,11 @@ CMAEvolutionStrategyOptimizer::InitializeConstants( void )
   }
   else if( this->m_RecombinationWeightsPreset == "superlinear" )
   {
-    const double logmud = vcl_log( mud + 1.0 );
+    const double logmud = std::log( mud + 1.0 );
     for( unsigned int i = 0; i < mu; ++i )
     {
       this->m_RecombinationWeights[ i ]
-        = logmud - vcl_log( static_cast< double >( i + 1 ) );
+        = logmud - std::log( static_cast< double >( i + 1 ) );
     }
   }
   this->m_RecombinationWeights /= this->m_RecombinationWeights.sum();
@@ -365,7 +366,7 @@ CMAEvolutionStrategyOptimizer::InitializeConstants( void )
   /** Update only every 'period' iterations */
   if( this->m_UpdateBDPeriod == 0 )
   {
-    this->m_UpdateBDPeriod = static_cast< unsigned int >( vcl_floor( 1.0 / c_cov / Nd / 10.0 ) );
+    this->m_UpdateBDPeriod = static_cast< unsigned int >( std::floor( 1.0 / c_cov / Nd / 10.0 ) );
   }
   this->m_UpdateBDPeriod = vnl_math_max( static_cast< unsigned int >( 1 ), this->m_UpdateBDPeriod );
   if( this->m_UpdateBDPeriod >= this->m_MaximumNumberOfIterations )
@@ -690,7 +691,7 @@ CMAEvolutionStrategyOptimizer::UpdateHeaviside( void )
   /** Compute the Heaviside function: */
   this->m_Heaviside = false;
   const double normps        = this->m_ConjugateEvolutionPath.magnitude();
-  const double denom         = std::sqrt( 1.0 - vcl_pow( 1.0 - c_sigma, 2 * nextit ) );
+  const double denom         = std::sqrt( 1.0 - std::pow( 1.0 - c_sigma, 2 * nextit ) );
   const double righthandside = 1.5 + 1.0 / ( Nd - 0.5 );
   if( ( normps / denom / chiN ) < righthandside )
   {
@@ -805,8 +806,8 @@ CMAEvolutionStrategyOptimizer::UpdateSigma( void )
   if( this->GetUseDecayingSigma() )
   {
     const double it  = static_cast< double >( this->GetCurrentIteration() );
-    const double num = vcl_pow( this->m_SigmaDecayA + it, this->m_SigmaDecayAlpha );
-    const double den = vcl_pow( this->m_SigmaDecayA + it + 1.0, this->m_SigmaDecayAlpha );
+    const double num = std::pow( this->m_SigmaDecayA + it, this->m_SigmaDecayAlpha );
+    const double den = std::pow( this->m_SigmaDecayA + it + 1.0, this->m_SigmaDecayAlpha );
     this->m_CurrentSigma *= num / den;
   }
   else
@@ -815,7 +816,7 @@ CMAEvolutionStrategyOptimizer::UpdateSigma( void )
     const double chiN    = this->m_ExpectationNormNormalDistribution;
     const double c_sigma = this->m_ConjugateEvolutionPathConstant;
     const double d_sigma = this->m_SigmaDampingConstant;
-    this->m_CurrentSigma *= vcl_exp( ( normps / chiN - 1.0 ) * c_sigma / d_sigma );
+    this->m_CurrentSigma *= std::exp( ( normps / chiN - 1.0 ) * c_sigma / d_sigma );
   }
 
 } // end UpdateSigma
@@ -927,8 +928,8 @@ CMAEvolutionStrategyOptimizer::FixNumericalErrors( void )
   const double       c_sigma         = this->m_ConjugateEvolutionPathConstant;
   const double       c_cov           = this->m_CovarianceMatrixAdaptationConstant;
   const double       d_sigma         = this->m_SigmaDampingConstant;
-  const double       strange_factor  = vcl_exp( 0.05 + c_sigma / d_sigma );
-  const double       strange_factor2 = vcl_exp( 0.2 + c_sigma / d_sigma );
+  const double       strange_factor  = std::exp( 0.05 + c_sigma / d_sigma );
+  const double       strange_factor2 = std::exp( 0.2 + c_sigma / d_sigma );
   const unsigned int nextit          = this->m_CurrentIteration + 1;
 
   /** Check if m_MaximumDeviation and m_MinimumDeviation are satisfied. This
@@ -1188,7 +1189,7 @@ CMAEvolutionStrategyOptimizer::TestConvergence( bool firstCheck )
   bool         stepTooSmall = true;
   for( unsigned int i = 0; i < N; ++i )
   {
-    const double pci     = vcl_abs( this->m_EvolutionPath[ i ] );
+    const double pci     = std::abs( this->m_EvolutionPath[ i ] );
     double       sqrtCii = 1.0;
     if( this->m_UseCovarianceMatrixAdaptation )
     {

--- a/Components/Optimizers/ConjugateGradientFRPR/elxConjugateGradientFRPR.hxx
+++ b/Components/Optimizers/ConjugateGradientFRPR/elxConjugateGradientFRPR.hxx
@@ -20,6 +20,7 @@
 #define __elxConjugateGradientFRPR_hxx
 
 #include "elxConjugateGradientFRPR.h"
+#include <cmath>
 #include <iomanip>
 #include <string>
 #include "vnl/vnl_math.h"
@@ -131,7 +132,7 @@ ConjugateGradientFRPR< TElastix >
   this->SetStepLength( stepLength );
 
   /** Set the ValueTolerance; convergence is declared if:
-   * 2.0 * abs(f2 - f1) <=  ValueTolerance * (abs(f2) + vcl_abs(f1))
+   * 2.0 * abs(f2 - f1) <=  ValueTolerance * (abs(f2) + std::abs(f1))
    */
   double valueTolerance = 0.00001;
   this->m_Configuration->ReadParameter( valueTolerance,

--- a/Components/Transforms/AffineDTITransform/itkAffineDTI2DTransform.hxx
+++ b/Components/Transforms/AffineDTITransform/itkAffineDTI2DTransform.hxx
@@ -19,6 +19,7 @@
 #define __itkAffineDTI2DTransform_hxx
 
 #include "itkAffineDTI2DTransform.h"
+#include <cmath>
 
 namespace itk
 {
@@ -165,8 +166,8 @@ AffineDTI2DTransform< TScalarType >
 ::ComputeMatrix( void )
 {
   // need to check if angles are in the right order
-  const double cx  = vcl_cos( this->m_Angle[ 0 ] );
-  const double sx  = vcl_sin( this->m_Angle[ 0 ] );
+  const double cx  = std::cos( this->m_Angle[ 0 ] );
+  const double sx  = std::sin( this->m_Angle[ 0 ] );
   const double gx  = this->m_Shear[ 0 ];
   const double gy  = this->m_Shear[ 1 ];
   const double ssx = this->m_Scale[ 0 ];
@@ -248,16 +249,16 @@ AffineDTI2DTransform< TScalarType >
   jsj.resize( ParametersDimension );
 
   // need to check if angles are in the right order
-  const double cx  = vcl_cos( this->m_Angle[ 0 ] );
-  const double sx  = vcl_sin( this->m_Angle[ 0 ] );
+  const double cx  = std::cos( this->m_Angle[ 0 ] );
+  const double sx  = std::sin( this->m_Angle[ 0 ] );
   const double gx  = this->m_Shear[ 0 ];
   const double gy  = this->m_Shear[ 1 ];
   const double ssx = this->m_Scale[ 0 ];
   const double ssy = this->m_Scale[ 1 ];
 
   /** derivatives: */
-  const double cxd = -vcl_sin( this->m_Angle[ 0 ] );
-  const double sxd = vcl_cos( this->m_Angle[ 0 ] );
+  const double cxd = -std::sin( this->m_Angle[ 0 ] );
+  const double sxd = std::cos( this->m_Angle[ 0 ] );
 
   /** NB: opposite definition as in EulerTransform */
   MatrixType Rotation;

--- a/Components/Transforms/AffineDTITransform/itkAffineDTI3DTransform.hxx
+++ b/Components/Transforms/AffineDTITransform/itkAffineDTI3DTransform.hxx
@@ -36,6 +36,7 @@
 #define __itkAffineDTI3DTransform_hxx
 
 #include "itkAffineDTI3DTransform.h"
+#include <cmath>
 
 namespace itk
 {
@@ -192,12 +193,12 @@ AffineDTI3DTransform< TScalarType >
 ::ComputeMatrix( void )
 {
   // need to check if angles are in the right order
-  const double cx  = vcl_cos( this->m_Angle[ 0 ] );
-  const double sx  = vcl_sin( this->m_Angle[ 0 ] );
-  const double cy  = vcl_cos( this->m_Angle[ 1 ] );
-  const double sy  = vcl_sin( this->m_Angle[ 1 ] );
-  const double cz  = vcl_cos( this->m_Angle[ 2 ] );
-  const double sz  = vcl_sin( this->m_Angle[ 2 ] );
+  const double cx  = std::cos( this->m_Angle[ 0 ] );
+  const double sx  = std::sin( this->m_Angle[ 0 ] );
+  const double cy  = std::cos( this->m_Angle[ 1 ] );
+  const double sy  = std::sin( this->m_Angle[ 1 ] );
+  const double cz  = std::cos( this->m_Angle[ 2 ] );
+  const double sz  = std::sin( this->m_Angle[ 2 ] );
   const double gx  = this->m_Shear[ 0 ];
   const double gy  = this->m_Shear[ 1 ];
   const double gz  = this->m_Shear[ 2 ];
@@ -300,12 +301,12 @@ AffineDTI3DTransform< TScalarType >
   jsj.resize( ParametersDimension );
 
   // need to check if angles are in the right order
-  const double cx  = vcl_cos( this->m_Angle[ 0 ] );
-  const double sx  = vcl_sin( this->m_Angle[ 0 ] );
-  const double cy  = vcl_cos( this->m_Angle[ 1 ] );
-  const double sy  = vcl_sin( this->m_Angle[ 1 ] );
-  const double cz  = vcl_cos( this->m_Angle[ 2 ] );
-  const double sz  = vcl_sin( this->m_Angle[ 2 ] );
+  const double cx  = std::cos( this->m_Angle[ 0 ] );
+  const double sx  = std::sin( this->m_Angle[ 0 ] );
+  const double cy  = std::cos( this->m_Angle[ 1 ] );
+  const double sy  = std::sin( this->m_Angle[ 1 ] );
+  const double cz  = std::cos( this->m_Angle[ 2 ] );
+  const double sz  = std::sin( this->m_Angle[ 2 ] );
   const double gx  = this->m_Shear[ 0 ];
   const double gy  = this->m_Shear[ 1 ];
   const double gz  = this->m_Shear[ 2 ];
@@ -314,12 +315,12 @@ AffineDTI3DTransform< TScalarType >
   const double ssz = this->m_Scale[ 2 ];
 
   /** derivatives: */
-  const double cxd = -vcl_sin( this->m_Angle[ 0 ] );
-  const double sxd = vcl_cos( this->m_Angle[ 0 ] );
-  const double cyd = -vcl_sin( this->m_Angle[ 1 ] );
-  const double syd = vcl_cos( this->m_Angle[ 1 ] );
-  const double czd = -vcl_sin( this->m_Angle[ 2 ] );
-  const double szd = vcl_cos( this->m_Angle[ 2 ] );
+  const double cxd = -std::sin( this->m_Angle[ 0 ] );
+  const double sxd = std::cos( this->m_Angle[ 0 ] );
+  const double cyd = -std::sin( this->m_Angle[ 1 ] );
+  const double syd = std::cos( this->m_Angle[ 1 ] );
+  const double czd = -std::sin( this->m_Angle[ 2 ] );
+  const double szd = std::cos( this->m_Angle[ 2 ] );
 
   /** NB: opposite definition as in EulerTransform */
   MatrixType RotationX;

--- a/Components/Transforms/BSplineDeformableTransformWithDiffusion/elxBSplineTransformWithDiffusion.hxx
+++ b/Components/Transforms/BSplineDeformableTransformWithDiffusion/elxBSplineTransformWithDiffusion.hxx
@@ -24,7 +24,7 @@
 #include "itkBSplineResampleImageFunction.h"
 #include "itkBSplineDecompositionImageFilter.h"
 
-#include "vnl/vnl_math.h"
+#include <cmath>
 
 namespace elastix
 {
@@ -652,7 +652,7 @@ BSplineTransformWithDiffusion< TElastix >
   {
     int nrOfResolutions = static_cast< int >(
       this->GetRegistration()->GetAsITKBaseType()->GetNumberOfLevels() );
-    this->m_GridSpacingFactor *= vcl_pow( 2.0,
+    this->m_GridSpacingFactor *= std::pow( 2.0,
       static_cast< double >( nrOfResolutions - 1 ) );
   }
 
@@ -661,7 +661,7 @@ BSplineTransformWithDiffusion< TElastix >
   {
     gridspacing[ j ] = gridspacing[ j ] * this->m_GridSpacingFactor[ j ];
     gridorigin[ j ] -= gridspacing[ j ]
-      * vcl_floor( static_cast< double >( SplineOrder ) / 2.0 );
+      * std::floor( static_cast< double >( SplineOrder ) / 2.0 );
     gridindex[ j ] = 0; // isn't this always the case anyway?
     gridsize[ j ]  = static_cast< typename RegionType::SizeValueType >
       ( std::ceil( gridsize[ j ] / this->m_GridSpacingFactor[ j ] ) + SplineOrder );
@@ -733,7 +733,7 @@ BSplineTransformWithDiffusion< TElastix >
   {
     gridspacingHigh[ j ] = gridspacingHigh[ j ] * this->m_GridSpacingFactor[ j ];
     gridoriginHigh[ j ] -= gridspacingHigh[ j ]
-      * vcl_floor( static_cast< double >( SplineOrder ) / 2.0 );
+      * std::floor( static_cast< double >( SplineOrder ) / 2.0 );
     gridindexHigh[ j ] = 0; // isn't this always the case anyway?
     gridsizeHigh[ j ]  = static_cast< typename RegionType::SizeValueType >
       ( std::ceil( gridsizeHigh[ j ] / this->m_GridSpacingFactor[ j ] ) + SplineOrder );

--- a/Components/Transforms/WeightedCombinationTransform/elxWeightedCombinationTransform.hxx
+++ b/Components/Transforms/WeightedCombinationTransform/elxWeightedCombinationTransform.hxx
@@ -245,8 +245,9 @@ WeightedCombinationTransformElastix< TElastix >
   }
 
   /** Create a vector of subTransform pointers and initialize to null pointers.
+   * Note that std::vector will properly initialize its elements to null (by default).
    * \todo: make it a member variable if it appears to needed later */
-  TransformContainerType subTransforms( N, 0 );
+  TransformContainerType subTransforms( N );
 
   /** Load each subTransform */
   for( unsigned int i = 0; i < N; ++i )
@@ -283,7 +284,9 @@ WeightedCombinationTransformElastix< TElastix >
     PtrToCreator testcreator = 0;
     testcreator = this->GetElastix()->GetComponentDatabase()
       ->GetCreator( subTransformName, this->m_Elastix->GetDBIndex() );
-    subTransform = testcreator ? testcreator() : NULL;
+
+    // Note that ObjectType::Pointer() yields a default-constructed SmartPointer (null).
+    subTransform = testcreator ? testcreator() : typename ObjectType::Pointer();
 
     /** Cast to TransformBase */
     Superclass2 * elx_subTransform = dynamic_cast< Superclass2 * >(


### PR DESCRIPTION
Initial commits to support ITK5 with elastix CMake option USE_ALL_COMPONENTS:

- Replace vcl macro calls by directly using std, in all components 
- Fix USE_ALL_COMPONENTS ITK5 SmartPointer compile errors 
- Added USE_ALL_COMPONENTS ITK5 C++11 vnl_math_cuberoot workaround 