### PR TITLE
ITK 5 threading updates

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -47,8 +47,6 @@ if( NOT ELASTIX_BUILD_EXECUTABLE )
   #set( CMAKE_C_VISIBILITY_PRESET hidden )
   #set( CMAKE_CXX_VISIBILITY_PRESET hidden )
 
-  mark_as_advanced( BUILD_SHARED_LIBS )
-  option( BUILD_SHARED_LIBS "Build shared libraries?" OFF )
   if( BUILD_SHARED_LIBS )
     add_definitions( -D_ELASTIX_USE_SHARED_LIBRARY )
 

--- a/Common/CostFunctions/itkAdvancedImageToImageMetric.h
+++ b/Common/CostFunctions/itkAdvancedImageToImageMetric.h
@@ -379,7 +379,7 @@ protected:
   virtual inline void AfterThreadedGetValue( MeasureType & value ) const {}
 
   /** GetValue threader callback function. */
-  static ITK_THREAD_RETURN_TYPE GetValueThreaderCallback( void * arg );
+  static ITK_THREAD_RETURN_FUNCTION_CALL_CONVENTION GetValueThreaderCallback( void * arg );
 
   /** Launch MultiThread GetValue. */
   void LaunchGetValueThreaderCallback( void ) const;
@@ -393,13 +393,13 @@ protected:
     MeasureType & value, DerivativeType & derivative ) const {}
 
   /** GetValueAndDerivative threader callback function. */
-  static ITK_THREAD_RETURN_TYPE GetValueAndDerivativeThreaderCallback( void * arg );
+  static ITK_THREAD_RETURN_FUNCTION_CALL_CONVENTION GetValueAndDerivativeThreaderCallback( void * arg );
 
   /** Launch MultiThread GetValueAndDerivative. */
   void LaunchGetValueAndDerivativeThreaderCallback( void ) const;
 
   /** AccumulateDerivatives threader callback function. */
-  static ITK_THREAD_RETURN_TYPE AccumulateDerivativesThreaderCallback( void * arg );
+  static ITK_THREAD_RETURN_FUNCTION_CALL_CONVENTION AccumulateDerivativesThreaderCallback( void * arg );
 
   /** Variables for multi-threading. */
   bool m_UseMetricSingleThreaded;

--- a/Common/CostFunctions/itkAdvancedImageToImageMetric.hxx
+++ b/Common/CostFunctions/itkAdvancedImageToImageMetric.hxx
@@ -866,7 +866,7 @@ AdvancedImageToImageMetric< TFixedImage, TMovingImage >
  */
 
 template< class TFixedImage, class TMovingImage >
-ITK_THREAD_RETURN_TYPE
+ITK_THREAD_RETURN_FUNCTION_CALL_CONVENTION
 AdvancedImageToImageMetric< TFixedImage, TMovingImage >
 ::GetValueThreaderCallback( void * arg )
 {
@@ -907,7 +907,7 @@ AdvancedImageToImageMetric< TFixedImage, TMovingImage >
  */
 
 template< class TFixedImage, class TMovingImage >
-ITK_THREAD_RETURN_TYPE
+ITK_THREAD_RETURN_FUNCTION_CALL_CONVENTION
 AdvancedImageToImageMetric< TFixedImage, TMovingImage >
 ::GetValueAndDerivativeThreaderCallback( void * arg )
 {
@@ -948,7 +948,7 @@ AdvancedImageToImageMetric< TFixedImage, TMovingImage >
  */
 
 template< class TFixedImage, class TMovingImage >
-ITK_THREAD_RETURN_TYPE
+ITK_THREAD_RETURN_FUNCTION_CALL_CONVENTION
 AdvancedImageToImageMetric< TFixedImage, TMovingImage >
 ::AccumulateDerivativesThreaderCallback( void * arg )
 {

--- a/Common/CostFunctions/itkParzenWindowHistogramImageToImageMetric.h
+++ b/Common/CostFunctions/itkParzenWindowHistogramImageToImageMetric.h
@@ -71,7 +71,7 @@ namespace itk
  */
 
 template< class TFixedImage, class TMovingImage >
-class ParzenWindowHistogramImageToImageMetric :
+class ITK_TEMPLATE_EXPORT ParzenWindowHistogramImageToImageMetric :
   public AdvancedImageToImageMetric< TFixedImage, TMovingImage >
 {
 public:
@@ -331,7 +331,7 @@ protected:
   inline void AfterThreadedComputePDFs( void ) const;
 
   /** Helper function to launch the threads. */
-  static ITK_THREAD_RETURN_TYPE ComputePDFsThreaderCallback( void * arg );
+  static ITK_THREAD_RETURN_FUNCTION_CALL_CONVENTION ComputePDFsThreaderCallback( void * arg );
 
   /** Helper function to launch the threads. */
   void LaunchComputePDFsThreaderCallback( void ) const;

--- a/Common/CostFunctions/itkParzenWindowHistogramImageToImageMetric.hxx
+++ b/Common/CostFunctions/itkParzenWindowHistogramImageToImageMetric.hxx
@@ -1309,7 +1309,7 @@ ParzenWindowHistogramImageToImageMetric< TFixedImage, TMovingImage >
  */
 
 template< class TFixedImage, class TMovingImage >
-ITK_THREAD_RETURN_TYPE
+ITK_THREAD_RETURN_FUNCTION_CALL_CONVENTION
 ParzenWindowHistogramImageToImageMetric< TFixedImage, TMovingImage >
 ::ComputePDFsThreaderCallback( void * arg )
 {

--- a/Common/ImageSamplers/itkImageFullSampler.h
+++ b/Common/ImageSamplers/itkImageFullSampler.h
@@ -103,9 +103,7 @@ protected:
   void GenerateData( void ) override;
 
   /** Multi-threaded function that does the work. */
-  void ThreadedGenerateData(
-    const InputImageRegionType & inputRegionForThread,
-    ThreadIdType threadId ) override;
+  void DynamicThreadedGenerateData( const InputImageRegionType & inputRegionForThread) override;
 
 private:
 

--- a/Common/ImageSamplers/itkImageFullSampler.hxx
+++ b/Common/ImageSamplers/itkImageFullSampler.hxx
@@ -131,7 +131,7 @@ ImageFullSampler< TInputImage >
 
 
 /**
- * ******************* ThreadedGenerateData *******************
+ * ******************* DynamicThreadedGenerateData *******************
  */
 
 template< class TInputImage >

--- a/Common/ImageSamplers/itkImageRandomCoordinateSampler.h
+++ b/Common/ImageSamplers/itkImageRandomCoordinateSampler.h
@@ -123,9 +123,7 @@ protected:
   /** Multi-threaded functionality that does the work. */
   void BeforeThreadedGenerateData( void ) override;
 
-  void ThreadedGenerateData(
-    const InputImageRegionType & inputRegionForThread,
-    ThreadIdType threadId ) override;
+  void DynamicThreadedGenerateData( const InputImageRegionType & inputRegionForThread ) override;
 
   /** Generate a point randomly in a bounding box. */
   virtual void GenerateRandomCoordinate(
@@ -157,6 +155,7 @@ private:
 
   bool m_UseRandomSampleRegion;
 
+  std::atomic< ThreadIdType > m_WorkUnitId;
 };
 
 } // end namespace itk

--- a/Common/ImageSamplers/itkImageRandomCoordinateSampler.hxx
+++ b/Common/ImageSamplers/itkImageRandomCoordinateSampler.hxx
@@ -208,13 +208,8 @@ ImageRandomCoordinateSampler< TInputImage >
     }
   }
 
-  /** Initialize variables needed for threads. */
-  this->m_ThreaderSampleContainer.clear();
-  this->m_ThreaderSampleContainer.resize( this->GetNumberOfWorkUnits() );
-  for( std::size_t i = 0; i < this->GetNumberOfWorkUnits(); i++ )
-  {
-    this->m_ThreaderSampleContainer[ i ] = ImageSampleContainerType::New();
-  }
+  /** Initialize variables needed for work units. */
+  Superclass::BeforeThreadedGenerateData();
 
   this->m_WorkUnitId.store(0);
 
@@ -251,19 +246,17 @@ ImageRandomCoordinateSampler< TInputImage >
       - ( ( this->GetNumberOfWorkUnits() - 1 ) * chunkSize );
   }
 
-  /** Get a reference to the output and reserve memory for it. */
-  ImageSampleContainerPointer & sampleContainerThisThread // & ???
-    = this->m_ThreaderSampleContainer[ workUnitId ];
-  sampleContainerThisThread->Reserve( chunkSize );
+  ImageSampleContainerPointer sampleContainerThisWorkUnit = ImageSampleContainerType::New();
+  sampleContainerThisWorkUnit->Reserve( chunkSize );
 
-  /** Setup an iterator over the sampleContainerThisThread. */
+  /** Setup an iterator over the sampleContainerThisWorkUnit. */
   typename ImageSampleContainerType::Iterator iter;
-  typename ImageSampleContainerType::ConstIterator end = sampleContainerThisThread->End();
+  typename ImageSampleContainerType::ConstIterator end = sampleContainerThisWorkUnit->End();
 
   /** Fill the local sample container. */
   InputImageContinuousIndexType sampleCIndex;
   unsigned long                 sampleId = sampleStart;
-  for( iter = sampleContainerThisThread->Begin(); iter != end; ++iter )
+  for( iter = sampleContainerThisWorkUnit->Begin(); iter != end; ++iter )
   {
     /** Create a random point out of InputImageDimension random numbers. */
     for( unsigned int j = 0; j < InputImageDimension; ++j, sampleId++ )
@@ -283,6 +276,9 @@ ImageRandomCoordinateSampler< TInputImage >
       this->m_Interpolator->EvaluateAtContinuousIndex( sampleCIndex ) );
 
   } // end for loop
+
+  std::lock_guard<std::mutex> mutexHolder( this->m_Mutex );
+  this->m_ThreaderSampleContainer.push_back( sampleContainerThisWorkUnit );
 
 } // end ThreadedGenerateData()
 

--- a/Common/ImageSamplers/itkImageRandomSampler.h
+++ b/Common/ImageSamplers/itkImageRandomSampler.h
@@ -20,6 +20,8 @@
 
 #include "itkImageRandomSamplerBase.h"
 
+#include <atomic>
+
 namespace itk
 {
 /** \class ImageRandomSampler
@@ -87,9 +89,7 @@ protected:
   /** Functions that do the work. */
   void GenerateData( void ) override;
 
-  void ThreadedGenerateData(
-    const InputImageRegionType & inputRegionForThread,
-    ThreadIdType threadId ) override;
+  void DynamicThreadedGenerateData( const InputImageRegionType & inputRegionForThread ) override;
 
 private:
 
@@ -98,6 +98,7 @@ private:
   /** The private copy constructor. */
   void operator=( const Self & );            // purposely not implemented
 
+  std::atomic< ThreadIdType > m_WorkUnitId;
 };
 
 } // end namespace itk

--- a/Common/ImageSamplers/itkImageRandomSamplerSparseMask.h
+++ b/Common/ImageSamplers/itkImageRandomSamplerSparseMask.h
@@ -22,6 +22,8 @@
 #include "itkMersenneTwisterRandomVariateGenerator.h"
 #include "itkImageFullSampler.h"
 
+#include <atomic>
+
 namespace itk
 {
 /** \class ImageRandomSamplerSparseMask
@@ -97,9 +99,7 @@ protected:
   /** Multi-threaded functionality that does the work. */
   void BeforeThreadedGenerateData( void ) override;
 
-  void ThreadedGenerateData(
-    const InputImageRegionType & inputRegionForThread,
-    ThreadIdType threadId ) override;
+  void DynamicThreadedGenerateData( const InputImageRegionType & inputRegionForThread ) override;
 
   RandomGeneratorPointer     m_RandomGenerator;
   InternalFullSamplerPointer m_InternalFullSampler;
@@ -111,6 +111,7 @@ private:
   /** The private copy constructor. */
   void operator=( const Self & );                // purposely not implemented
 
+  std::atomic< ThreadIdType > m_WorkUnitId;
 };
 
 } // end namespace itk

--- a/Common/ImageSamplers/itkImageSamplerBase.h
+++ b/Common/ImageSamplers/itkImageSamplerBase.h
@@ -23,6 +23,8 @@
 #include "itkVectorDataContainer.h"
 #include "itkSpatialObject.h"
 
+#include <mutex>
+
 namespace itk
 {
 /** \class ImageSamplerBase
@@ -205,10 +207,13 @@ protected:
   void AfterThreadedGenerateData( void ) override;
 
   /***/
-  unsigned long                              m_NumberOfSamples;
-  std::vector< ImageSampleContainerPointer > m_ThreaderSampleContainer;
+  unsigned long                                           m_NumberOfSamples;
 
-  //tmp?
+  using ThreaderSampleContainerType = std::vector< ImageSampleContainerPointer >;
+  ThreaderSampleContainerType                             m_ThreaderSampleContainer;
+
+  std::mutex m_Mutex;
+
   bool m_UseMultiThread;
 
 private:
@@ -228,7 +233,6 @@ private:
 
   InputImageRegionType m_CroppedInputImageRegion;
   InputImageRegionType m_DummyInputImageRegion;
-
 };
 
 } // end namespace itk

--- a/Common/ImageSamplers/itkImageSamplerBase.hxx
+++ b/Common/ImageSamplers/itkImageSamplerBase.hxx
@@ -35,9 +35,7 @@ ImageSamplerBase< TInputImage >
   this->m_NumberOfMasks             = 0;
   this->m_NumberOfInputImageRegions = 0;
   this->m_NumberOfSamples           = 0;
-
-  //tmp?
-  this->m_UseMultiThread = false;
+  this->m_UseMultiThread            = false;
 
 } // end Constructor()
 
@@ -417,11 +415,6 @@ ImageSamplerBase< TInputImage >
 {
   /** Initialize variables needed for threads. */
   this->m_ThreaderSampleContainer.clear();
-  this->m_ThreaderSampleContainer.resize( this->GetNumberOfWorkUnits() );
-  for( std::size_t i = 0; i < this->GetNumberOfWorkUnits(); i++ )
-  {
-    this->m_ThreaderSampleContainer[ i ] = ImageSampleContainerType::New();
-  }
 
 } // end BeforeThreadedGenerateData()
 
@@ -437,9 +430,10 @@ ImageSamplerBase< TInputImage >
 {
   /** Get the combined number of samples. */
   this->m_NumberOfSamples = 0;
-  for( std::size_t i = 0; i < this->GetNumberOfWorkUnits(); i++ )
+
+  for( const auto & container : this->m_ThreaderSampleContainer )
   {
-    this->m_NumberOfSamples += this->m_ThreaderSampleContainer[ i ]->Size();
+    this->m_NumberOfSamples += container->Size();
   }
 
   /** Get handle to the output sample container. */
@@ -448,11 +442,11 @@ ImageSamplerBase< TInputImage >
   sampleContainer->reserve( this->m_NumberOfSamples );
 
   /** Combine the results of all threads. */
-  for( std::size_t i = 0; i < this->GetNumberOfWorkUnits(); i++ )
+  for( const auto & container : this->m_ThreaderSampleContainer )
   {
     sampleContainer->insert( sampleContainer->end(),
-      this->m_ThreaderSampleContainer[ i ]->begin(),
-      this->m_ThreaderSampleContainer[ i ]->end() );
+      container->begin(),
+      container->end() );
   }
 
 } // end AfterThreadedGenerateData()

--- a/Common/ImageSamplers/itkImageToVectorContainerFilter.h
+++ b/Common/ImageSamplers/itkImageToVectorContainerFilter.h
@@ -78,8 +78,7 @@ public:
   /** Get the output Mesh of this process object.  */
   OutputVectorContainerType * GetOutput( void );
 
-  /** Prepare the output. */
-  //virtual void GenerateOutputInformation( void );
+protected:
 
   /** A version of GenerateData() specific for image processing
    * filters.  This implementation will split the processing across
@@ -100,29 +99,28 @@ public:
 
   /** If an imaging filter can be implemented as a multithreaded
    * algorithm, the filter will provide an implementation of
-   * ThreadedGenerateData().  This superclass will automatically split
-   * the output image into a number of pieces, spawn multiple threads,
-   * and call ThreadedGenerateData() in each thread. Prior to spawning
-   * threads, the BeforeThreadedGenerateData() method is called. After
-   * all the threads have completed, the AfterThreadedGenerateData()
+   * DynamicThreadedGenerateData().  This superclass will automatically split
+   * the output image into a number of pieces
+   * and call DynamicThreadedGenerateData() in each work unit. Prior to
+   * parallel
+   * execution, the BeforeThreadedGenerateData() method is called. After
+   * all the work units have completed, the AfterThreadedGenerateData()
    * method is called. If an image processing filter cannot support
    * threading, that filter should provide an implementation of the
    * GenerateData() method instead of providing an implementation of
-   * ThreadedGenerateData().  If a filter provides a GenerateData()
+   * DynamicThreadedGenerateData().  If a filter provides a GenerateData()
    * method as its implementation, then the filter is responsible for
    * allocating the output data.  If a filter provides a
    * ThreadedGenerateData() method as its implementation, then the
    * output memory will allocated automatically by this superclass.
    * The ThreadedGenerateData() method should only produce the output
    * specified by "outputThreadRegion"
-   * parameter. ThreadedGenerateData() cannot write to any other
+   * parameter. DynamicThreadedGenerateData() cannot write to any other
    * portion of the output image (as this is responsibility of a
    * different thread).
    *
-   * \sa GenerateData(), SplitRequestedRegion() */
-  virtual void ThreadedGenerateData(
-    const InputImageRegionType & inputRegionForThread,
-    ThreadIdType threadId );
+   * \sa GenerateData() */
+  virtual void DynamicThreadedGenerateData( const InputImageRegionType & inputRegionForWorkUnit );
 
   /** If an imaging filter needs to perform processing after the buffer
    * has been allocated but before threads are spawned, the filter can
@@ -148,26 +146,6 @@ public:
    * a ThreadedGenerateData() method and NOT a GenerateData() method. */
   virtual void AfterThreadedGenerateData( void ) {}
 
-  /** Split the output's RequestedRegion into "numberOfSplits" pieces, returning
-   * region "i" as "splitRegion". This method is called "numberOfSplits" times. The
-   * regions must not overlap. The method returns the number of pieces that
-   * the routine is capable of splitting the output RequestedRegion,
-   * i.e. return value is less than or equal to "numberOfSplits". */
-  virtual unsigned int SplitRequestedRegion( const ThreadIdType & threadId,
-    const ThreadIdType & numberOfSplits, InputImageRegionType & splitRegion );
-
-  /** Static function used as a "callback" by the PlatformMultiThreader.  The threading
-   * library will call this routine for each thread, which will delegate the
-   * control to ThreadedGenerateData(). */
-  static ITK_THREAD_RETURN_TYPE ThreaderCallback( void * arg );
-
-  /** Internal structure used for passing image data into the threading library */
-  struct ThreadStruct //?
-  {
-    Pointer Filter;
-  };
-
-protected:
 
   /** The constructor. */
   ImageToVectorContainerFilter();

--- a/Common/ImageSamplers/itkVectorContainerSource.hxx
+++ b/Common/ImageSamplers/itkVectorContainerSource.hxx
@@ -39,9 +39,6 @@ VectorContainerSource< TOutputVectorContainer >
   this->ProcessObject::SetNumberOfRequiredOutputs( 1 );
   this->ProcessObject::SetNthOutput( 0, output.GetPointer() );
 
-  this->m_GenerateDataRegion          = 0;
-  this->m_GenerateDataNumberOfRegions = 0;
-
 } // end Constructor
 
 
@@ -144,9 +141,6 @@ VectorContainerSource< TOutputVectorContainer >
 ::PrintSelf( std::ostream & os, Indent indent ) const
 {
   Superclass::PrintSelf( os, indent );
-
-//   int m_GenerateDataRegion;
-//   int m_GenerateDataNumberOfRegions;
 } // end PrintSelf()
 
 

--- a/Common/Transforms/itkAdvancedImageMomentsCalculator.h
+++ b/Common/Transforms/itkAdvancedImageMomentsCalculator.h
@@ -249,7 +249,7 @@ protected:
   void LaunchComputeThreaderCallback(void) const;
 
   /** Compute threader callback function. */
-  static ITK_THREAD_RETURN_TYPE ComputeThreaderCallback(void * arg);
+  static ITK_THREAD_RETURN_FUNCTION_CALL_CONVENTION ComputeThreaderCallback(void * arg);
 
   /** The threaded implementation of Compute(). */
   virtual inline void ThreadedCompute(ThreadIdType threadID);

--- a/Common/Transforms/itkAdvancedImageMomentsCalculator.hxx
+++ b/Common/Transforms/itkAdvancedImageMomentsCalculator.hxx
@@ -347,7 +347,7 @@ AdvancedImageMomentsCalculator< TImage >
 */
 
 template< typename TImage >
-ITK_THREAD_RETURN_TYPE
+ITK_THREAD_RETURN_FUNCTION_CALL_CONVENTION
 AdvancedImageMomentsCalculator< TImage >
 ::ComputeThreaderCallback(void * arg)
 {

--- a/Common/itkComputeDisplacementDistribution.h
+++ b/Common/itkComputeDisplacementDistribution.h
@@ -185,7 +185,7 @@ protected:
   void LaunchComputeThreaderCallback( void ) const;
 
   /** Compute threader callback function. */
-  static ITK_THREAD_RETURN_TYPE ComputeThreaderCallback( void * arg );
+  static ITK_THREAD_RETURN_FUNCTION_CALL_CONVENTION ComputeThreaderCallback( void * arg );
 
   /** The threaded implementation of Compute(). */
   virtual inline void ThreadedCompute( ThreadIdType threadID );

--- a/Common/itkComputeDisplacementDistribution.hxx
+++ b/Common/itkComputeDisplacementDistribution.hxx
@@ -333,7 +333,7 @@ ComputeDisplacementDistribution< TFixedImage, TTransform >
  */
 
 template< class TFixedImage, class TTransform >
-ITK_THREAD_RETURN_TYPE
+ITK_THREAD_RETURN_FUNCTION_CALL_CONVENTION
 ComputeDisplacementDistribution< TFixedImage, TTransform >
 ::ComputeThreaderCallback( void * arg )
 {

--- a/Common/itkComputeDisplacementDistribution.hxx
+++ b/Common/itkComputeDisplacementDistribution.hxx
@@ -94,18 +94,18 @@ ComputeDisplacementDistribution< TFixedImage, TTransform >
    * each iteration, in the accumulate functions, in a multi-threaded fashion.
    * This has performance benefits for larger vector sizes.
    */
-  const ThreadIdType numberOfThreads = this->m_Threader->GetNumberOfWorkUnits();
+  const ThreadIdType numberOfWorkUnits = this->m_Threader->GetNumberOfWorkUnits();
 
   /** Only resize the array of structs when needed. */
-  if( this->m_ComputePerThreadVariablesSize != numberOfThreads )
+  if( this->m_ComputePerThreadVariablesSize != numberOfWorkUnits )
   {
     delete[] this->m_ComputePerThreadVariables;
-    this->m_ComputePerThreadVariables     = new AlignedComputePerThreadStruct[ numberOfThreads ];
-    this->m_ComputePerThreadVariablesSize = numberOfThreads;
+    this->m_ComputePerThreadVariables     = new AlignedComputePerThreadStruct[ numberOfWorkUnits ];
+    this->m_ComputePerThreadVariablesSize = numberOfWorkUnits;
   }
 
   /** Some initialization. */
-  for( ThreadIdType i = 0; i < numberOfThreads; ++i )
+  for( ThreadIdType i = 0; i < numberOfWorkUnits; ++i )
   {
     this->m_ComputePerThreadVariables[ i ].st_MaxJJ                 = NumericTraits< double >::Zero;
     this->m_ComputePerThreadVariables[ i ].st_Displacement          = NumericTraits< double >::Zero;

--- a/Components/Metrics/AdvancedKappaStatistic/itkAdvancedKappaStatisticImageToImageMetric.h
+++ b/Components/Metrics/AdvancedKappaStatistic/itkAdvancedKappaStatisticImageToImageMetric.h
@@ -221,7 +221,7 @@ protected:
     MeasureType & value, DerivativeType & derivative ) const override;
 
   /** AccumulateDerivatives threader callback function */
-  static ITK_THREAD_RETURN_TYPE AccumulateDerivativesThreaderCallback( void * arg );
+  static ITK_THREAD_RETURN_FUNCTION_CALL_CONVENTION AccumulateDerivativesThreaderCallback( void * arg );
 
 private:
 

--- a/Components/Metrics/AdvancedKappaStatistic/itkAdvancedKappaStatisticImageToImageMetric.hxx
+++ b/Components/Metrics/AdvancedKappaStatistic/itkAdvancedKappaStatisticImageToImageMetric.hxx
@@ -662,7 +662,7 @@ AdvancedKappaStatisticImageToImageMetric< TFixedImage, TMovingImage >
  */
 
 template< class TFixedImage, class TMovingImage >
-ITK_THREAD_RETURN_TYPE
+ITK_THREAD_RETURN_FUNCTION_CALL_CONVENTION
 AdvancedKappaStatisticImageToImageMetric< TFixedImage, TMovingImage >
 ::AccumulateDerivativesThreaderCallback( void * arg )
 {

--- a/Components/Metrics/AdvancedMattesMutualInformation/itkParzenWindowMutualInformationImageToImageMetric.h
+++ b/Components/Metrics/AdvancedMattesMutualInformation/itkParzenWindowMutualInformationImageToImageMetric.h
@@ -251,7 +251,7 @@ protected:
     DerivativeType & derivative ) const;
 
   /** Helper function to launch the threads. */
-  static ITK_THREAD_RETURN_TYPE ComputeDerivativeLowMemoryThreaderCallback( void * arg );
+  static ITK_THREAD_RETURN_FUNCTION_CALL_CONVENTION ComputeDerivativeLowMemoryThreaderCallback( void * arg );
 
   /** Helper function to launch the threads. */
   void LaunchComputeDerivativeLowMemoryThreaderCallback( void ) const;

--- a/Components/Metrics/AdvancedMattesMutualInformation/itkParzenWindowMutualInformationImageToImageMetric.hxx
+++ b/Components/Metrics/AdvancedMattesMutualInformation/itkParzenWindowMutualInformationImageToImageMetric.hxx
@@ -643,7 +643,7 @@ ParzenWindowMutualInformationImageToImageMetric< TFixedImage, TMovingImage >
  */
 
 template< class TFixedImage, class TMovingImage >
-ITK_THREAD_RETURN_TYPE
+ITK_THREAD_RETURN_FUNCTION_CALL_CONVENTION
 ParzenWindowMutualInformationImageToImageMetric< TFixedImage, TMovingImage >
 ::ComputeDerivativeLowMemoryThreaderCallback( void * arg )
 {

--- a/Components/Metrics/AdvancedNormalizedCorrelation/itkAdvancedNormalizedCorrelationImageToImageMetric.h
+++ b/Components/Metrics/AdvancedNormalizedCorrelation/itkAdvancedNormalizedCorrelationImageToImageMetric.h
@@ -236,7 +236,7 @@ protected:
     MeasureType & value, DerivativeType & derivative ) const override;
 
   /** AccumulateDerivatives threader callback function */
-  static ITK_THREAD_RETURN_TYPE AccumulateDerivativesThreaderCallback( void * arg );
+  static ITK_THREAD_RETURN_FUNCTION_CALL_CONVENTION AccumulateDerivativesThreaderCallback( void * arg );
 
 private:
 

--- a/Components/Metrics/AdvancedNormalizedCorrelation/itkAdvancedNormalizedCorrelationImageToImageMetric.hxx
+++ b/Components/Metrics/AdvancedNormalizedCorrelation/itkAdvancedNormalizedCorrelationImageToImageMetric.hxx
@@ -821,7 +821,7 @@ AdvancedNormalizedCorrelationImageToImageMetric< TFixedImage, TMovingImage >
  */
 
 template< class TFixedImage, class TMovingImage >
-ITK_THREAD_RETURN_TYPE
+ITK_THREAD_RETURN_FUNCTION_CALL_CONVENTION
 AdvancedNormalizedCorrelationImageToImageMetric< TFixedImage, TMovingImage >
 ::AccumulateDerivativesThreaderCallback( void * arg )
 {

--- a/Components/Metrics/PCAMetric/itkPCAMetric_F_multithreaded.h
+++ b/Components/Metrics/PCAMetric/itkPCAMetric_F_multithreaded.h
@@ -203,9 +203,9 @@ protected:
   inline void AfterThreadedComputeDerivative( DerivativeType & derivative ) const;
 
   /** Helper function to launch the threads. */
-  static ITK_THREAD_RETURN_TYPE GetSamplesThreaderCallback( void * arg );
+  static ITK_THREAD_RETURN_FUNCTION_CALL_CONVENTION GetSamplesThreaderCallback( void * arg );
 
-  static ITK_THREAD_RETURN_TYPE ComputeDerivativeThreaderCallback( void * arg );
+  static ITK_THREAD_RETURN_FUNCTION_CALL_CONVENTION ComputeDerivativeThreaderCallback( void * arg );
 
   /** Helper functions to launch the threads. */
   void LaunchGetSamplesThreaderCallback( void ) const;

--- a/Components/Metrics/PCAMetric/itkPCAMetric_F_multithreaded.hxx
+++ b/Components/Metrics/PCAMetric/itkPCAMetric_F_multithreaded.hxx
@@ -933,7 +933,7 @@ PCAMetric< TFixedImage, TMovingImage >
  */
 
 template< class TFixedImage, class TMovingImage >
-ITK_THREAD_RETURN_TYPE
+ITK_THREAD_RETURN_FUNCTION_CALL_CONVENTION
 PCAMetric< TFixedImage, TMovingImage >
 ::GetSamplesThreaderCallback( void * arg )
 {
@@ -1143,7 +1143,7 @@ PCAMetric< TFixedImage, TMovingImage >
  */
 
 template< class TFixedImage, class TMovingImage >
-ITK_THREAD_RETURN_TYPE
+ITK_THREAD_RETURN_FUNCTION_CALL_CONVENTION
 PCAMetric< TFixedImage, TMovingImage >
 ::ComputeDerivativeThreaderCallback( void * arg )
 {

--- a/Components/Optimizers/AdaptiveStochasticLBFGS/elxAdaptiveStochasticLBFGS.h
+++ b/Components/Optimizers/AdaptiveStochasticLBFGS/elxAdaptiveStochasticLBFGS.h
@@ -411,7 +411,7 @@ private:
   };
 
   /** The callback function. */
-  static itk::ITK_THREAD_RETURN_TYPE AdvanceOneStepThreaderCallback( void * arg );
+  static ITK_THREAD_RETURN_FUNCTION_CALL_CONVENTION AdvanceOneStepThreaderCallback( void * arg );
 
   /** The threaded implementation of AdvanceOneStep(). */
   inline void ThreadedAdvanceOneStep( ThreadIdType threadId, ParametersType & newPosition );

--- a/Components/Optimizers/AdaptiveStochasticVarianceReducedGradient/elxAdaptiveStochasticVarianceReducedGradient.h
+++ b/Components/Optimizers/AdaptiveStochasticVarianceReducedGradient/elxAdaptiveStochasticVarianceReducedGradient.h
@@ -444,7 +444,7 @@ private:
   };
 
   /** The callback function. */
-  static itk::ITK_THREAD_RETURN_TYPE AdvanceOneStepThreaderCallback( void * arg );
+  static ITK_THREAD_RETURN_FUNCTION_CALL_CONVENTION AdvanceOneStepThreaderCallback( void * arg );
 
   /** The threaded implementation of AdvanceOneStep(). */
   inline void ThreadedAdvanceOneStep( ThreadIdType threadId, ParametersType & newPosition );

--- a/Components/Optimizers/AdaptiveStochasticVarianceReducedGradient/itkStochasticVarianceReducedGradientDescentOptimizer.cxx
+++ b/Components/Optimizers/AdaptiveStochasticVarianceReducedGradient/itkStochasticVarianceReducedGradientDescentOptimizer.cxx
@@ -331,7 +331,7 @@ StochasticVarianceReducedGradientDescentOptimizer
  * ************ AdvanceOneStepThreaderCallback ****************************
  */
 
-ITK_THREAD_RETURN_TYPE StochasticVarianceReducedGradientDescentOptimizer
+ITK_THREAD_RETURN_FUNCTION_CALL_CONVENTION StochasticVarianceReducedGradientDescentOptimizer
 ::AdvanceOneStepThreaderCallback( void * arg )
 {
   /** Get the current thread id and user data. */

--- a/Components/Optimizers/AdaptiveStochasticVarianceReducedGradient/itkStochasticVarianceReducedGradientDescentOptimizer.h
+++ b/Components/Optimizers/AdaptiveStochasticVarianceReducedGradient/itkStochasticVarianceReducedGradientDescentOptimizer.h
@@ -208,7 +208,7 @@ private:
   bool m_UseEigen;
 
   /** The callback function. */
-  static ITK_THREAD_RETURN_TYPE AdvanceOneStepThreaderCallback( void * arg );
+  static ITK_THREAD_RETURN_FUNCTION_CALL_CONVENTION AdvanceOneStepThreaderCallback( void * arg );
 
   /** The threaded implementation of AdvanceOneStep(). */
   inline void ThreadedAdvanceOneStep( ThreadIdType threadId, ParametersType & newPosition );

--- a/Components/Optimizers/StandardStochasticGradientDescent/itkStochasticGradientDescentOptimizer.cxx
+++ b/Components/Optimizers/StandardStochasticGradientDescent/itkStochasticGradientDescentOptimizer.cxx
@@ -329,7 +329,7 @@ StochasticGradientDescentOptimizer
  * ************ AdvanceOneStepThreaderCallback ****************************
  */
 
-ITK_THREAD_RETURN_TYPE StochasticGradientDescentOptimizer
+ITK_THREAD_RETURN_FUNCTION_CALL_CONVENTION StochasticGradientDescentOptimizer
 ::AdvanceOneStepThreaderCallback( void * arg )
 {
   /** Get the current thread id and user data. */

--- a/Components/Optimizers/StandardStochasticGradientDescent/itkStochasticGradientDescentOptimizer.h
+++ b/Components/Optimizers/StandardStochasticGradientDescent/itkStochasticGradientDescentOptimizer.h
@@ -209,7 +209,7 @@ private:
   bool m_UseEigen;
 
   /** The callback function. */
-  static ITK_THREAD_RETURN_TYPE AdvanceOneStepThreaderCallback( void * arg );
+  static ITK_THREAD_RETURN_FUNCTION_CALL_CONVENTION AdvanceOneStepThreaderCallback( void * arg );
 
   /** The threaded implementation of AdvanceOneStep(). */
   inline void ThreadedAdvanceOneStep( ThreadIdType threadId, ParametersType & newPosition );

--- a/Core/Main/elxParameterObject.h
+++ b/Core/Main/elxParameterObject.h
@@ -64,7 +64,7 @@ public:
   void AddParameterMap( const ParameterMapType & parameterMap );
   const ParameterMapType& GetParameterMap( const unsigned int& index ) const;
   itkGetConstReferenceMacro( ParameterMap, ParameterMapVectorType );
-  unsigned int GetNumberOfParameterMaps() const { return this->m_ParameterMap.size(); }
+  unsigned int GetNumberOfParameterMaps() const { return static_cast< unsigned int >( this->m_ParameterMap.size() ); }
 
   void SetParameter( const unsigned int& index, const ParameterKeyType& key, const ParameterValueType& value );
   void SetParameter( const unsigned int& index, const ParameterKeyType& key, const ParameterValueVectorType& value );

--- a/Testing/itkAccumulateDerivativesParallellizationTest.cxx
+++ b/Testing/itkAccumulateDerivativesParallellizationTest.cxx
@@ -146,7 +146,7 @@ public:
  *********** AccumulateDerivativesThreaderCallback *************
  */
 
-  static itk::ITK_THREAD_RETURN_TYPE AccumulateDerivativesThreaderCallback( void * arg )
+  static ITK_THREAD_RETURN_FUNCTION_CALL_CONVENTION AccumulateDerivativesThreaderCallback( void * arg )
   {
     ThreadInfoType * infoStruct  = static_cast< ThreadInfoType * >( arg );
     ThreadIdType     threadID    = infoStruct->WorkUnitID;

--- a/Testing/itkAdvanceOneStepParallellizationTest.cxx
+++ b/Testing/itkAdvanceOneStepParallellizationTest.cxx
@@ -169,7 +169,7 @@ public:
 
 
   /** The callback function. */
-  static itk::ITK_THREAD_RETURN_TYPE AdvanceOneStepThreaderCallback( void * arg )
+  static ITK_THREAD_RETURN_FUNCTION_CALL_CONVENTION AdvanceOneStepThreaderCallback( void * arg )
   {
     /** Get the current thread id and user data. */
     ThreadInfoType *             infoStruct = static_cast< ThreadInfoType * >( arg );


### PR DESCRIPTION
@N-Dekker @mstaring @stefanklein there was more to do than expected for the Windows Python packages, but we are green now :-).

I updated the sampler parallelism for ITK 5. This uses the *dynamic* threading methods -- when the TBB backend is enabled, the number of work units adjust dynamically at runtime based on the data and algorithm characteristics and CPU load. I did not have time to continue this throughout the rest of the codebase, but it serves as an example.