### PR TITLE
COMP: fixed the VisitDimension OpenCL compilation issues

### DIFF
--- a/Common/TypeList.h
+++ b/Common/TypeList.h
@@ -59,12 +59,6 @@
 #ifndef __TypeList_H__
 #define __TypeList_H__
 
-#if defined( __clang__ )
-#define CLANG_TEMPLATE template
-#else
-#define CLANG_TEMPLATE
-#endif
-
 namespace typelist
 {
 
@@ -491,9 +485,9 @@ struct Visit
   {
     typedef typename TTypeList::Head Head;
     typedef typename TTypeList::Tail Tail;
-    visitor.CLANG_TEMPLATE operator()< Head >( );
+    visitor.template operator()< Head >( );
     Visit< Tail > next;
-    next.CLANG_TEMPLATE operator()< Predicate >( visitor );
+    next.template operator()< Predicate >( visitor );
   }
 
 
@@ -502,9 +496,9 @@ struct Visit
   {
     typedef typename TTypeList::Head Head;
     typedef typename TTypeList::Tail Tail;
-    visitor.CLANG_TEMPLATE operator()< Head >( );
+    visitor.template operator()< Head >( );
     Visit< Tail > next;
-    next.CLANG_TEMPLATE operator()< Predicate >( visitor );
+    next.template operator()< Predicate >( visitor );
   }
 
 
@@ -542,9 +536,9 @@ struct VisitDimension
   {
     typedef typename TTypeList::Head Head;
     typedef typename TTypeList::Tail Tail;
-    visitor.CLANG_TEMPLATE operator()< Head, Dimension >( );
+    visitor.template operator()< Head, Dimension >( );
     VisitDimension< Tail, Dimension > next;
-    next.CLANG_TEMPLATE operator()< Predicate >( visitor );
+    next.template operator()< Predicate >( visitor );
   }
 
 
@@ -553,9 +547,9 @@ struct VisitDimension
   {
     typedef typename TTypeList::Head Head;
     typedef typename TTypeList::Tail Tail;
-    visitor.CLANG_TEMPLATE operator()< Head, Dimension >( );
+    visitor.template operator()< Head, Dimension >( );
     VisitDimension< Tail, Dimension > next;
-    next.CLANG_TEMPLATE operator()< Predicate >( visitor );
+    next.template operator()< Predicate >( visitor );
   }
 
 
@@ -598,7 +592,7 @@ struct DualVisit
   void operator()( Visitor & visitor ) const
   {
     DualVisitImpl< TLeftTypeList, TRightTypeList > impl;
-    return impl.CLANG_TEMPLATE operator()< Visitor >( visitor );
+    impl.template operator()< Visitor >( visitor );
   }
 
 
@@ -606,7 +600,7 @@ struct DualVisit
   void operator()( const Visitor & visitor ) const
   {
     DualVisitImpl< TLeftTypeList, TRightTypeList > impl;
-    return impl.CLANG_TEMPLATE operator()< Visitor >( visitor );
+    impl.template operator()< Visitor >( visitor );
   }
 
 
@@ -637,7 +631,7 @@ struct DualVisitImpl
     goRight.visitRHS< Visitor >( visitor );
 
     DualVisitImpl< LeftTail, TRightTypeList > goLeft;
-    goLeft.CLANG_TEMPLATE operator()< Visitor >( visitor );
+    goLeft.template operator()< Visitor >( visitor );
   }
 
 
@@ -650,7 +644,7 @@ struct DualVisitImpl
     goRight.visitRHS< Visitor >( visitor );
 
     DualVisitImpl< LeftTail, TRightTypeList > goLeft;
-    goLeft.CLANG_TEMPLATE operator()< Visitor >( visitor );
+    goLeft.template operator()< Visitor >( visitor );
   }
 
 
@@ -661,10 +655,10 @@ struct DualVisitImpl
     typedef typename TRightTypeList::Head RightHead;
     typedef typename TRightTypeList::Tail RightTail;
 
-    visitor.CLANG_TEMPLATE operator()< LeftHead, RightHead >( );
+    visitor.template operator()< LeftHead, RightHead >( );
 
     DualVisitImpl< TLeftTypeList, RightTail > goRight;
-    goRight.CLANG_TEMPLATE                    visitRHS< Visitor >( visitor );
+    goRight.template visitRHS< Visitor >( visitor );
   }
 
 
@@ -675,10 +669,10 @@ struct DualVisitImpl
     typedef typename TRightTypeList::Head RightHead;
     typedef typename TRightTypeList::Tail RightTail;
 
-    visitor.CLANG_TEMPLATE operator()< LeftHead, RightHead >( );
+    visitor.template operator()< LeftHead, RightHead >( );
 
     DualVisitImpl< TLeftTypeList, RightTail > goRight;
-    goRight.CLANG_TEMPLATE                    visitRHS< Visitor >( visitor );
+    goRight.template visitRHS< Visitor >( visitor );
   }
 
 
@@ -741,7 +735,7 @@ struct DualVisitDimension
   void operator()( Visitor & visitor ) const
   {
     DualVisitDimensionImpl< TLeftTypeList, TRightTypeList, Dimension > impl;
-    return impl.CLANG_TEMPLATE operator()< Visitor >( visitor );
+    impl.template operator()< Visitor >( visitor );
   }
 
 
@@ -749,7 +743,7 @@ struct DualVisitDimension
   void operator()( const Visitor & visitor ) const
   {
     DualVisitDimensionImpl< TLeftTypeList, TRightTypeList, Dimension > impl;
-    return impl.CLANG_TEMPLATE operator()< Visitor >( visitor );
+    impl.template operator()< Visitor >( visitor );
   }
 
 
@@ -780,7 +774,7 @@ struct DualVisitDimensionImpl
     goRight.visitRHS< Visitor >( visitor );
 
     DualVisitDimensionImpl< LeftTail, TRightTypeList, Dimension > goLeft;
-    goLeft.CLANG_TEMPLATE operator()< Visitor >( visitor );
+    goLeft.template operator()< Visitor >( visitor );
   }
 
 
@@ -793,7 +787,7 @@ struct DualVisitDimensionImpl
     goRight.visitRHS< Visitor >( visitor );
 
     DualVisitDimensionImpl< LeftTail, TRightTypeList, Dimension > goLeft;
-    goLeft.CLANG_TEMPLATE operator()< Visitor >( visitor );
+    goLeft.template operator()< Visitor >( visitor );
   }
 
 
@@ -804,10 +798,10 @@ struct DualVisitDimensionImpl
     typedef typename TRightTypeList::Head RightHead;
     typedef typename TRightTypeList::Tail RightTail;
 
-    visitor.CLANG_TEMPLATE operator()< LeftHead, RightHead, Dimension >( );
+    visitor.template operator()< LeftHead, RightHead, Dimension >( );
 
     DualVisitDimensionImpl< TLeftTypeList, RightTail, Dimension > goRight;
-    goRight.CLANG_TEMPLATE                                        visitRHS< Visitor >( visitor );
+    goRight.template visitRHS< Visitor >( visitor );
   }
 
 
@@ -818,10 +812,10 @@ struct DualVisitDimensionImpl
     typedef typename TRightTypeList::Head RightHead;
     typedef typename TRightTypeList::Tail RightTail;
 
-    visitor.CLANG_TEMPLATE operator()< LeftHead, RightHead, Dimension >( );
+    visitor.template operator()< LeftHead, RightHead, Dimension >( );
 
     DualVisitDimensionImpl< TLeftTypeList, RightTail, Dimension > goRight;
-    goRight.CLANG_TEMPLATE                                        visitRHS< Visitor >( visitor );
+    goRight.template visitRHS< Visitor >( visitor );
   }
 
 


### PR DESCRIPTION
Reported by @kaspermarstal

opencl fixed pyramid:/home/kasper/dev/Elastix/Common/TypeList.h:494:45: error: expected primary-expression before ‘>’ token

    visitor.CLANG_TEMPLATE operator()< Head >( );and/home/kasper/dev/Elastix/Components/FixedImagePyramids/OpenCLFixedGenericPyramid/elxOpenCLFixedGenericPyramid.cxx:21:45:   required from here

/home/kasper/dev/Elastix/Common/TypeList.h:744:63: error: return-statement with a value, in function returning 'void' [-fpermissive]

    return impl.CLANG_TEMPLATE operator()< Visitor >( visitor );