### PR TITLE
BUG: ParameterObject argument for itkTypeMacro

### DIFF
--- a/Core/Main/elxElastixFilter.h
+++ b/Core/Main/elxElastixFilter.h
@@ -47,7 +47,7 @@ public:
   itkNewMacro( Self );
 
   /** Run-time type information (and related methods). */
-  itkTypeMacro( Self, itk::ImageSource );
+  itkTypeMacro( ElastixFilter, itk::ImageSource );
 
   /** Typedefs. */
   typedef elastix::ElastixMain                      ElastixMainType;

--- a/Core/Main/elxParameterObject.h
+++ b/Core/Main/elxParameterObject.h
@@ -39,7 +39,7 @@ public:
   typedef itk::SmartPointer< Self >       Pointer;
   typedef itk::SmartPointer< const Self > ConstPointer;
   itkNewMacro( Self );
-  itkTypeMacro( Self, itk::DataObject );
+  itkTypeMacro( ParameterObject, itk::DataObject );
 
   typedef std::string                                            ParameterKeyType;
   typedef std::string                                            ParameterValueType;

--- a/Core/Main/elxTransformixFilter.h
+++ b/Core/Main/elxTransformixFilter.h
@@ -47,7 +47,7 @@ public:
   itkNewMacro( Self );
 
   /** Run-time type information (and related methods). */
-  itkTypeMacro( Self, itk::ImageSource );
+  itkTypeMacro( TransformixFilter, itk::ImageSource );
 
   /** Typedefs. */
   typedef elastix::TransformixMain             TransformixMainType;


### PR DESCRIPTION
The first argument to itkTypeMacro is used to generate the output of the
GetClassName() method -- this should be the specific class name instead
of Self.