### PR TITLE
BUG: Add elastix_exe and transformix_exe to CMake install (issue #305)

### DIFF
--- a/Core/CMakeLists.txt
+++ b/Core/CMakeLists.txt
@@ -217,7 +217,7 @@ if( NOT WIN32 )
     PROPERTIES INSTALL_RPATH "${CMAKE_INSTALL_PREFIX}/lib:${ITK_DIR}" )
 endif()
 
-install( TARGETS elastix_lib transformix_lib elxCore
+install( TARGETS elastix_exe transformix_exe elastix_lib transformix_lib elxCore
   ARCHIVE DESTINATION ${ELASTIX_ARCHIVE_DIR}
   LIBRARY DESTINATION ${ELASTIX_LIBRARY_DIR}
   RUNTIME DESTINATION ${ELASTIX_RUNTIME_DIR}


### PR DESCRIPTION
Aims to fix issue #305 "Elastix 5.0.1 binaries (elastix and transformix) not installed by default cmake build", reported by Ben Darwin (@bcdarwin).