### PR TITLE
Avoid unnecessary clamp (itkSetClampMacro) and float truncations

### DIFF
--- a/Components/Optimizers/QuasiNewtonLBFGS/itkQuasiNewtonLBFGSOptimizer.h
+++ b/Components/Optimizers/QuasiNewtonLBFGS/itkQuasiNewtonLBFGSOptimizer.h
@@ -126,7 +126,7 @@ public:
   /** Setting: the memory. The number of iterations that are used
    * to estimate the Hessian. 5 by default. 0 results in (normalised) gradient
    * descent search directions */
-  itkSetClampMacro( Memory, unsigned int, 0, NumericTraits< unsigned int >::max() );
+  itkSetMacro( Memory, unsigned int );
   itkGetConstMacro( Memory, unsigned int );
 
 protected:

--- a/Testing/itkAdvancedBSplineDeformableTransformTest.cxx
+++ b/Testing/itkAdvancedBSplineDeformableTransformTest.cxx
@@ -153,7 +153,7 @@ main( int argc, char * argv[] )
 
   /** Declare variables. */
   InputPointType inputPoint;
-  inputPoint.Fill( 4.1 );
+  inputPoint.Fill( 4.1f );
   JacobianType                  jacobian;
   SpatialJacobianType           spatialJacobian;
   SpatialHessianType            spatialHessian;

--- a/Testing/itkBSplineInterpolationDerivativeWeightFunctionTest.cxx
+++ b/Testing/itkBSplineInterpolationDerivativeWeightFunctionTest.cxx
@@ -60,8 +60,8 @@ main( int argc, char * argv[] )
    * NOTE: don't change this, since the hard-coded ground truth depends on this.
    */
   ContinuousIndexType cindex;
-  cindex[ 0 ] =  3.1;
-  cindex[ 1 ] = -2.2;
+  cindex[ 0 ] =  3.1f;
+  cindex[ 1 ] = -2.2f;
   foWeightFunction->SetDerivativeDirection( 0 );
 
   /** Run evaluate for the first order derivative. */

--- a/Testing/itkBSplineInterpolationSODerivativeWeightFunctionTest.cxx
+++ b/Testing/itkBSplineInterpolationSODerivativeWeightFunctionTest.cxx
@@ -62,8 +62,8 @@ main( int argc, char * argv[] )
    * NOTE: don't change this, since the hard-coded ground truth depends on this.
    */
   ContinuousIndexType cindex;
-  cindex[ 0 ] =  3.1;
-  cindex[ 1 ] = -2.2;
+  cindex[ 0 ] =  3.1f;
+  cindex[ 1 ] = -2.2f;
   soWeightFunction->SetDerivativeDirections( 0, 1 );
 
   /** Run evaluate for the second order derivative. */

--- a/Testing/itkBSplineInterpolationWeightFunctionTest.cxx
+++ b/Testing/itkBSplineInterpolationWeightFunctionTest.cxx
@@ -67,7 +67,7 @@ main( int argc, char * argv[] )
 
   /** Create and fill a continuous index. */
   ContinuousIndexType2D cindex;
-  cindex.Fill( 0.1 );
+  cindex.Fill( 0.1f );
 
   /** Run evaluate for the original ITK implementation. */
   WeightsType2D weights2D = weightFunction2D->Evaluate( cindex );
@@ -165,7 +165,7 @@ main( int argc, char * argv[] )
 
   /** Create and fill a continuous index. */
   ContinuousIndexType3D cindex3D;
-  cindex3D.Fill( 0.1 );
+  cindex3D.Fill( 0.1f );
 
   /** Run evaluate for the original ITK implementation. */
   WeightsType3D weights3D = weightFunction3D->Evaluate( cindex3D );


### PR DESCRIPTION
Fixes a few obvious compile warnings