### PR TITLE
TransformBase style improvements, mostly regarding WriteToFile(const ParametersType &)

### DIFF
--- a/Core/ComponentBaseClasses/elxTransformBase.hxx
+++ b/Core/ComponentBaseClasses/elxTransformBase.hxx
@@ -700,20 +700,16 @@ TransformBase<TElastix>::WriteToFile(const ParametersType & param) const
   transparOutput << "(MovingInternalImagePixelType \"" << movpix << "\")" << std::endl;
 
   /** Get the Size, Spacing and Origin of the fixed image. */
-  typedef typename FixedImageType::SizeType      FixedImageSizeType;
-  typedef typename FixedImageType::IndexType     FixedImageIndexType;
-  typedef typename FixedImageType::SpacingType   FixedImageSpacingType;
-  typedef typename FixedImageType::PointType     FixedImageOriginType;
-  typedef typename FixedImageType::DirectionType FixedImageDirectionType;
-  FixedImageSizeType    size = this->m_Elastix->GetFixedImage()->GetLargestPossibleRegion().GetSize();
-  FixedImageIndexType   index = this->m_Elastix->GetFixedImage()->GetLargestPossibleRegion().GetIndex();
-  FixedImageSpacingType spacing = this->m_Elastix->GetFixedImage()->GetSpacing();
-  FixedImageOriginType  origin = this->m_Elastix->GetFixedImage()->GetOrigin();
+  const auto size = this->m_Elastix->GetFixedImage()->GetLargestPossibleRegion().GetSize();
+  const auto index = this->m_Elastix->GetFixedImage()->GetLargestPossibleRegion().GetIndex();
+  const auto spacing = this->m_Elastix->GetFixedImage()->GetSpacing();
+  const auto origin = this->m_Elastix->GetFixedImage()->GetOrigin();
+
   /** The following line would be logically: */
   // FixedImageDirectionType direction =
   //  this->m_Elastix->GetFixedImage()->GetDirection();
   /** But to support the UseDirectionCosines option, we should do it like this: */
-  FixedImageDirectionType direction;
+  typename FixedImageType::DirectionType direction;
   this->GetElastix()->GetOriginalFixedImageDirection(direction);
 
   /** Write image Size. */
@@ -883,20 +879,15 @@ TransformBase<TElastix>::CreateTransformParametersMap(const ParametersType & par
   parameterValues.clear();
 
   /** Get the Size, Spacing and Origin of the fixed image. */
-  typedef typename FixedImageType::SizeType      FixedImageSizeType;
-  typedef typename FixedImageType::IndexType     FixedImageIndexType;
-  typedef typename FixedImageType::SpacingType   FixedImageSpacingType;
-  typedef typename FixedImageType::PointType     FixedImageOriginType;
-  typedef typename FixedImageType::DirectionType FixedImageDirectionType;
-  FixedImageSizeType    size = this->m_Elastix->GetFixedImage()->GetLargestPossibleRegion().GetSize();
-  FixedImageIndexType   index = this->m_Elastix->GetFixedImage()->GetLargestPossibleRegion().GetIndex();
-  FixedImageSpacingType spacing = this->m_Elastix->GetFixedImage()->GetSpacing();
-  FixedImageOriginType  origin = this->m_Elastix->GetFixedImage()->GetOrigin();
+  const auto size = this->m_Elastix->GetFixedImage()->GetLargestPossibleRegion().GetSize();
+  const auto index = this->m_Elastix->GetFixedImage()->GetLargestPossibleRegion().GetIndex();
+  const auto spacing = this->m_Elastix->GetFixedImage()->GetSpacing();
+  const auto origin = this->m_Elastix->GetFixedImage()->GetOrigin();
   /** The following line would be logically: */
   // FixedImageDirectionType direction =
   //  this->m_Elastix->GetFixedImage()->GetDirection();
   /** But to support the UseDirectionCosines option, we should do it like this: */
-  FixedImageDirectionType direction;
+  typename FixedImageType::DirectionType direction;
   this->GetElastix()->GetOriginalFixedImageDirection(direction);
 
   /** Write image Size. */
@@ -1062,15 +1053,12 @@ TransformBase<TElastix>::TransformPointsSomePoints(const std::string filename) c
 {
   /** Typedef's. */
   typedef typename FixedImageType::RegionType                FixedImageRegionType;
-  typedef typename FixedImageType::PointType                 FixedImageOriginType;
-  typedef typename FixedImageType::SpacingType               FixedImageSpacingType;
   typedef typename FixedImageType::IndexType                 FixedImageIndexType;
   typedef typename FixedImageIndexType::IndexValueType       FixedImageIndexValueType;
   typedef typename MovingImageType::IndexType                MovingImageIndexType;
   typedef typename MovingImageIndexType::IndexValueType      MovingImageIndexValueType;
   typedef itk::ContinuousIndex<double, FixedImageDimension>  FixedImageContinuousIndexType;
   typedef itk::ContinuousIndex<double, MovingImageDimension> MovingImageContinuousIndexType;
-  typedef typename FixedImageType::DirectionType             FixedImageDirectionType;
 
   typedef unsigned char DummyIPPPixelType;
   typedef itk::DefaultStaticMeshTraits<DummyIPPPixelType, FixedImageDimension, FixedImageDimension, CoordRepType>
@@ -1122,10 +1110,10 @@ TransformBase<TElastix>::TransformPointsSomePoints(const std::string filename) c
    * which we can use to convert between points and indices.
    * By taking the image from the resampler output, the UseDirectionCosines
    * parameter is automatically taken into account. */
-  FixedImageRegionType    region;
-  FixedImageOriginType    origin = this->m_Elastix->GetElxResamplerBase()->GetAsITKBaseType()->GetOutputOrigin();
-  FixedImageSpacingType   spacing = this->m_Elastix->GetElxResamplerBase()->GetAsITKBaseType()->GetOutputSpacing();
-  FixedImageDirectionType direction = this->m_Elastix->GetElxResamplerBase()->GetAsITKBaseType()->GetOutputDirection();
+  FixedImageRegionType region;
+  const auto           origin = this->m_Elastix->GetElxResamplerBase()->GetAsITKBaseType()->GetOutputOrigin();
+  const auto           spacing = this->m_Elastix->GetElxResamplerBase()->GetAsITKBaseType()->GetOutputSpacing();
+  const auto           direction = this->m_Elastix->GetElxResamplerBase()->GetAsITKBaseType()->GetOutputDirection();
   region.SetIndex(this->m_Elastix->GetElxResamplerBase()->GetAsITKBaseType()->GetOutputStartIndex());
   region.SetSize(this->m_Elastix->GetElxResamplerBase()->GetAsITKBaseType()->GetSize());
 

--- a/Core/ComponentBaseClasses/elxTransformBase.hxx
+++ b/Core/ComponentBaseClasses/elxTransformBase.hxx
@@ -372,7 +372,7 @@ TransformBase<TElastix>::ReadFromFile(void)
     {
       std::string dataFileName = "";
       this->m_Configuration->ReadParameter(dataFileName, "TransformParameters", 0);
-      std::ifstream infile(dataFileName.c_str(), std::ios::in | std::ios::binary);
+      std::ifstream infile(dataFileName, std::ios_base::binary);
       infile.read(reinterpret_cast<char *>(this->m_TransformParametersPointer->data_block()),
                   sizeof(ValueType) * numberOfParameters);
       numberOfParametersFound = infile.gcount() / sizeof(ValueType); // for sanity check
@@ -637,7 +637,7 @@ TransformBase<TElastix>::WriteToFile(const ParametersType & param) const
       dataFileName += ".dat";
       xout["transpar"] << "(TransformParameters \"" << dataFileName << "\")" << std::endl;
 
-      std::ofstream outfile(dataFileName.c_str(), ios::out | ios::binary);
+      std::ofstream outfile(dataFileName, std::ios_base::binary);
       outfile.write(reinterpret_cast<const char *>(param.data_block()), sizeof(ValueType) * nrP);
       outfile.close();
     }
@@ -1214,7 +1214,7 @@ TransformBase<TElastix>::TransformPointsSomePoints(const std::string filename) c
   /** Create filename and file stream. */
   std::string outputPointsFileName = this->m_Configuration->GetCommandLineArgument("-out");
   outputPointsFileName += "outputpoints.txt";
-  std::ofstream outputPointsFile(outputPointsFileName.c_str());
+  std::ofstream outputPointsFile(outputPointsFileName);
   outputPointsFile << std::showpoint << std::fixed;
   elxout << "  The transformed points are saved in: " << outputPointsFileName << std::endl;
 

--- a/Core/ComponentBaseClasses/elxTransformBase.hxx
+++ b/Core/ComponentBaseClasses/elxTransformBase.hxx
@@ -658,15 +658,9 @@ TransformBase<TElastix>::WriteToFile(const ParametersType & param) const
                  << std::endl;
 
   /** Write the way the transform parameters are written. */
-  transparOutput << "(UseBinaryFormatForTransformationParameters ";
-  if (this->m_UseBinaryFormatForTransformationParameters)
-  {
-    transparOutput << "\"true\")" << std::endl;
-  }
-  else
-  {
-    transparOutput << "\"false\")" << std::endl;
-  }
+  transparOutput << "(UseBinaryFormatForTransformationParameters \""
+                 << BaseComponent::BoolToString(this->m_UseBinaryFormatForTransformationParameters) << "\")"
+                 << std::endl;
 
   /** Write the way Transforms are combined.
    *  Set it to the default "Compose" when no combination transform is used. */
@@ -766,12 +760,8 @@ TransformBase<TElastix>::WriteToFile(const ParametersType & param) const
   /** Write whether the direction cosines should be taken into account.
    * This parameter is written from elastix 4.203.
    */
-  std::string useDirectionCosinesBool = "false";
-  if (this->GetElastix()->GetUseDirectionCosines())
-  {
-    useDirectionCosinesBool = "true";
-  }
-  transparOutput << "(UseDirectionCosines \"" << useDirectionCosinesBool << "\")" << std::endl;
+  transparOutput << "(UseDirectionCosines \""
+                 << BaseComponent::BoolToString(this->GetElastix()->GetUseDirectionCosines()) << "\")" << std::endl;
 
 } // end WriteToFile()
 
@@ -959,13 +949,8 @@ TransformBase<TElastix>::CreateTransformParametersMap(const ParametersType & par
   /** Write whether the direction cosines should be taken into account.
    * This parameter is written from elastix 4.203.
    */
-  std::string useDirectionCosinesBool = "false";
-  if (this->GetElastix()->GetUseDirectionCosines())
-  {
-    useDirectionCosinesBool = "true";
-  }
   parameterName = "UseDirectionCosines";
-  parameterValues.push_back(useDirectionCosinesBool);
+  parameterValues.push_back(BaseComponent::BoolToString(this->GetElastix()->GetUseDirectionCosines()));
   paramsMap->insert(make_pair(parameterName, parameterValues));
   parameterValues.clear();
 

--- a/Core/ComponentBaseClasses/elxTransformBase.hxx
+++ b/Core/ComponentBaseClasses/elxTransformBase.hxx
@@ -616,16 +616,16 @@ template <class TElastix>
 void
 TransformBase<TElastix>::WriteToFile(const ParametersType & param) const
 {
-  using namespace xl;
+  auto & transparOutput = xl::get_xout()["transpar"];
 
   /** Write the name of this transform. */
-  xout["transpar"] << "(Transform \"" << this->elxGetClassName() << "\")" << std::endl;
+  transparOutput << "(Transform \"" << this->elxGetClassName() << "\")" << std::endl;
 
   /** Get the number of parameters of this transform. */
   const unsigned int nrP = param.GetSize();
 
   /** Write the number of parameters of this transform. */
-  xout["transpar"] << "(NumberOfParameters " << nrP << ")" << std::endl;
+  transparOutput << "(NumberOfParameters " << nrP << ")" << std::endl;
 
   /** Write the parameters of this transform. */
   if (this->m_ReadWriteTransformParameters)
@@ -635,7 +635,7 @@ TransformBase<TElastix>::WriteToFile(const ParametersType & param) const
       /** Writing in binary format is faster for large vectors, and slightly more accurate. */
       std::string dataFileName = this->GetTransformParametersFileName();
       dataFileName += ".dat";
-      xout["transpar"] << "(TransformParameters \"" << dataFileName << "\")" << std::endl;
+      transparOutput << "(TransformParameters \"" << dataFileName << "\")" << std::endl;
 
       std::ofstream outfile(dataFileName, std::ios_base::binary);
       outfile.write(reinterpret_cast<const char *>(param.data_block()), sizeof(ValueType) * nrP);
@@ -644,28 +644,28 @@ TransformBase<TElastix>::WriteToFile(const ParametersType & param) const
     else
     {
       /** In this case, write in a normal way to the parameter file. */
-      xout["transpar"] << "(TransformParameters ";
+      transparOutput << "(TransformParameters ";
       for (unsigned int i = 0; i < nrP - 1; i++)
       {
-        xout["transpar"] << param[i] << " ";
+        transparOutput << param[i] << " ";
       }
-      xout["transpar"] << param[nrP - 1] << ")" << std::endl;
+      transparOutput << param[nrP - 1] << ")" << std::endl;
     }
   }
 
   /** Write the name of the parameters-file of the initial transform. */
-  xout["transpar"] << "(InitialTransformParametersFileName \"" << this->GetInitialTransformParametersFileName() << "\")"
-                   << std::endl;
+  transparOutput << "(InitialTransformParametersFileName \"" << this->GetInitialTransformParametersFileName() << "\")"
+                 << std::endl;
 
   /** Write the way the transform parameters are written. */
-  xout["transpar"] << "(UseBinaryFormatForTransformationParameters ";
+  transparOutput << "(UseBinaryFormatForTransformationParameters ";
   if (this->m_UseBinaryFormatForTransformationParameters)
   {
-    xout["transpar"] << "\"true\")" << std::endl;
+    transparOutput << "\"true\")" << std::endl;
   }
   else
   {
-    xout["transpar"] << "\"false\")" << std::endl;
+    transparOutput << "\"false\")" << std::endl;
   }
 
   /** Write the way Transforms are combined.
@@ -680,24 +680,24 @@ TransformBase<TElastix>::WriteToFile(const ParametersType & param) const
     }
   }
 
-  xout["transpar"] << "(HowToCombineTransforms \"" << combinationMethod << "\")" << std::endl;
+  transparOutput << "(HowToCombineTransforms \"" << combinationMethod << "\")" << std::endl;
 
   /** Write image specific things. */
-  xout["transpar"] << std::endl << "// Image specific" << std::endl;
+  transparOutput << std::endl << "// Image specific" << std::endl;
 
   /** Write image dimensions. */
   unsigned int FixDim = FixedImageDimension;
   unsigned int MovDim = MovingImageDimension;
-  xout["transpar"] << "(FixedImageDimension " << FixDim << ")" << std::endl;
-  xout["transpar"] << "(MovingImageDimension " << MovDim << ")" << std::endl;
+  transparOutput << "(FixedImageDimension " << FixDim << ")" << std::endl;
+  transparOutput << "(MovingImageDimension " << MovDim << ")" << std::endl;
 
   /** Write image pixel types. */
   std::string fixpix = "float";
   std::string movpix = "float";
   this->m_Configuration->ReadParameter(fixpix, "FixedInternalImagePixelType", 0);
   this->m_Configuration->ReadParameter(movpix, "MovingInternalImagePixelType", 0);
-  xout["transpar"] << "(FixedInternalImagePixelType \"" << fixpix << "\")" << std::endl;
-  xout["transpar"] << "(MovingInternalImagePixelType \"" << movpix << "\")" << std::endl;
+  transparOutput << "(FixedInternalImagePixelType \"" << fixpix << "\")" << std::endl;
+  transparOutput << "(MovingInternalImagePixelType \"" << movpix << "\")" << std::endl;
 
   /** Get the Size, Spacing and Origin of the fixed image. */
   typedef typename FixedImageType::SizeType      FixedImageSizeType;
@@ -717,55 +717,55 @@ TransformBase<TElastix>::WriteToFile(const ParametersType & param) const
   this->GetElastix()->GetOriginalFixedImageDirection(direction);
 
   /** Write image Size. */
-  xout["transpar"] << "(Size ";
+  transparOutput << "(Size ";
   for (unsigned int i = 0; i < FixedImageDimension - 1; i++)
   {
-    xout["transpar"] << size[i] << " ";
+    transparOutput << size[i] << " ";
   }
-  xout["transpar"] << size[FixedImageDimension - 1] << ")" << std::endl;
+  transparOutput << size[FixedImageDimension - 1] << ")" << std::endl;
 
   /** Write image Index. */
-  xout["transpar"] << "(Index ";
+  transparOutput << "(Index ";
   for (unsigned int i = 0; i < FixedImageDimension - 1; i++)
   {
-    xout["transpar"] << index[i] << " ";
+    transparOutput << index[i] << " ";
   }
-  xout["transpar"] << index[FixedImageDimension - 1] << ")" << std::endl;
+  transparOutput << index[FixedImageDimension - 1] << ")" << std::endl;
 
   /** Set the precision of cout to 10, because Spacing and
    * Origin must have at least one digit precision.
    */
-  xout["transpar"] << std::setprecision(10);
+  transparOutput << std::setprecision(10);
 
   /** Write image Spacing. */
-  xout["transpar"] << "(Spacing ";
+  transparOutput << "(Spacing ";
   for (unsigned int i = 0; i < FixedImageDimension - 1; i++)
   {
-    xout["transpar"] << spacing[i] << " ";
+    transparOutput << spacing[i] << " ";
   }
-  xout["transpar"] << spacing[FixedImageDimension - 1] << ")" << std::endl;
+  transparOutput << spacing[FixedImageDimension - 1] << ")" << std::endl;
 
   /** Write image Origin. */
-  xout["transpar"] << "(Origin ";
+  transparOutput << "(Origin ";
   for (unsigned int i = 0; i < FixedImageDimension - 1; i++)
   {
-    xout["transpar"] << origin[i] << " ";
+    transparOutput << origin[i] << " ";
   }
-  xout["transpar"] << origin[FixedImageDimension - 1] << ")" << std::endl;
+  transparOutput << origin[FixedImageDimension - 1] << ")" << std::endl;
 
   /** Write direction cosines. */
-  xout["transpar"] << "(Direction";
+  transparOutput << "(Direction";
   for (unsigned int i = 0; i < FixedImageDimension; i++)
   {
     for (unsigned int j = 0; j < FixedImageDimension; j++)
     {
-      xout["transpar"] << " " << direction(j, i);
+      transparOutput << " " << direction(j, i);
     }
   }
-  xout["transpar"] << ")" << std::endl;
+  transparOutput << ")" << std::endl;
 
   /** Set the precision back to default value. */
-  xout["transpar"] << std::setprecision(this->m_Elastix->GetDefaultOutputPrecision());
+  transparOutput << std::setprecision(this->m_Elastix->GetDefaultOutputPrecision());
 
   /** Write whether the direction cosines should be taken into account.
    * This parameter is written from elastix 4.203.
@@ -775,7 +775,7 @@ TransformBase<TElastix>::WriteToFile(const ParametersType & param) const
   {
     useDirectionCosinesBool = "true";
   }
-  xout["transpar"] << "(UseDirectionCosines \"" << useDirectionCosinesBool << "\")" << std::endl;
+  transparOutput << "(UseDirectionCosines \"" << useDirectionCosinesBool << "\")" << std::endl;
 
 } // end WriteToFile()
 

--- a/Core/Install/elxBaseComponent.h
+++ b/Core/Install/elxBaseComponent.h
@@ -159,6 +159,13 @@ public:
   static std::string
   ConvertSecondsToDHMS(const double totalSeconds, const unsigned int precision);
 
+  /** Convenience function to convert a boolean to a text string. */
+  static constexpr const char *
+  BoolToString(const bool arg)
+  {
+    return arg ? "true" : "false";
+  }
+
 protected:
   BaseComponent() = default;
   virtual ~BaseComponent() = default;


### PR DESCRIPTION
Cleaning up the code, preparing to extend `TransformBase::WriteToFile(const ParametersType &)` to support other file formats (TFM, HDF5) 