### PR TITLE
COMP: Remove cmake* from .gitignore

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -33,7 +33,6 @@
 
 # Generated files and
 help/
-cmake*
 Makefile
 CMakeFiles/
 CTestTestfile.cmake


### PR DESCRIPTION
Having cmake* in there stopped Gokhan Gunay from adding his CMakeLists file to pull request #236 (Addition of PointToSurface metric).