### PR TITLE
STYLE: Make itk::Object base class of ElastixBase, move data from ElastixTemplate to ElastixBase

### DIFF
--- a/Core/Kernel/elxElastixBase.cxx
+++ b/Core/Kernel/elxElastixBase.cxx
@@ -476,6 +476,61 @@ ElastixBase::AfterRegistrationBase( void )
 
 } // end AfterRegistrationBase()
 
+/**
+ * ********************** GetResultImage *************************
+ */
+
+itk::DataObject*
+ElastixBase::GetResultImage( const unsigned int idx ) const
+{
+  if( idx < this->GetNumberOfResultImages() )
+  {
+    return this->m_ResultImageContainer->ElementAt( idx ).GetPointer();
+  }
+
+  return nullptr;
+
+} // end GetResultImage()
+
+
+/**
+ * ********************** SetResultImage *************************
+ */
+
+void
+ElastixBase::SetResultImage( DataObjectPointer result_image )
+{
+  this->SetResultImageContainer(
+    GenerateDataObjectContainer( result_image ) );
+} // end SetResultImage()
+
+
+/**
+* ********************** GetResultDeformationField *************************
+*/
+
+itk::DataObject*
+ElastixBase::GetResultDeformationField( unsigned int idx ) const
+{
+  if (idx < this->GetNumberOfResultDeformationFields() )
+  {
+    return this->m_ResultDeformationFieldContainer->ElementAt( idx ).GetPointer();
+  }
+
+  return nullptr;
+
+} // end GetResultDeformationField()
+
+/**
+* ********************** SetResultDeformationField *************************
+*/
+
+void
+ElastixBase::SetResultDeformationField( DataObjectPointer result_deformationfield )
+{
+  this->SetResultDeformationFieldContainer(
+    ElastixBase::GenerateDataObjectContainer( result_deformationfield ) );
+} // end SetResultDeformationField()
 
 /**
  * ******************** GetUseDirectionCosines ********************
@@ -508,6 +563,39 @@ const ElastixBase::FlatDirectionCosinesType &
 ElastixBase::GetOriginalFixedImageDirectionFlat( void ) const
 {
   return this->m_OriginalFixedImageDirection;
+}
+
+
+/**
+ * ************** GetTransformParametersMap *****************
+ */
+
+itk::ParameterMapInterface::ParameterMapType
+ElastixBase::GetTransformParametersMap( void ) const
+{
+  return this->m_TransformParametersMap;
+} // end GetTransformParametersMap()
+
+
+/**
+ * ************** SetConfigurations *********************
+ */
+
+void
+ElastixBase::SetConfigurations( const std::vector< ConfigurationPointer > & configurations )
+{
+  this->m_Configurations = configurations;
+}
+
+
+/**
+ * ************** GetConfiguration *********************
+ */
+
+ElastixBase::ConfigurationPointer
+ElastixBase::GetConfiguration( const size_t index ) const
+{
+  return this->m_Configurations[ index ];
 }
 
 

--- a/Core/Kernel/elxElastixBase.cxx
+++ b/Core/Kernel/elxElastixBase.cxx
@@ -84,12 +84,7 @@ ElastixBase::SetDBIndex( DBIndexType _arg )
   if( this->m_DBIndex != _arg )
   {
     this->m_DBIndex = _arg;
-
-    itk::Object * thisasobject = dynamic_cast< itk::Object * >( this );
-    if( thisasobject )
-    {
-      thisasobject->Modified();
-    }
+    this->itk::Object::Modified();
   }
 
 } // end SetDBIndex()

--- a/Core/Kernel/elxElastixBase.cxx
+++ b/Core/Kernel/elxElastixBase.cxx
@@ -176,6 +176,24 @@ ElastixBase::ElastixBase()
 
 
 /**
+ * ********************* GenerateDataObjectContainer ***********************
+ */
+
+ElastixBase::DataObjectContainerPointer
+ElastixBase::GenerateDataObjectContainer( DataObjectPointer dataObject )
+{
+  /** Allocate container pointer. */
+  const auto container = DataObjectContainerType::New();
+
+  /** Store object in container. */
+  container->push_back(dataObject);
+
+  /** Return the pointer to the new container. */
+  return container;
+}
+
+
+/**
  * ********************* SetDBIndex ***********************
  */
 

--- a/Core/Kernel/elxElastixBase.h
+++ b/Core/Kernel/elxElastixBase.h
@@ -467,29 +467,9 @@ public:
 
   };
 
-  class MultipleDataObjectFiller
-  {
-public:
-
-    /** GenerateImageContainer. */
-    static DataObjectContainerPointer GenerateImageContainer(
-      DataObjectPointer image )
-    {
-      /** Allocate image container pointer. */
-      const auto imageContainer = DataObjectContainerType::New();
-
-      /** Store image in image container. */
-      imageContainer->push_back( image );
-
-      /** Return the pointer to the new image container. */
-      return imageContainer;
-    } // end GenerateImageContainer()
-
-
-    /** Constructor and destructor. */
-    MultipleDataObjectFiller() = default;
-    ~MultipleDataObjectFiller() = default;
-  };
+  /** Generates a container that contains the specified data object */
+  static DataObjectContainerPointer GenerateDataObjectContainer(
+    DataObjectPointer dataObject );
 
 private:
 

--- a/Core/Kernel/elxElastixBase.h
+++ b/Core/Kernel/elxElastixBase.h
@@ -168,6 +168,12 @@ public:
     unsigned int, std::string >               FileNameContainerType;
   typedef FileNameContainerType::Pointer FileNameContainerPointer;
 
+  /** Result image */
+  typedef itk::DataObject ResultImageType;
+
+  /** Result deformation field */
+  typedef itk::DataObject ResultDeformationFieldType;
+
   /** Other typedef's. */
   typedef ComponentDatabase                ComponentDatabaseType;
   typedef ComponentDatabaseType::Pointer   ComponentDatabasePointer;
@@ -330,6 +336,15 @@ public:
 
   void AfterRegistrationBase( void ) override;
 
+  ResultImageType* GetResultImage(const unsigned int idx = 0) const;
+
+  void SetResultImage( DataObjectPointer result_image );
+
+  ResultDeformationFieldType* GetResultDeformationField( unsigned int idx = 0 ) const;
+
+  void SetResultDeformationField( DataObjectPointer result_deformationfield );
+
+
   /** Get the default precision of xout.
    * (The value assumed when no DefaultOutputPrecision is given in the
    * parameter file.
@@ -356,10 +371,13 @@ public:
   virtual void CreateTransformParametersMap( void ) = 0;
 
   /** Gets transformation parameters map. */
-  virtual ParameterMapType GetTransformParametersMap( void ) const = 0;
+  ParameterMapType GetTransformParametersMap( void ) const;
 
   /** Set configuration vector. Library only. */
-  virtual void SetConfigurations( std::vector< ConfigurationPointer > & configurations ) = 0;
+  void SetConfigurations( const std::vector< ConfigurationPointer > & configurations );
+
+  /** Return configuration from vector of configurations. Library only. */
+  ConfigurationPointer GetConfiguration( const size_t index ) const;
 
 protected:
 

--- a/Core/Kernel/elxElastixBase.h
+++ b/Core/Kernel/elxElastixBase.h
@@ -539,19 +539,6 @@ private:
   /** Use or ignore direction cosines. */
   bool m_UseDirectionCosines;
 
-  /** Read a series of command line options that satisfy the following syntax:
-   * {-f,-f0} \<filename0\> [-f1 \<filename1\> [ -f2 \<filename2\> ... ] ]
-   *
-   * This function is used by BeforeAllBase, and is not meant be used
-   * at other locations. The errorcode remains the input value if no errors
-   * occur. It is set to errorcode | 1 if the option was not given.
-   */
-  FileNameContainerPointer GenerateFileNameContainer(
-    const std::string & optionkey,
-    int & errorcode,
-    bool printerrors,
-    bool printinfo ) const;
-
 };
 
 } // end namespace elastix

--- a/Core/Kernel/elxElastixBase.h
+++ b/Core/Kernel/elxElastixBase.h
@@ -63,7 +63,7 @@
     if( this->m_##_name != _arg ) \
     { \
       this->m_##_name = _arg; \
-      this->GetAsITKBaseType()->Modified(); \
+      this->itk::Object::Modified(); \
     } \
   }
 //end elxSetObjectMacro
@@ -142,7 +142,7 @@ namespace elastix
  * \ingroup Kernel
  */
 
-class ElastixBase : public BaseComponent
+class ElastixBase : public itk::Object, public BaseComponent
 {
 public:
 
@@ -178,18 +178,6 @@ public:
 
   /** Typedef that is used in the elastix dll version. */
   typedef itk::ParameterMapInterface::ParameterMapType ParameterMapType;
-
-  /** The itk class that ElastixTemplate is expected to inherit from
-   * Of course ElastixTemplate also inherits from this class (ElastixBase).
-   */
-  typedef itk::Object ITKBaseType;
-
-  /** Cast to ITKBaseType. */
-  virtual ITKBaseType * GetAsITKBaseType( void )
-  {
-    return dynamic_cast< ITKBaseType * >( this );
-  }
-
 
   /** Set/Get the Configuration Object. */
   elxGetObjectMacro( Configuration, ConfigurationType );

--- a/Core/Kernel/elxElastixBase.h
+++ b/Core/Kernel/elxElastixBase.h
@@ -39,6 +39,7 @@
 #include <itkDataObject.h>
 #include <itkImageFileReader.h>
 #include <itkObject.h>
+#include <itkTimeProbe.h>
 #include <itkVectorContainer.h>
 
 #include <fstream>
@@ -178,6 +179,9 @@ public:
 
   /** Typedef that is used in the elastix dll version. */
   typedef itk::ParameterMapInterface::ParameterMapType ParameterMapType;
+
+  /** Typedef's for Timer class. */
+  typedef itk::TimeProbe TimerType;
 
   /** Set/Get the Configuration Object. */
   elxGetObjectMacro( Configuration, ConfigurationType );
@@ -367,6 +371,25 @@ protected:
   ComponentDatabasePointer m_ComponentDatabase;
 
   FlatDirectionCosinesType m_OriginalFixedImageDirection;
+
+  /** Timers. */
+  TimerType m_Timer0{};
+  TimerType m_IterationTimer{};
+  TimerType m_ResolutionTimer{};
+
+  /** Store the CurrentTransformParameterFileName. */
+  std::string m_CurrentTransformParameterFileName;
+
+  /** A vector of configuration objects, needed when transformix is used as library. */
+  std::vector< ConfigurationPointer > m_Configurations;
+
+  /** Count the number of iterations. */
+  unsigned int m_IterationCounter{};
+
+  /** Stores transformation parameters map. */
+  ParameterMapType m_TransformParametersMap;
+
+  std::ofstream m_IterationInfoFile;
 
   /** Convenient mini class to load the files specified by a filename container
    * The function GenerateImageContainer can be used without instantiating an

--- a/Core/Kernel/elxElastixTemplate.h
+++ b/Core/Kernel/elxElastixTemplate.h
@@ -58,18 +58,14 @@
  */
 
 #define elxGetBaseMacro( _name, _elxbasetype ) \
-  _elxbasetype * GetElx##_name##Base( void ) const \
-  { \
-    return this->GetElx##_name##Base( 0 ); \
-  } \
-  _elxbasetype * GetElx##_name##Base( unsigned int idx ) const \
+  _elxbasetype * GetElx##_name##Base( const unsigned int idx = 0 ) const \
   { \
     if( idx < this->GetNumberOf##_name##s() ) \
     { \
       return dynamic_cast< _elxbasetype * >( \
         this->Get##_name##Container()->ElementAt( idx ).GetPointer() ); \
     } \
-    return 0; \
+    return nullptr; \
   }
 //end elxGetBaseMacro
 
@@ -211,40 +207,18 @@ public:
   /** Get pointers to the images. They are obtained from the
    * {Fixed,Moving}ImageContainer and casted to the appropriate type.
    */
-  FixedImageType * GetFixedImage( void ) const
-  {
-    return this->GetFixedImage( 0 );
-  }
 
+  FixedImageType * GetFixedImage( unsigned int idx = 0 ) const;
 
-  FixedImageType * GetFixedImage( unsigned int idx ) const;
-
-  MovingImageType * GetMovingImage( void ) const
-  {
-    return this->GetMovingImage( 0 );
-  }
-
-
-  MovingImageType * GetMovingImage( unsigned int idx ) const;
+  MovingImageType * GetMovingImage( unsigned int idx = 0 ) const;
 
   /** Get pointers to the masks. They are obtained from the
    * {Fixed,Moving}MaskContainer and casted to the appropriate type.
    */
-  FixedMaskType * GetFixedMask( void ) const
-  {
-    return this->GetFixedMask( 0 );
-  }
 
+  FixedMaskType * GetFixedMask( unsigned int idx = 0 ) const;
 
-  FixedMaskType * GetFixedMask( unsigned int idx ) const;
-
-  MovingMaskType * GetMovingMask( void ) const
-  {
-    return this->GetMovingMask( 0 );
-  }
-
-
-  MovingMaskType * GetMovingMask( unsigned int idx ) const;
+  MovingMaskType * GetMovingMask( unsigned int idx = 0 ) const;
 
   /** Get pointers to the result image. They are obtained from the
    * ResultImageContainer and casted to the appropriate type.
@@ -259,14 +233,7 @@ public:
 
   int SetResultImage( DataObjectPointer result_image );
 
-
-  ResultDeformationFieldType * GetResultDeformationField( void ) const
-  {
-    return this->GetResultDeformationField( 0 );
-  }
-
-
-  ResultDeformationFieldType * GetResultDeformationField( unsigned int idx ) const;
+  ResultDeformationFieldType * GetResultDeformationField( unsigned int idx = 0 ) const;
 
   int SetResultDeformationField( DataObjectPointer result_deformationfield );
 

--- a/Core/Kernel/elxElastixTemplate.h
+++ b/Core/Kernel/elxElastixTemplate.h
@@ -111,14 +111,13 @@ namespace elastix
  */
 
 template< class TFixedImage, class TMovingImage >
-class ElastixTemplate final : public itk::Object, public ElastixBase
+class ElastixTemplate final : public ElastixBase
 {
 public:
 
   /** Standard itk. */
   typedef ElastixTemplate                 Self;
-  typedef itk::Object                     Superclass1;
-  typedef ElastixBase                     Superclass2;
+  typedef ElastixBase                     Superclass;
   typedef itk::SmartPointer< Self >       Pointer;
   typedef itk::SmartPointer< const Self > ConstPointer;
 
@@ -126,7 +125,7 @@ public:
   itkNewMacro( Self );
 
   /** Run-time type information (and related methods). */
-  itkTypeMacro( ElastixTemplate, itk::Object );
+  itkTypeMacro( ElastixTemplate, ElastixBase );
 
   /** Typedef's for this class. */
   typedef TFixedImage                       FixedImageType;
@@ -308,7 +307,7 @@ public:
 
   ConfigurationPointer GetConfiguration()
   {
-    return Superclass2::GetConfiguration();
+    return Superclass::GetConfiguration();
   }
 
 

--- a/Core/Kernel/elxElastixTemplate.h
+++ b/Core/Kernel/elxElastixTemplate.h
@@ -126,12 +126,6 @@ public:
   typedef typename FixedImageType::Pointer  FixedImagePointer;
   typedef typename MovingImageType::Pointer MovingImagePointer;
 
-  /** Result image */
-  typedef itk::DataObject ResultImageType;
-
-  /** Result deformation field */
-  typedef itk::DataObject ResultDeformationFieldType;
-
   /** For using the Dimensions. */
   itkStaticConstMacro( Dimension,       unsigned int, FixedImageType::ImageDimension );
   itkStaticConstMacro( FixedDimension,  unsigned int, FixedImageType::ImageDimension );
@@ -214,23 +208,6 @@ public:
 
   MovingMaskType * GetMovingMask( unsigned int idx = 0 ) const;
 
-  /** Get pointers to the result image. They are obtained from the
-   * ResultImageContainer and casted to the appropriate type.
-   */
-  ResultImageType * GetResultImage( void ) const
-  {
-    return this->GetResultImage( 0 );
-  }
-
-
-  ResultImageType * GetResultImage( unsigned int idx ) const;
-
-  int SetResultImage( DataObjectPointer result_image );
-
-  ResultDeformationFieldType * GetResultDeformationField( unsigned int idx = 0 ) const;
-
-  int SetResultDeformationField( DataObjectPointer result_deformationfield );
-
   /** Main functions:
    * Run() for registration, and ApplyTransform() for just
    * applying a transform to an image.
@@ -260,18 +237,6 @@ public:
   /** Get the name of the current transform parameter file. */
   itkGetStringMacro( CurrentTransformParameterFileName );
 
-  /** Set configuration vector. Library only. */
-  void SetConfigurations( std::vector< ConfigurationPointer > & configurations ) override;
-
-  /** Return configuration from vector of configurations. Library only. */
-  ConfigurationPointer GetConfiguration( const size_t index );
-
-  ConfigurationPointer GetConfiguration()
-  {
-    return Superclass::GetConfiguration();
-  }
-
-
   /** Get the original direction cosines of the fixed image. Returns
    * false if it failed to determine the original fixed image direction. In
    * that case the direction var is left unchanged. If no fixed image is
@@ -294,9 +259,6 @@ private:
 
   /** CreateTransformParametersMap. */
   void CreateTransformParametersMap( void ) override;
-
-  /** GetTransformParametersMap. */
-  ParameterMapType GetTransformParametersMap( void ) const override;
 
   /** Open the IterationInfoFile, where the table with iteration info is written to. */
   void OpenIterationInfoFile( void );

--- a/Core/Kernel/elxElastixTemplate.h
+++ b/Core/Kernel/elxElastixTemplate.h
@@ -38,10 +38,7 @@
 #include "elxResampleInterpolatorBase.h"
 #include "elxTransformBase.h"
 
-#include "itkTimeProbe.h"
-
 #include <sstream>
-#include <fstream>
 
 /**
  * Macro that defines to functions. In the case of
@@ -177,9 +174,6 @@ public:
   typedef ResampleInterpolatorBase< Self > ResampleInterpolatorBaseType;
   typedef elx::TransformBase< Self >       TransformBaseType;
 
-  /** Typedef's for Timer class. */
-  typedef itk::TimeProbe TimerType;
-
   /** Typedef's for ApplyTransform.
    * \todo How useful is this? It is not consequently supported, since the
    * the input image is stored in the MovingImageContainer anyway.
@@ -294,20 +288,6 @@ private:
   AfterEachIterationCommandPointer   m_AfterEachIterationCommand{};
   AfterEachResolutionCommandPointer  m_AfterEachResolutionCommand{};
 
-  /** Timers. */
-  TimerType m_Timer0{};
-  TimerType m_IterationTimer{};
-  TimerType m_ResolutionTimer{};
-
-  /** Store the CurrentTransformParameterFileName. */
-  std::string m_CurrentTransformParameterFileName;
-
-  /** A vector of configuration objects, needed when transformix is used as library. */
-  std::vector< ConfigurationPointer > m_Configurations;
-
-  /** Count the number of iterations. */
-  unsigned int m_IterationCounter{};
-
   /** CreateTransformParameterFile. */
   void CreateTransformParameterFile( const std::string FileName,
     const bool ToLog );
@@ -318,13 +298,8 @@ private:
   /** GetTransformParametersMap. */
   ParameterMapType GetTransformParametersMap( void ) const override;
 
-  /** Stores transformation parameters map. */
-  ParameterMapType m_TransformParametersMap;
-
   /** Open the IterationInfoFile, where the table with iteration info is written to. */
   void OpenIterationInfoFile( void );
-
-  std::ofstream m_IterationInfoFile;
 
   /** Used by the callback functions, BeforeEachResolution() etc.).
    * This method calls a function in each component, in the following order:

--- a/Core/Kernel/elxElastixTemplate.hxx
+++ b/Core/Kernel/elxElastixTemplate.hxx
@@ -116,72 +116,6 @@ typename ElastixTemplate< TFixedImage, TMovingImage >::MovingMaskType
 
 } // end SetMovingMask()
 
-/**
- * ********************** GetResultImage *************************
- */
-
-template< class TFixedImage, class TMovingImage >
-typename ElastixTemplate< TFixedImage, TMovingImage >::ResultImageType
-* ElastixTemplate< TFixedImage, TMovingImage >
-::GetResultImage( unsigned int idx ) const
-{
-  if( idx < this->GetNumberOfResultImages() )
-  {
-    return dynamic_cast< ResultImageType * >(
-      this->GetResultImageContainer()->ElementAt( idx ).GetPointer() );
-  }
-
-  return nullptr;
-
-} // end GetResultImage()
-
-/**
- * ********************** SetResultImage *************************
- */
-
-template< class TFixedImage, class TMovingImage >
-int
-ElastixTemplate< TFixedImage, TMovingImage >
-::SetResultImage( DataObjectPointer result_image )
-{
-  this->SetResultImageContainer(
-    ElastixBase::GenerateDataObjectContainer( result_image ) );
-  return 0;
-} // end SetResultImage()
-
-
-/**
-* ********************** GetResultDeformationField *************************
-*/
-
-template< class TFixedImage, class TMovingImage >
-typename ElastixTemplate< TFixedImage, TMovingImage >::ResultDeformationFieldType
-* ElastixTemplate< TFixedImage, TMovingImage >
-::GetResultDeformationField( unsigned int idx ) const
-{
-  if (idx < this->GetNumberOfResultDeformationFields() )
-  {
-    return dynamic_cast< ResultDeformationFieldType * >(
-      this->GetResultDeformationFieldContainer()->ElementAt( idx ).GetPointer() );
-  }
-
-  return nullptr;
-
-} // end GetResultDeformationField()
-
-/**
-* ********************** SetResultDeformationField *************************
-*/
-
-template< class TFixedImage, class TMovingImage >
-int
-ElastixTemplate< TFixedImage, TMovingImage >
-::SetResultDeformationField( DataObjectPointer result_deformationfield )
-{
-  this->SetResultDeformationFieldContainer(
-    ElastixBase::GenerateDataObjectContainer( result_deformationfield ) );
-  return 0;
-} // end SetResultDeformationField()
 
 /**
  * **************************** Run *****************************
@@ -937,20 +871,6 @@ ElastixTemplate< TFixedImage, TMovingImage >
 
 
 /**
- * ************** GetTransformParametersMap *****************
- */
-
-template< class TFixedImage, class TMovingImage >
-itk::ParameterMapInterface::ParameterMapType
-//somehow using typedef ParameterMapType does not compile!
-ElastixTemplate< TFixedImage, TMovingImage >
-::GetTransformParametersMap( void ) const
-{
-  return this->m_TransformParametersMap;
-} // end GetTransformParametersMap()
-
-
-/**
  * ************** CreateTransformParametersMap ******************
  */
 
@@ -1270,32 +1190,6 @@ ElastixTemplate< TFixedImage, TMovingImage >
   }
 
 } // end SetOriginalFixedImageDirection()
-
-
-/**
- * ************** SetConfigurations *********************
- */
-
-template< class TFixedImage, class TMovingImage >
-void
-ElastixTemplate< TFixedImage, TMovingImage >
-::SetConfigurations( std::vector< ConfigurationPointer > & configurations )
-{
-  this->m_Configurations.clear();
-  this->m_Configurations = configurations;
-}
-
-
-/**
- * ************** GetConfiguration *********************
- */
-
-template< class TFixedImage, class TMovingImage >
-typename ElastixTemplate< TFixedImage, TMovingImage >::ConfigurationPointer
-ElastixTemplate< TFixedImage, TMovingImage >::GetConfiguration( const size_t index )
-{
-  return this->m_Configurations[ index ];
-}
 
 
 } // end namespace elastix

--- a/Core/Kernel/elxElastixTemplate.hxx
+++ b/Core/Kernel/elxElastixTemplate.hxx
@@ -145,7 +145,7 @@ ElastixTemplate< TFixedImage, TMovingImage >
 ::SetResultImage( DataObjectPointer result_image )
 {
   this->SetResultImageContainer(
-    MultipleDataObjectFiller::GenerateImageContainer( result_image ) );
+    ElastixBase::GenerateDataObjectContainer( result_image ) );
   return 0;
 } // end SetResultImage()
 
@@ -179,7 +179,7 @@ ElastixTemplate< TFixedImage, TMovingImage >
 ::SetResultDeformationField( DataObjectPointer result_deformationfield )
 {
   this->SetResultDeformationFieldContainer(
-    MultipleDataObjectFiller::GenerateImageContainer( result_deformationfield ) );
+    ElastixBase::GenerateDataObjectContainer( result_deformationfield ) );
   return 0;
 } // end SetResultDeformationField()
 


### PR DESCRIPTION
Aims to reduce "template code bloat" during compilation, and increase compilation speed.