### PR TITLE
STYLE: Add const to maps passed by ref to ElastixMain member functions

### DIFF
--- a/Core/Configuration/elxConfiguration.cxx
+++ b/Core/Configuration/elxConfiguration.cxx
@@ -189,7 +189,7 @@ Configuration
 int
 Configuration
 ::Initialize( const CommandLineArgumentMapType & _arg,
-  ParameterFileParserType::ParameterMapType & inputMap )
+  const ParameterFileParserType::ParameterMapType & inputMap )
 {
   /** The first part is getting the command line arguments and setting them
    * in the configuration. From the command line arguments we find the name

--- a/Core/Configuration/elxConfiguration.h
+++ b/Core/Configuration/elxConfiguration.h
@@ -93,7 +93,7 @@ public:
   virtual int Initialize( const CommandLineArgumentMapType & _arg );
 
   virtual int Initialize( const CommandLineArgumentMapType & _arg,
-    ParameterFileParserType::ParameterMapType & inputMap );
+    const ParameterFileParserType::ParameterMapType & inputMap );
 
   /** True, if Initialize was successfully called. */
   virtual bool IsInitialized( void ) const; //to elxconfigurationbase

--- a/Core/Kernel/elxElastixMain.cxx
+++ b/Core/Kernel/elxElastixMain.cxx
@@ -187,7 +187,7 @@ ElastixMain::~ElastixMain()
 
 void
 ElastixMain
-::EnterCommandLineArguments( ArgumentMapType & argmap )
+::EnterCommandLineArguments( const ArgumentMapType & argmap )
 {
 
   /** Initialize the configuration object with the
@@ -209,8 +209,8 @@ ElastixMain
 
 void
 ElastixMain
-::EnterCommandLineArguments( ArgumentMapType & argmap,
-  ParameterMapType & inputMap )
+::EnterCommandLineArguments( const ArgumentMapType & argmap,
+  const ParameterMapType & inputMap )
 {
   /** Initialize the configuration object with the
    * command line parameters entered by the user.
@@ -230,8 +230,8 @@ ElastixMain
 
 void
 ElastixMain
-::EnterCommandLineArguments( ArgumentMapType & argmap,
-  std::vector< ParameterMapType > & inputMaps )
+::EnterCommandLineArguments( const ArgumentMapType & argmap,
+  const std::vector< ParameterMapType > & inputMaps )
 {
   this->m_Configurations.clear();
   this->m_Configurations.resize( inputMaps.size() );
@@ -443,7 +443,7 @@ ElastixMain::Run( void )
  */
 
 int
-ElastixMain::Run( ArgumentMapType & argmap )
+ElastixMain::Run( const ArgumentMapType & argmap )
 {
   this->EnterCommandLineArguments( argmap );
   return this->Run();
@@ -456,8 +456,8 @@ ElastixMain::Run( ArgumentMapType & argmap )
 
 int
 ElastixMain
-::Run( ArgumentMapType & argmap,
-  ParameterMapType & inputMap )
+::Run( const ArgumentMapType & argmap,
+  const ParameterMapType & inputMap )
 {
   this->EnterCommandLineArguments( argmap, inputMap );
   return this->Run();

--- a/Core/Kernel/elxElastixMain.h
+++ b/Core/Kernel/elxElastixMain.h
@@ -239,14 +239,14 @@ public:
    * if elastix.exe is used to do a registration.
    * The Configuration object will be initialized in this way.
    */
-  virtual void EnterCommandLineArguments( ArgumentMapType & argmap );
+  virtual void EnterCommandLineArguments( const ArgumentMapType & argmap );
 
-  virtual void EnterCommandLineArguments( ArgumentMapType & argmap,
-    ParameterMapType & inputMap );
+  virtual void EnterCommandLineArguments( const ArgumentMapType & argmap,
+    const ParameterMapType & inputMap );
 
   // Version used when elastix is used as a library.
-  virtual void EnterCommandLineArguments( ArgumentMapType & argmap,
-    std::vector< ParameterMapType > & inputMaps );
+  virtual void EnterCommandLineArguments( const ArgumentMapType & argmap,
+    const std::vector< ParameterMapType > & inputMaps );
 
   /** Start the registration
    * run() without command line parameters; it assumes that
@@ -259,9 +259,9 @@ public:
    * this version of 'run' first calls this->EnterCommandLineParameters(argc,argv)
    * and then calls run().
    */
-  virtual int Run( ArgumentMapType & argmap );
+  virtual int Run( const ArgumentMapType & argmap );
 
-  virtual int Run( ArgumentMapType & argmap, ParameterMapType & inputMap );
+  virtual int Run( const ArgumentMapType & argmap, const ParameterMapType & inputMap );
 
   /** Set process priority, which is read from the command line arguments.
    * Syntax:

--- a/Core/Kernel/elxTransformixMain.cxx
+++ b/Core/Kernel/elxTransformixMain.cxx
@@ -170,7 +170,7 @@ TransformixMain::Run( void )
  */
 
 int
-TransformixMain::Run( ArgumentMapType & argmap )
+TransformixMain::Run( const ArgumentMapType & argmap )
 {
   this->EnterCommandLineArguments( argmap );
   return this->Run();
@@ -183,8 +183,8 @@ TransformixMain::Run( ArgumentMapType & argmap )
 
 int
 TransformixMain::Run(
-  ArgumentMapType & argmap,
-  ParameterMapType & inputMap )
+  const ArgumentMapType & argmap,
+  const ParameterMapType & inputMap )
 {
   this->EnterCommandLineArguments( argmap, inputMap );
   return this->Run();
@@ -197,8 +197,8 @@ TransformixMain::Run(
 
 int
 TransformixMain::Run(
-  ArgumentMapType & argmap,
-  std::vector< ParameterMapType > & inputMaps )
+  const ArgumentMapType & argmap,
+  const std::vector< ParameterMapType > & inputMaps )
 {
   this->EnterCommandLineArguments( argmap, inputMaps );
   return this->Run();

--- a/Core/Kernel/elxTransformixMain.h
+++ b/Core/Kernel/elxTransformixMain.h
@@ -91,12 +91,12 @@ public:
   int Run( void ) override;
 
   /** Overwrite Run( argmap ) from superclass. Simply calls the superclass. */
-  int Run( ArgumentMapType & argmap ) override;
+  int Run( const ArgumentMapType & argmap ) override;
 
-  int Run( ArgumentMapType & argmap, ParameterMapType & inputMap ) override;
+  int Run( const ArgumentMapType & argmap, const ParameterMapType & inputMap ) override;
 
   /** Run version for using transformix as library. */
-  virtual int Run( ArgumentMapType & argmap, std::vector< ParameterMapType > & inputMaps );
+  virtual int Run( const ArgumentMapType & argmap, const std::vector< ParameterMapType > & inputMaps );
 
   /** Get and Set input- and outputImage. */
   virtual void SetInputImageContainer(


### PR DESCRIPTION
Changed signature of `ElastixMain`, `TransformixMain`, and `Configuration` member functions, to pass maps by `const` instead of by non-const reference.

Improved code readability and type safety.