### PR TITLE
ENH: Enable almost all components by default

### DIFF
--- a/Components/FixedImagePyramids/FixedShrinkingPyramid/CMakeLists.txt
+++ b/Components/FixedImagePyramids/FixedShrinkingPyramid/CMakeLists.txt
@@ -1,5 +1,5 @@
 
-ADD_ELXCOMPONENT( FixedShrinkingPyramid OFF
+ADD_ELXCOMPONENT( FixedShrinkingPyramid # Was OFF by default before elastix 5.0.1
  elxFixedShrinkingPyramid.h
  elxFixedShrinkingPyramid.hxx
  elxFixedShrinkingPyramid.cxx )

--- a/Components/Interpolators/BSplineInterpolatorFloat/CMakeLists.txt
+++ b/Components/Interpolators/BSplineInterpolatorFloat/CMakeLists.txt
@@ -1,5 +1,5 @@
 
-ADD_ELXCOMPONENT( BSplineInterpolatorFloat OFF
+ADD_ELXCOMPONENT( BSplineInterpolatorFloat # Was OFF by default before elastix 5.0.1
  elxBSplineInterpolatorFloat.h
  elxBSplineInterpolatorFloat.hxx
  elxBSplineInterpolatorFloat.cxx )

--- a/Components/Interpolators/NearestNeighborInterpolator/CMakeLists.txt
+++ b/Components/Interpolators/NearestNeighborInterpolator/CMakeLists.txt
@@ -1,5 +1,5 @@
 
-ADD_ELXCOMPONENT( NearestNeighborInterpolator OFF
+ADD_ELXCOMPONENT( NearestNeighborInterpolator # Was OFF by default before elastix 5.0.1
  elxNearestNeighborInterpolator.h
  elxNearestNeighborInterpolator.hxx
  elxNearestNeighborInterpolator.cxx )

--- a/Components/Interpolators/RayCastInterpolator/CMakeLists.txt
+++ b/Components/Interpolators/RayCastInterpolator/CMakeLists.txt
@@ -1,5 +1,5 @@
 
-ADD_ELXCOMPONENT( RayCastInterpolator OFF
+ADD_ELXCOMPONENT( RayCastInterpolator # Was OFF by default before elastix 5.0.1
  elxRayCastInterpolator.h
  elxRayCastInterpolator.hxx
  elxRayCastInterpolator.cxx )

--- a/Components/Metrics/AdvancedKappaStatistic/CMakeLists.txt
+++ b/Components/Metrics/AdvancedKappaStatistic/CMakeLists.txt
@@ -1,5 +1,5 @@
 
-ADD_ELXCOMPONENT( AdvancedKappaStatisticMetric OFF
+ADD_ELXCOMPONENT( AdvancedKappaStatisticMetric # Was OFF by default before elastix 5.0.1
  elxAdvancedKappaStatisticMetric.h
  elxAdvancedKappaStatisticMetric.hxx
  elxAdvancedKappaStatisticMetric.cxx

--- a/Components/Metrics/DisplacementMagnitudePenalty/CMakeLists.txt
+++ b/Components/Metrics/DisplacementMagnitudePenalty/CMakeLists.txt
@@ -1,5 +1,5 @@
 
-ADD_ELXCOMPONENT( DisplacementMagnitudePenalty OFF
+ADD_ELXCOMPONENT( DisplacementMagnitudePenalty # Was OFF by default before elastix 5.0.1
  elxDisplacementMagnitudePenalty.h
  elxDisplacementMagnitudePenalty.hxx
  elxDisplacementMagnitudePenalty.cxx

--- a/Components/Metrics/GradientDifference/CMakeLists.txt
+++ b/Components/Metrics/GradientDifference/CMakeLists.txt
@@ -1,5 +1,5 @@
 
-ADD_ELXCOMPONENT( GradientDifferenceMetric OFF
+ADD_ELXCOMPONENT( GradientDifferenceMetric # Was OFF by default before elastix 5.0.1
  elxGradientDifferenceMetric.h
  elxGradientDifferenceMetric.hxx
  elxGradientDifferenceMetric.cxx

--- a/Components/Metrics/MissingStructurePenalty/CMakeLists.txt
+++ b/Components/Metrics/MissingStructurePenalty/CMakeLists.txt
@@ -1,4 +1,4 @@
-ADD_ELXCOMPONENT( MissingStructurePenalty OFF
+ADD_ELXCOMPONENT( MissingStructurePenalty # Was OFF by default before elastix 5.0.1
  elxMissingStructurePenalty.cxx
  elxMissingStructurePenalty.h
  elxMissingStructurePenalty.hxx

--- a/Components/Metrics/NormalizedGradientCorrelation/CMakeLists.txt
+++ b/Components/Metrics/NormalizedGradientCorrelation/CMakeLists.txt
@@ -1,5 +1,5 @@
 
-ADD_ELXCOMPONENT( NormalizedGradientCorrelationMetric OFF
+ADD_ELXCOMPONENT( NormalizedGradientCorrelationMetric # Was OFF by default before elastix 5.0.1
  elxNormalizedGradientCorrelationMetric.h
  elxNormalizedGradientCorrelationMetric.hxx
  elxNormalizedGradientCorrelationMetric.cxx

--- a/Components/Metrics/PatternIntensity/CMakeLists.txt
+++ b/Components/Metrics/PatternIntensity/CMakeLists.txt
@@ -1,5 +1,5 @@
 
-ADD_ELXCOMPONENT( PatternIntensityMetric OFF
+ADD_ELXCOMPONENT( PatternIntensityMetric # Was OFF by default before elastix 5.0.1
  elxPatternIntensityMetric.h
  elxPatternIntensityMetric.hxx
  elxPatternIntensityMetric.cxx

--- a/Components/Metrics/PolydataDummyPenalty/CMakeLists.txt
+++ b/Components/Metrics/PolydataDummyPenalty/CMakeLists.txt
@@ -1,4 +1,4 @@
-ADD_ELXCOMPONENT( PolydataDummyPenalty OFF
+ADD_ELXCOMPONENT( PolydataDummyPenalty # Was OFF by default before elastix 5.0.1
  elxPolydataDummyPenalty.cxx
  elxPolydataDummyPenalty.h
  elxPolydataDummyPenalty.hxx

--- a/Components/Metrics/StatisticalShapePenalty/CMakeLists.txt
+++ b/Components/Metrics/StatisticalShapePenalty/CMakeLists.txt
@@ -1,5 +1,5 @@
 
-ADD_ELXCOMPONENT( StatisticalShapePenalty OFF
+ADD_ELXCOMPONENT( StatisticalShapePenalty # Was OFF by default before elastix 5.0.1
  elxStatisticalShapePenalty.cxx
  elxStatisticalShapePenalty.h
  elxStatisticalShapePenalty.hxx

--- a/Components/MovingImagePyramids/MovingShrinkingPyramid/CMakeLists.txt
+++ b/Components/MovingImagePyramids/MovingShrinkingPyramid/CMakeLists.txt
@@ -1,5 +1,5 @@
 
-ADD_ELXCOMPONENT( MovingShrinkingPyramid OFF
+ADD_ELXCOMPONENT( MovingShrinkingPyramid # Was OFF by default before elastix 5.0.1
  elxMovingShrinkingPyramid.h
  elxMovingShrinkingPyramid.hxx
  elxMovingShrinkingPyramid.cxx )

--- a/Components/Optimizers/AdaGrad/CMakeLists.txt
+++ b/Components/Optimizers/AdaGrad/CMakeLists.txt
@@ -1,5 +1,5 @@
 
-ADD_ELXCOMPONENT( AdaGrad
+ADD_ELXCOMPONENT( AdaGrad OFF # OFF by default after elastix 5.0.1
  elxAdaGrad.h
  elxAdaGrad.hxx
  elxAdaGrad.cxx

--- a/Components/Optimizers/AdaptiveStochasticLBFGS/CMakeLists.txt
+++ b/Components/Optimizers/AdaptiveStochasticLBFGS/CMakeLists.txt
@@ -1,5 +1,5 @@
 
-ADD_ELXCOMPONENT( AdaptiveStochasticLBFGS
+ADD_ELXCOMPONENT( AdaptiveStochasticLBFGS OFF # OFF by default after elastix 5.0.1
  elxAdaptiveStochasticLBFGS.h
  elxAdaptiveStochasticLBFGS.hxx
  elxAdaptiveStochasticLBFGS.cxx

--- a/Components/Optimizers/AdaptiveStochasticVarianceReducedGradient/CMakeLists.txt
+++ b/Components/Optimizers/AdaptiveStochasticVarianceReducedGradient/CMakeLists.txt
@@ -1,5 +1,5 @@
 
-ADD_ELXCOMPONENT( AdaptiveStochasticVarianceReducedGradient
+ADD_ELXCOMPONENT( AdaptiveStochasticVarianceReducedGradient OFF # OFF by default after elastix 5.0.1
  elxAdaptiveStochasticVarianceReducedGradient.h
  elxAdaptiveStochasticVarianceReducedGradient.hxx
  elxAdaptiveStochasticVarianceReducedGradient.cxx

--- a/Components/Optimizers/CMAEvolutionStrategy/CMakeLists.txt
+++ b/Components/Optimizers/CMAEvolutionStrategy/CMakeLists.txt
@@ -1,5 +1,5 @@
 
-ADD_ELXCOMPONENT( CMAEvolutionStrategy OFF
+ADD_ELXCOMPONENT( CMAEvolutionStrategy # Was OFF by default before elastix 5.0.1
  elxCMAEvolutionStrategy.h
  elxCMAEvolutionStrategy.hxx
  elxCMAEvolutionStrategy.cxx

--- a/Components/Optimizers/ConjugateGradientFRPR/CMakeLists.txt
+++ b/Components/Optimizers/ConjugateGradientFRPR/CMakeLists.txt
@@ -1,5 +1,5 @@
 
-ADD_ELXCOMPONENT( ConjugateGradientFRPR OFF
+ADD_ELXCOMPONENT( ConjugateGradientFRPR # Was OFF by default before elastix 5.0.1
  elxConjugateGradientFRPR.h
  elxConjugateGradientFRPR.hxx
  elxConjugateGradientFRPR.cxx )

--- a/Components/Optimizers/RSGDEachParameterApart/CMakeLists.txt
+++ b/Components/Optimizers/RSGDEachParameterApart/CMakeLists.txt
@@ -1,5 +1,5 @@
 
-ADD_ELXCOMPONENT( RSGDEachParameterApart OFF
+ADD_ELXCOMPONENT( RSGDEachParameterApart # Was OFF by default before elastix 5.0.1
  elxRSGDEachParameterApart.h
  elxRSGDEachParameterApart.hxx
  elxRSGDEachParameterApart.cxx

--- a/Components/Optimizers/Simplex/CMakeLists.txt
+++ b/Components/Optimizers/Simplex/CMakeLists.txt
@@ -1,5 +1,5 @@
 
-ADD_ELXCOMPONENT( Simplex OFF
+ADD_ELXCOMPONENT( Simplex # Was OFF by default before elastix 5.0.1
  elxSimplex.h
  elxSimplex.hxx
  elxSimplex.cxx )

--- a/Components/Optimizers/SimultaneousPerturbation/CMakeLists.txt
+++ b/Components/Optimizers/SimultaneousPerturbation/CMakeLists.txt
@@ -1,5 +1,5 @@
 
-ADD_ELXCOMPONENT( SimultaneousPerturbation OFF
+ADD_ELXCOMPONENT( SimultaneousPerturbation # Was OFF by default before elastix 5.0.1
  elxSimultaneousPerturbation.h
  elxSimultaneousPerturbation.hxx
  elxSimultaneousPerturbation.cxx )

--- a/Components/ResampleInterpolators/BSplineResampleInterpolatorFloat/CMakeLists.txt
+++ b/Components/ResampleInterpolators/BSplineResampleInterpolatorFloat/CMakeLists.txt
@@ -1,5 +1,5 @@
 
-ADD_ELXCOMPONENT( BSplineResampleInterpolatorFloat OFF
+ADD_ELXCOMPONENT( BSplineResampleInterpolatorFloat # Was OFF by default before elastix 5.0.1
  elxBSplineResampleInterpolatorFloat.h
  elxBSplineResampleInterpolatorFloat.hxx
  elxBSplineResampleInterpolatorFloat.cxx )

--- a/Components/ResampleInterpolators/LinearResampleInterpolator/CMakeLists.txt
+++ b/Components/ResampleInterpolators/LinearResampleInterpolator/CMakeLists.txt
@@ -1,5 +1,5 @@
 
-ADD_ELXCOMPONENT( LinearResampleInterpolator OFF
+ADD_ELXCOMPONENT( LinearResampleInterpolator # Was OFF by default before elastix 5.0.1
  elxLinearResampleInterpolator.h
  elxLinearResampleInterpolator.hxx
  elxLinearResampleInterpolator.cxx )

--- a/Components/ResampleInterpolators/NearestNeighborResampleInterpolator/CMakeLists.txt
+++ b/Components/ResampleInterpolators/NearestNeighborResampleInterpolator/CMakeLists.txt
@@ -1,5 +1,5 @@
 
-ADD_ELXCOMPONENT( NearestNeighborResampleInterpolator OFF
+ADD_ELXCOMPONENT( NearestNeighborResampleInterpolator # Was OFF by default before elastix 5.0.1
  elxNearestNeighborResampleInterpolator.h
  elxNearestNeighborResampleInterpolator.hxx
  elxNearestNeighborResampleInterpolator.cxx )

--- a/Components/ResampleInterpolators/RayCastResampleInterpolator/CMakeLists.txt
+++ b/Components/ResampleInterpolators/RayCastResampleInterpolator/CMakeLists.txt
@@ -1,5 +1,5 @@
 
-ADD_ELXCOMPONENT( RayCastResampleInterpolator OFF
+ADD_ELXCOMPONENT( RayCastResampleInterpolator # Was OFF by default before elastix 5.0.1
  elxRayCastResampleInterpolator.h
  elxRayCastResampleInterpolator.hxx
  elxRayCastResampleInterpolator.cxx )

--- a/Components/Transforms/AffineDTITransform/CMakeLists.txt
+++ b/Components/Transforms/AffineDTITransform/CMakeLists.txt
@@ -1,5 +1,5 @@
 
-ADD_ELXCOMPONENT( AffineDTITransformElastix OFF
+ADD_ELXCOMPONENT( AffineDTITransformElastix # Was OFF by default before elastix 5.0.1
  elxAffineDTITransform.h
  elxAffineDTITransform.hxx
  elxAffineDTITransform.cxx

--- a/Components/Transforms/AffineLogTransform/CMakeLists.txt
+++ b/Components/Transforms/AffineLogTransform/CMakeLists.txt
@@ -1,5 +1,5 @@
 
-ADD_ELXCOMPONENT( AffineLogTransformElastix OFF
+ADD_ELXCOMPONENT( AffineLogTransformElastix # Was OFF by default before elastix 5.0.1
  elxAffineLogTransform.h
  elxAffineLogTransform.hxx
  elxAffineLogTransform.cxx

--- a/Components/Transforms/MultiBSplineTransformWithNormal/CMakeLists.txt
+++ b/Components/Transforms/MultiBSplineTransformWithNormal/CMakeLists.txt
@@ -1,5 +1,5 @@
 
-ADD_ELXCOMPONENT( MultiBSplineTransformWithNormal OFF
+ADD_ELXCOMPONENT( MultiBSplineTransformWithNormal # Was OFF by default before elastix 5.0.1
  elxMultiBSplineTransformWithNormal.h
  elxMultiBSplineTransformWithNormal.hxx
  elxMultiBSplineTransformWithNormal.cxx

--- a/Components/Transforms/SimilarityTransform/CMakeLists.txt
+++ b/Components/Transforms/SimilarityTransform/CMakeLists.txt
@@ -1,5 +1,5 @@
 
-ADD_ELXCOMPONENT( SimilarityTransformElastix OFF
+ADD_ELXCOMPONENT( SimilarityTransformElastix # Was OFF by default before elastix 5.0.1
  elxSimilarityTransform.h
  elxSimilarityTransform.hxx
  elxSimilarityTransform.cxx

--- a/Components/Transforms/WeightedCombinationTransform/CMakeLists.txt
+++ b/Components/Transforms/WeightedCombinationTransform/CMakeLists.txt
@@ -1,5 +1,5 @@
 
-ADD_ELXCOMPONENT( WeightedCombinationTransformElastix OFF
+ADD_ELXCOMPONENT( WeightedCombinationTransformElastix # Was OFF by default before elastix 5.0.1
  elxWeightedCombinationTransform.h
  elxWeightedCombinationTransform.hxx
  elxWeightedCombinationTransform.cxx


### PR DESCRIPTION
Removed default "OFF" for `ADD_ELXCOMPONENT` calls of 27 components.

Note that Optimizers/PreconditionedGradientDescent is still OFF by default because of its SuiteSparse library dependency.

Transforms/BSplineDeformableTransformWithDiffusion also remained OFF by default.