### PR TITLE
BUG: Close output streams at the end of GenerateData()

### DIFF
--- a/Core/Kernel/elxElastixMain.cxx
+++ b/Core/Kernel/elxElastixMain.cxx
@@ -130,6 +130,24 @@ namespace elastix
 {
 
 /**
+ * ********************* xoutManager ******************************
+ */
+
+xoutManager::xoutManager( const std::string& logFileName, const bool setupLogging, const bool setupCout )
+{
+  if (xoutSetup(logFileName.c_str(), setupLogging, setupCout))
+  {
+    itkGenericExceptionMacro("Error while setting up xout");
+  }
+}
+
+xoutManager::Guard::~Guard()
+{
+  g_data = {};
+}
+
+
+/**
  * ********************* Constructor ****************************
  */
 

--- a/Core/Kernel/elxElastixMain.cxx
+++ b/Core/Kernel/elxElastixMain.cxx
@@ -34,7 +34,7 @@
 #include "itkOpenCLSetup.h"
 #endif
 
-namespace elastix
+namespace
 {
 
 using namespace xl;
@@ -46,16 +46,21 @@ using namespace xl;
  * by xoutSetup.
  */
 
-/** \todo move to ElastixMain class, as static vars? */
+struct Data
+{
+  /** xout TargetCells. */
+  xoutbase_type   Xout;
+  xoutsimple_type WarningXout;
+  xoutsimple_type ErrorXout;
+  xoutsimple_type StandardXout;
+  xoutsimple_type CoutOnlyXout;
+  xoutsimple_type LogOnlyXout;
+  std::ofstream   LogFileStream;
+};
 
-/** xout TargetCells. */
-xoutbase_type   g_xout;
-xoutsimple_type g_WarningXout;
-xoutsimple_type g_ErrorXout;
-xoutsimple_type g_StandardXout;
-xoutsimple_type g_CoutOnlyXout;
-xoutsimple_type g_LogOnlyXout;
-std::ofstream   g_LogFileStream;
+Data g_data;
+
+} // end unnamed namespace
 
 /**
  * ********************* xoutSetup ******************************
@@ -65,19 +70,16 @@ std::ofstream   g_LogFileStream;
  */
 
 int
-xoutSetup( const char * logfilename, bool setupLogging, bool setupCout )
+elastix::xoutSetup( const char * logfilename, bool setupLogging, bool setupCout )
 {
-  /** The namespace of xout. */
-  using namespace xl;
-
   int returndummy = 0;
-  set_xout( &g_xout );
+  set_xout( &g_data.Xout );
 
   if( setupLogging )
   {
     /** Open the logfile for writing. */
-    g_LogFileStream.open( logfilename );
-    if( !g_LogFileStream.is_open() )
+    g_data.LogFileStream.open( logfilename );
+    if( !g_data.LogFileStream.is_open() )
     {
       std::cerr << "ERROR: LogFile cannot be opened!" << std::endl;
       return 1;
@@ -87,7 +89,7 @@ xoutSetup( const char * logfilename, bool setupLogging, bool setupCout )
   /** Set std::cout and the logfile as outputs of xout. */
   if( setupLogging )
   {
-    returndummy |= xout.AddOutput( "log", &g_LogFileStream );
+    returndummy |= xout.AddOutput( "log", &g_data.LogFileStream );
   }
   if( setupCout )
   {
@@ -95,24 +97,24 @@ xoutSetup( const char * logfilename, bool setupLogging, bool setupCout )
   }
 
   /** Set outputs of LogOnly and CoutOnly. */
-  returndummy |= g_LogOnlyXout.AddOutput( "log", &g_LogFileStream );
-  returndummy |= g_CoutOnlyXout.AddOutput( "cout", &std::cout );
+  returndummy |= g_data.LogOnlyXout.AddOutput( "log", &g_data.LogFileStream );
+  returndummy |= g_data.CoutOnlyXout.AddOutput( "cout", &std::cout );
 
   /** Copy the outputs to the warning-, error- and standard-xouts. */
-  g_WarningXout.SetOutputs( xout.GetCOutputs() );
-  g_ErrorXout.SetOutputs( xout.GetCOutputs() );
-  g_StandardXout.SetOutputs( xout.GetCOutputs() );
+  g_data.WarningXout.SetOutputs( xout.GetCOutputs() );
+  g_data.ErrorXout.SetOutputs( xout.GetCOutputs() );
+  g_data.StandardXout.SetOutputs( xout.GetCOutputs() );
 
-  g_WarningXout.SetOutputs( xout.GetXOutputs() );
-  g_ErrorXout.SetOutputs( xout.GetXOutputs() );
-  g_StandardXout.SetOutputs( xout.GetXOutputs() );
+  g_data.WarningXout.SetOutputs( xout.GetXOutputs() );
+  g_data.ErrorXout.SetOutputs( xout.GetXOutputs() );
+  g_data.StandardXout.SetOutputs( xout.GetXOutputs() );
 
   /** Link the warning-, error- and standard-xouts to xout. */
-  returndummy |= xout.AddTargetCell( "warning", &g_WarningXout );
-  returndummy |= xout.AddTargetCell( "error", &g_ErrorXout );
-  returndummy |= xout.AddTargetCell( "standard", &g_StandardXout );
-  returndummy |= xout.AddTargetCell( "logonly", &g_LogOnlyXout );
-  returndummy |= xout.AddTargetCell( "coutonly", &g_CoutOnlyXout );
+  returndummy |= xout.AddTargetCell( "warning", &g_data.WarningXout );
+  returndummy |= xout.AddTargetCell( "error", &g_data.ErrorXout );
+  returndummy |= xout.AddTargetCell( "standard", &g_data.StandardXout );
+  returndummy |= xout.AddTargetCell( "logonly", &g_data.LogOnlyXout );
+  returndummy |= xout.AddTargetCell( "coutonly", &g_data.CoutOnlyXout );
 
   /** Format the output. */
   xout[ "standard" ] << std::fixed;
@@ -123,6 +125,9 @@ xoutSetup( const char * logfilename, bool setupLogging, bool setupCout )
 
 } // end xoutSetup()
 
+
+namespace elastix
+{
 
 /**
  * ********************* Constructor ****************************

--- a/Core/Kernel/elxElastixMain.h
+++ b/Core/Kernel/elxElastixMain.h
@@ -22,12 +22,15 @@
 #include "elxComponentLoader.h"
 
 #include "elxElastixBase.h"
-#include "itkObject.h"
-
-#include <iostream>
-#include <fstream>
-
 #include "itkParameterMapInterface.h"
+
+#include <itkObject.h>
+
+// Standard C++ header files:
+#include <fstream>
+#include <iostream>
+#include <string>
+
 
 namespace elastix
 {
@@ -49,6 +52,36 @@ namespace elastix
  * It returns 0 if everything went ok. 1 otherwise.
  */
 extern int xoutSetup( const char * logfilename, bool setupLogging, bool setupCout );
+
+
+/** Manages setting up and closing the "xout" output streams.
+ */
+class xoutManager
+{
+public:
+  ITK_DISALLOW_COPY_AND_ASSIGN(xoutManager);
+
+  /** This explicit constructor does set up the "xout" output streams. */
+  explicit xoutManager( const std::string & logfilename, const bool setupLogging, const bool setupCout );
+
+  /** The default-constructor only just constructs a manager object */ 
+  xoutManager() = default;
+
+  /** The destructor closes the "xout" output streams. */
+  ~xoutManager() = default;
+
+private:
+
+  struct Guard
+  {
+    ITK_DISALLOW_COPY_AND_ASSIGN(Guard);
+    Guard() = default;
+    ~Guard();
+  };
+
+  const Guard m_Guard{};
+};
+
 
 /**
  * \class ElastixMain

--- a/Core/Main/elastixlib.cxx
+++ b/Core/Main/elastixlib.cxx
@@ -197,6 +197,7 @@ ELASTIX::RegisterImages(
 
   /** Setup xout. */
   const std::string logFileName = performLogging ? (outFolder + "elastix.log") : "";
+  const elx::xoutManager manager{};
   int returndummy = elx::xoutSetup( logFileName.c_str(), performLogging, performCout );
   if( ( returndummy != 0 ) && performCout )
   {

--- a/Core/Main/elxElastixFilter.hxx
+++ b/Core/Main/elxElastixFilter.hxx
@@ -199,10 +199,7 @@ ElastixFilter< TFixedImage, TMovingImage >
   }
 
   // Setup xout
-  if( elx::xoutSetup( logFileName.c_str(), this->GetLogToFile(), this->GetLogToConsole() ) )
-  {
-    itkExceptionMacro( "Error while setting up xout" );
-  }
+  const elx::xoutManager manager( logFileName, this->GetLogToFile(), this->GetLogToConsole() );
 
   // Run the (possibly multiple) registration(s)
   for( unsigned int i = 0; i < parameterMapVector.size(); ++i )

--- a/Core/Main/elxTransformixFilter.hxx
+++ b/Core/Main/elxTransformixFilter.hxx
@@ -155,10 +155,7 @@ TransformixFilter< TMovingImage >
   }
 
   // Setup xout
-  if( elx::xoutSetup( logFileName.c_str(), this->GetLogToFile(), this->GetLogToConsole() ) )
-  {
-    itkExceptionMacro( "Error while setting up xout" );
-  }
+  const elx::xoutManager manager( logFileName, this->GetLogToFile(), this->GetLogToConsole() );
 
   // Instantiate transformix
   TransformixMainPointer transformix = TransformixMainType::New();

--- a/Core/Main/itkElastixRegistrationMethod.hxx
+++ b/Core/Main/itkElastixRegistrationMethod.hxx
@@ -219,10 +219,7 @@ ElastixRegistrationMethod<TFixedImage, TMovingImage>::GenerateData()
   }
 
   // Setup xout
-  if (elastix::xoutSetup(logFileName.c_str(), this->GetLogToFile(), this->GetLogToConsole()))
-  {
-    itkExceptionMacro("Error while setting up xout");
-  }
+  const elastix::xoutManager manager(logFileName, this->GetLogToFile(), this->GetLogToConsole());
 
   // Run the (possibly multiple) registration(s)
   for (unsigned int i = 0; i < parameterMapVector.size(); ++i)

--- a/Core/Main/itkTransformixFilter.hxx
+++ b/Core/Main/itkTransformixFilter.hxx
@@ -159,10 +159,7 @@ TransformixFilter<TMovingImage>::GenerateData()
   }
 
   // Setup xout
-  if (elx::xoutSetup(logFileName.c_str(), this->GetLogToFile(), this->GetLogToConsole()))
-  {
-    itkExceptionMacro("Error while setting up xout");
-  }
+  const elx::xoutManager manager(logFileName, this->GetLogToFile(), this->GetLogToConsole());
 
   // Instantiate transformix
   TransformixMainPointer transformix = TransformixMainType::New();

--- a/Core/Main/transformixlib.cxx
+++ b/Core/Main/transformixlib.cxx
@@ -171,6 +171,7 @@ TRANSFORMIX::TransformImage(
   argMap.insert( ArgumentMapEntryType( "-argv0", "transformix" ) );
 
   /** Setup xout. */
+  const elx::xoutManager manager{};
   int returndummy2 = elx::xoutSetup( logFileName.c_str(), performLogging, performCout );
   if( returndummy2 && performCout )
   {


### PR DESCRIPTION
Implements the "core part" of issue #297, "Feature Request: Allow closing log file in library"

ITKElastix issue https://github.com/InsightSoftwareConsortium/ITKElastix/issues/61 "Is the log file really closed?"