### PR TITLE
BUG: Try fixing #70 CL_OUT_OF_RESOURCES exception

### DIFF
--- a/Common/OpenCL/Filters/itkGPURecursiveGaussianImageFilter.hxx
+++ b/Common/OpenCL/Filters/itkGPURecursiveGaussianImageFilter.hxx
@@ -52,14 +52,12 @@ GPURecursiveGaussianImageFilter< TInputImage, TOutputImage >
 
   this->m_DeviceLocalMemorySize = ( localMemSize / 3 ) / sizeof( float );
   
-  //Added by HUC 
-  //Original implementation set BUFFSIZE as (local memory size)/3, which can handle up to 1365 pixels along one dimension
-  //But in Device with larger local memory size(eg. GTX 2080Ti with 48KB local memory, BUFFZISE=4096), the BUFFSIZE would become
-  //overkill for most medical implementation, and would use up all GPU global memoy due to memory spill;
-  
-  this->m_DeviceLocalMemorySize = ( this->m_DeviceLocalMemorySize > 1024)?(1024):( this->m_DeviceLocalMemorySize);
+  /**Original implementation set BUFFSIZE as (local memory size)/3, which can handle up to 1365 pixels along one dimension*/
+  /**But in Device with larger local memory size(eg. GTX 2080Ti with 48KB local memory, BUFFZISE=4096), the BUFFSIZE would become*/
+  /**overkill for most medical implementation, and would use up all GPU global memoy during kernel excution;*/
 
-  //End add by HUC
+  this->m_DeviceLocalMemorySize = ( this->m_DeviceLocalMemorySize > 1024 )?( 1024 ):( this->m_DeviceLocalMemorySize );
+
 
   defines << "#define BUFFSIZE " << this->m_DeviceLocalMemorySize << "\n";
   defines << "#define BUFFPIXELTYPE float" << "\n";

--- a/Common/OpenCL/Filters/itkGPURecursiveGaussianImageFilter.hxx
+++ b/Common/OpenCL/Filters/itkGPURecursiveGaussianImageFilter.hxx
@@ -51,6 +51,15 @@ GPURecursiveGaussianImageFilter< TInputImage, TOutputImage >
     = this->m_GPUKernelManager->GetContext()->GetDefaultDevice().GetLocalMemorySize();
 
   this->m_DeviceLocalMemorySize = ( localMemSize / 3 ) / sizeof( float );
+  
+  //Added by HUC 
+  //Original implementation set BUFFSIZE as (local memory size)/3, which can handle up to 1365 pixels along one dimension
+  //But in Device with larger local memory size(eg. GTX 2080Ti with 48KB local memory, BUFFZISE=4096), the BUFFSIZE would become
+  //overkill for most medical implementation, and would use up all GPU global memoy due to memory spill;
+  
+  this->m_DeviceLocalMemorySize = ( this->m_DeviceLocalMemorySize > 1024)?(1024):( this->m_DeviceLocalMemorySize);
+
+  //End add by HUC
 
   defines << "#define BUFFSIZE " << this->m_DeviceLocalMemorySize << "\n";
   defines << "#define BUFFPIXELTYPE float" << "\n";

--- a/Common/OpenCL/ITKimprovements/itkGPUImage.h
+++ b/Common/OpenCL/ITKimprovements/itkGPUImage.h
@@ -221,6 +221,20 @@ public:
   itkGetConstReferenceMacro( IndexToPhysicalPoint, DirectionType );
   itkGetConstReferenceMacro( PhysicalPointToIndex, DirectionType );
 
+  //Add for: OpenCL memory error CL_OUT_OF_RESOURCES, Issue#70
+  template <typename UPixelType, unsigned int NUImageDimension = VImageDimension>
+  struct Rebind
+    {
+      using Type = itk::GPUImage<UPixelType, NUImageDimension>;
+    };
+
+
+  template <typename UPixelType, unsigned int NUImageDimension = VImageDimension>
+    using RebindImageType = itk::GPUImage<UPixelType, NUImageDimension>;
+  //End add for: OpenCL memory error CL_OUT_OF_RESOURCES, Issue#70
+
+
+
 protected:
 
   GPUImage();

--- a/Common/OpenCL/ITKimprovements/itkGPUImage.h
+++ b/Common/OpenCL/ITKimprovements/itkGPUImage.h
@@ -221,7 +221,7 @@ public:
   itkGetConstReferenceMacro( IndexToPhysicalPoint, DirectionType );
   itkGetConstReferenceMacro( PhysicalPointToIndex, DirectionType );
 
-  //Add for: OpenCL memory error CL_OUT_OF_RESOURCES, Issue#70
+  /** GPUImage counterpart*/
   template <typename UPixelType, unsigned int NUImageDimension = VImageDimension>
   struct Rebind
     {
@@ -231,7 +231,6 @@ public:
 
   template <typename UPixelType, unsigned int NUImageDimension = VImageDimension>
     using RebindImageType = itk::GPUImage<UPixelType, NUImageDimension>;
-  //End add for: OpenCL memory error CL_OUT_OF_RESOURCES, Issue#70
 
 
 

--- a/Components/FixedImagePyramids/OpenCLFixedGenericPyramid/elxOpenCLFixedGenericPyramid.hxx
+++ b/Components/FixedImagePyramids/OpenCLFixedGenericPyramid/elxOpenCLFixedGenericPyramid.hxx
@@ -201,14 +201,10 @@ OpenCLFixedGenericPyramid< TElastix >
 
   if( computedUsingOpenCL )
   {
-    /* Try fixing the error encountered during fixing CL_OUT_OF_RESOURCE issue #70 
-     * Original GraftOutput() only grafts first output, and the output Image after 2nd level is not grafted. 
-     */
     // Graft output
-    for(int i=0 ; i< this->GetNumberOfLevels();i++){
-      this->GraftNthOutput(i, this->m_GPUPyramid->GetOutput(i) );
+    for( int i=0 ; i < this->GetNumberOfLevels() ; i++ ){
+      this->GraftNthOutput( i, this->m_GPUPyramid->GetOutput( i ) );
     }
-    // End try fixing the error encountered during fixing CL_OUT_OF_RESOURCE issue #70
 
     // Report OpenCL device to the log
     this->ReportToLog();

--- a/Components/FixedImagePyramids/OpenCLFixedGenericPyramid/elxOpenCLFixedGenericPyramid.hxx
+++ b/Components/FixedImagePyramids/OpenCLFixedGenericPyramid/elxOpenCLFixedGenericPyramid.hxx
@@ -201,8 +201,14 @@ OpenCLFixedGenericPyramid< TElastix >
 
   if( computedUsingOpenCL )
   {
+    /* Try fixing the error encountered during fixing CL_OUT_OF_RESOURCE issue #70 
+     * Original GraftOutput() only grafts first output, and the output Image after 2nd level is not grafted. 
+     */
     // Graft output
-    this->GraftOutput( this->m_GPUPyramid->GetOutput() );
+    for(int i=0 ; i< this->GetNumberOfLevels();i++){
+      this->GraftNthOutput(i, this->m_GPUPyramid->GetOutput(i) );
+    }
+    // End try fixing the error encountered during fixing CL_OUT_OF_RESOURCE issue #70
 
     // Report OpenCL device to the log
     this->ReportToLog();

--- a/Components/MovingImagePyramids/OpenCLMovingGenericPyramid/elxOpenCLMovingGenericPyramid.hxx
+++ b/Components/MovingImagePyramids/OpenCLMovingGenericPyramid/elxOpenCLMovingGenericPyramid.hxx
@@ -201,8 +201,14 @@ OpenCLMovingGenericPyramid< TElastix >
 
   if( computedUsingOpenCL )
   {
+    /* Try fixing the error encountered during fixing CL_OUT_OF_RESOURCE issue #70
+     * Original GraftOutput() only grafts first output, and the output Image after 2nd level is not grafted.
+     */
     // Graft output
-    this->GraftOutput( this->m_GPUPyramid->GetOutput() );
+    for(int i=0 ; i< this->GetNumberOfLevels();i++){
+      this->GraftNthOutput(i, this->m_GPUPyramid->GetOutput(i) );
+    }
+    // End try fixing the error encountered during fixing CL_OUT_OF_RESOURCE issue #70
 
     // Report OpenCL device to the log
     this->ReportToLog();

--- a/Components/MovingImagePyramids/OpenCLMovingGenericPyramid/elxOpenCLMovingGenericPyramid.hxx
+++ b/Components/MovingImagePyramids/OpenCLMovingGenericPyramid/elxOpenCLMovingGenericPyramid.hxx
@@ -201,14 +201,10 @@ OpenCLMovingGenericPyramid< TElastix >
 
   if( computedUsingOpenCL )
   {
-    /* Try fixing the error encountered during fixing CL_OUT_OF_RESOURCE issue #70
-     * Original GraftOutput() only grafts first output, and the output Image after 2nd level is not grafted.
-     */
     // Graft output
-    for(int i=0 ; i< this->GetNumberOfLevels();i++){
-      this->GraftNthOutput(i, this->m_GPUPyramid->GetOutput(i) );
+    for( int i=0 ; i < this->GetNumberOfLevels() ; i++ ){
+      this->GraftNthOutput( i, this->m_GPUPyramid->GetOutput( i ) );
     }
-    // End try fixing the error encountered during fixing CL_OUT_OF_RESOURCE issue #70
 
     // Report OpenCL device to the log
     this->ReportToLog();


### PR DESCRIPTION
In this PR, I tried to resolved issue #70 by adding GPUImage counterpart of template rebind and adding recursive grafting in OpenCL Pyramids.
Besides, an memory allocation limit is added to GPURecursiveGaussianImageFilter to reduce unnecessary large amount of GPU global memory allocation in the kernel.  
Detailed discussion is in #70. 