### PR TITLE
COMP: Include itkMacro.h instead of itkExceptionObject.h

### DIFF
--- a/Common/CostFunctions/itkLimiterFunctionBase.h
+++ b/Common/CostFunctions/itkLimiterFunctionBase.h
@@ -19,7 +19,7 @@
 #define __itkLimiterFunctionBase_h
 
 #include "itkFunctionBase.h"
-#include "itkExceptionObject.h"
+#include "itkMacro.h"
 
 namespace itk
 {

--- a/Common/CostFunctions/itkSingleValuedPointSetToPointSetMetric.h
+++ b/Common/CostFunctions/itkSingleValuedPointSetToPointSetMetric.h
@@ -37,7 +37,7 @@
 #include "itkImageBase.h"
 #include "itkAdvancedTransform.h"
 #include "itkSingleValuedCostFunction.h"
-#include "itkExceptionObject.h"
+#include "itkMacro.h"
 #include "itkSpatialObject.h"
 #include "itkPointSet.h"
 

--- a/Common/Transforms/itkAdvancedCombinationTransform.h
+++ b/Common/Transforms/itkAdvancedCombinationTransform.h
@@ -19,7 +19,7 @@
 #define __itkAdvancedCombinationTransform_h
 
 #include "itkAdvancedTransform.h"
-#include "itkExceptionObject.h"
+#include "itkMacro.h"
 
 namespace itk
 {

--- a/Common/Transforms/itkAdvancedMatrixOffsetTransformBase.h
+++ b/Common/Transforms/itkAdvancedMatrixOffsetTransformBase.h
@@ -39,7 +39,7 @@
 
 #include "itkMatrix.h"
 #include "itkAdvancedTransform.h"
-#include "itkExceptionObject.h"
+#include "itkMacro.h"
 #include "itkMacro.h"
 
 namespace itk

--- a/Common/Transforms/itkAdvancedRigid2DTransform.h
+++ b/Common/Transforms/itkAdvancedRigid2DTransform.h
@@ -36,7 +36,7 @@
 
 #include <iostream>
 #include "itkAdvancedMatrixOffsetTransformBase.h"
-#include "itkExceptionObject.h"
+#include "itkMacro.h"
 
 namespace itk
 {

--- a/Common/Transforms/itkAdvancedRigid3DTransform.h
+++ b/Common/Transforms/itkAdvancedRigid3DTransform.h
@@ -36,7 +36,7 @@
 
 #include <iostream>
 #include "itkAdvancedMatrixOffsetTransformBase.h"
-#include "itkExceptionObject.h"
+#include "itkMacro.h"
 #include "itkMatrix.h"
 #include "itkVersor.h"
 

--- a/Common/Transforms/itkAdvancedTranslationTransform.h
+++ b/Common/Transforms/itkAdvancedTranslationTransform.h
@@ -36,7 +36,7 @@
 
 #include <iostream>
 #include "itkAdvancedTransform.h"
-#include "itkExceptionObject.h"
+#include "itkMacro.h"
 #include "itkMatrix.h"
 
 namespace itk

--- a/Common/itkImageFileCastWriter.h
+++ b/Common/itkImageFileCastWriter.h
@@ -20,7 +20,7 @@
 
 #include "itkImageFileWriter.h"
 #include "itkImageIOBase.h"
-#include "itkExceptionObject.h"
+#include "itkMacro.h"
 #include "itkSize.h"
 #include "itkImageIORegion.h"
 #include "itkCastImageFilter.h"

--- a/Common/itkMeshFileReaderBase.h
+++ b/Common/itkMeshFileReaderBase.h
@@ -19,7 +19,7 @@
 #define __itkMeshFileReaderBase_h
 
 #include "itkMeshSource.h"
-#include "itkExceptionObject.h"
+#include "itkMacro.h"
 #include "itkMeshFileReader.h" // for MeshFileReaderException
 
 namespace itk

--- a/Common/itkMultiResolutionGaussianSmoothingPyramidImageFilter.hxx
+++ b/Common/itkMultiResolutionGaussianSmoothingPyramidImageFilter.hxx
@@ -40,7 +40,7 @@
 #include "itkMultiResolutionGaussianSmoothingPyramidImageFilter.h"
 #include "itkCastImageFilter.h"
 #include "itkRecursiveGaussianImageFilter.h"
-#include "itkExceptionObject.h"
+#include "itkMacro.h"
 
 #include "vnl/vnl_math.h"
 

--- a/Components/Optimizers/AdaptiveStochasticLBFGS/elxAdaptiveStochasticLBFGS.hxx
+++ b/Components/Optimizers/AdaptiveStochasticLBFGS/elxAdaptiveStochasticLBFGS.hxx
@@ -30,7 +30,7 @@
 #include "itkTimeProbe.h"
 #include "itkCommand.h"
 #include "itkEventObject.h"
-#include "itkExceptionObject.h"
+#include "itkMacro.h"
 
 #ifdef ELASTIX_USE_OPENMP
 #include <omp.h>

--- a/Components/Optimizers/AdaptiveStochasticVarianceReducedGradient/elxAdaptiveStochasticVarianceReducedGradient.hxx
+++ b/Components/Optimizers/AdaptiveStochasticVarianceReducedGradient/elxAdaptiveStochasticVarianceReducedGradient.hxx
@@ -30,7 +30,7 @@
 #include "itkTimeProbe.h"
 #include "itkCommand.h"
 #include "itkEventObject.h"
-#include "itkExceptionObject.h"
+#include "itkMacro.h"
 
 #ifdef ELASTIX_USE_OPENMP
 #include <omp.h>

--- a/Components/Optimizers/AdaptiveStochasticVarianceReducedGradient/itkStochasticVarianceReducedGradientDescentOptimizer.cxx
+++ b/Components/Optimizers/AdaptiveStochasticVarianceReducedGradient/itkStochasticVarianceReducedGradientDescentOptimizer.cxx
@@ -22,7 +22,7 @@
 
 #include "itkCommand.h"
 #include "itkEventObject.h"
-#include "itkExceptionObject.h"
+#include "itkMacro.h"
 
 #ifdef ELASTIX_USE_OPENMP
 #include <omp.h>

--- a/Components/Optimizers/CMAEvolutionStrategy/itkCMAEvolutionStrategyOptimizer.cxx
+++ b/Components/Optimizers/CMAEvolutionStrategy/itkCMAEvolutionStrategyOptimizer.cxx
@@ -26,7 +26,7 @@
 #include <cmath>
 #include "itkCommand.h"
 #include "itkEventObject.h"
-#include "itkExceptionObject.h"
+#include "itkMacro.h"
 
 namespace itk
 {

--- a/Components/Optimizers/FiniteDifferenceGradientDescent/itkFiniteDifferenceGradientDescentOptimizer.cxx
+++ b/Components/Optimizers/FiniteDifferenceGradientDescent/itkFiniteDifferenceGradientDescentOptimizer.cxx
@@ -22,7 +22,7 @@
 #include "itkFiniteDifferenceGradientDescentOptimizer.h"
 #include "itkCommand.h"
 #include "itkEventObject.h"
-#include "itkExceptionObject.h"
+#include "itkMacro.h"
 
 #include "math.h"
 #include "vnl/vnl_math.h"

--- a/Components/Optimizers/FullSearch/itkFullSearchOptimizer.cxx
+++ b/Components/Optimizers/FullSearch/itkFullSearchOptimizer.cxx
@@ -22,7 +22,7 @@
 #include "itkFullSearchOptimizer.h"
 #include "itkCommand.h"
 #include "itkEventObject.h"
-#include "itkExceptionObject.h"
+#include "itkMacro.h"
 #include "itkNumericTraits.h"
 
 namespace itk

--- a/Components/Optimizers/PreconditionedGradientDescent/itkPreconditionedGradientDescentOptimizer.cxx
+++ b/Components/Optimizers/PreconditionedGradientDescent/itkPreconditionedGradientDescentOptimizer.cxx
@@ -22,7 +22,7 @@
 
 #include "itkCommand.h"
 #include "itkEventObject.h"
-#include "itkExceptionObject.h"
+#include "itkMacro.h"
 #include "vnl/vnl_math.h"
 #include "vnl/vnl_vector.h"
 #include "vnl/algo/vnl_sparse_symmetric_eigensystem.h"

--- a/Components/Optimizers/StandardGradientDescent/itkGradientDescentOptimizer2.cxx
+++ b/Components/Optimizers/StandardGradientDescent/itkGradientDescentOptimizer2.cxx
@@ -20,7 +20,7 @@
 
 #include "itkCommand.h"
 #include "itkEventObject.h"
-#include "itkExceptionObject.h"
+#include "itkMacro.h"
 
 #ifdef ELASTIX_USE_OPENMP
 #include <omp.h>

--- a/Components/Optimizers/StandardStochasticGradientDescent/itkStochasticGradientDescentOptimizer.cxx
+++ b/Components/Optimizers/StandardStochasticGradientDescent/itkStochasticGradientDescentOptimizer.cxx
@@ -19,7 +19,7 @@
 #include "itkStochasticGradientDescentOptimizer.h"
 #include "itkCommand.h"
 #include "itkEventObject.h"
-#include "itkExceptionObject.h"
+#include "itkMacro.h"
 
 #ifdef ELASTIX_USE_OPENMP
 #include <omp.h>

--- a/Components/Transforms/DeformationFieldTransform/itkDeformationFieldInterpolatingTransform.h
+++ b/Components/Transforms/DeformationFieldTransform/itkDeformationFieldInterpolatingTransform.h
@@ -20,7 +20,7 @@
 
 #include <iostream>
 #include "itkAdvancedTransform.h"
-#include "itkExceptionObject.h"
+#include "itkMacro.h"
 #include "itkImage.h"
 #include "itkVectorInterpolateImageFunction.h"
 #include "itkVectorNearestNeighborInterpolateImageFunction.h"

--- a/Components/Transforms/TranslationStackTransform/itkAdvancedTranslationTransform.h
+++ b/Components/Transforms/TranslationStackTransform/itkAdvancedTranslationTransform.h
@@ -37,7 +37,7 @@
 
 #include <iostream>
 #include "itkAdvancedTransform.h"
-#include "itkExceptionObject.h"
+#include "itkMacro.h"
 #include "itkMatrix.h"
 
 namespace itk


### PR DESCRIPTION
To address

/home/matt/src/ITK/Modules/Core/Common/include/itkExceptionObject.h:19:2:
error: "Do not include itkExceptionObject.h directly,  include
itkMacro.h instead."

when building against ITK Git master.