### PR TITLE
DOC: Fix "AdvancedMeanSquares" parameter name

### DIFF
--- a/dox/manual/manual.tex
+++ b/dox/manual/manual.tex
@@ -2287,7 +2287,7 @@ is selected in the parameter file with:
 (FixedImagePyramid "FixedSmoothingImagePyramid" "FixedSmoothingImagePyramid" ...)
 (MovingImagePyramid "MovingSmoothingImagePyramid" "MovingSmoothingImagePyramid" ... )
 (Interpolator "BSplineInterpolator" "BSplineInterpolator" ...)
-(Metric "AdvancedMattesMutualInformation" "AdvancedMeanSquareDifference" ...)
+(Metric "AdvancedMattesMutualInformation" "AdvancedMeanSquares" ...)
 (ImageSampler "RandomCoordinate" "RandomCoordinate" ...)
 
 (Metric0Weight 0.125)


### PR DESCRIPTION
The parameter name in the manual was not according to the implementation of elastix. Issue encountered by @ViktorvdValk