### PR TITLE
COMP: Apply Clang Tidy-Fix modernize-use-override to Common/OpenCL

### DIFF
--- a/Common/OpenCL/Factories/itkGPUObjectFactoryBase.h
+++ b/Common/OpenCL/Factories/itkGPUObjectFactoryBase.h
@@ -47,7 +47,7 @@ public:
   typedef SmartPointer< const Self > ConstPointer;
 
   /** Class methods used to interface with the registered factories. */
-  virtual const char * GetITKSourceVersion() const { return ITK_SOURCE_VERSION; }
+  const char * GetITKSourceVersion() const override { return ITK_SOURCE_VERSION; }
 
   /** Run-time type information (and related methods). */
   itkTypeMacro( GPUObjectFactoryBase, ObjectFactoryBase );
@@ -64,7 +64,7 @@ public:
 protected:
 
   GPUObjectFactoryBase() {}
-  virtual ~GPUObjectFactoryBase() {}
+  ~GPUObjectFactoryBase() override {}
 
   /** Register methods for 1D. */
   virtual void Register1D() {}

--- a/Common/OpenCL/Filters/itkGPUAdvancedBSplineDeformableTransform.h
+++ b/Common/OpenCL/Filters/itkGPUAdvancedBSplineDeformableTransform.h
@@ -71,7 +71,7 @@ protected:
   GPUAdvancedBSplineDeformableTransform();
   virtual ~GPUAdvancedBSplineDeformableTransform() {}
 
-  virtual void PrintSelf( std::ostream & os, Indent indent ) const override;
+  void PrintSelf( std::ostream & os, Indent indent ) const override;
 
   void CopyCoefficientImagesToGPU( void );
 

--- a/Common/OpenCL/Filters/itkGPUAdvancedCombinationTransformCopier.h
+++ b/Common/OpenCL/Filters/itkGPUAdvancedCombinationTransformCopier.h
@@ -145,8 +145,8 @@ public:
 protected:
 
   GPUAdvancedCombinationTransformCopier();
-  virtual ~GPUAdvancedCombinationTransformCopier() {}
-  virtual void PrintSelf( std::ostream & os, Indent indent ) const override;
+  ~GPUAdvancedCombinationTransformCopier() override {}
+  void PrintSelf( std::ostream & os, Indent indent ) const override;
 
   /** Method to copy the transforms parameters. */
   bool CopyToCurrentTransform(

--- a/Common/OpenCL/Filters/itkGPUBSplineBaseTransform.h
+++ b/Common/OpenCL/Filters/itkGPUBSplineBaseTransform.h
@@ -64,7 +64,7 @@ public:
   typedef FixedArray< GPUDataManagerPointer, NDimensions >      GPUCoefficientImageBaseArray;
 
   /** Returns true, the transform is BSpline transform. */
-  virtual bool IsBSplineTransform( void ) const { return true; }
+  bool IsBSplineTransform( void ) const override { return true; }
 
   /** Get the GPU array of coefficient images. */
   const GPUCoefficientImageArray GetGPUCoefficientImages( void ) const;
@@ -83,11 +83,11 @@ protected:
   virtual void SetSplineOrder( const unsigned int splineOrder );
 
   GPUBSplineBaseTransform();
-  virtual ~GPUBSplineBaseTransform() {}
+  ~GPUBSplineBaseTransform() override {}
 
   /** Returns OpenCL \a source code for the transform.
    * Returns true if source code was combined, false otherwise. */
-  virtual bool GetSourceCode( std::string & source ) const override;
+  bool GetSourceCode( std::string & source ) const override;
 
   GPUCoefficientImageArray     m_GPUBSplineTransformCoefficientImages;
   GPUCoefficientImageBaseArray m_GPUBSplineTransformCoefficientImagesBase;

--- a/Common/OpenCL/Filters/itkGPUBSplineDecompositionImageFilter.h
+++ b/Common/OpenCL/Filters/itkGPUBSplineDecompositionImageFilter.h
@@ -81,7 +81,7 @@ protected:
 
   GPUBSplineDecompositionImageFilter();
   ~GPUBSplineDecompositionImageFilter(){}
-  virtual void PrintSelf( std::ostream & os, Indent indent ) const override;
+  void PrintSelf( std::ostream & os, Indent indent ) const override;
 
   virtual void GPUGenerateData( void );
 

--- a/Common/OpenCL/Filters/itkGPUBSplineInterpolateImageFunction.h
+++ b/Common/OpenCL/Filters/itkGPUBSplineInterpolateImageFunction.h
@@ -88,11 +88,11 @@ protected:
 
   GPUBSplineInterpolateImageFunction();
   ~GPUBSplineInterpolateImageFunction() {}
-  virtual void PrintSelf( std::ostream & os, Indent indent ) const override;
+  void PrintSelf( std::ostream & os, Indent indent ) const override;
 
   /** Returns OpenCL \a source code for the transform.
    * Returns true if source code was combined, false otherwise. */
-  virtual bool GetSourceCode( std::string & source ) const override;
+  bool GetSourceCode( std::string & source ) const override;
 
 private:
 

--- a/Common/OpenCL/Filters/itkGPUBSplineTransform.h
+++ b/Common/OpenCL/Filters/itkGPUBSplineTransform.h
@@ -71,7 +71,7 @@ protected:
   GPUBSplineTransform();
   virtual ~GPUBSplineTransform() {}
 
-  virtual void PrintSelf( std::ostream & os, Indent indent ) const override;
+  void PrintSelf( std::ostream & os, Indent indent ) const override;
 
   void CopyCoefficientImagesToGPU();
 

--- a/Common/OpenCL/Filters/itkGPUCastImageFilter.h
+++ b/Common/OpenCL/Filters/itkGPUCastImageFilter.h
@@ -50,12 +50,12 @@ public:
 
   GPUCast() {}
 
-  ~GPUCast() {}
+  ~GPUCast() override {}
 
   /** Setup GPU kernel arguments for this functor.
    * Returns current argument index to set additional arguments in the GPU kernel.
    */
-  int SetGPUKernelArguments( OpenCLKernelManager::Pointer KernelManager, int KernelHandle )
+  int SetGPUKernelArguments( OpenCLKernelManager::Pointer KernelManager, int KernelHandle ) override
   {
     return 0;
   }

--- a/Common/OpenCL/Filters/itkGPUCompositeTransformBase.h
+++ b/Common/OpenCL/Filters/itkGPUCompositeTransformBase.h
@@ -97,15 +97,15 @@ public:
 protected:
 
   GPUCompositeTransformBase() {}
-  virtual ~GPUCompositeTransformBase() {}
+  ~GPUCompositeTransformBase() override {}
 
   /** Returns OpenCL \a source code for the transform.
    * Returns true if source code was combined, false otherwise. */
-  virtual bool GetSourceCode( std::string & source ) const override;
+  bool GetSourceCode( std::string & source ) const override;
 
   /** Returns data manager that stores all settings for the transform \a index.
    * Used by combination transforms. */
-  virtual GPUDataManager::Pointer GetParametersDataManager( const std::size_t index ) const override;
+  GPUDataManager::Pointer GetParametersDataManager( const std::size_t index ) const override;
 
 private:
 

--- a/Common/OpenCL/Filters/itkGPUIdentityTransform.h
+++ b/Common/OpenCL/Filters/itkGPUIdentityTransform.h
@@ -60,17 +60,17 @@ public:
 
   /** Returns true if the derived transform is identity transform,
    * false otherwise. */
-  virtual bool IsIdentityTransform( void ) const { return true; }
+  bool IsIdentityTransform( void ) const override { return true; }
 
 protected:
 
   GPUIdentityTransform();
-  virtual ~GPUIdentityTransform() {}
-  virtual void PrintSelf( std::ostream & os, Indent indent ) const override;
+  ~GPUIdentityTransform() override {}
+  void PrintSelf( std::ostream & os, Indent indent ) const override;
 
   /** Returns OpenCL \a source code for the transform.
    * Returns true if source code was combined, false otherwise. */
-  virtual bool GetSourceCode( std::string & source ) const override;
+  bool GetSourceCode( std::string & source ) const override;
 
 private:
 

--- a/Common/OpenCL/Filters/itkGPUInterpolateImageFunction.h
+++ b/Common/OpenCL/Filters/itkGPUInterpolateImageFunction.h
@@ -63,11 +63,11 @@ public:
 protected:
 
   GPUInterpolateImageFunction();
-  ~GPUInterpolateImageFunction() {}
-  virtual void PrintSelf( std::ostream & os, Indent indent ) const override;
+  ~GPUInterpolateImageFunction() override {}
+  void PrintSelf( std::ostream & os, Indent indent ) const override;
 
   /** Returns data manager that stores all settings for the transform. */
-  virtual GPUDataManager::Pointer GetParametersDataManager( void ) const override;
+  GPUDataManager::Pointer GetParametersDataManager( void ) const override;
 
 private:
 

--- a/Common/OpenCL/Filters/itkGPUInterpolatorCopier.h
+++ b/Common/OpenCL/Filters/itkGPUInterpolatorCopier.h
@@ -133,8 +133,8 @@ public:
 protected:
 
   GPUInterpolatorCopier();
-  virtual ~GPUInterpolatorCopier() {}
-  virtual void PrintSelf( std::ostream & os, Indent indent ) const override;
+  ~GPUInterpolatorCopier() override {}
+  void PrintSelf( std::ostream & os, Indent indent ) const override;
 
 private:
 

--- a/Common/OpenCL/Filters/itkGPULinearInterpolateImageFunction.h
+++ b/Common/OpenCL/Filters/itkGPULinearInterpolateImageFunction.h
@@ -64,11 +64,11 @@ protected:
 
   GPULinearInterpolateImageFunction();
   ~GPULinearInterpolateImageFunction() {}
-  virtual void PrintSelf( std::ostream & os, Indent indent ) const override;
+  void PrintSelf( std::ostream & os, Indent indent ) const override;
 
   /** Returns OpenCL \a source code for the transform.
    * Returns true if source code was combined, false otherwise. */
-  virtual bool GetSourceCode( std::string & source ) const override;
+  bool GetSourceCode( std::string & source ) const override;
 
 private:
 

--- a/Common/OpenCL/Filters/itkGPUMatrixOffsetTransformBase.h
+++ b/Common/OpenCL/Filters/itkGPUMatrixOffsetTransformBase.h
@@ -54,7 +54,7 @@ public:
   itkTypeMacro( GPUMatrixOffsetTransformBase, GPUSuperclass );
 
   /**  */
-  virtual bool IsMatrixOffsetTransform( void ) const { return true; }
+  bool IsMatrixOffsetTransform( void ) const override { return true; }
 
   /** Type of the scalar representing coordinate and vector elements. */
   typedef TScalarType ScalarType;
@@ -84,14 +84,14 @@ public:
 protected:
 
   GPUMatrixOffsetTransformBase();
-  virtual ~GPUMatrixOffsetTransformBase() {}
+  ~GPUMatrixOffsetTransformBase() override {}
 
   /** Returns OpenCL \a source code for the transform.
    * Returns true if source code was combined, false otherwise. */
-  virtual bool GetSourceCode( std::string & source ) const override;
+  bool GetSourceCode( std::string & source ) const override;
 
   /** Returns data manager that stores all settings for the transform. */
-  virtual GPUDataManager::Pointer GetParametersDataManager( void ) const override;
+  GPUDataManager::Pointer GetParametersDataManager( void ) const override;
 
 private:
 

--- a/Common/OpenCL/Filters/itkGPUNearestNeighborInterpolateImageFunction.h
+++ b/Common/OpenCL/Filters/itkGPUNearestNeighborInterpolateImageFunction.h
@@ -64,11 +64,11 @@ protected:
 
   GPUNearestNeighborInterpolateImageFunction();
   ~GPUNearestNeighborInterpolateImageFunction() {}
-  virtual void PrintSelf( std::ostream & os, Indent indent ) const override;
+  void PrintSelf( std::ostream & os, Indent indent ) const override;
 
   /** Returns OpenCL \a source code for the transform.
    * Returns true if source code was combined, false otherwise. */
-  virtual bool GetSourceCode( std::string & source ) const override;
+  bool GetSourceCode( std::string & source ) const override;
 
 private:
 

--- a/Common/OpenCL/Filters/itkGPURecursiveGaussianImageFilter.h
+++ b/Common/OpenCL/Filters/itkGPURecursiveGaussianImageFilter.h
@@ -81,7 +81,7 @@ protected:
   GPURecursiveGaussianImageFilter();
   ~GPURecursiveGaussianImageFilter(){}
 
-  virtual void PrintSelf( std::ostream & os, Indent indent ) const override;
+  void PrintSelf( std::ostream & os, Indent indent ) const override;
 
   virtual void GPUGenerateData();
 

--- a/Common/OpenCL/Filters/itkGPUResampleImageFilter.h
+++ b/Common/OpenCL/Filters/itkGPUResampleImageFilter.h
@@ -124,7 +124,7 @@ protected:
 
   GPUResampleImageFilter();
   ~GPUResampleImageFilter() {}
-  virtual void PrintSelf( std::ostream & os, Indent indent ) const override;
+  void PrintSelf( std::ostream & os, Indent indent ) const override;
 
   virtual void GPUGenerateData( void );
 

--- a/Common/OpenCL/Filters/itkGPUShrinkImageFilter.h
+++ b/Common/OpenCL/Filters/itkGPUShrinkImageFilter.h
@@ -86,7 +86,7 @@ protected:
 
   GPUShrinkImageFilter();
   ~GPUShrinkImageFilter(){}
-  virtual void PrintSelf( std::ostream & os, Indent indent ) const override;
+  void PrintSelf( std::ostream & os, Indent indent ) const override;
 
   virtual void GPUGenerateData();
 

--- a/Common/OpenCL/Filters/itkGPUTransformCopier.h
+++ b/Common/OpenCL/Filters/itkGPUTransformCopier.h
@@ -125,8 +125,8 @@ public:
 protected:
 
   GPUTransformCopier();
-  virtual ~GPUTransformCopier() {}
-  virtual void PrintSelf( std::ostream & os, Indent indent ) const override;
+  ~GPUTransformCopier() override {}
+  void PrintSelf( std::ostream & os, Indent indent ) const override;
 
   /** Method to copy the transforms parameters. */
   bool CopyTransform(

--- a/Common/OpenCL/Filters/itkGPUTranslationTransformBase.h
+++ b/Common/OpenCL/Filters/itkGPUTranslationTransformBase.h
@@ -51,7 +51,7 @@ public:
   itkTypeMacro( GPUTranslationTransformBase, GPUSuperclass );
 
   /** Returns true, the transform is translation transform. */
-  virtual bool IsTranslationTransform( void ) const { return true; }
+  bool IsTranslationTransform( void ) const override { return true; }
 
   /** Type of the scalar representing coordinate and vector elements. */
   typedef TScalarType ScalarType;
@@ -69,14 +69,14 @@ public:
 protected:
 
   GPUTranslationTransformBase();
-  virtual ~GPUTranslationTransformBase() {}
+  ~GPUTranslationTransformBase() override {}
 
   /** Returns OpenCL \a source code for the transform.
    * Returns true if source code was combined, false otherwise. */
-  virtual bool GetSourceCode( std::string & source ) const override;
+  bool GetSourceCode( std::string & source ) const override;
 
   /** Returns data manager that stores all settings for the transform. */
-  virtual GPUDataManager::Pointer GetParametersDataManager( void ) const override;
+  GPUDataManager::Pointer GetParametersDataManager( void ) const override;
 
 private:
 

--- a/Common/OpenCL/ITKimprovements/itkGPUDataManager.h
+++ b/Common/OpenCL/ITKimprovements/itkGPUDataManager.h
@@ -150,8 +150,8 @@ public:
 protected:
 
   GPUDataManager();
-  virtual ~GPUDataManager();
-  virtual void PrintSelf( std::ostream & os, Indent indent ) const;
+  ~GPUDataManager() override;
+  void PrintSelf( std::ostream & os, Indent indent ) const override;
 
 protected:
 

--- a/Common/OpenCL/ITKimprovements/itkGPUImage.h
+++ b/Common/OpenCL/ITKimprovements/itkGPUImage.h
@@ -96,7 +96,7 @@ public:
   typedef NeighborhoodAccessorFunctor< Self > NeighborhoodAccessorFunctorType;
 
   /** Allocate CPU and GPU memory space */
-  virtual void Allocate( bool initialize = false ) override;
+  void Allocate( bool initialize = false ) override;
 
   void AllocateGPU( void );
 

--- a/Common/OpenCL/ITKimprovements/itkGPUImageDataManager.h
+++ b/Common/OpenCL/ITKimprovements/itkGPUImageDataManager.h
@@ -82,10 +82,10 @@ public:
   void SetImagePointer( typename ImageType::Pointer img );
 
   /** actual GPU->CPU memory copy takes place here */
-  virtual void UpdateCPUBuffer();
+  void UpdateCPUBuffer() override;
 
   /** actual CPU->GPU memory copy takes place here */
-  virtual void UpdateGPUBuffer();
+  void UpdateGPUBuffer() override;
 
   /** Grafting GPU Image Data */
   virtual void Graft( const GPUImageDataManager * data );
@@ -93,7 +93,7 @@ public:
 protected:
 
   GPUImageDataManager() { m_Image = nullptr; }
-  virtual ~GPUImageDataManager() {}
+  ~GPUImageDataManager() override {}
 
 private:
 

--- a/Common/OpenCL/ITKimprovements/itkOpenCLContext.h
+++ b/Common/OpenCL/ITKimprovements/itkOpenCLContext.h
@@ -444,7 +444,7 @@ protected:
 
   /** Destroys this OpenCL context object. If the underlying
    * GetContextId() has been created, then it will be released. */
-  virtual ~OpenCLContext();
+  ~OpenCLContext() override;
 
   /** \internal
    * This method is only used when CMake OpenCL profiling is enabled. */

--- a/Common/OpenCL/ITKimprovements/itkOpenCLKernelManager.h
+++ b/Common/OpenCL/ITKimprovements/itkOpenCLKernelManager.h
@@ -136,7 +136,7 @@ public:
 protected:
 
   OpenCLKernelManager();
-  virtual ~OpenCLKernelManager();
+  ~OpenCLKernelManager() override;
 
   bool CheckArgumentReady( const std::size_t kernelId );
 

--- a/Common/OpenCL/ITKimprovements/itkOpenCLLogger.h
+++ b/Common/OpenCL/ITKimprovements/itkOpenCLLogger.h
@@ -69,7 +69,7 @@ public:
   bool IsCreated() const;
 
   /** Overloaded. */
-  virtual void Write( PriorityLevelEnum level, std::string const & content ) override;
+  void Write( PriorityLevelEnum level, std::string const & content ) override;
 
 protected:
 
@@ -77,7 +77,7 @@ protected:
   OpenCLLogger();
 
   /** Destructor */
-  virtual ~OpenCLLogger();
+  ~OpenCLLogger() override;
 
   /** Initialize */
   void Initialize();

--- a/Common/OpenCL/ITKimprovements/itkOpenCLMacro.h
+++ b/Common/OpenCL/ITKimprovements/itkOpenCLMacro.h
@@ -158,9 +158,9 @@ public:
   OpenCLCompileError( const std::string & file, unsigned int lineNumber ) : ExceptionObject( file, lineNumber ) {}
 
   /** Virtual destructor needed for subclasses. Has to have empty throw(). */
-  virtual ~OpenCLCompileError() throw( ) {}
+  ~OpenCLCompileError() throw( ) override {}
 
-  virtual const char * GetNameOfClass() const override
+  const char * GetNameOfClass() const override
   { return "OpenCLCompileError"; }
 };
 


### PR DESCRIPTION
Fixes warnings from Common/OpenCL when ELASTIX_USE_OPENCL=ON, like:

> In file included from _deps/elx-src/Common/OpenCL/ITKimprovements/itkGPUDataManager.cxx:35:
> _deps/elx-src/Common/OpenCL/ITKimprovements/itkGPUDataManager.h:154:16: warning: 'PrintSelf' overrides a member function but is not marked 'override' [-Winconsistent-missing-override]
  virtual void PrintSelf( std::ostream & os, Indent indent ) const;

https://github.com/InsightSoftwareConsortium/ITKElastix/pull/58/checks?check_run_id=1096122147#step:4:2219

Follow-up to elastix issue #110 ("-Winconsistent-missing-override on MacOS") by Harmen Stoppels