### PR TITLE
COMP: Added C++11 override to Components

### DIFF
--- a/Components/Metrics/KNNGraphAlphaMutualInformation/KNN/itkANNBruteForceTree.h
+++ b/Components/Metrics/KNNGraphAlphaMutualInformation/KNN/itkANNBruteForceTree.h
@@ -66,10 +66,10 @@ public:
   //}
 
   /** Generate the tree. */
-  virtual void GenerateTree( void );
+  void GenerateTree( void ) override;
 
   /** Get the ANN tree. */
-  virtual ANNPointSetType * GetANNTree( void ) const
+  ANNPointSetType * GetANNTree( void ) const override
   {
     return this->m_ANNTree;
   }
@@ -78,7 +78,7 @@ public:
 protected:
 
   ANNBruteForceTree();
-  virtual ~ANNBruteForceTree();
+  ~ANNBruteForceTree() override;
 
   /** Member variables. */
   ANNBruteForceTreeType * m_ANNTree;

--- a/Components/Metrics/KNNGraphAlphaMutualInformation/KNN/itkANNStandardTreeSearch.h
+++ b/Components/Metrics/KNNGraphAlphaMutualInformation/KNN/itkANNStandardTreeSearch.h
@@ -69,13 +69,13 @@ public:
   itkGetConstMacro( ErrorBound, double );
 
   /** Search the nearest neighbours of a query point qp. */
-  virtual void Search( const MeasurementVectorType & qp, IndexArrayType & ind,
-    DistanceArrayType & dists );
+  void Search( const MeasurementVectorType & qp, IndexArrayType & ind,
+    DistanceArrayType & dists ) override;
 
 protected:
 
   ANNStandardTreeSearch();
-  virtual ~ANNStandardTreeSearch();
+  ~ANNStandardTreeSearch() override;
 
   /** Member variables. */
   double m_ErrorBound;

--- a/Components/Metrics/KNNGraphAlphaMutualInformation/KNN/itkANNbdTree.h
+++ b/Components/Metrics/KNNGraphAlphaMutualInformation/KNN/itkANNbdTree.h
@@ -69,7 +69,7 @@ public:
   std::string GetShrinkingRule( void );
 
   /** Generate the tree. */
-  virtual void GenerateTree( void );
+  void GenerateTree( void ) override;
 
 protected:
 
@@ -77,10 +77,10 @@ protected:
   ANNbdTree();
 
   /** Destructor. */
-  virtual ~ANNbdTree() {}
+  ~ANNbdTree() override {}
 
   /** PrintSelf. */
-  virtual void PrintSelf( std::ostream & os, Indent indent ) const;
+  void PrintSelf( std::ostream & os, Indent indent ) const override;
 
   /** Member variables. */
   ShrinkingRuleType m_ShrinkingRule;

--- a/Components/Metrics/KNNGraphAlphaMutualInformation/KNN/itkBinaryANNTreeSearchBase.h
+++ b/Components/Metrics/KNNGraphAlphaMutualInformation/KNN/itkBinaryANNTreeSearchBase.h
@@ -69,14 +69,14 @@ public:
   typedef BinaryANNTreeBase< ListSampleType > BinaryANNTreeType;
 
   /** Set and get the binary tree. */
-  virtual void SetBinaryTree( BinaryTreeType * tree );
+  void SetBinaryTree( BinaryTreeType * tree ) override;
 
   //const BinaryTreeType * GetBinaryTree( void ) const;
 
 protected:
 
   BinaryANNTreeSearchBase();
-  virtual ~BinaryANNTreeSearchBase();
+  ~BinaryANNTreeSearchBase() override;
 
   /** Member variables. */
   typename BinaryANNTreeType::Pointer m_BinaryTreeAsITKANNType;

--- a/Components/Registrations/MultiMetricMultiResolutionRegistration/elxMultiMetricMultiResolutionRegistration.h
+++ b/Components/Registrations/MultiMetricMultiResolutionRegistration/elxMultiMetricMultiResolutionRegistration.h
@@ -194,25 +194,25 @@ public:
    * \li Set the fixed image regions.
    * \li Add the sub metric columns to the iteration info object.
    */
-  virtual void BeforeRegistration( void );
+  void BeforeRegistration( void ) override;
 
   /** Execute stuff before each resolution:
    * \li Update masks with an erosion.
    * \li Set the metric weights.
    */
-  virtual void BeforeEachResolution( void );
+  void BeforeEachResolution( void ) override;
 
   /** Execute stuff after each iteration
    * \li Print the latest computed submetric values to screen.
    */
-  virtual void AfterEachIteration( void );
+  void AfterEachIteration( void ) override;
 
 protected:
 
   /** The constructor. */
   MultiMetricMultiResolutionRegistration();
   /** The destructor. */
-  virtual ~MultiMetricMultiResolutionRegistration() {}
+  ~MultiMetricMultiResolutionRegistration() override {}
 
   /** Typedef's for mask support. */
   typedef typename Superclass2::MaskPixelType                  MaskPixelType;

--- a/Components/Transforms/SplineKernelTransform/itkElasticBodyReciprocalSplineKernelTransform2.h
+++ b/Components/Transforms/SplineKernelTransform/itkElasticBodyReciprocalSplineKernelTransform2.h
@@ -89,7 +89,7 @@ public:
    * \f$\alpha = 8 ( 1 - \nu ) - 1\f$
    */
   //itkSetMacro( Alpha, TScalarType ); Cant use the macro because the matrices must be recomputed
-  virtual void SetAlpha( TScalarType Alpha )
+  void SetAlpha( TScalarType Alpha ) override
   {
     this->m_Alpha            = Alpha;
     this->m_LMatrixComputed  = false;
@@ -102,7 +102,7 @@ public:
   itkGetConstMacro( Alpha, TScalarType );
 
   /** Convenience method */
-  virtual void SetPoissonRatio( const TScalarType Nu )
+  void SetPoissonRatio( const TScalarType Nu ) override
   {
     if( Nu > -1.0 && Nu < 0.5 )
     {
@@ -111,7 +111,7 @@ public:
   }
 
 
-  virtual const TScalarType GetPoissonRatio( void ) const
+  const TScalarType GetPoissonRatio( void ) const override
   {
     return 1.0 - ( this->m_Alpha + 1.0 ) / 8.0;
   }
@@ -129,8 +129,8 @@ public:
 protected:
 
   ElasticBodyReciprocalSplineKernelTransform2();
-  virtual ~ElasticBodyReciprocalSplineKernelTransform2() {}
-  void PrintSelf( std::ostream & os, Indent indent ) const;
+  ~ElasticBodyReciprocalSplineKernelTransform2() override {}
+  void PrintSelf( std::ostream & os, Indent indent ) const override;
 
   /** These (rather redundant) typedefs are needed because on SGI, typedefs
    * are not inherited */
@@ -144,7 +144,7 @@ protected:
    * \f$r(x) = \sqrt{ x_1^2 + x_2^2 + x_3^2 } \f$ and
    * \f$I\f$ is the identity matrix.
    */
-  void ComputeG( const InputVectorType & x, GMatrixType & GMatrix ) const;
+  void ComputeG( const InputVectorType & x, GMatrixType & GMatrix ) const override;
 
   /** alpha, Poisson's ratio */
   TScalarType m_Alpha;


### PR DESCRIPTION
Follow-up to commit 5c875097f4d309f1704072e3db68fc92751f0399, 5 April 2019:
"COMP: Added override by Clang Tidy-Fix modernize-use-override"