### PR TITLE
COMP: elxParameterObject size_t to unsigned int

### DIFF
--- a/Core/Main/elxParameterObject.h
+++ b/Core/Main/elxParameterObject.h
@@ -64,7 +64,7 @@ public:
   void AddParameterMap( const ParameterMapType & parameterMap );
   const ParameterMapType& GetParameterMap( const unsigned int& index ) const;
   itkGetConstReferenceMacro( ParameterMap, ParameterMapVectorType );
-  unsigned int GetNumberOfParameterMaps() const { return this->m_ParameterMap.size(); }
+  unsigned int GetNumberOfParameterMaps() const { return static_cast< unsigned int >(this->m_ParameterMap.size()); }
 
   void SetParameter( const unsigned int& index, const ParameterKeyType& key, const ParameterValueType& value );
   void SetParameter( const unsigned int& index, const ParameterKeyType& key, const ParameterValueVectorType& value );


### PR DESCRIPTION
To address:

  d:\a\1\build\_deps\elastix_fetch-src\core\main\elxParameterObject.h(67): warning C4267: 'return': conversion from 'size_t' to 'unsigned int', possible loss of data