### PR TITLE
STYLE: Remove Superclass::TransformCategoryType (ITK legacy)

### DIFF
--- a/Common/Transforms/itkAdvancedBSplineDeformableTransformBase.h
+++ b/Common/Transforms/itkAdvancedBSplineDeformableTransformBase.h
@@ -75,7 +75,6 @@ public:
     InputCovariantVectorType;
   typedef typename Superclass::OutputCovariantVectorType
     OutputCovariantVectorType;
-  typedef typename Superclass::TransformCategoryType TransformCategoryType;
 
   typedef typename Superclass
     ::NonZeroJacobianIndicesType NonZeroJacobianIndicesType;

--- a/Common/Transforms/itkAdvancedCombinationTransform.h
+++ b/Common/Transforms/itkAdvancedCombinationTransform.h
@@ -98,7 +98,6 @@ public:
   typedef typename Superclass::InternalMatrixType            InternalMatrixType;
   typedef typename Superclass::InverseTransformBaseType      InverseTransformBaseType;
   typedef typename Superclass::InverseTransformBasePointer   InverseTransformBasePointer;
-  typedef typename Superclass::TransformCategoryType         TransformCategoryType;
   typedef typename Superclass::MovingImageGradientType       MovingImageGradientType;
   typedef typename Superclass::MovingImageGradientValueType  MovingImageGradientValueType;
 

--- a/Common/Transforms/itkAdvancedIdentityTransform.h
+++ b/Common/Transforms/itkAdvancedIdentityTransform.h
@@ -98,7 +98,6 @@ public:
   /** Type of the input parameters. */
   typedef typename Superclass::ParametersType         ParametersType;
   typedef typename Superclass::NumberOfParametersType NumberOfParametersType;
-  typedef typename Superclass::TransformCategoryType  TransformCategoryType;
 
   /** Type of the Jacobian matrix. */
   typedef typename Superclass::JacobianType JacobianType;

--- a/Common/Transforms/itkAdvancedMatrixOffsetTransformBase.h
+++ b/Common/Transforms/itkAdvancedMatrixOffsetTransformBase.h
@@ -135,7 +135,6 @@ public:
   typedef typename Superclass::OutputVnlVectorType   OutputVnlVectorType;
   typedef typename Superclass::InputPointType        InputPointType;
   typedef typename Superclass::OutputPointType       OutputPointType;
-  typedef typename Superclass::TransformCategoryType TransformCategoryType;
 
   typedef typename Superclass
     ::NonZeroJacobianIndicesType NonZeroJacobianIndicesType;

--- a/Common/Transforms/itkAdvancedTranslationTransform.h
+++ b/Common/Transforms/itkAdvancedTranslationTransform.h
@@ -81,7 +81,6 @@ public:
   typedef typename Superclass::ParametersType         ParametersType;
   typedef typename Superclass::FixedParametersType    FixedParametersType;
   typedef typename Superclass::NumberOfParametersType NumberOfParametersType;
-  typedef typename Superclass::TransformCategoryType  TransformCategoryType;
 
   /** Standard Jacobian container. */
   typedef typename Superclass::JacobianType JacobianType;


### PR DESCRIPTION
ITK's `TransformBaseTemplate::TransformCategoryType` was removed with commit https://github.com/InsightSoftwareConsortium/ITK/commit/33daf9494eb93940c4646f9e9a83e8e24a9bf376 "ENH: Consistent use of typed enums, naming", by Matt McCormick, Dec 6, 2019.

It was then defined "legacy" with commit https://github.com/InsightSoftwareConsortium/ITK/commit/0775d4a616a56f024ca40f849076c513981dc27e "COMP: expose TransformCategoryType under LEGACY", by Dženan Zukić, Jan 7, 2020.

This commit aims to pave the way for `ITK_LEGACY_REMOVE`, as in pull request https://github.com/SuperElastix/elastix/pull/245 by Matt McCormick.