### PR TITLE
Replace vnl_math function calls (cuberoot, abs) by std calls

### DIFF
--- a/Common/LineSearchOptimizers/itkMoreThuenteLineSearchOptimizer.cxx
+++ b/Common/LineSearchOptimizers/itkMoreThuenteLineSearchOptimizer.cxx
@@ -20,8 +20,8 @@
 #define __itkMoreThuenteLineSearchOptimizer_cxx
 
 #include "itkMoreThuenteLineSearchOptimizer.h"
+#include <cmath> // For abs.
 #include <limits>
-#include "vnl/vnl_math.h"
 
 namespace itk
 {
@@ -449,7 +449,7 @@ MoreThuenteLineSearchOptimizer
   MeasureType ftest1 = this->m_finit + step * this->m_dgtest;
 
   this->m_SufficientDecreaseConditionSatisfied = ( this->m_f <= ftest1 );
-  this->m_CurvatureConditionSatisfied          = ( vnl_math::abs( this->m_dg ) <=
+  this->m_CurvatureConditionSatisfied          = ( std::abs( this->m_dg ) <=
     this->GetGradientTolerance() * ( -this->m_dginit ) );
 
   if( ( this->m_brackt
@@ -594,12 +594,12 @@ MoreThuenteLineSearchOptimizer
     const double & stx = this->m_stepx;
     const double & sty = this->m_stepy;
 
-    if( vnl_math::abs( sty - stx ) >= .66 * this->m_width1 )
+    if( std::abs( sty - stx ) >= .66 * this->m_width1 )
     {
       this->m_step = stx + .5 * ( sty - stx );
     }
     this->m_width1 = this->m_width;
-    this->m_width  = vnl_math::abs( sty - stx );
+    this->m_width  = std::abs( sty - stx );
   }
 
 } // end ForceSufficientDecreaseInIntervalWidth()
@@ -714,7 +714,7 @@ MoreThuenteLineSearchOptimizer
 
   /* DETERMINE IF THE DERIVATIVES HAVE OPPOSITE SIGN. */
 
-  sgnd = dp * ( dx / vnl_math::abs( dx ) );
+  sgnd = dp * ( dx / std::abs( dx ) );
 
   /*     FIRST CASE. A HIGHER FUNCTION VALUE. */
   /*     THE MINIMUM IS BRACKETED. IF THE CUBIC STEP IS CLOSER */
@@ -727,8 +727,8 @@ MoreThuenteLineSearchOptimizer
     bound      = true;
     theta      = ( fx - fp ) * 3 / ( stp - stx ) + dx + dp;
     s          = std::max(
-      std::max( vnl_math::abs( theta ), vnl_math::abs( dx ) ),
-      vnl_math::abs( dp ) );
+      std::max( std::abs( theta ), std::abs( dx ) ),
+      std::abs( dp ) );
     d__1  = theta / s;
     gamma = s * std::sqrt( d__1 * d__1 - dx / s * ( dp / s ) );
     if( stp < stx )
@@ -741,7 +741,7 @@ MoreThuenteLineSearchOptimizer
     stpc = stx + r * ( stp - stx );
     stpq = stx
       + dx / ( ( fx - fp ) / ( stp - stx ) + dx ) / 2 * ( stp - stx );
-    if( vnl_math::abs( stpc - stx ) < vnl_math::abs( stpq - stx ) )
+    if( std::abs( stpc - stx ) < std::abs( stpq - stx ) )
     {
       stpf = stpc;
     }
@@ -763,8 +763,8 @@ MoreThuenteLineSearchOptimizer
     bound      = false;
     theta      = ( fx - fp ) * 3 / ( stp - stx ) + dx + dp;
     s          = std::max(
-      std::max( vnl_math::abs( theta ), vnl_math::abs( dx ) ),
-      vnl_math::abs( dp ) );
+      std::max( std::abs( theta ), std::abs( dx ) ),
+      std::abs( dp ) );
     d__1  = theta / s;
     gamma = s * std::sqrt( d__1 * d__1 - dx / s * ( dp / s ) );
     if( stp > stx )
@@ -776,7 +776,7 @@ MoreThuenteLineSearchOptimizer
     r    = p / q;
     stpc = stp + r * ( stx - stp );
     stpq = stp + dp / ( dp - dx ) * ( stx - stp );
-    if( vnl_math::abs( stpc - stp ) > vnl_math::abs( stpq - stp ) )
+    if( std::abs( stpc - stp ) > std::abs( stpq - stp ) )
     {
       stpf = stpc;
     }
@@ -796,14 +796,14 @@ MoreThuenteLineSearchOptimizer
     /*     CLOSEST TO STX IS TAKEN, ELSE THE STEP FARTHEST AWAY IS TAKEN. */
 
   }
-  else if( vnl_math::abs( dp ) < vnl_math::abs( dx ) )
+  else if( std::abs( dp ) < std::abs( dx ) )
   {
     returncode = 3;
     bound      = true;
     theta      = ( fx - fp ) * 3 / ( stp - stx ) + dx + dp;
     s          = std::max(
-      std::max( vnl_math::abs( theta ), vnl_math::abs( dx ) ),
-      vnl_math::abs( dp ) );
+      std::max( std::abs( theta ), std::abs( dx ) ),
+      std::abs( dp ) );
 
     /* THE CASE GAMMA = 0 ONLY ARISES IF THE CUBIC DOES NOT TEND */
     /* TO INFINITY IN THE DIRECTION OF THE STEP. */
@@ -833,7 +833,7 @@ MoreThuenteLineSearchOptimizer
     stpq = stp + dp / ( dp - dx ) * ( stx - stp );
     if( brackt )
     {
-      if( vnl_math::abs( stp - stpc ) < vnl_math::abs( stp - stpq ) )
+      if( std::abs( stp - stpc ) < std::abs( stp - stpq ) )
       {
         stpf = stpc;
       }
@@ -844,7 +844,7 @@ MoreThuenteLineSearchOptimizer
     }
     else
     {
-      if( vnl_math::abs( stp - stpc ) > vnl_math::abs( stp - stpq ) )
+      if( std::abs( stp - stpc ) > std::abs( stp - stpq ) )
       {
         stpf = stpc;
       }
@@ -868,8 +868,8 @@ MoreThuenteLineSearchOptimizer
     {
       theta = ( fp - fy ) * 3 / ( sty - stp ) + dy + dp;
       s     = std::max(
-        std::max( vnl_math::abs( theta ), vnl_math::abs( dy ) ),
-        vnl_math::abs( dp ) );
+        std::max( std::abs( theta ), std::abs( dy ) ),
+        std::abs( dp ) );
       d__1  = theta / s;
       gamma = s * std::sqrt( d__1 * d__1 - dy / s * ( dp / s ) );
       if( stp > sty )

--- a/Common/Transforms/itkBSplineSecondOrderDerivativeKernelFunction2.h
+++ b/Common/Transforms/itkBSplineSecondOrderDerivativeKernelFunction2.h
@@ -20,6 +20,7 @@
 
 #include "itkKernelFunctionBase.h"
 #include "vnl/vnl_math.h"
+#include <cmath> // For abs.
 
 namespace itk
 {
@@ -103,7 +104,7 @@ private:
   /** Second order spline. */
   inline double Evaluate( const Dispatch< 2 > &, const double & u ) const
   {
-    double absValue = vnl_math::abs( u );
+    double absValue = std::abs( u );
 
     if( absValue < 0.5 )
     {
@@ -139,7 +140,7 @@ private:
   /**  Third order spline. */
   inline double Evaluate( const Dispatch< 3 > &, const double & u ) const
   {
-    const double absValue = vnl_math::abs( u );
+    const double absValue = std::abs( u );
 
     if( absValue < 1.0 )
     {

--- a/Common/itkComputePreconditionerUsingDisplacementDistribution.hxx
+++ b/Common/itkComputePreconditionerUsingDisplacementDistribution.hxx
@@ -29,6 +29,8 @@
 #include "itkZeroFluxNeumannPadImageFilter.h"
 #include "itkSmoothingRecursiveGaussianImageFilter.h"
 
+#include <cmath> // For abs.
+
 
 namespace itk
 {
@@ -215,7 +217,7 @@ ComputePreconditionerUsingDisplacementDistribution< TFixedImage, TTransform >
       }
 
       // Use the absolute value
-      jacj_g( i ) = vnl_math::abs( temp );
+      jacj_g( i ) = std::abs( temp );
     }
 
     /** A support region is where this voxel has the affect on the B-Spline
@@ -258,7 +260,7 @@ ComputePreconditionerUsingDisplacementDistribution< TFixedImage, TTransform >
 #elif METHOD_BSPLINE == 3
       // MS: the following will use the Jacobian as weights
       const unsigned int pj = jacind[ j ];
-      const double weight = vnl_math::abs( jacj( nonzerodim, j ) );
+      const double weight = std::abs( jacj( nonzerodim, j ) );
       // YQ: the weight is positive.
 
       /** localStepSize keeps track of the mean displacement.
@@ -414,7 +416,7 @@ ComputePreconditionerUsingDisplacementDistribution< TFixedImage, TTransform >
         }
 
         // Use the absolute value
-        jacj_g( i ) = vnl_math::abs( temp );
+        jacj_g( i ) = std::abs( temp );
       }
       displacement2_j = jacj_g.magnitude();
     }
@@ -427,9 +429,9 @@ ComputePreconditionerUsingDisplacementDistribution< TFixedImage, TTransform >
       double jacj_current = 0.0;
       for( unsigned int i = 0; i < outdim; ++i )
       {
-        jacj_current += vnl_math::abs( jacj( i, j ) );
+        jacj_current += std::abs( jacj( i, j ) );
       }
-      displacement_j = vnl_math::abs( jacj_current * exactgradient( pj ) );
+      displacement_j = std::abs( jacj_current * exactgradient( pj ) );
 
       if( transformIsBSpline )
       {
@@ -455,9 +457,9 @@ ComputePreconditionerUsingDisplacementDistribution< TFixedImage, TTransform >
             double jacj_k = 0.0;
             for( unsigned int i = 0; i < outdim; ++i )
             {
-              jacj_k += vnl_math::abs( jacj( i, k ) );
+              jacj_k += std::abs( jacj( i, k ) );
             }
-            diff_jacobian = vnl_math::abs( jacj_k - jacj_current );
+            diff_jacobian = std::abs( jacj_k - jacj_current );
             if( diff_jacobian > 0 && mindiffCheck )
             {
               mindiff = diff_jacobian;
@@ -489,13 +491,13 @@ ComputePreconditionerUsingDisplacementDistribution< TFixedImage, TTransform >
             double jacj_k = 0.0;
             for( unsigned int i = 0; i < outdim; ++i )
             {
-              jacj_k += vnl_math::abs( jacj( i, k ) );
+              jacj_k += std::abs( jacj( i, k ) );
             }
 
-            diff_jacobian = vnl_math::abs( jacj_k - jacj_current );
+            diff_jacobian = std::abs( jacj_k - jacj_current );
             weight = std::exp( -( vnl_math::sqr( diff_jacobian / weight_sigma ) / 2.0 ) );
 
-            sum_displacement += vnl_math::abs( jacj_k * exactgradient( pk ) ) * weight;
+            sum_displacement += std::abs( jacj_k * exactgradient( pk ) ) * weight;
             sum_weight += weight;
           } // end if
         } // end for loop regularization

--- a/Common/itkComputePreconditionerUsingDisplacementDistribution.hxx
+++ b/Common/itkComputePreconditionerUsingDisplacementDistribution.hxx
@@ -151,7 +151,7 @@ ComputePreconditionerUsingDisplacementDistribution< TFixedImage, TTransform >
   double supportRegionDimension = 1;
   if( outdim == 3 )
   {
-    supportRegionDimension = vnl_math::cuberoot( double(supportRegionSize) );
+    supportRegionDimension = std::cbrt( double(supportRegionSize) );
   }
   else if( outdim == 2 )
   {

--- a/Components/Metrics/AdvancedKappaStatistic/itkAdvancedKappaStatisticImageToImageMetric.hxx
+++ b/Components/Metrics/AdvancedKappaStatistic/itkAdvancedKappaStatisticImageToImageMetric.hxx
@@ -19,6 +19,7 @@
 #define _itkAdvancedKappaStatisticImageToImageMetric_hxx
 
 #include "itkAdvancedKappaStatisticImageToImageMetric.h"
+#include <cmath> // For abs.
 
 namespace itk
 {
@@ -205,8 +206,8 @@ AdvancedKappaStatisticImageToImageMetric< TFixedImage, TMovingImage >
       /** Update the intermediate values. */
       if( this->m_UseForegroundValue )
       {
-        const RealType diffFixed  = vnl_math::abs( fixedImageValue - this->m_ForegroundValue );
-        const RealType diffMoving = vnl_math::abs( movingImageValue - this->m_ForegroundValue );
+        const RealType diffFixed  = std::abs( fixedImageValue - this->m_ForegroundValue );
+        const RealType diffMoving = std::abs( movingImageValue - this->m_ForegroundValue );
         if( diffFixed < this->m_Epsilon ) { fixedForegroundArea++; }
         if( diffMoving < this->m_Epsilon ) { movingForegroundArea++; }
         if( diffFixed < this->m_Epsilon
@@ -724,8 +725,8 @@ AdvancedKappaStatisticImageToImageMetric< TFixedImage, TMovingImage >
   bool usableFixedSample = false;
   if( this->m_UseForegroundValue )
   {
-    const RealType diffFixed  = vnl_math::abs( fixedImageValue - this->m_ForegroundValue );
-    const RealType diffMoving = vnl_math::abs( movingImageValue - this->m_ForegroundValue );
+    const RealType diffFixed  = std::abs( fixedImageValue - this->m_ForegroundValue );
+    const RealType diffMoving = std::abs( movingImageValue - this->m_ForegroundValue );
     if( diffFixed < this->m_Epsilon ) { fixedForegroundArea++; usableFixedSample = true; }
     if( diffMoving < this->m_Epsilon ) { movingForegroundArea++; }
     if( diffFixed < this->m_Epsilon
@@ -829,8 +830,8 @@ AdvancedKappaStatisticImageToImageMetric< TFixedImage, TMovingImage >
         plusIndex[ i ]  = currIndex[ i ] + 1;
         const RealType minusVal  = static_cast< RealType >( this->m_MovingImage->GetPixel( minusIndex ) );
         const RealType plusVal   = static_cast< RealType >( this->m_MovingImage->GetPixel( plusIndex ) );
-        const RealType minusDiff = vnl_math::abs( minusVal - this->m_ForegroundValue );
-        const RealType plusDiff  = vnl_math::abs(  plusVal - this->m_ForegroundValue );
+        const RealType minusDiff = std::abs( minusVal - this->m_ForegroundValue );
+        const RealType plusDiff  = std::abs(  plusVal - this->m_ForegroundValue );
 
         /** Calculate the gradient. */
         if( minusDiff >= this->m_Epsilon && plusDiff < this->m_Epsilon )

--- a/Components/Optimizers/AdaGrad/elxAdaGrad.hxx
+++ b/Components/Optimizers/AdaGrad/elxAdaGrad.hxx
@@ -20,6 +20,7 @@
 
 #include "elxAdaGrad.h"
 
+#include <cmath> // For abs.
 #include <iomanip>
 #include <string>
 #include <vector>
@@ -926,8 +927,8 @@ AdaGrad< TElastix >
    * the rank, in case of maximum likelihood. In case of no maximum likelihood,
    * the rank equals Pd.
    */
-  gg = vnl_math::abs( exactgg );
-  ee = vnl_math::abs( diffgg );
+  gg = std::abs( exactgg );
+  ee = std::abs( diffgg );
 
   /** Set back useRandomSampleRegion flag to what it was. */
   for( unsigned int m = 0; m < M; ++m )

--- a/Components/Optimizers/PreconditionedStochasticGradientDescent/elxPreconditionedStochasticGradientDescent.hxx
+++ b/Components/Optimizers/PreconditionedStochasticGradientDescent/elxPreconditionedStochasticGradientDescent.hxx
@@ -20,6 +20,7 @@
 
 #include "elxPreconditionedStochasticGradientDescent.h"
 
+#include <cmath> // For abs.
 #include <iomanip>
 #include <string>
 #include <vector>
@@ -940,8 +941,8 @@ PreconditionedStochasticGradientDescent< TElastix >
    * the rank, in case of maximum likelihood. In case of no maximum likelihood,
    * the rank equals Pd.
    */
-  gg = vnl_math::abs( exactgg );
-  ee = vnl_math::abs( diffgg );
+  gg = std::abs( exactgg );
+  ee = std::abs( diffgg );
 
   /** Set back useRandomSampleRegion flag to what it was. */
   for( unsigned int m = 0; m < M; ++m )

--- a/Testing/itkAdvancedLinearInterpolatorTest.cxx
+++ b/Testing/itkAdvancedLinearInterpolatorTest.cxx
@@ -27,8 +27,9 @@
 #include "itkImageRegionIterator.h"
 #include "itkMersenneTwisterRandomVariateGenerator.h"
 #include "itkImageFileWriter.h"
-#include "vnl/vnl_math.h"
 #include "itkTimeProbe.h"
+
+#include <cmath> // For abs.
 
 //-------------------------------------------------------------------------------------
 
@@ -187,13 +188,13 @@ TestInterpolators( void )
     std::cout << "B-spline: " << valueBSpline  << "   " << derivBSpline  << std::endl;
     std::cout << "B-spline: " << valueBSpline2 << "   " << derivBSpline2 << "\n" << std::endl;
 
-    if( vnl_math::abs( valueLinA - valueBSpline ) > 1.0e-3 )
+    if( std::abs( valueLinA - valueBSpline ) > 1.0e-3 )
     {
       std::cerr << "ERROR: there is a difference in the interpolated value, "
                 << "between the linear and the 1st-order B-spline interpolator." << std::endl;
       return false;
     }
-    if( vnl_math::abs( valueBSpline - valueBSpline2 ) > 1.0e-3 )
+    if( std::abs( valueBSpline - valueBSpline2 ) > 1.0e-3 )
     {
       std::cerr << "ERROR: there is a difference in the interpolated value, "
                 << "within the 1st-order B-spline interpolator (inconsistency)." << std::endl;


### PR DESCRIPTION
Replaced calls to:

    vnl_math::abs
    vnl_math::cuberoot

Note: this pull request does not touch calls to:

    vnl_math::sqr
    vnl_math::rnd
    vnl_math::sgn
    vnl_math::sgn0

Those functions do not seem to have an equivalent function in the Standartd C++ Library.
    