### PR TITLE
BUG: Add missing itk::ImageMaskSpatialObject Update() calls (issue #179)

### DIFF
--- a/Components/Registrations/MultiResolutionRegistration/elxMultiResolutionRegistration.hxx
+++ b/Components/Registrations/MultiResolutionRegistration/elxMultiResolutionRegistration.hxx
@@ -205,10 +205,6 @@ MultiResolutionRegistration< TElastix >
     this->GetElastix()->GetFixedMask(), useFixedMaskErosion,
     this->GetFixedImagePyramid(), level );
 
-  if (fixedMask != nullptr)
-  {
-    fixedMask->Update();
-  }
   this->GetModifiableMetric()->SetFixedImageMask( fixedMask );
 
   /** Stop timer and print the elapsed time. */

--- a/Components/Transforms/AdvancedAffineTransform/itkCenteredTransformInitializer2.hxx
+++ b/Components/Transforms/AdvancedAffineTransform/itkCenteredTransformInitializer2.hxx
@@ -103,6 +103,7 @@ CenteredTransformInitializer2< TTransform, TFixedImage, TMovingImage >
     {
       fixedMaskAsSpatialObject = FixedMaskSpatialObjectType::New();
       fixedMaskAsSpatialObject->SetImage( this->m_FixedImageMask );
+      fixedMaskAsSpatialObject->Update();
     }
 
     typename MovingMaskSpatialObjectType::Pointer movingMaskAsSpatialObject;  // default-constructed (null)
@@ -110,6 +111,7 @@ CenteredTransformInitializer2< TTransform, TFixedImage, TMovingImage >
     {
       movingMaskAsSpatialObject = MovingMaskSpatialObjectType::New();
       movingMaskAsSpatialObject->SetImage( this->m_MovingImageMask );
+      movingMaskAsSpatialObject->Update();
     }
 
     // Moments

--- a/Components/Transforms/TranslationTransform/itkTranslationTransformInitializer.hxx
+++ b/Components/Transforms/TranslationTransform/itkTranslationTransformInitializer.hxx
@@ -87,6 +87,7 @@ TranslationTransformInitializer< TTransform, TFixedImage, TMovingImage >
     {
       fixedMaskAsSpatialObject = FixedMaskSpatialObjectType::New();
       fixedMaskAsSpatialObject->SetImage( this->m_FixedMask );
+      fixedMaskAsSpatialObject->Update();
     }
 
     typename MovingMaskSpatialObjectType::Pointer movingMaskAsSpatialObject; // default-constructed (null)
@@ -94,6 +95,7 @@ TranslationTransformInitializer< TTransform, TFixedImage, TMovingImage >
     {
       movingMaskAsSpatialObject = MovingMaskSpatialObjectType::New();
       movingMaskAsSpatialObject->SetImage( this->m_MovingMask );
+      movingMaskAsSpatialObject->Update();
     }
 
     // Compute the image moments

--- a/Core/ComponentBaseClasses/elxRegistrationBase.hxx
+++ b/Core/ComponentBaseClasses/elxRegistrationBase.hxx
@@ -115,6 +115,7 @@ RegistrationBase< TElastix >
   if( !useMaskErosion || !pyramid )
   {
     fixedMaskSpatialObject->SetImage( maskImage );
+    fixedMaskSpatialObject->Update();
     return fixedMaskSpatialObject;
   }
 
@@ -148,6 +149,7 @@ RegistrationBase< TElastix >
   erodedFixedMaskAsImage->DisconnectPipeline();
 
   fixedMaskSpatialObject->SetImage( erodedFixedMaskAsImage );
+  fixedMaskSpatialObject->Update();
   return fixedMaskSpatialObject;
 
 } // end GenerateFixedMaskSpatialObject()
@@ -175,6 +177,7 @@ RegistrationBase< TElastix >
   if( !useMaskErosion || !pyramid )
   {
     movingMaskSpatialObject->SetImage( maskImage );
+    movingMaskSpatialObject->Update();
     return movingMaskSpatialObject;
   }
 
@@ -208,6 +211,7 @@ RegistrationBase< TElastix >
   erodedMovingMaskAsImage->DisconnectPipeline();
 
   movingMaskSpatialObject->SetImage( erodedMovingMaskAsImage );
+  movingMaskSpatialObject->Update();
   return movingMaskSpatialObject;
 
 } // end GenerateMovingMaskSpatialObject()


### PR DESCRIPTION
itk::ImageMaskSpatialObject::Update() should be called on various places, when the mask image is set, to ensure that the bounding box (in world space) is up-to-date.

Fixes issue #179, "Error when using fixed mask in MultiMetricMultiResolutionRegistration", reported by Patrick Carnahan (@pcarnah).