### PR TITLE
COMP: elastix.h localTimeValue initialization

### DIFF
--- a/Core/Main/elastix.h
+++ b/Core/Main/elastix.h
@@ -96,7 +96,7 @@ GetCurrentDateAndTime( void )
 
   // Make a copy of the internal object from std::localtime, to reduce the
   // risk of a race condition.
-  const std::tm localTimeValue{ *localTimePtr };
+  const std::tm localTimeValue( *localTimePtr );
 
   constexpr std::size_t maxNumberOfChars{ 32 };
   char timeAsString[maxNumberOfChars]{};


### PR DESCRIPTION
To address:

_deps/elastix_fetch-src/Core/Main/elastix.h: In function ‘std::string
GetCurrentDateAndTime()’:
_deps/elastix_fetch-src/Core/Main/elastix.h:99:47: error: cannot convert
‘const tm’ to ‘int’ in initialization
   const std::tm localTimeValue{ *localTimePtr };

with GCC 4.8.