### PR TITLE
ENH: Replace __ELASTIX_VERSION by ELASTIX_VERSION_MAJOR/MINOR/PATCH

### DIFF
--- a/CMake/elastixVersion.cmake
+++ b/CMake/elastixVersion.cmake
@@ -1,0 +1,4 @@
+# Elastix version number components.
+set(ELASTIX_VERSION_MAJOR "5")
+set(ELASTIX_VERSION_MINOR "0")
+set(ELASTIX_VERSION_PATCH "1")

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -14,18 +14,6 @@ cmake_policy( SET CMP0012 NEW )
 cmake_policy( SET CMP0042 NEW )
 
 #---------------------------------------------------------------------
-# Get version information.
-
-# Get the version number of elastix
-file( STRINGS ${elastix_SOURCE_DIR}/Core/Install/elxBaseComponent.h
-  ELASTIX_VERSION REGEX "\(#define\ __ELASTIX_VERSION\)" )
-string( SUBSTRING ${ELASTIX_VERSION} 26 3 ELASTIX_VERSION )
-
-# Split version in major minor. Assuming no patch number, just x.y
-string( REGEX MATCH "[0-9]+" ELASTIX_VERSION_MAJOR "${ELASTIX_VERSION}" )
-string( REGEX REPLACE "([0-9]+)\\." "" ELASTIX_VERSION_MINOR "${ELASTIX_VERSION}" )
-
-#---------------------------------------------------------------------
 include( CTest )
 
   # The following may make smaller and quicker loading libraries,
@@ -42,6 +30,10 @@ include( ${ITK_USE_FILE} )
 # Add the CMake dir as an additional module path,
 # so that CMake is able to find the FindPackage modules.
 list( APPEND CMAKE_MODULE_PATH ${CMAKE_CURRENT_SOURCE_DIR}/CMake )
+
+#---------------------------------------------------------------------
+# Get version information.
+include( elastixVersion )
 
 # Function for exporting targets
 include(elastixExportTarget)
@@ -427,10 +419,9 @@ if( ELASTIX_ENABLE_PACKAGER )
   # Version information
   # If the next line is uncommented the package name will be like
   # elastix-4.3-win64 instead of elastix-4.3.0-win64
-  #set( CPACK_PACKAGE_VERSION ${ELASTIX_VERSION} )
   set( CPACK_PACKAGE_VERSION_MAJOR ${ELASTIX_VERSION_MAJOR} )
   set( CPACK_PACKAGE_VERSION_MINOR ${ELASTIX_VERSION_MINOR} )
-  set( CPACK_PACKAGE_VERSION_PATCH "0" )
+  set( CPACK_PACKAGE_VERSION_PATCH ${ELASTIX_VERSION_PATCH} )
 
   # Also install the copyright file, since when the user enables packaging
   # we assume that the package is meant to distribute.

--- a/Core/CMakeLists.txt
+++ b/Core/CMakeLists.txt
@@ -87,6 +87,12 @@ source_group( "ComponentBaseClasses" FILES ${ComponentBaseClassFiles} )
 source_group( "ProgressCommand" FILES ${ProgressCommandFiles} )
 
 #---------------------------------------------------------------------
+
+configure_file(
+  elxVersionMacros.h.in
+  elxVersionMacros.h)
+
+#---------------------------------------------------------------------
 # Create the elxCore library.
 
 add_library( elxCore STATIC

--- a/Core/Install/elxBaseComponent.h
+++ b/Core/Install/elxBaseComponent.h
@@ -40,9 +40,6 @@
 
 #include <string>
 
-/** The current elastix version. */
-#define __ELASTIX_VERSION 5.000
-
 /** All elastix components should be in namespace elastix. */
 namespace elastix
 {

--- a/Core/Kernel/elxElastixBase.cxx
+++ b/Core/Kernel/elxElastixBase.cxx
@@ -16,6 +16,7 @@
  *
  *=========================================================================*/
 #include "elxElastixBase.h"
+#include <Core/elxVersionMacros.h>
 #include <sstream>
 #include "itkMersenneTwisterRandomVariateGenerator.h"
 
@@ -110,11 +111,7 @@ ElastixBase::BeforeAllBase( void )
   elxout << std::setprecision( this->m_DefaultOutputPrecision );
 
   /** Print to log file. */
-  elxout << std::fixed;
-  elxout << std::showpoint;
-  elxout << std::setprecision( 3 );
-  elxout << "ELASTIX version: " << __ELASTIX_VERSION << std::endl;
-  elxout << std::setprecision( this->GetDefaultOutputPrecision() );
+  elxout << "ELASTIX version: " ELASTIX_VERSION_STRING "\n";
 
   /** Check Command line options and print them to the logfile. */
   elxout << "Command line options from ElastixBase:" << std::endl;
@@ -262,10 +259,7 @@ ElastixBase::BeforeAllTransformixBase( void )
   int returndummy = 0;
 
   /** Print to log file. */
-  elxout << std::fixed;
-  elxout << std::showpoint;
-  elxout << std::setprecision( 3 );
-  elxout << "ELASTIX version: " << __ELASTIX_VERSION << std::endl;
+  elxout << "ELASTIX version: " ELASTIX_VERSION_STRING "\n";
   elxout << std::setprecision( this->GetDefaultOutputPrecision() );
 
   /** Check Command line options and print them to the logfile. */

--- a/Core/Main/elastix.cxx
+++ b/Core/Main/elastix.cxx
@@ -19,6 +19,7 @@
 // Elastix header files:
 #include "elastix.h"
 #include "elxElastixMain.h"
+#include <Core/elxVersionMacros.h>
 #include "itkUseMevisDicomTiff.h"
 
 // ITK header files:
@@ -57,20 +58,13 @@ main( int argc, char ** argv )
     }
     else if( argument == "--version" )
     {
-      std::cout << std::fixed;
-      std::cout << std::showpoint;
-      std::cout << std::setprecision( 3 );
-      std::cout << "elastix version: " << __ELASTIX_VERSION << std::endl;
+      std::cout << "elastix version: " ELASTIX_VERSION_STRING << std::endl;
       return 0;
     }
     else if (argument == "--extended-version")
     {
       std::cout
-        << std::fixed
-        << std::showpoint
-        << std::setprecision(3)
-        << "elastix version: "
-        << __ELASTIX_VERSION
+        << "elastix version: " ELASTIX_VERSION_STRING
         << "\nITK version: "
         << ITK_VERSION_MAJOR << '.'
         << ITK_VERSION_MINOR << '.'
@@ -372,10 +366,7 @@ void
 PrintHelp( void )
 {
   /** Print the version. */
-  std::cout << std::fixed;
-  std::cout << std::showpoint;
-  std::cout << std::setprecision( 3 );
-  std::cout << "elastix version: " << __ELASTIX_VERSION << "\n" << std::endl;
+  std::cout << "elastix version: " << ELASTIX_VERSION_STRING "\n\n";
 
   /** What is elastix? */
   std::cout << "elastix registers a moving image to a fixed image.\n";

--- a/Core/Main/transformix.cxx
+++ b/Core/Main/transformix.cxx
@@ -19,6 +19,7 @@
  // Elastix header files:
 #include "elastix.h"
 #include "elxTransformixMain.h"
+#include <Core/elxVersionMacros.h>
 #include "itkUseMevisDicomTiff.h"
 
 // ITK header files:
@@ -50,10 +51,7 @@ main( int argc, char ** argv )
     }
     else if( argument == "--version" )
     {
-      std::cout << std::fixed;
-      std::cout << std::showpoint;
-      std::cout << std::setprecision( 3 );
-      std::cout << "transformix version: " << __ELASTIX_VERSION << std::endl;
+      std::cout << "transformix version: " ELASTIX_VERSION_STRING << std::endl;
       return 0;
     }
     else
@@ -250,10 +248,7 @@ void
 PrintHelp( void )
 {
   /** Print the version. */
-  std::cout << std::fixed;
-  std::cout << std::showpoint;
-  std::cout << std::setprecision( 3 );
-  std::cout << "transformix version: " << __ELASTIX_VERSION << "\n" << std::endl;
+  std::cout << "transformix version: " ELASTIX_VERSION_STRING "\n\n";
 
   /** What is transformix? */
   std::cout << "transformix applies a transform on an input image and/or "

--- a/Core/elxVersionMacros.h.in
+++ b/Core/elxVersionMacros.h.in
@@ -1,0 +1,35 @@
+/*=========================================================================
+ *
+ *  Copyright UMC Utrecht and contributors
+ *
+ *  Licensed under the Apache License, Version 2.0 (the "License");
+ *  you may not use this file except in compliance with the License.
+ *  You may obtain a copy of the License at
+ *
+ *        http://www.apache.org/licenses/LICENSE-2.0.txt
+ *
+ *  Unless required by applicable law or agreed to in writing, software
+ *  distributed under the License is distributed on an "AS IS" BASIS,
+ *  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *  See the License for the specific language governing permissions and
+ *  limitations under the License.
+ *
+ *=========================================================================*/
+#ifndef elxVersionMacros_h
+#define elxVersionMacros_h
+
+// Note: This header file is generated automatically, by CMake configure_file.
+
+/** Major component of elastix version. */
+#define ELASTIX_VERSION_MAJOR @ELASTIX_VERSION_MAJOR@
+
+/** Minor component of elastix version. */
+#define ELASTIX_VERSION_MINOR @ELASTIX_VERSION_MINOR@
+
+/** Patch component of elastix version. */
+#define ELASTIX_VERSION_PATCH @ELASTIX_VERSION_PATCH@
+
+/** String representation of elastix version. */
+#define ELASTIX_VERSION_STRING "@ELASTIX_VERSION_MAJOR@.@ELASTIX_VERSION_MINOR@.@ELASTIX_VERSION_PATCH@"
+
+#endif


### PR DESCRIPTION
And added `GetElastixVersionString()` helper function.

(Discussed with Marius Staring at internal superelastix.slack.com channel #elastix)