### PR TITLE
Remove virtual keywords to fix Clang "Call bypasses virtual dispatch" warnings 

### DIFF
--- a/Common/LineSearchOptimizers/itkMoreThuenteLineSearchOptimizer.h
+++ b/Common/LineSearchOptimizers/itkMoreThuenteLineSearchOptimizer.h
@@ -196,7 +196,7 @@ protected:
   CheckSettings(void);
 
   /** Initialize the interval of uncertainty etc. */
-  virtual void
+  void
   InitializeLineSearch(void);
 
   /** Set the minimum and maximum steps to correspond to the

--- a/Components/Optimizers/ConjugateGradient/itkGenericConjugateGradientOptimizer.h
+++ b/Components/Optimizers/ConjugateGradient/itkGenericConjugateGradientOptimizer.h
@@ -130,7 +130,7 @@ public:
   itkGetConstMacro(MaxNrOfItWithoutImprovement, unsigned long);
 
   /** Setting: the definition of \f$\beta\f$, by default "DaiYuanHestenesStiefel" */
-  virtual void
+  void
   SetBetaDefinition(const BetaDefinitionType & arg);
 
   itkGetConstReferenceMacro(BetaDefinition, BetaDefinitionType);
@@ -175,7 +175,7 @@ protected:
    * pointer to a method that computes \f$\beta\f$.
    * Called in the constructor of this class, and possibly by subclasses.
    */
-  virtual void
+  void
   AddBetaDefinition(const BetaDefinitionType & name, ComputeBetaFunctionType function);
 
   /**

--- a/Core/Install/elxBaseComponent.cxx
+++ b/Core/Install/elxBaseComponent.cxx
@@ -129,7 +129,6 @@ BaseComponent::ConvertSecondsToDHMS(const double totalSeconds, const unsigned in
   if (minutes != 0 || nonzero)
   {
     make_string << minutes << "m";
-    nonzero = true;
   }
   make_string << std::showpoint << std::fixed << std::setprecision(precision);
   make_string << dSeconds << "s";

--- a/Core/Install/elxComponentLoader.h
+++ b/Core/Install/elxComponentLoader.h
@@ -65,7 +65,7 @@ public:
   LoadComponents(const char * argv0);
 
   /** Function to unload components. */
-  virtual void
+  void
   UnloadComponents(void);
 
 protected:

--- a/Core/Main/elastix.h
+++ b/Core/Main/elastix.h
@@ -79,7 +79,6 @@ ConvertSecondsToDHMS(const double totalSeconds, const unsigned int precision = 0
   if (minutes != 0 || nonzero)
   {
     make_string << minutes << "m";
-    nonzero = true;
   }
   make_string << std::showpoint << std::fixed << std::setprecision(precision);
   make_string << dSeconds << "s";

--- a/Core/elxProgressCommand.h
+++ b/Core/elxProgressCommand.h
@@ -113,7 +113,7 @@ public:
   ConnectObserver(itk::ProcessObject * filter);
 
   /** Disconnect an observer to a process object. */
-  virtual void
+  void
   DisconnectObserver(itk::ProcessObject * filter);
 
   /** Standard Command virtual methods. */


### PR DESCRIPTION
and also removed two assignments that appeared unnecessary.