### PR TITLE
STYLE: Replace tabs by spaces

### DIFF
--- a/.editorconfig
+++ b/.editorconfig
@@ -1,0 +1,11 @@
+# EditorConfig: https://EditorConfig.org
+
+# This is the top-most EditorConfig file
+root = true
+
+# Apply to any source file
+[*.*]
+
+# Indentation of two spaces 
+indent_style = space
+indent_size = 2

--- a/dox/externalproject/itkTimerTest.cxx
+++ b/dox/externalproject/itkTimerTest.cxx
@@ -61,10 +61,10 @@ int TestZeroTimeOutput( void )
 
 int main( int argc, char *argv[] )
 {
-	int errorCode = TestStartStop() || TestZeroTimeOutput();
-	
-	std::cerr << "Elastix code was successfully used outside the Elastix tree!" << std::endl;
+  int errorCode = TestStartStop() || TestZeroTimeOutput();
 
-	return errorCode;
+  std::cerr << "Elastix code was successfully used outside the Elastix tree!" << std::endl;
+
+  return errorCode;
 } // end main()
 


### PR DESCRIPTION
Replaced tabs, found by Visual Studio (Find In Files...) by spaces, as requested by Marius @mstaring

Added EditorConfig file, to preserve the formatting style during future editing.