### PR TITLE
Support TFM + HDF5 file format for initial transform parameter file

### DIFF
--- a/Common/Transforms/elxTransformIO.cxx
+++ b/Common/Transforms/elxTransformIO.cxx
@@ -92,7 +92,7 @@ elastix::TransformIO::CreateCorrespondingElxTransform(const itk::TransformBaseTe
 
     if (object != nullptr)
     {
-      return dynamic_cast<itk::TransformBaseTemplate<double> *>(&*creator());
+      return dynamic_cast<itk::TransformBaseTemplate<double> *>(&*object);
     }
   }
   return nullptr;

--- a/Common/Transforms/elxTransformIO.h
+++ b/Common/Transforms/elxTransformIO.h
@@ -55,6 +55,13 @@ public:
   static void
   Write(const itk::TransformBaseTemplate<double> & itkTransform, const std::string & fileName);
 
+  static itk::SmartPointer<itk::TransformBaseTemplate<double>>
+  Read(const std::string & fileName);
+
+  static itk::TransformBaseTemplate<double>::Pointer
+  CreateCorrespondingElxTransform(const itk::TransformBaseTemplate<double> & itkTransform,
+                                  const std::string &                        fixedPixelType,
+                                  const std::string &                        movingPixelType);
 
   /// Makes the deformation field file name, as used by BSplineTransformWithDiffusion and DeformationFieldTransform.
   template <typename TElastixTransform>

--- a/Components/Transforms/ExternalTransform/CMakeLists.txt
+++ b/Components/Transforms/ExternalTransform/CMakeLists.txt
@@ -1,0 +1,6 @@
+
+ADD_ELXCOMPONENT( ExternalTransform
+ elxExternalTransform.h
+ elxExternalTransform.hxx
+ elxExternalTransform.cxx )
+

--- a/Components/Transforms/ExternalTransform/elxExternalTransform.cxx
+++ b/Components/Transforms/ExternalTransform/elxExternalTransform.cxx
@@ -1,0 +1,23 @@
+/*=========================================================================
+ *
+ *  Copyright UMC Utrecht and contributors
+ *
+ *  Licensed under the Apache License, Version 2.0 (the "License");
+ *  you may not use this file except in compliance with the License.
+ *  You may obtain a copy of the License at
+ *
+ *        http://www.apache.org/licenses/LICENSE-2.0.txt
+ *
+ *  Unless required by applicable law or agreed to in writing, software
+ *  distributed under the License is distributed on an "AS IS" BASIS,
+ *  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *  See the License for the specific language governing permissions and
+ *  limitations under the License.
+ *
+ *=========================================================================*/
+
+#include "elxMacro.h"
+#include "elxSupportedImageTypes.h"
+#include "elxExternalTransform.h"
+
+elxInstallMacro(ExternalTransform);

--- a/Components/Transforms/ExternalTransform/elxExternalTransform.h
+++ b/Components/Transforms/ExternalTransform/elxExternalTransform.h
@@ -1,0 +1,111 @@
+/*=========================================================================
+ *
+ *  Copyright UMC Utrecht and contributors
+ *
+ *  Licensed under the Apache License, Version 2.0 (the "License");
+ *  you may not use this file except in compliance with the License.
+ *  You may obtain a copy of the License at
+ *
+ *        http://www.apache.org/licenses/LICENSE-2.0.txt
+ *
+ *  Unless required by applicable law or agreed to in writing, software
+ *  distributed under the License is distributed on an "AS IS" BASIS,
+ *  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *  See the License for the specific language governing permissions and
+ *  limitations under the License.
+ *
+ *=========================================================================*/
+#ifndef elxExternalTransform_h
+#define elxExternalTransform_h
+
+#include "itkAdvancedCombinationTransform.h"
+#include "elxTransformBase.h"
+
+#include <itkMacro.h>
+#include <itkSmartPointer.h>
+
+namespace elastix
+{
+
+/**
+ * \class ExternalTransform
+ *
+ * This class is represents an external ITK transform.
+ *
+ * The parameters used in this class are:
+ * \parameter Transform: Select this transform as follows:\n
+ *    <tt>(Transform "ExternalTransform")</tt>
+ * \parameter TransformFileName: \n
+ *    example: <tt>(TransformFileName "Transform.h5")</tt> \n
+ *    By default "" is assumed.
+ *
+ * \ingroup Transforms
+ */
+
+template <class TElastix>
+class ITK_TEMPLATE_EXPORT ExternalTransform
+  : public itk::AdvancedCombinationTransform<typename elx::TransformBase<TElastix>::CoordRepType,
+                                             elx::TransformBase<TElastix>::FixedImageDimension>
+  , public elx::TransformBase<TElastix>
+{
+public:
+  ITK_DISALLOW_COPY_AND_ASSIGN(ExternalTransform);
+
+  /** Standard ITK-stuff. */
+  using Self = ExternalTransform;
+  using Pointer = itk::SmartPointer<Self>;
+  using ConstPointer = itk::SmartPointer<const Self>;
+
+  using ITKTransformType = itk::Transform<double, TElastix::FixedDimension, TElastix::MovingDimension>;
+
+  /** Method for creation through the object factory. */
+  itkNewMacro(Self);
+
+  /** Run-time type information (and related methods). */
+  itkTypeMacro(ExternalTransform, itk::AdvancedCombinationTransform);
+
+  /** Name of this class.
+   * Use this name in the parameter file to select this specific transform. \n
+   * example: <tt>(Transform "ExternalTransform")</tt>\n
+   */
+  elxClassNameMacro("ExternalTransform");
+
+  ITKTransformType *
+  GetITKTransform(void) override
+  {
+    std::string transformFileName;
+    this->m_Configuration->ReadParameter(transformFileName, "TransformFileName", 0);
+
+    if (transformFileName != m_TransformFileName)
+    {
+      m_ITKTransform = dynamic_cast<ITKTransformType *>(TransformIO::Read(transformFileName).GetPointer());
+      m_TransformFileName = std::move(transformFileName);
+    }
+    return m_ITKTransform.GetPointer();
+  }
+
+private:
+  /** Default-constructor. */
+  ExternalTransform() = default;
+
+  /** Destructor. */
+  ~ExternalTransform() override = default;
+
+  elxOverrideGetSelfMacro;
+
+  /** Creates a map of the parameters specific for this (derived) transform type. */
+  itk::ParameterFileParser::ParameterMapType
+  CreateDerivedTransformParametersMap(void) const override;
+
+  itk::SmartPointer<ITKTransformType> m_ITKTransform;
+
+  std::string m_TransformFileName;
+};
+
+} // end namespace elastix
+
+#ifndef ITK_MANUAL_INSTANTIATION
+#  include "elxExternalTransform.hxx"
+#endif
+
+#endif // end #ifndef elxExternalTransform_h

--- a/Components/Transforms/ExternalTransform/elxExternalTransform.hxx
+++ b/Components/Transforms/ExternalTransform/elxExternalTransform.hxx
@@ -1,0 +1,42 @@
+/*=========================================================================
+ *
+ *  Copyright UMC Utrecht and contributors
+ *
+ *  Licensed under the Apache License, Version 2.0 (the "License");
+ *  you may not use this file except in compliance with the License.
+ *  You may obtain a copy of the License at
+ *
+ *        http://www.apache.org/licenses/LICENSE-2.0.txt
+ *
+ *  Unless required by applicable law or agreed to in writing, software
+ *  distributed under the License is distributed on an "AS IS" BASIS,
+ *  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *  See the License for the specific language governing permissions and
+ *  limitations under the License.
+ *
+ *=========================================================================*/
+#ifndef elxExternalTransform_hxx
+#define elxExternalTransform_hxx
+
+#include "elxExternalTransform.h"
+#include "elxTransformIO.h"
+
+namespace elastix
+{
+
+/**
+ * ************************* CreateDerivedTransformParametersMap ************************
+ */
+
+template <class TElastix>
+itk::ParameterFileParser::ParameterMapType
+ExternalTransform<TElastix>::CreateDerivedTransformParametersMap(void) const
+{
+  return { { "TransformFileName", { m_TransformFileName } } };
+
+} // end CreateDerivedTransformParametersMap()
+
+
+} // end namespace elastix
+
+#endif // end #ifndef elxExternalTransform_hxx

--- a/Core/ComponentBaseClasses/elxResamplerBase.hxx
+++ b/Core/ComponentBaseClasses/elxResamplerBase.hxx
@@ -278,7 +278,7 @@ ResamplerBase<TElastix>::SetComponents(void)
   /** Set the transform, the interpolator and the inputImage
    * (which is the moving image).
    */
-  this->GetAsITKBaseType()->SetTransform(dynamic_cast<TransformType *>(this->m_Elastix->GetElxTransformBase()));
+  this->GetAsITKBaseType()->SetTransform(this->m_Elastix->GetElxTransformBase()->GetITKTransform());
 
   this->GetAsITKBaseType()->SetInterpolator(
     dynamic_cast<InterpolatorType *>(this->m_Elastix->GetElxResampleInterpolatorBase()));

--- a/Core/ComponentBaseClasses/elxTransformBase.h
+++ b/Core/ComponentBaseClasses/elxTransformBase.h
@@ -209,6 +209,14 @@ public:
     return &(this->GetSelf());
   }
 
+  /** Retrieves the transform. */
+  virtual itk::Transform<double, FixedImageDimension, MovingImageDimension> *
+  GetITKTransform(void)
+  {
+    return &(this->GetSelf());
+  }
+
+
   /** Execute stuff before the actual transformation:
    * \li Check the appearance of inputpoints to be transformed.
    */

--- a/Core/ComponentBaseClasses/elxTransformBase.hxx
+++ b/Core/ComponentBaseClasses/elxTransformBase.hxx
@@ -337,8 +337,11 @@ TransformBase<TElastix>::ReadFromFile(void)
   this->m_Configuration->ReadParameter(
     useBinaryFormatForTransformationParameters, "UseBinaryFormatForTransformationParameters", 0);
 
+  std::string transformFileName;
+  this->m_Configuration->ReadParameter(transformFileName, "TransformFileName", 0, false);
+
   /** Read the TransformParameters. */
-  if (this->m_ReadWriteTransformParameters)
+  if (this->m_ReadWriteTransformParameters && transformFileName.empty())
   {
     /** Get the TransformParameters pointer. */
     this->m_TransformParametersPointer.reset(new ParametersType(numberOfParameters));

--- a/Core/Kernel/elxTransformixMain.cxx
+++ b/Core/Kernel/elxTransformixMain.cxx
@@ -107,13 +107,14 @@ TransformixMain::Run(void)
   elastixBase.SetConfiguration(this->m_Configuration);
   elastixBase.SetDBIndex(this->m_DBIndex);
 
-  /** Populate the component containers. No default is specified for the Transform. */
+  /** Populate the component containers. */
   elastixBase.SetResampleInterpolatorContainer(
     this->CreateComponents("ResampleInterpolator", "FinalBSplineInterpolator", errorCode));
 
   elastixBase.SetResamplerContainer(this->CreateComponents("Resampler", "DefaultResampler", errorCode));
 
-  elastixBase.SetTransformContainer(this->CreateComponents("Transform", "", errorCode));
+  /** By default, the transform is specified by an external file (.HDF5 or .TFM). */
+  elastixBase.SetTransformContainer(this->CreateComponents("Transform", "File", errorCode));
 
   /** Check if all components could be created. */
   if (errorCode != 0)


### PR DESCRIPTION
Added support for the TFM (Insight Transform File, .tfm) and the HDF5 (.h5) file format, for initial transform parameter files, as specified by the parameter `InitialTransformParametersFileName`.

Internally added `TransformIO::Read` and `TransformIO::CreateCorrespondingElxTransform`, which is then called by `TransformBase::ReadInitialTransformFromFile`.

Note: the currect commit only supports transform files that can be read by ITK's `itk::TransformFileReader`. And only those ITK transform types for which a corresponding elastix transform can be created.