### PR TITLE
STYLE : Updated manual to correctly describe checkout of 5.0.0 branch

### DIFF
--- a/dox/manual/manual.tex
+++ b/dox/manual/manual.tex
@@ -1227,7 +1227,7 @@ the GCC compiler under Linux/MacOS.
     \end{verbatim}
   \item Checkout the release you are interested in:
     \begin{verbatim}
-    git checkout v5.0.0
+    git checkout 5.0.0
     \end{verbatim}
   \item Follow the \texttt{develop} branch for the latest development.
     NB: this version might be unstable!


### PR DESCRIPTION
The current manual instructs the user to use `git checkout v5.0.0` to get the latest release. The tags for this repository do not include the `v` prefix. The correct commmand should be `git checkout 5.0.0`.