### PR TITLE
STYLE: Add CMake, _MSC_BUILD, ITK_VERSION_PATCH to --extended-version

### DIFF
--- a/Core/CMakeLists.txt
+++ b/Core/CMakeLists.txt
@@ -141,6 +141,8 @@ else()
   )
 endif()
 
+target_compile_definitions(elastix PRIVATE ELX_CMAKE_VERSION="${CMAKE_VERSION}")
+
 #---------------------------------------------------------------------
 # Create the transformix executable.
 

--- a/Core/Main/elastix.cxx
+++ b/Core/Main/elastix.cxx
@@ -57,14 +57,17 @@ main( int argc, char ** argv )
         << "elastix version: "
         << __ELASTIX_VERSION
         << "\nITK version: "
-        << ITK_VERSION_STRING
+        << ITK_VERSION_MAJOR << '.'
+        << ITK_VERSION_MINOR << '.'
+        << ITK_VERSION_PATCH
         << "\nBuild date: "
         << __DATE__
         << ' '
         << __TIME__
-#ifdef _MSC_VER
+#ifdef _MSC_FULL_VER
         << "\nCompiler: Visual C++ version "
-        << _MSC_FULL_VER
+        << _MSC_FULL_VER << '.'
+        << _MSC_BUILD
 #endif
 #ifdef __clang__
         << "\nCompiler: Clang"
@@ -80,9 +83,11 @@ main( int argc, char ** argv )
         << __VERSION__
 #endif
 #endif
-        << "\nMemory addressing: "
+        << "\nMemory address size: "
         << std::numeric_limits<std::size_t>::digits
         << "-bit"
+        << "\nCMake version: "
+        << ELX_CMAKE_VERSION
         << std::endl;
       return 0;
     }


### PR DESCRIPTION
 Extended the output of the elastix command-line option "--extended-version" by adding:

 * The CMake version number
 * _MSC_BUILD: the revision number element of MSVC's version number
 * The patch component of ITK's version number

It appeared that `ITK_VERSION_STRING` only shows the major and the minor version component, for example, "5.0". With this commit, the patch number is included, as in "5.0.1".

The CMake version number is explicitly mentioned at https://github.com/SuperElastix/elastix/releases so it seems useful to provide it through command-line option "--extended-version" as well.

