### PR TITLE
COMP: Remove itk::InvalidImageMomentsError from Calculator hxx file

### DIFF
--- a/Common/Transforms/itkAdvancedImageMomentsCalculator.hxx
+++ b/Common/Transforms/itkAdvancedImageMomentsCalculator.hxx
@@ -26,29 +26,6 @@
 
 namespace itk
 {
-class InvalidImageMomentsError : public ExceptionObject
-{
-public:
-  /**
-   * Constructor. Needed to ensure the exception object can be copied.
-   */
-  InvalidImageMomentsError(const char * file, unsigned int lineNumber)
-    : ExceptionObject(file, lineNumber)
-  {
-    this->SetDescription("No valid image moments are available.");
-  }
-
-  /**
-   * Constructor. Needed to ensure the exception object can be copied.
-   */
-  InvalidImageMomentsError(const std::string & file, unsigned int lineNumber)
-    : ExceptionObject(file, lineNumber)
-  {
-    this->SetDescription("No valid image moments are available.");
-  }
-
-  itkTypeMacro(InvalidImageMomentsError, ExceptionObject);
-};
 
 //----------------------------------------------------------------------
 // Construct without computing moments


### PR DESCRIPTION
The class `itk::InvalidImageMomentsError` appears unused, while it has been defined twice:

 - https://github.com/InsightSoftwareConsortium/ITK/blob/v5.1.1/Modules/Filtering/ImageStatistics/include/itkImageMomentsCalculator.hxx#L28
 - https://github.com/SuperElastix/elastix/blob/5.0.1/Common/Transforms/itkAdvancedImageMomentsCalculator.hxx#L29

Which caused compilation errors like:

> ITK511\Modules\Filtering\ImageStatistics\include\itkImageMomentsCalculator.hxx(28,32): error C2011: 'itk::InvalidImageMomentsError': 'class' type redefinition
> elx\elastix\Common\Transforms\itkAdvancedImageMomentsCalculator.hxx(29): message : see declaration of 'itk::InvalidImageMomentsError'

When doing:

    #include "AdvancedAffineTransform/elxAdvancedAffineTransform.h"
    #include "EulerTransform/elxEulerTransform.h"

Note that hxx files are meant for implementation only. A class defined within an hxx file should not be not be part of the interface (API), otherwise it should be defined in the h file instead.