### PR TITLE
BUG: Avoid overflow, passing number of pixels to sampleContainer Reserve

### DIFF
--- a/Common/ImageSamplers/itkImageSamplerBase.h
+++ b/Common/ImageSamplers/itkImageSamplerBase.h
@@ -41,7 +41,7 @@ namespace itk
 template< class TInputImage >
 class ImageSamplerBase :
   public ImageToVectorContainerFilter< TInputImage,
-  VectorDataContainer< unsigned long, ImageSample< TInputImage > > >
+  VectorDataContainer< std::size_t, ImageSample< TInputImage > > >
 {
 public:
 
@@ -49,7 +49,7 @@ public:
   typedef ImageSamplerBase Self;
   typedef ImageToVectorContainerFilter<
     TInputImage, VectorDataContainer<
-    unsigned long, ImageSample< TInputImage > > > Superclass;
+    std::size_t, ImageSample< TInputImage > > > Superclass;
   typedef SmartPointer< Self >       Pointer;
   typedef SmartPointer< const Self > ConstPointer;
 
@@ -75,7 +75,7 @@ public:
 
   /** Other typdefs. */
   typedef ImageSample< InputImageType >                         ImageSampleType;
-  typedef VectorDataContainer< unsigned long, ImageSampleType > ImageSampleContainerType;
+  typedef VectorDataContainer< std::size_t, ImageSampleType >   ImageSampleContainerType;
   typedef typename ImageSampleContainerType::Pointer            ImageSampleContainerPointer;
   typedef typename InputImageType::SizeType                     InputImageSizeType;
   typedef typename InputImageType::IndexType                    InputImageIndexType;


### PR DESCRIPTION
Philipp Heinrich reported a case of integer overflow, when the number of pixels passed the function `sampleContainer->Reserve` could not be represented in an `unsigned long, at

"Re: [elastix-imageregistration] Re: Elastix crashes without any notice"
https://groups.google.com/forum/?utm_source=footer#!msg/elastix-imageregistration/Q1e1b2UNIQI/ySXTCJdvAwAJ

The overflow would occur in `ImageFullSampler::GenerateData()`:

https://github.com/SuperElastix/elastix/blob/421cc17074ca06388ea71c37f1150d1d6b4601f5/Common/ImageSamplers/itkImageFullSampler.hxx#L64

This commit should fix this issue by using `std::size_t`, instead of `unsigned long`, as `TElementIdentifier` template argument of `VectorDataContainer`.