### PR TITLE
COMP: Remove unreachable code from Transforms

### DIFF
--- a/Common/Transforms/itkAdvancedBSplineDeformableTransformBase.h
+++ b/Common/Transforms/itkAdvancedBSplineDeformableTransformBase.h
@@ -226,7 +226,6 @@ public:
   OutputVectorType TransformVector( const InputVectorType & ) const override
   {
     itkExceptionMacro( << "Method not applicable for deformable transform." );
-    return OutputVectorType();
   }
 
 
@@ -236,7 +235,6 @@ public:
   OutputVnlVectorType TransformVector( const InputVnlVectorType & ) const override
   {
     itkExceptionMacro( << "Method not applicable for deformable transform. " );
-    return OutputVnlVectorType();
   }
 
 
@@ -247,7 +245,6 @@ public:
     const InputCovariantVectorType & ) const override
   {
     itkExceptionMacro( << "Method not applicable for deformable transform. " );
-    return OutputCovariantVectorType();
   }
 
 

--- a/Common/Transforms/itkAdvancedCombinationTransform.hxx
+++ b/Common/Transforms/itkAdvancedCombinationTransform.hxx
@@ -427,7 +427,6 @@ AdvancedCombinationTransform< TScalarType, NDimensions >
      */
 
     itkExceptionMacro( << "ERROR: not implemented" );
-    return false;
 
 //     /** Try create the inverse of the initial transform. */
 //     InitialTransformPointer inverseT0 = InitialTransformType::New();

--- a/Common/Transforms/itkBSplineSecondOrderDerivativeKernelFunction2.h
+++ b/Common/Transforms/itkBSplineSecondOrderDerivativeKernelFunction2.h
@@ -170,8 +170,6 @@ private:
   inline double Evaluate( const DispatchBase &, const double & ) const
   {
     itkExceptionMacro( "Evaluate not implemented for spline order " << SplineOrder );
-    return 0.0; // This is to avoid compiler warning about missing
-    // return statement.  It should never be evaluated.
   }
 
 

--- a/Components/Transforms/SplineKernelTransform/itkKernelTransform2.hxx
+++ b/Components/Transforms/SplineKernelTransform/itkKernelTransform2.hxx
@@ -331,7 +331,6 @@ KernelTransform2< TScalarType, NDimensions >
   {
     itkExceptionMacro( << "ERROR: invalid matrix inversion method ("
                        << this->m_MatrixInversionMethod << ")" );
-    this->m_LInverseComputed = false;
   }
 
 } // end ComputeLInverse()


### PR DESCRIPTION
Fixes six Visual C++ 2019 Warning level 4 warnings, saying:

> warning C4702: unreachable code

These warnings occurred in Common/Transforms and Components/Transforms.