### PR TITLE
COMP: Use ModifiedTimeType instead of unsigned long

### DIFF
--- a/Common/Transforms/itkTransformToDeterminantOfSpatialJacobianSource.h
+++ b/Common/Transforms/itkTransformToDeterminantOfSpatialJacobianSource.h
@@ -179,7 +179,7 @@ public:
   virtual void BeforeThreadedGenerateData( void );
 
   /** Compute the Modified Time based on changes to the components. */
-  unsigned long GetMTime( void ) const;
+  ModifiedTimeType GetMTime( void ) const;
 
 protected:
 

--- a/Common/Transforms/itkTransformToDeterminantOfSpatialJacobianSource.hxx
+++ b/Common/Transforms/itkTransformToDeterminantOfSpatialJacobianSource.hxx
@@ -337,11 +337,11 @@ TransformToDeterminantOfSpatialJacobianSource< TOutputImage, TTransformPrecision
  * Verify if any of the components has been modified.
  */
 template< class TOutputImage, class TTransformPrecisionType >
-unsigned long
+ModifiedTimeType
 TransformToDeterminantOfSpatialJacobianSource< TOutputImage, TTransformPrecisionType >
 ::GetMTime( void ) const
 {
-  unsigned long latestTime = Object::GetMTime();
+  ModifiedTimeType latestTime = Object::GetMTime();
 
   if( this->m_Transform )
   {

--- a/Common/Transforms/itkTransformToSpatialJacobianSource.h
+++ b/Common/Transforms/itkTransformToSpatialJacobianSource.h
@@ -171,7 +171,7 @@ public:
   virtual void BeforeThreadedGenerateData( void );
 
   /** Compute the Modified Time based on changes to the components. */
-  unsigned long GetMTime( void ) const;
+  ModifiedTimeType GetMTime( void ) const;
 
 protected:
 

--- a/Common/Transforms/itkTransformToSpatialJacobianSource.hxx
+++ b/Common/Transforms/itkTransformToSpatialJacobianSource.hxx
@@ -344,11 +344,11 @@ TransformToSpatialJacobianSource< TOutputImage, TTransformPrecisionType >
  * Verify if any of the components has been modified.
  */
 template< class TOutputImage, class TTransformPrecisionType >
-unsigned long
+ModifiedTimeType
 TransformToSpatialJacobianSource< TOutputImage, TTransformPrecisionType >
 ::GetMTime( void ) const
 {
-  unsigned long latestTime = Object::GetMTime();
+  ModifiedTimeType latestTime = Object::GetMTime();
 
   if( this->m_Transform )
   {

--- a/Common/itkImageSpatialObject2.h
+++ b/Common/itkImageSpatialObject2.h
@@ -124,7 +124,7 @@ public:
   bool ComputeLocalBoundingBox() const;
 
   /** Returns the latest modified time of the object and its component. */
-  unsigned long GetMTime( void ) const;
+  ModifiedTimeType GetMTime( void ) const;
 
   /** Set the slice position */
   void SetSlicePosition( unsigned int dimension, int position );

--- a/Common/itkImageSpatialObject2.hxx
+++ b/Common/itkImageSpatialObject2.hxx
@@ -379,12 +379,12 @@ ImageSpatialObject2< TDimension,  PixelType >
 
 /** Get the modification time */
 template< unsigned int TDimension, class PixelType >
-unsigned long
+ModifiedTimeType
 ImageSpatialObject2< TDimension,  PixelType >
 ::GetMTime( void ) const
 {
-  unsigned long latestMTime = Superclass::GetMTime();
-  unsigned long imageMTime  = m_Image->GetMTime();
+  ModifiedTimeType latestMTime = Superclass::GetMTime();
+  ModifiedTimeType imageMTime  = m_Image->GetMTime();
 
   if( imageMTime > latestMTime )
   {

--- a/Common/itkMultiResolutionImageRegistrationMethod2.h
+++ b/Common/itkMultiResolutionImageRegistrationMethod2.h
@@ -239,7 +239,7 @@ public:
   /** Method to return the latest modified time of this object or
    * any of its cached ivars.
    */
-  unsigned long GetMTime( void ) const ITK_OVERRIDE;
+  ModifiedTimeType GetMTime( void ) const ITK_OVERRIDE;
 
 protected:
 

--- a/Common/itkMultiResolutionImageRegistrationMethod2.hxx
+++ b/Common/itkMultiResolutionImageRegistrationMethod2.hxx
@@ -417,12 +417,12 @@ MultiResolutionImageRegistrationMethod2< TFixedImage, TMovingImage >
 
 
 template< typename TFixedImage, typename TMovingImage >
-unsigned long
+ModifiedTimeType
 MultiResolutionImageRegistrationMethod2< TFixedImage, TMovingImage >
 ::GetMTime( void ) const
 {
-  unsigned long mtime = Superclass::GetMTime();
-  unsigned long m;
+  ModifiedTimeType mtime = Superclass::GetMTime();
+  ModifiedTimeType m;
 
   // Some of the following should be removed once ivars are put in the
   // input and output lists

--- a/Components/Registrations/MultiMetricMultiResolutionRegistration/itkCombinationImageToImageMetric.h
+++ b/Components/Registrations/MultiMetricMultiResolutionRegistration/itkCombinationImageToImageMetric.h
@@ -401,7 +401,7 @@ public:
   /** Method to return the latest modified time of this object or any of its
    * cached ivars.
    */
-  virtual unsigned long GetMTime() const;
+  virtual ModifiedTimeType GetMTime() const;
 
 protected:
 

--- a/Components/Registrations/MultiMetricMultiResolutionRegistration/itkCombinationImageToImageMetric.hxx
+++ b/Components/Registrations/MultiMetricMultiResolutionRegistration/itkCombinationImageToImageMetric.hxx
@@ -973,12 +973,12 @@ CombinationImageToImageMetric< TFixedImage, TMovingImage >
  */
 
 template< class TFixedImage, class TMovingImage >
-unsigned long
+ModifiedTimeType
 CombinationImageToImageMetric< TFixedImage, TMovingImage >
 ::GetMTime( void ) const
 {
-  unsigned long mtime = this->Superclass::GetMTime();
-  unsigned long m;
+  ModifiedTimeType mtime = this->Superclass::GetMTime();
+  ModifiedTimeType m;
 
   // Some of the following should be removed once this 'ivars' are put in the
   // input and output lists

--- a/Components/Registrations/MultiMetricMultiResolutionRegistration/itkMultiMetricMultiResolutionImageRegistrationMethod.h
+++ b/Components/Registrations/MultiMetricMultiResolutionRegistration/itkMultiMetricMultiResolutionImageRegistrationMethod.h
@@ -241,7 +241,7 @@ public:
   /** Method to return the latest modified time of this object or
    * any of its cached ivars.
    */
-  unsigned long GetMTime( void ) const;
+  ModifiedTimeType GetMTime( void ) const;
 
   /** Get the last transformation parameters visited by
    * the optimizer. Return the member variable declared in this class,

--- a/Components/Registrations/MultiMetricMultiResolutionRegistration/itkMultiMetricMultiResolutionImageRegistrationMethod.hxx
+++ b/Components/Registrations/MultiMetricMultiResolutionRegistration/itkMultiMetricMultiResolutionImageRegistrationMethod.hxx
@@ -449,12 +449,12 @@ MultiMetricMultiResolutionImageRegistrationMethod< TFixedImage, TMovingImage >
  */
 
 template< typename TFixedImage, typename TMovingImage >
-unsigned long
+ModifiedTimeType
 MultiMetricMultiResolutionImageRegistrationMethod< TFixedImage, TMovingImage >
 ::GetMTime( void ) const
 {
-  unsigned long mtime = Superclass::GetMTime();
-  unsigned long m;
+  ModifiedTimeType mtime = Superclass::GetMTime();
+  ModifiedTimeType m;
 
   // Some of the following should be removed once ivars are put in the
   // input and output lists

--- a/Components/Registrations/MultiResolutionRegistrationWithFeatures/itkMultiInputMultiResolutionImageRegistrationMethodBase.h
+++ b/Components/Registrations/MultiResolutionRegistrationWithFeatures/itkMultiInputMultiResolutionImageRegistrationMethodBase.h
@@ -236,7 +236,7 @@ public:
   /** Method to return the latest modified time of this object or
    * any of its cached ivars.
    */
-  unsigned long GetMTime( void ) const;
+  ModifiedTimeType GetMTime( void ) const;
 
 protected:
 

--- a/Components/Registrations/MultiResolutionRegistrationWithFeatures/itkMultiInputMultiResolutionImageRegistrationMethodBase.hxx
+++ b/Components/Registrations/MultiResolutionRegistrationWithFeatures/itkMultiInputMultiResolutionImageRegistrationMethodBase.hxx
@@ -550,12 +550,12 @@ MultiInputMultiResolutionImageRegistrationMethodBase< TFixedImage, TMovingImage 
  */
 
 template< typename TFixedImage, typename TMovingImage >
-unsigned long
+ModifiedTimeType
 MultiInputMultiResolutionImageRegistrationMethodBase< TFixedImage, TMovingImage >
 ::GetMTime() const
 {
-  unsigned long mtime = Superclass::GetMTime();
-  unsigned long m;
+  ModifiedTimeType mtime = Superclass::GetMTime();
+  ModifiedTimeType m;
 
   // Some of the following should be removed once ivars are put in the
   // input and output lists


### PR DESCRIPTION
Used `ModifiedTimeType` for modified time, instead of `unsigned long`, thereby fixing many Elastix/ITK5 compile errors, like this:

    error C2555: 'itk::ImageSpatialObject2::GetMTime': overriding virtual function return type differs and is not covariant from 'itk::SpatialObject::GetMTime'

Related ITK commits:

  @mstaring, 2012-09-24: https://github.com/InsightSoftwareConsortium/ITK/commit/cbf91c49e4e598adfc5b36e0d55c58c4dedae8d7
  @dzenanz, 2019-03-29: https://github.com/InsightSoftwareConsortium/ITK/commit/0598727d390e861f70b00a4a96a9c58e26b57036