### PR TITLE
COMP: Upgraded ITKv5_VERSION, to fix elastix compile errors with ITK5

### DIFF
--- a/Testing/CI/Azure/ci.yml
+++ b/Testing/CI/Azure/ci.yml
@@ -1,6 +1,6 @@
 variables:
   ITKv4_VERSION: release-4.13
-  ITKv5_VERSION: e018653622038ca7651d21769acfec539f01344d # master branch as of 22-01-2019
+  ITKv5_VERSION: eb431fa16ae8b3a93e65db1f77e57e73dc83c6a2 # master branch as of Feb 10, 2019
   ITK_SOURCE_DIR: $(Agent.BuildDirectory)/ITK-source
   ITK_BINARY_DIR: $(Agent.BuildDirectory)/ITK-build
   ELASTIX_SOURCE_DIR: $(Build.Repository.LocalPath)


### PR DESCRIPTION
Upgraded ITKv5_VERSION to today's revision of ITK's git master branch, which includes:

  COMP: Fix support itk::VectorContainer<TElementIdentifier, bool>
  https://github.com/InsightSoftwareConsortium/ITK/commit/8bd9a0d58c19adc38c0e58ea65be2fedaa2962e6

  COMP: Fix SymmetricEigenAnalysis support TMatrix = itk::Array2D<T>
  https://github.com/InsightSoftwareConsortium/ITK/commit/d7e352985f6c8e44cec02d9ad7e6eecebe32595f

These fixes appear necessary to compile elastix with ITKv5