### PR TITLE
Remove virtual from ElastixBase member functions 

### DIFF
--- a/Core/Kernel/elxElastixBase.h
+++ b/Core/Kernel/elxElastixBase.h
@@ -51,14 +51,14 @@
  * These macros are undef'd at the end of this file
  */
 #define elxGetObjectMacro( _name, _type ) \
-  virtual _type * Get##_name( void ) const \
+  _type * Get##_name( void ) const \
   { \
     return this->m_##_name.GetPointer(); \
   }
 //end elxGetObjectMacro
 
 #define elxSetObjectMacro( _name, _type ) \
-  virtual void Set##_name( _type * _arg ) \
+  void Set##_name( _type * _arg ) \
   { \
     if( this->m_##_name != _arg ) \
     { \
@@ -70,11 +70,11 @@
 
 /** defines for example: GetNumberOfMetrics() */
 #define elxGetNumberOfMacro( _name ) \
-  virtual unsigned int GetNumberOf##_name##s( void ) const \
+  unsigned int GetNumberOf##_name##s( void ) const \
   { \
-    if( this->Get##_name##Container() != nullptr ) \
+    if( this->m_##_name##Container != nullptr ) \
     { \
-      return this->Get##_name##Container()->Size(); \
+      return this->m_##_name##Container->Size(); \
     } \
     return 0; \
   }

--- a/Core/Kernel/elxElastixBase.h
+++ b/Core/Kernel/elxElastixBase.h
@@ -196,9 +196,9 @@ public:
   elxSetObjectMacro( Configuration, ConfigurationType );
 
   /** Set the database index of the instantiated elastix object. */
-  virtual void SetDBIndex( DBIndexType _arg );
+  void SetDBIndex( DBIndexType _arg );
 
-  virtual DBIndexType GetDBIndex( void )
+  DBIndexType GetDBIndex( void )
   {
     return this->m_DBIndex;
   }
@@ -329,7 +329,7 @@ public:
   /** Function that is called at the very beginning of ElastixTemplate::ApplyTransform().
    * It checks the command line input arguments.
    */
-  virtual int BeforeAllTransformixBase( void );
+  int BeforeAllTransformixBase( void );
 
   /** Functions called before and after registration.
    * They install/uninstall the xout["iteration"] field.
@@ -342,7 +342,7 @@ public:
    * (The value assumed when no DefaultOutputPrecision is given in the
    * parameter file.
    */
-  virtual int GetDefaultOutputPrecision( void ) const
+  int GetDefaultOutputPrecision( void ) const
   {
     return this->m_DefaultOutputPrecision;
   }
@@ -351,14 +351,14 @@ public:
   /** Get whether direction cosines should be taken into account (true)
    * or ignored (false). This depends on the UseDirectionCosines
    * parameter. */
-  virtual bool GetUseDirectionCosines( void ) const;
+  bool GetUseDirectionCosines( void ) const;
 
   /** Set/Get the original fixed image direction as a flat array
    * (d11 d21 d31 d21 d22 etc ) */
-  virtual void SetOriginalFixedImageDirectionFlat(
+  void SetOriginalFixedImageDirectionFlat(
     const FlatDirectionCosinesType & arg );
 
-  virtual const FlatDirectionCosinesType & GetOriginalFixedImageDirectionFlat( void ) const;
+  const FlatDirectionCosinesType & GetOriginalFixedImageDirectionFlat( void ) const;
 
   /** Creates transformation parameters map. */
   virtual void CreateTransformParametersMap( void ) = 0;


### PR DESCRIPTION
The `virtual` keyword should only be used for member functions that are meant to be overridden in a derived class.