### PR TITLE
BUG: Transform UseAddition should affect CreateTransformParametersMap

### DIFF
--- a/Core/ComponentBaseClasses/elxTransformBase.hxx
+++ b/Core/ComponentBaseClasses/elxTransformBase.hxx
@@ -856,9 +856,9 @@ TransformBase<TElastix>::CreateTransformParametersMap(const ParametersType & par
   const CombinationTransformType * dummyComboTransform = dynamic_cast<const CombinationTransformType *>(this);
   if (dummyComboTransform)
   {
-    if (dummyComboTransform->GetUseComposition())
+    if (dummyComboTransform->GetUseAddition())
     {
-      combinationMethod = "Compose";
+      combinationMethod = "Add";
     }
   }
 


### PR DESCRIPTION
After calling `elxTransform.SetUseAddition(true)`, a call to `CreateTransformParametersMap` should yield a map with parameterMap["HowToCombineTransforms"] returning "Add", and not "Compose". Just like `TransformBase::WriteToFile` writes "(HowToCombineTransforms Add)", in that case.

This commit aims to fix this bug, and includes a GoogleTest unit test. Discussed with Marius (@mstaring) at our internal weekly elastix sprint.