### PR TITLE
COMP: Removed AdvancedTransform::InverseJacobianPositionType

### DIFF
--- a/Common/Transforms/itkAdvancedTransform.h
+++ b/Common/Transforms/itkAdvancedTransform.h
@@ -113,7 +113,6 @@ public:
   typedef typename Superclass::NumberOfParametersType NumberOfParametersType;
   typedef typename Superclass::DerivativeType         DerivativeType;
   typedef typename Superclass::JacobianType           JacobianType;
-  typedef typename Superclass::InverseJacobianPositionType InverseJacobianPositionType;
   typedef typename Superclass::InputVectorType        InputVectorType;
   typedef typename Superclass::OutputVectorType       OutputVectorType;
   typedef typename Superclass
@@ -241,13 +240,6 @@ public:
     const InputPointType & itkNotUsed( p ), JacobianType & itkNotUsed( j ) ) const
   {
     itkExceptionMacro( << "This ITK4 function is currently not used in elastix." );
-  }
-
-
-  virtual void ComputeJacobianWithRespectToPosition(
-    const InputPointType & itkNotUsed( p ), InverseJacobianPositionType & itkNotUsed( j ) ) const
-  {
-    itkExceptionMacro( << "This ITK function is currently not used in elastix." );
   }
 
 


### PR DESCRIPTION
Removed both `InverseJacobianPositionType` and `ComputeJacobianWithRespectToPosition(p, j)` from `AdvancedTransform`.

Neither the type nor the member function appear to be used. The type definition causes compilation errors with ITK4:

    itkAdvancedTransform.h(116): error C2039: 'InverseJacobianPositionType': is not a member of 'itk::Transform'