### PR TITLE
STYLE: Remove include guards from *.cxx files

### DIFF
--- a/Core/Configuration/elxConfiguration.cxx
+++ b/Core/Configuration/elxConfiguration.cxx
@@ -15,8 +15,6 @@
  *  limitations under the License.
  *
  *=========================================================================*/
-#ifndef __elxConfiguration_CXX__
-#define __elxConfiguration_CXX__
 
 #include "elxConfiguration.h"
 
@@ -266,5 +264,3 @@ Configuration
 
 
 } // end namespace elastix
-
-#endif // end #ifndef __elxMyConfiguration_CXX__

--- a/Core/Main/transformixlib.cxx
+++ b/Core/Main/transformixlib.cxx
@@ -15,8 +15,6 @@
  *  limitations under the License.
  *
  *=========================================================================*/
-#ifndef __transformixlib_CXX_
-#define __transformixlib_CXX_
 
 #include "transformixlib.h"
 #include "elastix.h" // For ConvertSecondsToDHMS and GetCurrentDateAndTime.
@@ -252,5 +250,3 @@ TRANSFORMIX::TransformImage(
 } // end TransformImage()
 
 } // namespace transformix
-
-#endif // end #ifndef __transformixlib_CXX_


### PR DESCRIPTION
Include guards are only useful for files that are included by `#include`. (In practice: *.h and *.hxx files)