### PR TITLE
COMP: Move #include "itkOpenCLContext.h" from elxElastixMain.h to elxElastixMain.cxx and elxTransformixMain.cxx

### DIFF
--- a/Core/Kernel/elxElastixMain.cxx
+++ b/Core/Kernel/elxElastixMain.cxx
@@ -30,6 +30,7 @@
 #include "itkPlatformMultiThreader.h"
 
 #ifdef ELASTIX_USE_OPENCL
+#include "itkOpenCLContext.h"
 #include "itkOpenCLSetup.h"
 #endif
 

--- a/Core/Kernel/elxElastixMain.h
+++ b/Core/Kernel/elxElastixMain.h
@@ -29,10 +29,6 @@
 
 #include "itkParameterMapInterface.h"
 
-#ifdef ELASTIX_USE_OPENCL
-#include "itkOpenCLContext.h"
-#endif
-
 namespace elastix
 {
 

--- a/Core/Kernel/elxTransformixMain.cxx
+++ b/Core/Kernel/elxTransformixMain.cxx
@@ -29,6 +29,7 @@
 #include "elxMacro.h"
 
 #ifdef ELASTIX_USE_OPENCL
+#include "itkOpenCLContext.h"
 #include "itkOpenCLSetup.h"
 #endif
 


### PR DESCRIPTION
Moved the `#include "itkOpenCLContext.h"` from elxElastixMain.h to elxElastixMain.cxx and elxTransformixMain.cxx, hoping to ease fixing the error:

> /work/_skbuild/linux-x86_64-3.5/cmake-build/_deps/elx-src/Core/Kernel/elxElastixMain.h:33:10: fatal error: 'itkOpenCLContext.h' file not found

at https://github.com/InsightSoftwareConsortium/ITKElastix/pull/58/checks?check_run_id=1096122268#step:4:2894

(Pull request https://github.com/InsightSoftwareConsortium/ITKElastix/pull/58 "ENH: Switch to latest version of SuperElastix/elastix (using ITK 5.1.1)")