### PR TITLE
ENH: Upgrade azure CI from macOS-10.14 to macOS-10.13

### DIFF
--- a/Testing/CI/Azure/ci.yml
+++ b/Testing/CI/Azure/ci.yml
@@ -162,7 +162,7 @@ jobs:
 - job: macOS
   timeoutInMinutes: 0
   pool:
-    vmImage: 'macOS-10.13'
+    vmImage: 'macOS-10.14'
   strategy:
     matrix:
       ITKv4:


### PR DESCRIPTION
Upgrade from LLVM 9.1.0 (clang-902.0.39.2) to LLVM 10.0.1 (clang-1001.0.46.3)