### PR TITLE
COMP: Trailing return type (auto) for xoutsimple GetXOutputs/GetCOutputs

### DIFF
--- a/Common/xout/xoutsimple.hxx
+++ b/Common/xout/xoutsimple.hxx
@@ -94,8 +94,8 @@ xoutsimple< charT, traits >::SetOutputs( const XStreamMapType & outputmap )
  */
 
 template< class charT, class traits >
-const typename xoutsimple< charT, traits >::XStreamMapType
-& xoutsimple< charT, traits >::GetXOutputs( void )
+auto xoutsimple< charT, traits >::GetXOutputs( void )
+-> const XStreamMapType &
 {
   return this->m_XTargetCells;
 
@@ -106,8 +106,8 @@ const typename xoutsimple< charT, traits >::XStreamMapType
  */
 
 template< class charT, class traits >
-const typename xoutsimple< charT, traits >::CStreamMapType
-& xoutsimple< charT, traits >::GetCOutputs( void )
+auto xoutsimple< charT, traits >::GetCOutputs( void )
+-> const CStreamMapType &
 {
   return this->m_CTargetCells;
 


### PR DESCRIPTION
Aims to fix ITKElastix Ubuntu build-linux-python-packages error:

> _deps/elx-src/Common/xout/xoutsimple.hxx:98:3: error: prototype for ‘const typename xoutlibrary::xoutsimple<charT, traits>::XStreamMapType& xoutlibrary::xoutsimple<charT, traits>::GetXOutputs()’ does not match any in class ‘xoutlibrary::xoutsimple<charT, traits>’

https://github.com/N-Dekker/ITKElastix/runs/1263271436#step:5:1863