### PR TITLE
STYLE: Add const to ELASTIX and TRANSFORMIX member functions

### DIFF
--- a/Core/Main/elastixlib.cxx
+++ b/Core/Main/elastixlib.cxx
@@ -64,6 +64,13 @@ ELASTIX::~ELASTIX()
  * ******************* GetResultImage ***********************
  */
 
+ELASTIX::ConstImagePointer
+ELASTIX::GetResultImage(void) const
+{
+  return this->m_ResultImage;
+} // end GetResultImage()
+
+
 ELASTIX::ImagePointer
 ELASTIX::GetResultImage(void)
 {
@@ -78,7 +85,7 @@ ELASTIX::GetResultImage(void)
 ELASTIX::ParameterMapType
 ELASTIX::GetTransformParameterMap(void) const
 {
-  return this->m_TransformParametersList[this->m_TransformParametersList.size() - 1];
+  return this->m_TransformParametersList.back();
 } // end GetTransformParameterMap()
 
 

--- a/Core/Main/elastixlib.cxx
+++ b/Core/Main/elastixlib.cxx
@@ -76,7 +76,7 @@ ELASTIX::GetResultImage(void)
  */
 
 ELASTIX::ParameterMapType
-ELASTIX::GetTransformParameterMap(void)
+ELASTIX::GetTransformParameterMap(void) const
 {
   return this->m_TransformParametersList[this->m_TransformParametersList.size() - 1];
 } // end GetTransformParameterMap()
@@ -87,7 +87,7 @@ ELASTIX::GetTransformParameterMap(void)
  */
 
 ELASTIX::ParameterMapListType
-ELASTIX::GetTransformParameterMapList(void)
+ELASTIX::GetTransformParameterMapList(void) const 
 {
   return this->m_TransformParametersList;
 } // end GetTransformParameterMapList()

--- a/Core/Main/elastixlib.h
+++ b/Core/Main/elastixlib.h
@@ -40,8 +40,9 @@ class ELASTIXLIB_API ELASTIX
 {
 public:
   // typedefs for images
-  typedef itk::DataObject Image;
-  typedef Image::Pointer  ImagePointer;
+  typedef itk::DataObject     Image;
+  typedef Image::Pointer      ImagePointer;
+  typedef Image::ConstPointer ConstImagePointer;
 
   // typedefs for parameter map
   typedef itk::ParameterFileParser::ParameterValuesType           ParameterValuesType;
@@ -104,6 +105,10 @@ public:
                  ObjectPointer                         transform = nullptr);
 
   /** Getter for result image. */
+  ConstImagePointer
+  GetResultImage(void) const;
+
+  /** Getter for result image. Non-const overload */
   ImagePointer
   GetResultImage(void);
 

--- a/Core/Main/elastixlib.h
+++ b/Core/Main/elastixlib.h
@@ -109,11 +109,11 @@ public:
 
   /** Get transform parameters of last registration step. */
   ParameterMapType
-  GetTransformParameterMap(void);
+  GetTransformParameterMap(void) const;
 
   /** Get transform parameters of all registration steps. */
   ParameterMapListType
-  GetTransformParameterMapList(void);
+  GetTransformParameterMapList(void) const;
 
 private:
   /* the result images */

--- a/Core/Main/transformixlib.cxx
+++ b/Core/Main/transformixlib.cxx
@@ -63,6 +63,13 @@ TRANSFORMIX::~TRANSFORMIX()
  * ******************* GetResultImage ***********************
  */
 
+TRANSFORMIX::ConstImagePointer
+TRANSFORMIX::GetResultImage(void) const
+{
+  return this->m_ResultImage;
+} // end GetResultImage()
+
+
 TRANSFORMIX::ImagePointer
 TRANSFORMIX::GetResultImage(void)
 {

--- a/Core/Main/transformixlib.h
+++ b/Core/Main/transformixlib.h
@@ -37,8 +37,9 @@ class ELASTIXLIB_API TRANSFORMIX
 {
 public:
   // typedefs for images
-  typedef itk::DataObject Image;
-  typedef Image::Pointer  ImagePointer;
+  typedef itk::DataObject     Image;
+  typedef Image::Pointer      ImagePointer;
+  typedef Image::ConstPointer ConstImagePointer;
 
   // typedefs for parameter map
   typedef itk::ParameterFileParser::ParameterValuesType           ParameterValuesType;
@@ -74,6 +75,10 @@ public:
                  bool                            performCout);
 
   /** Getter for result image. */
+  ConstImagePointer
+  GetResultImage(void) const;
+
+  /** Getter for result image. Non-const overload */
   ImagePointer
   GetResultImage(void);
 


### PR DESCRIPTION
Added `const` keywords to the declarations of `ELASTIX::GetTransformParameterMap(void)` and `ELASTIX::GetTransformParameterMapList(void)`. These two member functions do not modify the state of an `ELASTIX` library object in any way.

See also C++ Core Guidelines (August 3, 2020) "Con.2: By default, make member functions const", https://isocpp.github.io/CppCoreGuidelines/CppCoreGuidelines#Rconst-fct

Also added const overloads of `GetResultImage()` to ELASTIX and TRANSFORMIX library classes.