### PR TITLE
ENH: Add BaseComponent::ParameterMapToString(map) + unit test

### DIFF
--- a/Common/GTesting/elxBaseComponentGTest.cxx
+++ b/Common/GTesting/elxBaseComponentGTest.cxx
@@ -72,6 +72,53 @@ GTEST_TEST(BaseComponent, BoolToString)
 }
 
 
+GTEST_TEST(BaseComponent, ParameterMapToString)
+{
+  EXPECT_EQ(elx::BaseComponent::ParameterMapToString({}), std::string{});
+  EXPECT_EQ(elx::BaseComponent::ParameterMapToString({ { "A", {} } }), "(A)\n");
+  EXPECT_EQ(elx::BaseComponent::ParameterMapToString({ { "Numbers", { "0", "1" } } }), "(Numbers 0 1)\n");
+  EXPECT_EQ(elx::BaseComponent::ParameterMapToString({ { "Letters", { "a", "z" } } }), "(Letters \"a\" \"z\")\n");
+
+  // A realistic example:
+  const std::string expectedString = R"((Direction 0 0 0 0)
+(FixedImageDimension 2)
+(FixedInternalImagePixelType "float")
+(HowToCombineTransforms "Compose")
+(Index 0 0)
+(InitialTransformParametersFileName "NoInitialTransform")
+(MovingImageDimension 2)
+(MovingInternalImagePixelType "float")
+(NumberOfParameters 2)
+(Origin 0 0)
+(Size 0 0)
+(Spacing 1 1)
+(Transform "TranslationTransform")
+(TransformParameters 0 0)
+(UseBinaryFormatForTransformationParameters "false")
+(UseDirectionCosines "true")
+)";
+
+  EXPECT_EQ(
+    elx::BaseComponent::ParameterMapToString({ { "Direction", { "0", "0", "0", "0" } },
+                                               { "FixedImageDimension", { "2" } },
+                                               { "FixedInternalImagePixelType", { "float" } },
+                                               { "HowToCombineTransforms", { "Compose" } },
+                                               { "Index", { "0", "0" } },
+                                               { "InitialTransformParametersFileName", { "NoInitialTransform" } },
+                                               { "MovingImageDimension", { "2" } },
+                                               { "MovingInternalImagePixelType", { "float" } },
+                                               { "NumberOfParameters", { "2" } },
+                                               { "Origin", { "0", "0" } },
+                                               { "Size", { "0", "0" } },
+                                               { "Spacing", { "1", "1" } },
+                                               { "Transform", { "TranslationTransform" } },
+                                               { "TransformParameters", { "0", "0" } },
+                                               { "UseBinaryFormatForTransformationParameters", { "false" } },
+                                               { "UseDirectionCosines", { "true" } } }),
+    expectedString);
+}
+
+
 GTEST_TEST(BaseComponent, ToString)
 {
   // Note that this is different from std::to_string(false) and

--- a/Core/ComponentBaseClasses/elxTransformBase.hxx
+++ b/Core/ComponentBaseClasses/elxTransformBase.hxx
@@ -595,8 +595,6 @@ template <class TElastix>
 void
 TransformBase<TElastix>::WriteToFile(const ParametersType & param) const
 {
-  auto & transparOutput = xl::get_xout()["transpar"];
-
   ParameterMapType parameterMap;
 
   this->CreateTransformParametersMap(param, &parameterMap);
@@ -654,16 +652,7 @@ TransformBase<TElastix>::WriteToFile(const ParametersType & param) const
   parameterMap["UseBinaryFormatForTransformationParameters"] = { BaseComponent::ToString(
     this->m_UseBinaryFormatForTransformationParameters) };
 
-  for (const auto & parameter : parameterMap)
-  {
-    transparOutput << '(' << parameter.first;
-
-    for (const auto & value : parameter.second)
-    {
-      transparOutput << ' ' << (BaseComponent::IsNumber(value) ? value : ('"' + value + '"'));
-    }
-    transparOutput << ")\n";
-  }
+  xl::xout["transpar"] << BaseComponent::ParameterMapToString(parameterMap);
 
 } // end WriteToFile()
 

--- a/Core/Install/elxBaseComponent.h
+++ b/Core/Install/elxBaseComponent.h
@@ -42,6 +42,7 @@
 #include <vnl_vector.h>
 
 #include <iterator>
+#include <map>
 #include <string>
 #include <type_traits> // For is_integral and is_same.
 #include <vector>
@@ -69,6 +70,10 @@ class BaseComponent
 {
 public:
   ITK_DISALLOW_COPY_AND_ASSIGN(BaseComponent);
+
+  /** Corresponds with typedefs from the elastix class itk::ParameterFileParser. */
+  using ParameterValuesType = std::vector<std::string>;
+  using ParameterMapType = std::map<std::string, ParameterValuesType>;
 
   /**
    * Callback methods that each component of elastix is supposed
@@ -190,6 +195,11 @@ public:
   {
     return arg ? "true" : "false";
   }
+
+
+  /** Converts the specified parameter map to a text string, according to the elastix parameter text file format. */
+  static std::string
+  ParameterMapToString(const ParameterMapType &);
 
   /** Convenience function overload to convert a Boolean to a text string. */
   static std::string


### PR DESCRIPTION
Aims to improve performance and thread-safety of `TransformBase::WriteToFile`.

Intended to be reused by `WriteToFile` member functions of other classes from "Core/ComponentBaseClasses".