### PR TITLE
PERF: Improve elastix::Configuration Get and Set CommandLineArgument

### DIFF
--- a/Core/Configuration/elxConfiguration.cxx
+++ b/Core/Configuration/elxConfiguration.cxx
@@ -234,17 +234,19 @@ Configuration
  * ****************** GetCommandLineArgument ********************
  */
 
-const std::string
+std::string
 Configuration
 ::GetCommandLineArgument( const std::string & key ) const
 {
+  const auto found = this->m_CommandLineArgumentMap.find(key);
+
   /** Check if the argument was given. If no return "". */
-  if( this->m_CommandLineArgumentMap.count( key ) == 0 )
+  if( found == this->m_CommandLineArgumentMap.end() )
   {
     return "";
   }
 
-  return this->m_CommandLineArgumentMap.find( key )->second.c_str();
+  return found->second;
 
 } // end GetCommandLineArgument()
 
@@ -257,11 +259,7 @@ void
 Configuration
 ::SetCommandLineArgument( const std::string & key, const std::string & value )
 {
-  /** Remove all (!) entries with key 'key' and
-   * insert one entry ( key, value ).
-   */
-  this->m_CommandLineArgumentMap.erase( key );
-  this->m_CommandLineArgumentMap.insert( CommandLineEntryType( key, value ) );
+  this->m_CommandLineArgumentMap[ key ] = value;
 
 } // end SetCommandLineArgument()
 

--- a/Core/Configuration/elxConfiguration.h
+++ b/Core/Configuration/elxConfiguration.h
@@ -75,7 +75,7 @@ public:
   typedef ParameterMapInterfaceType::Pointer ParameterMapInterfacePointer;
 
   /** Get and Set CommandLine arguments into the argument map. */
-  const std::string GetCommandLineArgument( const std::string & key ) const;
+  std::string GetCommandLineArgument( const std::string & key ) const;
 
   void SetCommandLineArgument( const std::string & key, const std::string & value );
 


### PR DESCRIPTION
Improved `GetCommandLineArgument`:

 - Removed `const` from its return type, to allow fast (noexcept) move semantics.
 - Removed a `map::count(key)` call.
 - Removed conversion between `std::string` and `const char*` (`c_str()`).

Simplified `SetCommandLineArgument` by using `map::operator[]`.