### PR TITLE
COMP: Explicitly disable BUILD_SHARED_LIBS

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -3,6 +3,10 @@ cmake_minimum_required( VERSION 2.8 )
 project( elastix )
 set(CMAKE_CXX_STANDARD 11)
 
+if( BUILD_SHARED_LIBS )
+  message(FATAL_ERROR "Elastix does not support BUILD_SHARED_LIBS")
+endif()
+
 #---------------------------------------------------------------------
 cmake_policy( SET CMP0012 NEW )
 if( POLICY CMP0033 )

--- a/Core/Install/elxMacro.h
+++ b/Core/Install/elxMacro.h
@@ -291,19 +291,9 @@ public: \
  *      Dll export    *
  *                    *
  ********************************************************************************/
-// Note: Consumers of the DLL must define the symbol _ELASTIX_USE_SHARED_LIBRARY.
-// No such symbol is required for users of the static library.
-//
+
 #if ( defined( _WIN32 ) || defined( WIN32 ) )
-#  ifdef _ELASTIX_USE_SHARED_LIBRARY
-#    ifdef elastix_EXPORTS
-#      define ELASTIXLIB_API __declspec( dllexport )
-#    else
-#      define ELASTIXLIB_API __declspec( dllimport )
-#    endif
-#  else
-#    define ELASTIXLIB_API
-#  endif
+#  define ELASTIXLIB_API
 #else
 #  if ( __GNUC__ >= 4 || defined( __clang__ ) )
 #    define ELASTIXLIB_API __attribute__ ( ( visibility( "default" ) ) )

--- a/dox/manual/manual.tex
+++ b/dox/manual/manual.tex
@@ -2832,9 +2832,9 @@ using the -p option of the \elastix\ executable multiple times).
 To build \elastix\ as a library you have to disable the
 \texttt{ELASTIX\_BUILD\_EXECUTABLE} option in CMake. With this
 option disabled a build project for a static library will be
-created. If you want to create a dynamic library (not very well
-tested), you have to enable the \texttt{BUILD\_SHARED\_LIBS}
-option.
+created. Note that \elastix\ cannot be built as a dynamic library:
+The CMake option \texttt{BUILD\_SHARED\_LIBS} should be \texttt{OFF},
+when building \elastix\.
 
 \subsubsection{Linking with the \elastix\ library}
 
@@ -2863,10 +2863,6 @@ sources (the directory having the \texttt{UseElastix.cmake} file).
 If you want to control better to which binaries you link \elastix,
 use the CMake \texttt{target\_link\_libraries} directive instead.
 
-If \elastix\ is supplied as a shared library (DLL), you need to define
-the preprocessor symbol \texttt{\_ELASTIX\_USE\_SHARED\_LIBRARY}.
-No such symbol is required when linking against a static
-\elastix\ library.
 
 \subsubsection{Preparing registration parameter settings}
 


### PR DESCRIPTION
Attempts to build shared Elastix libraries have led to various problems, including a core dump recently reported by Luisa Sanchez Brea.

Pull request #145 "Make BUILD_SHARED_LIBS do its job" by Harmen Stoppels (@haampie) was abandoned because of lack of resources at our side.

This commit prevents users from accidentally switching on the CMake option `BUILD_SHARED_LIBS` for Elastix.

Moreover, it drops support for the macro `_ELASTIX_USE_SHARED_LIBRARY`.

The manual (TeX file) is adjusted accordingly.