### PR TITLE
ENH: Better indexed inputs and output support in itk::TransformixFilter

### DIFF
--- a/Core/Main/itkTransformixFilter.h
+++ b/Core/Main/itkTransformixFilter.h
@@ -88,6 +88,8 @@ public:
   typedef typename itk::Image<itk::Vector<float, TMovingImage::ImageDimension>, TMovingImage::ImageDimension>
     OutputDeformationFieldType;
 
+  using DataObjectPointerArraySizeType = ProcessObject::DataObjectPointerArraySizeType;
+
   using InputImageType = TMovingImage;
   itkStaticConstMacro(MovingImageDimension, unsigned int, TMovingImage::ImageDimension);
 
@@ -95,9 +97,19 @@ public:
   virtual void
   SetMovingImage(TMovingImage * inputImage);
   const InputImageType *
-  GetMovingImage(void);
+  GetMovingImage() const;
   virtual void
-  RemoveMovingImage(void);
+  RemoveMovingImage();
+
+  /* Standard filter indexed input / output methods */
+  void
+  SetInput(InputImageType * movingImage);
+  const InputImageType *
+  GetInput() const;
+  void
+  SetInput(DataObjectPointerArraySizeType index, DataObject * input);
+  const DataObject *
+  GetInput(DataObjectPointerArraySizeType index) const;
 
   /** Set/Get/Remove moving point set filename. */
   itkSetMacro(FixedPointSetFileName, std::string);
@@ -132,6 +144,16 @@ public:
 
   const ParameterObjectType *
   GetTransformParameterObject() const;
+
+  using Superclass::GetOutput;
+  DataObject *
+  GetOutput(unsigned int idx);
+  const DataObject *
+  GetOutput(unsigned int idx) const;
+  OutputImageType *
+  GetOutput();
+  const OutputImageType *
+  GetOutput() const;
 
   OutputDeformationFieldType *
   GetOutputDeformationField();
@@ -194,8 +216,6 @@ private:
   /** Tell the compiler we want all definitions of Get/Set/Remove
    *  from ProcessObject and TransformixFilter.
    */
-  using ProcessObject::SetInput;
-  using ProcessObject::GetInput;
   using ProcessObject::RemoveInput;
 
   std::string m_FixedPointSetFileName;

--- a/Core/Main/itkTransformixFilter.hxx
+++ b/Core/Main/itkTransformixFilter.hxx
@@ -44,8 +44,9 @@ namespace itk
 template <typename TMovingImage>
 TransformixFilter<TMovingImage>::TransformixFilter()
 {
-  this->SetPrimaryInputName("TransformParameterObject");
-  this->SetPrimaryOutputName("ResultImage");
+  this->SetPrimaryInputName("MovingImage");
+  this->AddRequiredInputName("TransformParameterObject", 1);
+
   this->SetOutput("ResultDeformationField", this->MakeOutput("ResultDeformationField"));
 
   this->m_FixedPointSetFileName = "";
@@ -71,11 +72,11 @@ TransformixFilter<TMovingImage>::GenerateData()
   // on some platforms.
   const unsigned int movingImageDimension = MovingImageDimension;
 
-  if (this->IsEmpty(itkDynamicCastInDebugMode<TMovingImage *>(this->GetInput("InputImage"))) &&
+  if (this->IsEmpty(this->GetMovingImage()) &&
       this->GetFixedPointSetFileName().empty() && !this->GetComputeSpatialJacobian() &&
       !this->GetComputeDeterminantOfSpatialJacobian() && !this->GetComputeDeformationField())
   {
-    itkExceptionMacro("Expected at least one of SeTMovingImage(), "
+    itkExceptionMacro("Expected at least one of SetMovingImage(), "
                       << "SetFixedPointSetFileName() "
                       << "ComputeSpatialJacobianOn(), "
                       << "ComputeDeterminantOfSpatialJacobianOn() or "
@@ -115,7 +116,7 @@ TransformixFilter<TMovingImage>::GenerateData()
   }
 
   // Setup output directory
-  // Only the input "InputImage" does not require an output directory
+  // Only the input "MovingImage" does not require an output directory
   if ((this->GetComputeSpatialJacobian() || this->GetComputeDeterminantOfSpatialJacobian() ||
        this->GetComputeDeformationField() || !this->GetFixedPointSetFileName().empty() || this->GetLogToFile()) &&
       this->GetOutputDirectory().empty())
@@ -169,16 +170,15 @@ TransformixFilter<TMovingImage>::GenerateData()
 
   // Setup transformix for warping input image if given
   DataObjectContainerPointer inputImageContainer = nullptr;
-  if (!this->IsEmpty(itkDynamicCastInDebugMode<TMovingImage *>(this->GetInput("InputImage"))))
+  if (!this->IsEmpty(this->GetMovingImage()))
   {
     inputImageContainer = DataObjectContainerType::New();
-    inputImageContainer->CreateElementAt(0) = this->GetInput("InputImage");
+    inputImageContainer->InsertElement(0, const_cast<InputImageType *>(this->GetMovingImage()));
     transformix->SetInputImageContainer(inputImageContainer);
   }
 
   // Get ParameterMap
-  ParameterObjectPointer transformParameterObject =
-    itkDynamicCastInDebugMode<elastix::ParameterObject *>(this->GetInput("TransformParameterObject"));
+  ParameterObjectPointer transformParameterObject = this->GetTransformParameterObject();
   ParameterMapVectorType transformParameterMapVector = transformParameterObject->GetParameterMap();
 
   // Assert user did not set empty parameter map
@@ -225,7 +225,7 @@ TransformixFilter<TMovingImage>::GenerateData()
   if (resultImageContainer.IsNotNull() && resultImageContainer->Size() > 0 &&
       resultImageContainer->ElementAt(0).IsNotNull())
   {
-    this->GraftOutput("ResultImage", resultImageContainer->ElementAt(0));
+    this->GraftOutput(resultImageContainer->ElementAt(0));
   }
   // Optionally, save result deformation field
   DataObjectContainerPointer resultDeformationFieldContainer = transformix->GetResultDeformationFieldContainer();
@@ -241,11 +241,7 @@ template <typename TMovingImage>
 typename TransformixFilter<TMovingImage>::DataObjectPointer
 TransformixFilter<TMovingImage>::MakeOutput(const DataObjectIdentifierType & key)
 {
-  if (key == "ResultImage")
-  {
-    return TMovingImage::New().GetPointer();
-  }
-  else if (key == "ResultDeformationField")
+  if (key == "ResultDeformationField")
   {
     return OutputDeformationFieldType::New().GetPointer();
   }
@@ -358,15 +354,15 @@ template <typename TMovingImage>
 void
 TransformixFilter<TMovingImage>::SetMovingImage(TMovingImage * inputImage)
 {
-  this->SetInput("InputImage", inputImage);
+  this->ProcessObject::SetInput("MovingImage", inputImage);
 }
 
 
 template <typename TMovingImage>
 const typename TransformixFilter<TMovingImage>::InputImageType *
-TransformixFilter<TMovingImage>::GetMovingImage()
+TransformixFilter<TMovingImage>::GetMovingImage() const
 {
-  return itkDynamicCastInDebugMode<TMovingImage *>(this->GetInput("InputImage"));
+  return itkDynamicCastInDebugMode<const TMovingImage *>(this->ProcessObject::GetInput("MovingImage"));
 }
 
 
@@ -374,15 +370,62 @@ template <typename TMovingImage>
 void
 TransformixFilter<TMovingImage>::RemoveMovingImage()
 {
-  this->RemoveInput("InputImage");
+  this->ProcessObject::RemoveInput("MovingImage");
+}
+
+template <typename TMovingImage>
+void
+TransformixFilter<TMovingImage>::SetInput(InputImageType * inputImage)
+{
+  this->ProcessObject::SetInput("MovingImage", inputImage);
+}
+
+
+template <typename TMovingImage>
+const typename TransformixFilter<TMovingImage>::InputImageType *
+TransformixFilter<TMovingImage>::GetInput() const
+{
+  return itkDynamicCastInDebugMode<const TMovingImage *>(this->ProcessObject::GetInput("MovingImage"));
+}
+
+template <typename TMovingImage>
+const DataObject *
+TransformixFilter<TMovingImage>::GetInput(DataObjectPointerArraySizeType index) const
+{
+  switch (index)
+  {
+    case 0:
+      return this->GetMovingImage();
+    case 1:
+      return this->GetTransformParameterObject();
+    default:
+      return this->ProcessObject::GetInput(index);
+  }
 }
 
 
 template <typename TMovingImage>
 void
+TransformixFilter<TMovingImage>::SetInput(DataObjectPointerArraySizeType index, DataObject * input)
+{
+  switch (index)
+  {
+    case 0:
+      this->SetMovingImage(itkDynamicCastInDebugMode<TMovingImage *>(input));
+      break;
+    case 1:
+      this->SetTransformParameterObject(itkDynamicCastInDebugMode<ParameterObjectType *>(input));
+      break;
+    default:
+      this->ProcessObject::SetNthInput(index, input);
+  }
+}
+
+template <typename TMovingImage>
+void
 TransformixFilter<TMovingImage>::SetTransformParameterObject(ParameterObjectType * parameterObject)
 {
-  this->SetInput("TransformParameterObject", parameterObject);
+  this->ProcessObject::SetInput("TransformParameterObject", parameterObject);
 }
 
 
@@ -390,7 +433,7 @@ template <typename TMovingImage>
 typename TransformixFilter<TMovingImage>::ParameterObjectType *
 TransformixFilter<TMovingImage>::GetTransformParameterObject(void)
 {
-  return dynamic_cast<ParameterObjectType *>(this->GetInput("TransformParameterObject"));
+  return itkDynamicCastInDebugMode<ParameterObjectType *>(this->ProcessObject::GetInput("TransformParameterObject"));
 }
 
 
@@ -398,7 +441,7 @@ template <typename TMovingImage>
 const typename TransformixFilter<TMovingImage>::ParameterObjectType *
 TransformixFilter<TMovingImage>::GetTransformParameterObject() const
 {
-  return dynamic_cast<const ParameterObjectType *>(this->GetInput("TransformParameterObject"));
+  return itkDynamicCastInDebugMode<const ParameterObjectType *>(this->ProcessObject::GetInput("TransformParameterObject"));
 }
 
 
@@ -418,6 +461,39 @@ TransformixFilter<TMovingImage>::GetOutputDeformationField() const
   return itkDynamicCastInDebugMode<const OutputDeformationFieldType *>(
     this->itk::ProcessObject::GetOutput("ResultDeformationField"));
 }
+
+
+template <typename TMovingImage>
+typename TransformixFilter<TMovingImage>::OutputImageType *
+TransformixFilter<TMovingImage>::GetOutput()
+{
+  return static_cast<OutputImageType *>(this->ProcessObject::GetOutput(0));
+}
+
+
+template <typename TMovingImage>
+const typename TransformixFilter<TMovingImage>::OutputImageType *
+TransformixFilter<TMovingImage>::GetOutput() const
+{
+  return static_cast<const OutputImageType *>(this->ProcessObject::GetOutput(0));
+}
+
+
+template <typename TMovingImage>
+DataObject *
+TransformixFilter<TMovingImage>::GetOutput(unsigned int idx)
+{
+  return this->ProcessObject::GetOutput(idx);
+}
+
+
+template <typename TMovingImage>
+const DataObject *
+TransformixFilter<TMovingImage>::GetOutput(unsigned int idx) const
+{
+  return this->ProcessObject::GetOutput(idx);
+}
+
 
 
 template <typename TMovingImage>

--- a/Testing/CMakeLists.txt
+++ b/Testing/CMakeLists.txt
@@ -985,3 +985,8 @@ trx_add_test( TransformixMemoryTest
   -in ${TestDataDir}/3DCT_lung_baseline_small.mha
   -tp ${TestDataDir}/transformparameters.3DCT_lung.affine.txt )
 
+elx_add_test( TransformixFilterTest "" "Transformix"
+  ${TestDataDir}/3DCT_lung_baseline_small.mha
+  ${TestDataDir}/transformparameters.3DCT_lung.affine.txt
+  ${TestOutputDir}/TransformixFilterTest.mha )
+target_link_libraries( itkTransformixFilterTest elastix_lib transformix_lib )

--- a/Testing/itkTransformixFilterTest.cxx
+++ b/Testing/itkTransformixFilterTest.cxx
@@ -1,0 +1,74 @@
+/*=========================================================================
+ *
+ *  Copyright UMC Utrecht and contributors
+ *
+ *  Licensed under the Apache License, Version 2.0 (the "License");
+ *  you may not use this file except in compliance with the License.
+ *  You may obtain a copy of the License at
+ *
+ *        http://www.apache.org/licenses/LICENSE-2.0.txt
+ *
+ *  Unless required by applicable law or agreed to in writing, software
+ *  distributed under the License is distributed on an "AS IS" BASIS,
+ *  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *  See the License for the specific language governing permissions and
+ *  limitations under the License.
+ *
+ *=========================================================================*/
+
+#include "itkTransformixFilter.h"
+#include "itkImageFileReader.h"
+#include "itkImageFileWriter.h"
+#include "itkParameterFileParser.h"
+#include "elxParameterObject.h"
+
+//-------------------------------------------------------------------------------------
+
+int
+main( int argc, char * argv[] )
+{
+  /** Some basic type definitions. */
+  constexpr unsigned int Dimension = 3;
+  typedef float PixelType;
+
+  /** Check. */
+  if( argc != 4 )
+  {
+    std::cerr << "ERROR: Usage: "
+              << argv[0]
+              << " <movingImage> <transformParameters> <transformedImage>" << std::endl;
+    return 1;
+  }
+  const char * movingImageFile = argv[1];
+  const char * transformParametersFile = argv[2];
+  const char * transformedImageFile = argv[3];
+
+  /** Other typedefs. */
+  using ImageType = itk::Image<PixelType, Dimension>;
+
+  using ImageReaderType = itk::ImageFileReader<ImageType>;
+  auto imageReader = ImageReaderType::New();
+  imageReader->SetFileName(movingImageFile);
+  auto movingImage = imageReader->GetOutput();
+
+  auto parameterObject = elastix::ParameterObject::New();
+  parameterObject->ReadParameterFile(transformParametersFile);
+  parameterObject->Print(std::cout);
+
+  using TransformixType = itk::TransformixFilter<ImageType>;
+  auto transformix = TransformixType::New();
+  transformix->SetMovingImage(movingImage);
+  transformix->SetTransformParameterObject(parameterObject);
+  transformix->SetLogToConsole(true);
+  ImageType::Pointer resultImage = transformix->GetOutput();
+
+  using ImageWriterType = itk::ImageFileWriter<ImageType>;
+  auto imageWriter = ImageWriterType::New();
+  imageWriter->SetFileName(transformedImageFile);
+  imageWriter->SetInput(resultImage);
+  imageWriter->Update();
+
+  /** Return a value. */
+  return 0;
+
+} // end main


### PR DESCRIPTION
Improvements to help with functional Python interface.

GetOutput has indexed interface.

"MovingImage" is the required, first indexed input
("TransformParameterObject") is the second.