### PR TITLE
COMP: Use ITK 5.1.0 strongly typed enums in elxTransformBase

### DIFF
--- a/Common/OpenCL/ITKimprovements/itkOpenCLLogger.cxx
+++ b/Common/OpenCL/ITKimprovements/itkOpenCLLogger.cxx
@@ -111,7 +111,7 @@ OpenCLLogger::Initialize()
   }
 
   // Create an ITK Logger
-  LoggerBase::TimeStampFormatType timeStampFormat = LoggerBase::HUMANREADABLE;
+  LoggerBaseEnums::TimeStampFormat timeStampFormat = LoggerBaseEnums::TimeStampFormat::HUMANREADABLE;
   this->SetTimeStampFormat( timeStampFormat );
   const std::string humanReadableFormat = "%b %d %Y %H:%M:%S";
   this->SetHumanReadableFormat( humanReadableFormat );

--- a/Common/Transforms/itkAdvancedBSplineDeformableTransformBase.h
+++ b/Common/Transforms/itkAdvancedBSplineDeformableTransformBase.h
@@ -75,7 +75,7 @@ public:
     InputCovariantVectorType;
   typedef typename Superclass::OutputCovariantVectorType
     OutputCovariantVectorType;
-  typedef typename Superclass::TransformCategoryType TransformCategoryType;
+  typedef typename Superclass::TransformCategoryEnum TransformCategoryEnum;
 
   typedef typename Superclass
     ::NonZeroJacobianIndicesType NonZeroJacobianIndicesType;
@@ -267,9 +267,9 @@ public:
   /** Indicates the category transform.
    *  e.g. an affine transform, or a local one, e.g. a deformation field.
    */
-  TransformCategoryType GetTransformCategory( void ) const override
+  TransformCategoryEnum GetTransformCategory( void ) const override
   {
-    return Self::BSpline;
+    return TransformCategoryEnum::BSpline;
   }
 
 

--- a/Common/Transforms/itkAdvancedCombinationTransform.h
+++ b/Common/Transforms/itkAdvancedCombinationTransform.h
@@ -98,7 +98,7 @@ public:
   typedef typename Superclass::InternalMatrixType            InternalMatrixType;
   typedef typename Superclass::InverseTransformBaseType      InverseTransformBaseType;
   typedef typename Superclass::InverseTransformBasePointer   InverseTransformBasePointer;
-  typedef typename Superclass::TransformCategoryType         TransformCategoryType;
+  typedef typename Superclass::TransformCategoryEnum         TransformCategoryEnum;
   typedef typename Superclass::MovingImageGradientType       MovingImageGradientType;
   typedef typename Superclass::MovingImageGradientValueType  MovingImageGradientValueType;
 
@@ -231,7 +231,7 @@ public:
    * are linear, then return category Linear. Otherwise if all
    * transforms set to optimize are DisplacementFields, then
    * return DisplacementField category. */
-  TransformCategoryType GetTransformCategory() const override;
+  TransformCategoryEnum GetTransformCategory() const override;
 
   /** Whether the advanced transform has nonzero matrices. */
   bool GetHasNonZeroSpatialHessian( void ) const override;

--- a/Common/Transforms/itkAdvancedCombinationTransform.hxx
+++ b/Common/Transforms/itkAdvancedCombinationTransform.hxx
@@ -245,7 +245,7 @@ AdvancedCombinationTransform< TScalarType, NDimensions >
  */
 
 template< typename TScalarType, unsigned int NDimensions >
-typename AdvancedCombinationTransform< TScalarType, NDimensions >::TransformCategoryType
+typename AdvancedCombinationTransform< TScalarType, NDimensions >::TransformCategoryEnum
 AdvancedCombinationTransform< TScalarType, NDimensions >
 ::GetTransformCategory() const
 {
@@ -253,12 +253,12 @@ AdvancedCombinationTransform< TScalarType, NDimensions >
   const bool isLinearTransform = this->IsLinear();
   if( isLinearTransform )
   {
-    return Self::Linear;
+    return TransformCategoryEnum::Linear;
   }
 
   // It is unclear how you would prefer to define the rest of them,
   // lets just return Self::UnknownTransformCategory for now
-  return Self::UnknownTransformCategory;
+  return TransformCategoryEnum::UnknownTransformCategory;
 }
 
 

--- a/Common/Transforms/itkAdvancedIdentityTransform.h
+++ b/Common/Transforms/itkAdvancedIdentityTransform.h
@@ -98,7 +98,7 @@ public:
   /** Type of the input parameters. */
   typedef typename Superclass::ParametersType         ParametersType;
   typedef typename Superclass::NumberOfParametersType NumberOfParametersType;
-  typedef typename Superclass::TransformCategoryType  TransformCategoryType;
+  typedef typename Superclass::TransformCategoryEnum  TransformCategoryEnum;
 
   /** Type of the Jacobian matrix. */
   typedef typename Superclass::JacobianType JacobianType;
@@ -183,9 +183,9 @@ public:
   /** Indicates the category transform.
    *  e.g. an affine transform, or a local one, e.g. a deformation field.
    */
-  TransformCategoryType GetTransformCategory() const override
+  TransformCategoryEnum GetTransformCategory() const override
   {
-    return Self::Linear;
+    return TransformCategoryEnum::Linear;
   }
 
 

--- a/Common/Transforms/itkAdvancedMatrixOffsetTransformBase.h
+++ b/Common/Transforms/itkAdvancedMatrixOffsetTransformBase.h
@@ -135,7 +135,7 @@ public:
   typedef typename Superclass::OutputVnlVectorType   OutputVnlVectorType;
   typedef typename Superclass::InputPointType        InputPointType;
   typedef typename Superclass::OutputPointType       OutputPointType;
-  typedef typename Superclass::TransformCategoryType TransformCategoryType;
+  typedef typename Superclass::TransformCategoryEnum TransformCategoryEnum;
 
   typedef typename Superclass
     ::NonZeroJacobianIndicesType NonZeroJacobianIndicesType;
@@ -388,9 +388,9 @@ public:
   /** Indicates the category transform.
    *  e.g. an affine transform, or a local one, e.g. a deformation field.
    */
-  TransformCategoryType GetTransformCategory() const override
+  TransformCategoryEnum GetTransformCategory() const override
   {
-    return Self::Linear;
+    return TransformCategoryEnum::Linear;
   }
 
 

--- a/Common/Transforms/itkAdvancedTranslationTransform.h
+++ b/Common/Transforms/itkAdvancedTranslationTransform.h
@@ -81,7 +81,7 @@ public:
   typedef typename Superclass::ParametersType         ParametersType;
   typedef typename Superclass::FixedParametersType    FixedParametersType;
   typedef typename Superclass::NumberOfParametersType NumberOfParametersType;
-  typedef typename Superclass::TransformCategoryType  TransformCategoryType;
+  typedef typename Superclass::TransformCategoryEnum  TransformCategoryEnum;
 
   /** Standard Jacobian container. */
   typedef typename Superclass::JacobianType JacobianType;
@@ -233,9 +233,9 @@ public:
   /** Indicates the category transform.
    *  e.g. an affine transform, or a local one, e.g. a deformation field.
    */
-  TransformCategoryType GetTransformCategory() const override
+  TransformCategoryEnum GetTransformCategory() const override
   {
-    return Self::Linear;
+    return TransformCategoryEnum::Linear;
   }
 
 

--- a/Components/Optimizers/RegularStepGradientDescent/elxRegularStepGradientDescent.hxx
+++ b/Components/Optimizers/RegularStepGradientDescent/elxRegularStepGradientDescent.hxx
@@ -132,23 +132,23 @@ RegularStepGradientDescent< TElastix >
   switch( this->GetStopCondition() )
   {
 
-    case GradientMagnitudeTolerance:
+  case StopConditionEnum::GradientMagnitudeTolerance:
       stopcondition = "Minimum gradient magnitude has been reached";
       break;
 
-    case StepTooSmall:
+    case StopConditionEnum::StepTooSmall:
       stopcondition = "Minimum step size has been reached";
       break;
 
-    case MaximumNumberOfIterations:
+    case StopConditionEnum::MaximumNumberOfIterations:
       stopcondition = "Maximum number of iterations has been reached";
       break;
 
-    case ImageNotAvailable:
+    case StopConditionEnum::ImageNotAvailable:
       stopcondition = "No image available";
       break;
 
-    case CostFunctionError:
+    case StopConditionEnum::CostFunctionError:
       stopcondition = "Error in cost function";
       break;
 

--- a/Components/Optimizers/SimultaneousPerturbation/elxSimultaneousPerturbation.h
+++ b/Components/Optimizers/SimultaneousPerturbation/elxSimultaneousPerturbation.h
@@ -110,7 +110,6 @@ public:
   /** Typedef's inherited from Superclass1.*/
   typedef Superclass1::CostFunctionType    CostFunctionType;
   typedef Superclass1::CostFunctionPointer CostFunctionPointer;
-  typedef Superclass1::StopConditionType   StopConditionType;
 
   /** Typedef's inherited from Elastix.*/
   typedef typename Superclass2::ElastixType          ElastixType;

--- a/Components/Optimizers/SimultaneousPerturbation/elxSimultaneousPerturbation.hxx
+++ b/Components/Optimizers/SimultaneousPerturbation/elxSimultaneousPerturbation.hxx
@@ -176,11 +176,11 @@ SimultaneousPerturbation< TElastix >
   switch( this->GetStopCondition() )
   {
 
-    case MaximumNumberOfIterations:
+    case StopConditionSPSAOptimizerEnum::MaximumNumberOfIterations:
       stopcondition = "Maximum number of iterations has been reached";
       break;
 
-    case MetricError:
+    case StopConditionSPSAOptimizerEnum::MetricError:
       stopcondition = "Error in metric";
       break;
 

--- a/Core/ComponentBaseClasses/elxTransformBase.hxx
+++ b/Core/ComponentBaseClasses/elxTransformBase.hxx
@@ -37,6 +37,7 @@
 #include "itkMeshFileReader.h"
 #include "itkMeshFileWriter.h"
 #include "itkTransformMeshFilter.h"
+#include "itkCommonEnums.h"
 
 namespace itk
 {
@@ -72,7 +73,7 @@ public:
   void Execute( Object * caller, const EventObject & ) override
   {
     CallerType * castcaller = dynamic_cast< CallerType * >( caller );
-    castcaller->GetModifiableImageIO()->SetPixelType( ImageIOBase::VECTOR );
+    castcaller->GetModifiableImageIO()->SetPixelType( CommonEnums::IOPixel::VECTOR );
   }
 
 
@@ -80,7 +81,7 @@ public:
   {
     CallerType * castcaller = const_cast< CallerType * >(
       dynamic_cast< const CallerType * >( caller ) );
-    castcaller->GetModifiableImageIO()->SetPixelType( ImageIOBase::VECTOR );
+    castcaller->GetModifiableImageIO()->SetPixelType( CommonEnums::IOPixel::VECTOR );
   }
 
 

--- a/Testing/CI/Azure/ci.yml
+++ b/Testing/CI/Azure/ci.yml
@@ -1,5 +1,5 @@
 variables:
-  ITKv5_VERSION: v5.0.1
+  ITKv5_VERSION: v5.1.0
   ITK_SOURCE_DIR: $(Agent.BuildDirectory)/ITK-source
   ITK_BINARY_DIR: $(Agent.BuildDirectory)/ITK-build
   ELASTIX_SOURCE_DIR: $(Build.Repository.LocalPath)


### PR DESCRIPTION
To address:

In file included from _deps/elastix_fetch-src/Core/ComponentBaseClasses/elxTransformBase.h:384:0,
                 from _deps/elastix_fetch-src/Core/Kernel/elxElastixTemplate.h:39,
                 from _deps/elastix_fetch-src/Core/Install/elxIncludes.h:39,
                 from _deps/elastix_fetch-src/Components/FixedImagePyramids/FixedRecursivePyramid/elxFixedRecursivePyramid.h:21,
                 from _deps/elastix_fetch-src/Components/FixedImagePyramids/FixedRecursivePyramid/elxFixedRecursivePyramid.cxx:19:
_deps/elastix_fetch-src/Core/ComponentBaseClasses/elxTransformBase.hxx: In member function ‘void itk::PixelTypeChangeCommand<T>::Execute(itk::Object*, const itk::EventObject&)’:
_deps/elastix_fetch-src/Core/ComponentBaseClasses/elxTransformBase.hxx:75:55: error: ‘VECTOR’ is not a member of ‘itk::ImageIOBase’
     castcaller->GetModifiableImageIO()->SetPixelType( ImageIOBase::VECTOR );
                                                       ^
_deps/elastix_fetch-src/Core/ComponentBaseClasses/elxTransformBase.hxx: In member function ‘void itk::PixelTypeChangeCommand<T>::Execute(const itk::Object*, const itk::EventObject&)’:
_deps/elastix_fetch-src/Core/ComponentBaseClasses/elxTransformBase.hxx:83:55: error: ‘VECTOR’ is not a member of ‘itk::ImageIOBase’
     castcaller->GetModifiableImageIO()->SetPixelType( ImageIOBase::VECTOR );