### PR TITLE
COMP: Fix  Clang dangling-gsl warning in LoadComponents (issue #355)

### DIFF
--- a/Core/Install/elxComponentLoader.cxx
+++ b/Core/Install/elxComponentLoader.cxx
@@ -128,7 +128,7 @@ ComponentLoader::InstallSupportedImageTypes(void)
  */
 
 int
-ComponentLoader::LoadComponents(const char * /** argv0 */)
+ComponentLoader::LoadComponents(void)
 {
   int installReturnCode = 0;
 

--- a/Core/Install/elxComponentLoader.h
+++ b/Core/Install/elxComponentLoader.h
@@ -59,10 +59,9 @@ public:
   itkSetObjectMacro(ComponentDatabase, ComponentDatabaseType);
   itkGetModifiableObjectMacro(ComponentDatabase, ComponentDatabaseType);
 
-  /** Function to load components. The argv0 used to be useful
-   * to find the program directory, but is not used anymore. */
-  virtual int
-  LoadComponents(const char * argv0);
+  /** Function to load components. */
+  int
+  LoadComponents(void);
 
   /** Function to unload components. */
   void

--- a/Core/Kernel/elxElastixMain.cxx
+++ b/Core/Kernel/elxElastixMain.cxx
@@ -756,11 +756,8 @@ ElastixMain::LoadComponents(void)
     this->s_ComponentLoader->SetComponentDatabase(s_CDB);
   }
 
-  /** Get the current program. */
-  const char * argv0 = this->m_Configuration->GetCommandLineArgument("-argv0").c_str();
-
   /** Load the components. */
-  return this->s_ComponentLoader->LoadComponents(argv0);
+  return this->s_ComponentLoader->LoadComponents();
 
 } // end LoadComponents()
 


### PR DESCRIPTION
Removed `argv0` parameter from `ComponentLoader::LoadComponents`, as it is not used anymore. No longer passed a dangling pointer as `argv0` argument, fixing a Clang warning, reported by Matt McCormick:

> _deps/elx-src/Core/Kernel/elxElastixMain.cxx:791:7: warning: object backing the pointer will be destroyed at the end of the full-expression [-Wdangling-gsl]

At build "InsightSoftwareConsortium/ITKElastix-macos-10.15--refs/heads/transformix_extras"
https://open.cdash.org/viewBuildError.php?type=1&buildid=6869971

Thereby, fixed issue #355: ElastixMain LoadComponents - Clang warning "dangling-gsl"

Declared `ComponentLoader::LoadComponents` non-virtual, as it was not overridden anyway. Following C++ Core Guidelines (August 3, 2020), "C.132: Don't make a function virtual without reason", https://isocpp.github.io/CppCoreGuidelines/CppCoreGuidelines#Rh-virtual