### PR TITLE
STYLE: Run clang-format again

### DIFF
--- a/Common/CostFunctions/itkScaledSingleValuedCostFunction.cxx
+++ b/Common/CostFunctions/itkScaledSingleValuedCostFunction.cxx
@@ -120,8 +120,8 @@ ScaledSingleValuedCostFunction::GetDerivative(const ParametersType & parameters,
 
 void
 ScaledSingleValuedCostFunction::GetValueAndDerivative(const ParametersType & parameters,
-                                                       MeasureType &          value,
-                                                       DerivativeType &       derivative) const
+                                                      MeasureType &          value,
+                                                      DerivativeType &       derivative) const
 {
   /** F(y)= f(y/s) */
   /** dF/dy(y)= 1/s * df/dx(y/s) */

--- a/Common/LineSearchOptimizers/itkMoreThuenteLineSearchOptimizer.cxx
+++ b/Common/LineSearchOptimizers/itkMoreThuenteLineSearchOptimizer.cxx
@@ -576,17 +576,17 @@ MoreThuenteLineSearchOptimizer::ForceSufficientDecreaseInIntervalWidth(void)
 
 int
 MoreThuenteLineSearchOptimizer::SafeGuardedStep(double &       stx,
-                                                 double &       fx,
-                                                 double &       dx,
-                                                 double &       sty,
-                                                 double &       fy,
-                                                 double &       dy,
-                                                 double &       stp,
-                                                 const double & fp,
-                                                 const double & dp,
-                                                 bool &         brackt,
-                                                 const double & stpmin,
-                                                 const double & stpmax) const
+                                                double &       fx,
+                                                double &       dx,
+                                                double &       sty,
+                                                double &       fy,
+                                                double &       dy,
+                                                double &       stp,
+                                                const double & fp,
+                                                const double & dp,
+                                                bool &         brackt,
+                                                const double & stpmin,
+                                                const double & stpmax) const
 {
   /** This function is largely just a copy of the following function
    * taken from netlib/lbfgs.c */

--- a/Common/OpenCL/ITKimprovements/itkOpenCLProfilingTimeProbe.h
+++ b/Common/OpenCL/ITKimprovements/itkOpenCLProfilingTimeProbe.h
@@ -47,4 +47,4 @@ private:
 
 } // end namespace itk
 
-#endif //itkOpenCLProfilingTimeProbe_h
+#endif // itkOpenCLProfilingTimeProbe_h

--- a/Common/ParameterFileParser/itkParameterFileParser.cxx
+++ b/Common/ParameterFileParser/itkParameterFileParser.cxx
@@ -297,8 +297,8 @@ ParameterFileParser::GetParameterFromLine(const std::string & fullLine, const st
 
 void
 ParameterFileParser::SplitLine(const std::string &        fullLine,
-                                const std::string &        line,
-                                std::vector<std::string> & splittedLine) const
+                               const std::string &        line,
+                               std::vector<std::string> & splittedLine) const
 {
   splittedLine.clear();
   splittedLine.resize(1);

--- a/Common/ParameterFileParser/itkParameterMapInterface.cxx
+++ b/Common/ParameterFileParser/itkParameterMapInterface.cxx
@@ -80,10 +80,10 @@ ParameterMapInterface::CountNumberOfParameterEntries(const std::string & paramet
 
 bool
 ParameterMapInterface::ReadParameter(bool &              parameterValue,
-                                      const std::string & parameterName,
-                                      const unsigned int  entry_nr,
-                                      const bool          printThisErrorMessage,
-                                      std::string &       errorMessage) const
+                                     const std::string & parameterName,
+                                     const unsigned int  entry_nr,
+                                     const bool          printThisErrorMessage,
+                                     std::string &       errorMessage) const
 {
   /** Translate the default boolean to string. */
   std::string parameterValueString;
@@ -143,11 +143,11 @@ ParameterMapInterface::StringCast(const std::string & parameterValue, std::strin
 
 bool
 ParameterMapInterface::ReadParameter(std::vector<std::string> & parameterValues,
-                                      const std::string &        parameterName,
-                                      const unsigned int         entry_nr_start,
-                                      const unsigned int         entry_nr_end,
-                                      const bool                 printThisErrorMessage,
-                                      std::string &              errorMessage) const
+                                     const std::string &        parameterName,
+                                     const unsigned int         entry_nr_start,
+                                     const unsigned int         entry_nr_end,
+                                     const bool                 printThisErrorMessage,
+                                     std::string &              errorMessage) const
 {
   /** Reset the error message. */
   errorMessage = "";

--- a/Common/Transforms/itkAdvancedBSplineDeformableTransform.hxx
+++ b/Common/Transforms/itkAdvancedBSplineDeformableTransform.hxx
@@ -143,8 +143,8 @@ AdvancedBSplineDeformableTransform<TScalarType, NDimensions, VSplineOrder>::Adva
 
 // Destructor
 template <class TScalarType, unsigned int NDimensions, unsigned int VSplineOrder>
-AdvancedBSplineDeformableTransform<TScalarType, NDimensions, VSplineOrder>::~AdvancedBSplineDeformableTransform()
-= default;
+AdvancedBSplineDeformableTransform<TScalarType, NDimensions, VSplineOrder>::~AdvancedBSplineDeformableTransform() =
+  default;
 
 // Set the grid region
 template <class TScalarType, unsigned int NDimensions, unsigned int VSplineOrder>

--- a/Common/Transforms/itkAdvancedBSplineDeformableTransformBase.hxx
+++ b/Common/Transforms/itkAdvancedBSplineDeformableTransformBase.hxx
@@ -100,8 +100,7 @@ AdvancedBSplineDeformableTransformBase<TScalarType, NDimensions>::AdvancedBSplin
 
 // Destructor
 template <class TScalarType, unsigned int NDimensions>
-AdvancedBSplineDeformableTransformBase<TScalarType, NDimensions>::~AdvancedBSplineDeformableTransformBase()
-= default;
+AdvancedBSplineDeformableTransformBase<TScalarType, NDimensions>::~AdvancedBSplineDeformableTransformBase() = default;
 
 // Get the number of parameters
 template <class TScalarType, unsigned int NDimensions>

--- a/Common/Transforms/itkAdvancedCombinationTransform.h
+++ b/Common/Transforms/itkAdvancedCombinationTransform.h
@@ -575,7 +575,6 @@ protected:
                                                 NonZeroJacobianIndicesType &   nonZeroJacobianIndices) const;
 
 private:
-
   /** Declaration of members. */
   InitialTransformPointer m_InitialTransform;
   CurrentTransformPointer m_CurrentTransform;

--- a/Common/Transforms/itkAdvancedRigid2DTransform.hxx
+++ b/Common/Transforms/itkAdvancedRigid2DTransform.hxx
@@ -73,8 +73,7 @@ AdvancedRigid2DTransform<TScalarType>::AdvancedRigid2DTransform(unsigned int spa
 
 // Destructor
 template <class TScalarType>
-AdvancedRigid2DTransform<TScalarType>::~AdvancedRigid2DTransform()
-= default;
+AdvancedRigid2DTransform<TScalarType>::~AdvancedRigid2DTransform() = default;
 
 // Print self
 template <class TScalarType>

--- a/Common/Transforms/itkAdvancedRigid3DTransform.hxx
+++ b/Common/Transforms/itkAdvancedRigid3DTransform.hxx
@@ -60,8 +60,7 @@ AdvancedRigid3DTransform<TScalarType>::AdvancedRigid3DTransform(const MatrixType
 
 // Destructor
 template <class TScalarType>
-AdvancedRigid3DTransform<TScalarType>::~AdvancedRigid3DTransform()
-= default;
+AdvancedRigid3DTransform<TScalarType>::~AdvancedRigid3DTransform() = default;
 
 // Print self
 template <class TScalarType>

--- a/Common/Transforms/itkCyclicBSplineDeformableTransform.hxx
+++ b/Common/Transforms/itkCyclicBSplineDeformableTransform.hxx
@@ -33,8 +33,7 @@ CyclicBSplineDeformableTransform<TScalarType, NDimensions, VSplineOrder>::Cyclic
 
 /** Destructor. */
 template <class TScalarType, unsigned int NDimensions, unsigned int VSplineOrder>
-CyclicBSplineDeformableTransform<TScalarType, NDimensions, VSplineOrder>::~CyclicBSplineDeformableTransform()
-= default;
+CyclicBSplineDeformableTransform<TScalarType, NDimensions, VSplineOrder>::~CyclicBSplineDeformableTransform() = default;
 
 /** Set the grid region. */
 template <class TScalarType, unsigned int NDimensions, unsigned int VSplineOrder>

--- a/Common/Transforms/itkCyclicGridScheduleComputer.hxx
+++ b/Common/Transforms/itkCyclicGridScheduleComputer.hxx
@@ -31,8 +31,8 @@ namespace itk
  */
 
 template <typename TTransformScalarType, unsigned int VImageDimension>
-CyclicGridScheduleComputer<TTransformScalarType, VImageDimension>::CyclicGridScheduleComputer()
-= default; // end Constructor()
+CyclicGridScheduleComputer<TTransformScalarType, VImageDimension>::CyclicGridScheduleComputer() =
+  default; // end Constructor()
 
 /**
  * ********************* ComputeBSplineGrid ****************************

--- a/Common/Transforms/itkKernelFunctionBase2.h
+++ b/Common/Transforms/itkKernelFunctionBase2.h
@@ -60,8 +60,10 @@ public:
   Evaluate(const TRealValueType & u, TRealValueType * weights) const = 0;
 
 protected:
-  KernelFunctionBase2()= default;;
-  ~KernelFunctionBase2() override= default;;
+  KernelFunctionBase2() = default;
+  ;
+  ~KernelFunctionBase2() override = default;
+  ;
 };
 } // end namespace itk
 

--- a/Common/Transforms/itkKernelFunctionBase2.h
+++ b/Common/Transforms/itkKernelFunctionBase2.h
@@ -61,9 +61,7 @@ public:
 
 protected:
   KernelFunctionBase2() = default;
-  ;
   ~KernelFunctionBase2() override = default;
-  ;
 };
 } // end namespace itk
 

--- a/Common/itkAdvancedLinearInterpolateImageFunction.hxx
+++ b/Common/itkAdvancedLinearInterpolateImageFunction.hxx
@@ -30,8 +30,7 @@ namespace itk
  */
 
 template <class TInputImage, class TCoordRep>
-AdvancedLinearInterpolateImageFunction<TInputImage, TCoordRep>::AdvancedLinearInterpolateImageFunction()
-= default;
+AdvancedLinearInterpolateImageFunction<TInputImage, TCoordRep>::AdvancedLinearInterpolateImageFunction() = default;
 
 /**
  * ***************** EvaluateDerivativeAtContinuousIndex ***********************

--- a/Common/itkImageFileCastWriter.h
+++ b/Common/itkImageFileCastWriter.h
@@ -79,7 +79,6 @@ protected:
   GenerateData(void) override;
 
 private:
-
   /** Templated function that casts the input image and returns a
    * a pointer to the PixelBuffer. Assumes scalar singlecomponent images
    * The buffer data is valid until this->m_Caster is destroyed or assigned

--- a/Common/itkMultiResolutionGaussianSmoothingPyramidImageFilter.hxx
+++ b/Common/itkMultiResolutionGaussianSmoothingPyramidImageFilter.hxx
@@ -52,8 +52,8 @@ namespace itk
  */
 template <class TInputImage, class TOutputImage>
 MultiResolutionGaussianSmoothingPyramidImageFilter<TInputImage,
-                                                   TOutputImage>::MultiResolutionGaussianSmoothingPyramidImageFilter()
-= default;
+                                                   TOutputImage>::MultiResolutionGaussianSmoothingPyramidImageFilter() =
+  default;
 
 /*
  * Set the multi-resolution schedule

--- a/Common/itkScaledSingleValuedNonLinearOptimizer.cxx
+++ b/Common/itkScaledSingleValuedNonLinearOptimizer.cxx
@@ -105,7 +105,7 @@ ScaledSingleValuedNonLinearOptimizer::GetScaledValue(const ParametersType & para
 
 void
 ScaledSingleValuedNonLinearOptimizer::GetScaledDerivative(const ParametersType & parameters,
-                                                           DerivativeType &       derivative) const
+                                                          DerivativeType &       derivative) const
 {
   this->m_ScaledCostFunction->GetDerivative(parameters, derivative);
 
@@ -118,8 +118,8 @@ ScaledSingleValuedNonLinearOptimizer::GetScaledDerivative(const ParametersType &
 
 void
 ScaledSingleValuedNonLinearOptimizer::GetScaledValueAndDerivative(const ParametersType & parameters,
-                                                                   MeasureType &          value,
-                                                                   DerivativeType &       derivative) const
+                                                                  MeasureType &          value,
+                                                                  DerivativeType &       derivative) const
 {
   this->m_ScaledCostFunction->GetValueAndDerivative(parameters, value, derivative);
 

--- a/Components/Metrics/CorrespondingPointsEuclideanDistanceMetric/itkCorrespondingPointsEuclideanDistancePointMetric.hxx
+++ b/Components/Metrics/CorrespondingPointsEuclideanDistanceMetric/itkCorrespondingPointsEuclideanDistancePointMetric.hxx
@@ -29,8 +29,8 @@ namespace itk
 
 template <class TFixedPointSet, class TMovingPointSet>
 CorrespondingPointsEuclideanDistancePointMetric<TFixedPointSet,
-                                                TMovingPointSet>::CorrespondingPointsEuclideanDistancePointMetric()
-= default; // end Constructor
+                                                TMovingPointSet>::CorrespondingPointsEuclideanDistancePointMetric() =
+  default; // end Constructor
 
 /**
  * ******************* GetValue *******************

--- a/Components/Metrics/KNNGraphAlphaMutualInformation/KNN/itkANNFixedRadiusTreeSearch.hxx
+++ b/Components/Metrics/KNNGraphAlphaMutualInformation/KNN/itkANNFixedRadiusTreeSearch.hxx
@@ -40,8 +40,7 @@ ANNFixedRadiusTreeSearch<TBinaryTree>::ANNFixedRadiusTreeSearch()
  */
 
 template <class TBinaryTree>
-ANNFixedRadiusTreeSearch<TBinaryTree>::~ANNFixedRadiusTreeSearch()
-= default; // end Destructor
+ANNFixedRadiusTreeSearch<TBinaryTree>::~ANNFixedRadiusTreeSearch() = default; // end Destructor
 
 /**
  * ************************ Search *************************

--- a/Components/Metrics/KNNGraphAlphaMutualInformation/KNN/itkANNPriorityTreeSearch.hxx
+++ b/Components/Metrics/KNNGraphAlphaMutualInformation/KNN/itkANNPriorityTreeSearch.hxx
@@ -40,8 +40,7 @@ ANNPriorityTreeSearch<TBinaryTree>::ANNPriorityTreeSearch()
  */
 
 template <class TBinaryTree>
-ANNPriorityTreeSearch<TBinaryTree>::~ANNPriorityTreeSearch()
-= default; // end Destructor
+ANNPriorityTreeSearch<TBinaryTree>::~ANNPriorityTreeSearch() = default; // end Destructor
 
 /**
  * ************************ SetBinaryTree *************************

--- a/Components/Metrics/KNNGraphAlphaMutualInformation/KNN/itkANNStandardTreeSearch.hxx
+++ b/Components/Metrics/KNNGraphAlphaMutualInformation/KNN/itkANNStandardTreeSearch.hxx
@@ -39,8 +39,7 @@ ANNStandardTreeSearch<TBinaryTree>::ANNStandardTreeSearch()
  */
 
 template <class TBinaryTree>
-ANNStandardTreeSearch<TBinaryTree>::~ANNStandardTreeSearch()
-= default; // end Destructor
+ANNStandardTreeSearch<TBinaryTree>::~ANNStandardTreeSearch() = default; // end Destructor
 
 /**
  * ************************ Search *************************

--- a/Components/Metrics/KNNGraphAlphaMutualInformation/KNN/itkBinaryANNTreeBase.hxx
+++ b/Components/Metrics/KNNGraphAlphaMutualInformation/KNN/itkBinaryANNTreeBase.hxx
@@ -28,8 +28,7 @@ namespace itk
  */
 
 template <class TListSample>
-BinaryANNTreeBase<TListSample>::BinaryANNTreeBase()
-= default; // end Constructor
+BinaryANNTreeBase<TListSample>::BinaryANNTreeBase() = default; // end Constructor
 
 } // end namespace itk
 

--- a/Components/Metrics/KNNGraphAlphaMutualInformation/KNN/itkBinaryANNTreeSearchBase.hxx
+++ b/Components/Metrics/KNNGraphAlphaMutualInformation/KNN/itkBinaryANNTreeSearchBase.hxx
@@ -39,8 +39,7 @@ BinaryANNTreeSearchBase<TBinaryTree>::BinaryANNTreeSearchBase()
  */
 
 template <class TBinaryTree>
-BinaryANNTreeSearchBase<TBinaryTree>::~BinaryANNTreeSearchBase()
-= default; // end Destructor
+BinaryANNTreeSearchBase<TBinaryTree>::~BinaryANNTreeSearchBase() = default; // end Destructor
 
 /**
  * ************************ SetBinaryTree *************************

--- a/Components/Metrics/KNNGraphAlphaMutualInformation/KNN/itkBinaryTreeSearchBase.hxx
+++ b/Components/Metrics/KNNGraphAlphaMutualInformation/KNN/itkBinaryTreeSearchBase.hxx
@@ -40,8 +40,7 @@ BinaryTreeSearchBase<TBinaryTree>::BinaryTreeSearchBase()
  */
 
 template <class TBinaryTree>
-BinaryTreeSearchBase<TBinaryTree>::~BinaryTreeSearchBase()
-= default; // end Destructor
+BinaryTreeSearchBase<TBinaryTree>::~BinaryTreeSearchBase() = default; // end Destructor
 
 /**
  * ************************ SetBinaryTree *************************

--- a/Components/Metrics/MissingStructurePenalty/elxMissingStructurePenalty.hxx
+++ b/Components/Metrics/MissingStructurePenalty/elxMissingStructurePenalty.hxx
@@ -405,14 +405,14 @@ Function to read 2d structures by reading elastix point files (transformix forma
 the sequence of points to form a 2d connected polydata contour.
   */
   /** Typedef's. */
-  typedef typename FixedImageType::RegionType                FixedImageRegionType;
-  typedef typename FixedImageType::PointType                 FixedImageOriginType;
-  typedef typename FixedImageType::SpacingType               FixedImageSpacingType;
-  typedef typename FixedImageType::IndexType                 FixedImageIndexType;
-  typedef typename FixedImageIndexType::IndexValueType       FixedImageIndexValueType;
-  typedef typename MovingImageType::IndexType                MovingImageIndexType;
-  typedef itk::ContinuousIndex<double, FixedImageDimension>  FixedImageContinuousIndexType;
-  typedef typename FixedImageType::DirectionType             FixedImageDirectionType;
+  typedef typename FixedImageType::RegionType               FixedImageRegionType;
+  typedef typename FixedImageType::PointType                FixedImageOriginType;
+  typedef typename FixedImageType::SpacingType              FixedImageSpacingType;
+  typedef typename FixedImageType::IndexType                FixedImageIndexType;
+  typedef typename FixedImageIndexType::IndexValueType      FixedImageIndexValueType;
+  typedef typename MovingImageType::IndexType               MovingImageIndexType;
+  typedef itk::ContinuousIndex<double, FixedImageDimension> FixedImageContinuousIndexType;
+  typedef typename FixedImageType::DirectionType            FixedImageDirectionType;
 
   typedef unsigned char DummyIPPPixelType;
   typedef itk::DefaultStaticMeshTraits<DummyIPPPixelType, FixedImageDimension, FixedImageDimension, CoordRepType>

--- a/Components/Metrics/MissingStructurePenalty/itkMissingStructurePenalty.hxx
+++ b/Components/Metrics/MissingStructurePenalty/itkMissingStructurePenalty.hxx
@@ -40,8 +40,7 @@ MissingVolumeMeshPenalty<TFixedPointSet, TMovingPointSet>::MissingVolumeMeshPena
  */
 
 template <class TFixedPointSet, class TMovingPointSet>
-MissingVolumeMeshPenalty<TFixedPointSet, TMovingPointSet>::~MissingVolumeMeshPenalty()
-= default; // end Destructor
+MissingVolumeMeshPenalty<TFixedPointSet, TMovingPointSet>::~MissingVolumeMeshPenalty() = default; // end Destructor
 
 
 /**

--- a/Components/Metrics/PolydataDummyPenalty/elxPolydataDummyPenalty.hxx
+++ b/Components/Metrics/PolydataDummyPenalty/elxPolydataDummyPenalty.hxx
@@ -385,14 +385,14 @@ PolydataDummyPenalty<TElastix>::ReadTransformixPoints(const std::string &       
   Floris: Mainly copied from elxTransformBase.hxx
   */
   /** Typedef's. */
-  typedef typename FixedImageType::RegionType                FixedImageRegionType;
-  typedef typename FixedImageType::PointType                 FixedImageOriginType;
-  typedef typename FixedImageType::SpacingType               FixedImageSpacingType;
-  typedef typename FixedImageType::IndexType                 FixedImageIndexType;
-  typedef typename FixedImageIndexType::IndexValueType       FixedImageIndexValueType;
-  typedef typename MovingImageType::IndexType                MovingImageIndexType;
-  typedef itk::ContinuousIndex<double, FixedImageDimension>  FixedImageContinuousIndexType;
-  typedef typename FixedImageType::DirectionType             FixedImageDirectionType;
+  typedef typename FixedImageType::RegionType               FixedImageRegionType;
+  typedef typename FixedImageType::PointType                FixedImageOriginType;
+  typedef typename FixedImageType::SpacingType              FixedImageSpacingType;
+  typedef typename FixedImageType::IndexType                FixedImageIndexType;
+  typedef typename FixedImageIndexType::IndexValueType      FixedImageIndexValueType;
+  typedef typename MovingImageType::IndexType               MovingImageIndexType;
+  typedef itk::ContinuousIndex<double, FixedImageDimension> FixedImageContinuousIndexType;
+  typedef typename FixedImageType::DirectionType            FixedImageDirectionType;
 
   typedef unsigned char DummyIPPPixelType;
   typedef itk::DefaultStaticMeshTraits<DummyIPPPixelType, FixedImageDimension, FixedImageDimension, CoordRepType>

--- a/Components/Metrics/PolydataDummyPenalty/itkPolydataDummyPenalty.hxx
+++ b/Components/Metrics/PolydataDummyPenalty/itkPolydataDummyPenalty.hxx
@@ -39,8 +39,7 @@ MeshPenalty<TFixedPointSet, TMovingPointSet>::MeshPenalty()
  */
 
 template <class TFixedPointSet, class TMovingPointSet>
-MeshPenalty<TFixedPointSet, TMovingPointSet>::~MeshPenalty()
-= default; // end Destructor
+MeshPenalty<TFixedPointSet, TMovingPointSet>::~MeshPenalty() = default; // end Destructor
 
 /**
  * *********************** Initialize *****************************

--- a/Components/Metrics/SumSquaredTissueVolumeDifferenceMetric/elxSumSquaredTissueVolumeDifferenceMetric.h
+++ b/Components/Metrics/SumSquaredTissueVolumeDifferenceMetric/elxSumSquaredTissueVolumeDifferenceMetric.h
@@ -148,7 +148,6 @@ public:
 protected:
   /** The constructor. */
   SumSquaredTissueVolumeDifferenceMetric() = default;
-  ;
   /** The destructor. */
   ~SumSquaredTissueVolumeDifferenceMetric() override = default;
 

--- a/Components/Metrics/SumSquaredTissueVolumeDifferenceMetric/elxSumSquaredTissueVolumeDifferenceMetric.h
+++ b/Components/Metrics/SumSquaredTissueVolumeDifferenceMetric/elxSumSquaredTissueVolumeDifferenceMetric.h
@@ -147,7 +147,8 @@ public:
 
 protected:
   /** The constructor. */
-  SumSquaredTissueVolumeDifferenceMetric()= default;;
+  SumSquaredTissueVolumeDifferenceMetric() = default;
+  ;
   /** The destructor. */
   ~SumSquaredTissueVolumeDifferenceMetric() override = default;
 

--- a/Components/Metrics/SumSquaredTissueVolumeDifferenceMetric/itkSumSquaredTissueVolumeDifferenceImageToImageMetric.h
+++ b/Components/Metrics/SumSquaredTissueVolumeDifferenceMetric/itkSumSquaredTissueVolumeDifferenceImageToImageMetric.h
@@ -161,7 +161,6 @@ public:
 protected:
   SumSquaredTissueVolumeDifferenceImageToImageMetric();
   ~SumSquaredTissueVolumeDifferenceImageToImageMetric() override = default;
-  ;
 
   void
   PrintSelf(std::ostream & os, Indent indent) const override;

--- a/Components/Metrics/SumSquaredTissueVolumeDifferenceMetric/itkSumSquaredTissueVolumeDifferenceImageToImageMetric.h
+++ b/Components/Metrics/SumSquaredTissueVolumeDifferenceMetric/itkSumSquaredTissueVolumeDifferenceImageToImageMetric.h
@@ -160,7 +160,8 @@ public:
 
 protected:
   SumSquaredTissueVolumeDifferenceImageToImageMetric();
-  ~SumSquaredTissueVolumeDifferenceImageToImageMetric() override= default;;
+  ~SumSquaredTissueVolumeDifferenceImageToImageMetric() override = default;
+  ;
 
   void
   PrintSelf(std::ostream & os, Indent indent) const override;

--- a/Components/Optimizers/AdaptiveStochasticLBFGS/elxAdaptiveStochasticLBFGS.h
+++ b/Components/Optimizers/AdaptiveStochasticLBFGS/elxAdaptiveStochasticLBFGS.h
@@ -297,7 +297,8 @@ protected:
   typedef itk::Array<double>          DiagonalMatrixType;
 
   AdaptiveStochasticLBFGS();
-  ~AdaptiveStochasticLBFGS() override= default;;
+  ~AdaptiveStochasticLBFGS() override = default;
+  ;
 
   /** Variable to store the automatically determined settings for each resolution. */
   SettingsVectorType m_SettingsVector;

--- a/Components/Optimizers/AdaptiveStochasticLBFGS/elxAdaptiveStochasticLBFGS.h
+++ b/Components/Optimizers/AdaptiveStochasticLBFGS/elxAdaptiveStochasticLBFGS.h
@@ -298,7 +298,6 @@ protected:
 
   AdaptiveStochasticLBFGS();
   ~AdaptiveStochasticLBFGS() override = default;
-  ;
 
   /** Variable to store the automatically determined settings for each resolution. */
   SettingsVectorType m_SettingsVector;

--- a/Components/Optimizers/AdaptiveStochasticLBFGS/itkAdaptiveStochasticLBFGSOptimizer.h
+++ b/Components/Optimizers/AdaptiveStochasticLBFGS/itkAdaptiveStochasticLBFGSOptimizer.h
@@ -116,7 +116,8 @@ public:
 
 protected:
   AdaptiveStochasticLBFGSOptimizer();
-  ~AdaptiveStochasticLBFGSOptimizer() override= default;;
+  ~AdaptiveStochasticLBFGSOptimizer() override = default;
+  ;
 
   /** Function to update the current time
    * If UseAdaptiveStepSizes is false this function just increments

--- a/Components/Optimizers/AdaptiveStochasticLBFGS/itkAdaptiveStochasticLBFGSOptimizer.h
+++ b/Components/Optimizers/AdaptiveStochasticLBFGS/itkAdaptiveStochasticLBFGSOptimizer.h
@@ -117,7 +117,6 @@ public:
 protected:
   AdaptiveStochasticLBFGSOptimizer();
   ~AdaptiveStochasticLBFGSOptimizer() override = default;
-  ;
 
   /** Function to update the current time
    * If UseAdaptiveStepSizes is false this function just increments

--- a/Components/Optimizers/AdaptiveStochasticVarianceReducedGradient/elxAdaptiveStochasticVarianceReducedGradient.h
+++ b/Components/Optimizers/AdaptiveStochasticVarianceReducedGradient/elxAdaptiveStochasticVarianceReducedGradient.h
@@ -366,7 +366,8 @@ protected:
   typedef typename AdvancedTransformType::NonZeroJacobianIndicesType NonZeroJacobianIndicesType;
 
   AdaptiveStochasticVarianceReducedGradient();
-  ~AdaptiveStochasticVarianceReducedGradient() override= default;;
+  ~AdaptiveStochasticVarianceReducedGradient() override = default;
+  ;
 
   /** Variable to store the automatically determined settings for each resolution. */
   SettingsVectorType m_SettingsVector;

--- a/Components/Optimizers/AdaptiveStochasticVarianceReducedGradient/elxAdaptiveStochasticVarianceReducedGradient.h
+++ b/Components/Optimizers/AdaptiveStochasticVarianceReducedGradient/elxAdaptiveStochasticVarianceReducedGradient.h
@@ -367,7 +367,6 @@ protected:
 
   AdaptiveStochasticVarianceReducedGradient();
   ~AdaptiveStochasticVarianceReducedGradient() override = default;
-  ;
 
   /** Variable to store the automatically determined settings for each resolution. */
   SettingsVectorType m_SettingsVector;

--- a/Components/Optimizers/AdaptiveStochasticVarianceReducedGradient/itkAdaptiveStochasticVarianceReducedGradientOptimizer.h
+++ b/Components/Optimizers/AdaptiveStochasticVarianceReducedGradient/itkAdaptiveStochasticVarianceReducedGradientOptimizer.h
@@ -115,7 +115,6 @@ public:
 protected:
   AdaptiveStochasticVarianceReducedGradientOptimizer();
   ~AdaptiveStochasticVarianceReducedGradientOptimizer() override = default;
-  ;
 
   /** Function to update the current time
    * If UseAdaptiveStepSizes is false this function just increments

--- a/Components/Optimizers/AdaptiveStochasticVarianceReducedGradient/itkAdaptiveStochasticVarianceReducedGradientOptimizer.h
+++ b/Components/Optimizers/AdaptiveStochasticVarianceReducedGradient/itkAdaptiveStochasticVarianceReducedGradientOptimizer.h
@@ -114,7 +114,8 @@ public:
 
 protected:
   AdaptiveStochasticVarianceReducedGradientOptimizer();
-  ~AdaptiveStochasticVarianceReducedGradientOptimizer() override= default;;
+  ~AdaptiveStochasticVarianceReducedGradientOptimizer() override = default;
+  ;
 
   /** Function to update the current time
    * If UseAdaptiveStepSizes is false this function just increments

--- a/Components/Optimizers/AdaptiveStochasticVarianceReducedGradient/itkStandardStochasticVarianceReducedGradientDescentOptimizer.h
+++ b/Components/Optimizers/AdaptiveStochasticVarianceReducedGradient/itkStandardStochasticVarianceReducedGradientDescentOptimizer.h
@@ -127,7 +127,8 @@ public:
 
 protected:
   StandardStochasticVarianceReducedGradientOptimizer();
-  ~StandardStochasticVarianceReducedGradientOptimizer() override= default;;
+  ~StandardStochasticVarianceReducedGradientOptimizer() override = default;
+  ;
 
   /** Function to compute the step size for SGD at time/iteration k. */
   virtual double

--- a/Components/Optimizers/AdaptiveStochasticVarianceReducedGradient/itkStandardStochasticVarianceReducedGradientDescentOptimizer.h
+++ b/Components/Optimizers/AdaptiveStochasticVarianceReducedGradient/itkStandardStochasticVarianceReducedGradientDescentOptimizer.h
@@ -128,7 +128,6 @@ public:
 protected:
   StandardStochasticVarianceReducedGradientOptimizer();
   ~StandardStochasticVarianceReducedGradientOptimizer() override = default;
-  ;
 
   /** Function to compute the step size for SGD at time/iteration k. */
   virtual double

--- a/Components/Optimizers/AdaptiveStochasticVarianceReducedGradient/itkStochasticVarianceReducedGradientDescentOptimizer.cxx
+++ b/Components/Optimizers/AdaptiveStochasticVarianceReducedGradient/itkStochasticVarianceReducedGradientDescentOptimizer.cxx
@@ -335,7 +335,7 @@ StochasticVarianceReducedGradientDescentOptimizer::AdvanceOneStepThreaderCallbac
 
 void
 StochasticVarianceReducedGradientDescentOptimizer::ThreadedAdvanceOneStep(ThreadIdType     threadId,
-                                                                           ParametersType & newPosition)
+                                                                          ParametersType & newPosition)
 {
   /** Compute the range for this thread. */
   const unsigned int spaceDimension = this->GetScaledCostFunction()->GetNumberOfParameters();

--- a/Components/Optimizers/AdaptiveStochasticVarianceReducedGradient/itkStochasticVarianceReducedGradientDescentOptimizer.h
+++ b/Components/Optimizers/AdaptiveStochasticVarianceReducedGradient/itkStochasticVarianceReducedGradientDescentOptimizer.h
@@ -170,7 +170,8 @@ public:
 
 protected:
   StochasticVarianceReducedGradientDescentOptimizer();
-  ~StochasticVarianceReducedGradientDescentOptimizer() override= default;;
+  ~StochasticVarianceReducedGradientDescentOptimizer() override = default;
+  ;
   void
   PrintSelf(std::ostream & os, Indent indent) const override;
 

--- a/Components/Optimizers/AdaptiveStochasticVarianceReducedGradient/itkStochasticVarianceReducedGradientDescentOptimizer.h
+++ b/Components/Optimizers/AdaptiveStochasticVarianceReducedGradient/itkStochasticVarianceReducedGradientDescentOptimizer.h
@@ -171,7 +171,6 @@ public:
 protected:
   StochasticVarianceReducedGradientDescentOptimizer();
   ~StochasticVarianceReducedGradientDescentOptimizer() override = default;
-  ;
   void
   PrintSelf(std::ostream & os, Indent indent) const override;
 

--- a/Components/Optimizers/FullSearch/itkFullSearchOptimizer.cxx
+++ b/Components/Optimizers/FullSearch/itkFullSearchOptimizer.cxx
@@ -282,9 +282,9 @@ FullSearchOptimizer::ProcessSearchSpaceChanges(void)
  */
 void
 FullSearchOptimizer::AddSearchDimension(unsigned int   param_nr,
-                                         RangeValueType minimum,
-                                         RangeValueType maximum,
-                                         RangeValueType step)
+                                        RangeValueType minimum,
+                                        RangeValueType maximum,
+                                        RangeValueType step)
 {
   if (!m_SearchSpace)
   {

--- a/Components/Optimizers/PreconditionedGradientDescent/itkPreconditionedGradientDescentOptimizer.cxx
+++ b/Components/Optimizers/PreconditionedGradientDescent/itkPreconditionedGradientDescentOptimizer.cxx
@@ -278,8 +278,8 @@ PreconditionedGradientDescentOptimizer::AdvanceOneStep(void)
 
 void
 PreconditionedGradientDescentOptimizer::CholmodSolve(const DerivativeType & gradient,
-                                                      DerivativeType &       searchDirection,
-                                                      int                    solveType)
+                                                     DerivativeType &       searchDirection,
+                                                     int                    solveType)
 {
   /** This function uses m_CholmodGradient, m_CholmodCommon and m_CholmodFactor,
    * and is therefore not thread-safe.

--- a/Components/Optimizers/RSGDEachParameterApart/itkRSGDEachParameterApartOptimizer.cxx
+++ b/Components/Optimizers/RSGDEachParameterApart/itkRSGDEachParameterApartOptimizer.cxx
@@ -29,7 +29,7 @@ namespace itk
  */
 void
 RSGDEachParameterApartOptimizer::StepAlongGradient(const DerivativeType & factor,
-                                                    const DerivativeType & transformedGradient)
+                                                   const DerivativeType & transformedGradient)
 {
 
   itkDebugMacro(<< "factor = " << factor << "  transformedGradient= " << transformedGradient);

--- a/Components/Optimizers/StandardStochasticGradientDescent/itkStandardStochasticGradientDescentOptimizer.h
+++ b/Components/Optimizers/StandardStochasticGradientDescent/itkStandardStochasticGradientDescentOptimizer.h
@@ -134,7 +134,8 @@ public:
 
 protected:
   StandardStochasticGradientOptimizer();
-  ~StandardStochasticGradientOptimizer() override= default;;
+  ~StandardStochasticGradientOptimizer() override = default;
+  ;
 
   /** Function to compute the step size for SGD at time/iteration k. */
   virtual double

--- a/Components/Optimizers/StandardStochasticGradientDescent/itkStandardStochasticGradientDescentOptimizer.h
+++ b/Components/Optimizers/StandardStochasticGradientDescent/itkStandardStochasticGradientDescentOptimizer.h
@@ -135,7 +135,6 @@ public:
 protected:
   StandardStochasticGradientOptimizer();
   ~StandardStochasticGradientOptimizer() override = default;
-  ;
 
   /** Function to compute the step size for SGD at time/iteration k. */
   virtual double

--- a/Components/Optimizers/StandardStochasticGradientDescent/itkStochasticGradientDescentOptimizer.h
+++ b/Components/Optimizers/StandardStochasticGradientDescent/itkStochasticGradientDescentOptimizer.h
@@ -172,7 +172,6 @@ public:
 protected:
   StochasticGradientDescentOptimizer();
   ~StochasticGradientDescentOptimizer() override = default;
-  ;
   void
   PrintSelf(std::ostream & os, Indent indent) const override;
 

--- a/Components/Optimizers/StandardStochasticGradientDescent/itkStochasticGradientDescentOptimizer.h
+++ b/Components/Optimizers/StandardStochasticGradientDescent/itkStochasticGradientDescentOptimizer.h
@@ -171,7 +171,8 @@ public:
 
 protected:
   StochasticGradientDescentOptimizer();
-  ~StochasticGradientDescentOptimizer() override= default;;
+  ~StochasticGradientDescentOptimizer() override = default;
+  ;
   void
   PrintSelf(std::ostream & os, Indent indent) const override;
 

--- a/Components/Registrations/MultiResolutionRegistrationWithFeatures/itkMultiInputMultiResolutionImageRegistrationMethodBase.hxx
+++ b/Components/Registrations/MultiResolutionRegistrationWithFeatures/itkMultiInputMultiResolutionImageRegistrationMethodBase.hxx
@@ -76,8 +76,7 @@ itkImplementationSetMacro2(FixedImageInterpolator, FixedImageInterpolatorType *)
  */
 template <typename TFixedImage, typename TMovingImage>
 MultiInputMultiResolutionImageRegistrationMethodBase<TFixedImage, TMovingImage>::
-  MultiInputMultiResolutionImageRegistrationMethodBase()
-= default; // end Constructor()
+  MultiInputMultiResolutionImageRegistrationMethodBase() = default; // end Constructor()
 
 /**
  * **************** GetFixedImage **********************************

--- a/Components/Transforms/AdvancedBSplineTransform/elxAdvancedBSplineTransform.hxx
+++ b/Components/Transforms/AdvancedBSplineTransform/elxAdvancedBSplineTransform.hxx
@@ -32,8 +32,7 @@ namespace elastix
  */
 
 template <class TElastix>
-AdvancedBSplineTransform<TElastix>::AdvancedBSplineTransform()
-= default; // end Constructor()
+AdvancedBSplineTransform<TElastix>::AdvancedBSplineTransform() = default; // end Constructor()
 
 
 /**

--- a/Components/Transforms/AffineLogStackTransform/elxAffineLogStackTransform.hxx
+++ b/Components/Transforms/AffineLogStackTransform/elxAffineLogStackTransform.hxx
@@ -30,8 +30,7 @@ namespace elastix
  * ********************* Constructor ****************************
  */
 template <class TElastix>
-AffineLogStackTransform<TElastix>::AffineLogStackTransform()
-= default; // end Constructor
+AffineLogStackTransform<TElastix>::AffineLogStackTransform() = default; // end Constructor
 
 
 /**

--- a/Components/Transforms/BSplineStackTransform/elxBSplineStackTransform.hxx
+++ b/Components/Transforms/BSplineStackTransform/elxBSplineStackTransform.hxx
@@ -31,8 +31,7 @@ namespace elastix
  */
 
 template <class TElastix>
-BSplineStackTransform<TElastix>::BSplineStackTransform()
-= default; // end Constructor()
+BSplineStackTransform<TElastix>::BSplineStackTransform() = default; // end Constructor()
 
 
 /**

--- a/Components/Transforms/DeformationFieldTransform/itkDeformationFieldInterpolatingTransform.hxx
+++ b/Components/Transforms/DeformationFieldTransform/itkDeformationFieldInterpolatingTransform.hxx
@@ -42,8 +42,7 @@ DeformationFieldInterpolatingTransform<TScalarType, NDimensions, TComponentType>
 // Destructor
 template <class TScalarType, unsigned int NDimensions, class TComponentType>
 DeformationFieldInterpolatingTransform<TScalarType, NDimensions, TComponentType>::
-  ~DeformationFieldInterpolatingTransform()
-= default; // end Destructor
+  ~DeformationFieldInterpolatingTransform() = default; // end Destructor
 
 // Transform a point
 template <class TScalarType, unsigned int NDimensions, class TComponentType>

--- a/Components/Transforms/EulerStackTransform/elxEulerStackTransform.hxx
+++ b/Components/Transforms/EulerStackTransform/elxEulerStackTransform.hxx
@@ -27,8 +27,7 @@ namespace elastix
  * ********************* Constructor ****************************
  */
 template <class TElastix>
-EulerStackTransform<TElastix>::EulerStackTransform()
-= default; // end Constructor
+EulerStackTransform<TElastix>::EulerStackTransform() = default; // end Constructor
 
 
 /**

--- a/Components/Transforms/MultiBSplineTransformWithNormal/elxMultiBSplineTransformWithNormal.hxx
+++ b/Components/Transforms/MultiBSplineTransformWithNormal/elxMultiBSplineTransformWithNormal.hxx
@@ -35,8 +35,7 @@ namespace elastix
  */
 
 template <class TElastix>
-MultiBSplineTransformWithNormal<TElastix>::MultiBSplineTransformWithNormal()
-= default; // end Constructor()
+MultiBSplineTransformWithNormal<TElastix>::MultiBSplineTransformWithNormal() = default; // end Constructor()
 
 /**
  * ************ InitializeBSplineTransform ***************

--- a/Components/Transforms/MultiBSplineTransformWithNormal/itkMultiBSplineDeformableTransformWithNormal.hxx
+++ b/Components/Transforms/MultiBSplineTransformWithNormal/itkMultiBSplineDeformableTransformWithNormal.hxx
@@ -58,8 +58,7 @@ MultiBSplineDeformableTransformWithNormal<TScalarType, NDimensions, VSplineOrder
 // Destructor
 template <class TScalarType, unsigned int NDimensions, unsigned int VSplineOrder>
 MultiBSplineDeformableTransformWithNormal<TScalarType, NDimensions, VSplineOrder>::
-  ~MultiBSplineDeformableTransformWithNormal()
-= default;
+  ~MultiBSplineDeformableTransformWithNormal() = default;
 
 // Get the number of parameters
 template <class TScalarType, unsigned int NDimensions, unsigned int VSplineOrder>

--- a/Components/Transforms/RecursiveBSplineTransform/elxRecursiveBSplineTransform.hxx
+++ b/Components/Transforms/RecursiveBSplineTransform/elxRecursiveBSplineTransform.hxx
@@ -31,8 +31,7 @@ namespace elastix
  */
 
 template <class TElastix>
-RecursiveBSplineTransform<TElastix>::RecursiveBSplineTransform()
-= default; // end Constructor()
+RecursiveBSplineTransform<TElastix>::RecursiveBSplineTransform() = default; // end Constructor()
 
 
 /**

--- a/Core/Configuration/elxConfiguration.cxx
+++ b/Core/Configuration/elxConfiguration.cxx
@@ -184,7 +184,7 @@ Configuration::Initialize(const CommandLineArgumentMapType & _arg)
 
 int
 Configuration::Initialize(const CommandLineArgumentMapType &                _arg,
-                           const ParameterFileParserType::ParameterMapType & inputMap)
+                          const ParameterFileParserType::ParameterMapType & inputMap)
 {
   /** The first part is getting the command line arguments and setting them
    * in the configuration. From the command line arguments we find the name

--- a/Core/Kernel/elxElastixMain.cxx
+++ b/Core/Kernel/elxElastixMain.cxx
@@ -149,7 +149,7 @@ xoutManager::Guard::~Guard()
   // error: use of deleted function 'std::basic_ofstream<char>&
   // std::basic_ofstream<char>::operator=(const std::basic_ofstream<char>&)'
   g_data.~Data();
-  new( &g_data ) Data{};
+  new (&g_data) Data{};
 }
 
 

--- a/Core/Main/GTesting/ElastixFilterGTest.cxx
+++ b/Core/Main/GTesting/ElastixFilterGTest.cxx
@@ -63,13 +63,12 @@ GTEST_TEST(ElastixFilter, Translation)
 
   const auto parameterObject = elastix::ParameterObject::New();
 
-  const std::pair<std::string, std::string> parameterArray[] = {
-    // Parameters in alphabetic order:
-    { "ImageSampler", "Full" },
-    { "MaximumNumberOfIterations", "2" },
-    { "Metric", "AdvancedNormalizedCorrelation" },
-    { "Optimizer", "AdaptiveStochasticGradientDescent" },
-    { "Transform", "TranslationTransform" }
+  const std::pair<std::string, std::string> parameterArray[] = { // Parameters in alphabetic order:
+                                                                 { "ImageSampler", "Full" },
+                                                                 { "MaximumNumberOfIterations", "2" },
+                                                                 { "Metric", "AdvancedNormalizedCorrelation" },
+                                                                 { "Optimizer", "AdaptiveStochasticGradientDescent" },
+                                                                 { "Transform", "TranslationTransform" }
   };
 
   std::map<std::string, std::vector<std::string>> parameterMap;

--- a/Core/Main/GTesting/ElastixLibGTest.cxx
+++ b/Core/Main/GTesting/ElastixLibGTest.cxx
@@ -346,12 +346,11 @@ GTEST_TEST(ElastixLib, Translation3D)
   constexpr auto ImageDimension = 3;
   using ImageType = itk::Image<float, ImageDimension>;
 
-  const auto parameterMap =
-    CreateParameterMap<ImageDimension>({ { "ImageSampler", "Full" },
-                                         { "MaximumNumberOfIterations", "3" },
-                                         { "Metric", "AdvancedNormalizedCorrelation" },
-                                         { "Optimizer", "AdaptiveStochasticGradientDescent" },
-                                         { "Transform", "TranslationTransform" } });
+  const auto parameterMap = CreateParameterMap<ImageDimension>({ { "ImageSampler", "Full" },
+                                                                 { "MaximumNumberOfIterations", "3" },
+                                                                 { "Metric", "AdvancedNormalizedCorrelation" },
+                                                                 { "Optimizer", "AdaptiveStochasticGradientDescent" },
+                                                                 { "Transform", "TranslationTransform" } });
 
   const itk::Size<ImageDimension>   imageSize{ { 5, 7, 9 } };
   const itk::Size<ImageDimension>   regionSize = itk::Size<ImageDimension>::Filled(2);

--- a/Core/Main/GTesting/itkElastixRegistrationMethodGTest.cxx
+++ b/Core/Main/GTesting/itkElastixRegistrationMethodGTest.cxx
@@ -63,13 +63,12 @@ GTEST_TEST(itkElastixRegistrationMethod, Translation)
 
   const auto parameterObject = elastix::ParameterObject::New();
 
-  const std::pair<std::string, std::string> parameterArray[] = {
-    // Parameters in alphabetic order:
-    { "ImageSampler", "Full" },
-    { "MaximumNumberOfIterations", "2" },
-    { "Metric", "AdvancedNormalizedCorrelation" },
-    { "Optimizer", "AdaptiveStochasticGradientDescent" },
-    { "Transform", "TranslationTransform" }
+  const std::pair<std::string, std::string> parameterArray[] = { // Parameters in alphabetic order:
+                                                                 { "ImageSampler", "Full" },
+                                                                 { "MaximumNumberOfIterations", "2" },
+                                                                 { "Metric", "AdvancedNormalizedCorrelation" },
+                                                                 { "Optimizer", "AdaptiveStochasticGradientDescent" },
+                                                                 { "Transform", "TranslationTransform" }
   };
 
   std::map<std::string, std::vector<std::string>> parameterMap;

--- a/Core/Main/elastixlib.cxx
+++ b/Core/Main/elastixlib.cxx
@@ -94,7 +94,7 @@ ELASTIX::GetTransformParameterMap(void) const
  */
 
 ELASTIX::ParameterMapListType
-ELASTIX::GetTransformParameterMapList(void) const 
+ELASTIX::GetTransformParameterMapList(void) const
 {
   return this->m_TransformParametersList;
 } // end GetTransformParameterMapList()

--- a/Core/Main/elxElastixFilter.hxx
+++ b/Core/Main/elxElastixFilter.hxx
@@ -264,8 +264,7 @@ ElastixFilter<TFixedImage, TMovingImage>::GenerateData(void)
     }
 
     // TODO: Fix elastix corrupting default pixel value parameter
-    transformParameterMapVector.back()["DefaultPixelValue"] =
-      parameterMapVector[i]["DefaultPixelValue"];
+    transformParameterMapVector.back()["DefaultPixelValue"] = parameterMapVector[i]["DefaultPixelValue"];
   } // End loop over registrations
 
   // Save result image

--- a/Core/Main/elxParameterObject.cxx
+++ b/Core/Main/elxParameterObject.cxx
@@ -92,8 +92,8 @@ ParameterObject::GetParameterMap(const unsigned int & index) const
 
 void
 ParameterObject::SetParameter(const unsigned int &       index,
-                               const ParameterKeyType &   key,
-                               const ParameterValueType & value)
+                              const ParameterKeyType &   key,
+                              const ParameterValueType & value)
 {
   this->m_ParameterMap[index][key] = ParameterValueVectorType(1, value);
 }
@@ -105,8 +105,8 @@ ParameterObject::SetParameter(const unsigned int &       index,
 
 void
 ParameterObject::SetParameter(const unsigned int &             index,
-                               const ParameterKeyType &         key,
-                               const ParameterValueVectorType & value)
+                              const ParameterKeyType &         key,
+                              const ParameterValueVectorType & value)
 {
   this->m_ParameterMap[index][key] = value;
 }
@@ -254,7 +254,7 @@ ParameterObject::WriteParameterFile(void)
 
 void
 ParameterObject::WriteParameterFile(const ParameterMapType &      parameterMap,
-                                     const ParameterFileNameType & parameterFileName)
+                                    const ParameterFileNameType & parameterFileName)
 {
   std::ofstream parameterFile;
   parameterFile.exceptions(std::ofstream::failbit | std::ofstream::badbit);
@@ -341,7 +341,7 @@ ParameterObject::WriteParameterFile(const ParameterFileNameType & parameterFileN
 
 void
 ParameterObject::WriteParameterFile(const ParameterMapVectorType &      parameterMapVector,
-                                     const ParameterFileNameVectorType & parameterFileNameVector)
+                                    const ParameterFileNameVectorType & parameterFileNameVector)
 {
   if (parameterMapVector.size() != parameterFileNameVector.size())
   {
@@ -383,8 +383,8 @@ ParameterObject::WriteParameterFile(const ParameterFileNameVectorType & paramete
 
 const ParameterObject::ParameterMapType
 ParameterObject::GetDefaultParameterMap(const std::string &  transformName,
-                                         const unsigned int & numberOfResolutions,
-                                         const double &       finalGridSpacingInPhysicalUnits)
+                                        const unsigned int & numberOfResolutions,
+                                        const double &       finalGridSpacingInPhysicalUnits)
 {
   // Parameters that depend on size and number of resolutions
   ParameterMapType parameterMap = ParameterMapType();

--- a/Testing/itkCommandLineArgumentParser.cxx
+++ b/Testing/itkCommandLineArgumentParser.cxx
@@ -237,7 +237,7 @@ CommandLineArgumentParser::MarkArgumentAsRequired(const std::string & argument, 
 
 void
 CommandLineArgumentParser::MarkExactlyOneOfArgumentsAsRequired(const std::vector<std::string> & arguments,
-                                                                const std::string &              helpText)
+                                                               const std::string &              helpText)
 {
   std::pair<std::vector<std::string>, std::string> requiredArguments;
   requiredArguments.first = arguments;


### PR DESCRIPTION
Did rerun clang format as follows:

    find . -regex '.*\.\(hxx\|h\|cxx\)' -exec /c/Users/Niels_Dekker/AppData/Roaming/ClangPowerTools/LLVM/LLVM8.0.1/bin/clang-format.exe -style=file -i {} \;