### PR TITLE
STYLE: Rerun clang-format after pull request #363

### DIFF
--- a/Components/Transforms/AffineLogStackTransform/elxAffineLogStackTransform.hxx
+++ b/Components/Transforms/AffineLogStackTransform/elxAffineLogStackTransform.hxx
@@ -344,17 +344,18 @@ AffineLogStackTransform<TElastix>::SetScales(void)
 
   /** Check if automatic scales estimation is desired. */
   bool automaticScalesEstimation = false;
-  this->m_Configuration->ReadParameter(
-    automaticScalesEstimation, "AutomaticScalesEstimation", 0);
+  this->m_Configuration->ReadParameter(automaticScalesEstimation, "AutomaticScalesEstimation", 0);
 
   /** Check also AutomaticScalesEstimationStackTransform for backwards compatability. */
-  bool automaticScalesEstimationStackTransform = false; 
-  this->m_Configuration->ReadParameter( 
+  bool automaticScalesEstimationStackTransform = false;
+  this->m_Configuration->ReadParameter(
     automaticScalesEstimationStackTransform, "AutomaticScalesEstimationStackTransform", 0, false);
 
   if (automaticScalesEstimationStackTransform)
   {
-    xl::xout["warning"] << "WARNING: AutomaticScalesEstimationStackTransform is deprecated, use AutomaticScalesEstimation instead." << std::endl;
+    xl::xout["warning"]
+      << "WARNING: AutomaticScalesEstimationStackTransform is deprecated, use AutomaticScalesEstimation instead."
+      << std::endl;
     automaticScalesEstimation = automaticScalesEstimationStackTransform;
   }
 

--- a/Components/Transforms/EulerStackTransform/elxEulerStackTransform.hxx
+++ b/Components/Transforms/EulerStackTransform/elxEulerStackTransform.hxx
@@ -398,8 +398,7 @@ EulerStackTransform<TElastix>::SetScales(void)
 
   /** Check if automatic scales estimation is desired. */
   bool automaticScalesEstimation = false;
-  this->m_Configuration->ReadParameter(
-    automaticScalesEstimation, "AutomaticScalesEstimation", 0);
+  this->m_Configuration->ReadParameter(automaticScalesEstimation, "AutomaticScalesEstimation", 0);
 
   /** Check also AutomaticScalesEstimationStackTransform for backwards compatability. */
   bool automaticScalesEstimationStackTransform = false;
@@ -408,7 +407,9 @@ EulerStackTransform<TElastix>::SetScales(void)
 
   if (automaticScalesEstimationStackTransform)
   {
-    xl::xout["warning"] << "WARNING: AutomaticScalesEstimationStackTransform is deprecated, use AutomaticScalesEstimation instead." << std::endl;
+    xl::xout["warning"]
+      << "WARNING: AutomaticScalesEstimationStackTransform is deprecated, use AutomaticScalesEstimation instead."
+      << std::endl;
     automaticScalesEstimation = automaticScalesEstimationStackTransform;
   }
 


### PR DESCRIPTION
Reran:

    find . -regex '.*\.\(hxx\|h\|cxx\)' -exec '/c/Program Files/LLVM/8.0.1-ITK/clang-format.exe' -style=file -i {} \;

After merge of pull request #363 from ntatsisk/automaticScalesEstimationStackTransform, commit b6467ba7d6648d343582d57d55b8eec317ebea75 by Stefan Klein, 11 January 2021.