### PR TITLE
STYLE: Move CoordRepType typedef from ElastixTemplate<> to ElastixBase

### DIFF
--- a/Core/ComponentBaseClasses/elxInterpolatorBase.h
+++ b/Core/ComponentBaseClasses/elxInterpolatorBase.h
@@ -23,6 +23,7 @@
 #include "elxMacro.h"
 
 #include "elxBaseComponentSE.h"
+#include "elxElastixBase.h"
 
 #include "itkInterpolateImageFunction.h"
 
@@ -61,7 +62,7 @@ public:
 
   /** Other typedef's. */
   typedef typename ElastixType::MovingImageType InputImageType;
-  typedef typename ElastixType::CoordRepType    CoordRepType;
+  typedef ElastixBase::CoordRepType CoordRepType;
 
   /** ITKBaseType. */
   typedef itk::InterpolateImageFunction<

--- a/Core/ComponentBaseClasses/elxResampleInterpolatorBase.h
+++ b/Core/ComponentBaseClasses/elxResampleInterpolatorBase.h
@@ -23,6 +23,7 @@
 #include "elxMacro.h"
 
 #include "elxBaseComponentSE.h"
+#include "elxElastixBase.h"
 #include "itkInterpolateImageFunction.h"
 
 namespace elastix
@@ -60,7 +61,7 @@ public:
 
   /** Typedef's from elastix. */
   typedef typename ElastixType::MovingImageType InputImageType;
-  typedef typename ElastixType::CoordRepType    CoordRepType;
+  typedef ElastixBase::CoordRepType CoordRepType;
 
   /** Other typedef's. */
   typedef itk::InterpolateImageFunction<

--- a/Core/ComponentBaseClasses/elxResamplerBase.h
+++ b/Core/ComponentBaseClasses/elxResamplerBase.h
@@ -94,7 +94,7 @@ public:
   typedef typename ElastixType::MovingImageType InputImageType;
   typedef typename ElastixType::MovingImageType OutputImageType;
   //typedef typename ElastixType::FixedImageType      OutputImageType;
-  typedef typename ElastixType::CoordRepType CoordRepType;
+  typedef ElastixBase::CoordRepType CoordRepType;
 
   /** Other typedef's. */
   typedef itk::ResampleImageFilter<

--- a/Core/ComponentBaseClasses/elxTransformBase.h
+++ b/Core/ComponentBaseClasses/elxTransformBase.h
@@ -22,6 +22,7 @@
 #include "elxMacro.h"
 
 #include "elxBaseComponentSE.h"
+#include "elxElastixBase.h"
 #include "itkAdvancedTransform.h"
 #include "itkAdvancedCombinationTransform.h"
 #include "elxComponentDatabase.h"
@@ -151,7 +152,7 @@ public:
     ::CommandLineEntryType CommandLineEntryType;
 
   /** Elastix typedef's. */
-  typedef typename TElastix::CoordRepType    CoordRepType;
+  typedef ElastixBase::CoordRepType CoordRepType;
   typedef typename TElastix::FixedImageType  FixedImageType;
   typedef typename TElastix::MovingImageType MovingImageType;
 

--- a/Core/Kernel/elxElastixBase.h
+++ b/Core/Kernel/elxElastixBase.h
@@ -31,13 +31,16 @@
 #include "elxBaseComponent.h"
 #include "elxComponentDatabase.h"
 #include "elxConfiguration.h"
-#include "itkObject.h"
-#include "itkDataObject.h"
 #include "elxMacro.h"
 #include "xoutmain.h"
-#include "itkVectorContainer.h"
-#include "itkImageFileReader.h"
-#include "itkChangeInformationImageFilter.h"
+
+// ITK header files:
+#include <itkChangeInformationImageFilter.h>
+#include <itkCostFunction.h>
+#include <itkDataObject.h>
+#include <itkImageFileReader.h>
+#include <itkObject.h>
+#include <itkVectorContainer.h>
 
 #include <fstream>
 #include <iomanip>
@@ -170,6 +173,9 @@ public:
   typedef ComponentDatabaseType::Pointer   ComponentDatabasePointer;
   typedef ComponentDatabaseType::IndexType DBIndexType;
   typedef std::vector< double >            FlatDirectionCosinesType;
+
+  /** Type for representation of the transform coordinates. */
+  typedef itk::CostFunction::ParametersValueType CoordRepType;   // double
 
   /** Typedef that is used in the elastix dll version. */
   typedef itk::ParameterMapInterface::ParameterMapType ParameterMapType;

--- a/Core/Kernel/elxElastixTemplate.h
+++ b/Core/Kernel/elxElastixTemplate.h
@@ -169,9 +169,6 @@ public:
   /** Typedef for the UseDirectionCosines option. */
   typedef typename FixedImageType::DirectionType FixedImageDirectionType;
 
-  /** Type for representation of the transform coordinates. */
-  typedef itk::CostFunction::ParametersValueType CoordRepType;   // double
-
   /** BaseComponent. */
   typedef BaseComponent BaseComponentType;
 


### PR DESCRIPTION
Reduces unnecessary template argument type dependencies (as `ElastixTemplate` is a template, while `ElastixBase` is not).

Aims to eventually reduce compilation duration.