### PR TITLE
COMP: fixed the compilation for the ITK4.

### DIFF
--- a/Testing/itkTestHelper.h
+++ b/Testing/itkTestHelper.h
@@ -54,7 +54,7 @@
 
 // Allow calling, e.g, itk::MultiThreaderBase::GetGlobalDefaultNumberOfThreads()
 // with ITK4 (as well as ITK5).
-#if ITK_VERSION <= 4
+#if ITK_VERSION_MAJOR <= 4
 #define MultiThreaderBase MultiThreader
 #endif
 


### PR DESCRIPTION
Fixed the error reported by @kaspermarstal

[ 58%] Building CXX object Testing/CMakeFiles/itkGPUResampleImageFilterTest.dir/itkGPUResampleImageFilterTest.cxx.o

In file included from /home/kasper/dev/Elastix/Testing/itkGPUResampleImageFilterTest.cxx:18:0:

/home/kasper/dev/Elastix/Testing/itkGPUResampleImageFilterTest.cxx: In function ‘int main(int, char**)’:

/home/kasper/dev/Elastix/Testing/itkTestHelper.h:58:27: error: ‘itk::MultiThreader’ has not been declared

#define MultiThreaderBase MultiThreader

                          ^

/home/kasper/dev/Elastix/Testing/itkGPUResampleImageFilterTest.cxx:746:46: note: in expansion of macro ‘MultiThreaderBase’

  unsigned int maximumNumberOfThreads = itk::MultiThreaderBase::GetGlobalDefaultNumberOfThreads();