### PR TITLE
COMP: Fix ITK5 build issues

### DIFF
--- a/Common/CostFunctions/itkAdvancedImageToImageMetric.hxx
+++ b/Common/CostFunctions/itkAdvancedImageToImageMetric.hxx
@@ -889,7 +889,11 @@ AdvancedImageToImageMetric< TFixedImage, TMovingImage >
 
   temp->st_Metric->ThreadedGetValue( threadID );
 
+#if ITK_VERSION_MAJOR >= 5
+  return itk::ITK_THREAD_RETURN_DEFAULT_VALUE;
+#else
   return ITK_THREAD_RETURN_VALUE;
+#endif
 
 } // end GetValueThreaderCallback()
 
@@ -930,7 +934,11 @@ AdvancedImageToImageMetric< TFixedImage, TMovingImage >
 
   temp->st_Metric->ThreadedGetValueAndDerivative( threadID );
 
+#if ITK_VERSION_MAJOR >= 5
+  return itk::ITK_THREAD_RETURN_DEFAULT_VALUE;
+#else
   return ITK_THREAD_RETURN_VALUE;
+#endif
 
 } // end GetValueAndDerivativeThreaderCallback()
 
@@ -996,7 +1004,11 @@ AdvancedImageToImageMetric< TFixedImage, TMovingImage >
     temp->st_DerivativePointer[ j ] = tmp * normalization;
   }
 
+#if ITK_VERSION_MAJOR >= 5
+  return itk::ITK_THREAD_RETURN_DEFAULT_VALUE;
+#else
   return ITK_THREAD_RETURN_VALUE;
+#endif
 
 } // end AccumulateDerivativesThreaderCallback()
 

--- a/Common/CostFunctions/itkParzenWindowHistogramImageToImageMetric.hxx
+++ b/Common/CostFunctions/itkParzenWindowHistogramImageToImageMetric.hxx
@@ -1321,7 +1321,11 @@ ParzenWindowHistogramImageToImageMetric< TFixedImage, TMovingImage >
 
   temp->m_Metric->ThreadedComputePDFs( threadId );
 
+#if ITK_VERSION_MAJOR >= 5
+  return itk::ITK_THREAD_RETURN_DEFAULT_VALUE;
+#else
   return ITK_THREAD_RETURN_VALUE;
+#endif
 
 } // end ComputePDFsThreaderCallback()
 

--- a/Common/ImageSamplers/itkImageToVectorContainerFilter.hxx
+++ b/Common/ImageSamplers/itkImageToVectorContainerFilter.hxx
@@ -296,7 +296,11 @@ ImageToVectorContainerFilter< TInputImage, TOutputVectorContainer >
   //   few threads idle.
   //   }
 
+#if ITK_VERSION_MAJOR >= 5
+  return itk::ITK_THREAD_RETURN_DEFAULT_VALUE;
+#else
   return ITK_THREAD_RETURN_VALUE;
+#endif
 
 } // end ThreaderCallback()
 

--- a/Common/Transforms/itkAdvancedImageMomentsCalculator.hxx
+++ b/Common/Transforms/itkAdvancedImageMomentsCalculator.hxx
@@ -366,7 +366,11 @@ AdvancedImageMomentsCalculator< TImage >
   /** Call the real implementation. */
   temp->st_Self->ThreadedCompute(threadID);
 
+#if ITK_VERSION_MAJOR >= 5
+  return itk::ITK_THREAD_RETURN_DEFAULT_VALUE;
+#else
   return ITK_THREAD_RETURN_VALUE;
+#endif
 
 } // end ComputeThreaderCallback()
 

--- a/Common/itkComputeDisplacementDistribution.hxx
+++ b/Common/itkComputeDisplacementDistribution.hxx
@@ -352,7 +352,11 @@ ComputeDisplacementDistribution< TFixedImage, TTransform >
   /** Call the real implementation. */
   temp->st_Self->ThreadedCompute( threadID );
 
+#if ITK_VERSION_MAJOR >= 5
+  return itk::ITK_THREAD_RETURN_DEFAULT_VALUE;
+#else
   return ITK_THREAD_RETURN_VALUE;
+#endif
 
 } // end ComputeThreaderCallback()
 

--- a/Components/Metrics/AdvancedMattesMutualInformation/itkParzenWindowMutualInformationImageToImageMetric.hxx
+++ b/Components/Metrics/AdvancedMattesMutualInformation/itkParzenWindowMutualInformationImageToImageMetric.hxx
@@ -655,7 +655,11 @@ ParzenWindowMutualInformationImageToImageMetric< TFixedImage, TMovingImage >
 
   temp->m_Metric->ThreadedComputeDerivativeLowMemory( threadId );
 
+#if ITK_VERSION_MAJOR >= 5
+  return itk::ITK_THREAD_RETURN_DEFAULT_VALUE;
+#else
   return ITK_THREAD_RETURN_VALUE;
+#endif
 
 } // end ComputeDerivativeLowMemoryThreaderCallback()
 

--- a/Components/Metrics/AdvancedNormalizedCorrelation/itkAdvancedNormalizedCorrelationImageToImageMetric.hxx
+++ b/Components/Metrics/AdvancedNormalizedCorrelation/itkAdvancedNormalizedCorrelationImageToImageMetric.hxx
@@ -872,7 +872,11 @@ AdvancedNormalizedCorrelationImageToImageMetric< TFixedImage, TMovingImage >
       = ( derivativeF - sfm_smm * derivativeM ) * invertedDenominator;
   }
 
+#if ITK_VERSION_MAJOR >= 5
+  return itk::ITK_THREAD_RETURN_DEFAULT_VALUE;
+#else
   return ITK_THREAD_RETURN_VALUE;
+#endif
 
 } // end AccumulateDerivativesThreaderCallback()
 

--- a/Components/Metrics/PCAMetric/itkPCAMetric_F_multithreaded.hxx
+++ b/Components/Metrics/PCAMetric/itkPCAMetric_F_multithreaded.hxx
@@ -945,7 +945,11 @@ PCAMetric< TFixedImage, TMovingImage >
 
   temp->m_Metric->ThreadedGetSamples( threadId );
 
+#if ITK_VERSION_MAJOR >= 5
+  return itk::ITK_THREAD_RETURN_DEFAULT_VALUE;
+#else
   return ITK_THREAD_RETURN_VALUE;
+#endif
 
 } // GetSamplesThreaderCallback()
 
@@ -1155,7 +1159,11 @@ PCAMetric< TFixedImage, TMovingImage >
 
   temp->m_Metric->ThreadedComputeDerivative( threadId );
 
+#if ITK_VERSION_MAJOR >= 5
+  return itk::ITK_THREAD_RETURN_DEFAULT_VALUE;
+#else
   return ITK_THREAD_RETURN_VALUE;
+#endif
 
 } // end omputeDerivativeThreaderCallback()
 

--- a/Components/Optimizers/AdaptiveStochasticLBFGS/elxAdaptiveStochasticLBFGS.h
+++ b/Components/Optimizers/AdaptiveStochasticLBFGS/elxAdaptiveStochasticLBFGS.h
@@ -474,7 +474,11 @@ private:
   bool m_UseEigen;
 
   /** The callback function. */
+#if ITK_VERSION_MAJOR >= 5
+  static itk::ITK_THREAD_RETURN_TYPE AdvanceOneStepThreaderCallback( void * arg );
+#else
   static ITK_THREAD_RETURN_TYPE AdvanceOneStepThreaderCallback( void * arg );
+#endif
 
   /** The threaded implementation of AdvanceOneStep(). */
   inline void ThreadedAdvanceOneStep( ThreadIdType threadId, ParametersType & newPosition );

--- a/Components/Optimizers/AdaptiveStochasticVarianceReducedGradient/elxAdaptiveStochasticVarianceReducedGradient.h
+++ b/Components/Optimizers/AdaptiveStochasticVarianceReducedGradient/elxAdaptiveStochasticVarianceReducedGradient.h
@@ -495,7 +495,11 @@ private:
   bool m_UseEigen;
 
   /** The callback function. */
+#if ITK_VERSION_MAJOR >= 5
+  static itk::ITK_THREAD_RETURN_TYPE AdvanceOneStepThreaderCallback( void * arg );
+#else
   static ITK_THREAD_RETURN_TYPE AdvanceOneStepThreaderCallback( void * arg );
+#endif
 
   /** The threaded implementation of AdvanceOneStep(). */
   inline void ThreadedAdvanceOneStep( ThreadIdType threadId, ParametersType & newPosition );

--- a/Components/Optimizers/AdaptiveStochasticVarianceReducedGradient/itkStochasticVarianceReducedGradientDescentOptimizer.cxx
+++ b/Components/Optimizers/AdaptiveStochasticVarianceReducedGradient/itkStochasticVarianceReducedGradientDescentOptimizer.cxx
@@ -343,7 +343,11 @@ ITK_THREAD_RETURN_TYPE StochasticVarianceReducedGradientDescentOptimizer
   /** Call the real implementation. */
   temp->t_Optimizer->ThreadedAdvanceOneStep( threadID, *( temp->t_NewPosition ) );
 
+#if ITK_VERSION_MAJOR >= 5
+  return itk::ITK_THREAD_RETURN_DEFAULT_VALUE;
+#else
   return ITK_THREAD_RETURN_VALUE;
+#endif
 
 } // end AdvanceOneStepThreaderCallback()
 

--- a/Components/Optimizers/StandardStochasticGradientDescent/itkStochasticGradientDescentOptimizer.cxx
+++ b/Components/Optimizers/StandardStochasticGradientDescent/itkStochasticGradientDescentOptimizer.cxx
@@ -341,7 +341,11 @@ ITK_THREAD_RETURN_TYPE StochasticGradientDescentOptimizer
   /** Call the real implementation. */
   temp->t_Optimizer->ThreadedAdvanceOneStep( threadID, *( temp->t_NewPosition ) );
 
+#if ITK_VERSION_MAJOR >= 5
+  return itk::ITK_THREAD_RETURN_DEFAULT_VALUE;
+#else
   return ITK_THREAD_RETURN_VALUE;
+#endif
 
 } // end AdvanceOneStepThreaderCallback()
 


### PR DESCRIPTION
There were a few simple things that prevented from Elastic to build with ITK5. This commit fixes these, preserving former ITK version compatibility with preprocessor ifs.