### PR TITLE
STYLE: Add const RecursiveBSplineTransformImplementation::GetJacobianOf

### DIFF
--- a/Common/Transforms/itkRecursiveBSplineTransform.hxx
+++ b/Common/Transforms/itkRecursiveBSplineTransform.hxx
@@ -509,7 +509,7 @@ RecursiveBSplineTransform< TScalar, NDimensions, VSplineOrder >
   /** Allocate memory for jsj. If you want also the Jacobian,
    * numberOfIndices more elements are needed.
    */
-  double dummy[ 1 ] = { 1.0 };
+  const double dummy[ 1 ] = { 1.0 };
 
   /** Recursively expand all weights (destroys dummy), and multiply with dc. */
   const double * dc      = this->m_PointToIndexMatrix2.GetVnlMatrix().data_block();
@@ -621,7 +621,7 @@ RecursiveBSplineTransform< TScalar, NDimensions, VSplineOrder >
    */
   double *       jshPtr     = jsh[ 0 ][ 0 ].GetVnlMatrix().data_block();
   const double * dc         = this->m_PointToIndexMatrix2.GetVnlMatrix().data_block();
-  double         dummy[ 1 ] = { 1.0 };
+  const double dummy[ 1 ] = { 1.0 };
   RecursiveBSplineTransformImplementation< SpaceDimension, SpaceDimension, SplineOrder, TScalar >
     ::GetJacobianOfSpatialHessian( jshPtr, weightsPointer, derivativeWeightsPointer, hessianWeightsPointer, dc, dummy );
 

--- a/Common/Transforms/itkRecursiveBSplineTransformImplementation.h
+++ b/Common/Transforms/itkRecursiveBSplineTransformImplementation.h
@@ -286,7 +286,7 @@ public:
     const double * weights1D,                   // normal B-spline weights
     const double * derivativeWeights1D,         // 1st derivative of B-spline
     const double * directionCosines,
-    InternalFloatType * jsj )
+    const InternalFloatType * const jsj )
   {
     const unsigned int helperDim = OutputDimension - SpaceDimension + 1;
 
@@ -323,7 +323,7 @@ public:
     const double * derivativeWeights1D,         // 1st derivative of B-spline
     const double * hessianWeights1D,            // 2nd derivative of B-spline
     const double * directionCosines,
-    InternalFloatType * jsh )
+    const InternalFloatType * const jsh )
   {
     const unsigned int helperDim   = OutputDimension - SpaceDimension;
     const unsigned int helperDimW  = ( helperDim + 1 ) * ( helperDim + 2 ) / 2;
@@ -482,7 +482,7 @@ public:
     const double * weights1D,                   // normal B-spline weights
     const double * derivativeWeights1D,         // 1st derivative of B-spline
     const double * directionCosines,
-    InternalFloatType * jsj )
+    const InternalFloatType * const jsj )
   {
     /** Copy the correct elements to the output.
      * Note that the first element jsj[0] is the normal Jacobian. We ignore it for now.
@@ -522,7 +522,7 @@ public:
     const double * derivativeWeights1D,         // 1st derivative of B-spline
     const double * hessianWeights1D,            // 2nd derivative of B-spline
     const double * directionCosines,
-    InternalFloatType * jsh )
+    const InternalFloatType * const jsh )
   {
     double jsh_tmp[ OutputDimension * OutputDimension ];
     double matrixProduct[ OutputDimension * OutputDimension ];


### PR DESCRIPTION
Fix const-correctness of last parameter of static `RecursiveBSplineTransformImplementation` member functions `GetJacobianOfSpatialJacobian` and `GetJacobianOfSpatialHessian` (a pointer to InternalFloatType).