### PR TITLE
COMP: Replace vnl_math_max in PreconditionedGradientDescent (issue #234)

### DIFF
--- a/Components/Optimizers/PreconditionedGradientDescent/elxPreconditionedGradientDescent.hxx
+++ b/Components/Optimizers/PreconditionedGradientDescent/elxPreconditionedGradientDescent.hxx
@@ -22,6 +22,7 @@
 
 #include "itkAdvancedImageToImageMetric.h"
 #include "itkTimeProbe.h"
+#include <algorithm> // For max.
 #include <iomanip>
 #include <string>
 
@@ -514,7 +515,7 @@ PreconditionedGradientDescent<TElastix>
     const double K = 1.5;
     this->m_NumberOfGradientMeasurements = static_cast<unsigned int>(
       std::ceil( 8.0 / P / (K-1) / (K-1) ) );
-    this->m_NumberOfGradientMeasurements = vnl_math_max(
+    this->m_NumberOfGradientMeasurements = std::max(
       static_cast<unsigned int>( 2 ),
       this->m_NumberOfGradientMeasurements );
     elxout << "  NumberOfGradientMeasurements to estimate sigma_i: "
@@ -535,7 +536,7 @@ PreconditionedGradientDescent<TElastix>
   const double noisefactor = sigma1 / ( 2.0 * sigma1  + sigma2 + 1e-14 );
   const double a = a_max * noisefactor;
 
-  const double omega = vnl_math_max( 1e-14,
+  const double omega = std::max( 1e-14,
     this->m_SigmoidScaleFactor * ( sigma1 + sigma2 ) * std::sqrt( Pd ) );
   const double fmax = 1.0;
   const double fmin = -0.99 + 0.98 * noisefactor;

--- a/Components/Optimizers/PreconditionedGradientDescent/itkAdaptiveStochasticPreconditionedGradientDescentOptimizer.cxx
+++ b/Components/Optimizers/PreconditionedGradientDescent/itkAdaptiveStochasticPreconditionedGradientDescentOptimizer.cxx
@@ -20,7 +20,7 @@
 
 #include "itkAdaptiveStochasticPreconditionedGradientDescentOptimizer.h"
 
-#include "vnl/vnl_math.h"
+#include <algorithm> // For max.
 
 namespace itk
 {
@@ -67,7 +67,7 @@ AdaptiveStochasticPreconditionedGradientDescentOptimizer
       const double inprod = inner_product(
         this->m_PreviousSearchDirection, this->GetGradient() );
       this->m_CurrentTime += sigmoid(-inprod);
-      this->m_CurrentTime = vnl_math_max( 0.0, this->m_CurrentTime );
+      this->m_CurrentTime = std::max( 0.0, this->m_CurrentTime );
     }
 
     /** Save for next iteration */

--- a/Components/Optimizers/PreconditionedGradientDescent/itkPreconditionedGradientDescentOptimizer.cxx
+++ b/Components/Optimizers/PreconditionedGradientDescent/itkPreconditionedGradientDescentOptimizer.cxx
@@ -23,9 +23,9 @@
 #include "itkCommand.h"
 #include "itkEventObject.h"
 #include "itkMacro.h"
-#include "vnl/vnl_math.h"
 #include "vnl/vnl_vector.h"
 #include "vnl/algo/vnl_sparse_symmetric_eigensystem.h"
+#include <algorithm> // For max.
 
 namespace itk
 {
@@ -398,7 +398,7 @@ PreconditionedGradientDescentOptimizer
   for( unsigned int r = 0; r < spaceDimension; ++r )
   {
     PreconditionValueType & prr = precondition( r, r );
-    maxDiag = vnl_math_max( maxDiag, prr );
+    maxDiag = std::max( maxDiag, prr );
   }
 
   /** make positive definite by adding a small negligible fraction of maxDiag.


### PR DESCRIPTION
Replaced the four `vnl_math_max` calls in the PreconditionedGradientDescent component by corresponding `std::max` calls.

Addresses issue #234, "Probably a bug: vnl_math_max in elxPreconditionedGradientDescent", by Ibraheem Al-Dhamari (@idhamari).

Note that PreconditionedGradientDescent is switched off by default, as it depends on the SuiteSparse library (which may not be installed).

Discussed with Marius Staring (@mstaring).