### PR TITLE
STYLE: Modernize code of elxTransformBase

### DIFF
--- a/Core/ComponentBaseClasses/elxTransformBase.h
+++ b/Core/ComponentBaseClasses/elxTransformBase.h
@@ -27,8 +27,7 @@
 #include "elxComponentDatabase.h"
 #include "elxProgressCommand.h"
 
-#include <fstream>
-#include <iomanip>
+#include <memory> // For unique_ptr.
 
 namespace elastix
 {
@@ -130,6 +129,7 @@ class TransformBase :
   public BaseComponentSE< TElastix >
 {
 public:
+  ITK_DISALLOW_COPY_AND_ASSIGN(TransformBase);
 
   /** Standard ITK stuff. */
   typedef TransformBase               Self;
@@ -139,16 +139,17 @@ public:
   itkTypeMacro( TransformBase, BaseComponentSE );
 
   /** Typedef's from Superclass. */
-  typedef typename Superclass::ElastixType          ElastixType;
-  typedef typename Superclass::ElastixPointer       ElastixPointer;
-  typedef typename Superclass::ConfigurationType    ConfigurationType;
-  typedef typename Superclass::ConfigurationPointer ConfigurationPointer;
+  using typename Superclass::ElastixType;
+  using typename Superclass::ElastixPointer;
+  using typename Superclass::ConfigurationType;
+  using typename Superclass::ConfigurationPointer;
+  using typename Superclass::RegistrationType;
+  using typename Superclass::RegistrationPointer;
+
   typedef typename ConfigurationType
     ::CommandLineArgumentMapType CommandLineArgumentMapType;
   typedef typename ConfigurationType
     ::CommandLineEntryType CommandLineEntryType;
-  typedef typename Superclass::RegistrationType    RegistrationType;
-  typedef typename Superclass::RegistrationPointer RegistrationPointer;
 
   /** Elastix typedef's. */
   typedef typename ElastixType::CoordRepType    CoordRepType;
@@ -324,10 +325,10 @@ public:
 
 protected:
 
-  /** The constructor. */
-  TransformBase();
+  /** The default-constructor. */
+  TransformBase() = default;
   /** The destructor. */
-  ~TransformBase() override;
+  ~TransformBase() override = default;
 
   /** Estimate a scales vector
    * AutomaticScalesEstimation works like this:
@@ -347,20 +348,15 @@ protected:
   void AutomaticScalesEstimationStackTransform(
     const unsigned int & numSubTransforms, ScalesType & scales ) const;
 
+private:
+
   /** Member variables. */
-  ParametersType * m_TransformParametersPointer;
+  std::unique_ptr<ParametersType> m_TransformParametersPointer{};
   std::string      m_TransformParametersFileName;
   ParametersType   m_FinalParameters;
 
-private:
-
-  /** The private constructor. */
-  TransformBase( const Self & );   // purposely not implemented
-  /** The private copy constructor. */
-  void operator=( const Self & );  // purposely not implemented
-
   /** Boolean to decide whether or not the transform parameters are written. */
-  bool m_ReadWriteTransformParameters;
+  bool m_ReadWriteTransformParameters{ true };
 
   std::string GetInitialTransformParametersFileName( void ) const
   {
@@ -374,7 +370,7 @@ private:
   }
 
   /** Boolean to decide whether or not the transform parameters are written in binary format. */
-  bool m_UseBinaryFormatForTransformationParameters;
+  bool m_UseBinaryFormatForTransformationParameters{};
 
 };
 

--- a/Core/ComponentBaseClasses/elxTransformBase.hxx
+++ b/Core/ComponentBaseClasses/elxTransformBase.hxx
@@ -1858,18 +1858,13 @@ TransformBase< TElastix >
     itkExceptionMacro( << "No valid voxels found to estimate the scales." );
   }
 
-  /** Create iterator over the sample container. */
-  typename ImageSampleContainerType::ConstIterator iter;
-  typename ImageSampleContainerType::ConstIterator begin = sampleContainer->Begin();
-  typename ImageSampleContainerType::ConstIterator end   = sampleContainer->End();
-
   /** initialize */
   scales.Fill( 0.0 );
 
   /** Read fixed coordinates and get Jacobian. */
-  for( iter = begin; iter != end; ++iter )
+  for( const auto& sample : *sampleContainer )
   {
-    const InputPointType & point = ( *iter ).Value().m_ImageCoordinates;
+    const InputPointType & point = sample.m_ImageCoordinates;
     //const JacobianType & jacobian = thisITK->GetJacobian( point );
     JacobianType jacobian; NonZeroJacobianIndicesType nzji;
     thisITK->GetJacobian( point, jacobian, nzji );
@@ -1955,17 +1950,12 @@ TransformBase< TElastix >
     itkExceptionMacro( << "No valid voxels found to estimate the scales." );
   }
 
-  /** Create iterator over the sample container. */
-  typename ImageSampleContainerType::ConstIterator iter;
-  typename ImageSampleContainerType::ConstIterator begin = sampleContainer->Begin();
-  typename ImageSampleContainerType::ConstIterator end   = sampleContainer->End();
-
   /** Read fixed coordinates and get Jacobian. */
   JacobianType               jacobian;
   NonZeroJacobianIndicesType nzji;
-  for( iter = begin; iter != end; ++iter )
+  for( const auto& sample : *sampleContainer )
   {
-    const InputPointType & point = ( *iter ).Value().m_ImageCoordinates;
+    const InputPointType & point = sample.m_ImageCoordinates;
     //const JacobianType & jacobian = thisITK->GetJacobian( point );
     thisITK->GetJacobian( point, jacobian, nzji );
 

--- a/Core/ComponentBaseClasses/elxTransformBase.hxx
+++ b/Core/ComponentBaseClasses/elxTransformBase.hxx
@@ -23,7 +23,6 @@
 #include "itkPointSet.h"
 #include "itkDefaultStaticMeshTraits.h"
 #include "itkTransformixInputPointFileReader.h"
-#include "vnl/vnl_math.h"
 #include <itksys/SystemTools.hxx>
 #include "itkVector.h"
 #include "itkTransformToDisplacementFieldFilter.h"
@@ -38,6 +37,10 @@
 #include "itkMeshFileWriter.h"
 #include "itkTransformMeshFilter.h"
 #include "itkCommonEnums.h"
+
+#include <fstream>
+#include <iomanip> // For setprecision.
+
 
 namespace itk
 {
@@ -55,6 +58,7 @@ template< class T >
 class PixelTypeChangeCommand : public Command
 {
 public:
+  ITK_DISALLOW_COPY_AND_ASSIGN(PixelTypeChangeCommand);
 
   /** Standard class typedefs. */
   typedef PixelTypeChangeCommand    Self;
@@ -87,13 +91,8 @@ public:
 
 protected:
 
-  PixelTypeChangeCommand() {}
-  ~PixelTypeChangeCommand() override {}
-
-private:
-
-  PixelTypeChangeCommand( const Self & ); // purposely not implemented
-  void operator=( const Self & );         // purposely not implemented
+  PixelTypeChangeCommand() = default;
+  ~PixelTypeChangeCommand() override = default;
 
 };
 
@@ -102,37 +101,6 @@ private:
 namespace elastix
 {
 
-/**
- * ********************* Constructor ****************************
- */
-
-template< class TElastix >
-TransformBase< TElastix >
-::TransformBase()
-{
-  /** Initialize. */
-  this->m_TransformParametersPointer   = 0;
-  this->m_ReadWriteTransformParameters = true;
-  this->m_UseBinaryFormatForTransformationParameters = false;
-
-} // end Constructor()
-
-
-/**
- * ********************** Destructor ****************************
- */
-
-template< class TElastix >
-TransformBase< TElastix >
-::~TransformBase()
-{
-  /** Delete. */
-  if( this->m_TransformParametersPointer )
-  {
-    delete this->m_TransformParametersPointer;
-  }
-
-} // end Destructor()
 
 
 /**
@@ -413,11 +381,7 @@ TransformBase< TElastix >
   if( this->m_ReadWriteTransformParameters )
   {
     /** Get the TransformParameters pointer. */
-    if( this->m_TransformParametersPointer )
-    {
-      delete this->m_TransformParametersPointer;
-    }
-    this->m_TransformParametersPointer = new ParametersType( numberOfParameters );
+    this->m_TransformParametersPointer.reset(new ParametersType( numberOfParameters ));
 
     /** Read the TransformParameters. */
     std::size_t numberOfParametersFound = 0;

--- a/Core/ComponentBaseClasses/elxTransformBase.hxx
+++ b/Core/ComponentBaseClasses/elxTransformBase.hxx
@@ -573,7 +573,7 @@ TransformBase< TElastix >
 {
   /** Create a new configuration, which will be initialized with
    * the transformParameterFileName. */
-  ConfigurationPointer configurationInitialTransform = ConfigurationType::New();
+  const auto configurationInitialTransform = ConfigurationType::New();
 
   /** Create argmapInitialTransform. */
   CommandLineArgumentMapType argmapInitialTransform;
@@ -1133,7 +1133,7 @@ TransformBase< TElastix >
   typedef itk::Vector< float, FixedImageDimension > DeformationVectorType;
 
   /** Construct an ipp-file reader. */
-  typename IPPReaderType::Pointer ippReader = IPPReaderType::New();
+  const auto ippReader = IPPReaderType::New();
   ippReader->SetFileName( filename.c_str() );
 
   /** Read the input points. */
@@ -1187,7 +1187,7 @@ TransformBase< TElastix >
   region.SetSize(
     this->m_Elastix->GetElxResamplerBase()->GetAsITKBaseType()->GetSize() );
 
-  typename FixedImageType::Pointer dummyImage = FixedImageType::New();
+  const auto dummyImage = FixedImageType::New();
   dummyImage->SetRegions( region );
   dummyImage->SetOrigin( origin );
   dummyImage->SetSpacing( spacing );
@@ -1367,7 +1367,7 @@ TransformBase< TElastix >
     MeshType, MeshType, CombinationTransformType >       TransformMeshFilterType;
 
   /** Read the input points. */
-  typename MeshReaderType::Pointer meshReader = MeshReaderType::New();
+  const auto meshReader = MeshReaderType::New();
   meshReader->SetFileName( filename.c_str() );
   elxout << "  Reading input point file: " << filename << std::endl;
   try
@@ -1387,7 +1387,7 @@ TransformBase< TElastix >
 
   /** Apply the transform. */
   elxout << "  The input points are transformed." << std::endl;
-  typename TransformMeshFilterType::Pointer meshTransformer = TransformMeshFilterType::New();
+  const auto meshTransformer = TransformMeshFilterType::New();
   meshTransformer->SetTransform(
     const_cast< CombinationTransformType * >( this->GetAsCombinationTransform() ) );
   meshTransformer->SetInput( meshReader->GetOutput() );
@@ -1407,7 +1407,7 @@ TransformBase< TElastix >
   outputPointsFileName += "outputpoints.vtk";
   elxout << "  The transformed points are saved in: "
          <<  outputPointsFileName << std::endl;
-  typename MeshWriterType::Pointer meshWriter = MeshWriterType::New();
+  const auto meshWriter = MeshWriterType::New();
   meshWriter->SetFileName( outputPointsFileName.c_str() );
   meshWriter->SetInput( meshTransformer->GetOutput() );
 
@@ -1470,8 +1470,7 @@ TransformBase< TElastix >
     DeformationFieldImageType >                       ChangeInfoFilterType;
 
   /** Create an setup deformation field generator. */
-  typename DeformationFieldGeneratorType::Pointer defGenerator
-    = DeformationFieldGeneratorType::New();
+  const auto defGenerator = DeformationFieldGeneratorType::New();
   defGenerator->SetSize(
     this->m_Elastix->GetElxResamplerBase()->GetAsITKBaseType()->GetSize() );
   defGenerator->SetOutputSpacing(
@@ -1487,7 +1486,7 @@ TransformBase< TElastix >
   /** Possibly change direction cosines to their original value, as specified
    * in the tp-file, or by the fixed image. This is only necessary when
    * the UseDirectionCosines flag was set to false. */
-  typename ChangeInfoFilterType::Pointer infoChanger = ChangeInfoFilterType::New();
+  const auto infoChanger = ChangeInfoFilterType::New();
   FixedImageDirectionType originalDirection;
   bool                    retdc = this->GetElastix()->GetOriginalFixedImageDirection( originalDirection );
   infoChanger->SetOutputDirection( originalDirection );
@@ -1539,8 +1538,7 @@ WriteDeformationFieldImage(
                << "deformationField." << resultImageFormat;
 
   /** Write outputImage to disk. */
-  typename DeformationFieldWriterType::Pointer defWriter
-    = DeformationFieldWriterType::New();
+  const auto defWriter = DeformationFieldWriterType::New();
   defWriter->SetInput( deformationfield );
   defWriter->SetFileName( makeFileName.str().c_str() );
 
@@ -1601,7 +1599,7 @@ TransformBase< TElastix >
   typedef typename FixedImageType::DirectionType FixedImageDirectionType;
 
   /** Create an setup Jacobian generator. */
-  typename JacobianGeneratorType::Pointer jacGenerator = JacobianGeneratorType::New();
+  const auto jacGenerator = JacobianGeneratorType::New();
   jacGenerator->SetTransform( const_cast< const ITKBaseType * >(
       this->GetAsITKBaseType() ) );
   jacGenerator->SetOutputSize(
@@ -1621,7 +1619,7 @@ TransformBase< TElastix >
   /** Possibly change direction cosines to their original value, as specified
    * in the tp-file, or by the fixed image. This is only necessary when
    * the UseDirectionCosines flag was set to false. */
-  typename ChangeInfoFilterType::Pointer infoChanger = ChangeInfoFilterType::New();
+  const auto infoChanger = ChangeInfoFilterType::New();
   FixedImageDirectionType originalDirection;
   bool                    retdc = this->GetElastix()->GetOriginalFixedImageDirection( originalDirection );
   infoChanger->SetOutputDirection( originalDirection );
@@ -1639,7 +1637,7 @@ TransformBase< TElastix >
                << "spatialJacobian." << resultImageFormat;
 
   /** Write outputImage to disk. */
-  typename JacobianWriterType::Pointer jacWriter = JacobianWriterType::New();
+  const auto jacWriter = JacobianWriterType::New();
   jacWriter->SetInput( infoChanger->GetOutput() );
   jacWriter->SetFileName( makeFileName.str().c_str() );
 
@@ -1700,7 +1698,7 @@ TransformBase< TElastix >
     JacobianWriterType >                              PixelTypeChangeCommandType;
 
   /** Create an setup Jacobian generator. */
-  typename JacobianGeneratorType::Pointer jacGenerator = JacobianGeneratorType::New();
+  const auto jacGenerator = JacobianGeneratorType::New();
   jacGenerator->SetTransform( const_cast< const ITKBaseType * >(
       this->GetAsITKBaseType() ) );
   jacGenerator->SetOutputSize(
@@ -1721,7 +1719,7 @@ TransformBase< TElastix >
    * in the tp-file, or by the fixed image. This is only necessary when
    * the UseDirectionCosines flag was set to false.
    */
-  typename ChangeInfoFilterType::Pointer infoChanger = ChangeInfoFilterType::New();
+  const auto infoChanger = ChangeInfoFilterType::New();
   FixedImageDirectionType originalDirection;
   bool                    retdc = this->GetElastix()->GetOriginalFixedImageDirection( originalDirection );
   infoChanger->SetOutputDirection( originalDirection );
@@ -1738,12 +1736,11 @@ TransformBase< TElastix >
                << "fullSpatialJacobian." << resultImageFormat;
 
   /** Write outputImage to disk. */
-  typename JacobianWriterType::Pointer jacWriter = JacobianWriterType::New();
+  const auto jacWriter = JacobianWriterType::New();
   jacWriter->SetInput( infoChanger->GetOutput() );
   jacWriter->SetFileName( makeFileName.str().c_str() );
   /** Hack to change the pixel type to vector. Not necessary for mhd. */
-  typename PixelTypeChangeCommandType::Pointer jacStartWriteCommand
-    = PixelTypeChangeCommandType::New();
+  const auto jacStartWriteCommand = PixelTypeChangeCommandType::New();
   if( resultImageFormat != "mhd" )
   {
     jacWriter->AddObserver( itk::StartEvent(), jacStartWriteCommand );
@@ -1841,7 +1838,7 @@ TransformBase< TElastix >
   scales = ScalesType( N );
 
   /** Set up grid sampler. */
-  ImageSamplerPointer sampler = ImageSamplerType::New();
+  const auto sampler = ImageSamplerType::New();
   sampler->SetInput(
     this->GetRegistration()->GetAsITKBaseType()->GetFixedImage() );
   sampler->SetInputImageRegion(
@@ -1940,7 +1937,7 @@ TransformBase< TElastix >
   desiredRegion.SetIndex( start );
 
   /** Set up the grid sampler. */
-  ImageSamplerPointer sampler = ImageSamplerType::New();
+  const auto sampler = ImageSamplerType::New();
   sampler->SetInput( this->GetRegistration()->GetAsITKBaseType()->GetFixedImage() );
   sampler->SetInputImageRegion( desiredRegion );
 


### PR DESCRIPTION
- Used `using` for typedef's from Superclass
- Defaulted default-constructor and destructor (C++11).
- Replaced "purposely not implemented" by `ITK_DISALLOW_COPY_AND_ASSIGN` calls
- Made three protected data members `private`
- Replaced a raw pointer by `std::unique_ptr`
- Did clean up the #include's.
- Used `const auto` for variables that are initialized by `New()`
- Replaced old for-loops in `AutomaticScalesEstimation` and `AutomaticScalesEstimationStackTransform` by modern C++11 range-based for-loops.