### PR TITLE
Fix two more osx build warnings

### DIFF
--- a/Components/Optimizers/AdaptiveStochasticLBFGS/elxAdaptiveStochasticLBFGS.h
+++ b/Components/Optimizers/AdaptiveStochasticLBFGS/elxAdaptiveStochasticLBFGS.h
@@ -183,14 +183,6 @@ public:
   /** Stop optimization and pass on exception. */
   void MetricErrorResponse( itk::ExceptionObject & err ) override;
 
-  /** Codes of stopping conditions
-   * The MinimumStepSize stopcondition never occurs, but may
-   * be implemented in inheriting classes *
-  typedef enum {
-    MaximumNumberOfIterations,
-    MetricError,
-    MinimumStepSize } StopConditionType;
-
   /** Stop optimization.
   * \sa StopOptimization */
   void StopOptimization( void ) override;

--- a/Components/Optimizers/AdaptiveStochasticLBFGS/elxAdaptiveStochasticLBFGS.hxx
+++ b/Components/Optimizers/AdaptiveStochasticLBFGS/elxAdaptiveStochasticLBFGS.hxx
@@ -236,11 +236,11 @@ void AdaptiveStochasticLBFGS<TElastix>
   this->GetConfiguration()->ReadParameter( this->m_AutomaticLBFGSStepsizeEstimation,
     "AutomaticLBFGSstepsizeEstimation", this->GetComponentLabel(), level, 0 );
 
-  /** Set the GradientMagnitudeTolerance *
+  /** Set the GradientMagnitudeTolerance */
   double gradientMagnitudeTolerance = 0.000001;
   this->m_Configuration->ReadParameter( gradientMagnitudeTolerance,
     "GradientMagnitudeTolerance", this->GetComponentLabel(), level, 0 );
-  this->SetGradientMagnitudeTolerance( gradientMagnitudeTolerance );
+  // this->SetGradientMagnitudeTolerance( gradientMagnitudeTolerance );
 
   /** Set the scale of the windowa for H0. */
   double windowScale = 5;

--- a/Components/Optimizers/AdaptiveStochasticVarianceReducedGradient/elxAdaptiveStochasticVarianceReducedGradient.hxx
+++ b/Components/Optimizers/AdaptiveStochasticVarianceReducedGradient/elxAdaptiveStochasticVarianceReducedGradient.hxx
@@ -644,7 +644,7 @@ AdaptiveStochasticVarianceReducedGradient<TElastix>
     }
 
     this->m_CurrentInnerIteration = 0;
-    const int gradientFactor = 0.8;
+
     for ( unsigned i = 0; i < this->m_NumberOfInnerIterations; i++ )
     {
       unsigned int itp = i;


### PR DESCRIPTION
On osx there's a warning related to nested `/*` block comments (no idea why that's considered an issue, but well, why not fix it).

And there was some unused variable with the wrong type that led to

```
implicit conversion from 'double' to 'int' changes value from 0.8 to 0 [-Wliteral-conversion]
```