### PR TITLE
STYLE: Modernize code in BaseComponent.h

### DIFF
--- a/Core/Install/elxBaseComponent.cxx
+++ b/Core/Install/elxBaseComponent.cxx
@@ -18,7 +18,9 @@
 
 #include "elxBaseComponent.h"
 
-#include <cmath>
+#include <cmath> // For fmod.
+#include <iomanip> // For setprecision.
+#include <sstream> // For ostringstream.
 
 namespace
 {

--- a/Core/Install/elxBaseComponent.cxx
+++ b/Core/Install/elxBaseComponent.cxx
@@ -90,7 +90,7 @@ void BaseComponent::InitializeElastixExecutable()
 
 std::string
 BaseComponent::ConvertSecondsToDHMS(
-  const double totalSeconds, const unsigned int precision = 0 ) const
+  const double totalSeconds, const unsigned int precision )
 {
   /** Define days, hours, minutes. */
   const std::size_t secondsPerMinute = 60;

--- a/Core/Install/elxBaseComponent.h
+++ b/Core/Install/elxBaseComponent.h
@@ -65,6 +65,7 @@ namespace elastix
 class BaseComponent
 {
 public:
+  ITK_DISALLOW_COPY_AND_ASSIGN(BaseComponent);
 
   /**
    * Callback methods that each component of elastix is supposed
@@ -115,27 +116,24 @@ public:
    * parameter file for example, to distinguish between options
    * meant for Metric0 and for Metric1.
    */
-  virtual void SetComponentLabel( const char * label, unsigned int idx );
+  void SetComponentLabel( const char * label, unsigned int idx );
 
   /** Get the componentlabel as a string: "Metric0" for example. */
-  virtual const char * GetComponentLabel( void ) const;
+  const char * GetComponentLabel( void ) const;
 
   static bool IsElastixLibrary();
 
   static void InitializeElastixExecutable();
 
   /** Convenience function to convert seconds to day, hour, minute, second format. */
-  std::string ConvertSecondsToDHMS( const double totalSeconds, const unsigned int precision ) const;
+  static std::string ConvertSecondsToDHMS( const double totalSeconds, const unsigned int precision );
 
 protected:
 
-  BaseComponent() {}
-  virtual ~BaseComponent() {}
+  BaseComponent() = default;
+  virtual ~BaseComponent() = default;
 
 private:
-
-  BaseComponent( const BaseComponent & );     // purposely not implemented
-  void operator=( const BaseComponent & );    // purposely not implemented
 
   std::string m_ComponentLabel;
 

--- a/Core/Install/elxBaseComponent.h
+++ b/Core/Install/elxBaseComponent.h
@@ -36,11 +36,9 @@
 #pragma warning ( disable : 4503 )
 #endif
 
-#include <iostream>
-#include <sstream>
-#include <iomanip>    // std::setprecision
-
 #include "itkMacro.h" // itkTypeMacroNoParent
+
+#include <string>
 
 /** The current elastix version. */
 #define __ELASTIX_VERSION 5.000


### PR DESCRIPTION
- Declare ComponentLabel getter and setter non-virtual (In C++, the `virtual` keyword should only be used when it is really useful!)
- Declare ConvertSecondsToDHMS `static`, as it does not use `this`.
- Default default-constructor and destructor (C++11).
- Use ITK_DISALLOW_COPY_AND_ASSIGN instead of "purposely not implemented" (ITK 5 coding convention)
- Move `#include`'s from BaseComponent.h to BaseComponent.cxx (to reduce compilation times)