### PR TITLE
COMP: Allow build lib.cxx files w/ ITK_FUTURE_LEGACY_REMOVE (issue #85)

### DIFF
--- a/Core/Main/elastixlib.cxx
+++ b/Core/Main/elastixlib.cxx
@@ -294,12 +294,12 @@ ELASTIX::RegisterImages(
     /** Get the transform, the fixedImage and the movingImage
      * in order to put it in the (possibly) next registration.
      */
-    transform                   = elastixMain->GetFinalTransform();
-    fixedImageContainer         = elastixMain->GetFixedImageContainer();
-    movingImageContainer        = elastixMain->GetMovingImageContainer();
-    fixedMaskContainer          = elastixMain->GetFixedMaskContainer();
-    movingMaskContainer         = elastixMain->GetMovingMaskContainer();
-    resultImageContainer        = elastixMain->GetResultImageContainer();
+    transform                   = elastixMain->GetModifiableFinalTransform();
+    fixedImageContainer         = elastixMain->GetModifiableFixedImageContainer();
+    movingImageContainer        = elastixMain->GetModifiableMovingImageContainer();
+    fixedMaskContainer          = elastixMain->GetModifiableFixedMaskContainer();
+    movingMaskContainer         = elastixMain->GetModifiableMovingMaskContainer();
+    resultImageContainer        = elastixMain->GetModifiableResultImageContainer();
     fixedImageOriginalDirection = elastixMain->GetOriginalFixedImageDirectionFlat();
 
     /** Stop timer and print it. */

--- a/Core/Main/transformixlib.cxx
+++ b/Core/Main/transformixlib.cxx
@@ -213,7 +213,7 @@ TRANSFORMIX::TransformImage(
   }
 
   /** Get the result image */
-  resultImageContainer = transformix->GetResultImageContainer();
+  resultImageContainer = transformix->GetModifiableResultImageContainer();
 
   /** Stop timer and print it. */
   totaltimer.Stop();


### PR DESCRIPTION
Replaced calls to "Get" member functions by the corresponding "GetModifiable" member functions.

Follow-up to commit aa4bb6518441be05e8ac787bb635838d7a8d40dd, January 11 2019, COMP: Allow building with ITK_FUTURE_LEGACY_REMOVE=ON, fixing issue #85

Related to elastix issue #85: "Build with ITK_FUTURE_LEGACY_REMOVE=ON", from Dženan Zukić (@dzenanz).