### PR TITLE
Many manual fixes of missing override specifiers (issue #110)

### DIFF
--- a/Common/ImageSamplers/itkImageRandomSamplerBase.h
+++ b/Common/ImageSamplers/itkImageRandomSamplerBase.h
@@ -68,9 +68,6 @@ public:
   itkStaticConstMacro( InputImageDimension, unsigned int,
     Superclass::InputImageDimension );
 
-  /** Set the number of samples. */
-  itkSetClampMacro( NumberOfSamples, unsigned long, 1, NumericTraits< unsigned long >::max() );
-
 protected:
 
   /** The constructor. */

--- a/Common/Transforms/itkAdvancedSimilarity3DTransform.h
+++ b/Common/Transforms/itkAdvancedSimilarity3DTransform.h
@@ -126,15 +126,15 @@ public:
    * to within a specified tolerance, else an exception is thrown.
    *
    * \sa MatrixOffsetTransformBase::SetMatrix() */
-  virtual void SetMatrix( const MatrixType & matrix );
+  void SetMatrix( const MatrixType & matrix ) override;
 
   /** Set the transformation from a container of parameters This is typically
    * used by optimizers.  There are 7 parameters. The first three represent the
    * versor, the next three represent the translation and the last one
    * represents the scaling factor. */
-  void SetParameters( const ParametersType & parameters );
+  void SetParameters( const ParametersType & parameters ) override;
 
-  virtual const ParametersType & GetParameters( void ) const;
+  const ParametersType & GetParameters( void ) const override;
 
   /** Set/Get the value of the isotropic scaling factor */
   void SetScale( ScaleType scale );
@@ -142,10 +142,10 @@ public:
   itkGetConstReferenceMacro( Scale, ScaleType );
 
   /** This method computes the Jacobian matrix of the transformation. */
-  virtual void GetJacobian(
+  void GetJacobian(
     const InputPointType &,
     JacobianType &,
-    NonZeroJacobianIndicesType & ) const;
+    NonZeroJacobianIndicesType & ) const override;
 
 protected:
 
@@ -156,14 +156,14 @@ protected:
   AdvancedSimilarity3DTransform();
   ~AdvancedSimilarity3DTransform(){}
 
-  void PrintSelf( std::ostream & os, Indent indent ) const;
+  void PrintSelf( std::ostream & os, Indent indent ) const override;
 
   /** Recomputes the matrix by calling the Superclass::ComputeMatrix() and then
    * applying the scale factor. */
-  void ComputeMatrix();
+  void ComputeMatrix() override;
 
   /** Computes the parameters from an input matrix. */
-  void ComputeMatrixParameters();
+  void ComputeMatrixParameters() override;
 
   /** Update the m_JacobianOfSpatialJacobian.  */
   virtual void PrecomputeJacobianOfSpatialJacobian( void );

--- a/Common/Transforms/itkAdvancedVersorRigid3DTransform.h
+++ b/Common/Transforms/itkAdvancedVersorRigid3DTransform.h
@@ -125,15 +125,15 @@ public:
    * This is typically used by optimizers.
    * There are 6 parameters. The first three represent the
    * versor, the last three represent the translation. */
-  void SetParameters( const ParametersType & parameters );
+  void SetParameters( const ParametersType & parameters ) override;
 
-  virtual const ParametersType & GetParameters( void ) const;
+  const ParametersType & GetParameters( void ) const override;
 
   /** This method computes the Jacobian matrix of the transformation. */
-  virtual void GetJacobian(
+  void GetJacobian(
     const InputPointType &,
     JacobianType &,
-    NonZeroJacobianIndicesType & ) const;
+    NonZeroJacobianIndicesType & ) const override;
 
 protected:
 
@@ -144,11 +144,11 @@ protected:
   AdvancedVersorRigid3DTransform();
   ~AdvancedVersorRigid3DTransform(){}
 
-  void PrintSelf( std::ostream & os, Indent indent ) const;
+  void PrintSelf( std::ostream & os, Indent indent ) const override;
 
   /** This method must be made protected here because it is not a safe way of
    * initializing the Versor */
-  virtual void SetRotationMatrix( const MatrixType & matrix )
+  void SetRotationMatrix( const MatrixType & matrix ) override
   { this->Superclass::SetRotationMatrix( matrix ); }
 
 private:

--- a/Common/Transforms/itkAdvancedVersorTransform.h
+++ b/Common/Transforms/itkAdvancedVersorTransform.h
@@ -133,10 +133,10 @@ public:
    * of the right part of the versor. This can be seen
    * as the components of the vector parallel to the rotation
    * axis and multiplied by std::sin( angle / 2 ). */
-  void SetParameters( const ParametersType & parameters );
+  void SetParameters( const ParametersType & parameters ) override;
 
   /** Get the Transformation Parameters. */
-  const ParametersType & GetParameters( void ) const;
+  const ParametersType & GetParameters( void ) const override;
 
   /** Set the rotational part of the transform */
   void SetRotation( const VersorType & versor );
@@ -146,13 +146,13 @@ public:
   itkGetConstReferenceMacro( Versor, VersorType );
 
   /** Set the parameters to the IdentityTransform */
-  virtual void SetIdentity( void );
+  void SetIdentity( void ) override;
 
   /** This method computes the Jacobian matrix of the transformation. */
-  virtual void GetJacobian(
+  void GetJacobian(
     const InputPointType &,
     JacobianType &,
-    NonZeroJacobianIndicesType & ) const;
+    NonZeroJacobianIndicesType & ) const override;
 
 protected:
 
@@ -167,20 +167,20 @@ protected:
 
   /** This method must be made protected here because it is not a safe way of
    * initializing the Versor */
-  virtual void SetRotationMatrix( const MatrixType & matrix )
+  void SetRotationMatrix( const MatrixType & matrix ) override
   { this->Superclass::SetRotationMatrix( matrix ); }
 
   void SetVarVersor( const VersorType & newVersor )
   { m_Versor = newVersor; }
 
   /** Print contents of a AdvancedVersorTransform */
-  void PrintSelf( std::ostream & os, Indent indent ) const;
+  void PrintSelf( std::ostream & os, Indent indent ) const override;
 
   /** Compute Matrix
    *  Compute the components of the rotation matrix in the superclass */
-  void ComputeMatrix( void );
+  void ComputeMatrix( void ) override;
 
-  void ComputeMatrixParameters( void );
+  void ComputeMatrixParameters( void ) override;
 
 private:
 

--- a/Common/Transforms/itkEulerTransform.h
+++ b/Common/Transforms/itkEulerTransform.h
@@ -191,35 +191,92 @@ public:
   /** Make sure SetComputeZYX() is available, also in 2D,
    * in which case, its just a dummy function.
    */
-  void SetComputeZYX( const bool arg )
+  void SetComputeZYX( const bool ) // No override.
   {
-    if( SpaceDimension == 3 )
-    {
-      typedef AdvancedEuler3DTransform< ScalarType > Euler3DTransformType;
-      typename Euler3DTransformType::Pointer transform
-        = dynamic_cast< Euler3DTransformType * >( this );
-      if( transform )
-      {
-        transform->Euler3DTransformType::SetComputeZYX( arg );
-      }
-    }
+    static_assert(SpaceDimension != 3, "This is not the specialization is 3D!");
   }
 
 
   /** Make sure GetComputeZYX() is available, also in 2D,
    * in which case, it just returns false.
    */
-  bool GetComputeZYX( void ) const
+  bool GetComputeZYX( void ) const // No override.
   {
-    if( SpaceDimension == 3 )
+    static_assert(SpaceDimension != 3, "This is not the specialization is 3D!");
+    return false;
+  }
+
+
+protected:
+
+  EulerTransform(){}
+  ~EulerTransform() override{}
+
+private:
+
+  EulerTransform( const Self & );  // purposely not implemented
+  void operator=( const Self & );  // purposely not implemented
+
+};
+
+template< class TScalarType >
+class EulerTransform<TScalarType, 3> :
+  public EulerGroupTemplate<
+  TScalarType, 3 >::EulerTransform_tmp
+{
+public:
+
+  /** Standard ITK-stuff. */
+  typedef EulerTransform Self;
+  typedef typename EulerGroupTemplate<
+    TScalarType, 3 >
+    ::EulerTransform_tmp Superclass;
+  typedef SmartPointer< Self >       Pointer;
+  typedef SmartPointer< const Self > ConstPointer;
+
+  /** Method for creation through the object factory. */
+  itkNewMacro( Self );
+
+  /** Run-time type information (and related methods). */
+  itkTypeMacro( EulerTransform, EulerGroupTemplate );
+
+  /** Dimension of the domain space. */
+  itkStaticConstMacro( SpaceDimension, unsigned int, 3 );
+
+
+  /** Make sure SetComputeZYX() is available, also in 2D,
+   * in which case, its just a dummy function.
+   * \note This member function is only an `override` in 3D.
+   */
+  void SetComputeZYX( const bool arg ) override
+  {
+    static_assert(SpaceDimension == 3, "This specialization is for 3D only!");
+
+    typedef AdvancedEuler3DTransform< TScalarType > Euler3DTransformType;
+    typename Euler3DTransformType::Pointer transform
+      = dynamic_cast< Euler3DTransformType * >( this );
+    if( transform )
     {
-      typedef AdvancedEuler3DTransform< ScalarType > Euler3DTransformType;
-      typename Euler3DTransformType::ConstPointer transform
-        = dynamic_cast< const Euler3DTransformType * >( this );
-      if( transform )
-      {
-        return transform->Euler3DTransformType::GetComputeZYX();
-      }
+      transform->Euler3DTransformType::SetComputeZYX( arg );
+    }
+  }
+
+
+  /** Make sure GetComputeZYX() is available, also in 2D,
+   * in which case, it just returns false.
+   * \note This member function is only an `override` in 3D.
+   */
+  bool GetComputeZYX( void ) const override
+  {
+    static_assert(SpaceDimension == 3, "This specialization is for 3D only!");
+
+    typedef AdvancedEuler3DTransform< TScalarType > Euler3DTransformType;
+    typename Euler3DTransformType::ConstPointer transform
+      = dynamic_cast< const Euler3DTransformType * >( this );
+
+    if( transform )
+    {
+      return transform->Euler3DTransformType::GetComputeZYX();
     }
     return false;
   }

--- a/Common/itkNDImageBase.h
+++ b/Common/itkNDImageBase.h
@@ -181,13 +181,6 @@ public:
 
   virtual unsigned int GetImageDimension( void ) = 0;
 
-  /** Get the actual image */
-  virtual DataObject * GetModifiableImage( void ) = 0;
-
-  virtual ProcessObject * GetModifiableWriter( void ) = 0;
-
-  virtual ProcessObject * GetModifiableReader( void ) = 0;
-
   virtual void SetImageIOWriter( ImageIOBase * _arg ) = 0;
 
   virtual ImageIOBase * GetImageIOWriter( void ) = 0;

--- a/Common/itkRecursiveBSplineInterpolationWeightFunction.h
+++ b/Common/itkRecursiveBSplineInterpolationWeightFunction.h
@@ -115,9 +115,6 @@ public:
     itkGetStaticConstMacro( SpaceDimension ) > GetConstNumberOfIndicesHackType;
   itkStaticConstMacro( NumberOfIndices, unsigned int, GetConstNumberOfIndicesHackType::Value );
 
-  /** Get number of weights. */
-  itkGetConstMacro( NumberOfWeights, unsigned int );
-
   /** Get number of indices. */
   itkGetConstMacro( NumberOfIndices, unsigned int );
 

--- a/Components/Metrics/KNNGraphAlphaMutualInformation/KNN/itkANNFixedRadiusTreeSearch.h
+++ b/Components/Metrics/KNNGraphAlphaMutualInformation/KNN/itkANNFixedRadiusTreeSearch.h
@@ -73,8 +73,8 @@ public:
   itkGetConstMacro( SquaredRadius, double );
 
   /** Search the nearest neighbours of a query point qp. */
-  virtual void Search( const MeasurementVectorType & qp, IndexArrayType & ind,
-    DistanceArrayType & dists );
+  void Search( const MeasurementVectorType & qp, IndexArrayType & ind,
+    DistanceArrayType & dists ) override;
 
   /** Search the nearest neighbours of a query point qp. */
   virtual void Search( const MeasurementVectorType & qp, IndexArrayType & ind,
@@ -83,7 +83,7 @@ public:
 protected:
 
   ANNFixedRadiusTreeSearch();
-  virtual ~ANNFixedRadiusTreeSearch();
+  ~ANNFixedRadiusTreeSearch() override;
 
   /** Member variables. */
   double m_ErrorBound;

--- a/Components/Metrics/KNNGraphAlphaMutualInformation/KNN/itkANNPriorityTreeSearch.h
+++ b/Components/Metrics/KNNGraphAlphaMutualInformation/KNN/itkANNPriorityTreeSearch.h
@@ -73,15 +73,15 @@ public:
   itkGetConstMacro( ErrorBound, double );
 
   /** Search the nearest neighbours of a query point qp. */
-  virtual void Search( const MeasurementVectorType & qp, IndexArrayType & ind,
-    DistanceArrayType & dists );
+  void Search( const MeasurementVectorType & qp, IndexArrayType & ind,
+    DistanceArrayType & dists ) override;
 
-  virtual void SetBinaryTree( BinaryTreeType * tree );
+  void SetBinaryTree( BinaryTreeType * tree ) override;
 
 protected:
 
   ANNPriorityTreeSearch();
-  virtual ~ANNPriorityTreeSearch();
+  ~ANNPriorityTreeSearch() override;
 
   /** Member variables. */
   double          m_ErrorBound;

--- a/Components/Optimizers/AdaGrad/elxAdaGrad.h
+++ b/Components/Optimizers/AdaGrad/elxAdaGrad.h
@@ -285,9 +285,6 @@ public:
   itkSetMacro( MaximumNumberOfSamplingAttempts, SizeValueType );
   itkGetConstReferenceMacro( MaximumNumberOfSamplingAttempts, SizeValueType );
 
-  /** Get current gradient. */
-  itkGetConstReferenceMacro( PreconditionVector, ParametersType );
-
 protected :
 
   AdaGrad();
@@ -377,7 +374,6 @@ protected :
 
   double                    m_SigmoidScaleFactor;
   double                    m_NoiseFactor;
-  ParametersType            m_PreconditionVector;
   double                    m_GlobalStepSize;
   double                    m_RegularizationKappa;
   double                    m_ConditionNumber;

--- a/Components/Optimizers/AdaptiveStochasticLBFGS/elxAdaptiveStochasticLBFGS.h
+++ b/Components/Optimizers/AdaptiveStochasticLBFGS/elxAdaptiveStochasticLBFGS.h
@@ -221,42 +221,6 @@ public:
   /** Get the MaximumNumberOfSamplingAttempts. */
   itkGetConstReferenceMacro( MaximumNumberOfSamplingAttempts, SizeValueType );
 
-//   /** Set the learning rate. */
-//   itkSetMacro( LearningRate, double );
-//
-//   /** Get the learning rate. */
-//   itkGetConstReferenceMacro( LearningRate, double);
-
-  /** Set the number of iterations. */
-  itkSetMacro( NumberOfIterations, unsigned long );
-
-  /** Get the number of iterations. */
-  itkGetConstReferenceMacro( NumberOfIterations, unsigned long );
-
-  /** Get the current iteration number. */
-  itkGetConstMacro( CurrentIteration, unsigned int );
-
-  /** Get the inner LBFGSMemory. */
-  itkGetConstMacro( LBFGSMemory, unsigned int );
-
-  /** Get the current value. */
-  itkGetConstReferenceMacro( Value, double );
-
-  /** Get current gradient. */
-  itkGetConstReferenceMacro( Gradient, DerivativeType );
-
-  /** Get current search direction. */
-  itkGetConstReferenceMacro( SearchDir, DerivativeType );
-
-  /** Set the Previous Position. */
-  itkSetMacro( PreviousPosition, ParametersType );
-
-  /** Get the Previous Position. */
-  itkGetConstReferenceMacro( PreviousPosition, ParametersType);
-
-  /** Get the Previous gradient. */
-  itkGetConstReferenceMacro( PreviousGradient, DerivativeType);
-
   /** Type to count and reference number of threads */
   typedef unsigned int  ThreadIdType;
 
@@ -265,8 +229,6 @@ public:
   {
     this->m_Threader->SetNumberOfThreads( numberOfThreads );
   }
-  //itkGetConstReferenceMacro( NumberOfThreads, ThreadIdType );
-  itkSetMacro( UseMultiThread, bool );
 
 protected:
 
@@ -430,23 +392,10 @@ protected:
    * The optimizer stops when:
    * ||CurrentGradient|| < GradientMagnitudeTolerance * max(1, ||CurrentPosition||)
    */
-  //itkGetConstMacro( GradientMagnitudeTolerance, double );
-  //itkSetMacro( GradientMagnitudeTolerance, double );
 
-  //double                        m_Value;
-  //DerivativeType                m_Gradient;
-  //double                        m_LearningRate;
-  //StopConditionType             m_StopCondition;
-  //DerivativeType                m_PreviousGradient;
   DerivativeType                m_PreviousCurvatureGradient;
-  DerivativeType                m_SearchDir;
-  ThreaderType::Pointer         m_Threader;
 
-  //bool                          m_Stop;
-  unsigned long                 m_NumberOfIterations;
-  unsigned long                 m_CurrentIteration;
   double                        m_NoiseFactor;
-  unsigned long                 m_LBFGSMemory;
   unsigned int                  m_CurrentT;
   unsigned int                  m_PreviousT;
   unsigned int                  m_Bound;
@@ -463,15 +412,11 @@ private:
   void operator=( const Self& );           // purposely not implemented
 
   // multi-threaded AdvanceOneStep:
-  bool m_UseMultiThread;
   struct MultiThreaderParameterType
   {
     ParametersType *  t_NewPosition;
     Self *            t_Optimizer;
   };
-
-  bool m_UseOpenMP;
-  bool m_UseEigen;
 
   /** The callback function. */
 #if ITK_VERSION_MAJOR >= 5

--- a/Components/Optimizers/AdaptiveStochasticVarianceReducedGradient/elxAdaptiveStochasticVarianceReducedGradient.h
+++ b/Components/Optimizers/AdaptiveStochasticVarianceReducedGradient/elxAdaptiveStochasticVarianceReducedGradient.h
@@ -260,14 +260,6 @@ public:
   /** Stop optimization and pass on exception. */
   void MetricErrorResponse( itk::ExceptionObject & err ) override;
 
-  /** Codes of stopping conditions
-   * The MinimumStepSize stopcondition never occurs, but may
-   * be implemented in inheriting classes */
-  typedef enum {
-    MaximumNumberOfIterations,
-    MetricError,
-    MinimumStepSize } StopConditionType;
-
   /** Stop optimization.
   * \sa ResumeOptimization */
   void StopOptimization( void ) override;
@@ -294,33 +286,6 @@ public:
   /** Get the MaximumNumberOfSamplingAttempts. */
   itkGetConstReferenceMacro( MaximumNumberOfSamplingAttempts, SizeValueType );
 
-//   /** Set the learning rate. */
-//   itkSetMacro( LearningRate, double );
-//
-//   /** Get the learning rate. */
-//   itkGetConstReferenceMacro( LearningRate, double);
-
-  /** Set the number of iterations. */
-  itkSetMacro( NumberOfIterations, unsigned long );
-
-  /** Get the number of iterations. */
-  itkGetConstReferenceMacro( NumberOfIterations, unsigned long );
-
-  /** Get the current iteration number. */
-  itkGetConstMacro( CurrentIteration, unsigned int );
-
-  /** Get the current value. */
-  itkGetConstReferenceMacro( Value, double );
-
-  /** Get current gradient. */
-  itkGetConstReferenceMacro( Gradient, DerivativeType );
-
-  /** Set the Previous Position. */
-  itkSetMacro( PreviousPosition, ParametersType );
-
-  /** Get the Previous Position. */
-  itkGetConstReferenceMacro( PreviousPosition, ParametersType);
-
   /** Get the Previous gradient. */
   itkGetConstReferenceMacro( MeanGradient, DerivativeType);
 
@@ -332,11 +297,6 @@ public:
   {
     this->m_Threader->SetNumberOfThreads( numberOfThreads );
   }
-  //itkGetConstReferenceMacro( NumberOfThreads, ThreadIdType );
-  itkSetMacro( UseMultiThread, bool );
-
-  itkSetMacro( UseOpenMP, bool );
-  itkSetMacro( UseEigen, bool );
 
 protected:
 
@@ -466,16 +426,9 @@ protected:
    */
   virtual void AddRandomPerturbation( ParametersType & parameters, double sigma );
 
-  double                        m_Value;
-  DerivativeType                m_Gradient;
   DerivativeType                m_ExactGradient;
-  StopConditionType             m_StopCondition;
   DerivativeType                m_MeanGradient;
-  ThreaderType::Pointer         m_Threader;
 
-  bool                          m_Stop;
-//   unsigned long                 m_NumberOfIterations;
-//   unsigned long                 m_CurrentIteration;
   double                        m_NoiseFactor;
 
 private:
@@ -484,15 +437,11 @@ private:
   void operator=( const Self& );                     // purposely not implemented
 
   // multi-threaded AdvanceOneStep:
-  bool m_UseMultiThread;
   struct MultiThreaderParameterType
   {
     ParametersType *  t_NewPosition;
     Self *            t_Optimizer;
   };
-
-  bool m_UseOpenMP;
-  bool m_UseEigen;
 
   /** The callback function. */
 #if ITK_VERSION_MAJOR >= 5

--- a/Components/Optimizers/PreconditionedStochasticGradientDescent/elxPreconditionedStochasticGradientDescent.h
+++ b/Components/Optimizers/PreconditionedStochasticGradientDescent/elxPreconditionedStochasticGradientDescent.h
@@ -273,9 +273,6 @@ public:
   itkSetMacro( MaximumNumberOfSamplingAttempts, SizeValueType );
   itkGetConstReferenceMacro( MaximumNumberOfSamplingAttempts, SizeValueType );
 
-  /** Get current gradient. */
-  itkGetConstReferenceMacro( PreconditionVector, ParametersType );
-
 protected :
 
   PreconditionedStochasticGradientDescent();
@@ -364,7 +361,6 @@ protected :
 
   double                    m_SigmoidScaleFactor;
   double                    m_NoiseFactor;
-  ParametersType            m_PreconditionVector;
   double                    m_GlobalStepSize;
   double                    m_RegularizationKappa;
   double                    m_ConditionNumber;

--- a/Components/Registrations/MultiMetricMultiResolutionRegistration/itkCombinationImageToImageMetric.h
+++ b/Components/Registrations/MultiMetricMultiResolutionRegistration/itkCombinationImageToImageMetric.h
@@ -200,9 +200,6 @@ public:
   itkSetMacro( UseRelativeWeights, bool );
   itkGetMacro( UseRelativeWeights, bool );
 
-  /** \todo: Temporary, should think about interface. */
-  itkSetMacro( UseMultiThread, bool );
-
   /** Select which metrics are used.
    * This is useful in case you want to compute a certain measure, but not
    * actually use it during the registration.

--- a/Components/Registrations/MultiMetricMultiResolutionRegistration/itkMultiMetricMultiResolutionImageRegistrationMethod.h
+++ b/Components/Registrations/MultiMetricMultiResolutionRegistration/itkMultiMetricMultiResolutionImageRegistrationMethod.h
@@ -24,8 +24,8 @@
 
 /** defines a method that calls the same method
  * with an extra 0 argument */
-#define itkSimpleSetMacro( _name, _type ) \
-  virtual void Set##_name( _type _arg ) \
+#define elxOverrideSimpleSetMacro( _name, _type ) \
+  void Set##_name( _type _arg ) override \
   { \
     this->Set##_name( _arg, 0 ); \
   }
@@ -164,7 +164,7 @@ public:
   /** The following methods all have a similar pattern. The
    * SetFixedImage() just calls SetFixedImage(0).
    * SetFixedImage(0) also calls the Superclass::SetFixedImage(). This
-   * is defined by the itkSimpleSetMacro.
+   * is defined by the elxOverrideSimpleSetMacro.
    * GetFixedImage() just returns GetFixedImage(0) == Superclass::m_FixedImage.
    */
 
@@ -179,7 +179,7 @@ public:
   }
 
 
-  itkSimpleSetMacro( FixedImage, const FixedImageType * );
+  elxOverrideSimpleSetMacro( FixedImage, const FixedImageType * );
   itkSetNumberOfMacro( FixedImage );
   itkGetNumberOfMacro( FixedImage );
 
@@ -190,7 +190,7 @@ public:
 
   const MovingImageType * GetMovingImage( void ) const override
   { return this->GetMovingImage( 0 ); }
-  itkSimpleSetMacro( MovingImage, const MovingImageType * );
+  elxOverrideSimpleSetMacro( MovingImage, const MovingImageType * );
   itkSetNumberOfMacro( MovingImage );
   itkGetNumberOfMacro( MovingImage );
 
@@ -201,7 +201,7 @@ public:
 
   const FixedImageRegionType & GetFixedImageRegion( void ) const override
   { return this->GetFixedImageRegion( 0 ); }
-  itkSimpleSetMacro( FixedImageRegion, const FixedImageRegionType );
+  elxOverrideSimpleSetMacro( FixedImageRegion, const FixedImageRegionType );
   itkSetNumberOfMacro( FixedImageRegion );
   itkGetNumberOfMacro( FixedImageRegion );
 
@@ -212,7 +212,7 @@ public:
 
   InterpolatorType * GetInterpolator( void ) override
   { return this->GetInterpolator( 0 ); }
-  itkSimpleSetMacro( Interpolator, InterpolatorType * );
+  elxOverrideSimpleSetMacro( Interpolator, InterpolatorType * );
   itkSetNumberOfMacro( Interpolator );
   itkGetNumberOfMacro( Interpolator );
 
@@ -223,7 +223,7 @@ public:
 
   FixedImagePyramidType * GetFixedImagePyramid( void ) override
   { return this->GetFixedImagePyramid( 0 ); }
-  itkSimpleSetMacro( FixedImagePyramid, FixedImagePyramidType * );
+  elxOverrideSimpleSetMacro( FixedImagePyramid, FixedImagePyramidType * );
   itkSetNumberOfMacro( FixedImagePyramid );
   itkGetNumberOfMacro( FixedImagePyramid );
 
@@ -234,7 +234,7 @@ public:
 
   MovingImagePyramidType * GetMovingImagePyramid( void ) override
   { return this->GetMovingImagePyramid( 0 ); }
-  itkSimpleSetMacro( MovingImagePyramid, MovingImagePyramidType * );
+  elxOverrideSimpleSetMacro( MovingImagePyramid, MovingImagePyramidType * );
   itkSetNumberOfMacro( MovingImagePyramid );
   itkGetNumberOfMacro( MovingImagePyramid );
 
@@ -320,7 +320,7 @@ private:
 
 #undef itkSetNumberOfMacro
 #undef itkGetNumberOfMacro
-#undef itkSimpleSetMacro
+#undef elxOverrideSimpleSetMacro
 
 #ifndef ITK_MANUAL_INSTANTIATION
 #include "itkMultiMetricMultiResolutionImageRegistrationMethod.hxx"

--- a/Components/Registrations/MultiResolutionRegistrationWithFeatures/itkMultiInputMultiResolutionImageRegistrationMethodBase.h
+++ b/Components/Registrations/MultiResolutionRegistrationWithFeatures/itkMultiInputMultiResolutionImageRegistrationMethodBase.h
@@ -31,6 +31,12 @@
     this->Set##_name( _arg, 0 ); \
   }
 
+#define elxOverrideSimpleSetMacro( _name, _type ) \
+  void Set##_name( _type _arg ) override \
+  { \
+    this->Set##_name( _arg, 0 ); \
+  }
+
 /** defines for example: SetNumberOfInterpolators(). */
 #define itkSetNumberOfMacro( _name ) \
   virtual void SetNumberOf##_name##s( unsigned int _arg ) \
@@ -146,7 +152,7 @@ public:
   /** The following methods all have a similar pattern. The
    * SetFixedImage() just calls SetFixedImage(0).
    * SetFixedImage(0) also calls the Superclass::SetFixedImage(). This
-   * is defined by the itkSimpleSetMacro.
+   * is defined by the elxOverrideSimpleSetMacro.
    * GetFixedImage() just returns GetFixedImage(0) == Superclass::m_FixedImage.
    */
 
@@ -157,7 +163,7 @@ public:
 
   const FixedImageType * GetFixedImage( void ) const override
   { return this->GetFixedImage( 0 ); }
-  itkSimpleSetMacro( FixedImage, const FixedImageType * );
+  elxOverrideSimpleSetMacro( FixedImage, const FixedImageType * );
   itkSetNumberOfMacro( FixedImage );
   itkGetNumberOfMacro( FixedImage );
 
@@ -168,7 +174,7 @@ public:
 
   const FixedImageRegionType & GetFixedImageRegion( void ) const override
   { return this->GetFixedImageRegion( 0 ); }
-  itkSimpleSetMacro( FixedImageRegion, const FixedImageRegionType );
+  elxOverrideSimpleSetMacro( FixedImageRegion, const FixedImageRegionType );
   itkSetNumberOfMacro( FixedImageRegion );
   itkGetNumberOfMacro( FixedImageRegion );
 
@@ -179,7 +185,7 @@ public:
 
   FixedImagePyramidType * GetFixedImagePyramid( void ) override
   { return this->GetFixedImagePyramid( 0 ); }
-  itkSimpleSetMacro( FixedImagePyramid, FixedImagePyramidType * );
+  elxOverrideSimpleSetMacro( FixedImagePyramid, FixedImagePyramidType * );
   itkSetNumberOfMacro( FixedImagePyramid );
   itkGetNumberOfMacro( FixedImagePyramid );
 
@@ -190,7 +196,7 @@ public:
 
   const MovingImageType * GetMovingImage( void ) const override
   { return this->GetMovingImage( 0 ); }
-  itkSimpleSetMacro( MovingImage, const MovingImageType * );
+  elxOverrideSimpleSetMacro( MovingImage, const MovingImageType * );
   itkSetNumberOfMacro( MovingImage );
   itkGetNumberOfMacro( MovingImage );
 
@@ -201,7 +207,7 @@ public:
 
   MovingImagePyramidType * GetMovingImagePyramid( void ) override
   { return this->GetMovingImagePyramid( 0 ); }
-  itkSimpleSetMacro( MovingImagePyramid, MovingImagePyramidType * );
+  elxOverrideSimpleSetMacro( MovingImagePyramid, MovingImagePyramidType * );
   itkSetNumberOfMacro( MovingImagePyramid );
   itkGetNumberOfMacro( MovingImagePyramid );
 
@@ -212,7 +218,7 @@ public:
 
   InterpolatorType * GetInterpolator( void ) override
   { return this->GetInterpolator( 0 ); }
-  itkSimpleSetMacro( Interpolator, InterpolatorType * );
+  elxOverrideSimpleSetMacro( Interpolator, InterpolatorType * );
   itkSetNumberOfMacro( Interpolator );
   itkGetNumberOfMacro( Interpolator );
 
@@ -299,7 +305,7 @@ private:
 
 #undef itkSetNumberOfMacro
 #undef itkGetNumberOfMacro
-#undef itkSimpleSetMacro
+#undef elxOverrideSimpleSetMacro
 
 #ifndef ITK_MANUAL_INSTANTIATION
 #include "itkMultiInputMultiResolutionImageRegistrationMethodBase.hxx"

--- a/Components/Transforms/AffineDTITransform/itkAffineDTI3DTransform.h
+++ b/Components/Transforms/AffineDTITransform/itkAffineDTI3DTransform.h
@@ -136,17 +136,17 @@ public:
    * [ Rx Ry Rz Gx Gy Gz Sx Sy Sz Tx Ty Tz ]
    * ~rotation, scale, skew, translation
    */
-  void SetParameters( const ParametersType & parameters );
+  void SetParameters( const ParametersType & parameters ) override;
 
-  const ParametersType & GetParameters( void ) const;
+  const ParametersType & GetParameters( void ) const override;
 
   /** Compute the Jacobian of the transformation. */
-  virtual void GetJacobian(
+  void GetJacobian(
     const InputPointType &,
     JacobianType &,
-    NonZeroJacobianIndicesType & ) const;
+    NonZeroJacobianIndicesType & ) const override;
 
-  virtual void SetIdentity( void );
+  void SetIdentity( void ) override;
 
 protected:
 
@@ -158,7 +158,7 @@ protected:
 
   ~AffineDTI3DTransform(){}
 
-  void PrintSelf( std::ostream & os, Indent indent ) const;
+  void PrintSelf( std::ostream & os, Indent indent ) const override;
 
   /** Set values of angles etc directly without recomputing other parameters. */
   void SetVarAngleScaleShear(
@@ -167,9 +167,9 @@ protected:
     ScalarArrayType scale );
 
   /** Compute the components of the rotation matrix in the superclass. */
-  void ComputeMatrix( void );
+  void ComputeMatrix( void ) override;
 
-  void ComputeMatrixParameters( void );
+  void ComputeMatrixParameters( void ) override;
 
   /** Update the m_JacobianOfSpatialJacobian.  */
   virtual void PrecomputeJacobianOfSpatialJacobian( void );

--- a/Components/Transforms/SplineKernelTransform/itkElasticBodyReciprocalSplineKernelTransform2.h
+++ b/Components/Transforms/SplineKernelTransform/itkElasticBodyReciprocalSplineKernelTransform2.h
@@ -99,7 +99,7 @@ public:
 
 
   /** Get alpha */
-  itkGetConstMacro( Alpha, TScalarType );
+  elxOverrideGetConstMacro(Alpha, TScalarType);
 
   /** Convenience method */
   void SetPoissonRatio( const TScalarType Nu ) override

--- a/Components/Transforms/SplineKernelTransform/itkElasticBodySplineKernelTransform2.h
+++ b/Components/Transforms/SplineKernelTransform/itkElasticBodySplineKernelTransform2.h
@@ -99,7 +99,7 @@ public:
 
 
   /** Get alpha */
-  itkGetConstMacro( Alpha, TScalarType );
+  elxOverrideGetConstMacro( Alpha, TScalarType );
 
   /** Convenience method */
   void SetPoissonRatio( const TScalarType Nu ) override

--- a/Components/Transforms/WeightedCombinationTransform/itkWeightedCombinationTransform.h
+++ b/Components/Transforms/WeightedCombinationTransform/itkWeightedCombinationTransform.h
@@ -139,9 +139,6 @@ public:
    * is correct */
   void SetParameters( const ParametersType & param ) override;
 
-  /** Get the currently set parameters */
-  itkGetConstReferenceMacro( Parameters, ParametersType );
-
   /** Set the fixed parameters. */
   void SetFixedParameters( const ParametersType & ) override
   {

--- a/Core/Install/elxMacro.h
+++ b/Core/Install/elxMacro.h
@@ -254,14 +254,14 @@ public: \
  * This macro defines two functions.
  *
  * static const char * elxGetClassNameStatic(void){return _name;}
- * virtual const char * elxGetClassName(void){return _name;}
+ * const char * elxGetClassName( void ) const override { return _name; }
  *
  * Use this macro in every component that will be installed in the
  * ComponentDatabase, using "elxInstallMacro".
  */
 #define elxClassNameMacro( _name ) \
   static const char * elxGetClassNameStatic( void ) { return _name; } \
-  virtual const char * elxGetClassName( void ) const { return _name; }
+  const char * elxGetClassName( void ) const override { return _name; }
 
 /**
  *  elxout

--- a/Core/Install/elxMacro.h
+++ b/Core/Install/elxMacro.h
@@ -263,6 +263,16 @@ public: \
   static const char * elxGetClassNameStatic( void ) { return _name; } \
   const char * elxGetClassName( void ) const override { return _name; }
 
+ /** Get built-in type.  Creates an override of the virtual member Get"name"()
+  * This is the "const" form of the itkGetMacro.  It should be used unless
+  * the member can be changed through the "Get" access routine. */
+#define elxOverrideGetConstMacro(name, type)  \
+  type Get##name () const override    \
+    {                                 \
+    return this->m_##name;            \
+    }
+
+
 /**
  *  elxout
  *


### PR DESCRIPTION
Thirteen more commits that fix compilation warnings about missing `override` specifiers.

Previous `override` fixes (pull request #136 and #137) were applied automatically by clang-tidy (modernize-use-override), but the fixes from this pull request has to be done manually, and carefully.

This pull request hopefully completes the fixes for issue #110 ("-Winconsistent-missing-override on MacOS"), submitted by Harmen Stoppels @haampie