### PR TITLE
ENH: Replace InitializeElastixLibrary() by InitializeElastixExecutable()

### DIFF
--- a/Core/Install/elxBaseComponent.cxx
+++ b/Core/Install/elxBaseComponent.cxx
@@ -22,9 +22,9 @@
 
 namespace
 {
-bool IsElastixLibrary(const bool initialValue = false)
+bool IsElastixLibrary(const bool initialValue = true)
 {
-  // By default, assume that this is not the elastix library.
+  // By default, assume that this is the elastix library (not the elastix executable).
 
   // Note that the initialization of this static variable is thread-safe,
   // as supported by C++11 "magic statics".
@@ -77,9 +77,9 @@ bool BaseComponent::IsElastixLibrary()
   return ::IsElastixLibrary();
 }
 
-void BaseComponent::InitializeElastixLibrary()
+void BaseComponent::InitializeElastixExecutable()
 {
-  ::IsElastixLibrary(true);
+  ::IsElastixLibrary(false);
 }
 
 /**

--- a/Core/Install/elxBaseComponent.h
+++ b/Core/Install/elxBaseComponent.h
@@ -124,7 +124,7 @@ public:
 
   static bool IsElastixLibrary();
 
-  static void InitializeElastixLibrary();
+  static void InitializeElastixExecutable();
 
   /** Convenience function to convert seconds to day, hour, minute, second format. */
   std::string ConvertSecondsToDHMS( const double totalSeconds, const unsigned int precision ) const;

--- a/Core/Main/elastix.cxx
+++ b/Core/Main/elastix.cxx
@@ -38,6 +38,8 @@
 int
 main( int argc, char ** argv )
 {
+  elastix::BaseComponent::InitializeElastixExecutable();
+  assert( ! elastix::BaseComponent::IsElastixLibrary() );
 
   /** Check if "--help" or "--version" was asked for. */
   if( argc == 1 )

--- a/Core/Main/elastixlib.cxx
+++ b/Core/Main/elastixlib.cxx
@@ -48,7 +48,6 @@ namespace elastix
 
 ELASTIX::ELASTIX()
 {
-  BaseComponent::InitializeElastixLibrary();
   assert(BaseComponent::IsElastixLibrary());
 }
 

--- a/Core/Main/transformix.cxx
+++ b/Core/Main/transformix.cxx
@@ -31,6 +31,9 @@
 int
 main( int argc, char ** argv )
 {
+  elastix::BaseComponent::InitializeElastixExecutable();
+  assert(!elastix::BaseComponent::IsElastixLibrary());
+
   /** Check if "-help" or "--version" was asked for.*/
   if( argc == 1 )
   {


### PR DESCRIPTION
Kasper Marstal reported yesterday via direct messaging that the introduction of `IsElastixLibrary()`, pull request #231, commit 64ced5942604b055e3a11ee235af186811bf11dc (March 2, 2020, "Replace _ELASTIX_BUILD_LIBRARY by BaseComponent::IsElastixLibrary"), did break SimpleElastix.  SimpleElastix depends on the library interface, while it does not construct an `elastix::ELASTIX` library object.

The most elegant and reliable fix appears to be flipping the default value returned by `IsElastixLibrary()`, from `false` to `true`, and then ensuring that the value is set to `false` at the start of each run of the executable.