### PR TITLE
STYLE: Fix clang-format errors #358 (TransformOutputFileNameExtensions)

### DIFF
--- a/Common/Transforms/elxTransformIO.cxx
+++ b/Common/Transforms/elxTransformIO.cxx
@@ -29,8 +29,8 @@
 
 itk::TransformBaseTemplate<double>::Pointer
 elastix::TransformIO::CreateCorrespondingItkTransform(const elx::BaseComponent & elxTransform,
-                                                      const unsigned                             fixedImageDimension,
-                                                      const unsigned                             movingImageDimension)
+                                                      const unsigned             fixedImageDimension,
+                                                      const unsigned             movingImageDimension)
 {
   // Initialize the factory.
   itk::TransformFactoryBase::GetFactory();
@@ -52,8 +52,8 @@ elastix::TransformIO::CreateCorrespondingItkTransform(const elx::BaseComponent &
   }
   const auto substr = elxClassName.substr(0, transformSubstringPosition);
   const auto instanceName = (((substr == "Euler") || (substr == "Similarity"))
-                                ? (substr + std::to_string(fixedImageDimension) + 'D' + transformSubstring)
-                                : elxClassName) +
+                               ? (substr + std::to_string(fixedImageDimension) + 'D' + transformSubstring)
+                               : elxClassName) +
                             "_double_" + std::to_string(fixedImageDimension) + '_' +
                             std::to_string(movingImageDimension);
   const auto instance = itk::ObjectFactoryBase::CreateInstance(instanceName.c_str());

--- a/Common/Transforms/elxTransformIO.h
+++ b/Common/Transforms/elxTransformIO.h
@@ -35,14 +35,12 @@ public:
   }
 
   static void
-  SetParameters(const bool                                 fixed,
-                itk::TransformBaseTemplate<double> & transform,
+  SetParameters(const bool                               fixed,
+                itk::TransformBaseTemplate<double> &     transform,
                 const itk::OptimizerParameters<double> & parameters)
   {
     fixed ? transform.SetFixedParameters(parameters) : transform.SetParameters(parameters);
   }
-
-
 
 
   template <typename TElastixTransform>
@@ -53,8 +51,7 @@ public:
       elxTransform, TElastixTransform::FixedImageDimension, TElastixTransform::MovingImageDimension);
   }
 
-  static
-  void
+  static void
   Write(const itk::TransformBaseTemplate<double> & itkTransform, const std::string & fileName);
 
 private:

--- a/Core/ComponentBaseClasses/elxTransformBase.hxx
+++ b/Core/ComponentBaseClasses/elxTransformBase.hxx
@@ -661,9 +661,10 @@ TransformBase<TElastix>::WriteToFile(const ParametersType & param) const
   if (!transformOutputFileNameExtensions.empty())
   {
     elxout << "WARNING: Support for the parameter TransformOutputFileNameExtensions is still experimental!\n"
-      "Transform files stored by this feature may still be incomplete or incorrect!"<< std::endl;  
+              "Transform files stored by this feature may still be incomplete or incorrect!"
+           << std::endl;
 
-    const itk::TransformBaseTemplate<double>* const thisAsITKBase = this->GetAsITKBaseType();
+    const itk::TransformBaseTemplate<double> * const thisAsITKBase = this->GetAsITKBaseType();
     assert(thisAsITKBase != nullptr);
 
     const auto correspondingItkTransform = TransformIO::CreateCorrespondingItkTransform(*this);


### PR DESCRIPTION
Did rerun clang-format as follows:

    find . -regex '.*\.\(hxx\|h\|cxx\)' -exec /c/Users/Niels_Dekker/AppData/Roaming/ClangPowerTools/LLVM/LLVM8.0.1/bin/clang-format.exe -style=file -i {} \;

Formatting errors were introduced by merging pull request #358 ("ENH: Add parameter file support for TransformOutputFileNameExtensions")