### PR TITLE
COMP: Fix CMake 3.x warnings policy CMP0033 and CMP0007 (issue #21)

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -11,14 +11,6 @@ endif()
 
 #---------------------------------------------------------------------
 cmake_policy( SET CMP0012 NEW )
-if( POLICY CMP0033 )
-  # This policy was introduced in cmake 3, so we need to check for its
-  # existence. When the minimum cmake version above is upgraded to 3
-  # this if(POLICY) check can be removed.
-  cmake_policy( SET CMP0033 OLD )
-endif()
-
-cmake_policy( SET CMP0007 OLD )
 cmake_policy( SET CMP0042 NEW )
 
 #---------------------------------------------------------------------
@@ -581,10 +573,8 @@ endif()
 #---------------------------------------------------------------------
 # Make it easier to include elastix functionality in other programs.
 
-# Save library dependencies.
-# The library dependencies file.
-set( elxLIBRARY_DEPENDS_FILE ${elastix_BINARY_DIR}/elxLibraryDepends.cmake )
-export_library_dependencies( ${elxLIBRARY_DEPENDS_FILE} )
+
+
 
 # The build settings file. (necessary for elastix?)
 #set( ITK_BUILD_SETTINGS_FILE ${ITK_BINARY_DIR}/ITKBuildSettings.cmake )


### PR DESCRIPTION
Fixed the warnings reported by Jean-Christophe Fillion-Robin, issue #21 (August 8, 2017!):

> The OLD behavior for policy CMP0033 will be removed from a future version of CMake.
> The OLD behavior for policy CMP0007 will be removed from a future version of CMake.

Removed `export_library_dependencies` call, which is no longer supported now. ("The export_library_dependencies command should not be called; see CMP0033")