### PR TITLE
STYLE: Remove "include guards" from cxx files

### DIFF
--- a/Common/CostFunctions/itkScaledSingleValuedCostFunction.cxx
+++ b/Common/CostFunctions/itkScaledSingleValuedCostFunction.cxx
@@ -15,8 +15,6 @@
  *  limitations under the License.
  *
  *=========================================================================*/
-#ifndef __itkScaledSingleValuedCostFunction_cxx
-#define __itkScaledSingleValuedCostFunction_cxx
 
 #include "itkScaledSingleValuedCostFunction.h"
 #include "vnl/vnl_math.h"
@@ -288,5 +286,3 @@ ScaledSingleValuedCostFunction ::PrintSelf(std::ostream & os, Indent indent) con
 
 
 } // end namespace itk
-
-#endif // #ifndef __itkScaledSingleValuedCostFunction_cxx

--- a/Common/LineSearchOptimizers/itkLineSearchOptimizer.cxx
+++ b/Common/LineSearchOptimizers/itkLineSearchOptimizer.cxx
@@ -16,9 +16,6 @@
  *
  *=========================================================================*/
 
-#ifndef __itkLineSearchOptimizer_cxx
-#define __itkLineSearchOptimizer_cxx
-
 #include "itkLineSearchOptimizer.h"
 #include "itkNumericTraits.h"
 
@@ -104,5 +101,3 @@ LineSearchOptimizer ::PrintSelf(std::ostream & os, Indent indent) const
 
 
 } // end namespace itk
-
-#endif // #ifndef __itkLineSearchOptimizer_cxx

--- a/Common/LineSearchOptimizers/itkMoreThuenteLineSearchOptimizer.cxx
+++ b/Common/LineSearchOptimizers/itkMoreThuenteLineSearchOptimizer.cxx
@@ -16,9 +16,6 @@
  *
  *=========================================================================*/
 
-#ifndef __itkMoreThuenteLineSearchOptimizer_cxx
-#define __itkMoreThuenteLineSearchOptimizer_cxx
-
 #include "itkMoreThuenteLineSearchOptimizer.h"
 #include <cmath> // For abs.
 #include <limits>
@@ -948,5 +945,3 @@ MoreThuenteLineSearchOptimizer ::PrintSelf(std::ostream & os, Indent indent) con
 
 
 } // end namespace itk
-
-#endif // #ifndef __itkMoreThuenteLineSearchOptimizer_cxx

--- a/Common/MevisDicomTiff/itkUseMevisDicomTiff.cxx
+++ b/Common/MevisDicomTiff/itkUseMevisDicomTiff.cxx
@@ -15,8 +15,6 @@
  *  limitations under the License.
  *
  *=========================================================================*/
-#ifndef __itkUseMevisDicomTiff_cxx
-#define __itkUseMevisDicomTiff_cxx
 
 #include "itkUseMevisDicomTiff.h"
 
@@ -37,6 +35,3 @@ RegisterMevisDicomTiff(void)
                                           itk::ObjectFactoryBase::INSERT_AT_FRONT);
 #endif
 }
-
-
-#endif

--- a/Common/ParameterFileParser/itkParameterFileParser.cxx
+++ b/Common/ParameterFileParser/itkParameterFileParser.cxx
@@ -16,9 +16,6 @@
  *
  *=========================================================================*/
 
-#ifndef __itkParameterFileParser_cxx
-#define __itkParameterFileParser_cxx
-
 #include "itkParameterFileParser.h"
 
 #include <itksys/SystemTools.hxx>
@@ -409,5 +406,3 @@ ParameterFileParser ::ReturnParameterFileAsString(void)
 
 
 } // end namespace itk
-
-#endif // end __itkParameterFileParser_cxx

--- a/Common/itkScaledSingleValuedNonLinearOptimizer.cxx
+++ b/Common/itkScaledSingleValuedNonLinearOptimizer.cxx
@@ -15,8 +15,6 @@
  *  limitations under the License.
  *
  *=========================================================================*/
-#ifndef __itkScaledSingleValuedNonLinearOptimizer_cxx
-#define __itkScaledSingleValuedNonLinearOptimizer_cxx
 
 #include "itkScaledSingleValuedNonLinearOptimizer.h"
 
@@ -232,5 +230,3 @@ ScaledSingleValuedNonLinearOptimizer ::PrintSelf(std::ostream & os, Indent inden
 
 
 } // end namespace itk
-
-#endif // #ifndef __itkScaledSingleValuedNonLinearOptimizer_cxx

--- a/Common/xout/xoutmain.cxx
+++ b/Common/xout/xoutmain.cxx
@@ -15,8 +15,6 @@
  *  limitations under the License.
  *
  *=========================================================================*/
-#ifndef __xoutmain_cxx
-#define __xoutmain_cxx
 
 #include "xoutmain.h"
 
@@ -45,5 +43,3 @@ xout_valid()
 
 
 } // namespace xoutlibrary
-
-#endif // end #ifndef __xoutmain_cxx

--- a/Components/Metrics/KNNGraphAlphaMutualInformation/KNN/itkANNBinaryTreeCreator.cxx
+++ b/Components/Metrics/KNNGraphAlphaMutualInformation/KNN/itkANNBinaryTreeCreator.cxx
@@ -16,9 +16,6 @@
  *
  *=========================================================================*/
 
-#ifndef __itkANNBinaryTreeCreator_cxx
-#define __itkANNBinaryTreeCreator_cxx
-
 #include "itkANNBinaryTreeCreator.h"
 
 namespace itk
@@ -126,5 +123,3 @@ ANNBinaryTreeCreator::DecreaseReferenceCount(void)
 
 
 } // end namespace itk
-
-#endif // end #ifndef __itkANNBinaryTreeCreator_cxx

--- a/Components/Optimizers/AdaGrad/itkAdaptiveStepsizeOptimizer.cxx
+++ b/Components/Optimizers/AdaGrad/itkAdaptiveStepsizeOptimizer.cxx
@@ -15,8 +15,6 @@
  *  limitations under the License.
  *
  *=========================================================================*/
-#ifndef __itkAdaptiveStepsizeOptimizer_cxx
-#define __itkAdaptiveStepsizeOptimizer_cxx
 
 #include "itkAdaptiveStepsizeOptimizer.h"
 
@@ -90,5 +88,3 @@ AdaptiveStepsizeOptimizer ::UpdateCurrentTime(void)
 
 
 } // end namespace itk
-
-#endif // end #ifndef __itkVoxelWiseASGDOptimizer_cxx

--- a/Components/Optimizers/AdaptiveStochasticLBFGS/itkAdaptiveStochasticLBFGSOptimizer.cxx
+++ b/Components/Optimizers/AdaptiveStochasticLBFGS/itkAdaptiveStochasticLBFGSOptimizer.cxx
@@ -15,8 +15,6 @@
  *  limitations under the License.
  *
  *=========================================================================*/
-#ifndef __itkAdaptiveStochasticLBFGSOptimizer_cxx
-#define __itkAdaptiveStochasticLBFGSOptimizer_cxx
 
 #include "itkAdaptiveStochasticLBFGSOptimizer.h"
 
@@ -107,5 +105,3 @@ AdaptiveStochasticLBFGSOptimizer ::UpdateCurrentTime(void)
 
 
 } // end namespace itk
-
-#endif // end #ifndef __itkAdaptiveStochasticLBFGSOptimizer_cxx

--- a/Components/Optimizers/AdaptiveStochasticVarianceReducedGradient/itkAdaptiveStochasticVarianceReducedGradientOptimizer.cxx
+++ b/Components/Optimizers/AdaptiveStochasticVarianceReducedGradient/itkAdaptiveStochasticVarianceReducedGradientOptimizer.cxx
@@ -15,8 +15,6 @@
  *  limitations under the License.
  *
  *=========================================================================*/
-#ifndef __itkAdaptiveStochasticVarianceReducedGradientOptimizer_cxx
-#define __itkAdaptiveStochasticVarianceReducedGradientOptimizer_cxx
 
 #include "itkAdaptiveStochasticVarianceReducedGradientOptimizer.h"
 
@@ -87,5 +85,3 @@ AdaptiveStochasticVarianceReducedGradientOptimizer ::UpdateCurrentTime(void)
 
 
 } // end namespace itk
-
-#endif // end #ifndef __itkAdaptiveStochasticVarianceReducedGradientOptimizer_cxx

--- a/Components/Optimizers/AdaptiveStochasticVarianceReducedGradient/itkStandardStochasticVarianceReducedGradientDescentOptimizer.cxx
+++ b/Components/Optimizers/AdaptiveStochasticVarianceReducedGradient/itkStandardStochasticVarianceReducedGradientDescentOptimizer.cxx
@@ -15,8 +15,6 @@
  *  limitations under the License.
  *
  *=========================================================================*/
-#ifndef __itkStandardStochasticVarianceReducedGradientOptimizer_cxx
-#define __itkStandardStochasticVarianceReducedGradientOptimizer_cxx
 
 #include "itkStandardStochasticVarianceReducedGradientDescentOptimizer.h"
 
@@ -108,5 +106,3 @@ StandardStochasticVarianceReducedGradientOptimizer ::UpdateCurrentTime(void)
 
 
 } // end namespace itk
-
-#endif // end #ifndef __itkStandardStochasticVarianceReducedGradientOptimizer_cxx

--- a/Components/Optimizers/AdaptiveStochasticVarianceReducedGradient/itkStochasticVarianceReducedGradientDescentOptimizer.cxx
+++ b/Components/Optimizers/AdaptiveStochasticVarianceReducedGradient/itkStochasticVarianceReducedGradientDescentOptimizer.cxx
@@ -15,8 +15,6 @@
  *  limitations under the License.
  *
  *=========================================================================*/
-#ifndef _itkStochasticVarianceReducedGradientDescentOptimizer_cxx
-#define _itkStochasticVarianceReducedGradientDescentOptimizer_cxx
 
 #include "itkStochasticVarianceReducedGradientDescentOptimizer.h"
 
@@ -362,5 +360,3 @@ StochasticVarianceReducedGradientDescentOptimizer ::ThreadedAdvanceOneStep(Threa
 
 
 } // end namespace itk
-
-#endif

--- a/Components/Optimizers/CMAEvolutionStrategy/itkCMAEvolutionStrategyOptimizer.cxx
+++ b/Components/Optimizers/CMAEvolutionStrategy/itkCMAEvolutionStrategyOptimizer.cxx
@@ -16,9 +16,6 @@
  *
  *=========================================================================*/
 
-#ifndef __itkCMAEvolutionStrategyOptimizer_cxx
-#define __itkCMAEvolutionStrategyOptimizer_cxx
-
 #include "itkCMAEvolutionStrategyOptimizer.h"
 #include "itkSymmetricEigenAnalysis.h"
 #include "vnl/vnl_math.h"
@@ -1204,5 +1201,3 @@ CMAEvolutionStrategyOptimizer::TestConvergence(bool firstCheck)
 
 
 } // end namespace itk
-
-#endif // #ifndef __itkCMAEvolutionStrategyOptimizer_cxx

--- a/Components/Optimizers/ConjugateGradient/itkGenericConjugateGradientOptimizer.cxx
+++ b/Components/Optimizers/ConjugateGradient/itkGenericConjugateGradientOptimizer.cxx
@@ -16,9 +16,6 @@
  *
  *=========================================================================*/
 
-#ifndef __itkGenericConjugateGradientOptimizer_cxx
-#define __itkGenericConjugateGradientOptimizer_cxx
-
 #include "itkGenericConjugateGradientOptimizer.h"
 #include "vnl/vnl_math.h"
 
@@ -632,5 +629,3 @@ GenericConjugateGradientOptimizer ::PrintSelf(std::ostream & os, Indent indent) 
 
 
 } // end namespace itk
-
-#endif // #ifndef __itkGenericConjugateGradientOptimizer_cxx

--- a/Components/Optimizers/FiniteDifferenceGradientDescent/itkFiniteDifferenceGradientDescentOptimizer.cxx
+++ b/Components/Optimizers/FiniteDifferenceGradientDescent/itkFiniteDifferenceGradientDescentOptimizer.cxx
@@ -16,9 +16,6 @@
  *
  *=========================================================================*/
 
-#ifndef __itkFiniteDifferenceGradientDescentOptimizer_cxx
-#define __itkFiniteDifferenceGradientDescentOptimizer_cxx
-
 #include "itkFiniteDifferenceGradientDescentOptimizer.h"
 #include "itkCommand.h"
 #include "itkEventObject.h"
@@ -288,5 +285,3 @@ FiniteDifferenceGradientDescentOptimizer ::Compute_c(unsigned long k) const
 
 
 } // end namespace itk
-
-#endif // end #ifndef __itkFiniteDifferenceGradientDescentOptimizer_cxx

--- a/Components/Optimizers/FullSearch/itkFullSearchOptimizer.cxx
+++ b/Components/Optimizers/FullSearch/itkFullSearchOptimizer.cxx
@@ -16,9 +16,6 @@
  *
  *=========================================================================*/
 
-#ifndef __itkFullSearchOptimizer_cxx
-#define __itkFullSearchOptimizer_cxx
-
 #include "itkFullSearchOptimizer.h"
 #include "itkCommand.h"
 #include "itkEventObject.h"
@@ -445,5 +442,3 @@ FullSearchOptimizer ::IndexToPoint(const SearchSpaceIndexType & index)
 
 
 } // end namespace itk
-
-#endif // #ifndef __itkFullSearchOptimizer_cxx

--- a/Components/Optimizers/PreconditionedGradientDescent/itkAdaptiveStochasticPreconditionedGradientDescentOptimizer.cxx
+++ b/Components/Optimizers/PreconditionedGradientDescent/itkAdaptiveStochasticPreconditionedGradientDescentOptimizer.cxx
@@ -15,8 +15,6 @@
  *  limitations under the License.
  *
  *=========================================================================*/
-#ifndef __itkAdaptiveStochasticPreconditionedGradientDescentOptimizer_cxx
-#define __itkAdaptiveStochasticPreconditionedGradientDescentOptimizer_cxx
 
 #include "itkAdaptiveStochasticPreconditionedGradientDescentOptimizer.h"
 
@@ -81,5 +79,3 @@ AdaptiveStochasticPreconditionedGradientDescentOptimizer ::UpdateCurrentTime(voi
 
 
 } // end namespace itk
-
-#endif // end #ifndef __itkAdaptiveStochasticPreconditionedGradientDescentOptimizer_cxx

--- a/Components/Optimizers/PreconditionedGradientDescent/itkPreconditionedGradientDescentOptimizer.cxx
+++ b/Components/Optimizers/PreconditionedGradientDescent/itkPreconditionedGradientDescentOptimizer.cxx
@@ -15,8 +15,6 @@
  *  limitations under the License.
  *
  *=========================================================================*/
-#ifndef _itkPreconditionedGradientDescentOptimizer_cxx
-#define _itkPreconditionedGradientDescentOptimizer_cxx
 
 #include "itkPreconditionedGradientDescentOptimizer.h"
 
@@ -505,5 +503,3 @@ PreconditionedGradientDescentOptimizer ::SetPreconditionMatrix(PreconditionType 
 
 
 } // end namespace itk
-
-#endif

--- a/Components/Optimizers/PreconditionedGradientDescent/itkStochasticPreconditionedGradientDescentOptimizer.cxx
+++ b/Components/Optimizers/PreconditionedGradientDescent/itkStochasticPreconditionedGradientDescentOptimizer.cxx
@@ -15,8 +15,6 @@
  *  limitations under the License.
  *
  *=========================================================================*/
-#ifndef __itkStochasticPreconditionedGradientDescentOptimizer_cxx
-#define __itkStochasticPreconditionedGradientDescentOptimizer_cxx
 
 #include "itkStochasticPreconditionedGradientDescentOptimizer.h"
 #include "vnl/vnl_math.h"
@@ -93,5 +91,3 @@ StochasticPreconditionedGradientDescentOptimizer ::UpdateCurrentTime(void)
 
 
 } // end namespace itk
-
-#endif // end #ifndef __itkStochasticPreconditionedGradientDescentOptimizer_cxx

--- a/Components/Optimizers/PreconditionedStochasticGradientDescent/itkPreconditionedASGDOptimizer.cxx
+++ b/Components/Optimizers/PreconditionedStochasticGradientDescent/itkPreconditionedASGDOptimizer.cxx
@@ -15,8 +15,6 @@
  *  limitations under the License.
  *
  *=========================================================================*/
-#ifndef __itkPreconditionedASGDOptimizer_cxx
-#define __itkPreconditionedASGDOptimizer_cxx
 
 #include "itkPreconditionedASGDOptimizer.h"
 
@@ -90,5 +88,3 @@ PreconditionedASGDOptimizer ::UpdateCurrentTime(void)
 
 
 } // end namespace itk
-
-#endif // end #ifndef __itkVoxelWiseASGDOptimizer_cxx

--- a/Components/Optimizers/QuasiNewtonLBFGS/itkQuasiNewtonLBFGSOptimizer.cxx
+++ b/Components/Optimizers/QuasiNewtonLBFGS/itkQuasiNewtonLBFGSOptimizer.cxx
@@ -16,9 +16,6 @@
  *
  *=========================================================================*/
 
-#ifndef __itkQuasiNewtonLBFGSOptimizer_cxx
-#define __itkQuasiNewtonLBFGSOptimizer_cxx
-
 #include "itkQuasiNewtonLBFGSOptimizer.h"
 #include "itkArray.h"
 #include "vnl/vnl_math.h"
@@ -444,5 +441,3 @@ QuasiNewtonLBFGSOptimizer::TestConvergence(bool firstLineSearchDone)
 
 
 } // end namespace itk
-
-#endif // #ifndef __itkQuasiNewtonLBFGSOptimizer_cxx

--- a/Components/Optimizers/RSGDEachParameterApart/itkRSGDEachParameterApartBaseOptimizer.cxx
+++ b/Components/Optimizers/RSGDEachParameterApart/itkRSGDEachParameterApartBaseOptimizer.cxx
@@ -16,9 +16,6 @@
  *
  *=========================================================================*/
 
-#ifndef __itkRSGDEachParameterApartBaseOptimizer_cxx
-#define __itkRSGDEachParameterApartBaseOptimizer_cxx
-
 #include "itkRSGDEachParameterApartBaseOptimizer.h"
 #include "itkCommand.h"
 #include "itkEventObject.h"
@@ -287,5 +284,3 @@ RSGDEachParameterApartBaseOptimizer ::PrintSelf(std::ostream & os, Indent indent
 
 
 } // end namespace itk
-
-#endif

--- a/Components/Optimizers/RSGDEachParameterApart/itkRSGDEachParameterApartOptimizer.cxx
+++ b/Components/Optimizers/RSGDEachParameterApart/itkRSGDEachParameterApartOptimizer.cxx
@@ -16,9 +16,6 @@
  *
  *=========================================================================*/
 
-#ifndef __itkRSGDEachParameterApartOptimizer_cxx
-#define __itkRSGDEachParameterApartOptimizer_cxx
-
 #include "itkRSGDEachParameterApartOptimizer.h"
 #include "itkCommand.h"
 #include "itkEventObject.h"
@@ -55,5 +52,3 @@ RSGDEachParameterApartOptimizer ::StepAlongGradient(const DerivativeType & facto
 
 
 } // end namespace itk
-
-#endif

--- a/Components/Optimizers/StandardGradientDescent/itkStandardGradientDescentOptimizer.cxx
+++ b/Components/Optimizers/StandardGradientDescent/itkStandardGradientDescentOptimizer.cxx
@@ -15,8 +15,6 @@
  *  limitations under the License.
  *
  *=========================================================================*/
-#ifndef __itkStandardGradientDescentOptimizer_cxx
-#define __itkStandardGradientDescentOptimizer_cxx
 
 #include "itkStandardGradientDescentOptimizer.h"
 #include "vnl/vnl_math.h"
@@ -103,5 +101,3 @@ StandardGradientDescentOptimizer ::UpdateCurrentTime(void)
 
 
 } // end namespace itk
-
-#endif // end #ifndef __itkStandardGradientDescentOptimizer_cxx

--- a/Core/Install/elxComponentDatabase.cxx
+++ b/Core/Install/elxComponentDatabase.cxx
@@ -21,9 +21,6 @@
  *
  */
 
-#ifndef __elxComponentDatabase_cxx
-#define __elxComponentDatabase_cxx
-
 #include "elxComponentDatabase.h"
 #include "xoutmain.h"
 
@@ -165,5 +162,3 @@ ComponentDatabase::GetIndex(const PixelTypeDescriptionType & fixedPixelType,
 
 
 } // end namespace elastix
-
-#endif // end ifndef __elxComponentDatabase_cxx

--- a/Core/Install/elxComponentLoader.cxx
+++ b/Core/Install/elxComponentLoader.cxx
@@ -16,9 +16,6 @@
  *
  *=========================================================================*/
 
-#ifndef __elxComponentLoader_cxx
-#define __elxComponentLoader_cxx
-
 #include "elxComponentLoader.h"
 #include "elxSupportedImageTypes.h"
 #include "elxInstallFunctions.h"
@@ -182,5 +179,3 @@ ComponentLoader::UnloadComponents()
 
 
 } // end namespace elastix
-
-#endif //#ifndef __elxComponentLoader_cxx

--- a/Core/Main/elxParameterObject.cxx
+++ b/Core/Main/elxParameterObject.cxx
@@ -15,8 +15,6 @@
  *  limitations under the License.
  *
  *=========================================================================*/
-#ifndef elxParameterObject_cxx
-#define elxParameterObject_cxx
 
 #include "elxParameterObject.h"
 
@@ -535,5 +533,3 @@ ParameterObject ::PrintSelf(std::ostream & os, itk::Indent indent) const
 
 
 } // namespace elastix
-
-#endif // elxParameterObject_cxx


### PR DESCRIPTION
Include guards (like `#define FileName_h`) are intended to avoid the problem of double inclusion: https://en.wikipedia.org/wiki/Include_guard

They should only be used in header files (*.h, *.hxx).