### PR TITLE
COMP: Fix implicit conversion warnings itkAdvancedImageMomentsCalculator

### DIFF
--- a/Common/Transforms/itkAdvancedImageMomentsCalculator.hxx
+++ b/Common/Transforms/itkAdvancedImageMomentsCalculator.hxx
@@ -233,7 +233,7 @@ AdvancedImageMomentsCalculator< TImage >
     }
 
   // Compute principal moments and axes
-  vnl_symmetric_eigensystem< double > eigen( m_Cm.GetVnlMatrix() );
+  vnl_symmetric_eigensystem< double > eigen( m_Cm.GetVnlMatrix().as_ref() );
   vnl_diag_matrix< double >           pm = eigen.D;
   for ( unsigned int i = 0; i < ImageDimension; i++ )
     {
@@ -243,7 +243,7 @@ AdvancedImageMomentsCalculator< TImage >
 
   // Add a final reflection if needed for a proper rotation,
   // by multiplying the last row by the determinant
-  vnl_real_eigensystem                     eigenrot( m_Pa.GetVnlMatrix() );
+  vnl_real_eigensystem                     eigenrot( m_Pa.GetVnlMatrix().as_ref() );
   vnl_diag_matrix< std::complex< double > > eigenval = eigenrot.D;
   std::complex< double >                    det(1.0, 0.0);
 
@@ -504,7 +504,7 @@ AdvancedImageMomentsCalculator< TImage >
   }
 
   // Compute principal moments and axes
-  vnl_symmetric_eigensystem< double > eigen(m_Cm.GetVnlMatrix());
+  vnl_symmetric_eigensystem< double > eigen(m_Cm.GetVnlMatrix().as_ref());
   vnl_diag_matrix< double >           pm = eigen.D;
   for (unsigned int i = 0; i < ImageDimension; i++)
   {
@@ -514,7 +514,7 @@ AdvancedImageMomentsCalculator< TImage >
 
   // Add a final reflection if needed for a proper rotation,
   // by multiplying the last row by the determinant
-  vnl_real_eigensystem                     eigenrot(m_Pa.GetVnlMatrix());
+  vnl_real_eigensystem                     eigenrot(m_Pa.GetVnlMatrix().as_ref());
   vnl_diag_matrix< std::complex< double > > eigenval = eigenrot.D;
   std::complex< double >                    det(1.0, 0.0);
 


### PR DESCRIPTION
Addresses:

> itkAdvancedImageMomentsCalculator.hxx: warning: 'vnl_matrix_fixed::operator const vnl_matrix_ref<T>() const ' is deprecated: Implicit cast conversion is dangerous.

At https://open.cdash.org/viewBuildError.php?type=1&buildid=6758978
Site: GitHubActions
Build Name: InsightSoftwareConsortium/ITKElastix-ubuntu-18.04--refs/pull/60/merge
Build Time: 2020-09-12 22:46:31

Follow-up to pull request #280, "Fix vnl_matrix_fixed "Implicit cast conversion" warnings", commit 69bfa5ac64f05c54fcda14865713a3ad05185db3, 11 Sep 2020