### PR TITLE
COMP: Include header for std::pow

### DIFF
--- a/Core/Main/elxParameterObject.cxx
+++ b/Core/Main/elxParameterObject.cxx
@@ -23,7 +23,7 @@
 #include "itkFileTools.h"
 #include <fstream>
 #include <iostream>
-#include <math.h>
+#include <cmath>
 
 namespace elastix
 {

--- a/Core/Main/elxPixelType.h
+++ b/Core/Main/elxPixelType.h
@@ -18,6 +18,8 @@
 #ifndef elxPixelType_h
 #define elxPixelType_h
 
+#include <typeinfo>
+
 namespace elastix
 {
 // PixelType traits for writing types as strings to parameter files

--- a/Core/Main/elxPixelType.h
+++ b/Core/Main/elxPixelType.h
@@ -19,6 +19,7 @@
 #define elxPixelType_h
 
 #include <typeinfo>
+#include "itkMacro.h"
 
 namespace elastix
 {
@@ -30,7 +31,7 @@ struct PixelType
 {
   static const char * ToString()
   {
-    itkGenericExceptionMacro(<< "Pixel type \"" << typeid( T ).name() << "\" is not supported." )
+    itkGenericExceptionMacro(<< "Pixel type \"" << typeid( T ).name() << "\" is not supported." );
   }
 
 

--- a/Core/Main/elxPixelType.h
+++ b/Core/Main/elxPixelType.h
@@ -30,7 +30,7 @@ struct PixelType
 {
   static const char * ToString()
   {
-    itkGenericExceptionMacro( "Pixel type \"" << typeid( T ).name() << "\" is not supported." )
+    itkGenericExceptionMacro(<< "Pixel type \"" << typeid( T ).name() << "\" is not supported." )
   }
 
 


### PR DESCRIPTION
To address:

  _deps/elastix_fetch-src/Core/Main/elxParameterObject.cxx:499:80: error: 'pow' is not a member of 'std'