### PR TITLE
Make TransformBase member functions private and non-virtual

### DIFF
--- a/Core/ComponentBaseClasses/elxTransformBase.h
+++ b/Core/ComponentBaseClasses/elxTransformBase.h
@@ -198,7 +198,7 @@ public:
   typedef typename TElastix::ParameterMapType ParameterMapType;
 
   /** Cast to ITKBaseType. */
-  virtual ITKBaseType *
+  ITKBaseType *
   GetAsITKBaseType(void)
   {
     return dynamic_cast<ITKBaseType *>(this);
@@ -206,7 +206,7 @@ public:
 
 
   /** Cast to ITKBaseType, to use in const functions. */
-  virtual const ITKBaseType *
+  const ITKBaseType *
   GetAsITKBaseType(void) const
   {
     return dynamic_cast<const ITKBaseType *>(this);
@@ -215,15 +215,15 @@ public:
   /** Execute stuff before the actual transformation:
    * \li Check the appearance of inputpoints to be transformed.
    */
-  virtual int
+  int
   BeforeAllTransformix(void);
 
   /** Set the initial transform. */
-  virtual void
+  void
   SetInitialTransform(InitialTransformType * _arg);
 
   /** Set the TransformParametersFileName. */
-  virtual void
+  void
   SetTransformParametersFileName(const char * filename);
 
   /** Function to read transform-parameters from a file. */
@@ -239,39 +239,39 @@ public:
   WriteToFile(const ParametersType & param) const;
 
   /** Function to write transform-parameters to a file. */
-  virtual void
+  void
   WriteToFile(void) const;
 
   /** Macro for reading and writing the transform parameters in WriteToFile or not. */
-  virtual void
+  void
   SetReadWriteTransformParameters(const bool _arg);
 
   /** Function to read the initial transform parameters from a file. */
-  virtual void
+  void
   ReadInitialTransformFromFile(const char * transformParameterFileName);
 
   /** Function to read the initial transform parameters from the internally stored
    * configuration object.
    */
-  virtual void
+  void
   ReadInitialTransformFromVector(const size_t index);
 
   /** Function to transform coordinates from fixed to moving image. */
-  virtual void
+  void
   TransformPoints(void) const;
 
   /** Function to compute the determinant of the spatial Jacobian. */
-  virtual void
+  void
   ComputeDeterminantOfSpatialJacobian(void) const;
 
   /** Function to compute the determinant of the spatial Jacobian. */
-  virtual void
+  void
   ComputeSpatialJacobian(void) const;
 
   /** Makes sure that the final parameters from the registration components
    * are copied, set, and stored.
    */
-  virtual void
+  void
   SetFinalParameters(void);
 
 protected:
@@ -300,14 +300,14 @@ protected:
   AutomaticScalesEstimationStackTransform(const unsigned int & numSubTransforms, ScalesType & scales) const;
 
 private:
-  virtual const CombinationTransformType *
+  const CombinationTransformType *
   GetAsCombinationTransform(void) const
   {
     return dynamic_cast<const CombinationTransformType *>(this);
   }
 
 
-  virtual CombinationTransformType *
+  CombinationTransformType *
   GetAsCombinationTransform(void)
   {
     return dynamic_cast<CombinationTransformType *>(this);
@@ -332,18 +332,18 @@ private:
   AfterRegistrationBase(void) override;
 
   /** Get the initial transform. */
-  virtual const InitialTransformType *
+  const InitialTransformType *
   GetInitialTransform(void) const;
 
   /** Get the TransformParametersFileName. */
   itkGetStringMacro(TransformParametersFileName);
 
   /** Function to transform coordinates from fixed to moving image. */
-  virtual void
+  void
   TransformPointsSomePoints(const std::string filename) const;
 
   /** Function to transform coordinates from fixed to moving image, given as VTK file. */
-  virtual void
+  void
   TransformPointsSomePointsVTK(const std::string filename) const;
 
   /** Deprecation note: The plan is to split all Compute* and TransformPoints* functions
@@ -360,7 +360,7 @@ private:
   void WriteDeformationFieldImage(typename DeformationFieldImageType::Pointer) const;
 
   /** Legacy function that calls GenerateDeformationFieldImage and WriteDeformationFieldImage. */
-  virtual void
+  void
   TransformPointsAllPoints(void) const;
 
   /** Member variables. */

--- a/Core/ComponentBaseClasses/elxTransformBase.h
+++ b/Core/ComponentBaseClasses/elxTransformBase.h
@@ -212,48 +212,11 @@ public:
     return dynamic_cast<const ITKBaseType *>(this);
   }
 
-
-  virtual const CombinationTransformType *
-  GetAsCombinationTransform(void) const
-  {
-    return dynamic_cast<const CombinationTransformType *>(this);
-  }
-
-
-  virtual CombinationTransformType *
-  GetAsCombinationTransform(void)
-  {
-    return dynamic_cast<CombinationTransformType *>(this);
-  }
-
-
-  /** Execute stuff before everything else:
-   * \li Check the appearance of an initial transform.
-   */
-  int
-  BeforeAllBase(void) override;
-
   /** Execute stuff before the actual transformation:
    * \li Check the appearance of inputpoints to be transformed.
    */
   virtual int
   BeforeAllTransformix(void);
-
-  /** Execute stuff before the actual registration:
-   * \li Set the initial transform and how to group transforms.
-   */
-  void
-  BeforeRegistrationBase(void) override;
-
-  /** Execute stuff after the registration:
-   * \li Get and set the final parameters for the resampler.
-   */
-  void
-  AfterRegistrationBase(void) override;
-
-  /** Get the initial transform. */
-  virtual const InitialTransformType *
-  GetInitialTransform(void) const;
 
   /** Set the initial transform. */
   virtual void
@@ -262,9 +225,6 @@ public:
   /** Set the TransformParametersFileName. */
   virtual void
   SetTransformParametersFileName(const char * filename);
-
-  /** Get the TransformParametersFileName. */
-  itkGetStringMacro(TransformParametersFileName);
 
   /** Function to read transform-parameters from a file. */
   virtual void
@@ -299,31 +259,6 @@ public:
   /** Function to transform coordinates from fixed to moving image. */
   virtual void
   TransformPoints(void) const;
-
-  /** Function to transform coordinates from fixed to moving image. */
-  virtual void
-  TransformPointsSomePoints(const std::string filename) const;
-
-  /** Function to transform coordinates from fixed to moving image, given as VTK file. */
-  virtual void
-  TransformPointsSomePointsVTK(const std::string filename) const;
-
-  /** Deprecation note: The plan is to split all Compute* and TransformPoints* functions
-   *  into Generate* and Write* functions, since that would facilitate a proper library
-   *  interface. To keep everything functional during the transition period we need to
-   *  keep the orignal Compute* and TransformPoints* functions and let them just call
-   *  Generate* and Write*. These functions should be considered marked deprecated.
-   */
-
-  /** Function to transform all coordinates from fixed to moving image. */
-  typename DeformationFieldImageType::Pointer
-  GenerateDeformationFieldImage(void) const;
-
-  void WriteDeformationFieldImage(typename DeformationFieldImageType::Pointer) const;
-
-  /** Legacy function that calls GenerateDeformationFieldImage and WriteDeformationFieldImage. */
-  virtual void
-  TransformPointsAllPoints(void) const;
 
   /** Function to compute the determinant of the spatial Jacobian. */
   virtual void
@@ -365,6 +300,69 @@ protected:
   AutomaticScalesEstimationStackTransform(const unsigned int & numSubTransforms, ScalesType & scales) const;
 
 private:
+  virtual const CombinationTransformType *
+  GetAsCombinationTransform(void) const
+  {
+    return dynamic_cast<const CombinationTransformType *>(this);
+  }
+
+
+  virtual CombinationTransformType *
+  GetAsCombinationTransform(void)
+  {
+    return dynamic_cast<CombinationTransformType *>(this);
+  }
+
+  /** Execute stuff before everything else:
+   * \li Check the appearance of an initial transform.
+   */
+  int
+  BeforeAllBase(void) override;
+
+  /** Execute stuff before the actual registration:
+   * \li Set the initial transform and how to group transforms.
+   */
+  void
+  BeforeRegistrationBase(void) override;
+
+  /** Execute stuff after the registration:
+   * \li Get and set the final parameters for the resampler.
+   */
+  void
+  AfterRegistrationBase(void) override;
+
+  /** Get the initial transform. */
+  virtual const InitialTransformType *
+  GetInitialTransform(void) const;
+
+  /** Get the TransformParametersFileName. */
+  itkGetStringMacro(TransformParametersFileName);
+
+  /** Function to transform coordinates from fixed to moving image. */
+  virtual void
+  TransformPointsSomePoints(const std::string filename) const;
+
+  /** Function to transform coordinates from fixed to moving image, given as VTK file. */
+  virtual void
+  TransformPointsSomePointsVTK(const std::string filename) const;
+
+  /** Deprecation note: The plan is to split all Compute* and TransformPoints* functions
+   *  into Generate* and Write* functions, since that would facilitate a proper library
+   *  interface. To keep everything functional during the transition period we need to
+   *  keep the orignal Compute* and TransformPoints* functions and let them just call
+   *  Generate* and Write*. These functions should be considered marked deprecated.
+   */
+
+  /** Function to transform all coordinates from fixed to moving image. */
+  typename DeformationFieldImageType::Pointer
+  GenerateDeformationFieldImage(void) const;
+
+  void WriteDeformationFieldImage(typename DeformationFieldImageType::Pointer) const;
+
+  /** Legacy function that calls GenerateDeformationFieldImage and WriteDeformationFieldImage. */
+  virtual void
+  TransformPointsAllPoints(void) const;
+
   /** Member variables. */
   std::unique_ptr<ParametersType> m_TransformParametersPointer{};
   std::string                     m_TransformParametersFileName;

--- a/Core/ComponentBaseClasses/elxTransformBase.h
+++ b/Core/ComponentBaseClasses/elxTransformBase.h
@@ -363,14 +363,6 @@ private:
   void
   TransformPointsAllPoints(void) const;
 
-  /** Member variables. */
-  std::unique_ptr<ParametersType> m_TransformParametersPointer{};
-  std::string                     m_TransformParametersFileName;
-  ParametersType                  m_FinalParameters;
-
-  /** Boolean to decide whether or not the transform parameters are written. */
-  bool m_ReadWriteTransformParameters{ true };
-
   std::string
   GetInitialTransformParametersFileName(void) const
   {
@@ -382,6 +374,14 @@ private:
     const Self * t0 = dynamic_cast<const Self *>(this->GetInitialTransform());
     return t0->GetTransformParametersFileName();
   }
+
+  /** Member variables. */
+  std::unique_ptr<ParametersType> m_TransformParametersPointer{};
+  std::string                     m_TransformParametersFileName;
+  ParametersType                  m_FinalParameters;
+
+  /** Boolean to decide whether or not the transform parameters are written. */
+  bool m_ReadWriteTransformParameters{ true };
 
   /** Boolean to decide whether or not the transform parameters are written in binary format. */
   bool m_UseBinaryFormatForTransformationParameters{};


### PR DESCRIPTION
For the obvious reasons: `private` members are easier to maintain than `public` members, and the `virtual` keyword should only be used for member functions that are meant to be overridden in a derived class.

