### PR TITLE
ImageSpatialObject2 data member cleanup

### DIFF
--- a/Common/itkImageSpatialObject2.h
+++ b/Common/itkImageSpatialObject2.h
@@ -149,14 +149,17 @@ protected:
   ImageSpatialObject2( const Self & ); // purposely not implemented
   void operator=( const Self & );      // purposely not implemented
 
-  ImagePointer m_Image;
-
   ImageSpatialObject2();
   virtual ~ImageSpatialObject2();
 
   void PrintSelf( std::ostream & os, Indent indent ) const;
 
+private:
+
+  ImagePointer m_Image;
+
   int *       m_SlicePosition;
+
   std::string m_PixelType;
 
   typename InterpolatorType::Pointer m_Interpolator;

--- a/Common/itkImageSpatialObject2.h
+++ b/Common/itkImageSpatialObject2.h
@@ -43,6 +43,8 @@
 #include "itkInterpolateImageFunction.h"
 #include "itkNearestNeighborInterpolateImageFunction.h"
 
+#include <type_traits> // For is_same.
+
 namespace itk
 {
 
@@ -133,9 +135,30 @@ public:
   int GetSlicePosition( unsigned int dimension )
   { return m_SlicePosition[ dimension ]; }
 
-  const char * GetPixelType()
+  static const char * GetPixelType()
   {
-    return m_PixelType.c_str();
+    if (IsPixelType<short>())
+    {
+      return "short";
+    }
+    if (IsPixelType<unsigned char>())
+    {
+      return "unsigned char";
+    }
+    if (IsPixelType<unsigned short>())
+    {
+      return "unsigned short";
+    }
+    if (IsPixelType<float>())
+    {
+      return "float";
+    }
+    if (IsPixelType<double>())
+    {
+      return "double";
+    }
+    // PixelType not recognized.
+    return "";
   }
 
 
@@ -156,11 +179,15 @@ protected:
 
 private:
 
+  template <typename T>
+  static bool IsPixelType()
+  {
+    return std::is_same<PixelType, T>::value;
+  }
+
   ImagePointer m_Image;
 
   int m_SlicePosition[TDimension];
-
-  std::string m_PixelType;
 
   typename InterpolatorType::Pointer m_Interpolator;
 };

--- a/Common/itkImageSpatialObject2.h
+++ b/Common/itkImageSpatialObject2.h
@@ -158,7 +158,7 @@ private:
 
   ImagePointer m_Image;
 
-  int *       m_SlicePosition;
+  int m_SlicePosition[TDimension];
 
   std::string m_PixelType;
 

--- a/Common/itkImageSpatialObject2.hxx
+++ b/Common/itkImageSpatialObject2.hxx
@@ -49,14 +49,12 @@ namespace itk
 template< unsigned int TDimension, class PixelType >
 ImageSpatialObject2< TDimension,  PixelType >
 ::ImageSpatialObject2()
+  :
+  // Zero-initialize the elements of m_SlicePosition:
+  m_SlicePosition()
 {
   this->SetTypeName( "ImageSpatialObject2" );
   m_Image         = ImageType::New();
-  m_SlicePosition = new int[ TDimension ];
-  for( unsigned int i = 0; i < TDimension; i++ )
-  {
-    m_SlicePosition[ i ] = 0;
-  }
 
   this->ComputeBoundingBox();
   if( typeid( PixelType ) == typeid( short ) )
@@ -93,7 +91,6 @@ template< unsigned int TDimension, class PixelType >
 ImageSpatialObject2< TDimension,  PixelType >
 ::~ImageSpatialObject2()
 {
-  delete[] m_SlicePosition;
 }
 
 

--- a/Common/itkImageSpatialObject2.hxx
+++ b/Common/itkImageSpatialObject2.hxx
@@ -57,28 +57,10 @@ ImageSpatialObject2< TDimension,  PixelType >
   m_Image         = ImageType::New();
 
   this->ComputeBoundingBox();
-  if( typeid( PixelType ) == typeid( short ) )
+
+  if(GetPixelType()[0] == '\0')
   {
-    m_PixelType = "short";
-  }
-  else if( typeid( PixelType ) == typeid( unsigned char ) )
-  {
-    m_PixelType = "unsigned char";
-  }
-  else if( typeid( PixelType ) == typeid( unsigned short ) )
-  {
-    m_PixelType = "unsigned short";
-  }
-  else if( typeid( PixelType ) == typeid( float ) )
-  {
-    m_PixelType = "float";
-  }
-  else if( typeid( PixelType ) == typeid( double ) )
-  {
-    m_PixelType = "double";
-  }
-  else
-  {
+    // GetPixelType() returned an empty string.
     std::cout << "itk::ImageSpatialObject2() : PixelType not recognized" << std::endl;
   }
 


### PR DESCRIPTION
`ImageSpatialObject2` data member cleanup:

* Declared data members `private`
* Declared `m_SlicePosition` as array
* Declared `GetPixelType()` static and removed `m_PixelType`.