### PR TITLE
Replace NULL by C++11 nullptr

### DIFF
--- a/Common/CostFunctions/itkAdvancedImageToImageMetric.hxx
+++ b/Common/CostFunctions/itkAdvancedImageToImageMetric.hxx
@@ -102,9 +102,9 @@ AdvancedImageToImageMetric< TFixedImage, TMovingImage >
   this->m_ThreaderMetricParameters.st_Metric = this;
 
   // Multi-threading structs
-  this->m_GetValuePerThreadVariables                  = NULL;
+  this->m_GetValuePerThreadVariables                  = nullptr;
   this->m_GetValuePerThreadVariablesSize              = 0;
-  this->m_GetValueAndDerivativePerThreadVariables     = NULL;
+  this->m_GetValueAndDerivativePerThreadVariables     = nullptr;
   this->m_GetValueAndDerivativePerThreadVariablesSize = 0;
 
 } // end Constructor

--- a/Common/CostFunctions/itkParzenWindowHistogramImageToImageMetric.hxx
+++ b/Common/CostFunctions/itkParzenWindowHistogramImageToImageMetric.hxx
@@ -73,7 +73,7 @@ ParzenWindowHistogramImageToImageMetric< TFixedImage, TMovingImage >
   this->m_ParzenWindowHistogramThreaderParameters.m_Metric = this;
 
   // Multi-threading structs
-  this->m_ParzenWindowHistogramGetValueAndDerivativePerThreadVariables     = NULL;
+  this->m_ParzenWindowHistogramGetValueAndDerivativePerThreadVariables     = nullptr;
   this->m_ParzenWindowHistogramGetValueAndDerivativePerThreadVariablesSize = 0;
 
 } // end Constructor

--- a/Common/MevisDicomTiff/itkMevisDicomTiffImageIO.cxx
+++ b/Common/MevisDicomTiff/itkMevisDicomTiffImageIO.cxx
@@ -63,7 +63,7 @@ MevisDicomTiffImageIO
 ::MevisDicomTiffImageIO() :
   m_DcmFileName( "" ),
   m_TiffFileName( "" ),
-  m_TIFFImage( NULL ),
+  m_TIFFImage( nullptr ),
   m_TIFFDimension( 2 ),
   m_IsOpen( false ),
   m_Compression( 0 ),
@@ -168,7 +168,7 @@ MevisDicomTiffImageIO::FindElement(
     {
       if( it->GetVR() == gdcm::VR::SQ )
       {
-        if( it->GetValueAsSQ() != NULL )
+        if( it->GetValueAsSQ() != nullptr )
         {
           if( !it->GetValueAsSQ()->Begin()->GetNestedDataSet().IsEmpty() )
           {
@@ -293,7 +293,7 @@ MevisDicomTiffImageIO::CanReadFile( const char * filename )
 
   // checking if tiff is valid tif
   m_TIFFImage = TIFFOpen( m_TiffFileName.c_str(), "rc" ); // c is disable strip chopping
-  if( m_TIFFImage == NULL )
+  if( m_TIFFImage == nullptr )
   {
     itkDebugMacro( << "mevisIO:canreadfile(): error opening tif file " << m_TiffFileName );
     return false;
@@ -688,7 +688,7 @@ MevisDicomTiffImageIO::ReadImageInformation()
   // determine size
   // numberofcomponents
   // data type
-  if( m_TIFFImage == NULL )
+  if( m_TIFFImage == nullptr )
   {
     itkExceptionMacro( << "mevisIO:readimageinformation: error opening file " << m_TiffFileName );
     return;

--- a/Common/OpenCL/Filters/itkGPUAdvancedCombinationTransformCopier.hxx
+++ b/Common/OpenCL/Filters/itkGPUAdvancedCombinationTransformCopier.hxx
@@ -48,8 +48,8 @@ template< typename TTypeList, typename NDimensions, typename TAdvancedCombinatio
 GPUAdvancedCombinationTransformCopier< TTypeList, NDimensions, TAdvancedCombinationTransform, TOutputTransformPrecisionType >
 ::GPUAdvancedCombinationTransformCopier()
 {
-  this->m_InputTransform        = NULL;
-  this->m_Output                = NULL;
+  this->m_InputTransform        = nullptr;
+  this->m_Output                = nullptr;
   this->m_InternalTransformTime = 0;
   this->m_ExplicitMode          = true;
 }

--- a/Common/OpenCL/Filters/itkGPUCompositeTransformCopier.hxx
+++ b/Common/OpenCL/Filters/itkGPUCompositeTransformCopier.hxx
@@ -27,8 +27,8 @@ template<  typename TTypeList, typename NDimensions, typename TCompositeTransfor
 GPUCompositeTransformCopier< TTypeList, NDimensions, TCompositeTransform, TOutputTransformPrecisionType >
 ::GPUCompositeTransformCopier()
 {
-  this->m_InputTransform        = NULL;
-  this->m_Output                = NULL;
+  this->m_InputTransform        = nullptr;
+  this->m_Output                = nullptr;
   this->m_InternalTransformTime = 0;
   this->m_ExplicitMode          = true;
   this->m_TransformCopier       = GPUTransformCopierType::New();

--- a/Common/OpenCL/Filters/itkGPUInterpolatorCopier.hxx
+++ b/Common/OpenCL/Filters/itkGPUInterpolatorCopier.hxx
@@ -40,9 +40,9 @@ template< typename TTypeList, typename NDimensions, typename TInterpolator, type
 GPUInterpolatorCopier< TTypeList, NDimensions, TInterpolator, TOutputCoordRep >
 ::GPUInterpolatorCopier()
 {
-  this->m_InputInterpolator     = NULL;
-  this->m_Output                = NULL;
-  this->m_ExplicitOutput        = NULL;
+  this->m_InputInterpolator     = nullptr;
+  this->m_Output                = nullptr;
+  this->m_ExplicitOutput        = nullptr;
   this->m_InternalTransformTime = 0;
   this->m_ExplicitMode          = true;
 }

--- a/Common/OpenCL/Filters/itkGPUResampleImageFilter.hxx
+++ b/Common/OpenCL/Filters/itkGPUResampleImageFilter.hxx
@@ -77,8 +77,8 @@ GPUResampleImageFilter< TInputImage, TOutputImage, TInterpolatorPrecisionType >
   this->m_FilterPreGPUKernelHandle  = -1;
   this->m_FilterPostGPUKernelHandle = -1;
 
-  this->m_InterpolatorBase = NULL;
-  this->m_TransformBase    = NULL;
+  this->m_InterpolatorBase = nullptr;
+  this->m_TransformBase    = nullptr;
 
   this->m_RequestedNumberOfSplits = 5;
 

--- a/Common/OpenCL/Filters/itkGPUTransformCopier.hxx
+++ b/Common/OpenCL/Filters/itkGPUTransformCopier.hxx
@@ -48,8 +48,8 @@ template< typename TTypeList, typename NDimensions, typename TTransform, typenam
 GPUTransformCopier< TTypeList, NDimensions, TTransform, TOutputTransformPrecisionType >
 ::GPUTransformCopier()
 {
-  this->m_InputTransform        = NULL;
-  this->m_Output                = NULL;
+  this->m_InputTransform        = nullptr;
+  this->m_Output                = nullptr;
   this->m_InternalTransformTime = 0;
   this->m_ExplicitMode          = true;
 }

--- a/Common/OpenCL/ITKimprovements/itkGPUDataManager.cxx
+++ b/Common/OpenCL/ITKimprovements/itkGPUDataManager.cxx
@@ -40,8 +40,8 @@ namespace itk
 GPUDataManager::GPUDataManager()
 {
   m_Context   = OpenCLContext::GetInstance();
-  m_GPUBuffer = NULL;
-  m_CPUBuffer = NULL;
+  m_GPUBuffer = nullptr;
+  m_CPUBuffer = nullptr;
 
   m_CPUBufferLock = false;
   m_GPUBufferLock = false;
@@ -99,7 +99,7 @@ GPUDataManager::Allocate()
               << m_BufferSize << " Bytes" << std::endl;
 #endif
     m_GPUBuffer = clCreateBuffer( m_Context->GetContextId(),
-      m_MemFlags, m_BufferSize, NULL, &errid );
+      m_MemFlags, m_BufferSize, nullptr, &errid );
     m_Context->ReportError( errid, __FILE__, __LINE__, ITK_LOCATION );
     m_IsGPUBufferDirty = true;
   }
@@ -159,7 +159,7 @@ GPUDataManager::UpdateCPUBuffer()
 
   MutexHolderType holder( m_Mutex );
 
-  if( m_IsCPUBufferDirty && m_GPUBuffer != NULL && m_CPUBuffer != NULL )
+  if( m_IsCPUBufferDirty && m_GPUBuffer != nullptr && m_CPUBuffer != nullptr )
   {
 #if ( defined( _WIN32 ) && defined( _DEBUG ) ) || !defined( NDEBUG )
     std::cout << "clEnqueueReadBuffer, " << this
@@ -171,11 +171,11 @@ GPUDataManager::UpdateCPUBuffer()
 #ifdef OPENCL_PROFILING
     cl_event clEvent = NULL;
     errid = clEnqueueReadBuffer( m_Context->GetCommandQueue().GetQueueId(), m_GPUBuffer, CL_TRUE, 0,
-      m_BufferSize, m_CPUBuffer, 0, NULL,
+      m_BufferSize, m_CPUBuffer, 0, nullptr,
       &clEvent );
 #else
     errid = clEnqueueReadBuffer( m_Context->GetCommandQueue().GetQueueId(), m_GPUBuffer, CL_TRUE, 0,
-      m_BufferSize, m_CPUBuffer, 0, NULL, NULL );
+      m_BufferSize, m_CPUBuffer, 0, nullptr, nullptr);
 #endif
 
     m_Context->ReportError( errid, __FILE__, __LINE__, ITK_LOCATION );
@@ -197,7 +197,7 @@ GPUDataManager::UpdateGPUBuffer()
 
   MutexHolderType holder( m_Mutex );
 
-  if( m_IsGPUBufferDirty && m_CPUBuffer != NULL && m_GPUBuffer != NULL )
+  if( m_IsGPUBufferDirty && m_CPUBuffer != nullptr && m_GPUBuffer != nullptr )
   {
 #if ( defined( _WIN32 ) && defined( _DEBUG ) ) || !defined( NDEBUG )
     std::cout << "clEnqueueWriteBuffer, " << this << "::UpdateGPUBuffer CPU->GPU data copy "
@@ -208,12 +208,12 @@ GPUDataManager::UpdateGPUBuffer()
 #ifdef OPENCL_PROFILING
     cl_event clEvent = NULL;
     errid = clEnqueueWriteBuffer(
-      m_Context->GetCommandQueue().GetQueueId(), m_GPUBuffer, CL_TRUE, 0, m_BufferSize, m_CPUBuffer, 0, NULL,
+      m_Context->GetCommandQueue().GetQueueId(), m_GPUBuffer, CL_TRUE, 0, m_BufferSize, m_CPUBuffer, 0, nullptr,
       &clEvent );
 #else
     errid = clEnqueueWriteBuffer(
-      m_Context->GetCommandQueue().GetQueueId(), m_GPUBuffer, CL_TRUE, 0, m_BufferSize, m_CPUBuffer, 0, NULL,
-      NULL );
+      m_Context->GetCommandQueue().GetQueueId(), m_GPUBuffer, CL_TRUE, 0, m_BufferSize, m_CPUBuffer, 0, nullptr,
+      nullptr );
 #endif
     m_Context->ReportError( errid, __FILE__, __LINE__, ITK_LOCATION );
     //m_ContextManager->OpenCLProfile(clEvent, "clEnqueueWriteBuffer CPU->GPU");
@@ -308,8 +308,8 @@ GPUDataManager::Initialize()
   }
 
   m_BufferSize       = 0;
-  m_GPUBuffer        = NULL;
-  m_CPUBuffer        = NULL;
+  m_GPUBuffer        = nullptr;
+  m_CPUBuffer        = nullptr;
   m_MemFlags         = CL_MEM_READ_WRITE; // default flag
   m_IsGPUBufferDirty = false;
   m_IsCPUBufferDirty = false;

--- a/Common/OpenCL/ITKimprovements/itkGPUImageDataManager.h
+++ b/Common/OpenCL/ITKimprovements/itkGPUImageDataManager.h
@@ -92,7 +92,7 @@ public:
 
 protected:
 
-  GPUImageDataManager() { m_Image = NULL; }
+  GPUImageDataManager() { m_Image = nullptr; }
   virtual ~GPUImageDataManager() {}
 
 private:

--- a/Common/OpenCL/ITKimprovements/itkGPUImageDataManager.hxx
+++ b/Common/OpenCL/ITKimprovements/itkGPUImageDataManager.hxx
@@ -73,7 +73,7 @@ GPUImageDataManager< ImageType >::UpdateCPUBuffer()
     * correctly managed. Therefore, we check the time stamp of
     * CPU and GPU data as well
     */
-    if( ( m_IsCPUBufferDirty || ( gpu_time > cpu_time ) ) && m_GPUBuffer != NULL && m_CPUBuffer != NULL )
+    if( ( m_IsCPUBufferDirty || ( gpu_time > cpu_time ) ) && m_GPUBuffer != nullptr && m_CPUBuffer != nullptr )
     {
       cl_int errid;
 #if ( defined( _WIN32 ) && defined( _DEBUG ) ) || !defined( NDEBUG )
@@ -83,7 +83,7 @@ GPUImageDataManager< ImageType >::UpdateCPUBuffer()
 #ifdef OPENCL_PROFILING
       cl_event clEvent = NULL;
       errid = clEnqueueReadBuffer( m_Context->GetCommandQueue().GetQueueId(),
-        m_GPUBuffer, CL_TRUE, 0, m_BufferSize, m_CPUBuffer, 0, NULL, &clEvent );
+        m_GPUBuffer, CL_TRUE, 0, m_BufferSize, m_CPUBuffer, 0, nullptr, &clEvent );
 #else
       errid = clEnqueueReadBuffer( m_Context->GetCommandQueue().GetQueueId(),
         m_GPUBuffer, CL_TRUE, 0, m_BufferSize, m_CPUBuffer, 0, 0, 0 );
@@ -128,7 +128,7 @@ GPUImageDataManager< ImageType >::UpdateGPUBuffer()
     * correctly managed. Therefore, we check the time stamp of
     * CPU and GPU data as well
     */
-    if( ( m_IsGPUBufferDirty || ( gpu_time < cpu_time ) ) && m_CPUBuffer != NULL && m_GPUBuffer != NULL )
+    if( ( m_IsGPUBufferDirty || ( gpu_time < cpu_time ) ) && m_CPUBuffer != nullptr && m_GPUBuffer != nullptr )
     {
       cl_int errid;
 #if ( defined( _WIN32 ) && defined( _DEBUG ) ) || !defined( NDEBUG )
@@ -138,10 +138,10 @@ GPUImageDataManager< ImageType >::UpdateGPUBuffer()
 #ifdef OPENCL_PROFILING
       cl_event clEvent = NULL;
       errid = clEnqueueWriteBuffer( m_Context->GetCommandQueue().GetQueueId(),
-        m_GPUBuffer, CL_TRUE, 0, m_BufferSize, m_CPUBuffer, 0, NULL, &clEvent );
+        m_GPUBuffer, CL_TRUE, 0, m_BufferSize, m_CPUBuffer, 0, nullptr, &clEvent );
 #else
       errid = clEnqueueWriteBuffer( m_Context->GetCommandQueue().GetQueueId(),
-        m_GPUBuffer, CL_TRUE, 0, m_BufferSize, m_CPUBuffer, 0, NULL, NULL );
+        m_GPUBuffer, CL_TRUE, 0, m_BufferSize, m_CPUBuffer, 0, nullptr, nullptr );
 #endif
       m_Context->ReportError( errid, __FILE__, __LINE__, ITK_LOCATION );
       //m_ContextManager->OpenCLProfile(clEvent, "clEnqueueWriteBuffer CPU->GPU");

--- a/Common/OpenCL/ITKimprovements/itkOpenCLContext.cxx
+++ b/Common/OpenCL/ITKimprovements/itkOpenCLContext.cxx
@@ -996,7 +996,7 @@ OpenCLContext::CreateImageDevice( const OpenCLImageFormat & format,
   cl_mem mem = clCreateImage
       ( d->id, flags, &( format.m_Format ), &imageDesc, 0, &( d->last_error ) );
 #else
-  cl_mem mem = NULL;
+  cl_mem mem = nullptr;
   if( size.GetDimension() == 1 )
   {
     itkGenericExceptionMacro( << "OpenCLContext::CreateImageDevice() not supported for 1D." );
@@ -1056,7 +1056,7 @@ OpenCLContext::CreateImageHost( const OpenCLImageFormat & format,
   cl_mem mem = clCreateImage
       ( d->id, flags, &( format.m_Format ), &imageDesc, data, &( d->last_error ) );
 #else
-  cl_mem mem = NULL;
+  cl_mem mem = nullptr;
   if( size.GetDimension() == 1 )
   {
     itkGenericExceptionMacro( << "OpenCLContext::CreateImageHost() not supported for 1D." );
@@ -1109,7 +1109,7 @@ OpenCLContext::CreateImageCopy( const OpenCLImageFormat & format,
       ( d->id, flags, &( format.m_Format ), &imageDesc,
       const_cast< void * >( data ), &( d->last_error ) );
 #else
-  cl_mem mem = NULL;
+  cl_mem mem = nullptr;
   if( size.GetDimension() == 1 )
   {
     itkGenericExceptionMacro( << "OpenCLContext::CreateImageCopy() not supported for 1D." );
@@ -1765,8 +1765,8 @@ OpenCLContext::OpenCLProfile( cl_event clEvent,
     return;
   }
   cl_ulong start, end;
-  errid  = clGetEventProfilingInfo( clEvent, CL_PROFILING_COMMAND_END, sizeof( cl_ulong ), &end, NULL );
-  errid |= clGetEventProfilingInfo( clEvent, CL_PROFILING_COMMAND_START, sizeof( cl_ulong ), &start, NULL );
+  errid  = clGetEventProfilingInfo( clEvent, CL_PROFILING_COMMAND_END, sizeof( cl_ulong ), &end, nullptr );
+  errid |= clGetEventProfilingInfo( clEvent, CL_PROFILING_COMMAND_START, sizeof( cl_ulong ), &start, nullptr );
   this->ReportError( errid, __FILE__, __LINE__, ITK_LOCATION );
   if( errid != CL_SUCCESS )
   {

--- a/Common/OpenCL/ITKimprovements/itkOpenCLEvent.h
+++ b/Common/OpenCL/ITKimprovements/itkOpenCLEvent.h
@@ -171,7 +171,7 @@ public:
    * to report appropriate error information. */
   cl_int SetCallback( cl_int type,
     void ( CL_CALLBACK * pfn_notify )( cl_event, cl_int, void * ),
-    void * user_data = NULL );
+    void * user_data = nullptr );
 
   /** Returns the device time in nanoseconds when the command was queued for
    * execution on the host. The return value is only valid if the command has

--- a/Common/OpenCL/ITKimprovements/itkOpenCLImage.cxx
+++ b/Common/OpenCL/ITKimprovements/itkOpenCLImage.cxx
@@ -265,7 +265,7 @@ OpenCLImage::Map(
 {
   if( this->IsNull() || region.IsZero() )
   {
-    return NULL;
+    return nullptr;
   }
 
   cl_int      error;

--- a/Common/OpenCL/ITKimprovements/itkOpenCLKernel.cxx
+++ b/Common/OpenCL/ITKimprovements/itkOpenCLKernel.cxx
@@ -1334,12 +1334,12 @@ OpenCLKernel::LaunchKernel()
   if( gwoNull && lwsNull )
   {
     error = clEnqueueNDRangeKernel( d->context->GetActiveQueue(), this->m_KernelId,
-      work_dim, NULL, d->global_work_size.GetSizes(), NULL, 0, 0, &event );
+      work_dim, nullptr, d->global_work_size.GetSizes(), nullptr, 0, 0, &event );
   }
   else if( gwoNull && !lwsNull )
   {
     error = clEnqueueNDRangeKernel( d->context->GetActiveQueue(), this->m_KernelId,
-      work_dim, NULL, d->global_work_size.GetSizes(),
+      work_dim, nullptr, d->global_work_size.GetSizes(),
       ( d->local_work_size.GetWidth() ? d->local_work_size.GetSizes() : 0 ),
 
       0, 0, &event );
@@ -1348,7 +1348,7 @@ OpenCLKernel::LaunchKernel()
   {
     error = clEnqueueNDRangeKernel( d->context->GetActiveQueue(), this->m_KernelId,
       work_dim, d->global_work_offset.GetSizes(), d->global_work_size.GetSizes(),
-      NULL, 0, 0, &event );
+      nullptr, 0, 0, &event );
   }
   else
   {
@@ -1405,13 +1405,13 @@ OpenCLKernel::LaunchKernel( const OpenCLEventList & event_list )
   if( gwoNull && lwsNull )
   {
     error = clEnqueueNDRangeKernel( d->context->GetActiveQueue(), this->m_KernelId,
-      work_dim, NULL, d->global_work_size.GetSizes(), NULL,
+      work_dim, nullptr, d->global_work_size.GetSizes(), nullptr,
       event_list.GetSize(), event_list.GetEventData(), &event );
   }
   else if( gwoNull && !lwsNull )
   {
     error = clEnqueueNDRangeKernel( d->context->GetActiveQueue(), this->m_KernelId,
-      work_dim, NULL, d->global_work_size.GetSizes(),
+      work_dim, nullptr, d->global_work_size.GetSizes(),
       ( d->local_work_size.GetWidth() ? d->local_work_size.GetSizes() : 0 ),
       event_list.GetSize(), event_list.GetEventData(), &event );
   }
@@ -1419,7 +1419,7 @@ OpenCLKernel::LaunchKernel( const OpenCLEventList & event_list )
   {
     error = clEnqueueNDRangeKernel( d->context->GetActiveQueue(), this->m_KernelId,
       work_dim, d->global_work_offset.GetSizes(), d->global_work_size.GetSizes(),
-      NULL,
+      nullptr,
       event_list.GetSize(), event_list.GetEventData(), &event );
   }
   else

--- a/Common/OpenCL/ITKimprovements/itkOpenCLKernelManager.cxx
+++ b/Common/OpenCL/ITKimprovements/itkOpenCLKernelManager.cxx
@@ -210,7 +210,7 @@ OpenCLKernelManager::SetKernelArgWithImage(
 #endif
     // According OpenCL 1.1 specification clSetKernelArg arg_value could be NULL
     // object.
-    cl_mem null_buffer = NULL;
+    cl_mem null_buffer = nullptr;
     error = clSetKernelArg( this->GetKernel( kernelId ).GetKernelId(), argId, sizeof( cl_mem ), &null_buffer );
   }
 

--- a/Common/OpenCL/ITKimprovements/itkOpenCLKernelToImageBridge.hxx
+++ b/Common/OpenCL/ITKimprovements/itkOpenCLKernelToImageBridge.hxx
@@ -86,7 +86,7 @@ OpenCLKernelToImageBridge< TImage >::SetImageDataManager( OpenCLKernel & kernel,
   {
     // According OpenCL specification clSetKernelArg arg_value
     // could be NULL object.
-    cl_mem null_buffer = NULL;
+    cl_mem null_buffer = nullptr;
     error = kernel.SetArg( argumentIndex, &null_buffer, sizeof( cl_mem ) );
   }
 

--- a/Common/OpenCL/ITKimprovements/itkOpenCLLogger.cxx
+++ b/Common/OpenCL/ITKimprovements/itkOpenCLLogger.cxx
@@ -61,7 +61,7 @@ OpenCLLogger::New()
 OpenCLLogger::OpenCLLogger() :
   m_FileName( "_opencl.log" )
 {
-  this->m_FileStream = NULL;
+  this->m_FileStream = nullptr;
   this->m_Created    = false;
 }
 
@@ -105,7 +105,7 @@ OpenCLLogger::Initialize()
   {
     itkExceptionMacro( << "Unable to open file: " << logFileName );
     delete this->m_FileStream;
-    this->m_FileStream = NULL;
+    this->m_FileStream = nullptr;
     this->m_Created    = false;
     return;
   }

--- a/Common/OpenCL/ITKimprovements/itkOpenCLMemoryObject.h
+++ b/Common/OpenCL/ITKimprovements/itkOpenCLMemoryObject.h
@@ -146,7 +146,7 @@ public:
    * object, can be reused or freed. */
   cl_int SetDestructorCallback(
     void ( CL_CALLBACK * pfn_notify )( cl_mem, void * ),
-    void * user_data = NULL );
+    void * user_data = nullptr );
 
 protected:
 

--- a/Common/Transforms/itkAdvancedBSplineDeformableTransform.hxx
+++ b/Common/Transforms/itkAdvancedBSplineDeformableTransform.hxx
@@ -94,7 +94,7 @@ AdvancedBSplineDeformableTransform< TScalarType, NDimensions, VSplineOrder >
     this->m_WrappedImage[ j ]->SetOrigin( this->m_GridOrigin.GetDataPointer() );
     this->m_WrappedImage[ j ]->SetSpacing( this->m_GridSpacing.GetDataPointer() );
     this->m_WrappedImage[ j ]->SetDirection( this->m_GridDirection );
-    this->m_CoefficientImages[ j ] = NULL;
+    this->m_CoefficientImages[ j ] = nullptr;
   }
 
   // Setup variables for computing interpolation
@@ -378,7 +378,7 @@ AdvancedBSplineDeformableTransform< TScalarType, NDimensions, VSplineOrder >
   /** This implements a sparse version of the Jacobian. */
 
   /** Sanity check. */
-  if( this->m_InputParametersPointer == NULL )
+  if( this->m_InputParametersPointer == nullptr )
   {
     itkExceptionMacro( << "Cannot compute Jacobian: parameters not set" );
   }
@@ -756,7 +756,7 @@ AdvancedBSplineDeformableTransform< TScalarType, NDimensions, VSplineOrder >
 {
   // Can only compute Jacobian if parameters are set via
   // SetParameters or SetParametersByValue
-  if( this->m_InputParametersPointer == NULL )
+  if( this->m_InputParametersPointer == nullptr )
   {
     itkExceptionMacro( << "Cannot compute Jacobian: parameters not set" );
   }
@@ -860,7 +860,7 @@ AdvancedBSplineDeformableTransform< TScalarType, NDimensions, VSplineOrder >
 {
   // Can only compute Jacobian if parameters are set via
   // SetParameters or SetParametersByValue
-  if( this->m_InputParametersPointer == NULL )
+  if( this->m_InputParametersPointer == nullptr )
   {
     itkExceptionMacro( << "Cannot compute Jacobian: parameters not set" );
   }
@@ -1025,7 +1025,7 @@ AdvancedBSplineDeformableTransform< TScalarType, NDimensions, VSplineOrder >
 {
   // Can only compute Jacobian if parameters are set via
   // SetParameters or SetParametersByValue
-  if( this->m_InputParametersPointer == NULL )
+  if( this->m_InputParametersPointer == nullptr )
   {
     itkExceptionMacro( << "Cannot compute Jacobian: parameters not set" );
   }
@@ -1144,7 +1144,7 @@ AdvancedBSplineDeformableTransform< TScalarType, NDimensions, VSplineOrder >
 
   // Can only compute Jacobian if parameters are set via
   // SetParameters or SetParametersByValue
-  if( this->m_InputParametersPointer == NULL )
+  if( this->m_InputParametersPointer == nullptr )
   {
     itkExceptionMacro( << "Cannot compute Jacobian: parameters not set" );
   }

--- a/Common/Transforms/itkAdvancedBSplineDeformableTransformBase.hxx
+++ b/Common/Transforms/itkAdvancedBSplineDeformableTransformBase.hxx
@@ -56,7 +56,7 @@ AdvancedBSplineDeformableTransformBase< TScalarType, NDimensions >
     this->m_WrappedImage[ j ]->SetOrigin( this->m_GridOrigin.GetDataPointer() );
     this->m_WrappedImage[ j ]->SetSpacing( this->m_GridSpacing.GetDataPointer() );
     this->m_WrappedImage[ j ]->SetDirection( this->m_GridDirection );
-    this->m_CoefficientImages[ j ] = NULL;
+    this->m_CoefficientImages[ j ] = nullptr;
   }
 
   this->m_ValidRegion = this->m_GridRegion;
@@ -472,7 +472,7 @@ typename AdvancedBSplineDeformableTransformBase< TScalarType, NDimensions >
   /** NOTE: For efficiency, this class does not keep a copy of the parameters -
    * it just keeps pointer to input parameters.
    */
-  if( NULL == this->m_InputParametersPointer )
+  if( nullptr == this->m_InputParametersPointer )
   {
     itkExceptionMacro( << "Cannot GetParameters() because m_InputParametersPointer is NULL."
                        << " Perhaps SetCoefficientImages() has been called causing the NULL pointer." );
@@ -535,7 +535,7 @@ AdvancedBSplineDeformableTransformBase< TScalarType, NDimensions >
 
     // Clean up buffered parameters
     this->m_InternalParametersBuffer = ParametersType( 0 );
-    this->m_InputParametersPointer   = NULL;
+    this->m_InputParametersPointer   = nullptr;
 
   }
 

--- a/Common/Transforms/itkAdvancedImageMomentsCalculator.hxx
+++ b/Common/Transforms/itkAdvancedImageMomentsCalculator.hxx
@@ -72,7 +72,7 @@ AdvancedImageMomentsCalculator< TImage >::AdvancedImageMomentsCalculator(void)
   this->m_ThreaderParameters.st_Self = this;
 
   // Multi-threading structs
-  this->m_ComputePerThreadVariables = NULL;
+  this->m_ComputePerThreadVariables = nullptr;
   this->m_ComputePerThreadVariablesSize = 0;
   this->m_CenterOfGravityUsesLowerThreshold = false;
   this->m_NumberOfSamplesForCenteredTransformInitialization = 10000;

--- a/Common/Transforms/itkCyclicBSplineDeformableTransform.hxx
+++ b/Common/Transforms/itkCyclicBSplineDeformableTransform.hxx
@@ -312,7 +312,7 @@ CyclicBSplineDeformableTransform< TScalarType, NDimensions, VSplineOrder >
 {
   // Can only compute Jacobian if parameters are set via
   // SetParameters or SetParametersByValue
-  if( this->m_InputParametersPointer == NULL )
+  if( this->m_InputParametersPointer == nullptr )
   {
     itkExceptionMacro( << "Cannot compute Jacobian: parameters not set" );
   }

--- a/Common/Transforms/itkRecursiveBSplineTransform.hxx
+++ b/Common/Transforms/itkRecursiveBSplineTransform.hxx
@@ -459,7 +459,7 @@ RecursiveBSplineTransform< TScalar, NDimensions, VSplineOrder >
 {
   // Can only compute Jacobian if parameters are set via
   // SetParameters or SetParametersByValue
-  if( this->m_InputParametersPointer == NULL )
+  if( this->m_InputParametersPointer == nullptr )
   {
     itkExceptionMacro( << "Cannot compute Jacobian: parameters not set" );
   }
@@ -560,7 +560,7 @@ RecursiveBSplineTransform< TScalar, NDimensions, VSplineOrder >
 {
   // Can only compute Jacobian if parameters are set via
   // SetParameters or SetParametersByValue
-  if( this->m_InputParametersPointer == NULL )
+  if( this->m_InputParametersPointer == nullptr )
   {
     itkExceptionMacro( << "Cannot compute Jacobian: parameters not set" );
   }

--- a/Common/itkAdvancedRayCastInterpolateImageFunction.hxx
+++ b/Common/itkAdvancedRayCastInterpolateImageFunction.hxx
@@ -1192,7 +1192,7 @@ RayCastHelper< TInputImage, TCoordRep >
         m_RayIntersectionVoxels[ 0 ]
               = m_RayIntersectionVoxels[ 1 ]
               = m_RayIntersectionVoxels[ 2 ]
-              = m_RayIntersectionVoxels[ 3 ] = NULL;
+              = m_RayIntersectionVoxels[ 3 ] = nullptr;
       }
       break;
     }
@@ -1226,7 +1226,7 @@ RayCastHelper< TInputImage, TCoordRep >
         m_RayIntersectionVoxels[ 0 ]
               = m_RayIntersectionVoxels[ 1 ]
               = m_RayIntersectionVoxels[ 2 ]
-              = m_RayIntersectionVoxels[ 3 ] = NULL;
+              = m_RayIntersectionVoxels[ 3 ] = nullptr;
       }
       break;
     }
@@ -1261,7 +1261,7 @@ RayCastHelper< TInputImage, TCoordRep >
         m_RayIntersectionVoxels[ 0 ]
               = m_RayIntersectionVoxels[ 1 ]
               = m_RayIntersectionVoxels[ 2 ]
-              = m_RayIntersectionVoxels[ 3 ] = NULL;
+              = m_RayIntersectionVoxels[ 3 ] = nullptr;
       }
       break;
     }

--- a/Common/itkComputeDisplacementDistribution.hxx
+++ b/Common/itkComputeDisplacementDistribution.hxx
@@ -43,10 +43,10 @@ template< class TFixedImage, class TTransform >
 ComputeDisplacementDistribution< TFixedImage, TTransform >
 ::ComputeDisplacementDistribution()
 {
-  this->m_FixedImage                   = NULL;
-  this->m_FixedImageMask               = NULL;
-  this->m_Transform                    = NULL;
-  this->m_FixedImageMask               = NULL;
+  this->m_FixedImage                   = nullptr;
+  this->m_FixedImageMask               = nullptr;
+  this->m_Transform                    = nullptr;
+  this->m_FixedImageMask               = nullptr;
   this->m_NumberOfJacobianMeasurements = 0;
   this->m_SampleContainer              = 0;
 
@@ -58,7 +58,7 @@ ComputeDisplacementDistribution< TFixedImage, TTransform >
   this->m_ThreaderParameters.st_Self = this;
 
   // Multi-threading structs
-  this->m_ComputePerThreadVariables     = NULL;
+  this->m_ComputePerThreadVariables     = nullptr;
   this->m_ComputePerThreadVariablesSize = 0;
 
 } // end Constructor

--- a/Common/itkComputeJacobianTerms.hxx
+++ b/Common/itkComputeJacobianTerms.hxx
@@ -35,10 +35,10 @@ template< class TFixedImage, class TTransform >
 ComputeJacobianTerms< TFixedImage, TTransform >
 ::ComputeJacobianTerms()
 {
-  this->m_FixedImage     = NULL;
-  this->m_FixedImageMask = NULL;
-  this->m_Transform      = NULL;
-  this->m_FixedImageMask = NULL;
+  this->m_FixedImage     = nullptr;
+  this->m_FixedImageMask = nullptr;
+  this->m_Transform      = nullptr;
+  this->m_FixedImageMask = nullptr;
   this->m_UseScales      = false;
 
   this->m_MaxBandCovSize               = 0;

--- a/Common/itkReducedDimensionBSplineInterpolateImageFunction.hxx
+++ b/Common/itkReducedDimensionBSplineInterpolateImageFunction.hxx
@@ -111,7 +111,7 @@ ReducedDimensionBSplineInterpolateImageFunction< TImageType, TCoordRep, TCoeffic
   }
   else
   {
-    m_Coefficients = NULL;
+    m_Coefficients = nullptr;
   }
 }
 

--- a/Components/Metrics/AdvancedKappaStatistic/itkAdvancedKappaStatisticImageToImageMetric.hxx
+++ b/Components/Metrics/AdvancedKappaStatistic/itkAdvancedKappaStatisticImageToImageMetric.hxx
@@ -43,7 +43,7 @@ AdvancedKappaStatisticImageToImageMetric< TFixedImage, TMovingImage >
   this->m_Complement         = true;
 
   // Multi-threading structs
-  this->m_KappaGetValueAndDerivativePerThreadVariables     = NULL;
+  this->m_KappaGetValueAndDerivativePerThreadVariables     = nullptr;
   this->m_KappaGetValueAndDerivativePerThreadVariablesSize = 0;
 
 } // end Constructor

--- a/Components/Metrics/AdvancedNormalizedCorrelation/itkAdvancedNormalizedCorrelationImageToImageMetric.hxx
+++ b/Components/Metrics/AdvancedNormalizedCorrelation/itkAdvancedNormalizedCorrelationImageToImageMetric.hxx
@@ -42,7 +42,7 @@ AdvancedNormalizedCorrelationImageToImageMetric< TFixedImage, TMovingImage >
   this->SetUseMovingImageLimiter( false );
 
   // Multi-threading structs
-  this->m_CorrelationGetValueAndDerivativePerThreadVariables     = NULL;
+  this->m_CorrelationGetValueAndDerivativePerThreadVariables     = nullptr;
   this->m_CorrelationGetValueAndDerivativePerThreadVariablesSize = 0;
 
 } // end Constructor

--- a/Components/Metrics/KNNGraphAlphaMutualInformation/KNN/itkListSampleCArray.hxx
+++ b/Components/Metrics/KNNGraphAlphaMutualInformation/KNN/itkListSampleCArray.hxx
@@ -238,7 +238,7 @@ ListSampleCArray< TMeasurementVector, TInternalValue >
   {
     delete[] this->m_InternalContainer[ 0 ];
     delete[] this->m_InternalContainer;
-    this->m_InternalContainer = NULL;
+    this->m_InternalContainer = nullptr;
   }
 } // end DeallocateInternalContainer()
 

--- a/Components/Metrics/MissingStructurePenalty/elxMissingStructurePenalty.hxx
+++ b/Components/Metrics/MissingStructurePenalty/elxMissingStructurePenalty.hxx
@@ -345,9 +345,9 @@ MissingStructurePenalty< TElastix >
 
   /** Use pointer to the mesh data of fixedMesh; const_cast are assumed since outputMesh will only be used for writing the output*/
   FixedMeshConstPointer fixedMesh        = this->GetFixedMeshContainer()->ElementAt( meshId );
-  bool                  tempSetPointData = ( mappedMesh->GetPointData() == NULL );
-  bool                  tempSetCells     = ( mappedMesh->GetCells() == NULL );
-  bool                  tempSetCellData  = ( mappedMesh->GetCellData() == NULL );
+  bool                  tempSetPointData = ( mappedMesh->GetPointData() == nullptr );
+  bool                  tempSetCells     = ( mappedMesh->GetCells() == nullptr );
+  bool                  tempSetCellData  = ( mappedMesh->GetCellData() == nullptr );
 
   if( tempSetPointData )
   {
@@ -391,18 +391,18 @@ MissingStructurePenalty< TElastix >
   if( tempSetPointData )
   {
     // restore pointdata as undefined
-    mappedMesh->SetPointData( NULL );
+    mappedMesh->SetPointData( nullptr );
   }
 
   if( tempSetCells )
   {
     // restore cells as undefined
-    mappedMesh->SetCells( NULL );
+    mappedMesh->SetCells( nullptr );
   }
   if( tempSetCellData )
   {
     // restore celldata as undefined
-    mappedMesh->SetCellData( NULL );
+    mappedMesh->SetCellData( nullptr );
   }
 
 } // end WriteResultMesh()

--- a/Components/Metrics/MissingStructurePenalty/itkMissingStructurePenalty.hxx
+++ b/Components/Metrics/MissingStructurePenalty/itkMissingStructurePenalty.hxx
@@ -86,9 +86,9 @@ MissingVolumeMeshPenalty< TFixedPointSet, TMovingPointSet >
     // mappedMesh was constructed with a Cellscontainer and CellDatacontainer of size 0.
     // We use a null pointer to set them to undefined, which is also the default behavior of the MeshReader.
     // "Write result mesh" checks the null pointer and writes a mesh with the remaining data filled in from the fixed mesh.
-    mappedMesh->SetPointData( NULL );
-    mappedMesh->SetCells( NULL );
-    mappedMesh->SetCellData( NULL );
+    mappedMesh->SetPointData( nullptr );
+    mappedMesh->SetCells( nullptr );
+    mappedMesh->SetCellData( nullptr );
 
     this->m_MappedMeshContainer->SetElement( meshId, mappedMesh );
 

--- a/Components/Metrics/PCAMetric/itkPCAMetric_F_multithreaded.hxx
+++ b/Components/Metrics/PCAMetric/itkPCAMetric_F_multithreaded.hxx
@@ -51,7 +51,7 @@ PCAMetric< TFixedImage, TMovingImage >
   this->SetUseMovingImageLimiter( false );
 
   // Multi-threading structs
-  this->m_PCAMetricGetSamplesPerThreadVariables     = NULL;
+  this->m_PCAMetricGetSamplesPerThreadVariables     = nullptr;
   this->m_PCAMetricGetSamplesPerThreadVariablesSize = 0;
 
   /** Initialize the m_ParzenWindowHistogramThreaderParameters. */

--- a/Components/Metrics/PolydataDummyPenalty/elxPolydataDummyPenalty.hxx
+++ b/Components/Metrics/PolydataDummyPenalty/elxPolydataDummyPenalty.hxx
@@ -334,9 +334,9 @@ PolydataDummyPenalty< TElastix >
    * will only be used for writing the output.
    * */
   FixedMeshConstPointer fixedMesh        = this->GetFixedMeshContainer()->ElementAt( meshId );
-  bool                  tempSetPointData = ( mappedMesh->GetPointData() == NULL );
-  bool                  tempSetCells     = ( mappedMesh->GetCells() == NULL );
-  bool                  tempSetCellData  = ( mappedMesh->GetCellData() == NULL );
+  bool                  tempSetPointData = ( mappedMesh->GetPointData() == nullptr );
+  bool                  tempSetCells     = ( mappedMesh->GetCells() == nullptr );
+  bool                  tempSetCellData  = ( mappedMesh->GetCellData() == nullptr );
 
   if( tempSetPointData )
   {
@@ -376,16 +376,16 @@ PolydataDummyPenalty< TElastix >
 
   if( tempSetPointData )
   {
-    mappedMesh->SetPointData( NULL );
+    mappedMesh->SetPointData( nullptr );
   }
 
   if( tempSetCells )
   {
-    mappedMesh->SetCells( NULL );
+    mappedMesh->SetCells( nullptr );
   }
   if( tempSetCellData )
   {
-    mappedMesh->SetCellData( NULL );
+    mappedMesh->SetCellData( nullptr );
   }
 
 } // end WriteResultMesh()

--- a/Components/Metrics/PolydataDummyPenalty/itkPolydataDummyPenalty.hxx
+++ b/Components/Metrics/PolydataDummyPenalty/itkPolydataDummyPenalty.hxx
@@ -98,14 +98,14 @@ MeshPenalty< TFixedPointSet, TMovingPointSet >
     typename FixedMeshType::Pointer mappedMesh = FixedMeshType::New();
     mappedMesh->SetPoints( mappedPoints );
 
-    mappedMesh->SetPointData( NULL );
+    mappedMesh->SetPointData( nullptr );
     //mappedMesh->SetPointData(mappedPointNormals);
 
     // mappedMesh was constructed with a Cellscontainer and CellDatacontainer of size 0.
     // We use a null pointer to set them to undefined, which is also the default behavior of the MeshReader.
     // "Write result mesh" checks the null pointer and writes a mesh with the remaining data filled in from the fixed mesh.
-    mappedMesh->SetCells( NULL );
-    mappedMesh->SetCellData( NULL );
+    mappedMesh->SetCells( nullptr );
+    mappedMesh->SetCellData( nullptr );
 
     this->m_MappedMeshContainer->SetElement( meshId, mappedMesh );
   }

--- a/Components/Metrics/RigidityPenalty/itkTransformRigidityPenaltyTerm.hxx
+++ b/Components/Metrics/RigidityPenalty/itkTransformRigidityPenaltyTerm.hxx
@@ -85,7 +85,7 @@ TransformRigidityPenaltyTerm< TFixedImage, TScalarType >
   /** We don't use an image sampler for this advanced metric. */
   this->SetUseImageSampler( false );
 
-  this->m_BSplineTransform = NULL;
+  this->m_BSplineTransform = nullptr;
 
 } // end Constructor
 

--- a/Components/Metrics/StatisticalShapePenalty/itkStatisticalShapePointPenalty.hxx
+++ b/Components/Metrics/StatisticalShapePenalty/itkStatisticalShapePointPenalty.hxx
@@ -31,12 +31,12 @@ template< class TFixedPointSet, class TMovingPointSet >
 StatisticalShapePointPenalty< TFixedPointSet, TMovingPointSet >
 ::StatisticalShapePointPenalty()
 {
-  this->m_MeanVector              = NULL;
-  this->m_EigenVectors            = NULL;
-  this->m_EigenValues             = NULL;
-  this->m_EigenValuesRegularized  = NULL;
-  this->m_ProposalDerivative      = NULL;
-  this->m_InverseCovarianceMatrix = NULL;
+  this->m_MeanVector              = nullptr;
+  this->m_EigenVectors            = nullptr;
+  this->m_EigenValues             = nullptr;
+  this->m_EigenValuesRegularized  = nullptr;
+  this->m_ProposalDerivative      = nullptr;
+  this->m_InverseCovarianceMatrix = nullptr;
 
   this->m_ShrinkageIntensityNeedsUpdate = true;
   this->m_BaseVarianceNeedsUpdate       = true;
@@ -53,40 +53,40 @@ template< class TFixedPointSet, class TMovingPointSet >
 StatisticalShapePointPenalty< TFixedPointSet, TMovingPointSet >
 ::~StatisticalShapePointPenalty()
 {
-  if( this->m_MeanVector != NULL )
+  if( this->m_MeanVector != nullptr )
   {
     delete this->m_MeanVector;
-    this->m_MeanVector = NULL;
+    this->m_MeanVector = nullptr;
   }
-  if( this->m_CovarianceMatrix != NULL )
+  if( this->m_CovarianceMatrix != nullptr )
   {
     delete this->m_CovarianceMatrix;
-    this->m_CovarianceMatrix = NULL;
+    this->m_CovarianceMatrix = nullptr;
   }
-  if( this->m_EigenVectors != NULL )
+  if( this->m_EigenVectors != nullptr )
   {
     delete this->m_EigenVectors;
-    this->m_EigenVectors = NULL;
+    this->m_EigenVectors = nullptr;
   }
-  if( this->m_EigenValues != NULL )
+  if( this->m_EigenValues != nullptr )
   {
     delete this->m_EigenValues;
-    this->m_EigenValues = NULL;
+    this->m_EigenValues = nullptr;
   }
-  if( this->m_EigenValuesRegularized != NULL )
+  if( this->m_EigenValuesRegularized != nullptr )
   {
     delete this->m_EigenValuesRegularized;
-    this->m_EigenValuesRegularized = NULL;
+    this->m_EigenValuesRegularized = nullptr;
   }
-  if( this->m_ProposalDerivative != NULL )
+  if( this->m_ProposalDerivative != nullptr )
   {
     delete this->m_ProposalDerivative;
-    this->m_ProposalDerivative = NULL;
+    this->m_ProposalDerivative = nullptr;
   }
-  if( this->m_InverseCovarianceMatrix != NULL )
+  if( this->m_InverseCovarianceMatrix != nullptr )
   {
     delete this->m_InverseCovarianceMatrix;
-    this->m_InverseCovarianceMatrix = NULL;
+    this->m_InverseCovarianceMatrix = nullptr;
   }
 
 } // end Destructor
@@ -179,7 +179,7 @@ StatisticalShapePointPenalty< TFixedPointSet, TMovingPointSet >
          */
         this->m_InverseCovarianceMatrix = new vnl_matrix< double >( vnl_svd_inverse( regularizedCovariance ) );
       }
-      this->m_EigenValuesRegularized = NULL;
+      this->m_EigenValuesRegularized = nullptr;
       break;
     }
     case 1: // decomposed covariance (uniform regularization)
@@ -195,19 +195,19 @@ StatisticalShapePointPenalty< TFixedPointSet, TMovingPointSet >
       unsigned int nonZeroLength = 0;
       for(; lambdaIt != lambdaEnd && ( *lambdaIt ) > 1e-14; ++lambdaIt, ++nonZeroLength )
       {}
-      if( this->m_EigenValues != NULL )
+      if( this->m_EigenValues != nullptr )
       {
         delete this->m_EigenValues;
       }
       this->m_EigenValues = new VnlVectorType( pcaCovariance.lambdas().extract( nonZeroLength ) );
 
-      if( this->m_EigenVectors != NULL )
+      if( this->m_EigenVectors != nullptr )
       {
         delete this->m_EigenVectors;
       }
       this->m_EigenVectors = new VnlMatrixType( pcaCovariance.V().get_n_columns( 0, nonZeroLength ) );
 
-      if( this->m_EigenValuesRegularized == NULL )
+      if( this->m_EigenValuesRegularized == nullptr )
       {
         this->m_EigenValuesRegularized = new vnl_vector< double >( this->m_EigenValues->size() );
       }
@@ -245,7 +245,7 @@ StatisticalShapePointPenalty< TFixedPointSet, TMovingPointSet >
           *regularizedValue = *eigenValue;
         }
       }
-      this->m_InverseCovarianceMatrix = NULL;
+      this->m_InverseCovarianceMatrix = nullptr;
     }
     break;
     case 2: // decomposed scaled covariance (element specific regularization)
@@ -288,13 +288,13 @@ StatisticalShapePointPenalty< TFixedPointSet, TMovingPointSet >
         for(; lambdaIt != lambdaEnd && ( *lambdaIt ) > 1e-14; ++lambdaIt, ++nonZeroLength )
         {}
 
-        if( this->m_EigenValues != NULL )
+        if( this->m_EigenValues != nullptr )
         {
           delete this->m_EigenValues;
         }
         this->m_EigenValues = new VnlVectorType( pcaCovariance.lambdas().extract( nonZeroLength ) );
 
-        if( this->m_EigenVectors != NULL )
+        if( this->m_EigenVectors != nullptr )
         {
           delete this->m_EigenVectors;
         }
@@ -302,7 +302,7 @@ StatisticalShapePointPenalty< TFixedPointSet, TMovingPointSet >
       }
       if( this->m_ShrinkageIntensityNeedsUpdate || pcaNeedsUpdate )
       {
-        if( this->m_EigenValuesRegularized != NULL )
+        if( this->m_EigenValuesRegularized != nullptr )
         {
           delete this->m_EigenValuesRegularized;
         }
@@ -336,12 +336,12 @@ StatisticalShapePointPenalty< TFixedPointSet, TMovingPointSet >
       this->m_ShrinkageIntensityNeedsUpdate = false;
       this->m_BaseVarianceNeedsUpdate       = false;
       this->m_VariancesNeedsUpdate          = false;
-      this->m_InverseCovarianceMatrix       = NULL;
+      this->m_InverseCovarianceMatrix       = nullptr;
     }
     break;
     default:
-      this->m_InverseCovarianceMatrix = NULL;
-      this->m_EigenValuesRegularized  = NULL;
+      this->m_InverseCovarianceMatrix = nullptr;
+      this->m_EigenValuesRegularized  = nullptr;
   }
 
 } // end Initialize()
@@ -480,7 +480,7 @@ StatisticalShapePointPenalty< TFixedPointSet, TMovingPointSet >
     * fixedPointSet->GetNumberOfPoints();
 
   this->m_ProposalVector.set_size( this->m_ProposalLength );
-  this->m_ProposalDerivative = new ProposalDerivativeType( this->GetNumberOfParameters(), NULL );
+  this->m_ProposalDerivative = new ProposalDerivativeType( this->GetNumberOfParameters(), nullptr );
 
   /** Part 1:
    * - Copy point positions in proposal vector
@@ -548,14 +548,14 @@ StatisticalShapePointPenalty< TFixedPointSet, TMovingPointSet >
     typename ProposalDerivativeType::iterator proposalDerivativeEnd = this->m_ProposalDerivative->end();
     for(; proposalDerivativeIt != proposalDerivativeEnd; ++proposalDerivativeIt )
     {
-      if( *proposalDerivativeIt != NULL )
+      if( *proposalDerivativeIt != nullptr )
       {
         delete ( *proposalDerivativeIt );
       }
     }
   }
   delete this->m_ProposalDerivative;
-  this->m_ProposalDerivative = NULL;
+  this->m_ProposalDerivative = nullptr;
 
   this->CalculateCutOffValue( value );
 
@@ -617,7 +617,7 @@ StatisticalShapePointPenalty< TFixedPointSet, TMovingPointSet >
   for( unsigned int i = 0; i < nzji.size(); ++i )
   {
     const unsigned int mu = nzji[ i ];
-    if( ( *this->m_ProposalDerivative )[ mu ] == NULL )
+    if( ( *this->m_ProposalDerivative )[ mu ] == nullptr )
     {
       /** Create the big column vector if it does not yet exist for this mu*/
       ( *this->m_ProposalDerivative )[ mu ] = new VnlVectorType( this->m_ProposalLength, 0.0 );
@@ -683,7 +683,7 @@ StatisticalShapePointPenalty< TFixedPointSet, TMovingPointSet >
   typename ProposalDerivativeType::iterator proposalDerivativeEnd = m_ProposalDerivative->end();
   while( proposalDerivativeIt != proposalDerivativeEnd )
   {
-    if( *proposalDerivativeIt != NULL )
+    if( *proposalDerivativeIt != nullptr )
     {
       for( unsigned int d = 0; d < Self::FixedPointSetDimension; ++d )
       {
@@ -768,7 +768,7 @@ StatisticalShapePointPenalty< TFixedPointSet, TMovingPointSet >
 
   while( proposalDerivativeIt != proposalDerivativeEnd )
   {
-    if( *proposalDerivativeIt != NULL )
+    if( *proposalDerivativeIt != nullptr )
     {
       double & l2normDerivative = ( **proposalDerivativeIt )[ shapeLength + Self::FixedPointSetDimension ];
       l2normDerivative = 0; // initialize to zero
@@ -889,7 +889,7 @@ StatisticalShapePointPenalty< TFixedPointSet, TMovingPointSet >
 
   for(; proposalDerivativeIt != proposalDerivativeEnd; ++proposalDerivativeIt, ++derivativeIt )
   {
-    if( *proposalDerivativeIt != NULL )
+    if( *proposalDerivativeIt != nullptr )
     {
       switch( this->m_ShapeModelCalculation )
       {

--- a/Components/Optimizers/PreconditionedGradientDescent/itkPreconditionedGradientDescentOptimizer.cxx
+++ b/Components/Optimizers/PreconditionedGradientDescent/itkPreconditionedGradientDescentOptimizer.cxx
@@ -498,7 +498,7 @@ PreconditionedGradientDescentOptimizer
   double beta[2];
   beta[0] = 0.0; // this->GetDiagonalWeight() * largestEig; but we already did that above
   beta[1] = 0.0; // this is for potential imaginary part of complex number.
-  cholmod_factorize_p( cPrecondition, beta, NULL, 0,
+  cholmod_factorize_p( cPrecondition, beta, nullptr, 0,
     this->m_CholmodFactor, this->m_CholmodCommon );
 
   /** Store condition number of user */

--- a/Components/Transforms/MultiBSplineTransformWithNormal/itkMultiBSplineDeformableTransformWithNormal.hxx
+++ b/Components/Transforms/MultiBSplineTransformWithNormal/itkMultiBSplineDeformableTransformWithNormal.hxx
@@ -612,7 +612,7 @@ typename MultiBSplineDeformableTransformWithNormal< TScalarType, NDimensions, VS
   /** NOTE: For efficiency, this class does not keep a copy of the parameters -
    * it just keeps pointer to input parameters.
    */
-  if( NULL == this->m_InputParametersPointer )
+  if( nullptr == this->m_InputParametersPointer )
   {
     itkExceptionMacro(
         << "Cannot GetParameters() because m_InputParametersPointer is NULL. Perhaps SetCoefficientImages() has been called causing the NULL pointer." );
@@ -734,7 +734,7 @@ MultiBSplineDeformableTransformWithNormal< TScalarType, NDimensions, VSplineOrde
   // This implements a sparse version of the Jacobian.
   // Can only compute Jacobian if parameters are set via
   // SetParameters or SetParametersByValue
-  if( this->m_InputParametersPointer == NULL )
+  if( this->m_InputParametersPointer == nullptr )
   {
     itkExceptionMacro( << "Cannot compute Jacobian: parameters not set" );
   }
@@ -830,7 +830,7 @@ MultiBSplineDeformableTransformWithNormal< TScalarType, NDimensions, VSplineOrde
 
   // Can only compute Jacobian if parameters are set via
   // SetParameters or SetParametersByValue
-  if( this->m_InputParametersPointer == NULL )
+  if( this->m_InputParametersPointer == nullptr )
   {
     itkExceptionMacro( << "Cannot compute Jacobian: parameters not set" );
   }
@@ -866,7 +866,7 @@ MultiBSplineDeformableTransformWithNormal< TScalarType, NDimensions, VSplineOrde
 
   // Can only compute Jacobian if parameters are set via
   // SetParameters or SetParametersByValue
-  if( this->m_InputParametersPointer == NULL )
+  if( this->m_InputParametersPointer == nullptr )
   {
     itkExceptionMacro( << "Cannot compute Jacobian: parameters not set" );
   }
@@ -934,7 +934,7 @@ MultiBSplineDeformableTransformWithNormal< TScalarType, NDimensions, VSplineOrde
   // This implements a sparse version of the Jacobian.
   // Can only compute Jacobian if parameters are set via
   // SetParameters or SetParametersByValue
-  if( this->m_InputParametersPointer == NULL )
+  if( this->m_InputParametersPointer == nullptr )
   {
     itkExceptionMacro( << "Cannot compute Jacobian: parameters not set" );
   }
@@ -1036,7 +1036,7 @@ MultiBSplineDeformableTransformWithNormal< TScalarType, NDimensions, VSplineOrde
   // This implements a sparse version of the Jacobian.
   // Can only compute Jacobian if parameters are set via
   // SetParameters or SetParametersByValue
-  if( this->m_InputParametersPointer == NULL )
+  if( this->m_InputParametersPointer == nullptr )
   {
     itkExceptionMacro( << "Cannot compute Jacobian: parameters not set" );
   }

--- a/Core/Kernel/elxElastixBase.h
+++ b/Core/Kernel/elxElastixBase.h
@@ -402,7 +402,7 @@ public:
 
     static DataObjectContainerPointer GenerateImageContainer(
       FileNameContainerType * fileNameContainer, const std::string & imageDescription,
-      bool useDirectionCosines, DirectionType * originalDirectionCosines = NULL )
+      bool useDirectionCosines, DirectionType * originalDirectionCosines = nullptr )
     {
       DataObjectContainerPointer imageContainer = DataObjectContainerType::New();
 

--- a/Core/Main/elastix.h
+++ b/Core/Main/elastix.h
@@ -89,7 +89,7 @@ std::string
 GetCurrentDateAndTime( void )
 {
   // Obtain current time
-  time_t rawtime = time( NULL );
+  time_t rawtime = time( nullptr );
   // Convert to local time
   struct tm * timeinfo = localtime( &rawtime );
   // Convert to human-readable format

--- a/Core/Main/elastixlib.cxx
+++ b/Core/Main/elastixlib.cxx
@@ -458,7 +458,7 @@ std::string
 ELASTIX::GetCurrentDateAndTime( void )
 {
   // Obtain current time
-  time_t rawtime = time( NULL );
+  time_t rawtime = time( nullptr );
   // Convert to local time
   struct tm * timeinfo = localtime( &rawtime );
   // Convert to human-readable format

--- a/Core/Main/transformixlib.cxx
+++ b/Core/Main/transformixlib.cxx
@@ -296,7 +296,7 @@ std::string
 TRANSFORMIX::GetCurrentDateAndTime( void )
 {
   // Obtain current time
-  time_t rawtime = time( NULL );
+  time_t rawtime = time( nullptr );
   // Convert to local time
   struct tm * timeinfo = localtime( &rawtime );
   // Convert to human-readable format

--- a/Testing/itkAccumulateDerivativesParallellizationTest.cxx
+++ b/Testing/itkAccumulateDerivativesParallellizationTest.cxx
@@ -79,8 +79,8 @@ public:
   // Constructor
   MetricTEMP()
   {
-    this->m_ThreaderMetricParameters.st_Metric              = NULL;
-    this->m_ThreaderMetricParameters.st_DerivativePointer   = NULL;
+    this->m_ThreaderMetricParameters.st_Metric              = nullptr;
+    this->m_ThreaderMetricParameters.st_DerivativePointer   = nullptr;
     this->m_ThreaderMetricParameters.st_NormalizationFactor = 0.0;
 
     this->m_NumberOfParameters = 0;


### PR DESCRIPTION
This pull request aims to improve type safety, and modernize programming style, by using the C++11 `nullptr` keyword, instead of the old `NULL` macro.

It solves many Visual Studio 2017 Code Analysis warnings of the type:
> warning C26477: Use 'nullptr' rather than 0 or NULL (es.47).

 