### PR TITLE
COMP: Avoid GCC4 error xoutManager "use of deleted function", issue #331

### DIFF
--- a/Core/Kernel/elxElastixMain.cxx
+++ b/Core/Kernel/elxElastixMain.cxx
@@ -143,7 +143,13 @@ xoutManager::xoutManager( const std::string& logFileName, const bool setupLoggin
 
 xoutManager::Guard::~Guard()
 {
-  g_data = {};
+  // Destruct and reconstruct the data, in order to reset the output streams.
+  // Note: a simple assignment, `g_data = {}` would be preferable, but doing
+  // so triggered compilation errors on Linux / GCC 4.8:
+  // error: use of deleted function 'std::basic_ofstream<char>&
+  // std::basic_ofstream<char>::operator=(const std::basic_ofstream<char>&)'
+  g_data.~Data();
+  new( &g_data ) Data{};
 }
 
 


### PR DESCRIPTION
Worked around a GCC 4.8.2 compile error on ITKElastix build, reported by Matt McCormick, issue #331 (xout on `develop` branch do not build on Linux / GCC 4.8):

> _deps/elx-src/Core/Kernel/elxElastixMain.cxx: In destructor ‘elastix::xoutManager::Guard::~Guard()’:
> _deps/elx-src/Core/Kernel/elxElastixMain.cxx:146:10: error: use of deleted function ‘{anonymous}::Data& {anonymous}::Data::operator=({anonymous}::Data&&)’
...
> /opt/rh/devtoolset-2/root/usr/include/c++/4.8.2/fstream:599:11: error: use of deleted function ‘std::basic_ostream<char>& std::basic_ostream<char>::operator=(const std::basic_ostream<char>&)’