### PR TITLE
STYLE: Make xoutbase abstract and add xoutmain type for xout singleton

### DIFF
--- a/Common/xout/xoutbase.h
+++ b/Common/xout/xoutbase.h
@@ -57,11 +57,17 @@ public:
   typedef typename CStreamMapType::value_type   CStreamMapEntryType;
   typedef typename XStreamMapType::value_type   XStreamMapEntryType;
 
-  /** Constructors */
-  xoutbase() = default;
-
   /** Destructor */
-  virtual ~xoutbase() = default;
+  virtual ~xoutbase()
+#if !defined(_MSC_VER) || (_MSC_VER >= 1920)
+    // Preferably declare the destructor pure virtual, to ensure that this is an
+    // abstract base class. Unfortunately, doing so appears to trigger a weird
+    // compilation error with old Visual C++ versions (before Visual Studio 2019),
+    // specifically when having an `#include <valarray>`, saying:
+    // > error C2259: 'xoutlibrary::xoutbase<char,std::char_traits<char>>': cannot instantiate abstract class
+    = 0
+#endif
+    ;
 
   /** The operator [] simply calls this->SelectXCell(cellname).
    * It returns an x-cell */
@@ -160,6 +166,9 @@ public:
   GetXOutputs(void);
 
 protected:
+  /** Default-constructor. Only to be used by its derived classes. */
+  xoutbase() = default;
+
   /** Returns a target cell. */
   virtual Self &
   SelectXCell(const char * name);

--- a/Common/xout/xoutbase.hxx
+++ b/Common/xout/xoutbase.hxx
@@ -25,6 +25,18 @@ namespace xoutlibrary
 using namespace std;
 
 /**
+ * ********************* Destructor *****************************
+ *
+ * The destructor is defined here, as it is declared pure virtual.
+ * (A pure virtual member function cannot be defined directly at
+ * its declaration, in C++11, apparently.)
+ */
+
+template <class charT, class traits>
+xoutbase<charT, traits>::~xoutbase() = default;
+
+
+/**
  * ********************* operator[] *****************************
  */
 

--- a/Common/xout/xoutmain.cxx
+++ b/Common/xout/xoutmain.cxx
@@ -20,9 +20,9 @@
 
 namespace xoutlibrary
 {
-static xoutbase_type * local_xout = nullptr;
+static xoutmain * local_xout = nullptr;
 
-xoutbase_type &
+xoutmain &
 get_xout(void)
 {
   return *local_xout;
@@ -30,7 +30,7 @@ get_xout(void)
 
 
 void
-set_xout(xoutbase_type * arg)
+set_xout(xoutmain * arg)
 {
   local_xout = arg;
 }

--- a/Common/xout/xoutmain.h
+++ b/Common/xout/xoutmain.h
@@ -37,11 +37,15 @@ typedef xoutsimple<char> xoutsimple_type;
 typedef xoutrow<char>    xoutrow_type;
 typedef xoutcell<char>   xoutcell_type;
 
-xoutbase_type &
+/** The main xout class */
+class xoutmain : public xoutbase_type
+{};
+
+xoutmain &
 get_xout(void);
 
 void
-set_xout(xoutbase_type * arg);
+set_xout(xoutmain * arg);
 
 bool
 xout_valid();

--- a/Core/Kernel/elxElastixMain.cxx
+++ b/Core/Kernel/elxElastixMain.cxx
@@ -50,7 +50,7 @@ using namespace xl;
 struct Data
 {
   /** xout TargetCells. */
-  xoutbase_type   Xout;
+  xoutmain        Xout;
   xoutsimple_type WarningXout;
   xoutsimple_type ErrorXout;
   xoutsimple_type StandardXout;


### PR DESCRIPTION
Made `xoutbase<char>` an abstract base class (as was already documented), by declaring its destructor pure (`= 0`) virtual, and its default-constructor `protected`.

Derived an `xoutmain` class as the new type of the xout singleton.

Aims to clarify the design of the xout library, by distinguishing clearly between base and leaf classes. See also Scott Meyers's book "More Effective C++", Item 33: "Make non-leaf classes abstract".