### PR TITLE
COMP: No longer add BUILD_SHARED_LIBS option

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -33,22 +33,6 @@ include( CTest )
   #set( CMAKE_C_VISIBILITY_PRESET hidden )
   #set( CMAKE_CXX_VISIBILITY_PRESET hidden )
 
-mark_as_advanced( BUILD_SHARED_LIBS )
-option( BUILD_SHARED_LIBS "Build shared libraries?" OFF )
-if( BUILD_SHARED_LIBS )
-  add_definitions( -D_ELASTIX_USE_SHARED_LIBRARY )
-
-  # We need to make sure that also the ITK is compiled with shared
-  # libraries on. Related to flag (ITK_)BUILD_SHARED_LIBS. todo
-
-  # In order to compile a shared library, all static sub-libraries
-  # need to build position independend code.
-  # Otherwise an error similar to the following is raised:
-  #   relocation R_X86_64_32S against `.bss' can not be used when
-  #   making a shared object; recompile with -fPIC
-  set( CMAKE_POSITION_INDEPENDENT_CODE ON )
-endif()
-
 #---------------------------------------------------------------------
 # Find ITK.
 find_package( ITK 5.1.1 REQUIRED )


### PR DESCRIPTION
Aims to fix the following CMake Warning from https://open.cdash.org/build/6758579/configure Build: InsightSoftwareConsortium/ITKElastix-macos-10.15--refs/pull/60/merge

> CMake Warning (dev) at /Users/runner/work/ITKElastix/build/_deps/elx-src/CMakeLists.txt:37 (option):
>  Policy CMP0077 is not set: option() honors normal variables.  Run "cmake
> --help-policy CMP0077" for policy details.  Use the cmake_policy command to
> set the policy and suppress this warning.
>
> For compatibility with older versions of CMake, option is clearing the
> normal variable 'BUILD_SHARED_LIBS'.

Follow-up to commit bb902f795244a66ab830775b1e9ad2ad026bd233, "COMP: Explicitly disable BUILD_SHARED_LIBS", September 11, 2019.

Related to:
 - pull request #184 "COMP: Explicitly disable BUILD_SHARED_LIBS"
 - pull request #145 "Make BUILD_SHARED_LIBS do its job"
 - issue  #202 "Elastix 5.0 does not support shared libaray?"