### PR TITLE
ENH: Add SubTransforms to WeightedCombinationTransform parameter map

### DIFF
--- a/Common/GTesting/elxTransformIOGTest.cxx
+++ b/Common/GTesting/elxTransformIOGTest.cxx
@@ -517,7 +517,7 @@ struct WithDimension
         { "StackSpacing", { expectedOne } } });
     WithElastixTransform<TranslationTransformElastix>::Test_CreateTransformParametersMap_for_default_transform({});
     WithElastixTransform<WeightedCombinationTransformElastix>::Test_CreateTransformParametersMap_for_default_transform(
-      { { "NormalizeCombinationWeights", { expectedFalse } } });
+      { { "NormalizeCombinationWeights", { expectedFalse } }, { "SubTransforms", {} } });
   }
 };
 

--- a/Components/Transforms/WeightedCombinationTransform/elxWeightedCombinationTransform.hxx
+++ b/Components/Transforms/WeightedCombinationTransform/elxWeightedCombinationTransform.hxx
@@ -158,7 +158,8 @@ WeightedCombinationTransformElastix<TElastix>::CreateDerivedTransformParametersM
 {
   const auto & itkTransform = *m_WeightedCombinationTransform;
 
-  return { { "NormalizeCombinationWeights", { BaseComponent::ToString(itkTransform.GetNormalizeWeights()) } } };
+  return { { "NormalizeCombinationWeights", { BaseComponent::ToString(itkTransform.GetNormalizeWeights()) } },
+           { "SubTransforms", m_SubTransformFileNames } };
 
 } // end CustomizeTransformParametersMap()
 


### PR DESCRIPTION
Anticipating pull request https://github.com/SuperElastix/elastix/pull/385 "Sync Transform WriteToFile with CreateTransformParametersMap".