### PR TITLE
BUG: Use classic ITK thread model in Source and Filter classes for ITK5

### DIFF
--- a/Common/Transforms/itkTransformToDeterminantOfSpatialJacobianSource.hxx
+++ b/Common/Transforms/itkTransformToDeterminantOfSpatialJacobianSource.hxx
@@ -65,6 +65,11 @@ TransformToDeterminantOfSpatialJacobianSource< TOutputImage, TTransformPrecision
 
   this->m_Transform = AdvancedIdentityTransform< TTransformPrecisionType, ImageDimension >::New();
 
+#if ITK_VERSION_MAJOR >= 5
+  // Use the classic (ITK4) threading model, to ensure ThreadedGenerateData is being called.
+  this->itk::ImageSource<TOutputImage>::DynamicMultiThreadingOff();
+#endif
+
 } // end Constructor
 
 

--- a/Common/Transforms/itkTransformToSpatialJacobianSource.hxx
+++ b/Common/Transforms/itkTransformToSpatialJacobianSource.hxx
@@ -60,6 +60,11 @@ TransformToSpatialJacobianSource< TOutputImage, TTransformPrecisionType >
     itkExceptionMacro( "The specified output image type is not allowed for this filter" );
   }
 
+#if ITK_VERSION_MAJOR >= 5
+  // Use the classic (ITK4) threading model, to ensure ThreadedGenerateData is being called.
+  this->itk::ImageSource<TOutputImage>::DynamicMultiThreadingOff();
+#endif
+
 } // end Constructor
 
 

--- a/Common/itkComputeImageExtremaFilter.hxx
+++ b/Common/itkComputeImageExtremaFilter.hxx
@@ -32,6 +32,11 @@ template< typename TInputImage >
 {
   this->m_UseMask = false;
   this->m_SameGeometry = false;
+
+#if ITK_VERSION_MAJOR >= 5
+  // Use the classic (ITK4) threading model, to ensure ThreadedGenerateData is being called.
+  this->itk::ImageSource<TInputImage>::DynamicMultiThreadingOff();
+#endif
 }
 
 template< typename TInputImage >

--- a/Common/itkParabolicErodeDilateImageFilter.hxx
+++ b/Common/itkParabolicErodeDilateImageFilter.hxx
@@ -54,6 +54,11 @@ ParabolicErodeDilateImageFilter< TInputImage, doDilate, TOutputImage >
     m_MagnitudeSign = -1;
   }
   m_UseImageSpacing = false;
+
+#if ITK_VERSION_MAJOR >= 5
+  // Use the classic (ITK4) threading model, to ensure ThreadedGenerateData is being called.
+  this->itk::ImageSource<TInputImage>::DynamicMultiThreadingOff();
+#endif
 }
 
 


### PR DESCRIPTION
Switched off modern ITK5 DynamicMultiThreading for ITK5, as `ThreadedGenerateData` should still be called.

Should fix elastix-ITK5 test failures.

See also:
https://github.com/InsightSoftwareConsortium/ITK/blob/v5.0rc01/Documentation/ITK5MigrationGuide.md#multithreading-refactored