### PR TITLE
STYLE: Revert workaround GCC4 error xoutManager "use of deleted func..."

### DIFF
--- a/Core/Kernel/elxElastixMain.cxx
+++ b/Core/Kernel/elxElastixMain.cxx
@@ -143,13 +143,7 @@ xoutManager::xoutManager(const std::string & logFileName, const bool setupLoggin
 
 xoutManager::Guard::~Guard()
 {
-  // Destruct and reconstruct the data, in order to reset the output streams.
-  // Note: a simple assignment, `g_data = {}` would be preferable, but doing
-  // so triggered compilation errors on Linux / GCC 4.8:
-  // error: use of deleted function 'std::basic_ofstream<char>&
-  // std::basic_ofstream<char>::operator=(const std::basic_ofstream<char>&)'
-  g_data.~Data();
-  new (&g_data) Data{};
+  g_data = {};
 }
 
 


### PR DESCRIPTION
This reverts commit c106327239f2d2a0ef6962f00f86f8ae41e8781f "COMP: Avoid GCC4 error xoutManager "use of deleted function", issue #331"

Matt McCormick (@thewtex) informed us that GCC 4 no longer needs to be supported, as ITKElastix is upgraded to manylinux2014, which allows using GCC 9 instead.