### PR TITLE
ENH: specify required ITK components explicitly

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -22,8 +22,32 @@ include( CTest )
   #set( CMAKE_CXX_VISIBILITY_PRESET hidden )
 
 #---------------------------------------------------------------------
+option( ELASTIX_USE_OPENCL "Use OpenCL enabled GPU" OFF )
+set(_GPU_depends "")
+if(ELASTIX_USE_OPENCL)
+  list(APPEND _GPU_depends ITKGPUCommon)
+endif()
+
 # Find ITK.
-find_package( ITK 5.1.1 REQUIRED )
+find_package( ITK 5.1.1 REQUIRED COMPONENTS
+    ITKCommon
+    ITKDistanceMap
+    ITKImageGrid
+    ITKImageIntensity
+    ITKIOImageBase
+    ITKIOMeshBase
+    ITKIOMeshOBJ
+    ITKIOMeta
+    ITKIOXML
+    ITKMathematicalMorphology
+    ITKOptimizers
+    ITKRegistrationCommon
+    ITKSmoothing
+    ITKTestKernel
+    ITKThresholding
+    ITKTransform
+    ${_GPU_depends}
+    )
 include( ${ITK_USE_FILE} )
 
 #---------------------------------------------------------------------
@@ -40,8 +64,6 @@ include(elastixExportTarget)
 
 #---------------------------------------------------------------------
 # Find OpenCL.
-option( ELASTIX_USE_OPENCL "Use OpenCL enabled GPU" OFF )
-
 if( ELASTIX_USE_OPENCL )
   find_package( OpenCL REQUIRED QUIET )
 

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -31,21 +31,32 @@ endif()
 # Find ITK.
 find_package( ITK 5.1.1 REQUIRED COMPONENTS
     ITKCommon
+    ITKDisplacementField
     ITKDistanceMap
+    ITKGDCM
+    ITKImageCompose
+    ITKImageFunction
+    ITKImageGradient
     ITKImageGrid
     ITKImageIntensity
+    ITKImageStatistics
     ITKIOImageBase
     ITKIOMeshBase
     ITKIOMeshOBJ
     ITKIOMeta
+    ITKIOTransformBase
     ITKIOXML
     ITKMathematicalMorphology
+    ITKMesh
     ITKOptimizers
     ITKRegistrationCommon
     ITKSmoothing
+    ITKSpatialObjects
+    ITKStatistics
     ITKTestKernel
     ITKThresholding
     ITKTransform
+    ITKTransformFactory
     ${_GPU_depends}
     )
 include( ${ITK_USE_FILE} )

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -58,6 +58,9 @@ find_package( ITK 5.1.1 REQUIRED COMPONENTS
     ITKTransform
     ITKTransformFactory
     ${_GPU_depends}
+    ITKImageIO
+    ITKTransformIO
+    ITKMeshIO
     )
 include( ${ITK_USE_FILE} )
 


### PR DESCRIPTION
This avoids circular dependency when building ITKElastix as part of ITK.