### PR TITLE
ENH: DeformationFieldFileName when "TransformParameters." is not found

### DIFF
--- a/Components/Transforms/BSplineDeformableTransformWithDiffusion/elxBSplineTransformWithDiffusion.hxx
+++ b/Components/Transforms/BSplineDeformableTransformWithDiffusion/elxBSplineTransformWithDiffusion.hxx
@@ -991,7 +991,7 @@ BSplineTransformWithDiffusion<TElastix>::WriteToFile(const ParametersType & para
    */
   std::string                        ctpfn = this->GetElastix()->GetCurrentTransformParameterFileName();
   std::basic_string<char>::size_type pos = ctpfn.rfind("TransformParameters.");
-  std::string                        lastpart = ctpfn.substr(pos + 19, ctpfn.size() - pos - 19 - 4);
+  std::string lastpart = (pos == std::string::npos) ? "" : ctpfn.substr(pos + 19, ctpfn.size() - pos - 19 - 4);
 
   /** Write the filename of the deformationField image. */
   std::string resultImageFormat = "mhd";

--- a/Components/Transforms/DeformationFieldTransform/elxDeformationFieldTransform.hxx
+++ b/Components/Transforms/DeformationFieldTransform/elxDeformationFieldTransform.hxx
@@ -167,7 +167,7 @@ DeformationFieldTransform<TElastix>::WriteToFile(const ParametersType & param) c
    */
   std::string                        ctpfn = this->GetElastix()->GetCurrentTransformParameterFileName();
   std::basic_string<char>::size_type pos = ctpfn.rfind("TransformParameters.");
-  std::string                        lastpart = ctpfn.substr(pos + 19, ctpfn.size() - pos - 19 - 4);
+  std::string lastpart = (pos == std::string::npos) ? "" : ctpfn.substr(pos + 19, ctpfn.size() - pos - 19 - 4);
 
   /** Create the filename of the deformationField image. */
   std::string resultImageFormat = "mhd";


### PR DESCRIPTION
When the current transform parameter filename would not have "TransformParameters." as a substring, the creation of the "lastpart" of a `DeformationFieldFileName` would go wrong (typically causing an `std::out_of_range` exception). However, it still appears useful to make a `DeformationFieldFileName` in that case. Especially when trying to write a default-constructed transform, for test purposes.

This commit makes the "lastpart" empty, in that case. Discussed with Marius @mstaring at the weekly internal elastix sprint.