### PR TITLE
Fix various VS2017 /analyze and Clang Tidy warnings in Core and Common

### DIFF
--- a/Common/ParameterFileParser/itkParameterFileParser.cxx
+++ b/Common/ParameterFileParser/itkParameterFileParser.cxx
@@ -278,11 +278,11 @@ ParameterFileParser
 
   /** 3) Get the parameter values. */
   std::vector< std::string > parameterValues;
-  for( unsigned int i = 0; i < splittedLine.size(); ++i )
+  for( const auto& value: splittedLine )
   {
-    if( ! splittedLine[ i ].empty() )
+    if( ! value.empty() )
     {
-      parameterValues.push_back( splittedLine[ i ] );
+      parameterValues.push_back( value );
     }
   }
 
@@ -299,13 +299,13 @@ ParameterFileParser
 
   /** 5) Perform checks on the parameter values. */
   itksys::RegularExpression reInvalidCharacters2( "[,;!@#$%&|<>?]" );
-  for( unsigned int i = 0; i < parameterValues.size(); ++i )
+  for( const auto& parameterValue: parameterValues )
   {
     /** For all entries some characters are not allowed. */
-    if( reInvalidCharacters2.find( parameterValues[ i ] ) )
+    if( reInvalidCharacters2.find( parameterValue ) )
     {
       const std::string hint = "The parameter value \""
-        + parameterValues[ i ]
+        + parameterValue
         + "\" contains invalid characters (,;!@#$%&|<>?).";
       this->ThrowException( fullLine, hint );
     }
@@ -352,19 +352,18 @@ ParameterFileParser
   }
 
   /** Loop over the line. */
-  std::string::const_iterator it;
   unsigned int                index = 0;
   numQuotes = 0;
-  for( it = line.begin(); it < line.end(); ++it )
+  for( const char currentChar: line )
   {
-    if( *it == '"' )
+    if( currentChar == '"' )
     {
       /** Start a new element. */
       splittedLine.push_back( "" );
       index++;
       numQuotes++;
     }
-    else if( *it == ' ' )
+    else if( currentChar == ' ' )
     {
       /** Only start a new element if it is not a quote, otherwise just add
        * the space to the string.
@@ -376,13 +375,13 @@ ParameterFileParser
       }
       else
       {
-        splittedLine[ index ].push_back( *it );
+        splittedLine[ index ].push_back( currentChar );
       }
     }
     else
     {
       /** Add this character to the element. */
-      splittedLine[ index ].push_back( *it );
+      splittedLine[ index ].push_back( currentChar );
     }
   }
 

--- a/Common/ParameterFileParser/itkParameterFileParser.cxx
+++ b/Common/ParameterFileParser/itkParameterFileParser.cxx
@@ -24,6 +24,8 @@
 #include <itksys/SystemTools.hxx>
 #include <itksys/RegularExpression.hxx>
 
+#include <fstream>
+
 namespace itk
 {
 
@@ -68,15 +70,10 @@ ParameterFileParser
   this->BasicFileChecking();
 
   /** Open the parameter file for reading. */
-  if( this->m_ParameterFile.is_open() )
-  {
-    this->m_ParameterFile.clear();
-    this->m_ParameterFile.close();
-  }
-  this->m_ParameterFile.open( this->m_ParameterFileName, std::fstream::in );
+  std::ifstream parameterFile( this->m_ParameterFileName );
 
   /** Check if it opened. */
-  if( !this->m_ParameterFile.is_open() )
+  if( !parameterFile.is_open() )
   {
     itkExceptionMacro( << "ERROR: could not open "
                        << this->m_ParameterFileName
@@ -89,10 +86,10 @@ ParameterFileParser
   /** Loop over the parameter file, line by line. */
   std::string lineIn;
   std::string lineOut;
-  while( this->m_ParameterFile.good() )
+  while( parameterFile.good() )
   {
     /** Extract a line. */
-    itksys::SystemTools::GetLineFromStream( this->m_ParameterFile, lineIn );
+    itksys::SystemTools::GetLineFromStream( parameterFile, lineIn );
 
     /** Check this line. */
     const bool validLine = this->CheckLine( lineIn, lineOut );
@@ -105,10 +102,6 @@ ParameterFileParser
     // Otherwise, we simply ignore this line
 
   }
-
-  /** Close the parameter file. */
-  this->m_ParameterFile.clear();
-  this->m_ParameterFile.close();
 
 } // end ReadParameterFile()
 
@@ -422,15 +415,10 @@ ParameterFileParser
   this->BasicFileChecking();
 
   /** Open the parameter file for reading. */
-  if( this->m_ParameterFile.is_open() )
-  {
-    this->m_ParameterFile.clear();
-    this->m_ParameterFile.close();
-  }
-  this->m_ParameterFile.open( this->m_ParameterFileName, std::fstream::in );
+  std::ifstream parameterFile( this->m_ParameterFileName );
 
   /** Check if it opened. */
-  if( !this->m_ParameterFile.is_open() )
+  if( !parameterFile.is_open() )
   {
     itkExceptionMacro( << "ERROR: could not open "
                        << this->m_ParameterFileName
@@ -440,17 +428,13 @@ ParameterFileParser
   /** Loop over the parameter file, line by line. */
   std::string line;
   std::string output;
-  while( this->m_ParameterFile.good() )
+  while( parameterFile.good() )
   {
     /** Extract a line. */
-    itksys::SystemTools::GetLineFromStream( this->m_ParameterFile, line ); // \todo: returns bool
+    itksys::SystemTools::GetLineFromStream( parameterFile, line ); // \todo: returns bool
 
     output += line + "\n";
   }
-
-  /** Close the parameter file. */
-  this->m_ParameterFile.clear();
-  this->m_ParameterFile.close();
 
   /** Return the string. */
   return output;

--- a/Common/ParameterFileParser/itkParameterFileParser.cxx
+++ b/Common/ParameterFileParser/itkParameterFileParser.cxx
@@ -32,12 +32,7 @@ namespace itk
  */
 
 ParameterFileParser
-::ParameterFileParser()
-{
-  this->m_ParameterFileName = "";
-  this->m_ParameterMap.clear();
-
-} // end Constructor()
+::ParameterFileParser() = default;
 
 
 /**
@@ -45,14 +40,7 @@ ParameterFileParser
  */
 
 ParameterFileParser
-::~ParameterFileParser()
-{
-  if( this->m_ParameterFile.is_open() )
-  {
-    this->m_ParameterFile.close();
-  }
-
-} // end Destructor()
+::~ParameterFileParser() = default;
 
 
 /**

--- a/Common/ParameterFileParser/itkParameterFileParser.cxx
+++ b/Common/ParameterFileParser/itkParameterFileParser.cxx
@@ -85,7 +85,7 @@ ParameterFileParser
     this->m_ParameterFile.clear();
     this->m_ParameterFile.close();
   }
-  this->m_ParameterFile.open( this->m_ParameterFileName.c_str(), std::fstream::in );
+  this->m_ParameterFile.open( this->m_ParameterFileName, std::fstream::in );
 
   /** Check if it opened. */
   if( !this->m_ParameterFile.is_open() )
@@ -141,7 +141,7 @@ ParameterFileParser
 
   /** Basic error checking: existence. */
   bool exists = itksys::SystemTools::FileExists(
-    this->m_ParameterFileName.c_str() );
+    this->m_ParameterFileName );
   if( !exists )
   {
     itkExceptionMacro( << "ERROR: the file "
@@ -151,7 +151,7 @@ ParameterFileParser
 
   /** Basic error checking: file or directory. */
   bool isDir = itksys::SystemTools::FileIsDirectory(
-    this->m_ParameterFileName.c_str() );
+    this->m_ParameterFileName );
   if( isDir )
   {
     itkExceptionMacro( << "ERROR: the file "
@@ -232,8 +232,8 @@ ParameterFileParser
   }
 
   /** 3. Check if line is between brackets. */
-  if( !itksys::SystemTools::StringStartsWith( lineOut.c_str(), "(" )
-    || !itksys::SystemTools::StringEndsWith( lineOut.c_str(), ")" ) )
+  if( !itksys::SystemTools::StringStartsWith( lineOut, "(" )
+    || !itksys::SystemTools::StringEndsWith( lineOut, ")" ) )
   {
     std::string hint = "Line is not between brackets: \"(...)\".";
     this->ThrowException( lineIn, hint );
@@ -418,7 +418,7 @@ ParameterFileParser
     + "\nPlease correct you parameter file!";
 
   /** Throw exception. */
-  itkExceptionMacro( << errorMessage.c_str() );
+  itkExceptionMacro( << errorMessage );
 
 } // end ThrowException()
 
@@ -440,7 +440,7 @@ ParameterFileParser
     this->m_ParameterFile.clear();
     this->m_ParameterFile.close();
   }
-  this->m_ParameterFile.open( this->m_ParameterFileName.c_str(), std::fstream::in );
+  this->m_ParameterFile.open( this->m_ParameterFileName, std::fstream::in );
 
   /** Check if it opened. */
   if( !this->m_ParameterFile.is_open() )

--- a/Common/ParameterFileParser/itkParameterFileParser.cxx
+++ b/Common/ParameterFileParser/itkParameterFileParser.cxx
@@ -134,7 +134,7 @@ ParameterFileParser
 ::BasicFileChecking( void ) const
 {
   /** Check if the file name is given. */
-  if( this->m_ParameterFileName == "" )
+  if( this->m_ParameterFileName.empty() )
   {
     itkExceptionMacro( << "ERROR: FileName has not been set." );
   }
@@ -292,7 +292,7 @@ ParameterFileParser
   std::vector< std::string > parameterValues;
   for( unsigned int i = 0; i < splittedLine.size(); ++i )
   {
-    if( splittedLine[ i ] != "" )
+    if( ! splittedLine[ i ].empty() )
     {
       parameterValues.push_back( splittedLine[ i ] );
     }

--- a/Common/ParameterFileParser/itkParameterFileParser.cxx
+++ b/Common/ParameterFileParser/itkParameterFileParser.cxx
@@ -87,8 +87,8 @@ ParameterFileParser
   this->m_ParameterMap.clear();
 
   /** Loop over the parameter file, line by line. */
-  std::string lineIn  = "";
-  std::string lineOut = "";
+  std::string lineIn;
+  std::string lineOut;
   while( this->m_ParameterFile.good() )
   {
     /** Extract a line. */
@@ -439,7 +439,7 @@ ParameterFileParser
   }
 
   /** Loop over the parameter file, line by line. */
-  std::string line = "";
+  std::string line;
   std::string output;
   while( this->m_ParameterFile.good() )
   {

--- a/Common/ParameterFileParser/itkParameterFileParser.cxx
+++ b/Common/ParameterFileParser/itkParameterFileParser.cxx
@@ -95,7 +95,7 @@ ParameterFileParser
     itksys::SystemTools::GetLineFromStream( this->m_ParameterFile, lineIn );
 
     /** Check this line. */
-    bool validLine = this->CheckLine( lineIn, lineOut );
+    const bool validLine = this->CheckLine( lineIn, lineOut );
 
     if( validLine )
     {
@@ -128,7 +128,7 @@ ParameterFileParser
   }
 
   /** Basic error checking: existence. */
-  bool exists = itksys::SystemTools::FileExists(
+  const bool exists = itksys::SystemTools::FileExists(
     this->m_ParameterFileName );
   if( !exists )
   {
@@ -138,7 +138,7 @@ ParameterFileParser
   }
 
   /** Basic error checking: file or directory. */
-  bool isDir = itksys::SystemTools::FileIsDirectory(
+  const bool isDir = itksys::SystemTools::FileIsDirectory(
     this->m_ParameterFileName );
   if( isDir )
   {
@@ -148,7 +148,7 @@ ParameterFileParser
   }
 
   /** Check the extension. */
-  std::string ext = itksys::SystemTools::GetFilenameLastExtension(
+  const std::string ext = itksys::SystemTools::GetFilenameLastExtension(
     this->m_ParameterFileName );
   if( ext != ".txt" )
   {
@@ -205,7 +205,7 @@ ParameterFileParser
 
   /** 1. Check for non-empty lines. */
   itksys::RegularExpression reNonEmptyLine( "[^ ]+" );
-  bool                      match1 = reNonEmptyLine.find( lineOut );
+  const bool                match1 = reNonEmptyLine.find( lineOut );
   if( !match1 )
   {
     return false;
@@ -213,7 +213,7 @@ ParameterFileParser
 
   /** 2. Check for comments. */
   itksys::RegularExpression reComment( "^//" );
-  bool                      match2 = reComment.find( lineOut );
+  const bool                match2 = reComment.find( lineOut );
   if( match2 )
   {
     return false;
@@ -223,7 +223,7 @@ ParameterFileParser
   if( !itksys::SystemTools::StringStartsWith( lineOut, "(" )
     || !itksys::SystemTools::StringEndsWith( lineOut, ")" ) )
   {
-    std::string hint = "Line is not between brackets: \"(...)\".";
+    const std::string hint = "Line is not between brackets: \"(...)\".";
     this->ThrowException( lineIn, hint );
   }
 
@@ -232,10 +232,10 @@ ParameterFileParser
 
   /** 4. Check: the line should contain at least two words. */
   itksys::RegularExpression reTwoWords( "([ ]+)([^ ]+)" );
-  bool                      match4 = reTwoWords.find( lineOut );
+  const bool                match4 = reTwoWords.find( lineOut );
   if( !match4 )
   {
-    std::string hint = "Line does not contain a parameter name and value.";
+    const std::string hint = "Line does not contain a parameter name and value.";
     this->ThrowException( lineIn, hint );
   }
 
@@ -288,10 +288,10 @@ ParameterFileParser
 
   /** 4) Perform some checks on the parameter name. */
   itksys::RegularExpression reInvalidCharacters1( "[.,:;!@#$%^&-+|<>?]" );
-  bool                      match = reInvalidCharacters1.find( parameterName );
+  const bool                match = reInvalidCharacters1.find( parameterName );
   if( match )
   {
-    std::string hint = "The parameter \""
+    const std::string hint = "The parameter \""
       + parameterName
       + "\" contains invalid characters (.,:;!@#$%^&-+|<>?).";
     this->ThrowException( fullLine, hint );
@@ -304,7 +304,7 @@ ParameterFileParser
     /** For all entries some characters are not allowed. */
     if( reInvalidCharacters2.find( parameterValues[ i ] ) )
     {
-      std::string hint = "The parameter value \""
+      const std::string hint = "The parameter value \""
         + parameterValues[ i ]
         + "\" contains invalid characters (,;!@#$%&|<>?).";
       this->ThrowException( fullLine, hint );
@@ -314,7 +314,7 @@ ParameterFileParser
   /** 6) Insert this combination in the parameter map. */
   if( this->m_ParameterMap.count( parameterName ) )
   {
-    std::string hint = "The parameter \""
+    const std::string hint = "The parameter \""
       + parameterName
       + "\" is specified more than once.";
     this->ThrowException( fullLine, hint );
@@ -347,7 +347,7 @@ ParameterFileParser
   if( numQuotes % 2 == 1 )
   {
     /** An invalid parameter line. */
-    std::string hint = "This line has an odd number of quotes (\").";
+    const std::string hint = "This line has an odd number of quotes (\").";
     this->ThrowException( fullLine, hint );
   }
 
@@ -398,7 +398,7 @@ ParameterFileParser
 ::ThrowException( const std::string & line, const std::string & hint ) const
 {
   /** Construct an error message. */
-  std::string errorMessage
+  const std::string errorMessage
     = "ERROR: the following line in your parameter file is invalid: \n\""
     + line
     + "\"\n"

--- a/Common/ParameterFileParser/itkParameterFileParser.h
+++ b/Common/ParameterFileParser/itkParameterFileParser.h
@@ -25,7 +25,6 @@
 #include <map>
 #include <string>
 #include <vector>
-#include <fstream>
 
 namespace itk
 {
@@ -153,7 +152,6 @@ private:
 
   /** Member variables. */
   std::string      m_ParameterFileName;
-  std::ifstream    m_ParameterFile;
   ParameterMapType m_ParameterMap;
 
 };

--- a/Common/xout/xoutbase.h
+++ b/Common/xout/xoutbase.h
@@ -67,10 +67,10 @@ public:
   typedef typename XStreamMapType::value_type     XStreamMapEntryType;
 
   /** Constructors */
-  xoutbase();
+  xoutbase() = default;
 
   /** Destructor */
-  virtual ~xoutbase();
+  virtual ~xoutbase() = default;
 
   /** The operator [] simply calls this->SelectXCell(cellname).
    * It returns an x-cell */
@@ -163,7 +163,7 @@ protected:
 
   /** Boolean that says whether the Callback-function must be called.
    * False by default. */
-  bool m_Call;
+  bool m_Call{ false };
 
   /** Called each time << is used, but only when m_Call == true; */
   virtual void Callback( void ){}

--- a/Common/xout/xoutbase.hxx
+++ b/Common/xout/xoutbase.hxx
@@ -25,30 +25,6 @@ namespace xoutlibrary
 using namespace std;
 
 /**
- * ********************* Constructor ****************************
- */
-
-template< class charT, class traits >
-xoutbase< charT, traits >::xoutbase()
-{
-  this->m_Call = false;
-
-} // end Constructor
-
-
-/**
- * ********************* Destructor *****************************
- */
-
-template< class charT, class traits >
-xoutbase< charT, traits >::~xoutbase()
-{
-  //nothing
-
-} // end Destructor
-
-
-/**
  * ********************* operator[] *****************************
  */
 

--- a/Common/xout/xoutcell.hxx
+++ b/Common/xout/xoutcell.hxx
@@ -61,9 +61,9 @@ xoutcell< charT, traits >::WriteBufferedData( void )
   /** Make sure all data is written to the string */
   this->m_InternalBuffer << flush;
 
-  const std::string & strbuf = this->m_InternalBuffer.str();
+  const std::string strbuf = this->m_InternalBuffer.str();
 
-  const char * charbuf = strbuf.c_str();
+  const char * const charbuf = strbuf.c_str();
 
   /** Send the string to the outputs */
   for( CStreamMapIteratorType cit = this->m_COutputs.begin();

--- a/Core/Kernel/elxElastixBase.h
+++ b/Core/Kernel/elxElastixBase.h
@@ -367,7 +367,7 @@ public:
 protected:
 
   ElastixBase();
-  ~ElastixBase() override {}
+  ~ElastixBase() override = default;
 
   ConfigurationPointer     m_Configuration;
   DBIndexType              m_DBIndex;
@@ -467,8 +467,8 @@ public:
     } // GenerateImageContainer()
 
 
-    MultipleImageLoader(){}
-    ~MultipleImageLoader(){}
+    MultipleImageLoader() = default;
+    ~MultipleImageLoader() = default;
 
   };
 
@@ -494,8 +494,8 @@ public:
 
 
     /** Constructor and destructor. */
-    MultipleDataObjectFiller(){}
-    ~MultipleDataObjectFiller(){}
+    MultipleDataObjectFiller() = default;
+    ~MultipleDataObjectFiller() = default;
   };
 
 private:

--- a/Core/Kernel/elxElastixBase.h
+++ b/Core/Kernel/elxElastixBase.h
@@ -70,7 +70,7 @@
 #define elxGetNumberOfMacro( _name ) \
   virtual unsigned int GetNumberOf##_name##s( void ) const \
   { \
-    if( this->Get##_name##Container() != 0 ) \
+    if( this->Get##_name##Container() != nullptr ) \
     { \
       return this->Get##_name##Container()->Size(); \
     } \

--- a/Core/Main/elastix.cxx
+++ b/Core/Main/elastix.cxx
@@ -101,7 +101,6 @@ main( int argc, char ** argv )
   /** Some typedef's. */
   typedef elx::ElastixMain                            ElastixMainType;
   typedef ElastixMainType::Pointer                    ElastixMainPointer;
-  typedef std::vector< ElastixMainPointer >           ElastixMainVectorType;
   typedef ElastixMainType::ObjectPointer              ObjectPointer;
   typedef ElastixMainType::DataObjectContainerPointer DataObjectContainerPointer;
   typedef ElastixMainType::FlatDirectionCosinesType   FlatDirectionCosinesType;
@@ -115,9 +114,6 @@ main( int argc, char ** argv )
 
   /** Support Mevis Dicom Tiff (if selected in cmake) */
   RegisterMevisDicomTiff();
-
-  /** Some declarations and initializations. */
-  ElastixMainVectorType elastices;
 
   // Note that the following pointers are "smart", so they are defaulted-constructed to null.
   ObjectPointer              transform;
@@ -272,19 +268,19 @@ main( int argc, char ** argv )
   for( unsigned int i = 0; i < nrOfParameterFiles; i++ )
   {
     /** Create another instance of ElastixMain. */
-    elastices.push_back( ElastixMainType::New() );
+    const auto elastixMain = ElastixMainType::New();
 
     /** Set stuff we get from a former registration. */
-    elastices[ i ]->SetInitialTransform( transform );
-    elastices[ i ]->SetFixedImageContainer( fixedImageContainer );
-    elastices[ i ]->SetMovingImageContainer( movingImageContainer );
-    elastices[ i ]->SetFixedMaskContainer( fixedMaskContainer );
-    elastices[ i ]->SetMovingMaskContainer( movingMaskContainer );
-    elastices[ i ]->SetOriginalFixedImageDirectionFlat( fixedImageOriginalDirection );
+    elastixMain->SetInitialTransform( transform );
+    elastixMain->SetFixedImageContainer( fixedImageContainer );
+    elastixMain->SetMovingImageContainer( movingImageContainer );
+    elastixMain->SetFixedMaskContainer( fixedMaskContainer );
+    elastixMain->SetMovingMaskContainer( movingMaskContainer );
+    elastixMain->SetOriginalFixedImageDirectionFlat( fixedImageOriginalDirection );
 
     /** Set the current elastix-level. */
-    elastices[ i ]->SetElastixLevel( i );
-    elastices[ i ]->SetTotalNumberOfElastixLevels( nrOfParameterFiles );
+    elastixMain->SetElastixLevel( i );
+    elastixMain->SetTotalNumberOfElastixLevels( nrOfParameterFiles );
 
     /** Delete the previous ParameterFileName. */
     if( argMap.count( "-p" ) )
@@ -310,7 +306,7 @@ main( int argc, char ** argv )
     elxout << "Current time: " << GetCurrentDateAndTime() << "." << std::endl;
 
     /** Start registration. */
-    returndummy = elastices[ i ]->Run( argMap );
+    returndummy = elastixMain->Run( argMap );
 
     /** Check for errors. */
     if( returndummy != 0 )
@@ -322,12 +318,12 @@ main( int argc, char ** argv )
     /** Get the transform, the fixedImage and the movingImage
      * in order to put it in the (possibly) next registration.
      */
-    transform                   = elastices[ i ]->GetModifiableFinalTransform();
-    fixedImageContainer         = elastices[ i ]->GetModifiableFixedImageContainer();
-    movingImageContainer        = elastices[ i ]->GetModifiableMovingImageContainer();
-    fixedMaskContainer          = elastices[ i ]->GetModifiableFixedMaskContainer();
-    movingMaskContainer         = elastices[ i ]->GetModifiableMovingMaskContainer();
-    fixedImageOriginalDirection = elastices[ i ]->GetOriginalFixedImageDirectionFlat();
+    transform                   = elastixMain->GetModifiableFinalTransform();
+    fixedImageContainer         = elastixMain->GetModifiableFixedImageContainer();
+    movingImageContainer        = elastixMain->GetModifiableMovingImageContainer();
+    fixedMaskContainer          = elastixMain->GetModifiableFixedMaskContainer();
+    movingMaskContainer         = elastixMain->GetModifiableMovingMaskContainer();
+    fixedImageOriginalDirection = elastixMain->GetOriginalFixedImageDirectionFlat();
 
     /** Print a finish message. */
     elxout << "Running elastix with parameter file " << i
@@ -338,10 +334,6 @@ main( int argc, char ** argv )
     elxout << "\nCurrent time: " << GetCurrentDateAndTime() << "." << std::endl;
     elxout << "Time used for running elastix with this parameter file:\n  "
            << ConvertSecondsToDHMS( timer.GetMean(), 1 ) << ".\n" << std::endl;
-
-    /** Try to release some memory. */
-    elastices[ i ] = 0;
-
   } // end loop over registrations
 
   elxout << "-------------------------------------------------------------------------" << "\n" << std::endl;
@@ -355,11 +347,6 @@ main( int argc, char ** argv )
    * Make sure all the components that are defined in a Module (.DLL/.so)
    * are deleted before the modules are closed.
    */
-
-  for( unsigned int i = 0; i < nrOfParameterFiles; i++ )
-  {
-    elastices[ i ] = 0;
-  }
 
   transform            = 0;
   fixedImageContainer  = 0;

--- a/Core/Main/elastix.cxx
+++ b/Core/Main/elastix.cxx
@@ -128,14 +128,6 @@ main( int argc, char ** argv )
   /** Support Mevis Dicom Tiff (if selected in cmake) */
   RegisterMevisDicomTiff();
 
-  // Note that the following pointers are "smart", so they are defaulted-constructed to null.
-  ObjectPointer              transform;
-  DataObjectContainerPointer fixedImageContainer;
-  DataObjectContainerPointer movingImageContainer;
-  DataObjectContainerPointer fixedMaskContainer;
-  DataObjectContainerPointer movingMaskContainer;
-
-  FlatDirectionCosinesType   fixedImageOriginalDirection;
   int                        returndummy        = 0;
   unsigned long              nrOfParameterFiles = 0;
   ArgumentMapType            argMap;
@@ -272,6 +264,14 @@ main( int argc, char ** argv )
          << static_cast< unsigned int >( info.GetProcessorClockFrequency() )
          << " MHz." << std::endl;
 
+
+  ObjectPointer              transform            = nullptr;
+  DataObjectContainerPointer fixedImageContainer  = nullptr;
+  DataObjectContainerPointer movingImageContainer = nullptr;
+  DataObjectContainerPointer fixedMaskContainer   = nullptr;
+  DataObjectContainerPointer movingMaskContainer  = nullptr;
+  FlatDirectionCosinesType   fixedImageOriginalDirection;
+
   /**
    * ********************* START REGISTRATION *********************
    *
@@ -363,11 +363,11 @@ main( int argc, char ** argv )
    * are deleted before the modules are closed.
    */
 
-  transform            = 0;
-  fixedImageContainer  = 0;
-  movingImageContainer = 0;
-  fixedMaskContainer   = 0;
-  movingMaskContainer  = 0;
+  transform            = nullptr;
+  fixedImageContainer  = nullptr;
+  movingImageContainer = nullptr;
+  fixedMaskContainer   = nullptr;
+  movingMaskContainer  = nullptr;
 
   /** Close the modules. */
   ElastixMainType::UnloadComponents();

--- a/Core/Main/elastix.cxx
+++ b/Core/Main/elastix.cxx
@@ -124,7 +124,6 @@ main( int argc, char ** argv )
   /** Support Mevis Dicom Tiff (if selected in cmake) */
   RegisterMevisDicomTiff();
 
-  unsigned long              nrOfParameterFiles = 0;
   ArgumentMapType            argMap;
   std::queue< std::string >  parameterFileList;
   std::string                outFolder;
@@ -138,12 +137,11 @@ main( int argc, char ** argv )
     if( key == "-p" )
     {
       /** Queue the ParameterFileNames. */
-      nrOfParameterFiles++;
       parameterFileList.push( value );
       /** The different '-p' are stored in the argMap, with
        * keys p(1), p(2), etc. */
       std::ostringstream tempPname;
-      tempPname << "-p(" << nrOfParameterFiles << ")";
+      tempPname << "-p(" << parameterFileList.size() << ")";
       std::string tempPName = tempPname.str();
       argMap.insert( ArgumentMapEntryType( tempPName, value ) );
     }
@@ -194,7 +192,7 @@ main( int argc, char ** argv )
   int returndummy{};
 
   /** Check if at least once the option "-p" is given. */
-  if( nrOfParameterFiles == 0 )
+  if( parameterFileList.empty() )
   {
     std::cerr << "ERROR: No CommandLine option \"-p\" given!" << std::endl;
     returndummy |= -1;
@@ -270,6 +268,7 @@ main( int argc, char ** argv )
    * Do the (possibly multiple) registration(s).
    */
 
+  const auto nrOfParameterFiles = parameterFileList.size();
   assert(nrOfParameterFiles <= UINT_MAX);
 
   for( unsigned i{}; i < static_cast<unsigned>(nrOfParameterFiles); ++i )

--- a/Core/Main/elastix.cxx
+++ b/Core/Main/elastix.cxx
@@ -113,7 +113,6 @@ main( int argc, char ** argv )
 
   /** Some typedef's. */
   typedef elx::ElastixMain                            ElastixMainType;
-  typedef ElastixMainType::Pointer                    ElastixMainPointer;
   typedef ElastixMainType::ObjectPointer              ObjectPointer;
   typedef ElastixMainType::DataObjectContainerPointer DataObjectContainerPointer;
   typedef ElastixMainType::FlatDirectionCosinesType   FlatDirectionCosinesType;

--- a/Core/Main/elastix.cxx
+++ b/Core/Main/elastix.cxx
@@ -147,7 +147,7 @@ main( int argc, char ** argv )
       std::ostringstream tempPname( "" );
       tempPname << "-p(" << nrOfParameterFiles << ")";
       std::string tempPName = tempPname.str();
-      argMap.insert( ArgumentMapEntryType( tempPName.c_str(), value.c_str() ) );
+      argMap.insert( ArgumentMapEntryType( tempPName, value ) );
     }
     else
     {
@@ -156,14 +156,14 @@ main( int argc, char ** argv )
         /** Make sure that last character of the output folder equals a '/' or '\'. */
         const char last = value[ value.size() - 1 ];
         if( last != '/' && last != '\\' ) { value.append( "/" ); }
-        value = itksys::SystemTools::ConvertToOutputPath( value.c_str() );
+        value = itksys::SystemTools::ConvertToOutputPath( value );
 
         /** Note that on Windows, in case the output folder contains a space,
          * the path name is double quoted by ConvertToOutputPath, which is undesirable.
          * So, we remove these quotes again.
          */
-        if( itksys::SystemTools::StringStartsWith( value.c_str(), "\"" )
-          && itksys::SystemTools::StringEndsWith(   value.c_str(), "\"" ) )
+        if( itksys::SystemTools::StringStartsWith( value, "\"" )
+          && itksys::SystemTools::StringEndsWith(   value, "\"" ) )
         {
           value = value.substr( 1, value.length() - 2 );
         }
@@ -175,16 +175,16 @@ main( int argc, char ** argv )
       } // end if key == "-out"
 
       /** Attempt to save the arguments in the ArgumentMap. */
-      if( argMap.count( key.c_str() ) == 0 )
+      if( argMap.count( key ) == 0 )
       {
-        argMap.insert( ArgumentMapEntryType( key.c_str(), value.c_str() ) );
+        argMap.insert( ArgumentMapEntryType( key, value ) );
       }
       else
       {
         /** Duplicate arguments. */
         std::cerr << "WARNING!" << std::endl;
-        std::cerr << "Argument " << key.c_str() << "is only required once." << std::endl;
-        std::cerr << "Arguments " << key.c_str() << " " << value.c_str() << "are ignored" << std::endl;
+        std::cerr << "Argument " << key << "is only required once." << std::endl;
+        std::cerr << "Arguments " << key << " " << value << "are ignored" << std::endl;
       }
 
     } // end else (so, if key does not equal "-p")
@@ -207,7 +207,7 @@ main( int argc, char ** argv )
   if( outFolderPresent )
   {
     /** Check if the output directory exists. */
-    bool outFolderExists = itksys::SystemTools::FileIsDirectory( outFolder.c_str() );
+    bool outFolderExists = itksys::SystemTools::FileIsDirectory( outFolder );
     if( !outFolderExists )
     {
       std::cerr << "ERROR: the output directory \"" << outFolder << "\" does not exist." << std::endl;

--- a/Core/Main/elastix.cxx
+++ b/Core/Main/elastix.cxx
@@ -128,7 +128,6 @@ main( int argc, char ** argv )
   /** Support Mevis Dicom Tiff (if selected in cmake) */
   RegisterMevisDicomTiff();
 
-  int                        returndummy        = 0;
   unsigned long              nrOfParameterFiles = 0;
   ArgumentMapType            argMap;
   ParameterFileListType      parameterFileList;
@@ -199,6 +198,8 @@ main( int argc, char ** argv )
 
   /** The argv0 argument, required for finding the component.dll/so's. */
   argMap.insert( ArgumentMapEntryType( "-argv0", argv[ 0 ] ) );
+
+  int returndummy{};
 
   /** Check if at least once the option "-p" is given. */
   if( nrOfParameterFiles == 0 )
@@ -373,7 +374,7 @@ main( int argc, char ** argv )
   ElastixMainType::UnloadComponents();
 
   /** Exit and return the error code. */
-  return returndummy;
+  return 0;
 
 } // end main
 

--- a/Core/Main/elastix.cxx
+++ b/Core/Main/elastix.cxx
@@ -127,7 +127,6 @@ main( int argc, char ** argv )
   unsigned long              nrOfParameterFiles = 0;
   ArgumentMapType            argMap;
   std::queue< std::string >  parameterFileList;
-  bool                       outFolderPresent = false;
   std::string                outFolder;
   std::string                logFileName;
 
@@ -169,8 +168,7 @@ main( int argc, char ** argv )
         }
 
         /** Save this information. */
-        outFolderPresent = true;
-        outFolder        = value;
+        outFolder = value;
 
       } // end if key == "-out"
 
@@ -204,11 +202,10 @@ main( int argc, char ** argv )
   }
 
   /** Check if the -out option is given. */
-  if( outFolderPresent )
+  if( ! outFolder.empty() )
   {
     /** Check if the output directory exists. */
-    bool outFolderExists = itksys::SystemTools::FileIsDirectory( outFolder );
-    if( !outFolderExists )
+    if( ! itksys::SystemTools::FileIsDirectory( outFolder ) )
     {
       std::cerr << "ERROR: the output directory \"" << outFolder << "\" does not exist." << std::endl;
       std::cerr << "You are responsible for creating it." << std::endl;

--- a/Core/Main/elastix.cxx
+++ b/Core/Main/elastix.cxx
@@ -128,8 +128,8 @@ main( int argc, char ** argv )
   ArgumentMapType            argMap;
   std::queue< std::string >  parameterFileList;
   bool                       outFolderPresent = false;
-  std::string                outFolder        = "";
-  std::string                logFileName      = "";
+  std::string                outFolder;
+  std::string                logFileName;
 
   /** Put command line parameters into parameterFileList. */
   for( unsigned int i = 1; static_cast< long >( i ) < ( argc - 1 ); i += 2 )
@@ -144,7 +144,7 @@ main( int argc, char ** argv )
       parameterFileList.push( value );
       /** The different '-p' are stored in the argMap, with
        * keys p(1), p(2), etc. */
-      std::ostringstream tempPname( "" );
+      std::ostringstream tempPname;
       tempPname << "-p(" << nrOfParameterFiles << ")";
       std::string tempPName = tempPname.str();
       argMap.insert( ArgumentMapEntryType( tempPName, value ) );

--- a/Core/Main/elastix.cxx
+++ b/Core/Main/elastix.cxx
@@ -215,7 +215,7 @@ main( int argc, char ** argv )
       /** Setup xout. */
       const std::string logFileName = outFolder + "elastix.log";
       const int returndummy2{ elx::xoutSetup(logFileName.c_str(), true, true) };
-      if( returndummy2 )
+      if( returndummy2 != 0 )
       {
         std::cerr << "ERROR while setting up xout." << std::endl;
       }
@@ -229,7 +229,7 @@ main( int argc, char ** argv )
   }
 
   /** Stop if some fatal errors occurred. */
-  if( returndummy )
+  if( returndummy != 0 )
   {
     return returndummy;
   }

--- a/Core/Main/elastix.cxx
+++ b/Core/Main/elastix.cxx
@@ -128,7 +128,6 @@ main( int argc, char ** argv )
   ArgumentMapType            argMap;
   std::queue< std::string >  parameterFileList;
   std::string                outFolder;
-  std::string                logFileName;
 
   /** Put command line parameters into parameterFileList. */
   for( unsigned int i = 1; static_cast< long >( i ) < ( argc - 1 ); i += 2 )
@@ -214,7 +213,7 @@ main( int argc, char ** argv )
     else
     {
       /** Setup xout. */
-      logFileName = outFolder + "elastix.log";
+      const std::string logFileName = outFolder + "elastix.log";
       const int returndummy2{ elx::xoutSetup(logFileName.c_str(), true, true) };
       if( returndummy2 )
       {

--- a/Core/Main/elastix.cxx
+++ b/Core/Main/elastix.cxx
@@ -16,11 +16,22 @@
  *
  *=========================================================================*/
 
+// Elastix header files:
 #include "elastix.h"
 #include "elxElastixMain.h"
+#include "itkUseMevisDicomTiff.h"
 
+// ITK header files:
+#include <itkTimeProbe.h>
+#include <itksys/SystemInformation.hxx>
+#include <itksys/SystemTools.hxx>
+
+// Standard C++ header files:
 #include <cstddef> // For size_t.
+#include <iostream>
 #include <limits>
+#include <queue>
+#include <vector>
 
 int
 main( int argc, char ** argv )

--- a/Core/Main/elastix.cxx
+++ b/Core/Main/elastix.cxx
@@ -221,7 +221,7 @@ main( int argc, char ** argv )
     {
       /** Setup xout. */
       logFileName = outFolder + "elastix.log";
-      int returndummy2 = elx::xoutSetup( logFileName.c_str(), true, true );
+      const int returndummy2{ elx::xoutSetup(logFileName.c_str(), true, true) };
       if( returndummy2 )
       {
         std::cerr << "ERROR while setting up xout." << std::endl;

--- a/Core/Main/elastix.cxx
+++ b/Core/Main/elastix.cxx
@@ -27,6 +27,8 @@
 #include <itksys/SystemTools.hxx>
 
 // Standard C++ header files:
+#include <cassert>
+#include <climits> // For UINT_MAX.
 #include <cstddef> // For size_t.
 #include <iostream>
 #include <limits>
@@ -276,7 +278,9 @@ main( int argc, char ** argv )
    * Do the (possibly multiple) registration(s).
    */
 
-  for( unsigned int i = 0; i < nrOfParameterFiles; i++ )
+  assert(nrOfParameterFiles <= UINT_MAX);
+
+  for( unsigned i{}; i < static_cast<unsigned>(nrOfParameterFiles); ++i )
   {
     /** Create another instance of ElastixMain. */
     const auto elastixMain = ElastixMainType::New();

--- a/Core/Main/elastix.h
+++ b/Core/Main/elastix.h
@@ -18,20 +18,12 @@
 #ifndef __elastix_h
 #define __elastix_h
 
-#include "itkUseMevisDicomTiff.h"
-
 #include <cassert>
 #include <ctime>
-#include <iostream>
+#include <cmath>        // For fmod.
 #include <iomanip>      // std::setprecision
+#include <sstream>
 #include <string>
-#include <vector>
-#include <queue>
-#include "itkObject.h"
-#include "itkDataObject.h"
-#include <itksys/SystemTools.hxx>
-#include <itksys/SystemInformation.hxx>
-#include "itkTimeProbe.h"
 
 /** Declare PrintHelp function.
  *
@@ -68,7 +60,7 @@ ConvertSecondsToDHMS( const double totalSeconds, const unsigned int precision = 
 
   //iSeconds %= secondsPerMinute;
   //const std::size_t seconds = iSeconds;
-  const double dSeconds = fmod( totalSeconds, 60.0 );
+  const double dSeconds = std::fmod( totalSeconds, 60.0 );
 
   /** Create a string in days, hours, minutes and seconds. */
   bool               nonzero = false;

--- a/Core/Main/elastixlib.cxx
+++ b/Core/Main/elastixlib.cxx
@@ -21,6 +21,7 @@
 #define __elastixlib_cxx
 
 #include "elastixlib.h"
+#include "elastix.h" // For ConvertSecondsToDHMS and GetCurrentDateAndTime.
 
 #ifdef _ELASTIX_USE_MEVISDICOMTIFF
 #include "itkUseMevisDicomTiff.h"
@@ -401,64 +402,6 @@ ELASTIX::RegisterImages(
   return 0;
 
 } // end RegisterImages()
-
-
-/** ConvertSecondsToDHMS
- *
- */
-std::string
-ELASTIX::ConvertSecondsToDHMS( const double totalSeconds, const unsigned int precision )
-{
-  /** Define days, hours, minutes. */
-  const std::size_t secondsPerMinute = 60;
-  const std::size_t secondsPerHour   = 60 * secondsPerMinute;
-  const std::size_t secondsPerDay    = 24 * secondsPerHour;
-
-  /** Convert total seconds. */
-  std::size_t       iSeconds = static_cast< std::size_t >( totalSeconds );
-  const std::size_t days     = iSeconds / secondsPerDay;
-
-  iSeconds %= secondsPerDay;
-  const std::size_t hours = iSeconds / secondsPerHour;
-
-  iSeconds %= secondsPerHour;
-  const std::size_t minutes = iSeconds / secondsPerMinute;
-
-  //iSeconds %= secondsPerMinute;
-  //const std::size_t seconds = iSeconds;
-  const double dSeconds = fmod( totalSeconds, 60.0 );
-
-  /** Create a string in days, hours, minutes and seconds. */
-  bool               nonzero = false;
-  std::ostringstream make_string( "" );
-  if( days    != 0            ) { make_string << days    << "d"; nonzero = true; }
-  if( hours   != 0 || nonzero ) { make_string << hours   << "h"; nonzero = true; }
-  if( minutes != 0 || nonzero ) { make_string << minutes << "m"; nonzero = true; }
-  make_string << std::showpoint << std::fixed << std::setprecision( precision );
-  make_string << dSeconds << "s";
-
-  /** Return a value. */
-  return make_string.str();
-
-} // end ConvertSecondsToDHMS()
-
-
-/** Returns current date and time as a string. */
-std::string
-ELASTIX::GetCurrentDateAndTime( void )
-{
-  // Obtain current time
-  time_t rawtime = time( nullptr );
-  // Convert to local time
-  struct tm * timeinfo = localtime( &rawtime );
-  // Convert to human-readable format
-  std::string timeAsString = std::string( asctime( timeinfo ) );
-  // Erase newline character at end
-  timeAsString.erase( timeAsString.end() - 1 );
-  //timeAsString.pop_back() // c++11 feature
-
-  return timeAsString;
-} // end GetCurrentDateAndTime()
 
 
 } // end namespace elastix

--- a/Core/Main/elastixlib.cxx
+++ b/Core/Main/elastixlib.cxx
@@ -46,21 +46,13 @@ namespace elastix
  * ******************* Constructor ***********************
  */
 
-ELASTIX::ELASTIX() : m_ResultImage(nullptr)
-{
-} // end Constructor
-
+ELASTIX::ELASTIX() = default;
 
 /**
  * ******************* Destructor ***********************
  */
 
-ELASTIX::~ELASTIX()
-{
-  this->m_ResultImage = nullptr;
-  this->m_TransformParametersList.clear();
-} // end Destructor
-
+ELASTIX::~ELASTIX() = default;
 
 /**
  * ******************* GetResultImage ***********************

--- a/Core/Main/elastixlib.cxx
+++ b/Core/Main/elastixlib.cxx
@@ -148,13 +148,6 @@ ELASTIX::RegisterImages(
 
   /** Some declarations and initialisations. */
 
-  //ObjectPointer              transform = 0;
-  DataObjectContainerPointer fixedImageContainer  = nullptr;
-  DataObjectContainerPointer movingImageContainer = nullptr;
-  DataObjectContainerPointer fixedMaskContainer   = nullptr;
-  DataObjectContainerPointer movingMaskContainer  = nullptr;
-  DataObjectContainerPointer resultImageContainer = nullptr;
-  FlatDirectionCosinesType   fixedImageOriginalDirection;
   int                        returndummy = 0;
   ArgumentMapType            argMap;
   std::string                outFolder   = "";
@@ -249,10 +242,15 @@ ELASTIX::RegisterImages(
    ************************************************************************/
 
   /* Allocate and store images in containers */
-  fixedImageContainer                        = DataObjectContainerType::New();
-  movingImageContainer                       = DataObjectContainerType::New();
+  auto fixedImageContainer                   = DataObjectContainerType::New();
+  auto movingImageContainer                  = DataObjectContainerType::New();
   fixedImageContainer->CreateElementAt( 0 )  = fixedImage;
   movingImageContainer->CreateElementAt( 0 ) = movingImage;
+
+  DataObjectContainerPointer fixedMaskContainer   = nullptr;
+  DataObjectContainerPointer movingMaskContainer  = nullptr;
+  DataObjectContainerPointer resultImageContainer = nullptr;
+  FlatDirectionCosinesType   fixedImageOriginalDirection;
 
   /* Allocate and store masks in containers if available*/
   if( fixedMask )
@@ -269,12 +267,11 @@ ELASTIX::RegisterImages(
   //todo original direction cosin, problem is that Image type is unknown at this in elastixlib.cxx
   //for now in elaxElastixTemplate (Run()) direction cosines are taken from fixed image
 
-  /************************************************************************
-   *                                                  *
-   *    START REGISTRATION                            *
-   *  Do the (possibly multiple) registration(s).     *
-   *                                                  *
-   ************************************************************************/
+  /**
+   * ********************* START REGISTRATION *********************
+   *
+   * Do the (possibly multiple) registration(s).
+   */
   
   const auto nrOfParameterFiles = parameterMaps.size();
   assert(nrOfParameterFiles <= UINT_MAX);

--- a/Core/Main/elastixlib.cxx
+++ b/Core/Main/elastixlib.cxx
@@ -148,7 +148,6 @@ ELASTIX::RegisterImages(
 
   /** Some declarations and initialisations. */
 
-  std::string                logFileName;
   std::string                value;
 
   /** Setup the argumentMap for output path. */
@@ -180,29 +179,19 @@ ELASTIX::RegisterImages(
     ArgumentMapEntryType("-out", outFolder)
   };
 
-  if( performLogging )
+  /** Check if the output directory exists. */
+  if( performLogging && ! itksys::SystemTools::FileIsDirectory( outFolder ) )
   {
-    /** Check if the output directory exists. */
-    if( ! itksys::SystemTools::FileIsDirectory( outFolder ) )
+    if( performCout )
     {
-      if( performCout )
-      {
-        std::cerr << "ERROR: the output directory does not exist." << std::endl;
-        std::cerr << "You are responsible for creating it." << std::endl;
-      }
-      return -2;
+      std::cerr << "ERROR: the output directory does not exist." << std::endl;
+      std::cerr << "You are responsible for creating it." << std::endl;
     }
-    else
-    {
-      /** Setup xout. */
-      if( performLogging )
-      {
-        logFileName = outFolder + "elastix.log";
-      }
-    }
+    return -2;
   }
 
   /** Setup xout. */
+  const std::string logFileName = performLogging ? (outFolder + "elastix.log") : "";
   int returndummy = elx::xoutSetup( logFileName.c_str(), performLogging, performCout );
   if( returndummy && performCout )
   {

--- a/Core/Main/elastixlib.cxx
+++ b/Core/Main/elastixlib.cxx
@@ -183,8 +183,7 @@ ELASTIX::RegisterImages(
   if( performLogging )
   {
     /** Check if the output directory exists. */
-    bool outFolderExists = itksys::SystemTools::FileIsDirectory( outFolder );
-    if( !outFolderExists )
+    if( ! itksys::SystemTools::FileIsDirectory( outFolder ) )
     {
       if( performCout )
       {

--- a/Core/Main/elastixlib.cxx
+++ b/Core/Main/elastixlib.cxx
@@ -148,7 +148,7 @@ ELASTIX::RegisterImages(
 
   /** Some declarations and initialisations. */
 
-  std::string                logFileName = "";
+  std::string                logFileName;
   std::string                value;
 
   /** Setup the argumentMap for output path. */

--- a/Core/Main/elastixlib.cxx
+++ b/Core/Main/elastixlib.cxx
@@ -16,29 +16,27 @@
  *
  *=========================================================================*/
 
-// \todo: cxx's don't need ifdefs?
-#ifndef __elastixlib_cxx
-#define __elastixlib_cxx
-
+ // Elastix header files:
 #include "elastixlib.h"
+#include "elxElastixMain.h"
 #include "elastix.h" // For ConvertSecondsToDHMS and GetCurrentDateAndTime.
 
 #ifdef _ELASTIX_USE_MEVISDICOMTIFF
 #include "itkUseMevisDicomTiff.h"
 #endif
 
-#include "elxElastixMain.h"
+// ITK header files:
+#include <itkDataObject.h>
+#include <itkObject.h>
+#include <itkTimeProbe.h>
+#include <itksys/SystemInformation.hxx>
+#include <itksys/SystemTools.hxx>
+
+// Standard C++ header files:
 #include <iostream>
 #include <string>
-#include <vector>
 #include <queue>
-#include "itkObject.h"
-#include "itkDataObject.h"
-#include <itksys/SystemTools.hxx>
-#include <itksys/SystemInformation.hxx>
-
-#include "itkTimeProbe.h"
-#include <time.h>
+#include <vector>
 
 namespace elastix
 {
@@ -405,5 +403,3 @@ ELASTIX::RegisterImages(
 
 
 } // end namespace elastix
-
-#endif // end #ifndef __elastixlib_cxx

--- a/Core/Main/elastixlib.cxx
+++ b/Core/Main/elastixlib.cxx
@@ -33,6 +33,8 @@
 #include <itksys/SystemTools.hxx>
 
 // Standard C++ header files:
+#include <cassert>
+#include <climits> // For UINT_MAX.
 #include <iostream>
 #include <string>
 #include <queue>
@@ -169,10 +171,8 @@ ELASTIX::RegisterImages(
   ParameterFileListType      parameterFileList;
   std::string                outFolder   = "";
   std::string                logFileName = "";
-  unsigned short             i;
   std::string                key;
   std::string                value;
-  unsigned long              nrOfParameterFiles = parameterMaps.size();
 
   /** Setup the argumentMap for output path. */
   if( !outputPath.empty() )
@@ -287,8 +287,11 @@ ELASTIX::RegisterImages(
    *  Do the (possibly multiple) registration(s).     *
    *                                                  *
    ************************************************************************/
+  
+  const auto nrOfParameterFiles = parameterMaps.size();
+  assert(nrOfParameterFiles <= UINT_MAX);
 
-  for( i = 0; i < nrOfParameterFiles; i++ )
+  for( unsigned i{}; i < static_cast<unsigned>(nrOfParameterFiles); ++i )
   {
     /** Create another instance of ElastixMain. */
     const auto elastixMain = ElastixMainType::New();

--- a/Core/Main/elastixlib.cxx
+++ b/Core/Main/elastixlib.cxx
@@ -148,7 +148,6 @@ ELASTIX::RegisterImages(
 
   /** Some declarations and initialisations. */
 
-  int                        returndummy = 0;
   ArgumentMapType            argMap;
   std::string                outFolder   = "";
   std::string                logFileName = "";
@@ -219,7 +218,7 @@ ELASTIX::RegisterImages(
   argMap.insert( ArgumentMapEntryType( "-argv0", "elastix" ) );
 
   /** Setup xout. */
-  returndummy = elx::xoutSetup( logFileName.c_str(), performLogging, performCout );
+  int returndummy = elx::xoutSetup( logFileName.c_str(), performLogging, performCout );
   if( returndummy && performCout )
   {
     if( performCout )

--- a/Core/Main/elastixlib.cxx
+++ b/Core/Main/elastixlib.cxx
@@ -148,17 +148,13 @@ ELASTIX::RegisterImages(
 
   /** Some declarations and initialisations. */
 
-  ArgumentMapType            argMap;
-  std::string                outFolder   = "";
   std::string                logFileName = "";
-  std::string                key;
   std::string                value;
 
   /** Setup the argumentMap for output path. */
   if( !outputPath.empty() )
   {
     /** Put command line parameters into parameterFileList. */
-    key   = "-out";
     value = outputPath;
 
     /** Make sure that last character of the output folder equals a '/'. */
@@ -171,25 +167,18 @@ ELASTIX::RegisterImages(
   {
     /** Put command line parameters into parameterFileList. */
     //there must be an "-out", this is checked later in code!!
-    key   = "-out";
     value = "output_path_not_set";
   }
 
   /** Save this information. */
-  outFolder = value;
+  const auto outFolder = value;
 
-  /** Attempt to save the arguments in the ArgumentMap. */
-  if( argMap.count( key.c_str() ) == 0 )
+  const ArgumentMapType argMap
   {
-    argMap.insert( ArgumentMapEntryType( key.c_str(), value.c_str() ) );
-  }
-  else if( performCout )
-  {
-    /** Duplicate arguments. */
-    std::cerr << "WARNING!" << std::endl;
-    std::cerr << "Argument " << key.c_str() << "is only required once." << std::endl;
-    std::cerr << "Arguments " << key.c_str() << " " << value.c_str() << "are ignored" << std::endl;
-  }
+    /** The argv0 argument, required for finding the component.dll/so's. */
+    ArgumentMapEntryType("-argv0", "elastix"),
+    ArgumentMapEntryType("-out", outFolder)
+  };
 
   if( performLogging )
   {
@@ -213,9 +202,6 @@ ELASTIX::RegisterImages(
       }
     }
   }
-
-  /** The argv0 argument, required for finding the component.dll/so's. */
-  argMap.insert( ArgumentMapEntryType( "-argv0", "elastix" ) );
 
   /** Setup xout. */
   int returndummy = elx::xoutSetup( logFileName.c_str(), performLogging, performCout );
@@ -292,12 +278,6 @@ ELASTIX::RegisterImages(
     /** Set the current elastix-level. */
     elastixMain->SetElastixLevel( i );
     elastixMain->SetTotalNumberOfElastixLevels( nrOfParameterFiles );
-
-    /** Delete the previous ParameterFileName. */
-    if( argMap.count( "-p" ) )
-    {
-      argMap.erase( "-p" );
-    }
 
     /** Print a start message. */
     elxout << "-------------------------------------------------------------------------" << "\n" << std::endl;

--- a/Core/Main/elastixlib.cxx
+++ b/Core/Main/elastixlib.cxx
@@ -104,8 +104,8 @@ int
 ELASTIX::RegisterImages(
   ImagePointer fixedImage,
   ImagePointer movingImage,
-  ParameterMapType & parameterMap,
-  std::string outputPath,
+  const ParameterMapType & parameterMap,
+  const std::string & outputPath,
   bool performLogging,
   bool performCout,
   ImagePointer fixedMask,
@@ -131,8 +131,8 @@ int
 ELASTIX::RegisterImages(
   ImagePointer fixedImage,
   ImagePointer movingImage,
-  std::vector< ParameterMapType > & parameterMaps,
-  std::string outputPath,
+  const std::vector< ParameterMapType > & parameterMaps,
+  const std::string & outputPath,
   bool performLogging,
   bool performCout,
   ImagePointer fixedMask,

--- a/Core/Main/elastixlib.cxx
+++ b/Core/Main/elastixlib.cxx
@@ -37,7 +37,6 @@
 #include <climits> // For UINT_MAX.
 #include <iostream>
 #include <string>
-#include <queue>
 #include <vector>
 
 namespace elastix
@@ -151,8 +150,6 @@ ELASTIX::RegisterImages(
   typedef ArgumentMapType::value_type      ArgumentMapEntryType;
 
   typedef std::pair< std::string, std::string > ArgPairType;
-  typedef std::queue< ArgPairType >             ParameterFileListType;
-  typedef ParameterFileListType::value_type     ParameterFileListEntryType;
 
   // Clear output transform parameters
   this->m_TransformParametersList.clear();
@@ -168,7 +165,6 @@ ELASTIX::RegisterImages(
   FlatDirectionCosinesType   fixedImageOriginalDirection;
   int                        returndummy = 0;
   ArgumentMapType            argMap;
-  ParameterFileListType      parameterFileList;
   std::string                outFolder   = "";
   std::string                logFileName = "";
   std::string                key;

--- a/Core/Main/elastixlib.cxx
+++ b/Core/Main/elastixlib.cxx
@@ -193,7 +193,7 @@ ELASTIX::RegisterImages(
   /** Setup xout. */
   const std::string logFileName = performLogging ? (outFolder + "elastix.log") : "";
   int returndummy = elx::xoutSetup( logFileName.c_str(), performLogging, performCout );
-  if( returndummy && performCout )
+  if( ( returndummy != 0 ) && performCout )
   {
     if( performCout )
     {

--- a/Core/Main/elastixlib.cxx
+++ b/Core/Main/elastixlib.cxx
@@ -141,7 +141,6 @@ ELASTIX::RegisterImages(
   /** Some typedef's. */
   typedef elx::ElastixMain                            ElastixMainType;
   typedef ElastixMainType::Pointer                    ElastixMainPointer;
-  typedef std::vector< ElastixMainPointer >           ElastixMainVectorType;
   typedef ElastixMainType::ObjectPointer              ObjectPointer;
   typedef ElastixMainType::DataObjectContainerType    DataObjectContainerType;
   typedef ElastixMainType::DataObjectContainerPointer DataObjectContainerPointer;
@@ -158,7 +157,6 @@ ELASTIX::RegisterImages(
   this->m_TransformParametersList.clear();
 
   /** Some declarations and initialisations. */
-  ElastixMainVectorType elastices;
 
   //ObjectPointer              transform = 0;
   DataObjectContainerPointer fixedImageContainer  = nullptr;
@@ -294,20 +292,20 @@ ELASTIX::RegisterImages(
   for( i = 0; i < nrOfParameterFiles; i++ )
   {
     /** Create another instance of ElastixMain. */
-    elastices.push_back( ElastixMainType::New() );
+    const auto elastixMain = ElastixMainType::New();
 
     /** Set stuff we get from a former registration. */
-    elastices[ i ]->SetInitialTransform( transform );
-    elastices[ i ]->SetFixedImageContainer( fixedImageContainer );
-    elastices[ i ]->SetMovingImageContainer( movingImageContainer );
-    elastices[ i ]->SetFixedMaskContainer( fixedMaskContainer );
-    elastices[ i ]->SetMovingMaskContainer( movingMaskContainer );
-    elastices[ i ]->SetResultImageContainer( resultImageContainer );
-    elastices[ i ]->SetOriginalFixedImageDirectionFlat( fixedImageOriginalDirection );
+    elastixMain->SetInitialTransform( transform );
+    elastixMain->SetFixedImageContainer( fixedImageContainer );
+    elastixMain->SetMovingImageContainer( movingImageContainer );
+    elastixMain->SetFixedMaskContainer( fixedMaskContainer );
+    elastixMain->SetMovingMaskContainer( movingMaskContainer );
+    elastixMain->SetResultImageContainer( resultImageContainer );
+    elastixMain->SetOriginalFixedImageDirectionFlat( fixedImageOriginalDirection );
 
     /** Set the current elastix-level. */
-    elastices[ i ]->SetElastixLevel( i );
-    elastices[ i ]->SetTotalNumberOfElastixLevels( nrOfParameterFiles );
+    elastixMain->SetElastixLevel( i );
+    elastixMain->SetTotalNumberOfElastixLevels( nrOfParameterFiles );
 
     /** Delete the previous ParameterFileName. */
     if( argMap.count( "-p" ) )
@@ -325,7 +323,7 @@ ELASTIX::RegisterImages(
     elxout << "Current time: " << GetCurrentDateAndTime() << "." << std::endl;
 
     /** Start registration. */
-    returndummy = elastices[ i ]->Run( argMap, parameterMaps[ i ] );
+    returndummy = elastixMain->Run( argMap, parameterMaps[ i ] );
 
     /** Check for errors. */
     if( returndummy != 0 )
@@ -337,13 +335,13 @@ ELASTIX::RegisterImages(
     /** Get the transform, the fixedImage and the movingImage
      * in order to put it in the (possibly) next registration.
      */
-    transform                   = elastices[ i ]->GetFinalTransform();
-    fixedImageContainer         = elastices[ i ]->GetFixedImageContainer();
-    movingImageContainer        = elastices[ i ]->GetMovingImageContainer();
-    fixedMaskContainer          = elastices[ i ]->GetFixedMaskContainer();
-    movingMaskContainer         = elastices[ i ]->GetMovingMaskContainer();
-    resultImageContainer        = elastices[ i ]->GetResultImageContainer();
-    fixedImageOriginalDirection = elastices[ i ]->GetOriginalFixedImageDirectionFlat();
+    transform                   = elastixMain->GetFinalTransform();
+    fixedImageContainer         = elastixMain->GetFixedImageContainer();
+    movingImageContainer        = elastixMain->GetMovingImageContainer();
+    fixedMaskContainer          = elastixMain->GetFixedMaskContainer();
+    movingMaskContainer         = elastixMain->GetMovingMaskContainer();
+    resultImageContainer        = elastixMain->GetResultImageContainer();
+    fixedImageOriginalDirection = elastixMain->GetOriginalFixedImageDirectionFlat();
 
     /** Stop timer and print it. */
     timer.Stop();
@@ -352,7 +350,7 @@ ELASTIX::RegisterImages(
            << ConvertSecondsToDHMS( timer.GetMean(), 1 ) << ".\n" << std::endl;
 
     /** Get the transformation parameter map. */
-    this->m_TransformParametersList.push_back( elastices[ i ]->GetTransformParametersMap() );
+    this->m_TransformParametersList.push_back( elastixMain->GetTransformParametersMap() );
 
     /** Set initial transform to an index number instead of a parameter filename. */
     if( i > 0 )
@@ -362,10 +360,6 @@ ELASTIX::RegisterImages(
       this->m_TransformParametersList[ i ][ "InitialTransformParametersFileName" ][ 0 ]
         = toString.str();
     }
-
-    /** Try to release some memory. */
-    elastices[ i ] = nullptr;
-
   } // end loop over registrations
 
   elxout << "-------------------------------------------------------------------------"
@@ -386,10 +380,6 @@ ELASTIX::RegisterImages(
    *  Make sure all the components that are defined in a Module (.DLL/.so)
    *  are deleted before the modules are closed.
    */
-  for( i = 0; i < nrOfParameterFiles; i++ )
-  {
-    elastices[ i ] = nullptr;
-  }
 
   /* Set result image for output */
   if( resultImageContainer.IsNotNull() && resultImageContainer->Size() > 0 && resultImageContainer->ElementAt( 0 ).IsNotNull() )

--- a/Core/Main/elastixlib.cxx
+++ b/Core/Main/elastixlib.cxx
@@ -132,7 +132,6 @@ ELASTIX::RegisterImages(
 {
   /** Some typedef's. */
   typedef elx::ElastixMain                            ElastixMainType;
-  typedef ElastixMainType::Pointer                    ElastixMainPointer;
   typedef ElastixMainType::ObjectPointer              ObjectPointer;
   typedef ElastixMainType::DataObjectContainerType    DataObjectContainerType;
   typedef ElastixMainType::DataObjectContainerPointer DataObjectContainerPointer;

--- a/Core/Main/elastixlib.cxx
+++ b/Core/Main/elastixlib.cxx
@@ -183,7 +183,7 @@ ELASTIX::RegisterImages(
   if( performLogging )
   {
     /** Check if the output directory exists. */
-    bool outFolderExists = itksys::SystemTools::FileIsDirectory( outFolder.c_str() );
+    bool outFolderExists = itksys::SystemTools::FileIsDirectory( outFolder );
     if( !outFolderExists )
     {
       if( performCout )

--- a/Core/Main/elastixlib.h
+++ b/Core/Main/elastixlib.h
@@ -111,10 +111,6 @@ public:
   /** Get transform parameters of all registration steps. */
   ParameterMapListType GetTransformParameterMapList( void );
 
-  std::string ConvertSecondsToDHMS( const double totalSeconds, const unsigned int precision = 0 );
-
-  std::string GetCurrentDateAndTime( void );
-
 private:
 
   /* the result images */

--- a/Core/Main/elastixlib.h
+++ b/Core/Main/elastixlib.h
@@ -85,8 +85,8 @@ public:
    */
   int RegisterImages( ImagePointer fixedImage,
     ImagePointer movingImage,
-    ParameterMapType & parameterMap,
-    std::string outputPath,
+    const ParameterMapType & parameterMap,
+    const std::string & outputPath,
     bool performLogging,
     bool performCout,
     ImagePointer fixedMask = nullptr,
@@ -94,8 +94,8 @@ public:
 
   int RegisterImages( ImagePointer fixedImage,
     ImagePointer movingImage,
-    std::vector< ParameterMapType > & parameterMaps,
-    std::string outputPath,
+    const std::vector< ParameterMapType > & parameterMaps,
+    const std::string & outputPath,
     bool performLogging,
     bool performCout,
     ImagePointer fixedMask = nullptr,

--- a/Core/Main/transformix.cxx
+++ b/Core/Main/transformix.cxx
@@ -16,8 +16,17 @@
  *
  *=========================================================================*/
 
+ // Elastix header files:
 #include "elastix.h"
 #include "elxTransformixMain.h"
+#include "itkUseMevisDicomTiff.h"
+
+// ITK header files:
+#include <itkTimeProbe.h>
+
+// Standard C++ header files:
+#include <iostream>
+
 
 int
 main( int argc, char ** argv )

--- a/Core/Main/transformixlib.cxx
+++ b/Core/Main/transformixlib.cxx
@@ -19,6 +19,7 @@
 #define __transformixlib_CXX_
 
 #include "transformixlib.h"
+#include "elastix.h" // For ConvertSecondsToDHMS and GetCurrentDateAndTime.
 
 #ifdef _ELASTIX_USE_MEVISDICOMTIFF
 #include "itkUseMevisDicomTiff.h"
@@ -249,65 +250,6 @@ TRANSFORMIX::TransformImage(
   parameterMaps.push_back( parameterMap );
   return TransformImage( inputImage, parameterMaps, outputPath, performLogging, performCout );
 } // end TransformImage()
-
-
-/** ConvertSecondsToDHMS
- *
- */
-std::string
-TRANSFORMIX::ConvertSecondsToDHMS( const double totalSeconds, const unsigned int precision )
-{
-  /** Define days, hours, minutes. */
-  const std::size_t secondsPerMinute = 60;
-  const std::size_t secondsPerHour   = 60 * secondsPerMinute;
-  const std::size_t secondsPerDay    = 24 * secondsPerHour;
-
-  /** Convert total seconds. */
-  std::size_t       iSeconds = static_cast< std::size_t >( totalSeconds );
-  const std::size_t days     = iSeconds / secondsPerDay;
-
-  iSeconds %= secondsPerDay;
-  const std::size_t hours = iSeconds / secondsPerHour;
-
-  iSeconds %= secondsPerHour;
-  const std::size_t minutes = iSeconds / secondsPerMinute;
-
-  //iSeconds %= secondsPerMinute;
-  //const std::size_t seconds = iSeconds;
-  const double dSeconds = fmod( totalSeconds, 60.0 );
-
-  /** Create a string in days, hours, minutes and seconds. */
-  bool               nonzero = false;
-  std::ostringstream make_string( "" );
-  if( days    != 0            ) { make_string << days    << "d"; nonzero = true; }
-  if( hours   != 0 || nonzero ) { make_string << hours   << "h"; nonzero = true; }
-  if( minutes != 0 || nonzero ) { make_string << minutes << "m"; nonzero = true; }
-  make_string << std::showpoint << std::fixed << std::setprecision( precision );
-  make_string << dSeconds << "s";
-
-  /** Return a value. */
-  return make_string.str();
-
-} // end ConvertSecondsToDHMS()
-
-
-/** Returns current date and time as a string. */
-std::string
-TRANSFORMIX::GetCurrentDateAndTime( void )
-{
-  // Obtain current time
-  time_t rawtime = time( nullptr );
-  // Convert to local time
-  struct tm * timeinfo = localtime( &rawtime );
-  // Convert to human-readable format
-  std::string timeAsString = std::string( asctime( timeinfo ) );
-  // Erase newline character at end
-  timeAsString.erase( timeAsString.end() - 1 );
-  //timeAsString.pop_back() // c++11 feature
-
-  return timeAsString;
-} // end GetCurrentDateAndTime()
-
 
 } // namespace transformix
 

--- a/Core/Main/transformixlib.h
+++ b/Core/Main/transformixlib.h
@@ -75,10 +75,6 @@ public:
   /** Getter for result image. */
   ImagePointer GetResultImage( void );
 
-  std::string ConvertSecondsToDHMS( const double totalSeconds, const unsigned int precision = 0 );
-
-  std::string GetCurrentDateAndTime( void );
-
 private:
 
   ImagePointer m_ResultImage;


### PR DESCRIPTION
Fix  various Visual Studio 2017 Code Analysis warnings, Clang Tidy warnings and other style issues encountered when building "elastix.cxx", "elastixlib.cxx", and "itkParameterFileParser.cxx".