### PR TITLE
ENH: Bump elastix version from 4.9.0 to 5.0.0

### DIFF
--- a/Core/Install/elxBaseComponent.h
+++ b/Core/Install/elxBaseComponent.h
@@ -43,7 +43,7 @@
 #include "itkMacro.h" // itkTypeMacroNoParent
 
 /** The current elastix version. */
-#define __ELASTIX_VERSION 4.900
+#define __ELASTIX_VERSION 5.000
 
 /** All elastix components should be in namespace elastix. */
 namespace elastix

--- a/dox/ITKCompilationOptions.txt
+++ b/dox/ITKCompilationOptions.txt
@@ -1,4 +1,4 @@
-elastix 4.9 compiles with ITK 4.13.0 compiled with the default options.
+elastix 5.0.0 compiles with ITK 5.0.1 compiled with the default options.
 
 
 Optionally use ITK_USE_64BITS_IDS and ITK_LEGACY_REMOVE.


### PR DESCRIPTION
Increased __ELASTIX_VERSION and adjusted ITKCompilationOptions.txt

Note: the link to the manual (in CONTRIBUTING.md) should still be updated, once a new manual is available.