### PR TITLE
STYLE: Explicitly instantiate xout class templates, declare them extern

### DIFF
--- a/Common/xout/xoutbase.h
+++ b/Common/xout/xoutbase.h
@@ -201,6 +201,4 @@ protected:
 
 } // end namespace xoutlibrary
 
-#include "xoutbase.hxx"
-
 #endif // end #ifndef xoutbase_h

--- a/Common/xout/xoutcell.h
+++ b/Common/xout/xoutcell.h
@@ -36,7 +36,7 @@ using namespace std;
  */
 
 template <class charT, class traits = char_traits<charT>>
-class xoutcell : public xoutbase<charT, traits>
+class xoutcell final : public xoutbase<charT, traits>
 {
 public:
   /** Typdef's. */

--- a/Common/xout/xoutcell.h
+++ b/Common/xout/xoutcell.h
@@ -61,6 +61,4 @@ private:
 
 } // end namespace xoutlibrary
 
-#include "xoutcell.hxx"
-
 #endif // end #ifndef xoutcell_h

--- a/Common/xout/xoutmain.cxx
+++ b/Common/xout/xoutmain.cxx
@@ -18,6 +18,11 @@
 
 #include "xoutmain.h"
 
+#include "xoutbase.hxx"
+#include "xoutcell.hxx"
+#include "xoutrow.hxx"
+#include "xoutsimple.hxx"
+
 namespace xoutlibrary
 {
 static xoutbase_type * local_xout = nullptr;
@@ -41,5 +46,11 @@ xout_valid()
   return local_xout != nullptr;
 }
 
+
+// Explicit template instantiations.
+template class xoutbase<char>;
+template class xoutcell<char>;
+template class xoutrow<char>;
+template class xoutsimple<char>;
 
 } // namespace xoutlibrary

--- a/Common/xout/xoutmain.h
+++ b/Common/xout/xoutmain.h
@@ -32,6 +32,11 @@ namespace xl = xoutlibrary;
 /** Typedefs for the most common use of xout */
 namespace xoutlibrary
 {
+extern template class xoutbase<char>;
+extern template class xoutcell<char>;
+extern template class xoutrow<char>;
+extern template class xoutsimple<char>;
+
 typedef xoutbase<char>   xoutbase_type;
 typedef xoutsimple<char> xoutsimple_type;
 typedef xoutrow<char>    xoutrow_type;

--- a/Common/xout/xoutrow.h
+++ b/Common/xout/xoutrow.h
@@ -122,6 +122,4 @@ private:
 
 } // end namespace xoutlibrary
 
-#include "xoutrow.hxx"
-
 #endif // end #ifndef xoutrow_h

--- a/Common/xout/xoutrow.h
+++ b/Common/xout/xoutrow.h
@@ -41,7 +41,7 @@ using namespace std;
  */
 
 template <class charT, class traits = char_traits<charT>>
-class xoutrow : public xoutbase<charT, traits>
+class xoutrow final : public xoutbase<charT, traits>
 {
 public:
   typedef xoutrow                 Self;

--- a/Common/xout/xoutsimple.h
+++ b/Common/xout/xoutsimple.h
@@ -34,7 +34,7 @@ using namespace std;
  */
 
 template <class charT, class traits = char_traits<charT>>
-class xoutsimple : public xoutbase<charT, traits>
+class xoutsimple final : public xoutbase<charT, traits>
 {
 public:
   /** Typedef's.*/

--- a/Common/xout/xoutsimple.h
+++ b/Common/xout/xoutsimple.h
@@ -78,6 +78,4 @@ public:
 
 } // end namespace xoutlibrary
 
-#include "xoutsimple.hxx"
-
 #endif // end #ifndef xoutsimple_h


### PR DESCRIPTION
Aims to reduce compilation times.