### PR TITLE
STYLE: Remove space between class and member names in C++ source files

### DIFF
--- a/Common/CostFunctions/itkScaledSingleValuedCostFunction.cxx
+++ b/Common/CostFunctions/itkScaledSingleValuedCostFunction.cxx
@@ -26,7 +26,7 @@ namespace itk
  * **************** Constructor *****************************
  */
 
-ScaledSingleValuedCostFunction ::ScaledSingleValuedCostFunction()
+ScaledSingleValuedCostFunction::ScaledSingleValuedCostFunction()
 {
   this->m_UnscaledCostFunction = nullptr;
   this->m_UseScales = false;
@@ -40,7 +40,7 @@ ScaledSingleValuedCostFunction ::ScaledSingleValuedCostFunction()
  */
 
 ScaledSingleValuedCostFunction::MeasureType
-ScaledSingleValuedCostFunction ::GetValue(const ParametersType & parameters) const
+ScaledSingleValuedCostFunction::GetValue(const ParametersType & parameters) const
 {
   /** F(y)= f(y/s) */
 
@@ -78,7 +78,7 @@ ScaledSingleValuedCostFunction ::GetValue(const ParametersType & parameters) con
  */
 
 void
-ScaledSingleValuedCostFunction ::GetDerivative(const ParametersType & parameters, DerivativeType & derivative) const
+ScaledSingleValuedCostFunction::GetDerivative(const ParametersType & parameters, DerivativeType & derivative) const
 {
   /** dF/dy(y)= 1/s * df/dx(y/s) */
 
@@ -119,7 +119,7 @@ ScaledSingleValuedCostFunction ::GetDerivative(const ParametersType & parameters
  */
 
 void
-ScaledSingleValuedCostFunction ::GetValueAndDerivative(const ParametersType & parameters,
+ScaledSingleValuedCostFunction::GetValueAndDerivative(const ParametersType & parameters,
                                                        MeasureType &          value,
                                                        DerivativeType &       derivative) const
 {
@@ -165,7 +165,7 @@ ScaledSingleValuedCostFunction ::GetValueAndDerivative(const ParametersType & pa
  */
 
 unsigned int
-ScaledSingleValuedCostFunction ::GetNumberOfParameters(void) const
+ScaledSingleValuedCostFunction::GetNumberOfParameters(void) const
 {
   if (this->m_UnscaledCostFunction.IsNull())
   {
@@ -181,7 +181,7 @@ ScaledSingleValuedCostFunction ::GetNumberOfParameters(void) const
  */
 
 void
-ScaledSingleValuedCostFunction ::SetScales(const ScalesType & scales)
+ScaledSingleValuedCostFunction::SetScales(const ScalesType & scales)
 {
   itkDebugMacro("setting scales to " << scales);
   this->m_Scales = scales;
@@ -200,7 +200,7 @@ ScaledSingleValuedCostFunction ::SetScales(const ScalesType & scales)
  */
 
 void
-ScaledSingleValuedCostFunction ::SetSquaredScales(const ScalesType & squaredScales)
+ScaledSingleValuedCostFunction::SetSquaredScales(const ScalesType & squaredScales)
 {
   itkDebugMacro("setting squared scales to " << squaredScales);
   this->m_SquaredScales = squaredScales;
@@ -219,7 +219,7 @@ ScaledSingleValuedCostFunction ::SetSquaredScales(const ScalesType & squaredScal
  */
 
 void
-ScaledSingleValuedCostFunction ::ConvertScaledToUnscaledParameters(ParametersType & parameters) const
+ScaledSingleValuedCostFunction::ConvertScaledToUnscaledParameters(ParametersType & parameters) const
 {
   if (this->m_UseScales)
   {
@@ -245,7 +245,7 @@ ScaledSingleValuedCostFunction ::ConvertScaledToUnscaledParameters(ParametersTyp
  */
 
 void
-ScaledSingleValuedCostFunction ::ConvertUnscaledToScaledParameters(ParametersType & parameters) const
+ScaledSingleValuedCostFunction::ConvertUnscaledToScaledParameters(ParametersType & parameters) const
 {
   if (this->m_UseScales)
   {
@@ -271,7 +271,7 @@ ScaledSingleValuedCostFunction ::ConvertUnscaledToScaledParameters(ParametersTyp
  */
 
 void
-ScaledSingleValuedCostFunction ::PrintSelf(std::ostream & os, Indent indent) const
+ScaledSingleValuedCostFunction::PrintSelf(std::ostream & os, Indent indent) const
 {
   /** Call the superclass' PrintSelf. */
   Superclass::PrintSelf(os, indent);

--- a/Common/LineSearchOptimizers/itkLineSearchOptimizer.cxx
+++ b/Common/LineSearchOptimizers/itkLineSearchOptimizer.cxx
@@ -26,7 +26,7 @@ namespace itk
  * ******************* Constructor *******************
  */
 
-LineSearchOptimizer ::LineSearchOptimizer()
+LineSearchOptimizer::LineSearchOptimizer()
 {
   this->m_CurrentStepLength = NumericTraits<double>::Zero;
   this->m_MinimumStepLength = NumericTraits<double>::Zero;
@@ -46,7 +46,7 @@ LineSearchOptimizer ::LineSearchOptimizer()
  */
 
 void
-LineSearchOptimizer ::SetCurrentStepLength(double step)
+LineSearchOptimizer::SetCurrentStepLength(double step)
 {
   itkDebugMacro("Setting current step length to " << step);
 
@@ -73,7 +73,7 @@ LineSearchOptimizer ::SetCurrentStepLength(double step)
  */
 
 double
-LineSearchOptimizer ::DirectionalDerivative(const DerivativeType & derivative) const
+LineSearchOptimizer::DirectionalDerivative(const DerivativeType & derivative) const
 {
   /** Easy, thanks to the functions defined in vnl_vector.h */
   return inner_product(derivative, this->GetLineSearchDirection());
@@ -86,7 +86,7 @@ LineSearchOptimizer ::DirectionalDerivative(const DerivativeType & derivative) c
  */
 
 void
-LineSearchOptimizer ::PrintSelf(std::ostream & os, Indent indent) const
+LineSearchOptimizer::PrintSelf(std::ostream & os, Indent indent) const
 {
   /** Call the superclass' PrintSelf. */
   Superclass::PrintSelf(os, indent);

--- a/Common/LineSearchOptimizers/itkMoreThuenteLineSearchOptimizer.cxx
+++ b/Common/LineSearchOptimizers/itkMoreThuenteLineSearchOptimizer.cxx
@@ -27,7 +27,7 @@ namespace itk
  * ****************** Constructor *****************************
  */
 
-MoreThuenteLineSearchOptimizer ::MoreThuenteLineSearchOptimizer()
+MoreThuenteLineSearchOptimizer::MoreThuenteLineSearchOptimizer()
 {
   this->m_f = NumericTraits<MeasureType>::Zero;
   this->m_dg = 0.0;
@@ -50,7 +50,7 @@ MoreThuenteLineSearchOptimizer ::MoreThuenteLineSearchOptimizer()
  */
 
 void
-MoreThuenteLineSearchOptimizer ::SetInitialValue(MeasureType value)
+MoreThuenteLineSearchOptimizer::SetInitialValue(MeasureType value)
 {
   this->m_InitialValueProvided = true;
   this->m_f = value;
@@ -64,7 +64,7 @@ MoreThuenteLineSearchOptimizer ::SetInitialValue(MeasureType value)
  */
 
 void
-MoreThuenteLineSearchOptimizer ::SetInitialDerivative(const DerivativeType & derivative)
+MoreThuenteLineSearchOptimizer::SetInitialDerivative(const DerivativeType & derivative)
 {
   this->m_InitialDerivativeProvided = true;
   this->m_g = derivative;
@@ -78,7 +78,7 @@ MoreThuenteLineSearchOptimizer ::SetInitialDerivative(const DerivativeType & der
  */
 
 void
-MoreThuenteLineSearchOptimizer ::GetCurrentValueAndDerivative(MeasureType & value, DerivativeType & derivative) const
+MoreThuenteLineSearchOptimizer::GetCurrentValueAndDerivative(MeasureType & value, DerivativeType & derivative) const
 {
   value = m_f;
   derivative = m_g;
@@ -91,7 +91,7 @@ MoreThuenteLineSearchOptimizer ::GetCurrentValueAndDerivative(MeasureType & valu
  */
 
 void
-MoreThuenteLineSearchOptimizer ::GetCurrentDerivative(DerivativeType & derivative) const
+MoreThuenteLineSearchOptimizer::GetCurrentDerivative(DerivativeType & derivative) const
 {
   derivative = m_g;
 
@@ -103,7 +103,7 @@ MoreThuenteLineSearchOptimizer ::GetCurrentDerivative(DerivativeType & derivativ
  */
 
 MoreThuenteLineSearchOptimizer::MeasureType
-MoreThuenteLineSearchOptimizer ::GetCurrentValue(void) const
+MoreThuenteLineSearchOptimizer::GetCurrentValue(void) const
 {
   return m_f;
 
@@ -115,7 +115,7 @@ MoreThuenteLineSearchOptimizer ::GetCurrentValue(void) const
  */
 
 double
-MoreThuenteLineSearchOptimizer ::GetCurrentDirectionalDerivative(void) const
+MoreThuenteLineSearchOptimizer::GetCurrentDirectionalDerivative(void) const
 {
   return m_dg;
 
@@ -127,7 +127,7 @@ MoreThuenteLineSearchOptimizer ::GetCurrentDirectionalDerivative(void) const
  */
 
 void
-MoreThuenteLineSearchOptimizer ::StartOptimization(void)
+MoreThuenteLineSearchOptimizer::StartOptimization(void)
 {
   this->CheckSettings();
 
@@ -175,7 +175,7 @@ MoreThuenteLineSearchOptimizer ::StartOptimization(void)
  */
 
 void
-MoreThuenteLineSearchOptimizer ::StopOptimization(void)
+MoreThuenteLineSearchOptimizer::StopOptimization(void)
 {
   this->m_Stop = true;
   this->InvokeEvent(EndEvent());
@@ -188,7 +188,7 @@ MoreThuenteLineSearchOptimizer ::StopOptimization(void)
  */
 
 int
-MoreThuenteLineSearchOptimizer ::CheckSettings(void)
+MoreThuenteLineSearchOptimizer::CheckSettings(void)
 {
   if (this->GetCostFunction() == nullptr)
   {
@@ -231,7 +231,7 @@ MoreThuenteLineSearchOptimizer ::CheckSettings(void)
  */
 
 void
-MoreThuenteLineSearchOptimizer ::GetInitialValueAndDerivative(void)
+MoreThuenteLineSearchOptimizer::GetInitialValueAndDerivative(void)
 {
 
   if (!(this->m_InitialValueProvided && this->m_InitialDerivativeProvided))
@@ -283,7 +283,7 @@ MoreThuenteLineSearchOptimizer ::GetInitialValueAndDerivative(void)
  */
 
 void
-MoreThuenteLineSearchOptimizer ::InitializeLineSearch(void)
+MoreThuenteLineSearchOptimizer::InitializeLineSearch(void)
 {
   this->m_Stop = false;
   this->m_StopCondition = Unknown;
@@ -321,7 +321,7 @@ MoreThuenteLineSearchOptimizer ::InitializeLineSearch(void)
  */
 
 void
-MoreThuenteLineSearchOptimizer ::UpdateIntervalMinimumAndMaximum(void)
+MoreThuenteLineSearchOptimizer::UpdateIntervalMinimumAndMaximum(void)
 {
   const double xtrapf = 4.0;
 
@@ -347,7 +347,7 @@ MoreThuenteLineSearchOptimizer ::UpdateIntervalMinimumAndMaximum(void)
  */
 
 void
-MoreThuenteLineSearchOptimizer ::BoundStep(double & step) const
+MoreThuenteLineSearchOptimizer::BoundStep(double & step) const
 {
   step = std::max(step, this->GetMinimumStepLength());
   step = std::min(step, this->GetMaximumStepLength());
@@ -363,7 +363,7 @@ MoreThuenteLineSearchOptimizer ::BoundStep(double & step) const
  */
 
 void
-MoreThuenteLineSearchOptimizer ::PrepareForUnusualTermination(void)
+MoreThuenteLineSearchOptimizer::PrepareForUnusualTermination(void)
 {
   if ((this->m_brackt && (this->m_step <= this->m_stepmin || this->m_step >= this->m_stepmax)) ||
       this->m_CurrentIteration >= this->GetMaximumNumberOfIterations() - 1 || this->m_SafeGuardedStepFailed ||
@@ -382,7 +382,7 @@ MoreThuenteLineSearchOptimizer ::PrepareForUnusualTermination(void)
  */
 
 void
-MoreThuenteLineSearchOptimizer ::ComputeCurrentValueAndDerivative(void)
+MoreThuenteLineSearchOptimizer::ComputeCurrentValueAndDerivative(void)
 {
   try
   {
@@ -405,7 +405,7 @@ MoreThuenteLineSearchOptimizer ::ComputeCurrentValueAndDerivative(void)
  */
 
 void
-MoreThuenteLineSearchOptimizer ::TestConvergence(bool & stop)
+MoreThuenteLineSearchOptimizer::TestConvergence(bool & stop)
 {
   stop = false;
   const double & step = this->m_step;
@@ -463,7 +463,7 @@ MoreThuenteLineSearchOptimizer ::TestConvergence(bool & stop)
  */
 
 void
-MoreThuenteLineSearchOptimizer ::ComputeNewStepAndInterval(void)
+MoreThuenteLineSearchOptimizer::ComputeNewStepAndInterval(void)
 {
   int returncode = 0;
 
@@ -549,7 +549,7 @@ MoreThuenteLineSearchOptimizer ::ComputeNewStepAndInterval(void)
  */
 
 void
-MoreThuenteLineSearchOptimizer ::ForceSufficientDecreaseInIntervalWidth(void)
+MoreThuenteLineSearchOptimizer::ForceSufficientDecreaseInIntervalWidth(void)
 {
   if (this->m_brackt)
   {
@@ -575,7 +575,7 @@ MoreThuenteLineSearchOptimizer ::ForceSufficientDecreaseInIntervalWidth(void)
  */
 
 int
-MoreThuenteLineSearchOptimizer ::SafeGuardedStep(double &       stx,
+MoreThuenteLineSearchOptimizer::SafeGuardedStep(double &       stx,
                                                  double &       fx,
                                                  double &       dx,
                                                  double &       sty,
@@ -895,7 +895,7 @@ MoreThuenteLineSearchOptimizer ::SafeGuardedStep(double &       stx,
  */
 
 void
-MoreThuenteLineSearchOptimizer ::PrintSelf(std::ostream & os, Indent indent) const
+MoreThuenteLineSearchOptimizer::PrintSelf(std::ostream & os, Indent indent) const
 {
   /** Call the superclass' PrintSelf. */
   Superclass::PrintSelf(os, indent);

--- a/Common/MevisDicomTiff/itkMevisDicomTiffImageIOFactory.cxx
+++ b/Common/MevisDicomTiff/itkMevisDicomTiffImageIOFactory.cxx
@@ -23,7 +23,7 @@
 namespace itk
 {
 
-MevisDicomTiffImageIOFactory ::MevisDicomTiffImageIOFactory()
+MevisDicomTiffImageIOFactory::MevisDicomTiffImageIOFactory()
 {
   this->RegisterOverride("itkImageIOBase",
                          "itkMevisDicomTiffImageIO",
@@ -36,14 +36,14 @@ MevisDicomTiffImageIOFactory ::MevisDicomTiffImageIOFactory()
 MevisDicomTiffImageIOFactory ::~MevisDicomTiffImageIOFactory() {}
 
 const char *
-MevisDicomTiffImageIOFactory ::GetITKSourceVersion(void) const
+MevisDicomTiffImageIOFactory::GetITKSourceVersion(void) const
 {
   return ITK_SOURCE_VERSION;
 }
 
 
 const char *
-MevisDicomTiffImageIOFactory ::GetDescription(void) const
+MevisDicomTiffImageIOFactory::GetDescription(void) const
 {
   return "Mevis Dicom/TIFF ImageIO Factory, allows the loading of Mevis images into insight";
 }

--- a/Common/ParameterFileParser/itkParameterFileParser.cxx
+++ b/Common/ParameterFileParser/itkParameterFileParser.cxx
@@ -30,7 +30,7 @@ namespace itk
  * **************** Constructor ***************
  */
 
-ParameterFileParser ::ParameterFileParser() = default;
+ParameterFileParser::ParameterFileParser() = default;
 
 
 /**
@@ -45,7 +45,7 @@ ParameterFileParser ::~ParameterFileParser() = default;
  */
 
 const ParameterFileParser::ParameterMapType &
-ParameterFileParser ::GetParameterMap(void) const
+ParameterFileParser::GetParameterMap(void) const
 {
   return this->m_ParameterMap;
 
@@ -57,7 +57,7 @@ ParameterFileParser ::GetParameterMap(void) const
  */
 
 void
-ParameterFileParser ::ReadParameterFile(void)
+ParameterFileParser::ReadParameterFile(void)
 {
   /** Perform some basic checks. */
   this->BasicFileChecking();
@@ -101,7 +101,7 @@ ParameterFileParser ::ReadParameterFile(void)
  */
 
 void
-ParameterFileParser ::BasicFileChecking(void) const
+ParameterFileParser::BasicFileChecking(void) const
 {
   /** Check if the file name is given. */
   if (this->m_ParameterFileName.empty())
@@ -138,7 +138,7 @@ ParameterFileParser ::BasicFileChecking(void) const
  */
 
 bool
-ParameterFileParser ::CheckLine(const std::string & lineIn, std::string & lineOut) const
+ParameterFileParser::CheckLine(const std::string & lineIn, std::string & lineOut) const
 {
   /** Preprocessing of lineIn:
    * 1) Replace tabs with spaces
@@ -226,7 +226,7 @@ ParameterFileParser ::CheckLine(const std::string & lineIn, std::string & lineOu
  */
 
 void
-ParameterFileParser ::GetParameterFromLine(const std::string & fullLine, const std::string & line)
+ParameterFileParser::GetParameterFromLine(const std::string & fullLine, const std::string & line)
 {
   /** A line has a parameter name followed by one or more parameters.
    * They are all separated by one or more spaces (all tabs have been
@@ -296,7 +296,7 @@ ParameterFileParser ::GetParameterFromLine(const std::string & fullLine, const s
  */
 
 void
-ParameterFileParser ::SplitLine(const std::string &        fullLine,
+ParameterFileParser::SplitLine(const std::string &        fullLine,
                                 const std::string &        line,
                                 std::vector<std::string> & splittedLine) const
 {
@@ -357,7 +357,7 @@ ParameterFileParser ::SplitLine(const std::string &        fullLine,
  */
 
 void
-ParameterFileParser ::ThrowException(const std::string & line, const std::string & hint) const
+ParameterFileParser::ThrowException(const std::string & line, const std::string & hint) const
 {
   /** Construct an error message. */
   const std::string errorMessage = "ERROR: the following line in your parameter file is invalid: \n\"" + line + "\"\n" +
@@ -374,7 +374,7 @@ ParameterFileParser ::ThrowException(const std::string & line, const std::string
  */
 
 std::string
-ParameterFileParser ::ReturnParameterFileAsString(void)
+ParameterFileParser::ReturnParameterFileAsString(void)
 {
   /** Perform some basic checks. */
   this->BasicFileChecking();

--- a/Common/ParameterFileParser/itkParameterMapInterface.cxx
+++ b/Common/ParameterFileParser/itkParameterMapInterface.cxx
@@ -25,7 +25,7 @@ namespace itk
  * **************** Constructor ***************
  */
 
-ParameterMapInterface ::ParameterMapInterface()
+ParameterMapInterface::ParameterMapInterface()
 {
   this->m_ParameterMap.clear();
   this->m_PrintErrorMessages = true;
@@ -48,7 +48,7 @@ ParameterMapInterface ::~ParameterMapInterface()
  */
 
 void
-ParameterMapInterface ::SetParameterMap(const ParameterMapType & parMap)
+ParameterMapInterface::SetParameterMap(const ParameterMapType & parMap)
 {
   if (!parMap.empty())
   {
@@ -63,7 +63,7 @@ ParameterMapInterface ::SetParameterMap(const ParameterMapType & parMap)
  */
 
 std::size_t
-ParameterMapInterface ::CountNumberOfParameterEntries(const std::string & parameterName) const
+ParameterMapInterface::CountNumberOfParameterEntries(const std::string & parameterName) const
 {
   if (this->m_ParameterMap.count(parameterName))
   {
@@ -79,7 +79,7 @@ ParameterMapInterface ::CountNumberOfParameterEntries(const std::string & parame
  */
 
 bool
-ParameterMapInterface ::ReadParameter(bool &              parameterValue,
+ParameterMapInterface::ReadParameter(bool &              parameterValue,
                                       const std::string & parameterName,
                                       const unsigned int  entry_nr,
                                       const bool          printThisErrorMessage,
@@ -130,7 +130,7 @@ ParameterMapInterface ::ReadParameter(bool &              parameterValue,
  */
 
 bool
-ParameterMapInterface ::StringCast(const std::string & parameterValue, std::string & casted) const
+ParameterMapInterface::StringCast(const std::string & parameterValue, std::string & casted) const
 {
   casted = parameterValue;
   return true;
@@ -142,7 +142,7 @@ ParameterMapInterface ::StringCast(const std::string & parameterValue, std::stri
  */
 
 bool
-ParameterMapInterface ::ReadParameter(std::vector<std::string> & parameterValues,
+ParameterMapInterface::ReadParameter(std::vector<std::string> & parameterValues,
                                       const std::string &        parameterName,
                                       const unsigned int         entry_nr_start,
                                       const unsigned int         entry_nr_end,

--- a/Common/itkScaledSingleValuedNonLinearOptimizer.cxx
+++ b/Common/itkScaledSingleValuedNonLinearOptimizer.cxx
@@ -25,7 +25,7 @@ namespace itk
  * ****************** Constructor *********************************
  */
 
-ScaledSingleValuedNonLinearOptimizer ::ScaledSingleValuedNonLinearOptimizer()
+ScaledSingleValuedNonLinearOptimizer::ScaledSingleValuedNonLinearOptimizer()
 {
   this->m_Maximize = false;
   this->m_ScaledCostFunction = ScaledCostFunctionType::New();
@@ -38,7 +38,7 @@ ScaledSingleValuedNonLinearOptimizer ::ScaledSingleValuedNonLinearOptimizer()
  */
 
 void
-ScaledSingleValuedNonLinearOptimizer ::InitializeScales(void)
+ScaledSingleValuedNonLinearOptimizer::InitializeScales(void)
 {
   /** NB: we assume the scales entered by the user are meant
    * as squared scales (following the ITK convention)!
@@ -54,7 +54,7 @@ ScaledSingleValuedNonLinearOptimizer ::InitializeScales(void)
  */
 
 void
-ScaledSingleValuedNonLinearOptimizer ::SetCostFunction(CostFunctionType * costFunction)
+ScaledSingleValuedNonLinearOptimizer::SetCostFunction(CostFunctionType * costFunction)
 {
   this->m_ScaledCostFunction->SetUnscaledCostFunction(costFunction);
   this->Superclass::SetCostFunction(costFunction);
@@ -67,7 +67,7 @@ ScaledSingleValuedNonLinearOptimizer ::SetCostFunction(CostFunctionType * costFu
  */
 
 void
-ScaledSingleValuedNonLinearOptimizer ::SetUseScales(bool arg)
+ScaledSingleValuedNonLinearOptimizer::SetUseScales(bool arg)
 {
   this->m_ScaledCostFunction->SetUseScales(arg);
   this->Modified();
@@ -80,7 +80,7 @@ ScaledSingleValuedNonLinearOptimizer ::SetUseScales(bool arg)
  */
 
 bool
-ScaledSingleValuedNonLinearOptimizer ::GetUseScales(void) const
+ScaledSingleValuedNonLinearOptimizer::GetUseScales(void) const
 {
   return this->m_ScaledCostFunction->GetUseScales();
 
@@ -92,7 +92,7 @@ ScaledSingleValuedNonLinearOptimizer ::GetUseScales(void) const
  */
 
 ScaledSingleValuedNonLinearOptimizer::MeasureType
-ScaledSingleValuedNonLinearOptimizer ::GetScaledValue(const ParametersType & parameters) const
+ScaledSingleValuedNonLinearOptimizer::GetScaledValue(const ParametersType & parameters) const
 {
   return this->m_ScaledCostFunction->GetValue(parameters);
 
@@ -104,7 +104,7 @@ ScaledSingleValuedNonLinearOptimizer ::GetScaledValue(const ParametersType & par
  */
 
 void
-ScaledSingleValuedNonLinearOptimizer ::GetScaledDerivative(const ParametersType & parameters,
+ScaledSingleValuedNonLinearOptimizer::GetScaledDerivative(const ParametersType & parameters,
                                                            DerivativeType &       derivative) const
 {
   this->m_ScaledCostFunction->GetDerivative(parameters, derivative);
@@ -117,7 +117,7 @@ ScaledSingleValuedNonLinearOptimizer ::GetScaledDerivative(const ParametersType 
  */
 
 void
-ScaledSingleValuedNonLinearOptimizer ::GetScaledValueAndDerivative(const ParametersType & parameters,
+ScaledSingleValuedNonLinearOptimizer::GetScaledValueAndDerivative(const ParametersType & parameters,
                                                                    MeasureType &          value,
                                                                    DerivativeType &       derivative) const
 {
@@ -131,7 +131,7 @@ ScaledSingleValuedNonLinearOptimizer ::GetScaledValueAndDerivative(const Paramet
  */
 
 const ScaledSingleValuedNonLinearOptimizer::ParametersType &
-ScaledSingleValuedNonLinearOptimizer ::GetCurrentPosition(void) const
+ScaledSingleValuedNonLinearOptimizer::GetCurrentPosition(void) const
 {
   /** Get the current unscaled position. */
   const ParametersType & scaledCurrentPosition = this->GetScaledCurrentPosition();
@@ -161,7 +161,7 @@ ScaledSingleValuedNonLinearOptimizer ::GetCurrentPosition(void) const
  */
 
 void
-ScaledSingleValuedNonLinearOptimizer ::SetScaledCurrentPosition(const ParametersType & parameters)
+ScaledSingleValuedNonLinearOptimizer::SetScaledCurrentPosition(const ParametersType & parameters)
 {
   itkDebugMacro("setting scaled current position to " << parameters);
   this->m_ScaledCurrentPosition = parameters; // slow copy
@@ -175,7 +175,7 @@ ScaledSingleValuedNonLinearOptimizer ::SetScaledCurrentPosition(const Parameters
  */
 
 void
-ScaledSingleValuedNonLinearOptimizer ::SetCurrentPosition(const ParametersType & param)
+ScaledSingleValuedNonLinearOptimizer::SetCurrentPosition(const ParametersType & param)
 {
   /** Multiply the argument by the scales and set it as the
    * the ScaledCurrentPosition.
@@ -199,7 +199,7 @@ ScaledSingleValuedNonLinearOptimizer ::SetCurrentPosition(const ParametersType &
  */
 
 void
-ScaledSingleValuedNonLinearOptimizer ::SetMaximize(bool _arg)
+ScaledSingleValuedNonLinearOptimizer::SetMaximize(bool _arg)
 {
   itkDebugMacro("Setting Maximize to " << _arg);
   if (this->m_Maximize != _arg)
@@ -216,7 +216,7 @@ ScaledSingleValuedNonLinearOptimizer ::SetMaximize(bool _arg)
  */
 
 void
-ScaledSingleValuedNonLinearOptimizer ::PrintSelf(std::ostream & os, Indent indent) const
+ScaledSingleValuedNonLinearOptimizer::PrintSelf(std::ostream & os, Indent indent) const
 {
   /** Call the superclass' PrintSelf. */
   Superclass::PrintSelf(os, indent);

--- a/Components/Optimizers/AdaGrad/itkAdaptiveStepsizeOptimizer.cxx
+++ b/Components/Optimizers/AdaGrad/itkAdaptiveStepsizeOptimizer.cxx
@@ -28,7 +28,7 @@ namespace itk
  * ************************* Constructor ************************
  */
 
-AdaptiveStepsizeOptimizer ::AdaptiveStepsizeOptimizer()
+AdaptiveStepsizeOptimizer::AdaptiveStepsizeOptimizer()
 {
   this->m_UseAdaptiveStepSizes = true;
   this->m_SigmoidMax = 1.0;
@@ -43,7 +43,7 @@ AdaptiveStepsizeOptimizer ::AdaptiveStepsizeOptimizer()
  */
 
 void
-AdaptiveStepsizeOptimizer ::UpdateCurrentTime(void)
+AdaptiveStepsizeOptimizer::UpdateCurrentTime(void)
 {
   typedef itk::Functor::Sigmoid<double, double> SigmoidType;
 

--- a/Components/Optimizers/AdaptiveStochasticGradientDescent/itkAdaptiveStochasticGradientDescentOptimizer.cxx
+++ b/Components/Optimizers/AdaptiveStochasticGradientDescent/itkAdaptiveStochasticGradientDescentOptimizer.cxx
@@ -28,7 +28,7 @@ namespace itk
  * ************************* Constructor ************************
  */
 
-AdaptiveStochasticGradientDescentOptimizer ::AdaptiveStochasticGradientDescentOptimizer()
+AdaptiveStochasticGradientDescentOptimizer::AdaptiveStochasticGradientDescentOptimizer()
 {
   this->m_UseAdaptiveStepSizes = true;
   this->m_SigmoidMax = 1.0;
@@ -43,7 +43,7 @@ AdaptiveStochasticGradientDescentOptimizer ::AdaptiveStochasticGradientDescentOp
  */
 
 void
-AdaptiveStochasticGradientDescentOptimizer ::UpdateCurrentTime(void)
+AdaptiveStochasticGradientDescentOptimizer::UpdateCurrentTime(void)
 {
   typedef itk::Functor::Sigmoid<double, double> SigmoidType;
 

--- a/Components/Optimizers/AdaptiveStochasticLBFGS/itkAdaptiveStochasticLBFGSOptimizer.cxx
+++ b/Components/Optimizers/AdaptiveStochasticLBFGS/itkAdaptiveStochasticLBFGSOptimizer.cxx
@@ -28,7 +28,7 @@ namespace itk
  * ************************* Constructor ************************
  */
 
-AdaptiveStochasticLBFGSOptimizer ::AdaptiveStochasticLBFGSOptimizer()
+AdaptiveStochasticLBFGSOptimizer::AdaptiveStochasticLBFGSOptimizer()
 {
   this->m_UseAdaptiveStepSizes = true;
   this->m_SigmoidMax = 1.0;
@@ -44,7 +44,7 @@ AdaptiveStochasticLBFGSOptimizer ::AdaptiveStochasticLBFGSOptimizer()
  */
 
 void
-AdaptiveStochasticLBFGSOptimizer ::UpdateCurrentTime(void)
+AdaptiveStochasticLBFGSOptimizer::UpdateCurrentTime(void)
 {
   typedef itk::Functor::Sigmoid<double, double> SigmoidType;
 

--- a/Components/Optimizers/AdaptiveStochasticVarianceReducedGradient/itkAdaptiveStochasticVarianceReducedGradientOptimizer.cxx
+++ b/Components/Optimizers/AdaptiveStochasticVarianceReducedGradient/itkAdaptiveStochasticVarianceReducedGradientOptimizer.cxx
@@ -28,7 +28,7 @@ namespace itk
  * ************************* Constructor ************************
  */
 
-AdaptiveStochasticVarianceReducedGradientOptimizer ::AdaptiveStochasticVarianceReducedGradientOptimizer()
+AdaptiveStochasticVarianceReducedGradientOptimizer::AdaptiveStochasticVarianceReducedGradientOptimizer()
 {
   this->m_UseAdaptiveStepSizes = true;
   this->m_SigmoidMax = 1.0;
@@ -43,7 +43,7 @@ AdaptiveStochasticVarianceReducedGradientOptimizer ::AdaptiveStochasticVarianceR
  */
 
 void
-AdaptiveStochasticVarianceReducedGradientOptimizer ::UpdateCurrentTime(void)
+AdaptiveStochasticVarianceReducedGradientOptimizer::UpdateCurrentTime(void)
 {
   typedef itk::Functor::Sigmoid<double, double> SigmoidType;
 

--- a/Components/Optimizers/AdaptiveStochasticVarianceReducedGradient/itkStandardStochasticVarianceReducedGradientDescentOptimizer.cxx
+++ b/Components/Optimizers/AdaptiveStochasticVarianceReducedGradient/itkStandardStochasticVarianceReducedGradientDescentOptimizer.cxx
@@ -27,7 +27,7 @@ namespace itk
  * ************************* Constructor ************************
  */
 
-StandardStochasticVarianceReducedGradientOptimizer ::StandardStochasticVarianceReducedGradientOptimizer()
+StandardStochasticVarianceReducedGradientOptimizer::StandardStochasticVarianceReducedGradientOptimizer()
 {
   this->m_Param_a = 1.0;
   this->m_Param_A = 1.0;
@@ -56,7 +56,7 @@ StandardStochasticVarianceReducedGradientOptimizer::StartOptimization(void)
  */
 
 void
-StandardStochasticVarianceReducedGradientOptimizer ::AdvanceOneStep(void)
+StandardStochasticVarianceReducedGradientOptimizer::AdvanceOneStep(void)
 {
 
   this->SetLearningRate(this->Compute_a(this->m_CurrentTime));
@@ -73,7 +73,7 @@ StandardStochasticVarianceReducedGradientOptimizer ::AdvanceOneStep(void)
  */
 
 double
-StandardStochasticVarianceReducedGradientOptimizer ::Compute_a(double k) const
+StandardStochasticVarianceReducedGradientOptimizer::Compute_a(double k) const
 {
   return static_cast<double>(this->m_Param_a / std::pow(this->m_Param_A + k + 1.0, this->m_Param_alpha));
 
@@ -85,7 +85,7 @@ StandardStochasticVarianceReducedGradientOptimizer ::Compute_a(double k) const
  */
 
 double
-StandardStochasticVarianceReducedGradientOptimizer ::Compute_beta(double k) const
+StandardStochasticVarianceReducedGradientOptimizer::Compute_beta(double k) const
 {
   return static_cast<double>(this->m_Param_beta / std::pow(this->m_Param_A + k + 1.0, this->m_Param_alpha));
 
@@ -97,7 +97,7 @@ StandardStochasticVarianceReducedGradientOptimizer ::Compute_beta(double k) cons
  */
 
 void
-StandardStochasticVarianceReducedGradientOptimizer ::UpdateCurrentTime(void)
+StandardStochasticVarianceReducedGradientOptimizer::UpdateCurrentTime(void)
 {
   /** Simply Robbins-Monro: time=iterationnr. */
   this->m_CurrentTime += 1.0;

--- a/Components/Optimizers/AdaptiveStochasticVarianceReducedGradient/itkStochasticVarianceReducedGradientDescentOptimizer.cxx
+++ b/Components/Optimizers/AdaptiveStochasticVarianceReducedGradient/itkStochasticVarianceReducedGradientDescentOptimizer.cxx
@@ -38,7 +38,7 @@ namespace itk
  * ****************** Constructor ************************
  */
 
-StochasticVarianceReducedGradientDescentOptimizer ::StochasticVarianceReducedGradientDescentOptimizer()
+StochasticVarianceReducedGradientDescentOptimizer::StochasticVarianceReducedGradientDescentOptimizer()
 {
   itkDebugMacro("Constructor");
 
@@ -62,7 +62,7 @@ StochasticVarianceReducedGradientDescentOptimizer ::StochasticVarianceReducedGra
  */
 
 void
-StochasticVarianceReducedGradientDescentOptimizer ::PrintSelf(std::ostream & os, Indent indent) const
+StochasticVarianceReducedGradientDescentOptimizer::PrintSelf(std::ostream & os, Indent indent) const
 {
   this->Superclass::PrintSelf(os, indent);
 
@@ -83,7 +83,7 @@ StochasticVarianceReducedGradientDescentOptimizer ::PrintSelf(std::ostream & os,
  */
 
 void
-StochasticVarianceReducedGradientDescentOptimizer ::StartOptimization(void)
+StochasticVarianceReducedGradientDescentOptimizer::StartOptimization(void)
 {
   itkDebugMacro("StartOptimization");
 
@@ -108,7 +108,7 @@ StochasticVarianceReducedGradientDescentOptimizer ::StartOptimization(void)
  */
 
 void
-StochasticVarianceReducedGradientDescentOptimizer ::ResumeOptimization(void)
+StochasticVarianceReducedGradientDescentOptimizer::ResumeOptimization(void)
 {
   itkDebugMacro("ResumeOptimization");
 
@@ -169,7 +169,7 @@ StochasticVarianceReducedGradientDescentOptimizer ::ResumeOptimization(void)
  */
 
 void
-StochasticVarianceReducedGradientDescentOptimizer ::MetricErrorResponse(ExceptionObject & err)
+StochasticVarianceReducedGradientDescentOptimizer::MetricErrorResponse(ExceptionObject & err)
 {
   /** An exception has occurred. Terminate immediately. */
   this->m_StopCondition = MetricError;
@@ -186,7 +186,7 @@ StochasticVarianceReducedGradientDescentOptimizer ::MetricErrorResponse(Exceptio
  */
 
 void
-StochasticVarianceReducedGradientDescentOptimizer ::StopOptimization(void)
+StochasticVarianceReducedGradientDescentOptimizer::StopOptimization(void)
 {
   itkDebugMacro("StopOptimization");
 
@@ -200,7 +200,7 @@ StochasticVarianceReducedGradientDescentOptimizer ::StopOptimization(void)
  */
 
 void
-StochasticVarianceReducedGradientDescentOptimizer ::AdvanceOneStep(void)
+StochasticVarianceReducedGradientDescentOptimizer::AdvanceOneStep(void)
 {
   itkDebugMacro("AdvanceOneStep");
 
@@ -314,7 +314,7 @@ StochasticVarianceReducedGradientDescentOptimizer ::AdvanceOneStep(void)
  */
 
 ITK_THREAD_RETURN_FUNCTION_CALL_CONVENTION
-StochasticVarianceReducedGradientDescentOptimizer ::AdvanceOneStepThreaderCallback(void * arg)
+StochasticVarianceReducedGradientDescentOptimizer::AdvanceOneStepThreaderCallback(void * arg)
 {
   /** Get the current thread id and user data. */
   ThreadInfoType *             infoStruct = static_cast<ThreadInfoType *>(arg);
@@ -334,7 +334,7 @@ StochasticVarianceReducedGradientDescentOptimizer ::AdvanceOneStepThreaderCallba
  */
 
 void
-StochasticVarianceReducedGradientDescentOptimizer ::ThreadedAdvanceOneStep(ThreadIdType     threadId,
+StochasticVarianceReducedGradientDescentOptimizer::ThreadedAdvanceOneStep(ThreadIdType     threadId,
                                                                            ParametersType & newPosition)
 {
   /** Compute the range for this thread. */

--- a/Components/Optimizers/ConjugateGradient/itkGenericConjugateGradientOptimizer.cxx
+++ b/Components/Optimizers/ConjugateGradient/itkGenericConjugateGradientOptimizer.cxx
@@ -596,7 +596,7 @@ GenericConjugateGradientOptimizer::TestConvergence(bool itkNotUsed(firstLineSear
  */
 
 void
-GenericConjugateGradientOptimizer ::PrintSelf(std::ostream & os, Indent indent) const
+GenericConjugateGradientOptimizer::PrintSelf(std::ostream & os, Indent indent) const
 {
   /** Call the superclass' PrintSelf. */
   Superclass::PrintSelf(os, indent);

--- a/Components/Optimizers/FiniteDifferenceGradientDescent/itkFiniteDifferenceGradientDescentOptimizer.cxx
+++ b/Components/Optimizers/FiniteDifferenceGradientDescent/itkFiniteDifferenceGradientDescentOptimizer.cxx
@@ -31,7 +31,7 @@ namespace itk
  * ************************* Constructor ************************
  */
 
-FiniteDifferenceGradientDescentOptimizer ::FiniteDifferenceGradientDescentOptimizer()
+FiniteDifferenceGradientDescentOptimizer::FiniteDifferenceGradientDescentOptimizer()
 {
   itkDebugMacro("Constructor");
 
@@ -58,7 +58,7 @@ FiniteDifferenceGradientDescentOptimizer ::FiniteDifferenceGradientDescentOptimi
  */
 
 void
-FiniteDifferenceGradientDescentOptimizer ::PrintSelf(std::ostream & os, Indent indent) const
+FiniteDifferenceGradientDescentOptimizer::PrintSelf(std::ostream & os, Indent indent) const
 {
   Superclass::PrintSelf(os, indent);
 
@@ -76,7 +76,7 @@ FiniteDifferenceGradientDescentOptimizer ::PrintSelf(std::ostream & os, Indent i
  * *********************** StartOptimization ********************
  */
 void
-FiniteDifferenceGradientDescentOptimizer ::StartOptimization(void)
+FiniteDifferenceGradientDescentOptimizer::StartOptimization(void)
 {
   itkDebugMacro("StartOptimization");
 
@@ -106,7 +106,7 @@ FiniteDifferenceGradientDescentOptimizer ::StartOptimization(void)
  */
 
 void
-FiniteDifferenceGradientDescentOptimizer ::ResumeOptimization(void)
+FiniteDifferenceGradientDescentOptimizer::ResumeOptimization(void)
 {
   itkDebugMacro("ResumeOptimization");
 
@@ -212,7 +212,7 @@ FiniteDifferenceGradientDescentOptimizer ::ResumeOptimization(void)
  */
 
 void
-FiniteDifferenceGradientDescentOptimizer ::StopOptimization(void)
+FiniteDifferenceGradientDescentOptimizer::StopOptimization(void)
 {
   itkDebugMacro("StopOptimization");
 
@@ -227,7 +227,7 @@ FiniteDifferenceGradientDescentOptimizer ::StopOptimization(void)
  */
 
 void
-FiniteDifferenceGradientDescentOptimizer ::AdvanceOneStep(void)
+FiniteDifferenceGradientDescentOptimizer::AdvanceOneStep(void)
 {
   itkDebugMacro("AdvanceOneStep");
 
@@ -262,7 +262,7 @@ FiniteDifferenceGradientDescentOptimizer ::AdvanceOneStep(void)
  */
 
 double
-FiniteDifferenceGradientDescentOptimizer ::Compute_a(unsigned long k) const
+FiniteDifferenceGradientDescentOptimizer::Compute_a(unsigned long k) const
 {
   return static_cast<double>(this->m_Param_a / std::pow(this->m_Param_A + k + 1, this->m_Param_alpha));
 
@@ -277,7 +277,7 @@ FiniteDifferenceGradientDescentOptimizer ::Compute_a(unsigned long k) const
  */
 
 double
-FiniteDifferenceGradientDescentOptimizer ::Compute_c(unsigned long k) const
+FiniteDifferenceGradientDescentOptimizer::Compute_c(unsigned long k) const
 {
   return static_cast<double>(this->m_Param_c / std::pow(k + 1, this->m_Param_gamma));
 

--- a/Components/Optimizers/FullSearch/itkFullSearchOptimizer.cxx
+++ b/Components/Optimizers/FullSearch/itkFullSearchOptimizer.cxx
@@ -28,7 +28,7 @@ namespace itk
 /**
  * ************************ Constructor **************************
  */
-FullSearchOptimizer ::FullSearchOptimizer()
+FullSearchOptimizer::FullSearchOptimizer()
 {
   itkDebugMacro("Constructor");
 
@@ -49,7 +49,7 @@ FullSearchOptimizer ::FullSearchOptimizer()
  * ***************** Start the optimization **********************
  */
 void
-FullSearchOptimizer ::StartOptimization(void)
+FullSearchOptimizer::StartOptimization(void)
 {
 
   itkDebugMacro("StartOptimization");
@@ -83,7 +83,7 @@ FullSearchOptimizer ::StartOptimization(void)
  * ******************** Resume the optimization ******************
  */
 void
-FullSearchOptimizer ::ResumeOptimization(void)
+FullSearchOptimizer::ResumeOptimization(void)
 {
 
   itkDebugMacro("ResumeOptimization");
@@ -146,7 +146,7 @@ FullSearchOptimizer ::ResumeOptimization(void)
  * ************************** Stop optimization ******************
  */
 void
-FullSearchOptimizer ::StopOptimization(void)
+FullSearchOptimizer::StopOptimization(void)
 {
 
   itkDebugMacro("StopOptimization");
@@ -177,7 +177,7 @@ FullSearchOptimizer ::StopOptimization(void)
  */
 
 void
-FullSearchOptimizer ::UpdateCurrentPosition(void)
+FullSearchOptimizer::UpdateCurrentPosition(void)
 {
 
   itkDebugMacro("Current position updated.");
@@ -242,7 +242,7 @@ FullSearchOptimizer ::UpdateCurrentPosition(void)
  * ********************* ProcessSearchSpaceChanges **************
  */
 void
-FullSearchOptimizer ::ProcessSearchSpaceChanges(void)
+FullSearchOptimizer::ProcessSearchSpaceChanges(void)
 {
   if (m_SearchSpace->GetMTime() > m_LastSearchSpaceChanges)
   {
@@ -281,7 +281,7 @@ FullSearchOptimizer ::ProcessSearchSpaceChanges(void)
  * Add a dimension to the SearchSpace
  */
 void
-FullSearchOptimizer ::AddSearchDimension(unsigned int   param_nr,
+FullSearchOptimizer::AddSearchDimension(unsigned int   param_nr,
                                          RangeValueType minimum,
                                          RangeValueType maximum,
                                          RangeValueType step)
@@ -311,7 +311,7 @@ FullSearchOptimizer ::AddSearchDimension(unsigned int   param_nr,
  * Remove a dimension from the SearchSpace
  */
 void
-FullSearchOptimizer ::RemoveSearchDimension(unsigned int param_nr)
+FullSearchOptimizer::RemoveSearchDimension(unsigned int param_nr)
 {
   if (m_SearchSpace)
   {
@@ -326,7 +326,7 @@ FullSearchOptimizer ::RemoveSearchDimension(unsigned int param_nr)
  * Get the total number of iterations = sizes[0]*sizes[1]*sizes[2]* etc.....
  */
 unsigned long
-FullSearchOptimizer ::GetNumberOfIterations(void)
+FullSearchOptimizer::GetNumberOfIterations(void)
 {
   SearchSpaceSizeType sssize = this->GetSearchSpaceSize();
   unsigned int        maxssdim = this->GetNumberOfSearchSpaceDimensions();
@@ -351,7 +351,7 @@ FullSearchOptimizer ::GetNumberOfIterations(void)
  * Get the Dimension of the SearchSpace.
  */
 unsigned int
-FullSearchOptimizer ::GetNumberOfSearchSpaceDimensions(void)
+FullSearchOptimizer::GetNumberOfSearchSpaceDimensions(void)
 {
   this->ProcessSearchSpaceChanges();
   return this->m_NumberOfSearchSpaceDimensions;
@@ -365,7 +365,7 @@ FullSearchOptimizer ::GetNumberOfSearchSpaceDimensions(void)
  * SearchSpaceDimension)
  */
 const FullSearchOptimizer::SearchSpaceSizeType &
-FullSearchOptimizer ::GetSearchSpaceSize(void)
+FullSearchOptimizer::GetSearchSpaceSize(void)
 {
   this->ProcessSearchSpaceChanges();
   return this->m_SearchSpaceSize;
@@ -376,7 +376,7 @@ FullSearchOptimizer ::GetSearchSpaceSize(void)
  * ********************* PointToPosition ************************
  */
 FullSearchOptimizer::ParametersType
-FullSearchOptimizer ::PointToPosition(const SearchSpacePointType & point)
+FullSearchOptimizer::PointToPosition(const SearchSpacePointType & point)
 {
   const unsigned int searchSpaceDimension = this->GetNumberOfSearchSpaceDimensions();
 
@@ -406,7 +406,7 @@ FullSearchOptimizer ::PointToPosition(const SearchSpacePointType & point)
  * ********************* IndexToPosition ************************
  */
 FullSearchOptimizer::ParametersType
-FullSearchOptimizer ::IndexToPosition(const SearchSpaceIndexType & index)
+FullSearchOptimizer::IndexToPosition(const SearchSpaceIndexType & index)
 {
   return this->PointToPosition(this->IndexToPoint(index));
 }
@@ -416,7 +416,7 @@ FullSearchOptimizer ::IndexToPosition(const SearchSpaceIndexType & index)
  * ********************* IndexToPoint ***************************
  */
 FullSearchOptimizer::SearchSpacePointType
-FullSearchOptimizer ::IndexToPoint(const SearchSpaceIndexType & index)
+FullSearchOptimizer::IndexToPoint(const SearchSpaceIndexType & index)
 {
 
   const unsigned int   searchSpaceDimension = this->GetNumberOfSearchSpaceDimensions();

--- a/Components/Optimizers/PreconditionedGradientDescent/itkAdaptiveStochasticPreconditionedGradientDescentOptimizer.cxx
+++ b/Components/Optimizers/PreconditionedGradientDescent/itkAdaptiveStochasticPreconditionedGradientDescentOptimizer.cxx
@@ -26,7 +26,7 @@ namespace itk
  * ************************* Constructor ************************
  */
 
-AdaptiveStochasticPreconditionedGradientDescentOptimizer ::AdaptiveStochasticPreconditionedGradientDescentOptimizer()
+AdaptiveStochasticPreconditionedGradientDescentOptimizer::AdaptiveStochasticPreconditionedGradientDescentOptimizer()
 {
   this->m_UseAdaptiveStepSizes = true;
   this->m_SigmoidMax = 1.0;
@@ -40,7 +40,7 @@ AdaptiveStochasticPreconditionedGradientDescentOptimizer ::AdaptiveStochasticPre
  */
 
 void
-AdaptiveStochasticPreconditionedGradientDescentOptimizer ::UpdateCurrentTime(void)
+AdaptiveStochasticPreconditionedGradientDescentOptimizer::UpdateCurrentTime(void)
 {
   typedef itk::Functor::Sigmoid<double, double> SigmoidType;
 

--- a/Components/Optimizers/PreconditionedGradientDescent/itkPreconditionedGradientDescentOptimizer.cxx
+++ b/Components/Optimizers/PreconditionedGradientDescent/itkPreconditionedGradientDescentOptimizer.cxx
@@ -43,7 +43,7 @@ my_cholmod_handler(int status, const char * file, int line, const char * message
  * ****************** Constructor ************************
  */
 
-PreconditionedGradientDescentOptimizer ::PreconditionedGradientDescentOptimizer()
+PreconditionedGradientDescentOptimizer::PreconditionedGradientDescentOptimizer()
 {
   itkDebugMacro("Constructor");
 
@@ -116,7 +116,7 @@ PreconditionedGradientDescentOptimizer ::~PreconditionedGradientDescentOptimizer
  */
 
 void
-PreconditionedGradientDescentOptimizer ::PrintSelf(std::ostream & os, Indent indent) const
+PreconditionedGradientDescentOptimizer::PrintSelf(std::ostream & os, Indent indent) const
 {
   this->Superclass::PrintSelf(os, indent);
 
@@ -135,7 +135,7 @@ PreconditionedGradientDescentOptimizer ::PrintSelf(std::ostream & os, Indent ind
  */
 
 void
-PreconditionedGradientDescentOptimizer ::StartOptimization(void)
+PreconditionedGradientDescentOptimizer::StartOptimization(void)
 {
   this->m_CurrentIteration = 0;
 
@@ -159,7 +159,7 @@ PreconditionedGradientDescentOptimizer ::StartOptimization(void)
  */
 
 void
-PreconditionedGradientDescentOptimizer ::ResumeOptimization(void)
+PreconditionedGradientDescentOptimizer::ResumeOptimization(void)
 {
   itkDebugMacro("ResumeOptimization");
 
@@ -214,7 +214,7 @@ PreconditionedGradientDescentOptimizer ::ResumeOptimization(void)
  */
 
 void
-PreconditionedGradientDescentOptimizer ::MetricErrorResponse(ExceptionObject & err)
+PreconditionedGradientDescentOptimizer::MetricErrorResponse(ExceptionObject & err)
 {
   /** An exception has occurred. Terminate immediately. */
   this->m_StopCondition = MetricError;
@@ -231,7 +231,7 @@ PreconditionedGradientDescentOptimizer ::MetricErrorResponse(ExceptionObject & e
  */
 
 void
-PreconditionedGradientDescentOptimizer ::StopOptimization(void)
+PreconditionedGradientDescentOptimizer::StopOptimization(void)
 {
   itkDebugMacro("StopOptimization");
 
@@ -245,7 +245,7 @@ PreconditionedGradientDescentOptimizer ::StopOptimization(void)
  */
 
 void
-PreconditionedGradientDescentOptimizer ::AdvanceOneStep(void)
+PreconditionedGradientDescentOptimizer::AdvanceOneStep(void)
 {
   typedef DerivativeType::ValueType      DerivativeValueType;
   typedef DerivativeType::const_iterator DerivativeIteratorType;
@@ -277,7 +277,7 @@ PreconditionedGradientDescentOptimizer ::AdvanceOneStep(void)
  */
 
 void
-PreconditionedGradientDescentOptimizer ::CholmodSolve(const DerivativeType & gradient,
+PreconditionedGradientDescentOptimizer::CholmodSolve(const DerivativeType & gradient,
                                                       DerivativeType &       searchDirection,
                                                       int                    solveType)
 {
@@ -355,7 +355,7 @@ PreconditionedGradientDescentOptimizer ::CholmodSolve(const DerivativeType & gra
  */
 
 void
-PreconditionedGradientDescentOptimizer ::SetPreconditionMatrix(PreconditionType & precondition)
+PreconditionedGradientDescentOptimizer::SetPreconditionMatrix(PreconditionType & precondition)
 {
   /** Compute and modify eigensystem of preconditioning matrix.
    * Does not take into account scales (yet)!

--- a/Components/Optimizers/PreconditionedGradientDescent/itkStochasticPreconditionedGradientDescentOptimizer.cxx
+++ b/Components/Optimizers/PreconditionedGradientDescent/itkStochasticPreconditionedGradientDescentOptimizer.cxx
@@ -25,7 +25,7 @@ namespace itk
  * ************************* Constructor ************************
  */
 
-StochasticPreconditionedGradientDescentOptimizer ::StochasticPreconditionedGradientDescentOptimizer()
+StochasticPreconditionedGradientDescentOptimizer::StochasticPreconditionedGradientDescentOptimizer()
 {
   this->m_Param_a = 1.0;
   this->m_Param_A = 1.0;
@@ -42,7 +42,7 @@ StochasticPreconditionedGradientDescentOptimizer ::StochasticPreconditionedGradi
  */
 
 void
-StochasticPreconditionedGradientDescentOptimizer ::StartOptimization(void)
+StochasticPreconditionedGradientDescentOptimizer::StartOptimization(void)
 {
   this->m_CurrentTime = this->m_InitialTime;
   this->Superclass::StartOptimization();
@@ -54,7 +54,7 @@ StochasticPreconditionedGradientDescentOptimizer ::StartOptimization(void)
  */
 
 void
-StochasticPreconditionedGradientDescentOptimizer ::AdvanceOneStep(void)
+StochasticPreconditionedGradientDescentOptimizer::AdvanceOneStep(void)
 {
 
   this->SetLearningRate(this->Compute_a(this->m_CurrentTime));
@@ -71,7 +71,7 @@ StochasticPreconditionedGradientDescentOptimizer ::AdvanceOneStep(void)
  */
 
 double
-StochasticPreconditionedGradientDescentOptimizer ::Compute_a(double k) const
+StochasticPreconditionedGradientDescentOptimizer::Compute_a(double k) const
 {
   return static_cast<double>(this->m_Param_a / std::pow(this->m_Param_A + k + 1.0, this->m_Param_alpha));
 
@@ -83,7 +83,7 @@ StochasticPreconditionedGradientDescentOptimizer ::Compute_a(double k) const
  */
 
 void
-StochasticPreconditionedGradientDescentOptimizer ::UpdateCurrentTime(void)
+StochasticPreconditionedGradientDescentOptimizer::UpdateCurrentTime(void)
 {
   /** Simply Robbins-Monro: time = iteration number. */
   this->m_CurrentTime += 1.0;

--- a/Components/Optimizers/PreconditionedStochasticGradientDescent/itkPreconditionedASGDOptimizer.cxx
+++ b/Components/Optimizers/PreconditionedStochasticGradientDescent/itkPreconditionedASGDOptimizer.cxx
@@ -28,7 +28,7 @@ namespace itk
  * ************************* Constructor ************************
  */
 
-PreconditionedASGDOptimizer ::PreconditionedASGDOptimizer()
+PreconditionedASGDOptimizer::PreconditionedASGDOptimizer()
 {
   this->m_UseAdaptiveStepSizes = true;
   this->m_SigmoidMax = 1.0;
@@ -43,7 +43,7 @@ PreconditionedASGDOptimizer ::PreconditionedASGDOptimizer()
  */
 
 void
-PreconditionedASGDOptimizer ::UpdateCurrentTime(void)
+PreconditionedASGDOptimizer::UpdateCurrentTime(void)
 {
   typedef itk::Functor::Sigmoid<double, double> SigmoidType;
 

--- a/Components/Optimizers/RSGDEachParameterApart/itkRSGDEachParameterApartBaseOptimizer.cxx
+++ b/Components/Optimizers/RSGDEachParameterApart/itkRSGDEachParameterApartBaseOptimizer.cxx
@@ -57,7 +57,7 @@ RSGDEachParameterApartBaseOptimizer ::RSGDEachParameterApartBaseOptimizer()
  * Start the optimization
  */
 void
-RSGDEachParameterApartBaseOptimizer ::StartOptimization(void)
+RSGDEachParameterApartBaseOptimizer::StartOptimization(void)
 {
 
   itkDebugMacro("StartOptimization");
@@ -83,7 +83,7 @@ RSGDEachParameterApartBaseOptimizer ::StartOptimization(void)
  * Resume the optimization
  */
 void
-RSGDEachParameterApartBaseOptimizer ::ResumeOptimization(void)
+RSGDEachParameterApartBaseOptimizer::ResumeOptimization(void)
 {
 
   itkDebugMacro("ResumeOptimization");
@@ -145,7 +145,7 @@ RSGDEachParameterApartBaseOptimizer ::ResumeOptimization(void)
  * Stop optimization
  */
 void
-RSGDEachParameterApartBaseOptimizer ::StopOptimization(void)
+RSGDEachParameterApartBaseOptimizer::StopOptimization(void)
 {
 
   itkDebugMacro("StopOptimization");
@@ -159,7 +159,7 @@ RSGDEachParameterApartBaseOptimizer ::StopOptimization(void)
  * Advance one Step following the gradient direction
  */
 void
-RSGDEachParameterApartBaseOptimizer ::AdvanceOneStep(void)
+RSGDEachParameterApartBaseOptimizer::AdvanceOneStep(void)
 {
 
   itkDebugMacro("AdvanceOneStep");
@@ -258,7 +258,7 @@ RSGDEachParameterApartBaseOptimizer ::AdvanceOneStep(void)
 
 
 void
-RSGDEachParameterApartBaseOptimizer ::PrintSelf(std::ostream & os, Indent indent) const
+RSGDEachParameterApartBaseOptimizer::PrintSelf(std::ostream & os, Indent indent) const
 {
   Superclass::PrintSelf(os, indent);
   os << indent << "MaximumStepLength: " << m_MaximumStepLength << std::endl;

--- a/Components/Optimizers/RSGDEachParameterApart/itkRSGDEachParameterApartOptimizer.cxx
+++ b/Components/Optimizers/RSGDEachParameterApart/itkRSGDEachParameterApartOptimizer.cxx
@@ -28,7 +28,7 @@ namespace itk
  * This method will be overrided in non-vector spaces
  */
 void
-RSGDEachParameterApartOptimizer ::StepAlongGradient(const DerivativeType & factor,
+RSGDEachParameterApartOptimizer::StepAlongGradient(const DerivativeType & factor,
                                                     const DerivativeType & transformedGradient)
 {
 

--- a/Components/Optimizers/StandardGradientDescent/itkStandardGradientDescentOptimizer.cxx
+++ b/Components/Optimizers/StandardGradientDescent/itkStandardGradientDescentOptimizer.cxx
@@ -26,7 +26,7 @@ namespace itk
  * ************************* Constructor ************************
  */
 
-StandardGradientDescentOptimizer ::StandardGradientDescentOptimizer()
+StandardGradientDescentOptimizer::StandardGradientDescentOptimizer()
 {
   this->m_Param_a = 1.0;
   this->m_Param_A = 1.0;
@@ -56,7 +56,7 @@ StandardGradientDescentOptimizer::StartOptimization(void)
  */
 
 void
-StandardGradientDescentOptimizer ::AdvanceOneStep(void)
+StandardGradientDescentOptimizer::AdvanceOneStep(void)
 {
   /** Decide which type of step size is chosen. */
   if (this->m_UseConstantStep)
@@ -80,7 +80,7 @@ StandardGradientDescentOptimizer ::AdvanceOneStep(void)
  */
 
 double
-StandardGradientDescentOptimizer ::Compute_a(double k) const
+StandardGradientDescentOptimizer::Compute_a(double k) const
 {
   return static_cast<double>(this->m_Param_a / std::pow(this->m_Param_A + k + 1.0, this->m_Param_alpha));
 
@@ -92,7 +92,7 @@ StandardGradientDescentOptimizer ::Compute_a(double k) const
  */
 
 void
-StandardGradientDescentOptimizer ::UpdateCurrentTime(void)
+StandardGradientDescentOptimizer::UpdateCurrentTime(void)
 {
   /** Simply Robbins-Monro: time=iterationnr. */
   this->m_CurrentTime += 1.0;

--- a/Components/Optimizers/StandardStochasticGradientDescent/itkStandardStochasticGradientDescentOptimizer.cxx
+++ b/Components/Optimizers/StandardStochasticGradientDescent/itkStandardStochasticGradientDescentOptimizer.cxx
@@ -27,7 +27,7 @@ namespace itk
  * ************************* Constructor ************************
  */
 
-StandardStochasticGradientOptimizer ::StandardStochasticGradientOptimizer()
+StandardStochasticGradientOptimizer::StandardStochasticGradientOptimizer()
 {
   this->m_Param_a = 1.0;
   this->m_Param_A = 1.0;
@@ -56,7 +56,7 @@ StandardStochasticGradientOptimizer::StartOptimization(void)
  */
 
 void
-StandardStochasticGradientOptimizer ::AdvanceOneStep(void)
+StandardStochasticGradientOptimizer::AdvanceOneStep(void)
 {
 
   this->SetLearningRate(this->Compute_a(this->m_CurrentTime));
@@ -73,7 +73,7 @@ StandardStochasticGradientOptimizer ::AdvanceOneStep(void)
  */
 
 double
-StandardStochasticGradientOptimizer ::Compute_a(double k) const
+StandardStochasticGradientOptimizer::Compute_a(double k) const
 {
   return static_cast<double>(this->m_Param_a / std::pow(this->m_Param_A + k + 1.0, this->m_Param_alpha));
 
@@ -84,7 +84,7 @@ StandardStochasticGradientOptimizer ::Compute_a(double k) const
  */
 
 double
-StandardStochasticGradientOptimizer ::Compute_beta(double k) const
+StandardStochasticGradientOptimizer::Compute_beta(double k) const
 {
   return static_cast<double>(this->m_Param_beta / std::pow(this->m_Param_A + k + 1.0, this->m_Param_alpha));
 
@@ -96,7 +96,7 @@ StandardStochasticGradientOptimizer ::Compute_beta(double k) const
  */
 
 void
-StandardStochasticGradientOptimizer ::UpdateCurrentTime(void)
+StandardStochasticGradientOptimizer::UpdateCurrentTime(void)
 {
   /** Simply Robbins-Monro: time=iterationnr. */
   this->m_CurrentTime += 1.0;

--- a/Components/Optimizers/StandardStochasticGradientDescent/itkStochasticGradientDescentOptimizer.cxx
+++ b/Components/Optimizers/StandardStochasticGradientDescent/itkStochasticGradientDescentOptimizer.cxx
@@ -37,7 +37,7 @@ namespace itk
  * ****************** Constructor ************************
  */
 
-StochasticGradientDescentOptimizer ::StochasticGradientDescentOptimizer()
+StochasticGradientDescentOptimizer::StochasticGradientDescentOptimizer()
 {
   itkDebugMacro("Constructor");
 
@@ -61,7 +61,7 @@ StochasticGradientDescentOptimizer ::StochasticGradientDescentOptimizer()
  */
 
 void
-StochasticGradientDescentOptimizer ::PrintSelf(std::ostream & os, Indent indent) const
+StochasticGradientDescentOptimizer::PrintSelf(std::ostream & os, Indent indent) const
 {
   this->Superclass::PrintSelf(os, indent);
 
@@ -82,7 +82,7 @@ StochasticGradientDescentOptimizer ::PrintSelf(std::ostream & os, Indent indent)
  */
 
 void
-StochasticGradientDescentOptimizer ::StartOptimization(void)
+StochasticGradientDescentOptimizer::StartOptimization(void)
 {
   itkDebugMacro("StartOptimization");
 
@@ -107,7 +107,7 @@ StochasticGradientDescentOptimizer ::StartOptimization(void)
  */
 
 void
-StochasticGradientDescentOptimizer ::ResumeOptimization(void)
+StochasticGradientDescentOptimizer::ResumeOptimization(void)
 {
   itkDebugMacro("ResumeOptimization");
 
@@ -169,7 +169,7 @@ StochasticGradientDescentOptimizer ::ResumeOptimization(void)
  */
 
 void
-StochasticGradientDescentOptimizer ::MetricErrorResponse(ExceptionObject & err)
+StochasticGradientDescentOptimizer::MetricErrorResponse(ExceptionObject & err)
 {
   /** An exception has occurred. Terminate immediately. */
   this->m_StopCondition = MetricError;
@@ -186,7 +186,7 @@ StochasticGradientDescentOptimizer ::MetricErrorResponse(ExceptionObject & err)
  */
 
 void
-StochasticGradientDescentOptimizer ::StopOptimization(void)
+StochasticGradientDescentOptimizer::StopOptimization(void)
 {
   itkDebugMacro("StopOptimization");
 
@@ -200,7 +200,7 @@ StochasticGradientDescentOptimizer ::StopOptimization(void)
  */
 
 void
-StochasticGradientDescentOptimizer ::AdvanceOneStep(void)
+StochasticGradientDescentOptimizer::AdvanceOneStep(void)
 {
   itkDebugMacro("AdvanceOneStep");
 
@@ -312,7 +312,7 @@ StochasticGradientDescentOptimizer ::AdvanceOneStep(void)
  */
 
 ITK_THREAD_RETURN_FUNCTION_CALL_CONVENTION
-StochasticGradientDescentOptimizer ::AdvanceOneStepThreaderCallback(void * arg)
+StochasticGradientDescentOptimizer::AdvanceOneStepThreaderCallback(void * arg)
 {
   /** Get the current thread id and user data. */
   ThreadInfoType *             infoStruct = static_cast<ThreadInfoType *>(arg);
@@ -332,7 +332,7 @@ StochasticGradientDescentOptimizer ::AdvanceOneStepThreaderCallback(void * arg)
  */
 
 void
-StochasticGradientDescentOptimizer ::ThreadedAdvanceOneStep(ThreadIdType threadId, ParametersType & newPosition)
+StochasticGradientDescentOptimizer::ThreadedAdvanceOneStep(ThreadIdType threadId, ParametersType & newPosition)
 {
   /** Compute the range for this thread. */
   const unsigned int spaceDimension = this->GetScaledCostFunction()->GetNumberOfParameters();

--- a/Core/Configuration/elxConfiguration.cxx
+++ b/Core/Configuration/elxConfiguration.cxx
@@ -44,7 +44,7 @@ Configuration::Configuration()
  */
 
 void
-Configuration ::PrintParameterFile(void) const
+Configuration::PrintParameterFile(void) const
 {
   /** Read what's in the parameter file. */
   std::string params = this->m_ParameterFileParser->ReturnParameterFileAsString();
@@ -72,7 +72,7 @@ Configuration ::PrintParameterFile(void) const
  */
 
 int
-Configuration ::BeforeAll(void)
+Configuration::BeforeAll(void)
 {
   if (!BaseComponent::IsElastixLibrary())
   {
@@ -88,7 +88,7 @@ Configuration ::BeforeAll(void)
  */
 
 int
-Configuration ::BeforeAllTransformix(void)
+Configuration::BeforeAllTransformix(void)
 {
   this->PrintParameterFile();
   return 0;
@@ -101,7 +101,7 @@ Configuration ::BeforeAllTransformix(void)
  */
 
 int
-Configuration ::Initialize(const CommandLineArgumentMapType & _arg)
+Configuration::Initialize(const CommandLineArgumentMapType & _arg)
 {
   /** The first part is getting the command line arguments and setting them
    * in the configuration. From the command line arguments we find the name
@@ -183,7 +183,7 @@ Configuration ::Initialize(const CommandLineArgumentMapType & _arg)
  */
 
 int
-Configuration ::Initialize(const CommandLineArgumentMapType &                _arg,
+Configuration::Initialize(const CommandLineArgumentMapType &                _arg,
                            const ParameterFileParserType::ParameterMapType & inputMap)
 {
   /** The first part is getting the command line arguments and setting them
@@ -217,7 +217,7 @@ Configuration ::Initialize(const CommandLineArgumentMapType &                _ar
  */
 
 bool
-Configuration ::IsInitialized(void) const
+Configuration::IsInitialized(void) const
 {
   return this->m_IsInitialized;
 
@@ -229,7 +229,7 @@ Configuration ::IsInitialized(void) const
  */
 
 std::string
-Configuration ::GetCommandLineArgument(const std::string & key) const
+Configuration::GetCommandLineArgument(const std::string & key) const
 {
   const auto found = this->m_CommandLineArgumentMap.find(key);
 
@@ -249,7 +249,7 @@ Configuration ::GetCommandLineArgument(const std::string & key) const
  */
 
 void
-Configuration ::SetCommandLineArgument(const std::string & key, const std::string & value)
+Configuration::SetCommandLineArgument(const std::string & key, const std::string & value)
 {
   this->m_CommandLineArgumentMap[key] = value;
 

--- a/Core/Kernel/elxElastixMain.cxx
+++ b/Core/Kernel/elxElastixMain.cxx
@@ -216,7 +216,7 @@ ElastixMain::~ElastixMain()
  */
 
 void
-ElastixMain ::EnterCommandLineArguments(const ArgumentMapType & argmap)
+ElastixMain::EnterCommandLineArguments(const ArgumentMapType & argmap)
 {
 
   /** Initialize the configuration object with the
@@ -237,7 +237,7 @@ ElastixMain ::EnterCommandLineArguments(const ArgumentMapType & argmap)
  */
 
 void
-ElastixMain ::EnterCommandLineArguments(const ArgumentMapType & argmap, const ParameterMapType & inputMap)
+ElastixMain::EnterCommandLineArguments(const ArgumentMapType & argmap, const ParameterMapType & inputMap)
 {
   /** Initialize the configuration object with the
    * command line parameters entered by the user.
@@ -256,7 +256,7 @@ ElastixMain ::EnterCommandLineArguments(const ArgumentMapType & argmap, const Pa
  */
 
 void
-ElastixMain ::EnterCommandLineArguments(const ArgumentMapType & argmap, const std::vector<ParameterMapType> & inputMaps)
+ElastixMain::EnterCommandLineArguments(const ArgumentMapType & argmap, const std::vector<ParameterMapType> & inputMaps)
 {
   this->m_Configurations.clear();
   this->m_Configurations.resize(inputMaps.size());
@@ -466,7 +466,7 @@ ElastixMain::Run(const ArgumentMapType & argmap)
  */
 
 int
-ElastixMain ::Run(const ArgumentMapType & argmap, const ParameterMapType & inputMap)
+ElastixMain::Run(const ArgumentMapType & argmap, const ParameterMapType & inputMap)
 {
   this->EnterCommandLineArguments(argmap, inputMap);
   return this->Run();

--- a/Core/Main/elxParameterObject.cxx
+++ b/Core/Main/elxParameterObject.cxx
@@ -31,7 +31,7 @@ namespace elastix
  */
 
 void
-ParameterObject ::SetParameterMap(const ParameterMapType & parameterMap)
+ParameterObject::SetParameterMap(const ParameterMapType & parameterMap)
 {
   ParameterMapVectorType parameterMapVector = ParameterMapVectorType(1, parameterMap);
   this->SetParameterMap(parameterMapVector);
@@ -42,7 +42,7 @@ ParameterObject ::SetParameterMap(const ParameterMapType & parameterMap)
  */
 
 void
-ParameterObject ::SetParameterMap(const unsigned int & index, const ParameterMapType & parameterMap)
+ParameterObject::SetParameterMap(const unsigned int & index, const ParameterMapType & parameterMap)
 {
   this->m_ParameterMap[index] = parameterMap;
 }
@@ -53,7 +53,7 @@ ParameterObject ::SetParameterMap(const unsigned int & index, const ParameterMap
  */
 
 void
-ParameterObject ::SetParameterMap(const ParameterMapVectorType & parameterMap)
+ParameterObject::SetParameterMap(const ParameterMapVectorType & parameterMap)
 {
   if (this->m_ParameterMap != parameterMap)
   {
@@ -68,7 +68,7 @@ ParameterObject ::SetParameterMap(const ParameterMapVectorType & parameterMap)
  */
 
 void
-ParameterObject ::AddParameterMap(const ParameterMapType & parameterMap)
+ParameterObject::AddParameterMap(const ParameterMapType & parameterMap)
 {
   this->m_ParameterMap.push_back(parameterMap);
   this->Modified();
@@ -80,7 +80,7 @@ ParameterObject ::AddParameterMap(const ParameterMapType & parameterMap)
  */
 
 const ParameterObject::ParameterMapType &
-ParameterObject ::GetParameterMap(const unsigned int & index) const
+ParameterObject::GetParameterMap(const unsigned int & index) const
 {
   return this->m_ParameterMap[index];
 }
@@ -91,7 +91,7 @@ ParameterObject ::GetParameterMap(const unsigned int & index) const
  */
 
 void
-ParameterObject ::SetParameter(const unsigned int &       index,
+ParameterObject::SetParameter(const unsigned int &       index,
                                const ParameterKeyType &   key,
                                const ParameterValueType & value)
 {
@@ -104,7 +104,7 @@ ParameterObject ::SetParameter(const unsigned int &       index,
  */
 
 void
-ParameterObject ::SetParameter(const unsigned int &             index,
+ParameterObject::SetParameter(const unsigned int &             index,
                                const ParameterKeyType &         key,
                                const ParameterValueVectorType & value)
 {
@@ -117,7 +117,7 @@ ParameterObject ::SetParameter(const unsigned int &             index,
  */
 
 void
-ParameterObject ::SetParameter(const ParameterKeyType & key, const ParameterValueType & value)
+ParameterObject::SetParameter(const ParameterKeyType & key, const ParameterValueType & value)
 {
   for (unsigned int index = 0; index < this->GetNumberOfParameterMaps(); index++)
   {
@@ -131,7 +131,7 @@ ParameterObject ::SetParameter(const ParameterKeyType & key, const ParameterValu
  */
 
 void
-ParameterObject ::SetParameter(const ParameterKeyType & key, const ParameterValueVectorType & value)
+ParameterObject::SetParameter(const ParameterKeyType & key, const ParameterValueVectorType & value)
 {
   for (unsigned int index = 0; index < this->GetNumberOfParameterMaps(); index++)
   {
@@ -145,7 +145,7 @@ ParameterObject ::SetParameter(const ParameterKeyType & key, const ParameterValu
  */
 
 const ParameterObject::ParameterValueVectorType &
-ParameterObject ::GetParameter(const unsigned int & index, const ParameterKeyType & key)
+ParameterObject::GetParameter(const unsigned int & index, const ParameterKeyType & key)
 {
   return this->m_ParameterMap[index][key];
 }
@@ -156,7 +156,7 @@ ParameterObject ::GetParameter(const unsigned int & index, const ParameterKeyTyp
  */
 
 void
-ParameterObject ::RemoveParameter(const unsigned int & index, const ParameterKeyType & key)
+ParameterObject::RemoveParameter(const unsigned int & index, const ParameterKeyType & key)
 {
   this->m_ParameterMap[index].erase(key);
 }
@@ -167,7 +167,7 @@ ParameterObject ::RemoveParameter(const unsigned int & index, const ParameterKey
  */
 
 void
-ParameterObject ::RemoveParameter(const ParameterKeyType & key)
+ParameterObject::RemoveParameter(const ParameterKeyType & key)
 {
   for (unsigned int index = 0; index < this->GetNumberOfParameterMaps(); index++)
   {
@@ -181,7 +181,7 @@ ParameterObject ::RemoveParameter(const ParameterKeyType & key)
  */
 
 void
-ParameterObject ::ReadParameterFile(const ParameterFileNameType & parameterFileName)
+ParameterObject::ReadParameterFile(const ParameterFileNameType & parameterFileName)
 {
   ParameterFileParserPointer parameterFileParser = ParameterFileParserType::New();
   parameterFileParser->SetParameterFileName(parameterFileName);
@@ -195,7 +195,7 @@ ParameterObject ::ReadParameterFile(const ParameterFileNameType & parameterFileN
  */
 
 void
-ParameterObject ::ReadParameterFile(const ParameterFileNameVectorType & parameterFileNameVector)
+ParameterObject::ReadParameterFile(const ParameterFileNameVectorType & parameterFileNameVector)
 {
   if (parameterFileNameVector.size() == 0)
   {
@@ -221,7 +221,7 @@ ParameterObject ::ReadParameterFile(const ParameterFileNameVectorType & paramete
  */
 
 void
-ParameterObject ::AddParameterFile(const ParameterFileNameType & parameterFileName)
+ParameterObject::AddParameterFile(const ParameterFileNameType & parameterFileName)
 {
   ParameterFileParserPointer parameterFileParser = ParameterFileParserType::New();
   parameterFileParser->SetParameterFileName(parameterFileName);
@@ -236,7 +236,7 @@ ParameterObject ::AddParameterFile(const ParameterFileNameType & parameterFileNa
 
 
 void
-ParameterObject ::WriteParameterFile(void)
+ParameterObject::WriteParameterFile(void)
 {
   ParameterFileNameVectorType parameterFileNameVector;
   for (unsigned int i = 0; i < m_ParameterMap.size(); ++i)
@@ -253,7 +253,7 @@ ParameterObject ::WriteParameterFile(void)
  */
 
 void
-ParameterObject ::WriteParameterFile(const ParameterMapType &      parameterMap,
+ParameterObject::WriteParameterFile(const ParameterMapType &      parameterMap,
                                      const ParameterFileNameType & parameterFileName)
 {
   std::ofstream parameterFile;
@@ -318,7 +318,7 @@ ParameterObject ::WriteParameterFile(const ParameterMapType &      parameterMap,
  */
 
 void
-ParameterObject ::WriteParameterFile(const ParameterFileNameType & parameterFileName)
+ParameterObject::WriteParameterFile(const ParameterFileNameType & parameterFileName)
 {
   if (this->m_ParameterMap.size() == 0)
   {
@@ -340,7 +340,7 @@ ParameterObject ::WriteParameterFile(const ParameterFileNameType & parameterFile
  */
 
 void
-ParameterObject ::WriteParameterFile(const ParameterMapVectorType &      parameterMapVector,
+ParameterObject::WriteParameterFile(const ParameterMapVectorType &      parameterMapVector,
                                      const ParameterFileNameVectorType & parameterFileNameVector)
 {
   if (parameterMapVector.size() != parameterFileNameVector.size())
@@ -371,7 +371,7 @@ ParameterObject ::WriteParameterFile(const ParameterMapVectorType &      paramet
 
 
 void
-ParameterObject ::WriteParameterFile(const ParameterFileNameVectorType & parameterFileNameVector)
+ParameterObject::WriteParameterFile(const ParameterFileNameVectorType & parameterFileNameVector)
 {
   this->WriteParameterFile(this->m_ParameterMap, parameterFileNameVector);
 }
@@ -382,7 +382,7 @@ ParameterObject ::WriteParameterFile(const ParameterFileNameVectorType & paramet
  */
 
 const ParameterObject::ParameterMapType
-ParameterObject ::GetDefaultParameterMap(const std::string &  transformName,
+ParameterObject::GetDefaultParameterMap(const std::string &  transformName,
                                          const unsigned int & numberOfResolutions,
                                          const double &       finalGridSpacingInPhysicalUnits)
 {
@@ -496,7 +496,7 @@ ParameterObject ::GetDefaultParameterMap(const std::string &  transformName,
  */
 
 void
-ParameterObject ::PrintSelf(std::ostream & os, itk::Indent indent) const
+ParameterObject::PrintSelf(std::ostream & os, itk::Indent indent) const
 {
   Superclass::PrintSelf(os, indent);
 

--- a/Core/elxProgressCommand.cxx
+++ b/Core/elxProgressCommand.cxx
@@ -64,7 +64,7 @@ ProgressCommand::~ProgressCommand()
  */
 
 void
-ProgressCommand ::SetUpdateFrequency(const unsigned long numberOfVoxels, const unsigned long numberOfUpdates)
+ProgressCommand::SetUpdateFrequency(const unsigned long numberOfVoxels, const unsigned long numberOfUpdates)
 {
   /** Set the member variables. */
   this->m_NumberOfVoxels = numberOfVoxels;
@@ -96,7 +96,7 @@ ProgressCommand ::SetUpdateFrequency(const unsigned long numberOfVoxels, const u
  */
 
 void
-ProgressCommand ::ConnectObserver(itk::ProcessObject * filter)
+ProgressCommand::ConnectObserver(itk::ProcessObject * filter)
 {
   /** Disconnect from old observed filters. */
   this->DisconnectObserver(this->m_ObservedProcessObject);
@@ -117,7 +117,7 @@ ProgressCommand ::ConnectObserver(itk::ProcessObject * filter)
  */
 
 void
-ProgressCommand ::DisconnectObserver(itk::ProcessObject * filter)
+ProgressCommand::DisconnectObserver(itk::ProcessObject * filter)
 {
   if (this->m_StreamOutputIsConsole)
   {
@@ -137,7 +137,7 @@ ProgressCommand ::DisconnectObserver(itk::ProcessObject * filter)
  */
 
 void
-ProgressCommand ::Execute(itk::Object * caller, const itk::EventObject & event)
+ProgressCommand::Execute(itk::Object * caller, const itk::EventObject & event)
 {
   itk::ProcessObject * po = dynamic_cast<itk::ProcessObject *>(caller);
   if (!po)
@@ -158,7 +158,7 @@ ProgressCommand ::Execute(itk::Object * caller, const itk::EventObject & event)
  */
 
 void
-ProgressCommand ::Execute(const itk::Object * caller, const itk::EventObject & event)
+ProgressCommand::Execute(const itk::Object * caller, const itk::EventObject & event)
 {
   const itk::ProcessObject * po = dynamic_cast<const itk::ProcessObject *>(caller);
   if (!po)
@@ -179,7 +179,7 @@ ProgressCommand ::Execute(const itk::Object * caller, const itk::EventObject & e
  */
 
 void
-ProgressCommand ::PrintProgress(const float & progress) const
+ProgressCommand::PrintProgress(const float & progress) const
 {
   /** Print the progress to the screen. */
   const int progressInt = itk::Math::Round<float>(100 * progress);
@@ -200,7 +200,7 @@ ProgressCommand ::PrintProgress(const float & progress) const
  */
 
 void
-ProgressCommand ::UpdateAndPrintProgress(const unsigned long & currentVoxelNumber) const
+ProgressCommand::UpdateAndPrintProgress(const unsigned long & currentVoxelNumber) const
 {
   if (this->m_StreamOutputIsConsole)
   {
@@ -215,7 +215,7 @@ ProgressCommand ::UpdateAndPrintProgress(const unsigned long & currentVoxelNumbe
 
 
 ProgressCommand::Pointer
-ProgressCommand ::CreateAndSetUpdateFrequency(const unsigned long numberOfVoxels)
+ProgressCommand::CreateAndSetUpdateFrequency(const unsigned long numberOfVoxels)
 {
   const auto result = Self::New();
   result->Self::SetUpdateFrequency(numberOfVoxels, numberOfVoxels);
@@ -224,7 +224,7 @@ ProgressCommand ::CreateAndSetUpdateFrequency(const unsigned long numberOfVoxels
 }
 
 ProgressCommand::Pointer
-ProgressCommand ::CreateAndConnect(itk::ProcessObject & processObject)
+ProgressCommand::CreateAndConnect(itk::ProcessObject & processObject)
 {
   const auto result = Self::New();
   result->Self::ConnectObserver(&processObject);

--- a/Testing/itkCommandLineArgumentParser.cxx
+++ b/Testing/itkCommandLineArgumentParser.cxx
@@ -27,7 +27,7 @@ namespace itk
  * ******************* Constructor *******************
  */
 
-CommandLineArgumentParser ::CommandLineArgumentParser()
+CommandLineArgumentParser::CommandLineArgumentParser()
 {
   this->m_Argv.clear();
   this->m_ArgumentMap.clear();
@@ -41,7 +41,7 @@ CommandLineArgumentParser ::CommandLineArgumentParser()
  */
 
 void
-CommandLineArgumentParser ::SetCommandLineArguments(int argc, char ** argv)
+CommandLineArgumentParser::SetCommandLineArguments(int argc, char ** argv)
 {
   this->m_Argv.resize(argc);
   for (IndexType i = 0; i < static_cast<IndexType>(argc); i++)
@@ -58,7 +58,7 @@ CommandLineArgumentParser ::SetCommandLineArguments(int argc, char ** argv)
  */
 
 void
-CommandLineArgumentParser ::CreateArgumentMap(void)
+CommandLineArgumentParser::CreateArgumentMap(void)
 {
   for (IndexType i = 1; i < this->m_Argv.size(); ++i)
   {
@@ -77,7 +77,7 @@ CommandLineArgumentParser ::CreateArgumentMap(void)
  */
 
 bool
-CommandLineArgumentParser ::ArgumentExists(const std::string & key) const
+CommandLineArgumentParser::ArgumentExists(const std::string & key) const
 {
   if (this->m_ArgumentMap.count(key) == 0)
   {
@@ -93,7 +93,7 @@ CommandLineArgumentParser ::ArgumentExists(const std::string & key) const
  */
 
 void
-CommandLineArgumentParser ::PrintAllArguments() const
+CommandLineArgumentParser::PrintAllArguments() const
 {
   ArgumentMapType::const_iterator iter = this->m_ArgumentMap.begin();
 
@@ -110,7 +110,7 @@ CommandLineArgumentParser ::PrintAllArguments() const
  */
 
 bool
-CommandLineArgumentParser ::ExactlyOneExists(const std::vector<std::string> & keys) const
+CommandLineArgumentParser::ExactlyOneExists(const std::vector<std::string> & keys) const
 {
   unsigned int counter = 0;
   for (unsigned int i = 0; i < keys.size(); i++)
@@ -138,7 +138,7 @@ CommandLineArgumentParser ::ExactlyOneExists(const std::vector<std::string> & ke
  */
 
 bool
-CommandLineArgumentParser ::FindKey(const std::string & key, IndexType & keyIndex, IndexType & nextKeyIndex) const
+CommandLineArgumentParser::FindKey(const std::string & key, IndexType & keyIndex, IndexType & nextKeyIndex) const
 {
   /** Loop once over the arguments, to get the index of the key,
    * and that of the next key.
@@ -208,7 +208,7 @@ CommandLineArgumentParser::IsANumber(const std::string & arg) const
  */
 
 bool
-CommandLineArgumentParser ::StringCast(const std::string & parameterValue, std::string & casted) const
+CommandLineArgumentParser::StringCast(const std::string & parameterValue, std::string & casted) const
 {
   casted = parameterValue;
   return true;
@@ -221,7 +221,7 @@ CommandLineArgumentParser ::StringCast(const std::string & parameterValue, std::
  */
 
 void
-CommandLineArgumentParser ::MarkArgumentAsRequired(const std::string & argument, const std::string & helpText)
+CommandLineArgumentParser::MarkArgumentAsRequired(const std::string & argument, const std::string & helpText)
 {
   std::pair<std::string, std::string> requiredArgument;
   requiredArgument.first = argument;
@@ -236,7 +236,7 @@ CommandLineArgumentParser ::MarkArgumentAsRequired(const std::string & argument,
  */
 
 void
-CommandLineArgumentParser ::MarkExactlyOneOfArgumentsAsRequired(const std::vector<std::string> & arguments,
+CommandLineArgumentParser::MarkExactlyOneOfArgumentsAsRequired(const std::vector<std::string> & arguments,
                                                                 const std::string &              helpText)
 {
   std::pair<std::vector<std::string>, std::string> requiredArguments;
@@ -252,7 +252,7 @@ CommandLineArgumentParser ::MarkExactlyOneOfArgumentsAsRequired(const std::vecto
  */
 
 CommandLineArgumentParser::ReturnValue
-CommandLineArgumentParser ::CheckForRequiredArguments() const
+CommandLineArgumentParser::CheckForRequiredArguments() const
 {
   // If no arguments were specified at all, display the help text.
   if (this->m_Argv.size() == 1)


### PR DESCRIPTION
It appears that clang-format has in some cases introduced a space character between `ClassName` and `::MemberName`. This typically seems to have happened when there originally was a line break between the class name and the member name.

This commit fixes the formatting by removing those spaces, as follows:

    find . \( -iname *.cxx \) -exec perl -pi -w -e 's/([A-Z][a-z]+) \:\:([A-Z][a-z])/$1::$2/g;' {} \;

Follows ITK:
 - pull request https://github.com/InsightSoftwareConsortium/ITK/pull/2096
 - commit: https://github.com/InsightSoftwareConsortium/ITK/commit/734d6f84d728b343baae5ef66643a5568a5a30c7