### PR TITLE
COMP: Fix ITK_FUTURE_LEGACY_REMOVE constness compile errors

### DIFF
--- a/Common/itkComputePreconditionerUsingDisplacementDistribution.hxx
+++ b/Common/itkComputePreconditionerUsingDisplacementDistribution.hxx
@@ -739,7 +739,7 @@ ComputePreconditionerUsingDisplacementDistribution< TFixedImage, TTransform >
   CombinationTransformType * testPtr_combo
     = dynamic_cast< CombinationTransformType * >( this->m_Transform.GetPointer() );
   if( !testPtr_combo ) return; // throw an error?
-  BSplineTransformType * testPtr_bspline = dynamic_cast<BSplineTransformType *>( testPtr_combo->GetCurrentTransform() );
+  const auto testPtr_bspline = dynamic_cast<const BSplineTransformType *>( testPtr_combo->GetCurrentTransform() );
   if( !testPtr_bspline ) return; // throw an error?
 
   GridRegionType gridRegion = testPtr_bspline->GetGridRegion();

--- a/Components/Metrics/MissingStructurePenalty/elxMissingStructurePenalty.hxx
+++ b/Components/Metrics/MissingStructurePenalty/elxMissingStructurePenalty.hxx
@@ -340,7 +340,7 @@ MissingStructurePenalty< TElastix >
   /** Setup the pipeline. */
 
   /** Set the points of the latest transformation. */
-  const MappedMeshContainerPointer mappedMeshContainer = this->GetMappedMeshContainer();
+  const MappedMeshContainerPointer mappedMeshContainer = this->GetModifiableMappedMeshContainer();
   FixedMeshPointer                 mappedMesh          = mappedMeshContainer->ElementAt( meshId );
 
   /** Use pointer to the mesh data of fixedMesh; const_cast are assumed since outputMesh will only be used for writing the output*/

--- a/Components/Metrics/MissingStructurePenalty/itkMissingStructurePenalty.h
+++ b/Components/Metrics/MissingStructurePenalty/itkMissingStructurePenalty.h
@@ -132,7 +132,7 @@ public:
   itkGetConstObjectMacro( FixedMeshContainer, FixedMeshContainerType );
 
   itkSetObjectMacro( MappedMeshContainer, MappedMeshContainerType );
-  itkGetObjectMacro( MappedMeshContainer, MappedMeshContainerType );
+  itkGetModifiableObjectMacro( MappedMeshContainer, MappedMeshContainerType );
 
   /** Initialize the Metric by making sure that all the components are
   *  present and plugged together correctly.

--- a/Components/Metrics/PolydataDummyPenalty/elxPolydataDummyPenalty.hxx
+++ b/Components/Metrics/PolydataDummyPenalty/elxPolydataDummyPenalty.hxx
@@ -327,7 +327,7 @@ PolydataDummyPenalty< TElastix >
   typename MeshWriterType::Pointer meshWriter = MeshWriterType::New();
 
   /** Set the points of the latest transformation. */
-  const MappedMeshContainerPointer mappedMeshContainer = this->GetMappedMeshContainer();
+  const MappedMeshContainerPointer mappedMeshContainer = this->GetModifiableMappedMeshContainer();
   FixedMeshPointer                 mappedMesh          = mappedMeshContainer->ElementAt( meshId );
 
   /** Use pointer to the mesh data of fixedMesh; const_cast are assumed since outputMesh

--- a/Components/Metrics/PolydataDummyPenalty/itkPolydataDummyPenalty.h
+++ b/Components/Metrics/PolydataDummyPenalty/itkPolydataDummyPenalty.h
@@ -126,7 +126,7 @@ public:
   itkGetConstObjectMacro( FixedMeshContainer, FixedMeshContainerType );
 
   itkSetObjectMacro( MappedMeshContainer, MappedMeshContainerType );
-  itkGetObjectMacro( MappedMeshContainer, MappedMeshContainerType );
+  itkGetModifiableObjectMacro( MappedMeshContainer, MappedMeshContainerType );
 
   /** Get the mapped points. */
   //itkGetObjectMacro( MappedPoints, MeshPointsContainerPointer );

--- a/Components/Optimizers/AdaGrad/elxAdaGrad.hxx
+++ b/Components/Optimizers/AdaGrad/elxAdaGrad.hxx
@@ -553,7 +553,7 @@ AdaGrad< TElastix >
          << this->elxGetClassName() << " ..." << std::endl;
 
   /** Get current position to start the parameter estimation. */
-  this->GetRegistration()->GetAsITKBaseType()->GetTransform()->SetParameters(
+  this->GetRegistration()->GetAsITKBaseType()->GetModifiableTransform()->SetParameters(
     this->GetCurrentPosition() );
 
   /** Get the number of parameters. */
@@ -673,7 +673,7 @@ AdaGrad< TElastix >
   computeDisplacementDistribution->SetFixedImageRegion(testPtr->GetFixedImageRegion());
   computeDisplacementDistribution->SetFixedImageMask(testPtr->GetFixedImageMask());
   computeDisplacementDistribution->SetTransform(
-    this->GetRegistration()->GetAsITKBaseType()->GetTransform());
+    this->GetRegistration()->GetAsITKBaseType()->GetModifiableTransform());
   computeDisplacementDistribution->SetCostFunction(this->m_CostFunction);
   computeDisplacementDistribution->SetNumberOfJacobianMeasurements(
     this->m_NumberOfJacobianMeasurements);
@@ -1012,7 +1012,7 @@ AdaGrad< TElastix >
 ::CheckForAdvancedTransform( void )
 {
   typename TransformType::Pointer transform = this->GetRegistration()
-    ->GetAsITKBaseType()->GetTransform();
+    ->GetAsITKBaseType()->GetModifiableTransform();
 
   AdvancedTransformType * testPtr = dynamic_cast< AdvancedTransformType * >(
     transform.GetPointer() );

--- a/Components/Optimizers/AdaptiveStochasticLBFGS/elxAdaptiveStochasticLBFGS.hxx
+++ b/Components/Optimizers/AdaptiveStochasticLBFGS/elxAdaptiveStochasticLBFGS.hxx
@@ -967,7 +967,7 @@ AdaptiveStochasticLBFGS<TElastix>
   double maxJCJ = 0.0;
 
   /** Get current position to start the parameter estimation. */
-  this->GetRegistration()->GetAsITKBaseType()->GetTransform()->SetParameters(
+  this->GetRegistration()->GetAsITKBaseType()->GetModifiableTransform()->SetParameters(
     this->GetCurrentPosition() );
 
   /** Cast to advanced metric type. */
@@ -986,7 +986,7 @@ AdaptiveStochasticLBFGS<TElastix>
   computeJacobianTerms->SetFixedImageRegion( testPtr->GetFixedImageRegion() );
   computeJacobianTerms->SetFixedImageMask( testPtr->GetFixedImageMask() );
   computeJacobianTerms->SetTransform(
-    this->GetRegistration()->GetAsITKBaseType()->GetTransform() );
+    this->GetRegistration()->GetAsITKBaseType()->GetModifiableTransform() );
   computeJacobianTerms->SetMaxBandCovSize( this->m_MaxBandCovSize );
   computeJacobianTerms->SetNumberOfBandStructureSamples(
     this->m_NumberOfBandStructureSamples );
@@ -1116,7 +1116,7 @@ AdaptiveStochasticLBFGS<TElastix>
   itk::TimeProbe timer4 ,timer5;
 
   /** Get current position to start the parameter estimation. */
-  this->GetRegistration()->GetAsITKBaseType()->GetTransform()->SetParameters(
+  this->GetRegistration()->GetAsITKBaseType()->GetModifiableTransform()->SetParameters(
     this->GetCurrentPosition() );
 
   /** Get the user input. */
@@ -1140,7 +1140,7 @@ AdaptiveStochasticLBFGS<TElastix>
   computeDisplacementDistribution->SetFixedImageRegion( testPtr->GetFixedImageRegion() );
   computeDisplacementDistribution->SetFixedImageMask( testPtr->GetFixedImageMask() );
   computeDisplacementDistribution->SetTransform(
-    this->GetRegistration()->GetAsITKBaseType()->GetTransform() );
+    this->GetRegistration()->GetAsITKBaseType()->GetModifiableTransform() );
   computeDisplacementDistribution->SetCostFunction( this->m_CostFunction );
   computeDisplacementDistribution->SetNumberOfJacobianMeasurements(
     this->m_NumberOfJacobianMeasurements );
@@ -1236,7 +1236,7 @@ AdaptiveStochasticLBFGS<TElastix>
 ::AutomaticLBFGSStepsizeEstimation( void )
 {
   /** Get current position to start the parameter estimation. */
-  this->GetRegistration()->GetAsITKBaseType()->GetTransform()->SetParameters(
+  this->GetRegistration()->GetAsITKBaseType()->GetModifiableTransform()->SetParameters(
     this->GetCurrentPosition() );
 
   /** Get the user input. */
@@ -1260,7 +1260,7 @@ AdaptiveStochasticLBFGS<TElastix>
   computeDisplacementDistribution->SetFixedImageRegion( testPtr->GetFixedImageRegion() );
   computeDisplacementDistribution->SetFixedImageMask( testPtr->GetFixedImageMask() );
   computeDisplacementDistribution->SetTransform(
-    this->GetRegistration()->GetAsITKBaseType()->GetTransform() );
+    this->GetRegistration()->GetAsITKBaseType()->GetModifiableTransform() );
   computeDisplacementDistribution->SetCostFunction( this->m_CostFunction );
   computeDisplacementDistribution->SetNumberOfJacobianMeasurements(
     this->m_NumberOfJacobianMeasurements );
@@ -1570,7 +1570,7 @@ AdaptiveStochasticLBFGS<TElastix>
 ::CheckForAdvancedTransform( void )
 {
   typename TransformType::Pointer transform = this->GetRegistration()
-    ->GetAsITKBaseType()->GetTransform();
+    ->GetAsITKBaseType()->GetModifiableTransform();
 
   AdvancedTransformType * testPtr = dynamic_cast<AdvancedTransformType *>(
     transform.GetPointer() );

--- a/Components/Optimizers/AdaptiveStochasticVarianceReducedGradient/elxAdaptiveStochasticVarianceReducedGradient.hxx
+++ b/Components/Optimizers/AdaptiveStochasticVarianceReducedGradient/elxAdaptiveStochasticVarianceReducedGradient.hxx
@@ -595,7 +595,7 @@ AdaptiveStochasticVarianceReducedGradient<TElastix>
     timeCollector.Stop( "copy" );
 
     timeCollector.Start( "g1" );
-    this->GetRegistration()->GetAsITKBaseType()->GetMetric()->SetNumberOfWorkUnits(
+    this->GetRegistration()->GetAsITKBaseType()->GetModifiableMetric()->SetNumberOfWorkUnits(
       this->GetRegistration()->GetAsITKBaseType()->GetMetric()->GetThreader()->GetGlobalDefaultNumberOfThreads()
       );
     this->GetScaledDerivativeWithExceptionHandling( previousPosition, this->m_MeanGradient );
@@ -639,7 +639,7 @@ AdaptiveStochasticVarianceReducedGradient<TElastix>
       // (and large parameter vectors)
       if( this->m_NumberOfInnerLoopSamples < 300 )
       {
-        this->GetRegistration()->GetAsITKBaseType()->GetMetric()->SetNumberOfWorkUnits( 1 );
+        this->GetRegistration()->GetAsITKBaseType()->GetModifiableMetric()->SetNumberOfWorkUnits( 1 );
       }
     }
 
@@ -825,7 +825,7 @@ AdaptiveStochasticVarianceReducedGradient<TElastix>
   double maxJCJ = 0.0;
 
   /** Get current position to start the parameter estimation. */
-  this->GetRegistration()->GetAsITKBaseType()->GetTransform()->SetParameters(
+  this->GetRegistration()->GetAsITKBaseType()->GetModifiableTransform()->SetParameters(
     this->GetCurrentPosition() );
 
   /** Cast to advanced metric type. */
@@ -844,7 +844,7 @@ AdaptiveStochasticVarianceReducedGradient<TElastix>
   computeJacobianTerms->SetFixedImageRegion( testPtr->GetFixedImageRegion() );
   computeJacobianTerms->SetFixedImageMask( testPtr->GetFixedImageMask() );
   computeJacobianTerms->SetTransform(
-    this->GetRegistration()->GetAsITKBaseType()->GetTransform() );
+    this->GetRegistration()->GetAsITKBaseType()->GetModifiableTransform() );
   computeJacobianTerms->SetMaxBandCovSize( this->m_MaxBandCovSize );
   computeJacobianTerms->SetNumberOfBandStructureSamples(
     this->m_NumberOfBandStructureSamples );
@@ -974,7 +974,7 @@ AdaptiveStochasticVarianceReducedGradient<TElastix>
   itk::TimeProbe timer4, timer5;
 
   /** Get current position to start the parameter estimation. */
-  this->GetRegistration()->GetAsITKBaseType()->GetTransform()->SetParameters(
+  this->GetRegistration()->GetAsITKBaseType()->GetModifiableTransform()->SetParameters(
     this->GetCurrentPosition() );
 
   /** Get the user input. */
@@ -998,7 +998,7 @@ AdaptiveStochasticVarianceReducedGradient<TElastix>
   computeDisplacementDistribution->SetFixedImageRegion( testPtr->GetFixedImageRegion() );
   computeDisplacementDistribution->SetFixedImageMask( testPtr->GetFixedImageMask() );
   computeDisplacementDistribution->SetTransform(
-    this->GetRegistration()->GetAsITKBaseType()->GetTransform() );
+    this->GetRegistration()->GetAsITKBaseType()->GetModifiableTransform() );
   computeDisplacementDistribution->SetCostFunction( this->m_CostFunction );
   computeDisplacementDistribution->SetNumberOfJacobianMeasurements(
     this->m_NumberOfJacobianMeasurements );
@@ -1360,7 +1360,7 @@ AdaptiveStochasticVarianceReducedGradient<TElastix>
 ::CheckForAdvancedTransform( void )
 {
   typename TransformType::Pointer transform = this->GetRegistration()
-    ->GetAsITKBaseType()->GetTransform();
+    ->GetAsITKBaseType()->GetModifiableTransform();
 
   AdvancedTransformType * testPtr = dynamic_cast<AdvancedTransformType *>(
     transform.GetPointer() );

--- a/Components/Optimizers/PreconditionedStochasticGradientDescent/elxPreconditionedStochasticGradientDescent.hxx
+++ b/Components/Optimizers/PreconditionedStochasticGradientDescent/elxPreconditionedStochasticGradientDescent.hxx
@@ -554,7 +554,7 @@ PreconditionedStochasticGradientDescent< TElastix >
          << this->elxGetClassName() << " ..." << std::endl;
 
   /** Get current position to start the parameter estimation. */
-  this->GetRegistration()->GetAsITKBaseType()->GetTransform()->SetParameters(
+  this->GetRegistration()->GetAsITKBaseType()->GetModifiableTransform()->SetParameters(
     this->GetCurrentPosition() );
 
   /** Get the number of parameters. */
@@ -611,7 +611,7 @@ PreconditionedStochasticGradientDescent< TElastix >
   preconditionerEstimator->SetFixedImageRegion( testPtr->GetFixedImageRegion() );
   preconditionerEstimator->SetFixedImageMask( testPtr->GetFixedImageMask() );
   preconditionerEstimator->SetTransform(
-    this->GetRegistration()->GetAsITKBaseType()->GetTransform() );
+    this->GetRegistration()->GetAsITKBaseType()->GetModifiableTransform() );
   preconditionerEstimator->SetCostFunction( this->m_CostFunction );
   preconditionerEstimator->SetNumberOfJacobianMeasurements(
     this->m_NumberOfJacobianMeasurements );
@@ -675,7 +675,7 @@ PreconditionedStochasticGradientDescent< TElastix >
     computeDisplacementDistribution->SetFixedImageRegion( testPtr->GetFixedImageRegion() );
     computeDisplacementDistribution->SetFixedImageMask( testPtr->GetFixedImageMask() );
     computeDisplacementDistribution->SetTransform(
-      this->GetRegistration()->GetAsITKBaseType()->GetTransform() );
+      this->GetRegistration()->GetAsITKBaseType()->GetModifiableTransform() );
     computeDisplacementDistribution->SetCostFunction( this->m_CostFunction );
     computeDisplacementDistribution->SetNumberOfJacobianMeasurements(
       this->m_NumberOfJacobianMeasurements );
@@ -1026,7 +1026,7 @@ PreconditionedStochasticGradientDescent< TElastix >
 ::CheckForAdvancedTransform( void )
 {
   typename TransformType::Pointer transform = this->GetRegistration()
-    ->GetAsITKBaseType()->GetTransform();
+    ->GetAsITKBaseType()->GetModifiableTransform();
 
   AdvancedTransformType * testPtr = dynamic_cast< AdvancedTransformType * >(
     transform.GetPointer() );

--- a/Components/Transforms/AffineDTITransform/elxAffineDTITransform.hxx
+++ b/Components/Transforms/AffineDTITransform/elxAffineDTITransform.hxx
@@ -364,7 +364,7 @@ AffineDTITransformElastix< TElastix >
   elxout << "Scales for transform parameters are: " << newscales << std::endl;
 
   /** Set the scales into the optimizer. */
-  this->m_Registration->GetAsITKBaseType()->GetOptimizer()->SetScales( newscales );
+  this->m_Registration->GetAsITKBaseType()->GetModifiableOptimizer()->SetScales( newscales );
 
 } // end SetScales()
 

--- a/Components/Transforms/AffineLogTransform/elxAffineLogTransform.hxx
+++ b/Components/Transforms/AffineLogTransform/elxAffineLogTransform.hxx
@@ -364,7 +364,7 @@ AffineLogTransformElastix< TElastix >
   elxout << "Scales for transform parameters are: " << newscales << std::endl;
 
   /** Set the scales into the optimizer. */
-  this->m_Registration->GetAsITKBaseType()->GetOptimizer()->SetScales( newscales );
+  this->m_Registration->GetAsITKBaseType()->GetModifiableOptimizer()->SetScales( newscales );
 
 } // end SetScales()
 

--- a/Components/Transforms/MultiBSplineTransformWithNormal/elxMultiBSplineTransformWithNormal.hxx
+++ b/Components/Transforms/MultiBSplineTransformWithNormal/elxMultiBSplineTransformWithNormal.hxx
@@ -782,7 +782,7 @@ MultiBSplineTransformWithNormal< TElastix >::SetOptimizerScales( const unsigned 
   if( edgeWidth == 0 )
   {
     /** Just set the unit scales into the optimizer. */
-    this->m_Registration->GetAsITKBaseType()->GetOptimizer()->SetScales( newScales );
+    this->m_Registration->GetAsITKBaseType()->GetModifiableOptimizer()->SetScales( newScales );
     return;
   }
 
@@ -840,7 +840,7 @@ MultiBSplineTransformWithNormal< TElastix >::SetOptimizerScales( const unsigned 
   }
 
   /** Set the scales into the optimizer. */
-  this->m_Registration->GetAsITKBaseType()->GetOptimizer()->SetScales( newScales );
+  this->m_Registration->GetAsITKBaseType()->GetModifiableOptimizer()->SetScales( newScales );
 
 } // end SetOptimizerScales()
 

--- a/Components/Transforms/SimilarityTransform/elxSimilarityTransform.hxx
+++ b/Components/Transforms/SimilarityTransform/elxSimilarityTransform.hxx
@@ -364,7 +364,7 @@ SimilarityTransformElastix< TElastix >
   elxout << "Scales for transform parameters are: " << newscales << std::endl;
 
   /** Set the scales into the optimizer. */
-  this->m_Registration->GetAsITKBaseType()->GetOptimizer()->SetScales( newscales );
+  this->m_Registration->GetAsITKBaseType()->GetModifiableOptimizer()->SetScales( newscales );
 
 } // end SetScales()
 

--- a/Components/Transforms/WeightedCombinationTransform/elxWeightedCombinationTransform.hxx
+++ b/Components/Transforms/WeightedCombinationTransform/elxWeightedCombinationTransform.hxx
@@ -211,7 +211,7 @@ WeightedCombinationTransformElastix< TElastix >
   elxout << "Scales for transform parameters are: " << newscales << std::endl;
 
   /** And set the scales into the optimizer. */
-  this->m_Registration->GetAsITKBaseType()->GetOptimizer()->SetScales( newscales );
+  this->m_Registration->GetAsITKBaseType()->GetModifiableOptimizer()->SetScales( newscales );
 
 } // end SetScales()
 


### PR DESCRIPTION
Fixed errors like this, when ITK_FUTURE_LEGACY_REMOVE is on:

> elxAdaptiveStochasticLBFGS.hxx(1573): error C2440: 'initializing': cannot convert from 'const itk::AdvancedTransform<double,2,2> *' to 'itk::SmartPointer<itk::AdvancedTransform<double,2,2>>'

Replaced `itkGetObjectMacro` calls by `itkGetModifiableObjectMacro`, fixing errors like this:

> itkPolydataDummyPenalty.h(129): error C3861: 'purposeful_error': identifier not found