### PR TITLE
COMP: Quick-fix ITKElastix error: 'itkCostFunction.h' file not found

### DIFF
--- a/Core/Kernel/elxElastixBase.h
+++ b/Core/Kernel/elxElastixBase.h
@@ -36,7 +36,6 @@
 
 // ITK header files:
 #include <itkChangeInformationImageFilter.h>
-#include <itkCostFunction.h>
 #include <itkDataObject.h>
 #include <itkImageFileReader.h>
 #include <itkObject.h>
@@ -175,7 +174,7 @@ public:
   typedef std::vector< double >            FlatDirectionCosinesType;
 
   /** Type for representation of the transform coordinates. */
-  typedef itk::CostFunction::ParametersValueType CoordRepType;   // double
+  typedef double CoordRepType;   // itk::CostFunction::ParametersValueType
 
   /** Typedef that is used in the elastix dll version. */
   typedef itk::ParameterMapInterface::ParameterMapType ParameterMapType;


### PR DESCRIPTION
Removed `#include <itkCostFunction.h>` and then simply defined `ElastixBase::CoordRepType` as `double` (which is the same type as `itk::CostFunction::ParametersValueType` anyway).

Aims to fix:

> _deps/elx-src/Core/Kernel/elxElastixBase.h:39:10: fatal error: 'itkCostFunction.h' file not found
itkElastixRegistrationMethodTest.cxx

At https://open.cdash.org/viewBuildError.php?buildid=6806022
ITKElastix pull request https://github.com/InsightSoftwareConsortium/ITKElastix/pull/66