### PR TITLE
STYLE: Replace _ELASTIX_BUILD_LIBRARY by BaseComponent::IsElastixLibrary

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -40,7 +40,6 @@ mark_as_advanced( ELASTIX_BUILD_EXECUTABLE )
 option( ELASTIX_BUILD_EXECUTABLE "Generate executable or library?" ON )
 
 if( NOT ELASTIX_BUILD_EXECUTABLE )
-  add_definitions( -D_ELASTIX_BUILD_LIBRARY )
 
   # The following may make smaller and quicker loading libraries,
   # that hides unnecessary symbols. Available from CMake 3.0.0.

--- a/Components/Optimizers/AdaGrad/elxAdaGrad.hxx
+++ b/Components/Optimizers/AdaGrad/elxAdaGrad.hxx
@@ -837,13 +837,9 @@ AdaGrad< TElastix >
 
   }   // end if NewSamplesEveryIteration.
 
-#ifndef _ELASTIX_BUILD_LIBRARY
   /** Prepare for progress printing. */
-  ProgressCommandPointer progressObserver = ProgressCommandType::New();
-  progressObserver->SetUpdateFrequency(
-    this->m_NumberOfGradientMeasurements, this->m_NumberOfGradientMeasurements );
-  progressObserver->SetStartString( "  Progress: " );
-#endif
+  const auto progressObserver = BaseComponent::IsElastixLibrary() ?
+    nullptr : ProgressCommandType::CreateAndSetUpdateFrequency( this->m_NumberOfGradientMeasurements );
   elxout << "  Sampling gradients ..." << std::endl;
 
   /** Initialize some variables for storing gradients and their magnitudes. */
@@ -860,10 +856,11 @@ AdaGrad< TElastix >
   /** Compute gg for some random parameters. */
   for( unsigned int i = 0; i < this->m_NumberOfGradientMeasurements; ++i )
   {
-#ifndef _ELASTIX_BUILD_LIBRARY
-    /** Show progress 0-100% */
-    progressObserver->UpdateAndPrintProgress( i );
-#endif
+    if ( progressObserver != nullptr )
+    {
+      /** Show progress 0-100% */
+      progressObserver->UpdateAndPrintProgress( i );
+    }
     /** Generate a perturbation, according to:
      *    \mu_i ~ N( \mu_0, perturbationsigma^2 I ).
      */
@@ -914,9 +911,10 @@ AdaGrad< TElastix >
 
   } // end for loop over gradient measurements
 
-#ifdef _ELASTIX_BUILD_LIBARY
-  progressObserver->PrintProgress( 1.0 );
-#endif
+  if ( progressObserver != nullptr )
+  {
+    progressObserver->PrintProgress( 1.0 );
+  }
 
   /** Compute means. */
   exactgg /= this->m_NumberOfGradientMeasurements;

--- a/Components/Optimizers/AdaptiveStochasticGradientDescent/elxAdaptiveStochasticGradientDescent.hxx
+++ b/Components/Optimizers/AdaptiveStochasticGradientDescent/elxAdaptiveStochasticGradientDescent.hxx
@@ -906,13 +906,9 @@ AdaptiveStochasticGradientDescent< TElastix >
 
   } // end if NewSamplesEveryIteration.
 
-#ifndef _ELASTIX_BUILD_LIBRARY
   /** Prepare for progress printing. */
-  ProgressCommandPointer progressObserver = ProgressCommandType::New();
-  progressObserver->SetUpdateFrequency(
-    this->m_NumberOfGradientMeasurements, this->m_NumberOfGradientMeasurements );
-  progressObserver->SetStartString( "  Progress: " );
-#endif
+  const auto progressObserver = BaseComponent::IsElastixLibrary() ?
+    nullptr : ProgressCommandType::CreateAndSetUpdateFrequency( this->m_NumberOfGradientMeasurements );
   elxout << "  Sampling gradients ..." << std::endl;
 
   /** Initialize some variables for storing gradients and their magnitudes. */
@@ -927,10 +923,11 @@ AdaptiveStochasticGradientDescent< TElastix >
   /** Compute gg for some random parameters. */
   for( unsigned int i = 0; i < this->m_NumberOfGradientMeasurements; ++i )
   {
-#ifndef _ELASTIX_BUILD_LIBRARY
-    /** Show progress 0-100% */
-    progressObserver->UpdateAndPrintProgress( i );
-#endif
+    if ( progressObserver != nullptr )
+    {
+      /** Show progress 0-100% */
+      progressObserver->UpdateAndPrintProgress( i );
+    }
     /** Generate a perturbation, according to:
      *    \mu_i ~ N( \mu_0, perturbationsigma^2 I ).
      */
@@ -981,9 +978,10 @@ AdaptiveStochasticGradientDescent< TElastix >
 
   } // end for loop over gradient measurements
 
-#ifdef _ELASTIX_BUILD_LIBARY
-  progressObserver->PrintProgress( 1.0 );
-#endif
+  if ( progressObserver != nullptr )
+  {
+    progressObserver->PrintProgress( 1.0 );
+  }
 
   /** Compute means. */
   exactgg /= this->m_NumberOfGradientMeasurements;

--- a/Components/Optimizers/AdaptiveStochasticLBFGS/elxAdaptiveStochasticLBFGS.hxx
+++ b/Components/Optimizers/AdaptiveStochasticLBFGS/elxAdaptiveStochasticLBFGS.hxx
@@ -1399,13 +1399,9 @@ AdaptiveStochasticLBFGS<TElastix>
     } // end for loop over metrics
   } // end if NewSamplesEveryIteration.
 
-#ifndef _ELASTIX_BUILD_LIBRARY
   /** Prepare for progress printing. */
-  ProgressCommandPointer progressObserver = ProgressCommandType::New();
-  progressObserver->SetUpdateFrequency(
-    this->m_NumberOfGradientMeasurements, this->m_NumberOfGradientMeasurements );
-  progressObserver->SetStartString( "  Progress: " );
-#endif
+  const auto progressObserver = BaseComponent::IsElastixLibrary() ?
+    nullptr : ProgressCommandType::CreateAndSetUpdateFrequency( this->m_NumberOfGradientMeasurements );
   //elxout << "  Sampling gradients ..." << std::endl;
 
   /** Initialize some variables for storing gradients and their magnitudes. */
@@ -1420,10 +1416,11 @@ AdaptiveStochasticLBFGS<TElastix>
   /** Compute gg for some random parameters. */
   for( unsigned int i = 0 ; i < this->m_NumberOfGradientMeasurements; ++i )
   {
-#ifndef _ELASTIX_BUILD_LIBRARY
-    /** Show progress 0-100% */
-    progressObserver->UpdateAndPrintProgress( i );
-#endif
+    if ( progressObserver != nullptr )
+    {
+      /** Show progress 0-100% */
+      progressObserver->UpdateAndPrintProgress( i );
+    }
     /** Generate a perturbation, according to:
      *    \mu_i ~ N( \mu_0, perturbationsigma^2 I ).
      */
@@ -1473,9 +1470,10 @@ AdaptiveStochasticLBFGS<TElastix>
     } // end else: no stochastic gradients
 
   } // end for loop over gradient measurements
-#ifdef _ELASTIX_BUILD_LIBARY
-  progressObserver->PrintProgress( 1.0 );
-#endif
+  if ( progressObserver != nullptr )
+  {
+    progressObserver->PrintProgress( 1.0 );
+  }
   /** Compute means. */
   exactgg /= this->m_NumberOfGradientMeasurements;
   diffgg /= this->m_NumberOfGradientMeasurements;

--- a/Components/Optimizers/AdaptiveStochasticVarianceReducedGradient/elxAdaptiveStochasticVarianceReducedGradient.hxx
+++ b/Components/Optimizers/AdaptiveStochasticVarianceReducedGradient/elxAdaptiveStochasticVarianceReducedGradient.hxx
@@ -1188,13 +1188,9 @@ AdaptiveStochasticVarianceReducedGradient<TElastix>
     } // end for loop over metrics
   } // end if NewSamplesEveryIteration.
 
-#ifndef _ELASTIX_BUILD_LIBRARY
   /** Prepare for progress printing. */
-  ProgressCommandPointer progressObserver = ProgressCommandType::New();
-  progressObserver->SetUpdateFrequency(
-    this->m_NumberOfGradientMeasurements, this->m_NumberOfGradientMeasurements );
-  progressObserver->SetStartString( "  Progress: " );
-#endif
+  const auto progressObserver = BaseComponent::IsElastixLibrary() ?
+    nullptr : ProgressCommandType::CreateAndSetUpdateFrequency( this->m_NumberOfGradientMeasurements );
   elxout << "  Sampling gradients ..." << std::endl;
 
   /** Initialize some variables for storing gradients and their magnitudes. */
@@ -1209,10 +1205,11 @@ AdaptiveStochasticVarianceReducedGradient<TElastix>
   /** Compute gg for some random parameters. */
   for( unsigned int i = 0 ; i < this->m_NumberOfGradientMeasurements; ++i )
   {
-#ifndef _ELASTIX_BUILD_LIBRARY
-    /** Show progress 0-100% */
-    progressObserver->UpdateAndPrintProgress( i );
-#endif
+    if ( progressObserver != nullptr )
+    {
+      /** Show progress 0-100% */
+      progressObserver->UpdateAndPrintProgress( i );
+    }
     /** Generate a perturbation, according to:
      *    \mu_i ~ N( \mu_0, perturbationsigma^2 I ).
      */
@@ -1263,9 +1260,10 @@ AdaptiveStochasticVarianceReducedGradient<TElastix>
     } // end else: no stochastic gradients
 
   } // end for loop over gradient measurements
-#ifdef _ELASTIX_BUILD_LIBARY
-  progressObserver->PrintProgress( 1.0 );
-#endif
+  if ( progressObserver != nullptr )
+  {
+    progressObserver->PrintProgress( 1.0 );
+  }
   /** Compute means. */
   exactgg /= this->m_NumberOfGradientMeasurements;
   diffgg /= this->m_NumberOfGradientMeasurements;

--- a/Components/Optimizers/PreconditionedStochasticGradientDescent/elxPreconditionedStochasticGradientDescent.hxx
+++ b/Components/Optimizers/PreconditionedStochasticGradientDescent/elxPreconditionedStochasticGradientDescent.hxx
@@ -843,13 +843,9 @@ PreconditionedStochasticGradientDescent< TElastix >
 
   }   // end if NewSamplesEveryIteration.
 
-#ifndef _ELASTIX_BUILD_LIBRARY
   /** Prepare for progress printing. */
-  ProgressCommandPointer progressObserver = ProgressCommandType::New();
-  progressObserver->SetUpdateFrequency(
-    this->m_NumberOfGradientMeasurements, this->m_NumberOfGradientMeasurements );
-  progressObserver->SetStartString( "  Progress: " );
-#endif
+  const auto progressObserver = BaseComponent::IsElastixLibrary() ?
+    nullptr : ProgressCommandType::CreateAndSetUpdateFrequency( this->m_NumberOfGradientMeasurements );
   elxout << "  Sampling gradients ..." << std::endl;
 
   /** Initialize some variables for storing gradients and their magnitudes. */
@@ -866,10 +862,11 @@ PreconditionedStochasticGradientDescent< TElastix >
   /** Compute gg for some random parameters. */
   for( unsigned int i = 0; i < this->m_NumberOfGradientMeasurements; ++i )
   {
-#ifndef _ELASTIX_BUILD_LIBRARY
-    /** Show progress 0-100% */
-    progressObserver->UpdateAndPrintProgress( i );
-#endif
+    if ( progressObserver != nullptr )
+    {
+      /** Show progress 0-100% */
+      progressObserver->UpdateAndPrintProgress( i );
+    }
     /** Generate a perturbation, according to:
      *    \mu_i ~ N( \mu_0, perturbationsigma^2 I ).
      */
@@ -928,9 +925,10 @@ PreconditionedStochasticGradientDescent< TElastix >
 
   } // end for loop over gradient measurements
 
-#ifdef _ELASTIX_BUILD_LIBARY
-  progressObserver->PrintProgress( 1.0 );
-#endif
+  if ( progressObserver != nullptr )
+  {
+    progressObserver->PrintProgress( 1.0 );
+  }
 
   /** Compute means. */
   exactgg /= this->m_NumberOfGradientMeasurements;

--- a/Core/Configuration/elxConfiguration.cxx
+++ b/Core/Configuration/elxConfiguration.cxx
@@ -75,9 +75,10 @@ int
 Configuration
 ::BeforeAll( void )
 {
-#ifndef _ELASTIX_BUILD_LIBRARY
-  this->PrintParameterFile();
-#endif
+  if (!BaseComponent::IsElastixLibrary())
+  {
+    this->PrintParameterFile();
+  }
   return 0;
 
 } // end BeforeAll()

--- a/Core/Install/elxBaseComponent.cxx
+++ b/Core/Install/elxBaseComponent.cxx
@@ -20,6 +20,20 @@
 
 #include <cmath>
 
+namespace
+{
+bool IsElastixLibrary(const bool initialValue = false)
+{
+  // By default, assume that this is not the elastix library.
+
+  // Note that the initialization of this static variable is thread-safe,
+  // as supported by C++11 "magic statics".
+  static const bool isElastixLibrary{ initialValue };
+
+  return isElastixLibrary;
+}
+}
+
 namespace elastix
 {
 
@@ -57,6 +71,16 @@ BaseComponent::GetComponentLabel( void ) const
   return this->m_ComponentLabel.c_str();
 } // end GetComponentLabel()
 
+
+bool BaseComponent::IsElastixLibrary()
+{
+  return ::IsElastixLibrary();
+}
+
+void BaseComponent::InitializeElastixLibrary()
+{
+  ::IsElastixLibrary(true);
+}
 
 /**
  * ****************** ConvertSecondsToDHMS ****************************

--- a/Core/Install/elxBaseComponent.h
+++ b/Core/Install/elxBaseComponent.h
@@ -122,6 +122,10 @@ public:
   /** Get the componentlabel as a string: "Metric0" for example. */
   virtual const char * GetComponentLabel( void ) const;
 
+  static bool IsElastixLibrary();
+
+  static void InitializeElastixLibrary();
+
   /** Convenience function to convert seconds to day, hour, minute, second format. */
   std::string ConvertSecondsToDHMS( const double totalSeconds, const unsigned int precision ) const;
 

--- a/Core/Kernel/elxElastixBase.cxx
+++ b/Core/Kernel/elxElastixBase.cxx
@@ -124,12 +124,13 @@ ElastixBase::BeforeAllBase( void )
    * so print an error if they are not present.
    * Print also some info (second boolean = true).
    */
-#ifndef _ELASTIX_BUILD_LIBRARY
-  this->m_FixedImageFileNameContainer = this->GenerateFileNameContainer(
-    "-f", returndummy, true, true );
-  this->m_MovingImageFileNameContainer = this->GenerateFileNameContainer(
-    "-m", returndummy, true, true );
-#endif
+  if (!BaseComponent::IsElastixLibrary())
+  {
+    this->m_FixedImageFileNameContainer = this->GenerateFileNameContainer(
+      "-f", returndummy, true, true );
+    this->m_MovingImageFileNameContainer = this->GenerateFileNameContainer(
+      "-m", returndummy, true, true );
+  }
   /** Read the fixed and moving mask filenames. These are not obliged options,
    * so do not print any errors if they are not present.
    * Do print some info (second boolean = true).
@@ -269,20 +270,21 @@ ElastixBase::BeforeAllTransformixBase( void )
 
   /** Check Command line options and print them to the logfile. */
   elxout << "Command line options from ElastixBase:" << std::endl;
-#ifndef _ELASTIX_BUILD_LIBRARY
-  /** Read the input image filenames. These are not obliged options,
-   * so do not print an error if they are not present.
-   * Print also some info (second boolean = true)
-   * Save the result in the moving image file name container.
-   */
-  int inreturndummy = 0;
-  this->m_MovingImageFileNameContainer = this->GenerateFileNameContainer(
-    "-in", inreturndummy, false, true );
-  if( inreturndummy != 0 )
+  if (!BaseComponent::IsElastixLibrary())
   {
-    elxout << "-in       unspecified, so no input image specified" << std::endl;
+    /** Read the input image filenames. These are not obliged options,
+     * so do not print an error if they are not present.
+     * Print also some info (second boolean = true)
+     * Save the result in the moving image file name container.
+     */
+    int inreturndummy = 0;
+    this->m_MovingImageFileNameContainer = this->GenerateFileNameContainer(
+      "-in", inreturndummy, false, true );
+    if( inreturndummy != 0 )
+    {
+      elxout << "-in       unspecified, so no input image specified" << std::endl;
+    }
   }
-#endif
   /** Check for appearance of "-out". */
   std::string check = this->GetConfiguration()->GetCommandLineArgument( "-out" );
   if( check == "" )
@@ -312,12 +314,12 @@ ElastixBase::BeforeAllTransformixBase( void )
   {
     elxout << "-threads  " << check << std::endl;
   }
-#ifndef _ELASTIX_BUILD_LIBRARY
-  /** Print "-tp". */
-  check = this->GetConfiguration()->GetCommandLineArgument( "-tp" );
-  elxout << "-tp       " << check << std::endl;
-#endif
-
+  if (!BaseComponent::IsElastixLibrary())
+  {
+    /** Print "-tp". */
+    check = this->GetConfiguration()->GetCommandLineArgument("-tp");
+    elxout << "-tp       " << check << std::endl;
+  }
   /** Check the very important UseDirectionCosines parameter. */
   bool retudc = this->GetConfiguration()->ReadParameter( this->m_UseDirectionCosines,
     "UseDirectionCosines", 0 );

--- a/Core/Kernel/elxElastixMain.cxx
+++ b/Core/Kernel/elxElastixMain.cxx
@@ -490,62 +490,65 @@ ElastixMain::InitDBIndex( void )
     /** FixedImageDimension. */
     if( this->m_FixedImageDimension == 0 )
     {
-#ifndef _ELASTIX_BUILD_LIBRARY
-      /** Get the fixed image file name. */
-      std::string fixedImageFileName
-        = this->m_Configuration->GetCommandLineArgument( "-f" );
-      if( fixedImageFileName == "" )
+      if (!BaseComponent::IsElastixLibrary())
       {
-        fixedImageFileName = this->m_Configuration->GetCommandLineArgument( "-f0" );
-      }
-
-      /** Sanity check. */
-      if( fixedImageFileName == "" )
-      {
-        xout[ "error" ] << "ERROR: could not read fixed image." << std::endl;
-        xout[ "error" ] << "  both -f and -f0 are unspecified" << std::endl;
-        return 1;
-      }
-
-      /** Read it from the fixed image header. */
-      try
-      {
-        this->GetImageInformationFromFile( fixedImageFileName,
-          this->m_FixedImageDimension );
-      }
-      catch( itk::ExceptionObject & err )
-      {
-        xout[ "error" ] << "ERROR: could not read fixed image." << std::endl;
-        xout[ "error" ] << err << std::endl;
-        return 1;
-      }
-
-      /** Try to read it from the parameter file.
-       * This only serves as a check; elastix versions prior to 4.6 read the dimension
-       * from the parameter file, but now we read it from the image header.
-       */
-      unsigned int fixDimParameterFile  = 0;
-      bool         foundInParameterFile = this->m_Configuration->ReadParameter( fixDimParameterFile,
-        "FixedImageDimension", 0, false );
-
-      /** Check. */
-      if( foundInParameterFile )
-      {
-        if( fixDimParameterFile != this->m_FixedImageDimension )
+        /** Get the fixed image file name. */
+        std::string fixedImageFileName
+          = this->m_Configuration->GetCommandLineArgument( "-f" );
+        if( fixedImageFileName == "" )
         {
-          xout[ "error" ] << "ERROR: problem defining fixed image dimension.\n"
-                          << "  The parameter file says:     " << fixDimParameterFile << "\n"
-                          << "  The fixed image header says: " << this->m_FixedImageDimension << "\n"
-                          << "  Note that from elastix 4.6 the parameter file definition \"FixedImageDimension\" "
-                          << "is not needed anymore.\n  Please remove this entry from your parameter file."
-                          << std::endl;
+          fixedImageFileName = this->m_Configuration->GetCommandLineArgument( "-f0" );
+        }
+
+        /** Sanity check. */
+        if( fixedImageFileName == "" )
+        {
+          xout[ "error" ] << "ERROR: could not read fixed image." << std::endl;
+          xout[ "error" ] << "  both -f and -f0 are unspecified" << std::endl;
           return 1;
         }
+
+        /** Read it from the fixed image header. */
+        try
+        {
+          this->GetImageInformationFromFile( fixedImageFileName,
+            this->m_FixedImageDimension );
+        }
+        catch( itk::ExceptionObject & err )
+        {
+          xout[ "error" ] << "ERROR: could not read fixed image." << std::endl;
+          xout[ "error" ] << err << std::endl;
+          return 1;
+        }
+
+        /** Try to read it from the parameter file.
+         * This only serves as a check; elastix versions prior to 4.6 read the dimension
+         * from the parameter file, but now we read it from the image header.
+         */
+        unsigned int fixDimParameterFile  = 0;
+        bool         foundInParameterFile = this->m_Configuration->ReadParameter( fixDimParameterFile,
+          "FixedImageDimension", 0, false );
+
+        /** Check. */
+        if( foundInParameterFile )
+        {
+          if( fixDimParameterFile != this->m_FixedImageDimension )
+          {
+            xout[ "error" ] << "ERROR: problem defining fixed image dimension.\n"
+                            << "  The parameter file says:     " << fixDimParameterFile << "\n"
+                            << "  The fixed image header says: " << this->m_FixedImageDimension << "\n"
+                            << "  Note that from elastix 4.6 the parameter file definition \"FixedImageDimension\" "
+                            << "is not needed anymore.\n  Please remove this entry from your parameter file."
+                            << std::endl;
+            return 1;
+          }
+        }
       }
-#else
-      this->m_Configuration->ReadParameter( this->m_FixedImageDimension,
-        "FixedImageDimension", 0, false );
-#endif
+      else
+      {
+        this->m_Configuration->ReadParameter( this->m_FixedImageDimension,
+          "FixedImageDimension", 0, false );
+      }
 
       /** Just a sanity check, probably not needed. */
       if( this->m_FixedImageDimension == 0 )
@@ -568,63 +571,65 @@ ElastixMain::InitDBIndex( void )
     /** MovingImageDimension. */
     if( this->m_MovingImageDimension == 0 )
     {
-#ifndef _ELASTIX_BUILD_LIBRARY
-      /** Get the moving image file name. */
-      std::string movingImageFileName
-        = this->m_Configuration->GetCommandLineArgument( "-m" );
-      if( movingImageFileName == "" )
+      if (!BaseComponent::IsElastixLibrary())
       {
-        movingImageFileName = this->m_Configuration->GetCommandLineArgument( "-m0" );
-      }
-
-      /** Sanity check. */
-      if( movingImageFileName == "" )
-      {
-        xout[ "error" ] << "ERROR: could not read moving image." << std::endl;
-        xout[ "error" ] << "  both -m and -m0 are unspecified" << std::endl;
-        return 1;
-      }
-
-      /** Read it from the moving image header. */
-      try
-      {
-        this->GetImageInformationFromFile( movingImageFileName,
-          this->m_MovingImageDimension );
-      }
-      catch( itk::ExceptionObject & err )
-      {
-        xout[ "error" ] << "ERROR: could not read moving image." << std::endl;
-        xout[ "error" ] << err << std::endl;
-        return 1;
-      }
-
-      /** Try to read it from the parameter file.
-       * This only serves as a check; elastix versions prior to 4.6 read the dimension
-       * from the parameter file, but now we read it from the image header.
-       */
-      unsigned int movDimParameterFile  = 0;
-      bool         foundInParameterFile = this->m_Configuration->ReadParameter( movDimParameterFile,
-        "MovingImageDimension", 0, false );
-
-      /** Check. */
-      if( foundInParameterFile )
-      {
-        if( movDimParameterFile != this->m_MovingImageDimension )
+        /** Get the moving image file name. */
+        std::string movingImageFileName
+          = this->m_Configuration->GetCommandLineArgument( "-m" );
+        if( movingImageFileName == "" )
         {
-          xout[ "error" ] << "ERROR: problem defining moving image dimension.\n"
-                          << "  The parameter file says:      " << movDimParameterFile << "\n"
-                          << "  The moving image header says: " << this->m_MovingImageDimension << "\n"
-                          << "  Note that from elastix 4.6 the parameter file definition \"MovingImageDimension\" "
-                          << "is not needed anymore.\n  Please remove this entry from your parameter file."
-                          << std::endl;
+          movingImageFileName = this->m_Configuration->GetCommandLineArgument( "-m0" );
+        }
+
+        /** Sanity check. */
+        if( movingImageFileName == "" )
+        {
+          xout[ "error" ] << "ERROR: could not read moving image." << std::endl;
+          xout[ "error" ] << "  both -m and -m0 are unspecified" << std::endl;
           return 1;
         }
-      }
 
-#else
-      this->m_Configuration->ReadParameter( this->m_MovingImageDimension,
-        "MovingImageDimension", 0, false );
-#endif
+        /** Read it from the moving image header. */
+        try
+        {
+          this->GetImageInformationFromFile( movingImageFileName,
+            this->m_MovingImageDimension );
+        }
+        catch( itk::ExceptionObject & err )
+        {
+          xout[ "error" ] << "ERROR: could not read moving image." << std::endl;
+          xout[ "error" ] << err << std::endl;
+          return 1;
+        }
+
+        /** Try to read it from the parameter file.
+         * This only serves as a check; elastix versions prior to 4.6 read the dimension
+         * from the parameter file, but now we read it from the image header.
+         */
+        unsigned int movDimParameterFile  = 0;
+        bool         foundInParameterFile = this->m_Configuration->ReadParameter( movDimParameterFile,
+          "MovingImageDimension", 0, false );
+
+        /** Check. */
+        if( foundInParameterFile )
+        {
+          if( movDimParameterFile != this->m_MovingImageDimension )
+          {
+            xout[ "error" ] << "ERROR: problem defining moving image dimension.\n"
+                            << "  The parameter file says:      " << movDimParameterFile << "\n"
+                            << "  The moving image header says: " << this->m_MovingImageDimension << "\n"
+                            << "  Note that from elastix 4.6 the parameter file definition \"MovingImageDimension\" "
+                            << "is not needed anymore.\n  Please remove this entry from your parameter file."
+                            << std::endl;
+            return 1;
+          }
+        }
+      }
+      else
+      {
+        this->m_Configuration->ReadParameter( this->m_MovingImageDimension,
+          "MovingImageDimension", 0, false );
+      }
 
       /** Just a sanity check, probably not needed. */
       if( this->m_MovingImageDimension == 0 )

--- a/Core/Kernel/elxElastixTemplate.hxx
+++ b/Core/Kernel/elxElastixTemplate.hxx
@@ -503,11 +503,14 @@ ElastixTemplate< TFixedImage, TMovingImage >
      * Actually we could loop over all resamplers.
      * But for now, there seems to be no use yet for that.
      */
-#ifndef _ELASTIX_BUILD_LIBRARY
-    this->GetElxResamplerBase()->ResampleAndWriteResultImage( makeFileName.str().c_str() );
-#else
-    this->GetElxResamplerBase()->CreateItkResultImage();
-#endif
+    if (!BaseComponent::IsElastixLibrary())
+    {
+      this->GetElxResamplerBase()->ResampleAndWriteResultImage( makeFileName.str().c_str() );
+    }
+    else
+    {
+      this->GetElxResamplerBase()->CreateItkResultImage();
+    }
 
     /** Print the elapsed time for the resampling. */
     timer.Stop();
@@ -574,9 +577,10 @@ ElastixTemplate< TFixedImage, TMovingImage >
    * It print the Transform Parameter file to the log file. That's
    * why we call it after the other components.
    */
-#ifndef _ELASTIX_BUILD_LIBRARY
-  returndummy |= this->GetConfiguration()->BeforeAllTransformix();
-#endif
+  if (!BaseComponent::IsElastixLibrary())
+  {
+    returndummy |= this->GetConfiguration()->BeforeAllTransformix();
+  }
 
   /** Return a value. */
   return returndummy;
@@ -857,10 +861,11 @@ ElastixTemplate< TFixedImage, TMovingImage >
     this->CreateTransformParameterFile( FileName, true );
   }
 
-#ifdef _ELASTIX_BUILD_LIBRARY
-  /** Get the transform parameters. */
-  this->CreateTransformParametersMap(); // only relevant for dll!
-#endif
+  if (BaseComponent::IsElastixLibrary())
+  {
+    /** Get the transform parameters. */
+    this->CreateTransformParametersMap(); // only relevant for dll!
+  }
 
   timer.Stop();
   elxout << "\nCreating the TransformParameterFile took "

--- a/Core/Kernel/elxTransformixMain.cxx
+++ b/Core/Kernel/elxTransformixMain.cxx
@@ -98,9 +98,10 @@ TransformixMain::Run( void )
   itk::CreateOpenCLLogger( "transformix", this->m_Configuration->GetCommandLineArgument( "-out" ) );
 #endif
 
-#ifdef _ELASTIX_BUILD_LIBRARY
-  this->GetElastixBase()->SetConfigurations( this->m_Configurations );
-#endif // #ifdef _ELASTIX_BUILD_LIBRARY
+  if (BaseComponent::IsElastixLibrary())
+  {
+    this->GetElastixBase()->SetConfigurations( this->m_Configurations );
+  }
 
   /** Set some information in the ElastixBase. */
   this->GetElastixBase()->SetConfiguration( this->m_Configuration );

--- a/Core/Main/elastixlib.cxx
+++ b/Core/Main/elastixlib.cxx
@@ -46,13 +46,20 @@ namespace elastix
  * ******************* Constructor ***********************
  */
 
-ELASTIX::ELASTIX() = default;
+ELASTIX::ELASTIX()
+{
+  BaseComponent::InitializeElastixLibrary();
+  assert(BaseComponent::IsElastixLibrary());
+}
 
 /**
  * ******************* Destructor ***********************
  */
 
-ELASTIX::~ELASTIX() = default;
+ELASTIX::~ELASTIX()
+{
+  assert(BaseComponent::IsElastixLibrary());
+}
 
 /**
  * ******************* GetResultImage ***********************

--- a/Core/elxProgressCommand.cxx
+++ b/Core/elxProgressCommand.cxx
@@ -224,4 +224,26 @@ ProgressCommand
 } // end PrintProgress()
 
 
+ProgressCommand::Pointer
+ProgressCommand
+::CreateAndSetUpdateFrequency( const unsigned long numberOfVoxels )
+{
+  const auto result = Self::New();
+  result->Self::SetUpdateFrequency(numberOfVoxels, numberOfVoxels);
+  result->SetStartString("  Progress: ");
+  return result;
+}
+
+ProgressCommand::Pointer
+ProgressCommand
+::CreateAndConnect(itk::ProcessObject& processObject)
+{
+  const auto result = Self::New();
+  result->Self::ConnectObserver(&processObject);
+  result->Self::SetStartString("  Progress: ");
+  result->Self::SetEndString("%");
+  return result;
+}
+
+
 } // end namespace itk

--- a/Core/elxProgressCommand.h
+++ b/Core/elxProgressCommand.h
@@ -144,6 +144,10 @@ public:
   /** Get a boolean indicating if the output is a console. */
   itkGetConstReferenceMacro( StreamOutputIsConsole, bool );
 
+  static Pointer CreateAndSetUpdateFrequency(unsigned long numberOfVoxels);
+
+  static Pointer CreateAndConnect(itk::ProcessObject&);
+
 protected:
 
   /** The constructor. */


### PR DESCRIPTION
Replaced `_ELASTIX_BUILD_LIBRARY` preprocessor definition by static member function, `BaseComponent::IsElastixLibrary()`.

Anticipates sharing the intermediate binary object files between the Elastix executable and the Elastix library, possibly building them within the same project, or the same (Visual Studio) solution.