### PR TITLE
COMP: itkOpenCLLogger ITK 5.1 TimeStampFormat typed enum

### DIFF
--- a/Common/OpenCL/ITKimprovements/itkOpenCLLogger.cxx
+++ b/Common/OpenCL/ITKimprovements/itkOpenCLLogger.cxx
@@ -111,7 +111,7 @@ OpenCLLogger::Initialize()
   }
 
   // Create an ITK Logger
-  LoggerBase::TimeStampFormatType timeStampFormat = LoggerBase::HUMANREADABLE;
+  LoggerBaseEnums::TimeStampFormat timeStampFormat = LoggerBaseEnums::TimeStampFormat::HUMANREADABLE;
   this->SetTimeStampFormat( timeStampFormat );
   const std::string humanReadableFormat = "%b %d %Y %H:%M:%S";
   this->SetHumanReadableFormat( humanReadableFormat );


### PR DESCRIPTION
To address:

/home/matt/src/elastix/Common/OpenCL/ITKimprovements/itkOpenCLLogger.cxx:114:15:
error: no type named 'TimeStampFormatType' in 'itk::LoggerBase'; did you
mean 'TimeStampFormatEnum'?
  LoggerBase::TimeStampFormatType timeStampFormat =
  LoggerBase::HUMANREADABLE;
    ~~~~~~~~~~~~^~~~~~~~~~~~~~~~~~~
                  TimeStampFormatEnum
                  /home/matt/src/ITK/Modules/Core/Common/include/itkLoggerBase.h:110:9:
                  note: 'TimeStampFormatEnum' declared here
                    using TimeStampFormatEnum =
                    LoggerBaseEnums::TimeStampFormat;