### PR TITLE
ENH: Add MultiBSplineTransformWithNormalLabels to parameter map

### DIFF
--- a/Common/GTesting/elxTransformIOGTest.cxx
+++ b/Common/GTesting/elxTransformIOGTest.cxx
@@ -478,23 +478,23 @@ struct WithDimension
         ? ParameterMapType{ { "CenterOfRotationPoint", expectedZeros }, { "ComputeZYX", { expectedFalse } } }
         : ParameterMapType{ { "CenterOfRotationPoint", expectedZeros } });
 
-    [&expectedZeros, &expectedOnes] {
-      try
-      {
-        WithElastixTransform<MultiBSplineTransformWithNormal>::Test_CreateTransformParametersMap_for_default_transform(
-          { { "GridIndex", expectedZeros },
-            { "GridOrigin", expectedZeros },
-            { "GridSize", expectedZeros },
-            { "GridSpacing", expectedOnes } });
-      }
-      catch (const itk::ExceptionObject & exceptionObject)
-      {
-        // TODO Avoid this exception!
-        EXPECT_NE(std::strstr(exceptionObject.GetDescription(), "ERROR: Missing -labels argument!"), nullptr);
-        return;
-      }
+    try
+    {
+      WithElastixTransform<MultiBSplineTransformWithNormal>::Test_CreateTransformParametersMap_for_default_transform(
+        { { "GridIndex", expectedZeros },
+          { "GridOrigin", expectedZeros },
+          { "GridSize", expectedZeros },
+          { "GridSpacing", expectedOnes },
+          { "BSplineTransformSplineOrder", { "3" } },
+          { "GridDirection", expectedGridDirection },
+          { "MultiBSplineTransformWithNormalLabels", { itksys::SystemTools::GetCurrentWorkingDirectory() } } });
       EXPECT_FALSE("MultiBSplineTransformWithNormal::CreateTransformParametersMap is expected to throw an exception!");
-    }();
+    }
+    catch (const itk::ExceptionObject & exceptionObject)
+    {
+      // TODO Avoid this exception!
+      EXPECT_NE(std::strstr(exceptionObject.GetDescription(), "ERROR: Missing -labels argument!"), nullptr);
+    }
 
     WithElastixTransform<RecursiveBSplineTransform>::Test_CreateTransformParametersMap_for_default_transform(
       { { "BSplineTransformSplineOrder", { "3" } },

--- a/Components/Transforms/MultiBSplineTransformWithNormal/elxMultiBSplineTransformWithNormal.hxx
+++ b/Components/Transforms/MultiBSplineTransformWithNormal/elxMultiBSplineTransformWithNormal.hxx
@@ -716,14 +716,13 @@ MultiBSplineTransformWithNormal<TElastix>::CreateDerivedTransformParametersMap(v
   const auto & itkTransform = *m_MultiBSplineTransformWithNormal;
   const auto   gridRegion = itkTransform.GetGridRegion();
 
-  // TODO If necessary, add possibly missing parameters:
-  // - "MultiBSplineTransformWithNormalLabels" (which is written by WriteToFile).
   return { { "GridSize", BaseComponent::ToVectorOfStrings(gridRegion.GetSize()) },
            { "GridIndex", BaseComponent::ToVectorOfStrings(gridRegion.GetIndex()) },
            { "GridSpacing", BaseComponent::ToVectorOfStrings(itkTransform.GetGridSpacing()) },
            { "GridOrigin", BaseComponent::ToVectorOfStrings(itkTransform.GetGridOrigin()) },
            { "GridDirection", BaseComponent::ToVectorOfStrings(itkTransform.GetGridDirection()) },
-           { "BSplineTransformSplineOrder", { BaseComponent::ToString(m_SplineOrder) } } };
+           { "BSplineTransformSplineOrder", { BaseComponent::ToString(m_SplineOrder) } },
+           { "MultiBSplineTransformWithNormalLabels", { itksys::SystemTools::CollapseFullPath(m_LabelsPath) } } };
 
 } // end CustomizeTransformParametersMap()
 


### PR DESCRIPTION
Added "MultiBSplineTransformWithNormalLabels" to the transform parameter map of `MultiBSplineTransformWithNormal`, addressing a "TODO" comment.

Anticipating pull request https://github.com/SuperElastix/elastix/pull/385 "Sync Transform WriteToFile with CreateTransformParametersMap".

Also improved the `Test_CreateTransformParametersMap_for_default_transform()` unit test function for `MultiBSplineTransformWithNormal`. Note that this change is not yet completely unit tested, because `MultiBSplineTransformWithNormal::BeforeAll()` throws an exception, saying "ERROR: Missing -labels argument!".