### PR TITLE
STYLE: Replace `v[v.size() - 1]` by `v.back()`, in elastix Core

### DIFF
--- a/Core/Kernel/elxElastixBase.cxx
+++ b/Core/Kernel/elxElastixBase.cxx
@@ -274,7 +274,7 @@ ElastixBase::BeforeAllBase(void)
   {
     /** Make sure that last character of the output folder equals a '/' or '\'. */
     std::string folder(check);
-    const char  last = folder[folder.size() - 1];
+    const char  last = folder.back();
     if (last != '/' && last != '\\')
     {
       folder.append("/");

--- a/Core/Main/elastix.cxx
+++ b/Core/Main/elastix.cxx
@@ -129,7 +129,7 @@ main(int argc, char ** argv)
       if (key == "-out")
       {
         /** Make sure that last character of the output folder equals a '/' or '\'. */
-        const char last = value[value.size() - 1];
+        const char last = value.back();
         if (last != '/' && last != '\\')
         {
           value.append("/");

--- a/Core/Main/elxElastixFilter.hxx
+++ b/Core/Main/elxElastixFilter.hxx
@@ -130,7 +130,7 @@ ElastixFilter<TFixedImage, TMovingImage>::GenerateData(void)
   }
 
   // Elastix must always write result image to guarantee that the ITK pipeline is in a consistent state
-  parameterMapVector[parameterMapVector.size() - 1]["WriteResultImage"] = ParameterValueVectorType(1, "true");
+  parameterMapVector.back()["WriteResultImage"] = ParameterValueVectorType(1, "true");
 
   // Setup argument map
   ArgumentMapType argumentMap;
@@ -168,8 +168,7 @@ ElastixFilter<TFixedImage, TMovingImage>::GenerateData(void)
       itkExceptionMacro("Output directory \"" << this->GetOutputDirectory() << "\" does not exist.");
     }
 
-    if (this->GetOutputDirectory()[this->GetOutputDirectory().size() - 1] != '/' &&
-        this->GetOutputDirectory()[this->GetOutputDirectory().size() - 1] != '\\')
+    if (this->GetOutputDirectory().back() != '/' && this->GetOutputDirectory().back() != '\\')
     {
       this->SetOutputDirectory(this->GetOutputDirectory() + "/");
     }
@@ -265,7 +264,7 @@ ElastixFilter<TFixedImage, TMovingImage>::GenerateData(void)
     }
 
     // TODO: Fix elastix corrupting default pixel value parameter
-    transformParameterMapVector[transformParameterMapVector.size() - 1]["DefaultPixelValue"] =
+    transformParameterMapVector.back()["DefaultPixelValue"] =
       parameterMapVector[i]["DefaultPixelValue"];
   } // End loop over registrations
 

--- a/Core/Main/elxTransformixFilter.hxx
+++ b/Core/Main/elxTransformixFilter.hxx
@@ -124,8 +124,7 @@ TransformixFilter<TMovingImage>::GenerateData(void)
   }
   else
   {
-    if (this->GetOutputDirectory()[this->GetOutputDirectory().size() - 1] != '/' &&
-        this->GetOutputDirectory()[this->GetOutputDirectory().size() - 1] != '\\')
+    if (this->GetOutputDirectory().back() != '/' && this->GetOutputDirectory().back() != '\\')
     {
       this->SetOutputDirectory(this->GetOutputDirectory() + "/");
     }

--- a/Core/Main/itkElastixRegistrationMethod.hxx
+++ b/Core/Main/itkElastixRegistrationMethod.hxx
@@ -151,7 +151,7 @@ ElastixRegistrationMethod<TFixedImage, TMovingImage>::GenerateData()
   }
 
   // Elastix must always write result image to guarantee that the ITK pipeline is in a consistent state
-  parameterMapVector[parameterMapVector.size() - 1]["WriteResultImage"] = ParameterValueVectorType(1, "true");
+  parameterMapVector.back()["WriteResultImage"] = ParameterValueVectorType(1, "true");
 
   // Setup argument map
   ArgumentMapType argumentMap;
@@ -189,8 +189,7 @@ ElastixRegistrationMethod<TFixedImage, TMovingImage>::GenerateData()
       itkExceptionMacro("Output directory \"" << this->GetOutputDirectory() << "\" does not exist.");
     }
 
-    if (this->GetOutputDirectory()[this->GetOutputDirectory().size() - 1] != '/' &&
-        this->GetOutputDirectory()[this->GetOutputDirectory().size() - 1] != '\\')
+    if (this->GetOutputDirectory().back() != '/' && this->GetOutputDirectory().back() != '\\')
     {
       this->SetOutputDirectory(this->GetOutputDirectory() + "/");
     }
@@ -286,8 +285,7 @@ ElastixRegistrationMethod<TFixedImage, TMovingImage>::GenerateData()
     }
 
     // TODO: Fix elastix corrupting default pixel value parameter
-    transformParameterMapVector[transformParameterMapVector.size() - 1]["DefaultPixelValue"] =
-      parameterMapVector[i]["DefaultPixelValue"];
+    transformParameterMapVector.back()["DefaultPixelValue"] = parameterMapVector[i]["DefaultPixelValue"];
   } // End loop over registrations
 
   // Save result image

--- a/Core/Main/itkTransformixFilter.hxx
+++ b/Core/Main/itkTransformixFilter.hxx
@@ -136,8 +136,7 @@ TransformixFilter<TMovingImage>::GenerateData()
   }
   else
   {
-    if (this->GetOutputDirectory()[this->GetOutputDirectory().size() - 1] != '/' &&
-        this->GetOutputDirectory()[this->GetOutputDirectory().size() - 1] != '\\')
+    if (this->GetOutputDirectory().back() != '/' && this->GetOutputDirectory().back() != '\\')
     {
       this->SetOutputDirectory(this->GetOutputDirectory() + "/");
     }

--- a/Core/Main/transformix.cxx
+++ b/Core/Main/transformix.cxx
@@ -89,7 +89,7 @@ main(int argc, char ** argv)
     if (key == "-out")
     {
       /** Make sure that last character of the output folder equals a '/' or '\'. */
-      const char last = value[value.size() - 1];
+      const char last = value.back();
       if (last != '/' && last != '\\')
       {
         value.append("/");

--- a/Testing/itkCommandLineArgumentParser.cxx
+++ b/Testing/itkCommandLineArgumentParser.cxx
@@ -291,7 +291,7 @@ CommandLineArgumentParser ::CheckForRequiredArguments() const
       {
         std::cerr << exactlyOneOf[j] << ", ";
       }
-      std::cerr << exactlyOneOf[exactlyOneOf.size() - 1] << "} is required, but none or multiple are specified.\n  "
+      std::cerr << exactlyOneOf.back() << "} is required, but none or multiple are specified.\n  "
                 << this->m_RequiredExactlyOneArguments[i].second << std::endl;
 
       allRequiredArgumentsSpecified = false;


### PR DESCRIPTION
Improved code readability and simplicity by using `std` member function `back()`.