### PR TITLE
STYLE: Default default-constructors and destructors by C++11 `= default` 

### DIFF
--- a/Common/CostFunctions/itkExponentialLimiterFunction.h
+++ b/Common/CostFunctions/itkExponentialLimiterFunction.h
@@ -78,7 +78,7 @@ public:
 
 protected:
   ExponentialLimiterFunction();
-  ~ExponentialLimiterFunction() override {}
+  ~ExponentialLimiterFunction() override = default;
 
   virtual void
   ComputeLimiterSettings(void);

--- a/Common/CostFunctions/itkHardLimiterFunction.h
+++ b/Common/CostFunctions/itkHardLimiterFunction.h
@@ -69,8 +69,8 @@ public:
   Evaluate(const InputType & input, DerivativeType & derivative) const override;
 
 protected:
-  HardLimiterFunction() {}
-  ~HardLimiterFunction() override {}
+  HardLimiterFunction() = default;
+  ~HardLimiterFunction() override = default;
 
 private:
   HardLimiterFunction(const Self &) = delete;

--- a/Common/CostFunctions/itkLimiterFunctionBase.h
+++ b/Common/CostFunctions/itkLimiterFunctionBase.h
@@ -111,7 +111,7 @@ protected:
   }
 
 
-  ~LimiterFunctionBase() override {}
+  ~LimiterFunctionBase() override = default;
 
   OutputType m_UpperBound;
   OutputType m_LowerBound;

--- a/Common/CostFunctions/itkMultiInputImageToImageMetricBase.h
+++ b/Common/CostFunctions/itkMultiInputImageToImageMetricBase.h
@@ -348,7 +348,7 @@ protected:
   MultiInputImageToImageMetricBase();
 
   /** Destructor. */
-  ~MultiInputImageToImageMetricBase() override {}
+  ~MultiInputImageToImageMetricBase() override = default;
 
   /** Typedef's from the Superclass. */
   typedef typename Superclass::MovingImagePointType           MovingImagePointType;

--- a/Common/CostFunctions/itkScaledSingleValuedCostFunction.h
+++ b/Common/CostFunctions/itkScaledSingleValuedCostFunction.h
@@ -134,7 +134,7 @@ protected:
   /** The constructor. */
   ScaledSingleValuedCostFunction();
   /** The destructor. */
-  ~ScaledSingleValuedCostFunction() override {}
+  ~ScaledSingleValuedCostFunction() override = default;
 
   /** PrintSelf. */
   void

--- a/Common/CostFunctions/itkSingleValuedPointSetToPointSetMetric.h
+++ b/Common/CostFunctions/itkSingleValuedPointSetToPointSetMetric.h
@@ -174,7 +174,7 @@ public:
 
 protected:
   SingleValuedPointSetToPointSetMetric();
-  ~SingleValuedPointSetToPointSetMetric() override {}
+  ~SingleValuedPointSetToPointSetMetric() override = default;
 
   /** PrintSelf. */
   void

--- a/Common/CostFunctions/itkTransformPenaltyTerm.h
+++ b/Common/CostFunctions/itkTransformPenaltyTerm.h
@@ -127,10 +127,10 @@ protected:
   typedef typename Superclass::NonZeroJacobianIndicesType     NonZeroJacobianIndicesType;
 
   /** The constructor. */
-  TransformPenaltyTerm() {}
+  TransformPenaltyTerm() = default;
 
   /** The destructor. */
-  ~TransformPenaltyTerm() override {}
+  ~TransformPenaltyTerm() override = default;
 
   /** A function to check if the transform is B-spline, for speedup. */
   virtual bool

--- a/Common/ImageSamplers/itkImageFullSampler.h
+++ b/Common/ImageSamplers/itkImageFullSampler.h
@@ -90,9 +90,9 @@ public:
 
 protected:
   /** The constructor. */
-  ImageFullSampler() {}
+  ImageFullSampler() = default;
   /** The destructor. */
-  ~ImageFullSampler() override {}
+  ~ImageFullSampler() override = default;
 
   /** PrintSelf. */
   void

--- a/Common/ImageSamplers/itkImageGridSampler.h
+++ b/Common/ImageSamplers/itkImageGridSampler.h
@@ -137,7 +137,7 @@ protected:
   ImageGridSampler();
 
   /** The destructor. */
-  ~ImageGridSampler() override {}
+  ~ImageGridSampler() override = default;
 
   /** PrintSelf. */
   void

--- a/Common/ImageSamplers/itkImageRandomCoordinateSampler.h
+++ b/Common/ImageSamplers/itkImageRandomCoordinateSampler.h
@@ -106,7 +106,7 @@ protected:
   /** The constructor. */
   ImageRandomCoordinateSampler();
   /** The destructor. */
-  ~ImageRandomCoordinateSampler() override {}
+  ~ImageRandomCoordinateSampler() override = default;
 
   /** PrintSelf. */
   void

--- a/Common/ImageSamplers/itkImageRandomSampler.h
+++ b/Common/ImageSamplers/itkImageRandomSampler.h
@@ -76,9 +76,9 @@ public:
 
 protected:
   /** The constructor. */
-  ImageRandomSampler() {}
+  ImageRandomSampler() = default;
   /** The destructor. */
-  ~ImageRandomSampler() override {}
+  ~ImageRandomSampler() override = default;
 
   /** Functions that do the work. */
   void

--- a/Common/ImageSamplers/itkImageRandomSamplerBase.h
+++ b/Common/ImageSamplers/itkImageRandomSamplerBase.h
@@ -70,7 +70,7 @@ protected:
   ImageRandomSamplerBase();
 
   /** The destructor. */
-  ~ImageRandomSamplerBase() override {}
+  ~ImageRandomSamplerBase() override = default;
 
   /** Multi-threaded function that does the work. */
   void

--- a/Common/ImageSamplers/itkImageRandomSamplerSparseMask.h
+++ b/Common/ImageSamplers/itkImageRandomSamplerSparseMask.h
@@ -82,7 +82,7 @@ protected:
   /** The constructor. */
   ImageRandomSamplerSparseMask();
   /** The destructor. */
-  ~ImageRandomSamplerSparseMask() override {}
+  ~ImageRandomSamplerSparseMask() override = default;
 
   /** PrintSelf. */
   void

--- a/Common/ImageSamplers/itkImageSample.h
+++ b/Common/ImageSamplers/itkImageSample.h
@@ -35,8 +35,8 @@ class ImageSample
 {
 public:
   // ImageSample():m_ImageValue(0.0){};
-  ImageSample() {}
-  ~ImageSample() {}
+  ImageSample() = default;
+  ~ImageSample() = default;
 
   /** Typedef's. */
   typedef TImage                                      ImageType;

--- a/Common/ImageSamplers/itkImageSamplerBase.h
+++ b/Common/ImageSamplers/itkImageSamplerBase.h
@@ -184,7 +184,7 @@ protected:
   ImageSamplerBase();
 
   /** The destructor. */
-  ~ImageSamplerBase() override {}
+  ~ImageSamplerBase() override = default;
 
   /** PrintSelf. */
   void

--- a/Common/ImageSamplers/itkImageToVectorContainerFilter.h
+++ b/Common/ImageSamplers/itkImageToVectorContainerFilter.h
@@ -182,7 +182,7 @@ protected:
   /** The constructor. */
   ImageToVectorContainerFilter();
   /** The destructor. */
-  ~ImageToVectorContainerFilter() override {}
+  ~ImageToVectorContainerFilter() override = default;
 
   /** PrintSelf. */
   void

--- a/Common/ImageSamplers/itkMultiInputImageRandomCoordinateSampler.h
+++ b/Common/ImageSamplers/itkMultiInputImageRandomCoordinateSampler.h
@@ -108,7 +108,7 @@ protected:
   MultiInputImageRandomCoordinateSampler();
 
   /** The destructor. */
-  ~MultiInputImageRandomCoordinateSampler() override {}
+  ~MultiInputImageRandomCoordinateSampler() override = default;
 
   /** PrintSelf. */
   void

--- a/Common/ImageSamplers/itkVectorContainerSource.h
+++ b/Common/ImageSamplers/itkVectorContainerSource.h
@@ -73,7 +73,7 @@ protected:
   /** The constructor. */
   VectorContainerSource();
   /** The destructor. */
-  ~VectorContainerSource() override {}
+  ~VectorContainerSource() override = default;
 
   /** PrintSelf. */
   void

--- a/Common/ImageSamplers/itkVectorDataContainer.h
+++ b/Common/ImageSamplers/itkVectorDataContainer.h
@@ -157,7 +157,7 @@ public:
   class Iterator
   {
   public:
-    Iterator() {}
+    Iterator() = default;
     Iterator(size_type d, const VectorIterator & i)
       : m_Pos(d)
       , m_Iter(i)
@@ -256,7 +256,7 @@ public:
   class ConstIterator
   {
   public:
-    ConstIterator() {}
+    ConstIterator() = default;
     ConstIterator(size_type d, const VectorConstIterator & i)
       : m_Pos(d)
       , m_Iter(i)

--- a/Common/LineSearchOptimizers/itkLineSearchOptimizer.h
+++ b/Common/LineSearchOptimizers/itkLineSearchOptimizer.h
@@ -121,7 +121,7 @@ public:
 
 protected:
   LineSearchOptimizer();
-  ~LineSearchOptimizer() override {}
+  ~LineSearchOptimizer() override = default;
   void
   PrintSelf(std::ostream & os, Indent indent) const override;
 

--- a/Common/LineSearchOptimizers/itkMoreThuenteLineSearchOptimizer.h
+++ b/Common/LineSearchOptimizers/itkMoreThuenteLineSearchOptimizer.h
@@ -174,7 +174,7 @@ public:
 
 protected:
   MoreThuenteLineSearchOptimizer();
-  ~MoreThuenteLineSearchOptimizer() override {}
+  ~MoreThuenteLineSearchOptimizer() override = default;
 
   void
   PrintSelf(std::ostream & os, Indent indent) const override;

--- a/Common/OpenCL/Factories/itkGPUCastImageFilterFactory.h
+++ b/Common/OpenCL/Factories/itkGPUCastImageFilterFactory.h
@@ -102,7 +102,7 @@ public:
 
 protected:
   GPUCastImageFilterFactory2();
-  virtual ~GPUCastImageFilterFactory2() {}
+  virtual ~GPUCastImageFilterFactory2() = default;
 
   /** Register methods for 1D. */
   virtual void

--- a/Common/OpenCL/Factories/itkGPUIdentityTransformFactory.h
+++ b/Common/OpenCL/Factories/itkGPUIdentityTransformFactory.h
@@ -74,7 +74,7 @@ public:
 
 protected:
   GPUIdentityTransformFactory2();
-  virtual ~GPUIdentityTransformFactory2() {}
+  virtual ~GPUIdentityTransformFactory2() = default;
 
   /** Typedef for real type list. */
   typedef typelist::MakeTypeList<float, double>::Type RealTypeList;

--- a/Common/OpenCL/Factories/itkGPUImageFactory.h
+++ b/Common/OpenCL/Factories/itkGPUImageFactory.h
@@ -74,7 +74,7 @@ public:
 
 protected:
   GPUImageFactory2();
-  virtual ~GPUImageFactory2() {}
+  virtual ~GPUImageFactory2() = default;
 
   /** Register methods for 1D. */
   virtual void

--- a/Common/OpenCL/Factories/itkGPULinearInterpolateImageFunctionFactory.h
+++ b/Common/OpenCL/Factories/itkGPULinearInterpolateImageFunctionFactory.h
@@ -102,7 +102,7 @@ public:
 
 protected:
   GPULinearInterpolateImageFunctionFactory2();
-  virtual ~GPULinearInterpolateImageFunctionFactory2() {}
+  virtual ~GPULinearInterpolateImageFunctionFactory2() = default;
 
   /** Register methods for 1D. */
   virtual void

--- a/Common/OpenCL/Factories/itkGPUObjectFactoryBase.h
+++ b/Common/OpenCL/Factories/itkGPUObjectFactoryBase.h
@@ -66,8 +66,8 @@ public:
   RegisterAll();
 
 protected:
-  GPUObjectFactoryBase() {}
-  ~GPUObjectFactoryBase() override {}
+  GPUObjectFactoryBase() = default;
+  ~GPUObjectFactoryBase() override = default;
 
   /** Register methods for 1D. */
   virtual void

--- a/Common/OpenCL/Factories/itkGPURecursiveGaussianImageFilterFactory.h
+++ b/Common/OpenCL/Factories/itkGPURecursiveGaussianImageFilterFactory.h
@@ -106,7 +106,7 @@ public:
 
 protected:
   GPURecursiveGaussianImageFilterFactory2();
-  virtual ~GPURecursiveGaussianImageFilterFactory2() {}
+  virtual ~GPURecursiveGaussianImageFilterFactory2() = default;
 
   /** Register methods for 1D. */
   virtual void

--- a/Common/OpenCL/Factories/itkGPUResampleImageFilterFactory.h
+++ b/Common/OpenCL/Factories/itkGPUResampleImageFilterFactory.h
@@ -140,7 +140,7 @@ public:
 
 protected:
   GPUResampleImageFilterFactory2();
-  virtual ~GPUResampleImageFilterFactory2() {}
+  virtual ~GPUResampleImageFilterFactory2() = default;
 
   /** Register methods for 1D. */
   virtual void

--- a/Common/OpenCL/Factories/itkGPUShrinkImageFilterFactory.h
+++ b/Common/OpenCL/Factories/itkGPUShrinkImageFilterFactory.h
@@ -102,7 +102,7 @@ public:
 
 protected:
   GPUShrinkImageFilterFactory2();
-  virtual ~GPUShrinkImageFilterFactory2() {}
+  virtual ~GPUShrinkImageFilterFactory2() = default;
 
   /** Register methods for 1D. */
   virtual void

--- a/Common/OpenCL/Filters/itkGPUAdvancedBSplineDeformableTransform.h
+++ b/Common/OpenCL/Filters/itkGPUAdvancedBSplineDeformableTransform.h
@@ -71,7 +71,7 @@ public:
 
 protected:
   GPUAdvancedBSplineDeformableTransform();
-  virtual ~GPUAdvancedBSplineDeformableTransform() {}
+  virtual ~GPUAdvancedBSplineDeformableTransform() = default;
 
   void
   PrintSelf(std::ostream & os, Indent indent) const override;

--- a/Common/OpenCL/Filters/itkGPUAdvancedCombinationTransform.h
+++ b/Common/OpenCL/Filters/itkGPUAdvancedCombinationTransform.h
@@ -75,8 +75,8 @@ public:
   }
 
 protected:
-  GPUAdvancedCombinationTransform() {}
-  virtual ~GPUAdvancedCombinationTransform() {}
+  GPUAdvancedCombinationTransform() = default;
+  virtual ~GPUAdvancedCombinationTransform() = default;
   void
   PrintSelf(std::ostream & s, Indent indent) const override
   {

--- a/Common/OpenCL/Filters/itkGPUAdvancedCombinationTransformCopier.h
+++ b/Common/OpenCL/Filters/itkGPUAdvancedCombinationTransformCopier.h
@@ -143,7 +143,7 @@ public:
 
 protected:
   GPUAdvancedCombinationTransformCopier();
-  ~GPUAdvancedCombinationTransformCopier() override {}
+  ~GPUAdvancedCombinationTransformCopier() override = default;
   void
   PrintSelf(std::ostream & os, Indent indent) const override;
 

--- a/Common/OpenCL/Filters/itkGPUAdvancedEuler2DTransform.h
+++ b/Common/OpenCL/Filters/itkGPUAdvancedEuler2DTransform.h
@@ -80,8 +80,8 @@ public:
   }
 
 protected:
-  GPUAdvancedEuler2DTransform() {}
-  virtual ~GPUAdvancedEuler2DTransform() {}
+  GPUAdvancedEuler2DTransform() = default;
+  virtual ~GPUAdvancedEuler2DTransform() = default;
 
 private:
   GPUAdvancedEuler2DTransform(const Self & other) = delete;

--- a/Common/OpenCL/Filters/itkGPUAdvancedEuler3DTransform.h
+++ b/Common/OpenCL/Filters/itkGPUAdvancedEuler3DTransform.h
@@ -80,8 +80,8 @@ public:
   }
 
 protected:
-  GPUAdvancedEuler3DTransform() {}
-  virtual ~GPUAdvancedEuler3DTransform() {}
+  GPUAdvancedEuler3DTransform() = default;
+  virtual ~GPUAdvancedEuler3DTransform() = default;
 
 private:
   GPUAdvancedEuler3DTransform(const Self & other) = delete;

--- a/Common/OpenCL/Filters/itkGPUAdvancedMatrixOffsetTransformBase.h
+++ b/Common/OpenCL/Filters/itkGPUAdvancedMatrixOffsetTransformBase.h
@@ -82,8 +82,8 @@ public:
   }
 
 protected:
-  GPUAdvancedMatrixOffsetTransformBase() {}
-  virtual ~GPUAdvancedMatrixOffsetTransformBase() {}
+  GPUAdvancedMatrixOffsetTransformBase() = default;
+  virtual ~GPUAdvancedMatrixOffsetTransformBase() = default;
 
 private:
   GPUAdvancedMatrixOffsetTransformBase(const Self & other) = delete;

--- a/Common/OpenCL/Filters/itkGPUAdvancedSimilarity2DTransform.h
+++ b/Common/OpenCL/Filters/itkGPUAdvancedSimilarity2DTransform.h
@@ -80,8 +80,8 @@ public:
   }
 
 protected:
-  GPUAdvancedSimilarity2DTransform() {}
-  virtual ~GPUAdvancedSimilarity2DTransform() {}
+  GPUAdvancedSimilarity2DTransform() = default;
+  virtual ~GPUAdvancedSimilarity2DTransform() = default;
 
 private:
   GPUAdvancedSimilarity2DTransform(const Self & other) = delete;

--- a/Common/OpenCL/Filters/itkGPUAdvancedSimilarity3DTransform.h
+++ b/Common/OpenCL/Filters/itkGPUAdvancedSimilarity3DTransform.h
@@ -80,8 +80,8 @@ public:
   }
 
 protected:
-  GPUAdvancedSimilarity3DTransform() {}
-  virtual ~GPUAdvancedSimilarity3DTransform() {}
+  GPUAdvancedSimilarity3DTransform() = default;
+  virtual ~GPUAdvancedSimilarity3DTransform() = default;
 
 private:
   GPUAdvancedSimilarity3DTransform(const Self & other) = delete;

--- a/Common/OpenCL/Filters/itkGPUAdvancedTranslationTransform.h
+++ b/Common/OpenCL/Filters/itkGPUAdvancedTranslationTransform.h
@@ -66,8 +66,8 @@ public:
   }
 
 protected:
-  GPUAdvancedTranslationTransform() {}
-  virtual ~GPUAdvancedTranslationTransform() {}
+  GPUAdvancedTranslationTransform() = default;
+  virtual ~GPUAdvancedTranslationTransform() = default;
 
 private:
   GPUAdvancedTranslationTransform(const Self & other) = delete;

--- a/Common/OpenCL/Filters/itkGPUBSplineBaseTransform.h
+++ b/Common/OpenCL/Filters/itkGPUBSplineBaseTransform.h
@@ -88,7 +88,7 @@ protected:
   SetSplineOrder(const unsigned int splineOrder);
 
   GPUBSplineBaseTransform();
-  ~GPUBSplineBaseTransform() override {}
+  ~GPUBSplineBaseTransform() override = default;
 
   /** Returns OpenCL \a source code for the transform.
    * Returns true if source code was combined, false otherwise. */

--- a/Common/OpenCL/Filters/itkGPUBSplineInterpolateImageFunction.h
+++ b/Common/OpenCL/Filters/itkGPUBSplineInterpolateImageFunction.h
@@ -89,7 +89,7 @@ public:
 
 protected:
   GPUBSplineInterpolateImageFunction();
-  ~GPUBSplineInterpolateImageFunction() {}
+  ~GPUBSplineInterpolateImageFunction() = default;
   void
   PrintSelf(std::ostream & os, Indent indent) const override;
 

--- a/Common/OpenCL/Filters/itkGPUCastImageFilter.h
+++ b/Common/OpenCL/Filters/itkGPUCastImageFilter.h
@@ -47,9 +47,9 @@ template <typename TInput, typename TOutput>
 class GPUCast : public GPUFunctorBase
 {
 public:
-  GPUCast() {}
+  GPUCast() = default;
 
-  ~GPUCast() override {}
+  ~GPUCast() override = default;
 
   /** Setup GPU kernel arguments for this functor.
    * Returns current argument index to set additional arguments in the GPU kernel.
@@ -100,7 +100,7 @@ public:
 
 protected:
   GPUCastImageFilter();
-  virtual ~GPUCastImageFilter() {}
+  virtual ~GPUCastImageFilter() = default;
 
   /** Unlike CPU version, GPU version of binary threshold filter is not
   multi-threaded */

--- a/Common/OpenCL/Filters/itkGPUCompositeTransformBase.h
+++ b/Common/OpenCL/Filters/itkGPUCompositeTransformBase.h
@@ -104,8 +104,8 @@ public:
   IsBSplineTransform(const std::size_t index) const;
 
 protected:
-  GPUCompositeTransformBase() {}
-  ~GPUCompositeTransformBase() override {}
+  GPUCompositeTransformBase() = default;
+  ~GPUCompositeTransformBase() override = default;
 
   /** Returns OpenCL \a source code for the transform.
    * Returns true if source code was combined, false otherwise. */

--- a/Common/OpenCL/Filters/itkGPUIdentityTransform.h
+++ b/Common/OpenCL/Filters/itkGPUIdentityTransform.h
@@ -70,7 +70,7 @@ public:
 
 protected:
   GPUIdentityTransform();
-  ~GPUIdentityTransform() override {}
+  ~GPUIdentityTransform() override = default;
   void
   PrintSelf(std::ostream & os, Indent indent) const override;
 

--- a/Common/OpenCL/Filters/itkGPUInterpolateImageFunction.h
+++ b/Common/OpenCL/Filters/itkGPUInterpolateImageFunction.h
@@ -62,7 +62,7 @@ public:
 
 protected:
   GPUInterpolateImageFunction();
-  ~GPUInterpolateImageFunction() override {}
+  ~GPUInterpolateImageFunction() override = default;
   void
   PrintSelf(std::ostream & os, Indent indent) const override;
 

--- a/Common/OpenCL/Filters/itkGPUInterpolatorBase.h
+++ b/Common/OpenCL/Filters/itkGPUInterpolatorBase.h
@@ -54,7 +54,7 @@ public:
 
 protected:
   GPUInterpolatorBase();
-  virtual ~GPUInterpolatorBase() {}
+  virtual ~GPUInterpolatorBase() = default;
 
   GPUDataManager::Pointer m_ParametersDataManager;
 };

--- a/Common/OpenCL/Filters/itkGPUInterpolatorCopier.h
+++ b/Common/OpenCL/Filters/itkGPUInterpolatorCopier.h
@@ -127,7 +127,7 @@ public:
 
 protected:
   GPUInterpolatorCopier();
-  ~GPUInterpolatorCopier() override {}
+  ~GPUInterpolatorCopier() override = default;
   void
   PrintSelf(std::ostream & os, Indent indent) const override;
 

--- a/Common/OpenCL/Filters/itkGPULinearInterpolateImageFunction.h
+++ b/Common/OpenCL/Filters/itkGPULinearInterpolateImageFunction.h
@@ -60,7 +60,7 @@ public:
 
 protected:
   GPULinearInterpolateImageFunction();
-  ~GPULinearInterpolateImageFunction() {}
+  ~GPULinearInterpolateImageFunction() = default;
   void
   PrintSelf(std::ostream & os, Indent indent) const override;
 

--- a/Common/OpenCL/Filters/itkGPUMatrixOffsetTransformBase.h
+++ b/Common/OpenCL/Filters/itkGPUMatrixOffsetTransformBase.h
@@ -87,7 +87,7 @@ public:
 
 protected:
   GPUMatrixOffsetTransformBase();
-  ~GPUMatrixOffsetTransformBase() override {}
+  ~GPUMatrixOffsetTransformBase() override = default;
 
   /** Returns OpenCL \a source code for the transform.
    * Returns true if source code was combined, false otherwise. */

--- a/Common/OpenCL/Filters/itkGPUNearestNeighborInterpolateImageFunction.h
+++ b/Common/OpenCL/Filters/itkGPUNearestNeighborInterpolateImageFunction.h
@@ -62,7 +62,7 @@ public:
 
 protected:
   GPUNearestNeighborInterpolateImageFunction();
-  ~GPUNearestNeighborInterpolateImageFunction() {}
+  ~GPUNearestNeighborInterpolateImageFunction() = default;
   void
   PrintSelf(std::ostream & os, Indent indent) const override;
 

--- a/Common/OpenCL/Filters/itkGPURecursiveGaussianImageFilter.h
+++ b/Common/OpenCL/Filters/itkGPURecursiveGaussianImageFilter.h
@@ -74,7 +74,7 @@ public:
 
 protected:
   GPURecursiveGaussianImageFilter();
-  ~GPURecursiveGaussianImageFilter() {}
+  ~GPURecursiveGaussianImageFilter() = default;
 
   void
   PrintSelf(std::ostream & os, Indent indent) const override;

--- a/Common/OpenCL/Filters/itkGPUResampleImageFilter.h
+++ b/Common/OpenCL/Filters/itkGPUResampleImageFilter.h
@@ -118,7 +118,7 @@ public:
 
 protected:
   GPUResampleImageFilter();
-  ~GPUResampleImageFilter() {}
+  ~GPUResampleImageFilter() = default;
   void
   PrintSelf(std::ostream & os, Indent indent) const override;
 

--- a/Common/OpenCL/Filters/itkGPUShrinkImageFilter.h
+++ b/Common/OpenCL/Filters/itkGPUShrinkImageFilter.h
@@ -80,7 +80,7 @@ public:
 
 protected:
   GPUShrinkImageFilter();
-  ~GPUShrinkImageFilter() {}
+  ~GPUShrinkImageFilter() = default;
   void
   PrintSelf(std::ostream & os, Indent indent) const override;
 

--- a/Common/OpenCL/Filters/itkGPUTransformBase.h
+++ b/Common/OpenCL/Filters/itkGPUTransformBase.h
@@ -94,7 +94,7 @@ public:
 
 protected:
   GPUTransformBase();
-  virtual ~GPUTransformBase() {}
+  virtual ~GPUTransformBase() = default;
 
   GPUDataManager::Pointer m_ParametersDataManager;
 

--- a/Common/OpenCL/Filters/itkGPUTranslationTransformBase.h
+++ b/Common/OpenCL/Filters/itkGPUTranslationTransformBase.h
@@ -71,7 +71,7 @@ public:
 
 protected:
   GPUTranslationTransformBase();
-  ~GPUTranslationTransformBase() override {}
+  ~GPUTranslationTransformBase() override = default;
 
   /** Returns OpenCL \a source code for the transform.
    * Returns true if source code was combined, false otherwise. */

--- a/Common/OpenCL/ITKimprovements/itkGPUFunctorBase.h
+++ b/Common/OpenCL/ITKimprovements/itkGPUFunctorBase.h
@@ -51,10 +51,10 @@ class GPUFunctorBase
 {
 public:
   // constructor
-  GPUFunctorBase() {}
+  GPUFunctorBase() = default;
 
   // destructor
-  virtual ~GPUFunctorBase() {}
+  virtual ~GPUFunctorBase() = default;
 
   /** Setup GPU kernel arguments for this functor.
    * \return Current argument index to set additional arguments in the GPU kernel. */

--- a/Common/OpenCL/ITKimprovements/itkGPUImage.h
+++ b/Common/OpenCL/ITKimprovements/itkGPUImage.h
@@ -248,7 +248,7 @@ public:
 
 protected:
   GPUImage();
-  virtual ~GPUImage() {}
+  virtual ~GPUImage() = default;
 
   virtual void
   PrintSelf(std::ostream & os, Indent indent) const;

--- a/Common/OpenCL/ITKimprovements/itkGPUImageDataManager.h
+++ b/Common/OpenCL/ITKimprovements/itkGPUImageDataManager.h
@@ -95,7 +95,7 @@ public:
 
 protected:
   GPUImageDataManager() { m_Image = nullptr; }
-  ~GPUImageDataManager() override {}
+  ~GPUImageDataManager() override = default;
 
 private:
   GPUImageDataManager(const Self &) = delete;

--- a/Common/OpenCL/ITKimprovements/itkGPUImageToImageFilter.h
+++ b/Common/OpenCL/ITKimprovements/itkGPUImageToImageFilter.h
@@ -110,7 +110,7 @@ public:
 
 protected:
   GPUImageToImageFilter();
-  ~GPUImageToImageFilter() {}
+  ~GPUImageToImageFilter() = default;
 
   virtual void
   PrintSelf(std::ostream & os, Indent indent) const;

--- a/Common/OpenCL/ITKimprovements/itkGPUInPlaceImageFilter.h
+++ b/Common/OpenCL/ITKimprovements/itkGPUInPlaceImageFilter.h
@@ -91,8 +91,8 @@ public:
   typedef typename InputImageType::PixelType    InputImagePixelType;
 
 protected:
-  GPUInPlaceImageFilter() {}
-  ~GPUInPlaceImageFilter() {}
+  GPUInPlaceImageFilter() = default;
+  ~GPUInPlaceImageFilter() = default;
 
   virtual void
   PrintSelf(std::ostream & os, Indent indent) const;

--- a/Common/OpenCL/ITKimprovements/itkGPUUnaryFunctorImageFilter.h
+++ b/Common/OpenCL/ITKimprovements/itkGPUUnaryFunctorImageFilter.h
@@ -121,9 +121,9 @@ public:
 
 
 protected:
-  GPUUnaryFunctorImageFilter() {}
+  GPUUnaryFunctorImageFilter() = default;
 
-  virtual ~GPUUnaryFunctorImageFilter() {}
+  virtual ~GPUUnaryFunctorImageFilter() = default;
 
   virtual void
   GenerateOutputInformation();

--- a/Common/OpenCL/ITKimprovements/itkOpenCLBuffer.h
+++ b/Common/OpenCL/ITKimprovements/itkOpenCLBuffer.h
@@ -57,7 +57,7 @@ public:
   typedef OpenCLBuffer Self;
 
   /** Constructs a null OpenCL buffer object. */
-  OpenCLBuffer() {}
+  OpenCLBuffer() = default;
 
   /** Constructs an OpenCL buffer object that is initialized with the
    * native OpenCL identifier \a id, and associates it with \a context.

--- a/Common/OpenCL/ITKimprovements/itkOpenCLEventList.h
+++ b/Common/OpenCL/ITKimprovements/itkOpenCLEventList.h
@@ -38,7 +38,7 @@ public:
   typedef std::vector<cl_event> OpenCLEventListArrayType;
 
   /** Constructs an empty list of OpenCL events. */
-  OpenCLEventList() {}
+  OpenCLEventList() = default;
 
   /** Constructs a list of OpenCL events that contains event. If event is null,
    * this constructor will construct an empty list.

--- a/Common/OpenCL/ITKimprovements/itkOpenCLImage.h
+++ b/Common/OpenCL/ITKimprovements/itkOpenCLImage.h
@@ -43,7 +43,7 @@ public:
   typedef OpenCLMemoryObject Superclass;
 
   /** Constructs a null OpenCL image object. */
-  OpenCLImage() {}
+  OpenCLImage() = default;
 
   /** Constructs a OpenCL image object that is initialized with the
    * native OpenCL identifier \a id, and associates it with \a context.

--- a/Common/OpenCL/ITKimprovements/itkOpenCLMacro.h
+++ b/Common/OpenCL/ITKimprovements/itkOpenCLMacro.h
@@ -149,7 +149,7 @@ public:
   {}
 
   /** Virtual destructor needed for subclasses. */
-  ~OpenCLCompileError() override {}
+  ~OpenCLCompileError() override = default;
 
   const char *
   GetNameOfClass() const override

--- a/Common/Transforms/itkAdvancedBSplineDeformableTransform.hxx
+++ b/Common/Transforms/itkAdvancedBSplineDeformableTransform.hxx
@@ -144,7 +144,7 @@ AdvancedBSplineDeformableTransform<TScalarType, NDimensions, VSplineOrder>::Adva
 // Destructor
 template <class TScalarType, unsigned int NDimensions, unsigned int VSplineOrder>
 AdvancedBSplineDeformableTransform<TScalarType, NDimensions, VSplineOrder>::~AdvancedBSplineDeformableTransform()
-{}
+= default;
 
 // Set the grid region
 template <class TScalarType, unsigned int NDimensions, unsigned int VSplineOrder>

--- a/Common/Transforms/itkAdvancedBSplineDeformableTransformBase.hxx
+++ b/Common/Transforms/itkAdvancedBSplineDeformableTransformBase.hxx
@@ -101,7 +101,7 @@ AdvancedBSplineDeformableTransformBase<TScalarType, NDimensions>::AdvancedBSplin
 // Destructor
 template <class TScalarType, unsigned int NDimensions>
 AdvancedBSplineDeformableTransformBase<TScalarType, NDimensions>::~AdvancedBSplineDeformableTransformBase()
-{}
+= default;
 
 // Get the number of parameters
 template <class TScalarType, unsigned int NDimensions>

--- a/Common/Transforms/itkAdvancedCombinationTransform.h
+++ b/Common/Transforms/itkAdvancedCombinationTransform.h
@@ -332,7 +332,7 @@ protected:
   AdvancedCombinationTransform();
 
   /** Destructor. */
-  ~AdvancedCombinationTransform() override {}
+  ~AdvancedCombinationTransform() override = default;
 
   /** Declaration of members. */
   InitialTransformPointer m_InitialTransform;

--- a/Common/Transforms/itkAdvancedEuler3DTransform.h
+++ b/Common/Transforms/itkAdvancedEuler3DTransform.h
@@ -143,7 +143,7 @@ protected:
   AdvancedEuler3DTransform(const MatrixType & matrix, const OutputPointType & offset);
   AdvancedEuler3DTransform(unsigned int paramsSpaceDims);
 
-  ~AdvancedEuler3DTransform() override {}
+  ~AdvancedEuler3DTransform() override = default;
 
   void
   PrintSelf(std::ostream & os, Indent indent) const override;

--- a/Common/Transforms/itkAdvancedIdentityTransform.h
+++ b/Common/Transforms/itkAdvancedIdentityTransform.h
@@ -324,7 +324,7 @@ protected:
   }
 
 
-  ~AdvancedIdentityTransform() override {}
+  ~AdvancedIdentityTransform() override = default;
 
 private:
   AdvancedIdentityTransform(const Self &) = delete;

--- a/Common/Transforms/itkAdvancedMatrixOffsetTransformBase.h
+++ b/Common/Transforms/itkAdvancedMatrixOffsetTransformBase.h
@@ -460,7 +460,7 @@ protected:
   PrecomputeJacobians(unsigned int paramDims);
 
   /** Destroy an AdvancedMatrixOffsetTransformBase object. */
-  ~AdvancedMatrixOffsetTransformBase() override {}
+  ~AdvancedMatrixOffsetTransformBase() override = default;
 
   /** Print contents of an AdvancedMatrixOffsetTransformBase. */
   void

--- a/Common/Transforms/itkAdvancedRigid2DTransform.hxx
+++ b/Common/Transforms/itkAdvancedRigid2DTransform.hxx
@@ -74,7 +74,7 @@ AdvancedRigid2DTransform<TScalarType>::AdvancedRigid2DTransform(unsigned int spa
 // Destructor
 template <class TScalarType>
 AdvancedRigid2DTransform<TScalarType>::~AdvancedRigid2DTransform()
-{}
+= default;
 
 // Print self
 template <class TScalarType>

--- a/Common/Transforms/itkAdvancedRigid3DTransform.hxx
+++ b/Common/Transforms/itkAdvancedRigid3DTransform.hxx
@@ -61,7 +61,7 @@ AdvancedRigid3DTransform<TScalarType>::AdvancedRigid3DTransform(const MatrixType
 // Destructor
 template <class TScalarType>
 AdvancedRigid3DTransform<TScalarType>::~AdvancedRigid3DTransform()
-{}
+= default;
 
 // Print self
 template <class TScalarType>

--- a/Common/Transforms/itkAdvancedSimilarity2DTransform.h
+++ b/Common/Transforms/itkAdvancedSimilarity2DTransform.h
@@ -214,7 +214,7 @@ protected:
   AdvancedSimilarity2DTransform();
   AdvancedSimilarity2DTransform(unsigned int spaceDimension, unsigned int parametersDimension);
 
-  ~AdvancedSimilarity2DTransform() override {}
+  ~AdvancedSimilarity2DTransform() override = default;
   void
   PrintSelf(std::ostream & os, Indent indent) const override;
 

--- a/Common/Transforms/itkAdvancedSimilarity3DTransform.h
+++ b/Common/Transforms/itkAdvancedSimilarity3DTransform.h
@@ -146,7 +146,7 @@ protected:
   AdvancedSimilarity3DTransform(unsigned int outputSpaceDim, unsigned int paramDim);
   AdvancedSimilarity3DTransform(const MatrixType & matrix, const OutputVectorType & offset);
   AdvancedSimilarity3DTransform();
-  ~AdvancedSimilarity3DTransform() {}
+  ~AdvancedSimilarity3DTransform() = default;
 
   void
   PrintSelf(std::ostream & os, Indent indent) const override;

--- a/Common/Transforms/itkAdvancedTransform.h
+++ b/Common/Transforms/itkAdvancedTransform.h
@@ -293,7 +293,7 @@ public:
 protected:
   AdvancedTransform();
   AdvancedTransform(NumberOfParametersType numberOfParameters);
-  ~AdvancedTransform() override {}
+  ~AdvancedTransform() override = default;
 
   bool m_HasNonZeroSpatialHessian;
   bool m_HasNonZeroJacobianOfSpatialHessian;

--- a/Common/Transforms/itkAdvancedVersorRigid3DTransform.h
+++ b/Common/Transforms/itkAdvancedVersorRigid3DTransform.h
@@ -132,7 +132,7 @@ protected:
   AdvancedVersorRigid3DTransform(unsigned int outputSpaceDim, unsigned int paramDim);
   AdvancedVersorRigid3DTransform(const MatrixType & matrix, const OutputVectorType & offset);
   AdvancedVersorRigid3DTransform();
-  ~AdvancedVersorRigid3DTransform() {}
+  ~AdvancedVersorRigid3DTransform() = default;
 
   void
   PrintSelf(std::ostream & os, Indent indent) const override;

--- a/Common/Transforms/itkAdvancedVersorTransform.h
+++ b/Common/Transforms/itkAdvancedVersorTransform.h
@@ -158,7 +158,7 @@ protected:
   AdvancedVersorTransform();
 
   /** Destroy an AdvancedVersorTransform object */
-  ~AdvancedVersorTransform() {}
+  ~AdvancedVersorTransform() = default;
 
   /** This method must be made protected here because it is not a safe way of
    * initializing the Versor */

--- a/Common/Transforms/itkBSplineDerivativeKernelFunction2.h
+++ b/Common/Transforms/itkBSplineDerivativeKernelFunction2.h
@@ -90,8 +90,8 @@ public:
 
 
 protected:
-  BSplineDerivativeKernelFunction2() {}
-  ~BSplineDerivativeKernelFunction2() override {}
+  BSplineDerivativeKernelFunction2() = default;
+  ~BSplineDerivativeKernelFunction2() override = default;
 
   void
   PrintSelf(std::ostream & os, Indent indent) const override

--- a/Common/Transforms/itkBSplineInterpolationDerivativeWeightFunction.h
+++ b/Common/Transforms/itkBSplineInterpolationDerivativeWeightFunction.h
@@ -75,7 +75,7 @@ public:
 
 protected:
   BSplineInterpolationDerivativeWeightFunction();
-  ~BSplineInterpolationDerivativeWeightFunction() override {}
+  ~BSplineInterpolationDerivativeWeightFunction() override = default;
 
   /** Interpolation kernel types. */
   typedef typename Superclass::KernelType                       KernelType;

--- a/Common/Transforms/itkBSplineInterpolationSecondOrderDerivativeWeightFunction.h
+++ b/Common/Transforms/itkBSplineInterpolationSecondOrderDerivativeWeightFunction.h
@@ -76,7 +76,7 @@ public:
 
 protected:
   BSplineInterpolationSecondOrderDerivativeWeightFunction();
-  ~BSplineInterpolationSecondOrderDerivativeWeightFunction() override {}
+  ~BSplineInterpolationSecondOrderDerivativeWeightFunction() override = default;
 
   /** Interpolation kernel types. */
   typedef typename Superclass::KernelType                       KernelType;

--- a/Common/Transforms/itkBSplineInterpolationWeightFunction2.h
+++ b/Common/Transforms/itkBSplineInterpolationWeightFunction2.h
@@ -70,7 +70,7 @@ public:
 
 protected:
   BSplineInterpolationWeightFunction2();
-  ~BSplineInterpolationWeightFunction2() override {}
+  ~BSplineInterpolationWeightFunction2() override = default;
 
   /** Interpolation kernel types. */
   typedef typename Superclass::KernelType                       KernelType;

--- a/Common/Transforms/itkBSplineInterpolationWeightFunctionBase.h
+++ b/Common/Transforms/itkBSplineInterpolationWeightFunctionBase.h
@@ -124,7 +124,7 @@ public:
 
 protected:
   BSplineInterpolationWeightFunctionBase();
-  ~BSplineInterpolationWeightFunctionBase() override {}
+  ~BSplineInterpolationWeightFunctionBase() override = default;
 
   /** Interpolation kernel types. */
   typedef BSplineKernelFunction2<Self::SplineOrder>                      KernelType;

--- a/Common/Transforms/itkBSplineKernelFunction2.h
+++ b/Common/Transforms/itkBSplineKernelFunction2.h
@@ -95,8 +95,8 @@ public:
 
 
 protected:
-  BSplineKernelFunction2() {}
-  ~BSplineKernelFunction2() override {}
+  BSplineKernelFunction2() = default;
+  ~BSplineKernelFunction2() override = default;
 
   void
   PrintSelf(std::ostream & os, Indent indent) const override

--- a/Common/Transforms/itkBSplineSecondOrderDerivativeKernelFunction2.h
+++ b/Common/Transforms/itkBSplineSecondOrderDerivativeKernelFunction2.h
@@ -75,8 +75,8 @@ public:
 
 
 protected:
-  BSplineSecondOrderDerivativeKernelFunction2() {}
-  ~BSplineSecondOrderDerivativeKernelFunction2() override {}
+  BSplineSecondOrderDerivativeKernelFunction2() = default;
+  ~BSplineSecondOrderDerivativeKernelFunction2() override = default;
 
   void
   PrintSelf(std::ostream & os, Indent indent) const override

--- a/Common/Transforms/itkCyclicBSplineDeformableTransform.hxx
+++ b/Common/Transforms/itkCyclicBSplineDeformableTransform.hxx
@@ -34,7 +34,7 @@ CyclicBSplineDeformableTransform<TScalarType, NDimensions, VSplineOrder>::Cyclic
 /** Destructor. */
 template <class TScalarType, unsigned int NDimensions, unsigned int VSplineOrder>
 CyclicBSplineDeformableTransform<TScalarType, NDimensions, VSplineOrder>::~CyclicBSplineDeformableTransform()
-{}
+= default;
 
 /** Set the grid region. */
 template <class TScalarType, unsigned int NDimensions, unsigned int VSplineOrder>

--- a/Common/Transforms/itkCyclicGridScheduleComputer.h
+++ b/Common/Transforms/itkCyclicGridScheduleComputer.h
@@ -87,7 +87,7 @@ protected:
   CyclicGridScheduleComputer();
 
   /** The destructor. */
-  ~CyclicGridScheduleComputer() override {}
+  ~CyclicGridScheduleComputer() override = default;
 
 private:
   CyclicGridScheduleComputer(const Self &) = delete;

--- a/Common/Transforms/itkCyclicGridScheduleComputer.hxx
+++ b/Common/Transforms/itkCyclicGridScheduleComputer.hxx
@@ -32,7 +32,7 @@ namespace itk
 
 template <typename TTransformScalarType, unsigned int VImageDimension>
 CyclicGridScheduleComputer<TTransformScalarType, VImageDimension>::CyclicGridScheduleComputer()
-{} // end Constructor()
+= default; // end Constructor()
 
 /**
  * ********************* ComputeBSplineGrid ****************************

--- a/Common/Transforms/itkEulerTransform.h
+++ b/Common/Transforms/itkEulerTransform.h
@@ -187,8 +187,8 @@ public:
 
 
 protected:
-  EulerTransform() {}
-  ~EulerTransform() override {}
+  EulerTransform() = default;
+  ~EulerTransform() override = default;
 
 private:
   EulerTransform(const Self &) = delete;
@@ -255,8 +255,8 @@ public:
 
 
 protected:
-  EulerTransform() {}
-  ~EulerTransform() override {}
+  EulerTransform() = default;
+  ~EulerTransform() override = default;
 
 private:
   EulerTransform(const Self &) = delete;

--- a/Common/Transforms/itkGridScheduleComputer.h
+++ b/Common/Transforms/itkGridScheduleComputer.h
@@ -146,7 +146,7 @@ protected:
   GridScheduleComputer();
 
   /** The destructor. */
-  ~GridScheduleComputer() override {}
+  ~GridScheduleComputer() override = default;
 
   /** Declare member variables, needed for B-spline grid. */
   VectorSpacingType           m_GridSpacings;

--- a/Common/Transforms/itkKernelFunctionBase2.h
+++ b/Common/Transforms/itkKernelFunctionBase2.h
@@ -60,8 +60,8 @@ public:
   Evaluate(const TRealValueType & u, TRealValueType * weights) const = 0;
 
 protected:
-  KernelFunctionBase2(){};
-  ~KernelFunctionBase2() override{};
+  KernelFunctionBase2()= default;;
+  ~KernelFunctionBase2() override= default;;
 };
 } // end namespace itk
 

--- a/Common/Transforms/itkRecursiveBSplineTransform.h
+++ b/Common/Transforms/itkRecursiveBSplineTransform.h
@@ -185,7 +185,7 @@ public:
 
 protected:
   RecursiveBSplineTransform();
-  ~RecursiveBSplineTransform() override {}
+  ~RecursiveBSplineTransform() override = default;
 
   typedef typename Superclass::JacobianImageType JacobianImageType;
   typedef typename Superclass::JacobianPixelType JacobianPixelType;

--- a/Common/Transforms/itkStackTransform.h
+++ b/Common/Transforms/itkStackTransform.h
@@ -287,7 +287,7 @@ public:
 
 protected:
   StackTransform();
-  ~StackTransform() override {}
+  ~StackTransform() override = default;
 
 private:
   StackTransform(const Self &) = delete;

--- a/Common/Transforms/itkTransformToDeterminantOfSpatialJacobianSource.h
+++ b/Common/Transforms/itkTransformToDeterminantOfSpatialJacobianSource.h
@@ -190,7 +190,7 @@ public:
 
 protected:
   TransformToDeterminantOfSpatialJacobianSource();
-  ~TransformToDeterminantOfSpatialJacobianSource() override {}
+  ~TransformToDeterminantOfSpatialJacobianSource() override = default;
 
   void
   PrintSelf(std::ostream & os, Indent indent) const override;

--- a/Common/Transforms/itkTransformToSpatialJacobianSource.h
+++ b/Common/Transforms/itkTransformToSpatialJacobianSource.h
@@ -182,7 +182,7 @@ public:
 
 protected:
   TransformToSpatialJacobianSource();
-  ~TransformToSpatialJacobianSource() override {}
+  ~TransformToSpatialJacobianSource() override = default;
 
   void
   PrintSelf(std::ostream & os, Indent indent) const override;

--- a/Common/Transforms/itkUpsampleBSplineParametersFilter.h
+++ b/Common/Transforms/itkUpsampleBSplineParametersFilter.h
@@ -101,7 +101,7 @@ protected:
   UpsampleBSplineParametersFilter();
 
   /** Destructor. */
-  ~UpsampleBSplineParametersFilter() override {}
+  ~UpsampleBSplineParametersFilter() override = default;
 
   /** PrintSelf. */
   void

--- a/Common/itkAdvancedLinearInterpolateImageFunction.h
+++ b/Common/itkAdvancedLinearInterpolateImageFunction.h
@@ -117,7 +117,7 @@ public:
 
 protected:
   AdvancedLinearInterpolateImageFunction();
-  ~AdvancedLinearInterpolateImageFunction() override {}
+  ~AdvancedLinearInterpolateImageFunction() override = default;
 
 private:
   AdvancedLinearInterpolateImageFunction(const Self &) = delete;

--- a/Common/itkAdvancedLinearInterpolateImageFunction.hxx
+++ b/Common/itkAdvancedLinearInterpolateImageFunction.hxx
@@ -31,7 +31,7 @@ namespace itk
 
 template <class TInputImage, class TCoordRep>
 AdvancedLinearInterpolateImageFunction<TInputImage, TCoordRep>::AdvancedLinearInterpolateImageFunction()
-{}
+= default;
 
 /**
  * ***************** EvaluateDerivativeAtContinuousIndex ***********************

--- a/Common/itkAdvancedRayCastInterpolateImageFunction.h
+++ b/Common/itkAdvancedRayCastInterpolateImageFunction.h
@@ -191,7 +191,7 @@ protected:
   AdvancedRayCastInterpolateImageFunction();
 
   /// Destructor
-  ~AdvancedRayCastInterpolateImageFunction() override {}
+  ~AdvancedRayCastInterpolateImageFunction() override = default;
 
   /// Print the object
   void

--- a/Common/itkComputeImageExtremaFilter.h
+++ b/Common/itkComputeImageExtremaFilter.h
@@ -92,7 +92,7 @@ public:
 
 protected:
   ComputeImageExtremaFilter();
-  ~ComputeImageExtremaFilter() override {}
+  ~ComputeImageExtremaFilter() override = default;
 
   /** Initialize some accumulators before the threads run. */
   void

--- a/Common/itkComputeJacobianTerms.h
+++ b/Common/itkComputeJacobianTerms.h
@@ -106,7 +106,7 @@ public:
 
 protected:
   ComputeJacobianTerms();
-  ~ComputeJacobianTerms() override {}
+  ~ComputeJacobianTerms() override = default;
 
   typename FixedImageType::ConstPointer m_FixedImage;
   FixedImageRegionType                  m_FixedImageRegion;

--- a/Common/itkComputePreconditionerUsingDisplacementDistribution.h
+++ b/Common/itkComputePreconditionerUsingDisplacementDistribution.h
@@ -119,7 +119,7 @@ public:
 
 protected:
   ComputePreconditionerUsingDisplacementDistribution();
-  ~ComputePreconditionerUsingDisplacementDistribution() override {}
+  ~ComputePreconditionerUsingDisplacementDistribution() override = default;
 
   typedef typename Superclass::FixedImageIndexType           FixedImageIndexType;
   typedef typename Superclass::FixedImagePointType           FixedImagePointType;

--- a/Common/itkErodeMaskImageFilter.h
+++ b/Common/itkErodeMaskImageFilter.h
@@ -123,7 +123,7 @@ protected:
   ErodeMaskImageFilter();
 
   /** Destructor */
-  ~ErodeMaskImageFilter() override {}
+  ~ErodeMaskImageFilter() override = default;
 
   /** Standard pipeline method. While this class does not implement a
    * ThreadedGenerateData(), its GenerateData() delegates all

--- a/Common/itkGenericMultiResolutionPyramidImageFilter.h
+++ b/Common/itkGenericMultiResolutionPyramidImageFilter.h
@@ -231,7 +231,7 @@ public:
 
 protected:
   GenericMultiResolutionPyramidImageFilter();
-  ~GenericMultiResolutionPyramidImageFilter() override {}
+  ~GenericMultiResolutionPyramidImageFilter() override = default;
 
   /** PrintSelf. */
   void

--- a/Common/itkMeshFileReaderBase.h
+++ b/Common/itkMeshFileReaderBase.h
@@ -74,7 +74,7 @@ public:
 
 protected:
   MeshFileReaderBase();
-  ~MeshFileReaderBase() override {}
+  ~MeshFileReaderBase() override = default;
 
   /** Test whether the given filename exist and it is readable,
    * this is intended to be called before attempting to use

--- a/Common/itkMultiOrderBSplineDecompositionImageFilter.h
+++ b/Common/itkMultiOrderBSplineDecompositionImageFilter.h
@@ -137,7 +137,7 @@ public:
 
 protected:
   MultiOrderBSplineDecompositionImageFilter();
-  ~MultiOrderBSplineDecompositionImageFilter() override {}
+  ~MultiOrderBSplineDecompositionImageFilter() override = default;
   void
   PrintSelf(std::ostream & os, Indent indent) const override;
 

--- a/Common/itkMultiResolutionGaussianSmoothingPyramidImageFilter.h
+++ b/Common/itkMultiResolutionGaussianSmoothingPyramidImageFilter.h
@@ -187,7 +187,7 @@ public:
 
 protected:
   MultiResolutionGaussianSmoothingPyramidImageFilter();
-  ~MultiResolutionGaussianSmoothingPyramidImageFilter() override {}
+  ~MultiResolutionGaussianSmoothingPyramidImageFilter() override = default;
   void
   PrintSelf(std::ostream & os, Indent indent) const override;
 

--- a/Common/itkMultiResolutionGaussianSmoothingPyramidImageFilter.hxx
+++ b/Common/itkMultiResolutionGaussianSmoothingPyramidImageFilter.hxx
@@ -53,7 +53,7 @@ namespace itk
 template <class TInputImage, class TOutputImage>
 MultiResolutionGaussianSmoothingPyramidImageFilter<TInputImage,
                                                    TOutputImage>::MultiResolutionGaussianSmoothingPyramidImageFilter()
-{}
+= default;
 
 /*
  * Set the multi-resolution schedule

--- a/Common/itkMultiResolutionImageRegistrationMethod2.h
+++ b/Common/itkMultiResolutionImageRegistrationMethod2.h
@@ -246,7 +246,7 @@ protected:
   MultiResolutionImageRegistrationMethod2();
 
   /** Destructor. */
-  ~MultiResolutionImageRegistrationMethod2() override {}
+  ~MultiResolutionImageRegistrationMethod2() override = default;
 
   /** PrintSelf. */
   void

--- a/Common/itkMultiResolutionShrinkPyramidImageFilter.h
+++ b/Common/itkMultiResolutionShrinkPyramidImageFilter.h
@@ -75,8 +75,8 @@ public:
 #endif
 
 protected:
-  MultiResolutionShrinkPyramidImageFilter() {}
-  ~MultiResolutionShrinkPyramidImageFilter() override {}
+  MultiResolutionShrinkPyramidImageFilter() = default;
+  ~MultiResolutionShrinkPyramidImageFilter() override = default;
 
   /** Generate the output data. */
   void

--- a/Common/itkNDImageBase.h
+++ b/Common/itkNDImageBase.h
@@ -244,8 +244,8 @@ public:
   NewNDImage(unsigned int dim);
 
 protected:
-  NDImageBase() {}
-  ~NDImageBase() override {}
+  NDImageBase() = default;
+  ~NDImageBase() override = default;
 
   // virtual void PrintSelf(std::ostream& os, Indent indent) const = 0;
 

--- a/Common/itkNDImageTemplate.h
+++ b/Common/itkNDImageTemplate.h
@@ -227,7 +227,7 @@ public:
 
 protected:
   NDImageTemplate();
-  ~NDImageTemplate() override {}
+  ~NDImageTemplate() override = default;
 
   // virtual void PrintSelf(std::ostream& os, Indent indent) const;
 

--- a/Common/itkParabolicErodeDilateImageFilter.h
+++ b/Common/itkParabolicErodeDilateImageFilter.h
@@ -134,7 +134,7 @@ public:
 
 protected:
   ParabolicErodeDilateImageFilter();
-  ~ParabolicErodeDilateImageFilter() override {}
+  ~ParabolicErodeDilateImageFilter() override = default;
   void
   PrintSelf(std::ostream & os, Indent indent) const override;
 

--- a/Common/itkParabolicErodeImageFilter.h
+++ b/Common/itkParabolicErodeImageFilter.h
@@ -77,8 +77,8 @@ public:
       Here we prefer float in order to save memory.  */
 
 protected:
-  ParabolicErodeImageFilter() {}
-  ~ParabolicErodeImageFilter() override {}
+  ParabolicErodeImageFilter() = default;
+  ~ParabolicErodeImageFilter() override = default;
   //   void PrintSelf(std::ostream& os, Indent indent) const;
 
 private:

--- a/Common/itkRecursiveBSplineInterpolationWeightFunction.h
+++ b/Common/itkRecursiveBSplineInterpolationWeightFunction.h
@@ -135,7 +135,7 @@ public:
 
 protected:
   RecursiveBSplineInterpolationWeightFunction();
-  ~RecursiveBSplineInterpolationWeightFunction() override {}
+  ~RecursiveBSplineInterpolationWeightFunction() override = default;
   void
   PrintSelf(std::ostream & os, Indent indent) const override;
 

--- a/Common/itkReducedDimensionBSplineInterpolateImageFunction.h
+++ b/Common/itkReducedDimensionBSplineInterpolateImageFunction.h
@@ -188,7 +188,7 @@ public:
 
 protected:
   ReducedDimensionBSplineInterpolateImageFunction();
-  ~ReducedDimensionBSplineInterpolateImageFunction() override {}
+  ~ReducedDimensionBSplineInterpolateImageFunction() override = default;
   void
   PrintSelf(std::ostream & os, Indent indent) const override;
 

--- a/Common/itkScaledSingleValuedNonLinearOptimizer.h
+++ b/Common/itkScaledSingleValuedNonLinearOptimizer.h
@@ -133,7 +133,7 @@ protected:
   /** The constructor. */
   ScaledSingleValuedNonLinearOptimizer();
   /** The destructor. */
-  ~ScaledSingleValuedNonLinearOptimizer() override {}
+  ~ScaledSingleValuedNonLinearOptimizer() override = default;
 
   /** PrintSelf. */
   void

--- a/Components/FixedImagePyramids/FixedGenericPyramid/elxFixedGenericPyramid.h
+++ b/Components/FixedImagePyramids/FixedGenericPyramid/elxFixedGenericPyramid.h
@@ -126,9 +126,9 @@ public:
 
 protected:
   /** The constructor. */
-  FixedGenericPyramid() {}
+  FixedGenericPyramid() = default;
   /** The destructor. */
-  ~FixedGenericPyramid() override {}
+  ~FixedGenericPyramid() override = default;
 
 private:
   /** The deleted copy constructor. */

--- a/Components/FixedImagePyramids/FixedRecursivePyramid/elxFixedRecursivePyramid.h
+++ b/Components/FixedImagePyramids/FixedRecursivePyramid/elxFixedRecursivePyramid.h
@@ -85,9 +85,9 @@ public:
 
 protected:
   /** The constructor. */
-  FixedRecursivePyramid() {}
+  FixedRecursivePyramid() = default;
   /** The destructor. */
-  ~FixedRecursivePyramid() override {}
+  ~FixedRecursivePyramid() override = default;
 
 private:
   /** The deleted copy constructor. */

--- a/Components/FixedImagePyramids/FixedShrinkingPyramid/elxFixedShrinkingPyramid.h
+++ b/Components/FixedImagePyramids/FixedShrinkingPyramid/elxFixedShrinkingPyramid.h
@@ -85,9 +85,9 @@ public:
 
 protected:
   /** The constructor. */
-  FixedShrinkingPyramid() {}
+  FixedShrinkingPyramid() = default;
   /** The destructor. */
-  ~FixedShrinkingPyramid() override {}
+  ~FixedShrinkingPyramid() override = default;
 
 private:
   /** The deleted copy constructor. */

--- a/Components/FixedImagePyramids/FixedSmoothingPyramid/elxFixedSmoothingPyramid.h
+++ b/Components/FixedImagePyramids/FixedSmoothingPyramid/elxFixedSmoothingPyramid.h
@@ -87,9 +87,9 @@ public:
 
 protected:
   /** The constructor. */
-  FixedSmoothingPyramid() {}
+  FixedSmoothingPyramid() = default;
   /** The destructor. */
-  ~FixedSmoothingPyramid() override {}
+  ~FixedSmoothingPyramid() override = default;
 
 private:
   /** The deleted copy constructor. */

--- a/Components/FixedImagePyramids/OpenCLFixedGenericPyramid/elxOpenCLFixedGenericPyramid.h
+++ b/Components/FixedImagePyramids/OpenCLFixedGenericPyramid/elxOpenCLFixedGenericPyramid.h
@@ -108,7 +108,7 @@ protected:
   /** The constructor. */
   OpenCLFixedGenericPyramid();
   /** The destructor. */
-  virtual ~OpenCLFixedGenericPyramid() {}
+  virtual ~OpenCLFixedGenericPyramid() = default;
 
 private:
   /** The deleted copy constructor. */

--- a/Components/ImageSamplers/Full/elxFullSampler.h
+++ b/Components/ImageSamplers/Full/elxFullSampler.h
@@ -94,9 +94,9 @@ public:
 
 protected:
   /** The constructor. */
-  FullSampler() {}
+  FullSampler() = default;
   /** The destructor. */
-  ~FullSampler() override {}
+  ~FullSampler() override = default;
 
 private:
   /** The deleted copy constructor. */

--- a/Components/ImageSamplers/Grid/elxGridSampler.h
+++ b/Components/ImageSamplers/Grid/elxGridSampler.h
@@ -107,9 +107,9 @@ public:
 
 protected:
   /** The constructor. */
-  GridSampler() {}
+  GridSampler() = default;
   /** The destructor. */
-  ~GridSampler() override {}
+  ~GridSampler() override = default;
 
 private:
   /** The deleted copy constructor. */

--- a/Components/ImageSamplers/MultInputRandomCoordinate/elxMultiInputRandomCoordinateSampler.h
+++ b/Components/ImageSamplers/MultInputRandomCoordinate/elxMultiInputRandomCoordinateSampler.h
@@ -153,9 +153,9 @@ public:
 
 protected:
   /** The constructor. */
-  MultiInputRandomCoordinateSampler() {}
+  MultiInputRandomCoordinateSampler() = default;
   /** The destructor. */
-  ~MultiInputRandomCoordinateSampler() override {}
+  ~MultiInputRandomCoordinateSampler() override = default;
 
 private:
   /** The deleted copy constructor. */

--- a/Components/ImageSamplers/Random/elxRandomSampler.h
+++ b/Components/ImageSamplers/Random/elxRandomSampler.h
@@ -108,9 +108,9 @@ public:
 
 protected:
   /** The constructor. */
-  RandomSampler() {}
+  RandomSampler() = default;
   /** The destructor. */
-  ~RandomSampler() override {}
+  ~RandomSampler() override = default;
 
 private:
   /** The deleted copy constructor. */

--- a/Components/ImageSamplers/RandomCoordinate/elxRandomCoordinateSampler.h
+++ b/Components/ImageSamplers/RandomCoordinate/elxRandomCoordinateSampler.h
@@ -146,9 +146,9 @@ public:
 
 protected:
   /** The constructor. */
-  RandomCoordinateSampler() {}
+  RandomCoordinateSampler() = default;
   /** The destructor. */
-  ~RandomCoordinateSampler() override {}
+  ~RandomCoordinateSampler() override = default;
 
 private:
   /** The deleted copy constructor. */

--- a/Components/ImageSamplers/RandomSparseMask/elxRandomSamplerSparseMask.h
+++ b/Components/ImageSamplers/RandomSparseMask/elxRandomSamplerSparseMask.h
@@ -110,9 +110,9 @@ public:
 
 protected:
   /** The constructor. */
-  RandomSamplerSparseMask() {}
+  RandomSamplerSparseMask() = default;
   /** The destructor. */
-  ~RandomSamplerSparseMask() override {}
+  ~RandomSamplerSparseMask() override = default;
 
 private:
   /** The deleted copy constructor. */

--- a/Components/Interpolators/BSplineInterpolator/elxBSplineInterpolator.h
+++ b/Components/Interpolators/BSplineInterpolator/elxBSplineInterpolator.h
@@ -110,9 +110,9 @@ public:
 
 protected:
   /** The constructor. */
-  BSplineInterpolator() {}
+  BSplineInterpolator() = default;
   /** The destructor. */
-  ~BSplineInterpolator() override {}
+  ~BSplineInterpolator() override = default;
 
 private:
   /** The deleted copy constructor. */

--- a/Components/Interpolators/BSplineInterpolatorFloat/elxBSplineInterpolatorFloat.h
+++ b/Components/Interpolators/BSplineInterpolatorFloat/elxBSplineInterpolatorFloat.h
@@ -110,9 +110,9 @@ public:
 
 protected:
   /** The constructor. */
-  BSplineInterpolatorFloat() {}
+  BSplineInterpolatorFloat() = default;
   /** The destructor. */
-  ~BSplineInterpolatorFloat() override {}
+  ~BSplineInterpolatorFloat() override = default;
 
 private:
   /** The deleted copy constructor. */

--- a/Components/Interpolators/LinearInterpolator/elxLinearInterpolator.h
+++ b/Components/Interpolators/LinearInterpolator/elxLinearInterpolator.h
@@ -89,9 +89,9 @@ public:
 
 protected:
   /** The constructor. */
-  LinearInterpolator() {}
+  LinearInterpolator() = default;
   /** The destructor. */
-  ~LinearInterpolator() override {}
+  ~LinearInterpolator() override = default;
 
 private:
   /** The deleted copy constructor. */

--- a/Components/Interpolators/NearestNeighborInterpolator/elxNearestNeighborInterpolator.h
+++ b/Components/Interpolators/NearestNeighborInterpolator/elxNearestNeighborInterpolator.h
@@ -87,9 +87,9 @@ public:
 
 protected:
   /** The constructor. */
-  NearestNeighborInterpolator() {}
+  NearestNeighborInterpolator() = default;
   /** The destructor. */
-  ~NearestNeighborInterpolator() override {}
+  ~NearestNeighborInterpolator() override = default;
 
 private:
   /** The deleted copy constructor. */

--- a/Components/Interpolators/RayCastInterpolator/elxRayCastInterpolator.h
+++ b/Components/Interpolators/RayCastInterpolator/elxRayCastInterpolator.h
@@ -106,10 +106,10 @@ public:
 
 protected:
   /** The constructor. */
-  RayCastInterpolator() {}
+  RayCastInterpolator() = default;
 
   /** The destructor. */
-  ~RayCastInterpolator() override {}
+  ~RayCastInterpolator() override = default;
 
   int
   BeforeAll(void) override;

--- a/Components/Interpolators/ReducedDimensionBSplineInterpolator/elxReducedDimensionBSplineInterpolator.h
+++ b/Components/Interpolators/ReducedDimensionBSplineInterpolator/elxReducedDimensionBSplineInterpolator.h
@@ -108,9 +108,9 @@ public:
 
 protected:
   /** The constructor. */
-  ReducedDimensionBSplineInterpolator() {}
+  ReducedDimensionBSplineInterpolator() = default;
   /** The destructor. */
-  ~ReducedDimensionBSplineInterpolator() override {}
+  ~ReducedDimensionBSplineInterpolator() override = default;
 
 private:
   /** The deleted copy constructor. */

--- a/Components/Metrics/AdvancedKappaStatistic/elxAdvancedKappaStatisticMetric.h
+++ b/Components/Metrics/AdvancedKappaStatistic/elxAdvancedKappaStatisticMetric.h
@@ -145,9 +145,9 @@ public:
 
 protected:
   /** The constructor. */
-  AdvancedKappaStatisticMetric() {}
+  AdvancedKappaStatisticMetric() = default;
   /** The destructor. */
-  ~AdvancedKappaStatisticMetric() override {}
+  ~AdvancedKappaStatisticMetric() override = default;
 
 private:
   /** The deleted copy constructor. */

--- a/Components/Metrics/AdvancedMattesMutualInformation/elxAdvancedMattesMutualInformationMetric.h
+++ b/Components/Metrics/AdvancedMattesMutualInformation/elxAdvancedMattesMutualInformationMetric.h
@@ -216,7 +216,7 @@ protected:
   AdvancedMattesMutualInformationMetric();
 
   /** The destructor. */
-  ~AdvancedMattesMutualInformationMetric() override {}
+  ~AdvancedMattesMutualInformationMetric() override = default;
 
   unsigned long m_CurrentIteration;
 

--- a/Components/Metrics/AdvancedMattesMutualInformation/itkParzenWindowMutualInformationImageToImageMetric.h
+++ b/Components/Metrics/AdvancedMattesMutualInformation/itkParzenWindowMutualInformationImageToImageMetric.h
@@ -152,7 +152,7 @@ protected:
   ParzenWindowMutualInformationImageToImageMetric();
 
   /** The destructor. */
-  ~ParzenWindowMutualInformationImageToImageMetric() override {}
+  ~ParzenWindowMutualInformationImageToImageMetric() override = default;
 
   /** Protected Typedefs ******************/
 

--- a/Components/Metrics/AdvancedMeanSquares/elxAdvancedMeanSquaresMetric.h
+++ b/Components/Metrics/AdvancedMeanSquares/elxAdvancedMeanSquaresMetric.h
@@ -141,9 +141,9 @@ public:
 
 protected:
   /** The constructor. */
-  AdvancedMeanSquaresMetric() {}
+  AdvancedMeanSquaresMetric() = default;
   /** The destructor. */
-  ~AdvancedMeanSquaresMetric() override {}
+  ~AdvancedMeanSquaresMetric() override = default;
 
 private:
   /** The deleted copy constructor. */

--- a/Components/Metrics/AdvancedMeanSquares/itkAdvancedMeanSquaresImageToImageMetric.h
+++ b/Components/Metrics/AdvancedMeanSquares/itkAdvancedMeanSquaresImageToImageMetric.h
@@ -188,7 +188,7 @@ public:
 
 protected:
   AdvancedMeanSquaresImageToImageMetric();
-  ~AdvancedMeanSquaresImageToImageMetric() override {}
+  ~AdvancedMeanSquaresImageToImageMetric() override = default;
 
   void
   PrintSelf(std::ostream & os, Indent indent) const override;

--- a/Components/Metrics/AdvancedNormalizedCorrelation/elxAdvancedNormalizedCorrelationMetric.h
+++ b/Components/Metrics/AdvancedNormalizedCorrelation/elxAdvancedNormalizedCorrelationMetric.h
@@ -139,9 +139,9 @@ public:
 
 protected:
   /** The constructor. */
-  AdvancedNormalizedCorrelationMetric() {}
+  AdvancedNormalizedCorrelationMetric() = default;
   /** The destructor. */
-  ~AdvancedNormalizedCorrelationMetric() override {}
+  ~AdvancedNormalizedCorrelationMetric() override = default;
 
 private:
   /** The deleted copy constructor. */

--- a/Components/Metrics/BendingEnergyPenalty/elxTransformBendingEnergyPenaltyTerm.h
+++ b/Components/Metrics/BendingEnergyPenalty/elxTransformBendingEnergyPenaltyTerm.h
@@ -139,10 +139,10 @@ public:
 
 protected:
   /** The constructor. */
-  TransformBendingEnergyPenalty() {}
+  TransformBendingEnergyPenalty() = default;
 
   /** The destructor. */
-  ~TransformBendingEnergyPenalty() override {}
+  ~TransformBendingEnergyPenalty() override = default;
 
 private:
   /** The deleted copy constructor. */

--- a/Components/Metrics/BendingEnergyPenalty/itkTransformBendingEnergyPenaltyTerm.h
+++ b/Components/Metrics/BendingEnergyPenalty/itkTransformBendingEnergyPenaltyTerm.h
@@ -175,7 +175,7 @@ protected:
   TransformBendingEnergyPenaltyTerm();
 
   /** The destructor. */
-  ~TransformBendingEnergyPenaltyTerm() override {}
+  ~TransformBendingEnergyPenaltyTerm() override = default;
 
 private:
   /** The deleted copy constructor. */

--- a/Components/Metrics/CorrespondingPointsEuclideanDistanceMetric/elxCorrespondingPointsEuclideanDistanceMetric.h
+++ b/Components/Metrics/CorrespondingPointsEuclideanDistanceMetric/elxCorrespondingPointsEuclideanDistanceMetric.h
@@ -144,9 +144,9 @@ public:
 
 protected:
   /** The constructor. */
-  CorrespondingPointsEuclideanDistanceMetric() {}
+  CorrespondingPointsEuclideanDistanceMetric() = default;
   /** The destructor. */
-  ~CorrespondingPointsEuclideanDistanceMetric() override {}
+  ~CorrespondingPointsEuclideanDistanceMetric() override = default;
 
 private:
   /** The deleted copy constructor. */

--- a/Components/Metrics/CorrespondingPointsEuclideanDistanceMetric/itkCorrespondingPointsEuclideanDistancePointMetric.h
+++ b/Components/Metrics/CorrespondingPointsEuclideanDistanceMetric/itkCorrespondingPointsEuclideanDistancePointMetric.h
@@ -92,7 +92,7 @@ public:
 
 protected:
   CorrespondingPointsEuclideanDistancePointMetric();
-  ~CorrespondingPointsEuclideanDistancePointMetric() override {}
+  ~CorrespondingPointsEuclideanDistancePointMetric() override = default;
 
 private:
   CorrespondingPointsEuclideanDistancePointMetric(const Self &) = delete;

--- a/Components/Metrics/CorrespondingPointsEuclideanDistanceMetric/itkCorrespondingPointsEuclideanDistancePointMetric.hxx
+++ b/Components/Metrics/CorrespondingPointsEuclideanDistanceMetric/itkCorrespondingPointsEuclideanDistancePointMetric.hxx
@@ -30,7 +30,7 @@ namespace itk
 template <class TFixedPointSet, class TMovingPointSet>
 CorrespondingPointsEuclideanDistancePointMetric<TFixedPointSet,
                                                 TMovingPointSet>::CorrespondingPointsEuclideanDistancePointMetric()
-{} // end Constructor
+= default; // end Constructor
 
 /**
  * ******************* GetValue *******************

--- a/Components/Metrics/DisplacementMagnitudePenalty/elxDisplacementMagnitudePenalty.h
+++ b/Components/Metrics/DisplacementMagnitudePenalty/elxDisplacementMagnitudePenalty.h
@@ -129,10 +129,10 @@ public:
 
 protected:
   /** The constructor. */
-  DisplacementMagnitudePenalty() {}
+  DisplacementMagnitudePenalty() = default;
 
   /** The destructor. */
-  ~DisplacementMagnitudePenalty() override {}
+  ~DisplacementMagnitudePenalty() override = default;
 
 private:
   /** The deleted copy constructor. */

--- a/Components/Metrics/DisplacementMagnitudePenalty/itkDisplacementMagnitudePenaltyTerm.h
+++ b/Components/Metrics/DisplacementMagnitudePenalty/itkDisplacementMagnitudePenaltyTerm.h
@@ -127,7 +127,7 @@ protected:
   DisplacementMagnitudePenaltyTerm();
 
   /** The destructor. */
-  ~DisplacementMagnitudePenaltyTerm() override {}
+  ~DisplacementMagnitudePenaltyTerm() override = default;
 
   /** PrintSelf. *
   void PrintSelf( std::ostream& os, Indent indent ) const;*/

--- a/Components/Metrics/DistancePreservingRigidityPenalty/elxDistancePreservingRigidityPenaltyTerm.h
+++ b/Components/Metrics/DistancePreservingRigidityPenalty/elxDistancePreservingRigidityPenaltyTerm.h
@@ -162,10 +162,10 @@ public:
 
 protected:
   /** The constructor. */
-  DistancePreservingRigidityPenalty() {}
+  DistancePreservingRigidityPenalty() = default;
 
   /** The destructor. */
-  ~DistancePreservingRigidityPenalty() override {}
+  ~DistancePreservingRigidityPenalty() override = default;
 
 private:
   /** The deleted copy constructor. */

--- a/Components/Metrics/DistancePreservingRigidityPenalty/itkDistancePreservingRigidityPenaltyTerm.h
+++ b/Components/Metrics/DistancePreservingRigidityPenalty/itkDistancePreservingRigidityPenaltyTerm.h
@@ -203,7 +203,7 @@ protected:
   DistancePreservingRigidityPenaltyTerm();
 
   /** The destructor. */
-  ~DistancePreservingRigidityPenaltyTerm() override {}
+  ~DistancePreservingRigidityPenaltyTerm() override = default;
 
   /** PrintSelf. */
   void

--- a/Components/Metrics/GradientDifference/elxGradientDifferenceMetric.h
+++ b/Components/Metrics/GradientDifference/elxGradientDifferenceMetric.h
@@ -137,10 +137,10 @@ public:
 
 protected:
   /** The constructor. */
-  GradientDifferenceMetric() {}
+  GradientDifferenceMetric() = default;
 
   /** The destructor. */
-  ~GradientDifferenceMetric() override {}
+  ~GradientDifferenceMetric() override = default;
 
 private:
   /** The deleted copy constructor. */

--- a/Components/Metrics/GradientDifference/itkGradientDifferenceImageToImageMetric2.h
+++ b/Components/Metrics/GradientDifference/itkGradientDifferenceImageToImageMetric2.h
@@ -165,7 +165,7 @@ public:
 
 protected:
   GradientDifferenceImageToImageMetric();
-  ~GradientDifferenceImageToImageMetric() override {}
+  ~GradientDifferenceImageToImageMetric() override = default;
   void
   PrintSelf(std::ostream & os, Indent indent) const override;
 

--- a/Components/Metrics/KNNGraphAlphaMutualInformation/KNN/ann_1.1/src/brute.cpp
+++ b/Components/Metrics/KNNGraphAlphaMutualInformation/KNN/ann_1.1/src/brute.cpp
@@ -49,7 +49,7 @@ ANNbruteForce::ANNbruteForce(			// constructor from point array
 	dim = dd;  n_pts = n;  pts = pa;
 }
 
-ANNbruteForce::~ANNbruteForce() { }		// destructor (empty)
+ANNbruteForce::~ANNbruteForce() = default;		// destructor (empty)
 
 void ANNbruteForce::annkSearch(			// approx k near neighbor search
 	ANNpoint			q,				// query point

--- a/Components/Metrics/KNNGraphAlphaMutualInformation/KNN/ann_1.1/src/kd_tree.h
+++ b/Components/Metrics/KNNGraphAlphaMutualInformation/KNN/ann_1.1/src/kd_tree.h
@@ -46,7 +46,7 @@ using namespace std; // make std:: available
 class ANNkd_node
 { // generic kd-tree node (empty shell)
 public:
-  virtual ~ANNkd_node() {} // virtual distroyer
+  virtual ~ANNkd_node() = default; // virtual distroyer
 
   virtual void ann_search(ANNdist) = 0;     // tree search
   virtual void ann_pri_search(ANNdist) = 0; // priority search
@@ -105,7 +105,7 @@ public:
     bkt = b;   // the bucket
   }
 
-  ~ANNkd_leaf() override {} // destructor (none)
+  ~ANNkd_leaf() override = default; // destructor (none)
 
   void
   getStats(                          // get tree statistics

--- a/Components/Metrics/KNNGraphAlphaMutualInformation/KNN/itkANNBinaryTreeCreator.h
+++ b/Components/Metrics/KNNGraphAlphaMutualInformation/KNN/itkANNBinaryTreeCreator.h
@@ -100,8 +100,8 @@ public:
   DecreaseReferenceCount(void);
 
 protected:
-  ANNBinaryTreeCreator() {}
-  ~ANNBinaryTreeCreator() override {}
+  ANNBinaryTreeCreator() = default;
+  ~ANNBinaryTreeCreator() override = default;
 
 private:
   ANNBinaryTreeCreator(const Self &) = delete;

--- a/Components/Metrics/KNNGraphAlphaMutualInformation/KNN/itkANNFixedRadiusTreeSearch.hxx
+++ b/Components/Metrics/KNNGraphAlphaMutualInformation/KNN/itkANNFixedRadiusTreeSearch.hxx
@@ -41,7 +41,7 @@ ANNFixedRadiusTreeSearch<TBinaryTree>::ANNFixedRadiusTreeSearch()
 
 template <class TBinaryTree>
 ANNFixedRadiusTreeSearch<TBinaryTree>::~ANNFixedRadiusTreeSearch()
-{} // end Destructor
+= default; // end Destructor
 
 /**
  * ************************ Search *************************

--- a/Components/Metrics/KNNGraphAlphaMutualInformation/KNN/itkANNPriorityTreeSearch.hxx
+++ b/Components/Metrics/KNNGraphAlphaMutualInformation/KNN/itkANNPriorityTreeSearch.hxx
@@ -41,7 +41,7 @@ ANNPriorityTreeSearch<TBinaryTree>::ANNPriorityTreeSearch()
 
 template <class TBinaryTree>
 ANNPriorityTreeSearch<TBinaryTree>::~ANNPriorityTreeSearch()
-{} // end Destructor
+= default; // end Destructor
 
 /**
  * ************************ SetBinaryTree *************************

--- a/Components/Metrics/KNNGraphAlphaMutualInformation/KNN/itkANNStandardTreeSearch.hxx
+++ b/Components/Metrics/KNNGraphAlphaMutualInformation/KNN/itkANNStandardTreeSearch.hxx
@@ -40,7 +40,7 @@ ANNStandardTreeSearch<TBinaryTree>::ANNStandardTreeSearch()
 
 template <class TBinaryTree>
 ANNStandardTreeSearch<TBinaryTree>::~ANNStandardTreeSearch()
-{} // end Destructor
+= default; // end Destructor
 
 /**
  * ************************ Search *************************

--- a/Components/Metrics/KNNGraphAlphaMutualInformation/KNN/itkANNbdTree.h
+++ b/Components/Metrics/KNNGraphAlphaMutualInformation/KNN/itkANNbdTree.h
@@ -78,7 +78,7 @@ protected:
   ANNbdTree();
 
   /** Destructor. */
-  ~ANNbdTree() override {}
+  ~ANNbdTree() override = default;
 
   /** PrintSelf. */
   void

--- a/Components/Metrics/KNNGraphAlphaMutualInformation/KNN/itkBinaryANNTreeBase.h
+++ b/Components/Metrics/KNNGraphAlphaMutualInformation/KNN/itkBinaryANNTreeBase.h
@@ -64,7 +64,7 @@ protected:
   BinaryANNTreeBase();
 
   /** Destructor. */
-  ~BinaryANNTreeBase() override {}
+  ~BinaryANNTreeBase() override = default;
 
 private:
   BinaryANNTreeBase(const Self &) = delete;

--- a/Components/Metrics/KNNGraphAlphaMutualInformation/KNN/itkBinaryANNTreeBase.hxx
+++ b/Components/Metrics/KNNGraphAlphaMutualInformation/KNN/itkBinaryANNTreeBase.hxx
@@ -29,7 +29,7 @@ namespace itk
 
 template <class TListSample>
 BinaryANNTreeBase<TListSample>::BinaryANNTreeBase()
-{} // end Constructor
+= default; // end Constructor
 
 } // end namespace itk
 

--- a/Components/Metrics/KNNGraphAlphaMutualInformation/KNN/itkBinaryANNTreeSearchBase.hxx
+++ b/Components/Metrics/KNNGraphAlphaMutualInformation/KNN/itkBinaryANNTreeSearchBase.hxx
@@ -40,7 +40,7 @@ BinaryANNTreeSearchBase<TBinaryTree>::BinaryANNTreeSearchBase()
 
 template <class TBinaryTree>
 BinaryANNTreeSearchBase<TBinaryTree>::~BinaryANNTreeSearchBase()
-{} // end Destructor
+= default; // end Destructor
 
 /**
  * ************************ SetBinaryTree *************************

--- a/Components/Metrics/KNNGraphAlphaMutualInformation/KNN/itkBinaryTreeBase.h
+++ b/Components/Metrics/KNNGraphAlphaMutualInformation/KNN/itkBinaryTreeBase.h
@@ -78,7 +78,7 @@ protected:
   BinaryTreeBase();
 
   /** Destructor. */
-  ~BinaryTreeBase() override {}
+  ~BinaryTreeBase() override = default;
 
   /** PrintSelf. */
   void

--- a/Components/Metrics/KNNGraphAlphaMutualInformation/KNN/itkBinaryTreeSearchBase.hxx
+++ b/Components/Metrics/KNNGraphAlphaMutualInformation/KNN/itkBinaryTreeSearchBase.hxx
@@ -41,7 +41,7 @@ BinaryTreeSearchBase<TBinaryTree>::BinaryTreeSearchBase()
 
 template <class TBinaryTree>
 BinaryTreeSearchBase<TBinaryTree>::~BinaryTreeSearchBase()
-{} // end Destructor
+= default; // end Destructor
 
 /**
  * ************************ SetBinaryTree *************************

--- a/Components/Metrics/KNNGraphAlphaMutualInformation/elxKNNGraphAlphaMutualInformationMetric.h
+++ b/Components/Metrics/KNNGraphAlphaMutualInformation/elxKNNGraphAlphaMutualInformationMetric.h
@@ -170,9 +170,9 @@ public:
 
 protected:
   /** The constructor. */
-  KNNGraphAlphaMutualInformationMetric() {}
+  KNNGraphAlphaMutualInformationMetric() = default;
   /** The destructor. */
-  ~KNNGraphAlphaMutualInformationMetric() override {}
+  ~KNNGraphAlphaMutualInformationMetric() override = default;
 
 private:
   /** The deleted copy constructor. */

--- a/Components/Metrics/KNNGraphAlphaMutualInformation/itkKNNGraphAlphaMutualInformationImageToImageMetric.h
+++ b/Components/Metrics/KNNGraphAlphaMutualInformation/itkKNNGraphAlphaMutualInformationImageToImageMetric.h
@@ -257,7 +257,7 @@ protected:
   KNNGraphAlphaMutualInformationImageToImageMetric();
 
   /** Destructor. */
-  ~KNNGraphAlphaMutualInformationImageToImageMetric() override {}
+  ~KNNGraphAlphaMutualInformationImageToImageMetric() override = default;
 
   /** PrintSelf. */
   void

--- a/Components/Metrics/MissingStructurePenalty/elxMissingStructurePenalty.h
+++ b/Components/Metrics/MissingStructurePenalty/elxMissingStructurePenalty.h
@@ -183,7 +183,7 @@ protected:
   /** The constructor. */
   MissingStructurePenalty();
   /** The destructor. */
-  ~MissingStructurePenalty() override {}
+  ~MissingStructurePenalty() override = default;
 
 private:
   /** The deleted copy constructor. */

--- a/Components/Metrics/MissingStructurePenalty/itkMissingStructurePenalty.hxx
+++ b/Components/Metrics/MissingStructurePenalty/itkMissingStructurePenalty.hxx
@@ -41,7 +41,7 @@ MissingVolumeMeshPenalty<TFixedPointSet, TMovingPointSet>::MissingVolumeMeshPena
 
 template <class TFixedPointSet, class TMovingPointSet>
 MissingVolumeMeshPenalty<TFixedPointSet, TMovingPointSet>::~MissingVolumeMeshPenalty()
-{} // end Destructor
+= default; // end Destructor
 
 
 /**

--- a/Components/Metrics/NormalizedGradientCorrelation/elxNormalizedGradientCorrelationMetric.h
+++ b/Components/Metrics/NormalizedGradientCorrelation/elxNormalizedGradientCorrelationMetric.h
@@ -136,9 +136,9 @@ public:
 
 protected:
   /** The constructor. */
-  NormalizedGradientCorrelationMetric() {}
+  NormalizedGradientCorrelationMetric() = default;
   /** The destructor. */
-  ~NormalizedGradientCorrelationMetric() override {}
+  ~NormalizedGradientCorrelationMetric() override = default;
 
 private:
   /** The deleted copy constructor. */

--- a/Components/Metrics/NormalizedGradientCorrelation/itkNormalizedGradientCorrelationImageToImageMetric.h
+++ b/Components/Metrics/NormalizedGradientCorrelation/itkNormalizedGradientCorrelationImageToImageMetric.h
@@ -152,7 +152,7 @@ public:
 
 protected:
   NormalizedGradientCorrelationImageToImageMetric();
-  ~NormalizedGradientCorrelationImageToImageMetric() override {}
+  ~NormalizedGradientCorrelationImageToImageMetric() override = default;
   void
   PrintSelf(std::ostream & os, Indent indent) const override;
 

--- a/Components/Metrics/NormalizedMutualInformation/elxNormalizedMutualInformationMetric.h
+++ b/Components/Metrics/NormalizedMutualInformation/elxNormalizedMutualInformationMetric.h
@@ -173,7 +173,7 @@ protected:
 
 
   /** The destructor. */
-  ~NormalizedMutualInformationMetric() override {}
+  ~NormalizedMutualInformationMetric() override = default;
 
 private:
   /** The deleted copy constructor. */

--- a/Components/Metrics/NormalizedMutualInformation/itkParzenWindowNormalizedMutualInformationImageToImageMetric.h
+++ b/Components/Metrics/NormalizedMutualInformation/itkParzenWindowNormalizedMutualInformationImageToImageMetric.h
@@ -144,10 +144,10 @@ public:
 
 protected:
   /** The constructor. */
-  ParzenWindowNormalizedMutualInformationImageToImageMetric() {}
+  ParzenWindowNormalizedMutualInformationImageToImageMetric() = default;
 
   /** The destructor. */
-  ~ParzenWindowNormalizedMutualInformationImageToImageMetric() override {}
+  ~ParzenWindowNormalizedMutualInformationImageToImageMetric() override = default;
 
   /** Print Self. */
   void

--- a/Components/Metrics/PCAMetric/elxPCAMetric.h
+++ b/Components/Metrics/PCAMetric/elxPCAMetric.h
@@ -166,9 +166,9 @@ public:
 
 protected:
   /** The constructor. */
-  PCAMetric() {}
+  PCAMetric() = default;
   /** The destructor. */
-  ~PCAMetric() override {}
+  ~PCAMetric() override = default;
 
 private:
   /** The deleted copy constructor. */

--- a/Components/Metrics/PCAMetric2/elxPCAMetric2.h
+++ b/Components/Metrics/PCAMetric2/elxPCAMetric2.h
@@ -167,9 +167,9 @@ public:
 
 protected:
   /** The constructor. */
-  PCAMetric2() {}
+  PCAMetric2() = default;
   /** The destructor. */
-  ~PCAMetric2() override {}
+  ~PCAMetric2() override = default;
 
 private:
   /** The deleted copy constructor. */

--- a/Components/Metrics/PCAMetric2/itkPCAMetric2.h
+++ b/Components/Metrics/PCAMetric2/itkPCAMetric2.h
@@ -122,7 +122,7 @@ public:
 
 protected:
   PCAMetric2();
-  ~PCAMetric2() override {}
+  ~PCAMetric2() override = default;
   void
   PrintSelf(std::ostream & os, Indent indent) const override;
 

--- a/Components/Metrics/PatternIntensity/elxPatternIntensityMetric.h
+++ b/Components/Metrics/PatternIntensity/elxPatternIntensityMetric.h
@@ -136,9 +136,9 @@ public:
 
 protected:
   /** The constructor. */
-  PatternIntensityMetric() {}
+  PatternIntensityMetric() = default;
   /** The destructor. */
-  ~PatternIntensityMetric() override {}
+  ~PatternIntensityMetric() override = default;
 
 private:
   /** The deleted copy constructor. */

--- a/Components/Metrics/PatternIntensity/itkPatternIntensityImageToImageMetric.h
+++ b/Components/Metrics/PatternIntensity/itkPatternIntensityImageToImageMetric.h
@@ -162,7 +162,7 @@ public:
 
 protected:
   PatternIntensityImageToImageMetric();
-  ~PatternIntensityImageToImageMetric() override {}
+  ~PatternIntensityImageToImageMetric() override = default;
   void
   PrintSelf(std::ostream & os, Indent indent) const override;
 

--- a/Components/Metrics/PolydataDummyPenalty/elxPolydataDummyPenalty.h
+++ b/Components/Metrics/PolydataDummyPenalty/elxPolydataDummyPenalty.h
@@ -201,7 +201,7 @@ protected:
   /** The constructor. */
   PolydataDummyPenalty();
   /** The destructor. */
-  ~PolydataDummyPenalty() override {}
+  ~PolydataDummyPenalty() override = default;
 
 private:
   /** The deleted copy constructor. */

--- a/Components/Metrics/PolydataDummyPenalty/itkPolydataDummyPenalty.hxx
+++ b/Components/Metrics/PolydataDummyPenalty/itkPolydataDummyPenalty.hxx
@@ -40,7 +40,7 @@ MeshPenalty<TFixedPointSet, TMovingPointSet>::MeshPenalty()
 
 template <class TFixedPointSet, class TMovingPointSet>
 MeshPenalty<TFixedPointSet, TMovingPointSet>::~MeshPenalty()
-{} // end Destructor
+= default; // end Destructor
 
 /**
  * *********************** Initialize *****************************

--- a/Components/Metrics/RigidityPenalty/elxTransformRigidityPenaltyTerm.h
+++ b/Components/Metrics/RigidityPenalty/elxTransformRigidityPenaltyTerm.h
@@ -227,10 +227,10 @@ public:
 
 protected:
   /** The constructor. */
-  TransformRigidityPenalty() {}
+  TransformRigidityPenalty() = default;
 
   /** The destructor. */
-  ~TransformRigidityPenalty() override {}
+  ~TransformRigidityPenalty() override = default;
 
 private:
   /** The deleted copy constructor. */

--- a/Components/Metrics/RigidityPenalty/itkTransformRigidityPenaltyTerm.h
+++ b/Components/Metrics/RigidityPenalty/itkTransformRigidityPenaltyTerm.h
@@ -291,7 +291,7 @@ protected:
   /** The constructor. */
   TransformRigidityPenaltyTerm();
   /** The destructor. */
-  ~TransformRigidityPenaltyTerm() override {}
+  ~TransformRigidityPenaltyTerm() override = default;
 
   /** PrintSelf. */
   void

--- a/Components/Metrics/StatisticalShapePenalty/elxStatisticalShapePenalty.h
+++ b/Components/Metrics/StatisticalShapePenalty/elxStatisticalShapePenalty.h
@@ -176,9 +176,9 @@ public:
 
 protected:
   /** The constructor. */
-  StatisticalShapePenalty() {}
+  StatisticalShapePenalty() = default;
   /** The destructor. */
-  ~StatisticalShapePenalty() override {}
+  ~StatisticalShapePenalty() override = default;
 
 private:
   /** The deleted copy constructor. */

--- a/Components/Metrics/SumOfPairwiseCorrelationsMetric/elxSumOfPairwiseCorrelationCoefficientsMetric.h
+++ b/Components/Metrics/SumOfPairwiseCorrelationsMetric/elxSumOfPairwiseCorrelationCoefficientsMetric.h
@@ -168,10 +168,10 @@ public:
 
 protected:
   /** The constructor. */
-  SumOfPairwiseCorrelationCoefficientsMetric() {}
+  SumOfPairwiseCorrelationCoefficientsMetric() = default;
 
   /** The destructor. */
-  ~SumOfPairwiseCorrelationCoefficientsMetric() override {}
+  ~SumOfPairwiseCorrelationCoefficientsMetric() override = default;
 
 private:
   /** The deleted copy constructor. */

--- a/Components/Metrics/SumOfPairwiseCorrelationsMetric/itkSumOfPairwiseCorrelationCoefficientsMetric.h
+++ b/Components/Metrics/SumOfPairwiseCorrelationsMetric/itkSumOfPairwiseCorrelationCoefficientsMetric.h
@@ -124,7 +124,7 @@ public:
 
 protected:
   SumOfPairwiseCorrelationCoefficientsMetric();
-  ~SumOfPairwiseCorrelationCoefficientsMetric() override {}
+  ~SumOfPairwiseCorrelationCoefficientsMetric() override = default;
   void
   PrintSelf(std::ostream & os, Indent indent) const override;
 

--- a/Components/Metrics/SumSquaredTissueVolumeDifferenceMetric/elxSumSquaredTissueVolumeDifferenceMetric.h
+++ b/Components/Metrics/SumSquaredTissueVolumeDifferenceMetric/elxSumSquaredTissueVolumeDifferenceMetric.h
@@ -147,9 +147,9 @@ public:
 
 protected:
   /** The constructor. */
-  SumSquaredTissueVolumeDifferenceMetric(){};
+  SumSquaredTissueVolumeDifferenceMetric()= default;;
   /** The destructor. */
-  ~SumSquaredTissueVolumeDifferenceMetric() override {}
+  ~SumSquaredTissueVolumeDifferenceMetric() override = default;
 
 private:
   /** The deleted copy constructor. */

--- a/Components/Metrics/SumSquaredTissueVolumeDifferenceMetric/itkSumSquaredTissueVolumeDifferenceImageToImageMetric.h
+++ b/Components/Metrics/SumSquaredTissueVolumeDifferenceMetric/itkSumSquaredTissueVolumeDifferenceImageToImageMetric.h
@@ -160,7 +160,7 @@ public:
 
 protected:
   SumSquaredTissueVolumeDifferenceImageToImageMetric();
-  ~SumSquaredTissueVolumeDifferenceImageToImageMetric() override{};
+  ~SumSquaredTissueVolumeDifferenceImageToImageMetric() override= default;;
 
   void
   PrintSelf(std::ostream & os, Indent indent) const override;

--- a/Components/Metrics/VarianceOverLastDimension/elxVarianceOverLastDimensionMetric.h
+++ b/Components/Metrics/VarianceOverLastDimension/elxVarianceOverLastDimensionMetric.h
@@ -179,9 +179,9 @@ public:
 
 protected:
   /** The constructor. */
-  VarianceOverLastDimensionMetric() {}
+  VarianceOverLastDimensionMetric() = default;
   /** The destructor. */
-  ~VarianceOverLastDimensionMetric() override {}
+  ~VarianceOverLastDimensionMetric() override = default;
 
 private:
   /** The deleted copy constructor. */

--- a/Components/Metrics/VarianceOverLastDimension/itkVarianceOverLastDimensionImageMetric.h
+++ b/Components/Metrics/VarianceOverLastDimension/itkVarianceOverLastDimensionImageMetric.h
@@ -148,7 +148,7 @@ public:
 
 protected:
   VarianceOverLastDimensionImageMetric();
-  ~VarianceOverLastDimensionImageMetric() override {}
+  ~VarianceOverLastDimensionImageMetric() override = default;
   void
   PrintSelf(std::ostream & os, Indent indent) const override;
 

--- a/Components/MovingImagePyramids/MovingGenericPyramid/elxMovingGenericPyramid.h
+++ b/Components/MovingImagePyramids/MovingGenericPyramid/elxMovingGenericPyramid.h
@@ -126,9 +126,9 @@ public:
 
 protected:
   /** The constructor. */
-  MovingGenericPyramid() {}
+  MovingGenericPyramid() = default;
   /** The destructor. */
-  ~MovingGenericPyramid() override {}
+  ~MovingGenericPyramid() override = default;
 
 private:
   /** The deleted copy constructor. */

--- a/Components/MovingImagePyramids/MovingRecursivePyramid/elxMovingRecursivePyramid.h
+++ b/Components/MovingImagePyramids/MovingRecursivePyramid/elxMovingRecursivePyramid.h
@@ -84,9 +84,9 @@ public:
 
 protected:
   /** The constructor. */
-  MovingRecursivePyramid() {}
+  MovingRecursivePyramid() = default;
   /** The destructor. */
-  ~MovingRecursivePyramid() override {}
+  ~MovingRecursivePyramid() override = default;
 
 private:
   /** The deleted copy constructor. */

--- a/Components/MovingImagePyramids/MovingShrinkingPyramid/elxMovingShrinkingPyramid.h
+++ b/Components/MovingImagePyramids/MovingShrinkingPyramid/elxMovingShrinkingPyramid.h
@@ -85,9 +85,9 @@ public:
 
 protected:
   /** The constructor. */
-  MovingShrinkingPyramid() {}
+  MovingShrinkingPyramid() = default;
   /** The destructor. */
-  ~MovingShrinkingPyramid() override {}
+  ~MovingShrinkingPyramid() override = default;
 
 private:
   /** The deleted copy constructor. */

--- a/Components/MovingImagePyramids/MovingSmoothingPyramid/elxMovingSmoothingPyramid.h
+++ b/Components/MovingImagePyramids/MovingSmoothingPyramid/elxMovingSmoothingPyramid.h
@@ -86,9 +86,9 @@ public:
 
 protected:
   /** The constructor. */
-  MovingSmoothingPyramid() {}
+  MovingSmoothingPyramid() = default;
   /** The destructor. */
-  ~MovingSmoothingPyramid() override {}
+  ~MovingSmoothingPyramid() override = default;
 
 private:
   /** The deleted copy constructor. */

--- a/Components/MovingImagePyramids/OpenCLMovingGenericPyramid/elxOpenCLMovingGenericPyramid.h
+++ b/Components/MovingImagePyramids/OpenCLMovingGenericPyramid/elxOpenCLMovingGenericPyramid.h
@@ -108,7 +108,7 @@ protected:
   /** The constructor. */
   OpenCLMovingGenericPyramid();
   /** The destructor. */
-  virtual ~OpenCLMovingGenericPyramid() {}
+  virtual ~OpenCLMovingGenericPyramid() = default;
 
 private:
   /** The deleted copy constructor. */

--- a/Components/Optimizers/AdaGrad/elxAdaGrad.h
+++ b/Components/Optimizers/AdaGrad/elxAdaGrad.h
@@ -294,7 +294,7 @@ public:
 
 protected:
   AdaGrad();
-  ~AdaGrad() override {}
+  ~AdaGrad() override = default;
 
   /** Protected typedefs */
   typedef typename RegistrationType::FixedImageType  FixedImageType;

--- a/Components/Optimizers/AdaGrad/itkAdaptiveStepsizeOptimizer.h
+++ b/Components/Optimizers/AdaGrad/itkAdaptiveStepsizeOptimizer.h
@@ -117,7 +117,7 @@ public:
 
 protected:
   AdaptiveStepsizeOptimizer();
-  ~AdaptiveStepsizeOptimizer() override {}
+  ~AdaptiveStepsizeOptimizer() override = default;
 
   /** Function to update the current time
    * If UseAdaptiveStepSizes is false this function just increments

--- a/Components/Optimizers/AdaptiveStochasticGradientDescent/elxAdaptiveStochasticGradientDescent.h
+++ b/Components/Optimizers/AdaptiveStochasticGradientDescent/elxAdaptiveStochasticGradientDescent.h
@@ -341,7 +341,7 @@ protected:
   typedef typename AdvancedTransformType::NonZeroJacobianIndicesType NonZeroJacobianIndicesType;
 
   AdaptiveStochasticGradientDescent();
-  ~AdaptiveStochasticGradientDescent() override {}
+  ~AdaptiveStochasticGradientDescent() override = default;
 
   /** Variable to store the automatically determined settings for each resolution. */
   SettingsVectorType m_SettingsVector;

--- a/Components/Optimizers/AdaptiveStochasticGradientDescent/itkAdaptiveStochasticGradientDescentOptimizer.h
+++ b/Components/Optimizers/AdaptiveStochasticGradientDescent/itkAdaptiveStochasticGradientDescentOptimizer.h
@@ -116,7 +116,7 @@ public:
 
 protected:
   AdaptiveStochasticGradientDescentOptimizer();
-  ~AdaptiveStochasticGradientDescentOptimizer() override {}
+  ~AdaptiveStochasticGradientDescentOptimizer() override = default;
 
   /** Function to update the current time
    * If UseAdaptiveStepSizes is false this function just increments

--- a/Components/Optimizers/AdaptiveStochasticLBFGS/elxAdaptiveStochasticLBFGS.h
+++ b/Components/Optimizers/AdaptiveStochasticLBFGS/elxAdaptiveStochasticLBFGS.h
@@ -297,7 +297,7 @@ protected:
   typedef itk::Array<double>          DiagonalMatrixType;
 
   AdaptiveStochasticLBFGS();
-  ~AdaptiveStochasticLBFGS() override{};
+  ~AdaptiveStochasticLBFGS() override= default;;
 
   /** Variable to store the automatically determined settings for each resolution. */
   SettingsVectorType m_SettingsVector;

--- a/Components/Optimizers/AdaptiveStochasticLBFGS/itkAdaptiveStochasticLBFGSOptimizer.h
+++ b/Components/Optimizers/AdaptiveStochasticLBFGS/itkAdaptiveStochasticLBFGSOptimizer.h
@@ -116,7 +116,7 @@ public:
 
 protected:
   AdaptiveStochasticLBFGSOptimizer();
-  ~AdaptiveStochasticLBFGSOptimizer() override{};
+  ~AdaptiveStochasticLBFGSOptimizer() override= default;;
 
   /** Function to update the current time
    * If UseAdaptiveStepSizes is false this function just increments

--- a/Components/Optimizers/AdaptiveStochasticVarianceReducedGradient/elxAdaptiveStochasticVarianceReducedGradient.h
+++ b/Components/Optimizers/AdaptiveStochasticVarianceReducedGradient/elxAdaptiveStochasticVarianceReducedGradient.h
@@ -366,7 +366,7 @@ protected:
   typedef typename AdvancedTransformType::NonZeroJacobianIndicesType NonZeroJacobianIndicesType;
 
   AdaptiveStochasticVarianceReducedGradient();
-  ~AdaptiveStochasticVarianceReducedGradient() override{};
+  ~AdaptiveStochasticVarianceReducedGradient() override= default;;
 
   /** Variable to store the automatically determined settings for each resolution. */
   SettingsVectorType m_SettingsVector;

--- a/Components/Optimizers/AdaptiveStochasticVarianceReducedGradient/itkAdaptiveStochasticVarianceReducedGradientOptimizer.h
+++ b/Components/Optimizers/AdaptiveStochasticVarianceReducedGradient/itkAdaptiveStochasticVarianceReducedGradientOptimizer.h
@@ -114,7 +114,7 @@ public:
 
 protected:
   AdaptiveStochasticVarianceReducedGradientOptimizer();
-  ~AdaptiveStochasticVarianceReducedGradientOptimizer() override{};
+  ~AdaptiveStochasticVarianceReducedGradientOptimizer() override= default;;
 
   /** Function to update the current time
    * If UseAdaptiveStepSizes is false this function just increments

--- a/Components/Optimizers/AdaptiveStochasticVarianceReducedGradient/itkStandardStochasticVarianceReducedGradientDescentOptimizer.h
+++ b/Components/Optimizers/AdaptiveStochasticVarianceReducedGradient/itkStandardStochasticVarianceReducedGradientDescentOptimizer.h
@@ -127,7 +127,7 @@ public:
 
 protected:
   StandardStochasticVarianceReducedGradientOptimizer();
-  ~StandardStochasticVarianceReducedGradientOptimizer() override{};
+  ~StandardStochasticVarianceReducedGradientOptimizer() override= default;;
 
   /** Function to compute the step size for SGD at time/iteration k. */
   virtual double

--- a/Components/Optimizers/AdaptiveStochasticVarianceReducedGradient/itkStochasticVarianceReducedGradientDescentOptimizer.h
+++ b/Components/Optimizers/AdaptiveStochasticVarianceReducedGradient/itkStochasticVarianceReducedGradientDescentOptimizer.h
@@ -170,7 +170,7 @@ public:
 
 protected:
   StochasticVarianceReducedGradientDescentOptimizer();
-  ~StochasticVarianceReducedGradientDescentOptimizer() override{};
+  ~StochasticVarianceReducedGradientDescentOptimizer() override= default;;
   void
   PrintSelf(std::ostream & os, Indent indent) const override;
 

--- a/Components/Optimizers/CMAEvolutionStrategy/elxCMAEvolutionStrategy.h
+++ b/Components/Optimizers/CMAEvolutionStrategy/elxCMAEvolutionStrategy.h
@@ -176,8 +176,8 @@ public:
   AfterRegistration(void) override;
 
 protected:
-  CMAEvolutionStrategy() {}
-  ~CMAEvolutionStrategy() override {}
+  CMAEvolutionStrategy() = default;
+  ~CMAEvolutionStrategy() override = default;
 
   /** Call the superclass' implementation and print the value of some variables */
   void

--- a/Components/Optimizers/CMAEvolutionStrategy/itkCMAEvolutionStrategyOptimizer.h
+++ b/Components/Optimizers/CMAEvolutionStrategy/itkCMAEvolutionStrategyOptimizer.h
@@ -317,7 +317,7 @@ protected:
   CMAEvolutionStrategyOptimizer();
 
   /** Destructor */
-  ~CMAEvolutionStrategyOptimizer() override {}
+  ~CMAEvolutionStrategyOptimizer() override = default;
 
   /** PrintSelf */
   void

--- a/Components/Optimizers/ConjugateGradient/elxConjugateGradient.h
+++ b/Components/Optimizers/ConjugateGradient/elxConjugateGradient.h
@@ -161,7 +161,7 @@ public:
 
 protected:
   ConjugateGradient();
-  ~ConjugateGradient() override {}
+  ~ConjugateGradient() override = default;
 
   LineOptimizerPointer m_LineOptimizer;
 

--- a/Components/Optimizers/ConjugateGradient/itkGenericConjugateGradientOptimizer.h
+++ b/Components/Optimizers/ConjugateGradient/itkGenericConjugateGradientOptimizer.h
@@ -137,7 +137,7 @@ public:
 
 protected:
   GenericConjugateGradientOptimizer();
-  ~GenericConjugateGradientOptimizer() override {}
+  ~GenericConjugateGradientOptimizer() override = default;
 
   void
   PrintSelf(std::ostream & os, Indent indent) const override;

--- a/Components/Optimizers/ConjugateGradientFRPR/elxConjugateGradientFRPR.h
+++ b/Components/Optimizers/ConjugateGradientFRPR/elxConjugateGradientFRPR.h
@@ -146,7 +146,7 @@ public:
 
 protected:
   ConjugateGradientFRPR();
-  ~ConjugateGradientFRPR() override {}
+  ~ConjugateGradientFRPR() override = default;
 
   /** To store the latest computed derivative's magnitude */
   double m_CurrentDerivativeMagnitude;

--- a/Components/Optimizers/FiniteDifferenceGradientDescent/elxFiniteDifferenceGradientDescent.h
+++ b/Components/Optimizers/FiniteDifferenceGradientDescent/elxFiniteDifferenceGradientDescent.h
@@ -141,7 +141,7 @@ public:
 
 protected:
   FiniteDifferenceGradientDescent();
-  ~FiniteDifferenceGradientDescent() override {}
+  ~FiniteDifferenceGradientDescent() override = default;
 
   bool m_ShowMetricValues;
 

--- a/Components/Optimizers/FiniteDifferenceGradientDescent/itkFiniteDifferenceGradientDescentOptimizer.h
+++ b/Components/Optimizers/FiniteDifferenceGradientDescent/itkFiniteDifferenceGradientDescentOptimizer.h
@@ -137,7 +137,7 @@ public:
 
 protected:
   FiniteDifferenceGradientDescentOptimizer();
-  ~FiniteDifferenceGradientDescentOptimizer() override {}
+  ~FiniteDifferenceGradientDescentOptimizer() override = default;
 
   /** PrintSelf method.*/
   void

--- a/Components/Optimizers/FullSearch/elxFullSearchOptimizer.h
+++ b/Components/Optimizers/FullSearch/elxFullSearchOptimizer.h
@@ -133,7 +133,7 @@ public:
 
 protected:
   FullSearch();
-  ~FullSearch() override {}
+  ~FullSearch() override = default;
 
   NDImagePointer m_OptimizationSurface;
 

--- a/Components/Optimizers/FullSearch/itkFullSearchOptimizer.h
+++ b/Components/Optimizers/FullSearch/itkFullSearchOptimizer.h
@@ -216,7 +216,7 @@ public:
 
 protected:
   FullSearchOptimizer();
-  ~FullSearchOptimizer() override {}
+  ~FullSearchOptimizer() override = default;
 
   // void PrintSelf(std::ostream& os, Indent indent) const;
 

--- a/Components/Optimizers/Powell/elxPowell.h
+++ b/Components/Optimizers/Powell/elxPowell.h
@@ -103,8 +103,8 @@ public:
   SetInitialPosition(const ParametersType & param) override;
 
 protected:
-  Powell() {}
-  ~Powell() override {}
+  Powell() = default;
+  ~Powell() override = default;
 
 private:
   Powell(const Self &) = delete;

--- a/Components/Optimizers/PreconditionedStochasticGradientDescent/elxPreconditionedStochasticGradientDescent.h
+++ b/Components/Optimizers/PreconditionedStochasticGradientDescent/elxPreconditionedStochasticGradientDescent.h
@@ -282,7 +282,7 @@ public:
 
 protected:
   PreconditionedStochasticGradientDescent();
-  ~PreconditionedStochasticGradientDescent() override {}
+  ~PreconditionedStochasticGradientDescent() override = default;
 
   /** Protected typedefs */
   typedef typename RegistrationType::FixedImageType  FixedImageType;

--- a/Components/Optimizers/PreconditionedStochasticGradientDescent/itkPreconditionedASGDOptimizer.h
+++ b/Components/Optimizers/PreconditionedStochasticGradientDescent/itkPreconditionedASGDOptimizer.h
@@ -116,7 +116,7 @@ public:
 
 protected:
   PreconditionedASGDOptimizer();
-  ~PreconditionedASGDOptimizer() override {}
+  ~PreconditionedASGDOptimizer() override = default;
 
   /** Function to update the current time
    * If UseAdaptiveStepSizes is false this function just increments

--- a/Components/Optimizers/QuasiNewtonLBFGS/elxQuasiNewtonLBFGS.h
+++ b/Components/Optimizers/QuasiNewtonLBFGS/elxQuasiNewtonLBFGS.h
@@ -158,7 +158,7 @@ public:
 
 protected:
   QuasiNewtonLBFGS();
-  ~QuasiNewtonLBFGS() override {}
+  ~QuasiNewtonLBFGS() override = default;
 
   LineOptimizerPointer m_LineOptimizer;
 

--- a/Components/Optimizers/QuasiNewtonLBFGS/itkQuasiNewtonLBFGSOptimizer.h
+++ b/Components/Optimizers/QuasiNewtonLBFGS/itkQuasiNewtonLBFGSOptimizer.h
@@ -133,7 +133,7 @@ public:
 
 protected:
   QuasiNewtonLBFGSOptimizer();
-  ~QuasiNewtonLBFGSOptimizer() override {}
+  ~QuasiNewtonLBFGSOptimizer() override = default;
 
   // \todo: should be implemented
   void

--- a/Components/Optimizers/RSGDEachParameterApart/elxRSGDEachParameterApart.h
+++ b/Components/Optimizers/RSGDEachParameterApart/elxRSGDEachParameterApart.h
@@ -133,8 +133,8 @@ public:
   SetInitialPosition(const ParametersType & param) override;
 
 protected:
-  RSGDEachParameterApart() {}
-  ~RSGDEachParameterApart() override {}
+  RSGDEachParameterApart() = default;
+  ~RSGDEachParameterApart() override = default;
 
 private:
   RSGDEachParameterApart(const Self &) = delete;

--- a/Components/Optimizers/RSGDEachParameterApart/itkRSGDEachParameterApartBaseOptimizer.h
+++ b/Components/Optimizers/RSGDEachParameterApart/itkRSGDEachParameterApartBaseOptimizer.h
@@ -123,7 +123,7 @@ public:
 
 protected:
   RSGDEachParameterApartBaseOptimizer();
-  ~RSGDEachParameterApartBaseOptimizer() override {}
+  ~RSGDEachParameterApartBaseOptimizer() override = default;
   void
   PrintSelf(std::ostream & os, Indent indent) const override;
 

--- a/Components/Optimizers/RSGDEachParameterApart/itkRSGDEachParameterApartOptimizer.h
+++ b/Components/Optimizers/RSGDEachParameterApart/itkRSGDEachParameterApartOptimizer.h
@@ -70,8 +70,8 @@ public:
   typedef CostFunctionType::Pointer    CostFunctionPointer;
 
 protected:
-  RSGDEachParameterApartOptimizer() {}
-  ~RSGDEachParameterApartOptimizer() override {}
+  RSGDEachParameterApartOptimizer() = default;
+  ~RSGDEachParameterApartOptimizer() override = default;
 
   /** Advance one step along the corrected gradient taking into
    * account the steplengths represented by the factor array.

--- a/Components/Optimizers/RegularStepGradientDescent/elxRegularStepGradientDescent.h
+++ b/Components/Optimizers/RegularStepGradientDescent/elxRegularStepGradientDescent.h
@@ -127,8 +127,8 @@ public:
   SetInitialPosition(const ParametersType & param) override;
 
 protected:
-  RegularStepGradientDescent() {}
-  ~RegularStepGradientDescent() override {}
+  RegularStepGradientDescent() = default;
+  ~RegularStepGradientDescent() override = default;
 
 private:
   RegularStepGradientDescent(const Self &) = delete;

--- a/Components/Optimizers/Simplex/elxSimplex.h
+++ b/Components/Optimizers/Simplex/elxSimplex.h
@@ -103,8 +103,8 @@ public:
   SetInitialPosition(const ParametersType & param) override;
 
 protected:
-  Simplex() {}
-  ~Simplex() override {}
+  Simplex() = default;
+  ~Simplex() override = default;
 
 private:
   Simplex(const Self &) = delete;

--- a/Components/Optimizers/SimultaneousPerturbation/elxSimultaneousPerturbation.h
+++ b/Components/Optimizers/SimultaneousPerturbation/elxSimultaneousPerturbation.h
@@ -145,7 +145,7 @@ public:
 
 protected:
   SimultaneousPerturbation();
-  ~SimultaneousPerturbation() override {}
+  ~SimultaneousPerturbation() override = default;
 
   bool m_ShowMetricValues;
 

--- a/Components/Optimizers/StandardGradientDescent/elxStandardGradientDescent.h
+++ b/Components/Optimizers/StandardGradientDescent/elxStandardGradientDescent.h
@@ -150,7 +150,7 @@ public:
 
 protected:
   StandardGradientDescent();
-  ~StandardGradientDescent() override {}
+  ~StandardGradientDescent() override = default;
 
 private:
   StandardGradientDescent(const Self &) = delete;

--- a/Components/Optimizers/StandardGradientDescent/itkGradientDescentOptimizer2.h
+++ b/Components/Optimizers/StandardGradientDescent/itkGradientDescentOptimizer2.h
@@ -139,7 +139,7 @@ public:
 
 protected:
   GradientDescentOptimizer2();
-  ~GradientDescentOptimizer2() override {}
+  ~GradientDescentOptimizer2() override = default;
   void
   PrintSelf(std::ostream & os, Indent indent) const override;
 

--- a/Components/Optimizers/StandardGradientDescent/itkStandardGradientDescentOptimizer.h
+++ b/Components/Optimizers/StandardGradientDescent/itkStandardGradientDescentOptimizer.h
@@ -133,7 +133,7 @@ public:
 
 protected:
   StandardGradientDescentOptimizer();
-  ~StandardGradientDescentOptimizer() override {}
+  ~StandardGradientDescentOptimizer() override = default;
 
   /** Function to compute the parameter at time/iteration k. */
   virtual double

--- a/Components/Optimizers/StandardStochasticGradientDescent/itkStandardStochasticGradientDescentOptimizer.h
+++ b/Components/Optimizers/StandardStochasticGradientDescent/itkStandardStochasticGradientDescentOptimizer.h
@@ -134,7 +134,7 @@ public:
 
 protected:
   StandardStochasticGradientOptimizer();
-  ~StandardStochasticGradientOptimizer() override{};
+  ~StandardStochasticGradientOptimizer() override= default;;
 
   /** Function to compute the step size for SGD at time/iteration k. */
   virtual double

--- a/Components/Optimizers/StandardStochasticGradientDescent/itkStochasticGradientDescentOptimizer.h
+++ b/Components/Optimizers/StandardStochasticGradientDescent/itkStochasticGradientDescentOptimizer.h
@@ -171,7 +171,7 @@ public:
 
 protected:
   StochasticGradientDescentOptimizer();
-  ~StochasticGradientDescentOptimizer() override{};
+  ~StochasticGradientDescentOptimizer() override= default;;
   void
   PrintSelf(std::ostream & os, Indent indent) const override;
 

--- a/Components/Registrations/MultiMetricMultiResolutionRegistration/elxMultiMetricMultiResolutionRegistration.h
+++ b/Components/Registrations/MultiMetricMultiResolutionRegistration/elxMultiMetricMultiResolutionRegistration.h
@@ -208,7 +208,7 @@ protected:
   /** The constructor. */
   MultiMetricMultiResolutionRegistration();
   /** The destructor. */
-  ~MultiMetricMultiResolutionRegistration() override {}
+  ~MultiMetricMultiResolutionRegistration() override = default;
 
   /** Typedef's for mask support. */
   typedef typename Superclass2::MaskPixelType                  MaskPixelType;

--- a/Components/Registrations/MultiMetricMultiResolutionRegistration/itkCombinationImageToImageMetric.h
+++ b/Components/Registrations/MultiMetricMultiResolutionRegistration/itkCombinationImageToImageMetric.h
@@ -441,7 +441,7 @@ public:
 
 protected:
   CombinationImageToImageMetric();
-  ~CombinationImageToImageMetric() override {}
+  ~CombinationImageToImageMetric() override = default;
   void
   PrintSelf(std::ostream & os, Indent indent) const override;
 

--- a/Components/Registrations/MultiMetricMultiResolutionRegistration/itkMultiMetricMultiResolutionImageRegistrationMethod.h
+++ b/Components/Registrations/MultiMetricMultiResolutionRegistration/itkMultiMetricMultiResolutionImageRegistrationMethod.h
@@ -276,7 +276,7 @@ public:
 
 protected:
   MultiMetricMultiResolutionImageRegistrationMethod();
-  ~MultiMetricMultiResolutionImageRegistrationMethod() override {}
+  ~MultiMetricMultiResolutionImageRegistrationMethod() override = default;
   void
   PrintSelf(std::ostream & os, Indent indent) const override;
 

--- a/Components/Registrations/MultiResolutionRegistration/elxMultiResolutionRegistration.h
+++ b/Components/Registrations/MultiResolutionRegistration/elxMultiResolutionRegistration.h
@@ -134,9 +134,9 @@ public:
 
 protected:
   /** The constructor. */
-  MultiResolutionRegistration() {}
+  MultiResolutionRegistration() = default;
   /** The destructor. */
-  ~MultiResolutionRegistration() override {}
+  ~MultiResolutionRegistration() override = default;
 
   /** Typedef's for mask support. */
   typedef typename Superclass2::MaskPixelType                  MaskPixelType;

--- a/Components/Registrations/MultiResolutionRegistrationWithFeatures/elxMultiResolutionRegistrationWithFeatures.h
+++ b/Components/Registrations/MultiResolutionRegistrationWithFeatures/elxMultiResolutionRegistrationWithFeatures.h
@@ -155,10 +155,10 @@ public:
 
 protected:
   /** The constructor. */
-  MultiResolutionRegistrationWithFeatures() {}
+  MultiResolutionRegistrationWithFeatures() = default;
 
   /** The destructor. */
-  ~MultiResolutionRegistrationWithFeatures() override {}
+  ~MultiResolutionRegistrationWithFeatures() override = default;
 
   /** Typedef's for mask support. */
   typedef typename Superclass2::MaskPixelType                  MaskPixelType;

--- a/Components/Registrations/MultiResolutionRegistrationWithFeatures/itkMultiInputMultiResolutionImageRegistrationMethodBase.h
+++ b/Components/Registrations/MultiResolutionRegistrationWithFeatures/itkMultiInputMultiResolutionImageRegistrationMethodBase.h
@@ -265,7 +265,7 @@ protected:
   MultiInputMultiResolutionImageRegistrationMethodBase();
 
   /** Destructor. */
-  ~MultiInputMultiResolutionImageRegistrationMethodBase() override {}
+  ~MultiInputMultiResolutionImageRegistrationMethodBase() override = default;
 
   /** PrintSelf. */
   void

--- a/Components/Registrations/MultiResolutionRegistrationWithFeatures/itkMultiInputMultiResolutionImageRegistrationMethodBase.hxx
+++ b/Components/Registrations/MultiResolutionRegistrationWithFeatures/itkMultiInputMultiResolutionImageRegistrationMethodBase.hxx
@@ -77,7 +77,7 @@ itkImplementationSetMacro2(FixedImageInterpolator, FixedImageInterpolatorType *)
 template <typename TFixedImage, typename TMovingImage>
 MultiInputMultiResolutionImageRegistrationMethodBase<TFixedImage, TMovingImage>::
   MultiInputMultiResolutionImageRegistrationMethodBase()
-{} // end Constructor()
+= default; // end Constructor()
 
 /**
  * **************** GetFixedImage **********************************

--- a/Components/Registrations/MultiResolutionRegistrationWithFeatures/itkMultiResolutionImageRegistrationMethodWithFeatures.h
+++ b/Components/Registrations/MultiResolutionRegistrationWithFeatures/itkMultiResolutionImageRegistrationMethodWithFeatures.h
@@ -99,10 +99,10 @@ public:
 
 protected:
   /** Constructor. */
-  MultiResolutionImageRegistrationMethodWithFeatures() {}
+  MultiResolutionImageRegistrationMethodWithFeatures() = default;
 
   /** Destructor. */
-  ~MultiResolutionImageRegistrationMethodWithFeatures() override {}
+  ~MultiResolutionImageRegistrationMethodWithFeatures() override = default;
 
   /** Function called by PreparePyramids, which checks if the user input
    * regarding the image pyramids is ok.

--- a/Components/ResampleInterpolators/BSplineResampleInterpolator/elxBSplineResampleInterpolator.h
+++ b/Components/ResampleInterpolators/BSplineResampleInterpolator/elxBSplineResampleInterpolator.h
@@ -129,9 +129,9 @@ public:
 
 protected:
   /** The constructor. */
-  BSplineResampleInterpolator() {}
+  BSplineResampleInterpolator() = default;
   /** The destructor. */
-  ~BSplineResampleInterpolator() override {}
+  ~BSplineResampleInterpolator() override = default;
 
 private:
   /** The deleted copy constructor. */

--- a/Components/ResampleInterpolators/BSplineResampleInterpolatorFloat/elxBSplineResampleInterpolatorFloat.h
+++ b/Components/ResampleInterpolators/BSplineResampleInterpolatorFloat/elxBSplineResampleInterpolatorFloat.h
@@ -122,9 +122,9 @@ public:
 
 protected:
   /** The constructor. */
-  BSplineResampleInterpolatorFloat() {}
+  BSplineResampleInterpolatorFloat() = default;
   /** The destructor. */
-  ~BSplineResampleInterpolatorFloat() override {}
+  ~BSplineResampleInterpolatorFloat() override = default;
 
 private:
   /** The deleted copy constructor. */

--- a/Components/ResampleInterpolators/LinearResampleInterpolator/elxLinearResampleInterpolator.h
+++ b/Components/ResampleInterpolators/LinearResampleInterpolator/elxLinearResampleInterpolator.h
@@ -88,9 +88,9 @@ public:
 
 protected:
   /** The constructor. */
-  LinearResampleInterpolator() {}
+  LinearResampleInterpolator() = default;
   /** The destructor. */
-  ~LinearResampleInterpolator() override {}
+  ~LinearResampleInterpolator() override = default;
 
 private:
   /** The deleted copy constructor. */

--- a/Components/ResampleInterpolators/NearestNeighborResampleInterpolator/elxNearestNeighborResampleInterpolator.h
+++ b/Components/ResampleInterpolators/NearestNeighborResampleInterpolator/elxNearestNeighborResampleInterpolator.h
@@ -88,9 +88,9 @@ public:
 
 protected:
   /** The constructor. */
-  NearestNeighborResampleInterpolator() {}
+  NearestNeighborResampleInterpolator() = default;
   /** The destructor. */
-  ~NearestNeighborResampleInterpolator() override {}
+  ~NearestNeighborResampleInterpolator() override = default;
 
 private:
   /** The deleted copy constructor. */

--- a/Components/ResampleInterpolators/RDBSplineResampleInterpolator/elxRDBSplineResampleInterpolator.h
+++ b/Components/ResampleInterpolators/RDBSplineResampleInterpolator/elxRDBSplineResampleInterpolator.h
@@ -123,9 +123,9 @@ public:
 
 protected:
   /** The constructor. */
-  ReducedDimensionBSplineResampleInterpolator() {}
+  ReducedDimensionBSplineResampleInterpolator() = default;
   /** The destructor. */
-  ~ReducedDimensionBSplineResampleInterpolator() override {}
+  ~ReducedDimensionBSplineResampleInterpolator() override = default;
 
 private:
   /** The deleted copy constructor. */

--- a/Components/ResampleInterpolators/RayCastResampleInterpolator/elxRayCastResampleInterpolator.h
+++ b/Components/ResampleInterpolators/RayCastResampleInterpolator/elxRayCastResampleInterpolator.h
@@ -114,10 +114,10 @@ public:
 
 protected:
   /** The constructor. */
-  RayCastResampleInterpolator() {}
+  RayCastResampleInterpolator() = default;
 
   /** The destructor. */
-  ~RayCastResampleInterpolator() override {}
+  ~RayCastResampleInterpolator() override = default;
 
   /** Helper function to initialize the combination transform
    * with a pre-transform.

--- a/Components/Resamplers/MyStandardResampler/elxMyStandardResampler.h
+++ b/Components/Resamplers/MyStandardResampler/elxMyStandardResampler.h
@@ -90,9 +90,9 @@ public:
 
 protected:
   /** The constructor. */
-  MyStandardResampler() {}
+  MyStandardResampler() = default;
   /** The destructor. */
-  ~MyStandardResampler() override {}
+  ~MyStandardResampler() override = default;
 
 private:
   /** The deleted copy constructor. */

--- a/Components/Resamplers/OpenCLResampler/elxOpenCLResampler.h
+++ b/Components/Resamplers/OpenCLResampler/elxOpenCLResampler.h
@@ -122,7 +122,7 @@ protected:
   /** The constructor. */
   OpenCLResampler();
   /** The destructor. */
-  virtual ~OpenCLResampler() {}
+  virtual ~OpenCLResampler() = default;
 
   /** This method performs all configuration for GPU resampler. */
   void

--- a/Components/Transforms/AdvancedAffineTransform/elxAdvancedAffineTransform.h
+++ b/Components/Transforms/AdvancedAffineTransform/elxAdvancedAffineTransform.h
@@ -215,7 +215,7 @@ protected:
   /** The constructor. */
   AdvancedAffineTransformElastix();
   /** The destructor. */
-  ~AdvancedAffineTransformElastix() override {}
+  ~AdvancedAffineTransformElastix() override = default;
 
   /** Try to read the CenterOfRotationPoint from the transform parameter file
    * The CenterOfRotationPoint is already in world coordinates.

--- a/Components/Transforms/AdvancedAffineTransform/itkCenteredTransformInitializer2.h
+++ b/Components/Transforms/AdvancedAffineTransform/itkCenteredTransformInitializer2.h
@@ -201,7 +201,7 @@ public:
 
 protected:
   CenteredTransformInitializer2();
-  ~CenteredTransformInitializer2() override {}
+  ~CenteredTransformInitializer2() override = default;
 
   void
   PrintSelf(std::ostream & os, Indent indent) const override;

--- a/Components/Transforms/AdvancedBSplineTransform/elxAdvancedBSplineTransform.h
+++ b/Components/Transforms/AdvancedBSplineTransform/elxAdvancedBSplineTransform.h
@@ -289,7 +289,7 @@ protected:
   AdvancedBSplineTransform();
 
   /** The destructor. */
-  ~AdvancedBSplineTransform() override {}
+  ~AdvancedBSplineTransform() override = default;
 
   /** Read user-specified grid spacing and call the itkGridScheduleComputer. */
   virtual void

--- a/Components/Transforms/AdvancedBSplineTransform/elxAdvancedBSplineTransform.hxx
+++ b/Components/Transforms/AdvancedBSplineTransform/elxAdvancedBSplineTransform.hxx
@@ -33,7 +33,7 @@ namespace elastix
 
 template <class TElastix>
 AdvancedBSplineTransform<TElastix>::AdvancedBSplineTransform()
-{} // end Constructor()
+= default; // end Constructor()
 
 
 /**

--- a/Components/Transforms/AffineDTITransform/elxAffineDTITransform.h
+++ b/Components/Transforms/AffineDTITransform/elxAffineDTITransform.h
@@ -212,7 +212,7 @@ protected:
   /** The constructor. */
   AffineDTITransformElastix();
   /** The destructor. */
-  ~AffineDTITransformElastix() override {}
+  ~AffineDTITransformElastix() override = default;
 
   /** Try to read the CenterOfRotationPoint from the transform parameter file
    * The CenterOfRotationPoint is already in world coordinates. */

--- a/Components/Transforms/AffineDTITransform/itkAffineDTI2DTransform.h
+++ b/Components/Transforms/AffineDTITransform/itkAffineDTI2DTransform.h
@@ -134,7 +134,7 @@ protected:
   AffineDTI2DTransform(const MatrixType & matrix, const OutputPointType & offset);
   AffineDTI2DTransform(unsigned int outputSpaceDims, unsigned int paramsSpaceDims);
 
-  ~AffineDTI2DTransform() override {}
+  ~AffineDTI2DTransform() override = default;
 
   void
   PrintSelf(std::ostream & os, Indent indent) const override;

--- a/Components/Transforms/AffineDTITransform/itkAffineDTI3DTransform.h
+++ b/Components/Transforms/AffineDTITransform/itkAffineDTI3DTransform.h
@@ -149,7 +149,7 @@ protected:
   AffineDTI3DTransform(const MatrixType & matrix, const OutputPointType & offset);
   AffineDTI3DTransform(unsigned int outputSpaceDims, unsigned int paramsSpaceDims);
 
-  ~AffineDTI3DTransform() {}
+  ~AffineDTI3DTransform() = default;
 
   void
   PrintSelf(std::ostream & os, Indent indent) const override;

--- a/Components/Transforms/AffineDTITransform/itkAffineDTITransform.h
+++ b/Components/Transforms/AffineDTITransform/itkAffineDTITransform.h
@@ -166,8 +166,8 @@ public:
   typedef typename Superclass::InternalMatrixType             InternalMatrixType;
 
 protected:
-  AffineDTITransform() {}
-  ~AffineDTITransform() override {}
+  AffineDTITransform() = default;
+  ~AffineDTITransform() override = default;
 
 private:
   AffineDTITransform(const Self &) = delete;

--- a/Components/Transforms/AffineLogStackTransform/elxAffineLogStackTransform.h
+++ b/Components/Transforms/AffineLogStackTransform/elxAffineLogStackTransform.h
@@ -172,7 +172,7 @@ protected:
   AffineLogStackTransform();
 
   /** The destructor. */
-  ~AffineLogStackTransform() override {}
+  ~AffineLogStackTransform() override = default;
 
   /** Try to read the CenterOfRotationPoint from the transform parameter file
    * The CenterOfRotationPoint is already in world coordinates.

--- a/Components/Transforms/AffineLogStackTransform/elxAffineLogStackTransform.hxx
+++ b/Components/Transforms/AffineLogStackTransform/elxAffineLogStackTransform.hxx
@@ -31,7 +31,7 @@ namespace elastix
  */
 template <class TElastix>
 AffineLogStackTransform<TElastix>::AffineLogStackTransform()
-{} // end Constructor
+= default; // end Constructor
 
 
 /**

--- a/Components/Transforms/AffineLogTransform/elxAffineLogTransform.h
+++ b/Components/Transforms/AffineLogTransform/elxAffineLogTransform.h
@@ -176,7 +176,7 @@ protected:
   AffineLogTransformElastix();
 
   /** The destructor. */
-  ~AffineLogTransformElastix() override {}
+  ~AffineLogTransformElastix() override = default;
 
   /** Try to read the CenterOfRotationPoint from the transform parameter file
    * The CenterOfRotationPoint is already in world coordinates. */

--- a/Components/Transforms/AffineLogTransform/itkAffineLogTransform.h
+++ b/Components/Transforms/AffineLogTransform/itkAffineLogTransform.h
@@ -97,7 +97,7 @@ protected:
   AffineLogTransform(const MatrixType & matrix, const OutputPointType & offset);
   AffineLogTransform(unsigned int outputSpaceDims, unsigned int paramsSpaceDims);
 
-  ~AffineLogTransform() override {}
+  ~AffineLogTransform() override = default;
 
   void
   PrintSelf(std::ostream & os, Indent indent) const override;

--- a/Components/Transforms/BSplineDeformableTransformWithDiffusion/elxBSplineTransformWithDiffusion.h
+++ b/Components/Transforms/BSplineDeformableTransformWithDiffusion/elxBSplineTransformWithDiffusion.h
@@ -357,7 +357,7 @@ protected:
   /** The constructor. */
   BSplineTransformWithDiffusion();
   /** The destructor. */
-  ~BSplineTransformWithDiffusion() override {}
+  ~BSplineTransformWithDiffusion() override = default;
 
   /** Member variables. */
   SpacingType m_GridSpacingFactor;

--- a/Components/Transforms/BSplineDeformableTransformWithDiffusion/itkDeformationFieldRegulizer.h
+++ b/Components/Transforms/BSplineDeformableTransformWithDiffusion/itkDeformationFieldRegulizer.h
@@ -114,7 +114,7 @@ protected:
   /** The constructor. */
   DeformationFieldRegulizer();
   /** The destructor. */
-  ~DeformationFieldRegulizer() override {}
+  ~DeformationFieldRegulizer() override = default;
 
 private:
   /** The deleted copy constructor. */

--- a/Components/Transforms/BSplineDeformableTransformWithDiffusion/itkVectorMeanDiffusionImageFilter.h
+++ b/Components/Transforms/BSplineDeformableTransformWithDiffusion/itkVectorMeanDiffusionImageFilter.h
@@ -118,7 +118,7 @@ public:
 
 protected:
   VectorMeanDiffusionImageFilter();
-  ~VectorMeanDiffusionImageFilter() override {}
+  ~VectorMeanDiffusionImageFilter() override = default;
 
   void
   PrintSelf(std::ostream & os, Indent indent) const override;

--- a/Components/Transforms/BSplineStackTransform/elxBSplineStackTransform.h
+++ b/Components/Transforms/BSplineStackTransform/elxBSplineStackTransform.h
@@ -292,7 +292,7 @@ protected:
   BSplineStackTransform();
 
   /** The destructor. */
-  ~BSplineStackTransform() override {}
+  ~BSplineStackTransform() override = default;
 
   /** Read user-specified gridspacing and call the itkGridScheduleComputer. */
   virtual void

--- a/Components/Transforms/BSplineStackTransform/elxBSplineStackTransform.hxx
+++ b/Components/Transforms/BSplineStackTransform/elxBSplineStackTransform.hxx
@@ -32,7 +32,7 @@ namespace elastix
 
 template <class TElastix>
 BSplineStackTransform<TElastix>::BSplineStackTransform()
-{} // end Constructor()
+= default; // end Constructor()
 
 
 /**

--- a/Components/Transforms/DeformationFieldTransform/elxDeformationFieldTransform.h
+++ b/Components/Transforms/DeformationFieldTransform/elxDeformationFieldTransform.h
@@ -136,7 +136,7 @@ protected:
   /** The constructor. */
   DeformationFieldTransform();
   /** The destructor. */
-  ~DeformationFieldTransform() override {}
+  ~DeformationFieldTransform() override = default;
 
 private:
   /** The deleted copy constructor. */

--- a/Components/Transforms/DeformationFieldTransform/itkDeformationFieldInterpolatingTransform.hxx
+++ b/Components/Transforms/DeformationFieldTransform/itkDeformationFieldInterpolatingTransform.hxx
@@ -43,7 +43,7 @@ DeformationFieldInterpolatingTransform<TScalarType, NDimensions, TComponentType>
 template <class TScalarType, unsigned int NDimensions, class TComponentType>
 DeformationFieldInterpolatingTransform<TScalarType, NDimensions, TComponentType>::
   ~DeformationFieldInterpolatingTransform()
-{} // end Destructor
+= default; // end Destructor
 
 // Transform a point
 template <class TScalarType, unsigned int NDimensions, class TComponentType>

--- a/Components/Transforms/EulerStackTransform/elxEulerStackTransform.h
+++ b/Components/Transforms/EulerStackTransform/elxEulerStackTransform.h
@@ -219,7 +219,7 @@ protected:
   EulerStackTransform();
 
   /** The destructor. */
-  ~EulerStackTransform() override {}
+  ~EulerStackTransform() override = default;
 
   /** Try to read the CenterOfRotationPoint from the transform parameter file
    * The CenterOfRotationPoint is already in world coordinates.

--- a/Components/Transforms/EulerStackTransform/elxEulerStackTransform.hxx
+++ b/Components/Transforms/EulerStackTransform/elxEulerStackTransform.hxx
@@ -28,7 +28,7 @@ namespace elastix
  */
 template <class TElastix>
 EulerStackTransform<TElastix>::EulerStackTransform()
-{} // end Constructor
+= default; // end Constructor
 
 
 /**

--- a/Components/Transforms/EulerTransform/elxEulerTransform.h
+++ b/Components/Transforms/EulerTransform/elxEulerTransform.h
@@ -219,7 +219,7 @@ protected:
   /** The constructor. */
   EulerTransformElastix();
   /** The destructor. */
-  ~EulerTransformElastix() override {}
+  ~EulerTransformElastix() override = default;
 
   /** Try to read the CenterOfRotationPoint from the transform parameter file
    * The CenterOfRotationPoint is already in world coordinates.

--- a/Components/Transforms/MultiBSplineTransformWithNormal/elxMultiBSplineTransformWithNormal.h
+++ b/Components/Transforms/MultiBSplineTransformWithNormal/elxMultiBSplineTransformWithNormal.h
@@ -251,7 +251,7 @@ protected:
   MultiBSplineTransformWithNormal();
 
   /** The destructor. */
-  ~MultiBSplineTransformWithNormal() override {}
+  ~MultiBSplineTransformWithNormal() override = default;
 
   /** Read user-specified gridspacing and call the itkGridScheduleComputer. */
   virtual void

--- a/Components/Transforms/MultiBSplineTransformWithNormal/elxMultiBSplineTransformWithNormal.hxx
+++ b/Components/Transforms/MultiBSplineTransformWithNormal/elxMultiBSplineTransformWithNormal.hxx
@@ -36,7 +36,7 @@ namespace elastix
 
 template <class TElastix>
 MultiBSplineTransformWithNormal<TElastix>::MultiBSplineTransformWithNormal()
-{} // end Constructor()
+= default; // end Constructor()
 
 /**
  * ************ InitializeBSplineTransform ***************

--- a/Components/Transforms/MultiBSplineTransformWithNormal/itkMultiBSplineDeformableTransformWithNormal.hxx
+++ b/Components/Transforms/MultiBSplineTransformWithNormal/itkMultiBSplineDeformableTransformWithNormal.hxx
@@ -59,7 +59,7 @@ MultiBSplineDeformableTransformWithNormal<TScalarType, NDimensions, VSplineOrder
 template <class TScalarType, unsigned int NDimensions, unsigned int VSplineOrder>
 MultiBSplineDeformableTransformWithNormal<TScalarType, NDimensions, VSplineOrder>::
   ~MultiBSplineDeformableTransformWithNormal()
-{}
+= default;
 
 // Get the number of parameters
 template <class TScalarType, unsigned int NDimensions, unsigned int VSplineOrder>

--- a/Components/Transforms/RecursiveBSplineTransform/elxRecursiveBSplineTransform.h
+++ b/Components/Transforms/RecursiveBSplineTransform/elxRecursiveBSplineTransform.h
@@ -289,7 +289,7 @@ protected:
   RecursiveBSplineTransform();
 
   /** The destructor. */
-  ~RecursiveBSplineTransform() override {}
+  ~RecursiveBSplineTransform() override = default;
 
   /** Read user-specified grid spacing and call the itkGridScheduleComputer. */
   virtual void

--- a/Components/Transforms/RecursiveBSplineTransform/elxRecursiveBSplineTransform.hxx
+++ b/Components/Transforms/RecursiveBSplineTransform/elxRecursiveBSplineTransform.hxx
@@ -32,7 +32,7 @@ namespace elastix
 
 template <class TElastix>
 RecursiveBSplineTransform<TElastix>::RecursiveBSplineTransform()
-{} // end Constructor()
+= default; // end Constructor()
 
 
 /**

--- a/Components/Transforms/SimilarityTransform/elxSimilarityTransform.h
+++ b/Components/Transforms/SimilarityTransform/elxSimilarityTransform.h
@@ -214,7 +214,7 @@ protected:
   /** The constructor. */
   SimilarityTransformElastix();
   /** The destructor. */
-  ~SimilarityTransformElastix() override {}
+  ~SimilarityTransformElastix() override = default;
 
   /** Try to read the CenterOfRotation from the transform parameter file
    * This is an index value, and, thus, converted to world coordinates.

--- a/Components/Transforms/SimilarityTransform/itkSimilarityTransform.h
+++ b/Components/Transforms/SimilarityTransform/itkSimilarityTransform.h
@@ -167,8 +167,8 @@ public:
   typedef typename Superclass::InternalMatrixType             InternalMatrixType;
 
 protected:
-  SimilarityTransform() {}
-  ~SimilarityTransform() override {}
+  SimilarityTransform() = default;
+  ~SimilarityTransform() override = default;
 
 private:
   SimilarityTransform(const Self &) = delete;

--- a/Components/Transforms/SplineKernelTransform/elxSplineKernelTransform.h
+++ b/Components/Transforms/SplineKernelTransform/elxSplineKernelTransform.h
@@ -209,7 +209,7 @@ protected:
   /** The constructor. */
   SplineKernelTransform();
   /** The destructor. */
-  ~SplineKernelTransform() override {}
+  ~SplineKernelTransform() override = default;
 
   typedef itk::ThinPlateSplineKernelTransform2<CoordRepType, itkGetStaticConstMacro(SpaceDimension)>
     TPKernelTransformType;

--- a/Components/Transforms/SplineKernelTransform/itkElasticBodyReciprocalSplineKernelTransform2.h
+++ b/Components/Transforms/SplineKernelTransform/itkElasticBodyReciprocalSplineKernelTransform2.h
@@ -128,7 +128,7 @@ public:
 
 protected:
   ElasticBodyReciprocalSplineKernelTransform2();
-  ~ElasticBodyReciprocalSplineKernelTransform2() override {}
+  ~ElasticBodyReciprocalSplineKernelTransform2() override = default;
   void
   PrintSelf(std::ostream & os, Indent indent) const override;
 

--- a/Components/Transforms/SplineKernelTransform/itkElasticBodySplineKernelTransform2.h
+++ b/Components/Transforms/SplineKernelTransform/itkElasticBodySplineKernelTransform2.h
@@ -128,7 +128,7 @@ public:
 
 protected:
   ElasticBodySplineKernelTransform2();
-  ~ElasticBodySplineKernelTransform2() override {}
+  ~ElasticBodySplineKernelTransform2() override = default;
   void
   PrintSelf(std::ostream & os, Indent indent) const override;
 

--- a/Components/Transforms/SplineKernelTransform/itkThinPlateR2LogRSplineKernelTransform2.h
+++ b/Components/Transforms/SplineKernelTransform/itkThinPlateR2LogRSplineKernelTransform2.h
@@ -92,7 +92,7 @@ protected:
   ThinPlateR2LogRSplineKernelTransform2() { this->m_FastComputationPossible = true; }
 
 
-  ~ThinPlateR2LogRSplineKernelTransform2() override {}
+  ~ThinPlateR2LogRSplineKernelTransform2() override = default;
 
   /** These (rather redundant) typedefs are needed because on SGI, typedefs
    * are not inherited. */

--- a/Components/Transforms/SplineKernelTransform/itkThinPlateSplineKernelTransform2.h
+++ b/Components/Transforms/SplineKernelTransform/itkThinPlateSplineKernelTransform2.h
@@ -91,7 +91,7 @@ protected:
   ThinPlateSplineKernelTransform2() { this->m_FastComputationPossible = true; }
 
 
-  ~ThinPlateSplineKernelTransform2() override {}
+  ~ThinPlateSplineKernelTransform2() override = default;
 
   /** These (rather redundant) typedefs are needed because on SGI, typedefs
    * are not inherited.

--- a/Components/Transforms/SplineKernelTransform/itkVolumeSplineKernelTransform2.h
+++ b/Components/Transforms/SplineKernelTransform/itkVolumeSplineKernelTransform2.h
@@ -90,7 +90,7 @@ protected:
   VolumeSplineKernelTransform2() { this->m_FastComputationPossible = true; }
 
 
-  ~VolumeSplineKernelTransform2() override {}
+  ~VolumeSplineKernelTransform2() override = default;
 
   /** These (rather redundant) typedefs are needed because on SGI, typedefs
    * are not inherited. */

--- a/Components/Transforms/TranslationStackTransform/elxTranslationStackTransform.h
+++ b/Components/Transforms/TranslationStackTransform/elxTranslationStackTransform.h
@@ -153,7 +153,7 @@ protected:
   TranslationStackTransform();
 
   /** The destructor. */
-  ~TranslationStackTransform() override {}
+  ~TranslationStackTransform() override = default;
 
 private:
   /** The deleted copy constructor and assignment operator. */

--- a/Components/Transforms/TranslationTransform/elxTranslationTransform.h
+++ b/Components/Transforms/TranslationTransform/elxTranslationTransform.h
@@ -138,7 +138,7 @@ protected:
   /** The constructor. */
   TranslationTransformElastix();
   /** The destructor. */
-  ~TranslationTransformElastix() override {}
+  ~TranslationTransformElastix() override = default;
 
   TranslationTransformPointer m_TranslationTransform;
 

--- a/Components/Transforms/TranslationTransform/itkTranslationTransformInitializer.h
+++ b/Components/Transforms/TranslationTransform/itkTranslationTransformInitializer.h
@@ -143,7 +143,7 @@ public:
 
 protected:
   TranslationTransformInitializer();
-  ~TranslationTransformInitializer() override {}
+  ~TranslationTransformInitializer() override = default;
 
   void
   PrintSelf(std::ostream & os, Indent indent) const override;

--- a/Components/Transforms/WeightedCombinationTransform/elxWeightedCombinationTransform.h
+++ b/Components/Transforms/WeightedCombinationTransform/elxWeightedCombinationTransform.h
@@ -208,7 +208,7 @@ protected:
   /** The constructor. */
   WeightedCombinationTransformElastix();
   /** The destructor. */
-  ~WeightedCombinationTransformElastix() override {}
+  ~WeightedCombinationTransformElastix() override = default;
 
   WeightedCombinationTransformPointer m_WeightedCombinationTransform;
   std::vector<std::string>            m_SubTransformFileNames;

--- a/Components/Transforms/WeightedCombinationTransform/itkWeightedCombinationTransform.h
+++ b/Components/Transforms/WeightedCombinationTransform/itkWeightedCombinationTransform.h
@@ -236,7 +236,7 @@ public:
 
 protected:
   WeightedCombinationTransform();
-  ~WeightedCombinationTransform() override {}
+  ~WeightedCombinationTransform() override = default;
 
   TransformContainerType m_TransformContainer;
   double                 m_SumOfWeights;

--- a/Core/ComponentBaseClasses/elxFixedImagePyramidBase.h
+++ b/Core/ComponentBaseClasses/elxFixedImagePyramidBase.h
@@ -122,9 +122,9 @@ public:
 
 protected:
   /** The constructor. */
-  FixedImagePyramidBase() {}
+  FixedImagePyramidBase() = default;
   /** The destructor. */
-  ~FixedImagePyramidBase() override {}
+  ~FixedImagePyramidBase() override = default;
 
 private:
   /** The deleted copy constructor. */

--- a/Core/ComponentBaseClasses/elxImageSamplerBase.h
+++ b/Core/ComponentBaseClasses/elxImageSamplerBase.h
@@ -90,9 +90,9 @@ public:
 
 protected:
   /** The constructor. */
-  ImageSamplerBase() {}
+  ImageSamplerBase() = default;
   /** The destructor. */
-  ~ImageSamplerBase() override {}
+  ~ImageSamplerBase() override = default;
 
 private:
   /** The deleted copy constructor. */

--- a/Core/ComponentBaseClasses/elxInterpolatorBase.h
+++ b/Core/ComponentBaseClasses/elxInterpolatorBase.h
@@ -84,9 +84,9 @@ public:
 
 protected:
   /** The constructor. */
-  InterpolatorBase() {}
+  InterpolatorBase() = default;
   /** The destructor. */
-  ~InterpolatorBase() override {}
+  ~InterpolatorBase() override = default;
 
 private:
   /** The deleted copy constructor. */

--- a/Core/ComponentBaseClasses/elxMetricBase.h
+++ b/Core/ComponentBaseClasses/elxMetricBase.h
@@ -213,7 +213,7 @@ protected:
   /** The constructor. */
   MetricBase();
   /** The destructor. */
-  ~MetricBase() override {}
+  ~MetricBase() override = default;
 
   /**  Get the exact value. Mutual information computed over all points.
    * It is meant in situations when you optimize using just a subset of pixels,

--- a/Core/ComponentBaseClasses/elxMovingImagePyramidBase.h
+++ b/Core/ComponentBaseClasses/elxMovingImagePyramidBase.h
@@ -124,9 +124,9 @@ public:
 
 protected:
   /** The constructor. */
-  MovingImagePyramidBase() {}
+  MovingImagePyramidBase() = default;
   /** The destructor. */
-  ~MovingImagePyramidBase() override {}
+  ~MovingImagePyramidBase() override = default;
 
 private:
   /** The deleted copy constructor. */

--- a/Core/ComponentBaseClasses/elxOptimizerBase.h
+++ b/Core/ComponentBaseClasses/elxOptimizerBase.h
@@ -116,7 +116,7 @@ protected:
   /** The constructor. */
   OptimizerBase();
   /** The destructor. */
-  ~OptimizerBase() override {}
+  ~OptimizerBase() override = default;
 
   /** Force the metric to base its computation on a new subset of image samples.
    * Not every metric may have implemented this.

--- a/Core/ComponentBaseClasses/elxRegistrationBase.h
+++ b/Core/ComponentBaseClasses/elxRegistrationBase.h
@@ -149,9 +149,9 @@ public:
 
 protected:
   /** The constructor. */
-  RegistrationBase() {}
+  RegistrationBase() = default;
   /** The destructor. */
-  ~RegistrationBase() override {}
+  ~RegistrationBase() override = default;
 
   /** Typedef's for mask support. */
   typedef typename ElastixType::MaskPixelType                                       MaskPixelType;

--- a/Core/ComponentBaseClasses/elxResampleInterpolatorBase.h
+++ b/Core/ComponentBaseClasses/elxResampleInterpolatorBase.h
@@ -107,9 +107,9 @@ public:
 
 protected:
   /** The constructor. */
-  ResampleInterpolatorBase() {}
+  ResampleInterpolatorBase() = default;
   /** The destructor. */
-  ~ResampleInterpolatorBase() override {}
+  ~ResampleInterpolatorBase() override = default;
 
 private:
   /** The deleted copy constructor. */

--- a/Core/ComponentBaseClasses/elxResamplerBase.h
+++ b/Core/ComponentBaseClasses/elxResamplerBase.h
@@ -197,7 +197,7 @@ protected:
   /** The constructor. */
   ResamplerBase();
   /** The destructor. */
-  ~ResamplerBase() override {}
+  ~ResamplerBase() override = default;
 
   /** Method that sets the transform, the interpolator and the inputImage. */
   virtual void

--- a/Core/Configuration/elxConfiguration.h
+++ b/Core/Configuration/elxConfiguration.h
@@ -250,7 +250,7 @@ public:
 
 protected:
   Configuration();
-  ~Configuration() override {}
+  ~Configuration() override = default;
 
   /** Print the parameter file to the log file. Called by BeforeAll().
    * This function is not really generic. It's just added because it needs to be

--- a/Core/Install/elxComponentDatabase.h
+++ b/Core/Install/elxComponentDatabase.h
@@ -117,8 +117,8 @@ public:
            ImageDimensionType               movingDimension) const;
 
 protected:
-  ComponentDatabase() {}
-  ~ComponentDatabase() override {}
+  ComponentDatabase() = default;
+  ~ComponentDatabase() override = default;
 
 private:
   CreatorMapType CreatorMap;

--- a/Core/Kernel/elxTransformixMain.h
+++ b/Core/Kernel/elxTransformixMain.h
@@ -106,7 +106,7 @@ public:
   SetInputImageContainer(DataObjectContainerType * inputImageContainer);
 
 protected:
-  TransformixMain() {}
+  TransformixMain() = default;
   ~TransformixMain() override;
 
   /** InitDBIndex sets m_DBIndex to the value obtained

--- a/Testing/itkBSplineSecondOrderDerivativeKernelFunction.h
+++ b/Testing/itkBSplineSecondOrderDerivativeKernelFunction.h
@@ -72,7 +72,7 @@ protected:
   BSplineSecondOrderDerivativeKernelFunction() { m_KernelFunction = KernelType::New(); }
 
 
-  ~BSplineSecondOrderDerivativeKernelFunction() override {}
+  ~BSplineSecondOrderDerivativeKernelFunction() override = default;
   void
   PrintSelf(std::ostream & os, Indent indent) const override
   {

--- a/Testing/itkCommandLineArgumentParser.h
+++ b/Testing/itkCommandLineArgumentParser.h
@@ -231,7 +231,7 @@ public:
 
 protected:
   CommandLineArgumentParser();
-  ~CommandLineArgumentParser() override {}
+  ~CommandLineArgumentParser() override = default;
 
   /** General functionality: find a key. */
   bool


### PR DESCRIPTION
Replaced empty `{}` default-constructor and destructor implementations by `= default` (introduced with C++11).

Done by Clang Tidy Fix (LLVM 11.0) modernize-use-equals-default:
https://clang.llvm.org/extra/clang-tidy/checks/modernize-use-equals-default.html

Which explains that:
> The explicitly defaulted function declarations enable more opportunities in optimization, because the compiler might treat explicitly defaulted functions as trivial.