### PR TITLE
STYLE: No longer specify Fixed/Moving ImageDimension parameters in GTest

### DIFF
--- a/Core/Main/GTesting/ElastixFilterGTest.cxx
+++ b/Core/Main/GTesting/ElastixFilterGTest.cxx
@@ -65,11 +65,9 @@ GTEST_TEST(ElastixFilter, Translation)
 
   const std::pair<std::string, std::string> parameterArray[] = {
     // Parameters in alphabetic order:
-    { "FixedImageDimension", std::to_string(ImageDimension) },
     { "ImageSampler", "Full" },
     { "MaximumNumberOfIterations", "2" },
     { "Metric", "AdvancedNormalizedCorrelation" },
-    { "MovingImageDimension", std::to_string(ImageDimension) },
     { "Optimizer", "AdaptiveStochasticGradientDescent" },
     { "Transform", "TranslationTransform" }
   };

--- a/Core/Main/GTesting/itkElastixRegistrationMethodGTest.cxx
+++ b/Core/Main/GTesting/itkElastixRegistrationMethodGTest.cxx
@@ -65,11 +65,9 @@ GTEST_TEST(itkElastixRegistrationMethod, Translation)
 
   const std::pair<std::string, std::string> parameterArray[] = {
     // Parameters in alphabetic order:
-    { "FixedImageDimension", std::to_string(ImageDimension) },
     { "ImageSampler", "Full" },
     { "MaximumNumberOfIterations", "2" },
     { "Metric", "AdvancedNormalizedCorrelation" },
-    { "MovingImageDimension", std::to_string(ImageDimension) },
     { "Optimizer", "AdaptiveStochasticGradientDescent" },
     { "Transform", "TranslationTransform" }
   };


### PR DESCRIPTION
It appears unnecessary to specify "FixedImageDimension" and "MovingImageDimension" to `itkElastixRegistrationMethod`and `ElastixFilter`. As was mentioned during the internal weekly Elastix project sprint.