### PR TITLE
Remove bitwise AND assignment of literal bool values (true and false)

### DIFF
--- a/Common/CostFunctions/itkImageToImageMetricWithFeatures.h
+++ b/Common/CostFunctions/itkImageToImageMetricWithFeatures.h
@@ -244,7 +244,6 @@ protected:
   MovingFeatureInterpolatorVectorType m_MovingFeatureInterpolators;
 
   std::vector<bool>                    m_FeatureInterpolatorsIsBSpline;
-  bool                                 m_FeatureInterpolatorsAreBSpline;
   BSplineFeatureInterpolatorVectorType m_MovingFeatureBSplineInterpolators;
 
   /** Initialize variables for image derivative computation; this

--- a/Common/CostFunctions/itkImageToImageMetricWithFeatures.hxx
+++ b/Common/CostFunctions/itkImageToImageMetricWithFeatures.hxx
@@ -316,7 +316,6 @@ ImageToImageMetricWithFeatures<TFixedImage, TMovingImage, TFixedFeatureImage, TM
     if (testPtr)
     {
       this->m_FeatureInterpolatorsIsBSpline[i] = true;
-      this->m_FeatureInterpolatorsAreBSpline &= true;
       this->m_MovingFeatureBSplineInterpolators[i] = testPtr;
       itkDebugMacro(<< "Interpolator " << i << " is B-spline.");
     }

--- a/Common/CostFunctions/itkImageToImageMetricWithFeatures.hxx
+++ b/Common/CostFunctions/itkImageToImageMetricWithFeatures.hxx
@@ -306,7 +306,6 @@ ImageToImageMetricWithFeatures<TFixedImage, TMovingImage, TFixedFeatureImage, TM
    * Otherwise, an exception is thrown.
    */
   this->m_FeatureInterpolatorsIsBSpline.resize(this->m_NumberOfMovingFeatureImages, false);
-  this->m_FeatureInterpolatorsAreBSpline = true;
   this->m_MovingFeatureBSplineInterpolators.resize(this->m_NumberOfMovingFeatureImages);
   for (unsigned int i = 0; i < this->m_NumberOfMovingFeatureImages; ++i)
   {

--- a/Common/CostFunctions/itkMultiInputImageToImageMetricBase.hxx
+++ b/Common/CostFunctions/itkMultiInputImageToImageMetricBase.hxx
@@ -204,7 +204,7 @@ MultiInputImageToImageMetricBase<TFixedImage, TMovingImage>::CheckForBSplineInte
     }
     else
     {
-      this->m_InterpolatorsAreBSpline &= false;
+      this->m_InterpolatorsAreBSpline = false;
       itkDebugMacro(<< "Interpolator " << i << " is NOT B-spline.");
       itkExceptionMacro(<< "Interpolator " << i << " is NOT B-spline.");
     }

--- a/Common/CostFunctions/itkMultiInputImageToImageMetricBase.hxx
+++ b/Common/CostFunctions/itkMultiInputImageToImageMetricBase.hxx
@@ -198,7 +198,6 @@ MultiInputImageToImageMetricBase<TFixedImage, TMovingImage>::CheckForBSplineInte
 
     if (testPtr)
     {
-      this->m_InterpolatorsAreBSpline &= true;
       this->m_BSplineInterpolatorVector[i] = testPtr;
       itkDebugMacro(<< "Interpolator " << i << " is B-spline.");
     }

--- a/Components/Transforms/AdvancedAffineTransform/elxAdvancedAffineTransform.hxx
+++ b/Components/Transforms/AdvancedAffineTransform/elxAdvancedAffineTransform.hxx
@@ -194,14 +194,14 @@ AdvancedAffineTransformElastix<TElastix>::InitializeTransform(void)
     bool foundI = this->m_Configuration->ReadParameter(centerOfRotationIndex[i], "CenterOfRotation", i, false);
     if (!foundI)
     {
-      centerGivenAsIndex &= false;
+      centerGivenAsIndex = false;
     }
 
     /** Check COR point: Returns zero when parameter was in the parameter file. */
     bool foundP = this->m_Configuration->ReadParameter(centerOfRotationPoint[i], "CenterOfRotationPoint", i, false);
     if (!foundP)
     {
-      centerGivenAsPoint &= false;
+      centerGivenAsPoint = false;
     }
   } // end loop over SpaceDimension
 
@@ -488,7 +488,7 @@ AdvancedAffineTransformElastix<TElastix>::ReadCenterOfRotationPoint(InputPointTy
     bool found = this->m_Configuration->ReadParameter(centerOfRotationPoint[i], "CenterOfRotationPoint", i, false);
     if (!found)
     {
-      centerGivenAsPoint &= false;
+      centerGivenAsPoint = false;
     }
   }
 

--- a/Components/Transforms/AffineDTITransform/elxAffineDTITransform.hxx
+++ b/Components/Transforms/AffineDTITransform/elxAffineDTITransform.hxx
@@ -170,14 +170,14 @@ AffineDTITransformElastix<TElastix>::InitializeTransform(void)
     bool foundI = this->m_Configuration->ReadParameter(centerOfRotationIndex[i], "CenterOfRotation", i, false);
     if (!foundI)
     {
-      centerGivenAsIndex &= false;
+      centerGivenAsIndex = false;
     }
 
     /** Check COR point: Returns zero when parameter was in the parameter file. */
     bool foundP = this->m_Configuration->ReadParameter(centerOfRotationPoint[i], "CenterOfRotationPoint", i, false);
     if (!foundP)
     {
-      centerGivenAsPoint &= false;
+      centerGivenAsPoint = false;
     }
 
   } // end loop over SpaceDimension
@@ -370,7 +370,7 @@ AffineDTITransformElastix<TElastix>::ReadCenterOfRotationPoint(InputPointType & 
     bool found = this->m_Configuration->ReadParameter(centerOfRotationPoint[i], "CenterOfRotationPoint", i, false);
     if (!found)
     {
-      centerGivenAsPoint &= false;
+      centerGivenAsPoint = false;
     }
   }
 

--- a/Components/Transforms/AffineLogStackTransform/elxAffineLogStackTransform.hxx
+++ b/Components/Transforms/AffineLogStackTransform/elxAffineLogStackTransform.hxx
@@ -238,14 +238,14 @@ AffineLogStackTransform<TElastix>::InitializeTransform()
     bool foundI = this->m_Configuration->ReadParameter(centerOfRotationIndex[i], "CenterOfRotation", i, false);
     if (!foundI)
     {
-      centerGivenAsIndex &= false;
+      centerGivenAsIndex = false;
     }
 
     /** Check COR point: Returns zero when parameter was in the parameter file. */
     bool foundP = this->m_Configuration->ReadParameter(RDcenterOfRotationPoint[i], "CenterOfRotationPoint", i, false);
     if (!foundP)
     {
-      centerGivenAsPoint &= false;
+      centerGivenAsPoint = false;
     }
   } // end loop over SpaceDimension
 
@@ -464,7 +464,7 @@ AffineLogStackTransform<TElastix>::ReadCenterOfRotationPoint(ReducedDimensionInp
     bool found = this->m_Configuration->ReadParameter(RDcenterOfRotationPoint[i], "CenterOfRotationPoint", i, false);
     if (!found)
     {
-      centerGivenAsPoint &= false;
+      centerGivenAsPoint = false;
     }
   }
 

--- a/Components/Transforms/AffineLogTransform/elxAffineLogTransform.hxx
+++ b/Components/Transforms/AffineLogTransform/elxAffineLogTransform.hxx
@@ -173,14 +173,14 @@ AffineLogTransformElastix<TElastix>::InitializeTransform(void)
     bool foundI = this->m_Configuration->ReadParameter(centerOfRotationIndex[i], "CenterOfRotation", i, false);
     if (!foundI)
     {
-      centerGivenAsIndex &= false;
+      centerGivenAsIndex = false;
     }
 
     /** Check COR point: Returns zero when parameter was in the parameter file. */
     bool foundP = this->m_Configuration->ReadParameter(centerOfRotationPoint[i], "CenterOfRotationPoint", i, false);
     if (!foundP)
     {
-      centerGivenAsPoint &= false;
+      centerGivenAsPoint = false;
     }
 
   } // end loop over SpaceDimension
@@ -373,7 +373,7 @@ AffineLogTransformElastix<TElastix>::ReadCenterOfRotationPoint(InputPointType & 
     bool found = this->m_Configuration->ReadParameter(centerOfRotationPoint[i], "CenterOfRotationPoint", i, false);
     if (!found)
     {
-      centerGivenAsPoint &= false;
+      centerGivenAsPoint = false;
     }
   }
 

--- a/Components/Transforms/EulerStackTransform/elxEulerStackTransform.hxx
+++ b/Components/Transforms/EulerStackTransform/elxEulerStackTransform.hxx
@@ -235,7 +235,7 @@ EulerStackTransform<TElastix>::InitializeTransform()
     const bool foundI = this->m_Configuration->ReadParameter(centerOfRotationIndex[i], "CenterOfRotation", i, false);
     if (!foundI)
     {
-      centerGivenAsIndex &= false;
+      centerGivenAsIndex = false;
     }
 
     /** Check COR point: Returns zero when parameter was in the parameter file. */
@@ -243,7 +243,7 @@ EulerStackTransform<TElastix>::InitializeTransform()
       this->m_Configuration->ReadParameter(redDimCenterOfRotationPoint[i], "CenterOfRotationPoint", i, false);
     if (!foundP)
     {
-      centerGivenAsPoint &= false;
+      centerGivenAsPoint = false;
     }
   } // end loop over SpaceDimension
 
@@ -521,7 +521,7 @@ EulerStackTransform<TElastix>::ReadCenterOfRotationPoint(ReducedDimensionInputPo
       this->m_Configuration->ReadParameter(redDimCenterOfRotationPoint[i], "CenterOfRotationPoint", i, false);
     if (!found)
     {
-      centerGivenAsPoint &= false;
+      centerGivenAsPoint = false;
     }
   }
 

--- a/Components/Transforms/EulerTransform/elxEulerTransform.hxx
+++ b/Components/Transforms/EulerTransform/elxEulerTransform.hxx
@@ -220,14 +220,14 @@ EulerTransformElastix<TElastix>::InitializeTransform(void)
     bool foundI = this->m_Configuration->ReadParameter(centerOfRotationIndex[i], "CenterOfRotation", i, false);
     if (!foundI)
     {
-      centerGivenAsIndex &= false;
+      centerGivenAsIndex = false;
     }
 
     /** Check COR point: Returns zero when parameter was in the parameter file. */
     bool foundP = this->m_Configuration->ReadParameter(centerOfRotationPoint[i], "CenterOfRotationPoint", i, false);
     if (!foundP)
     {
-      centerGivenAsPoint &= false;
+      centerGivenAsPoint = false;
     }
 
   } // end loop over SpaceDimension
@@ -489,7 +489,7 @@ EulerTransformElastix<TElastix>::ReadCenterOfRotationPoint(InputPointType & rota
     bool found = this->m_Configuration->ReadParameter(centerOfRotationPoint[i], "CenterOfRotationPoint", i, false);
     if (!found)
     {
-      centerGivenAsPoint &= false;
+      centerGivenAsPoint = false;
     }
   }
 

--- a/Components/Transforms/SimilarityTransform/elxSimilarityTransform.hxx
+++ b/Components/Transforms/SimilarityTransform/elxSimilarityTransform.hxx
@@ -162,13 +162,13 @@ SimilarityTransformElastix<TElastix>::InitializeTransform(void)
     bool foundI = this->m_Configuration->ReadParameter(centerOfRotationIndex[i], "CenterOfRotation", i, false);
     if (!foundI)
     {
-      centerGivenAsIndex &= false;
+      centerGivenAsIndex = false;
     }
     /** Check COR point: Returns zero when parameter was in the parameter file. */
     bool foundP = this->m_Configuration->ReadParameter(centerOfRotationPoint[i], "CenterOfRotationPoint", i, false);
     if (!foundP)
     {
-      centerGivenAsPoint &= false;
+      centerGivenAsPoint = false;
     }
   } // end loop over SpaceDimension
 
@@ -369,7 +369,7 @@ SimilarityTransformElastix<TElastix>::ReadCenterOfRotationIndex(InputPointType &
     bool found = this->m_Configuration->ReadParameter(centerOfRotationIndex[i], "CenterOfRotation", i, false);
     if (!found)
     {
-      centerGivenAsIndex &= false;
+      centerGivenAsIndex = false;
     }
   }
 
@@ -472,7 +472,7 @@ SimilarityTransformElastix<TElastix>::ReadCenterOfRotationPoint(InputPointType &
     bool found = this->m_Configuration->ReadParameter(centerOfRotationPoint[i], "CenterOfRotationPoint", i, false);
     if (!found)
     {
-      centerGivenAsPoint &= false;
+      centerGivenAsPoint = false;
     }
   }
 


### PR DESCRIPTION
For any `bool` variable `b`, a statement of the form `b &= true` has no effect at all.

`b &= false` has exactly the same effect as a simple `b = false` assignment.