### PR TITLE
STYLE: add clang format check

### DIFF
--- a/.github/workflows/clang_format_check.yml
+++ b/.github/workflows/clang_format_check.yml
@@ -1,0 +1,17 @@
+name: test-clang-format
+
+on: [push]
+
+jobs:
+  build:
+    runs-on: ubuntu-latest
+
+    steps:
+    - uses: actions/checkout@v2
+    - uses: DoozyX/clang-format-lint-action@v0.11
+      with:
+        source: '.'
+        exclude: './CMake'
+        extensions: 'hxx,h,cxx'
+        clangFormatVersion: 8
+        style: file


### PR DESCRIPTION
The proposed style changes are given as output of GitHub actions, which fails if files do not adhere to the clang format file.