### PR TITLE
STYLE: Remove template arguments charT, traits from xout classes

### DIFF
--- a/Common/xout/CMakeLists.txt
+++ b/Common/xout/CMakeLists.txt
@@ -4,11 +4,12 @@ project( xout )
 
 set( xoutcfiles xoutmain.cxx xouttest.cxx )
 
-set( xouthxxfiles
-  xoutbase.hxx
-  xoutsimple.hxx
-  xoutrow.hxx
-  xoutcell.hxx )
+set( xoutcxxfiles
+  xoutbase.cxx
+  xoutmain.cxx
+  xoutsimple.cxx
+  xoutrow.cxx
+  xoutcell.cxx )
 
 set( xouthfiles
   xoutbase.h
@@ -18,7 +19,7 @@ set( xouthfiles
   xoutcell.h )
 
 # a lib defining the global variable xout.
-add_library( xoutlib STATIC xoutmain.cxx ${xouthxxfiles} ${xouthfiles} )
+add_library( xoutlib STATIC ${xoutcxxfiles} ${xouthfiles} )
 install( TARGETS xoutlib
   ARCHIVE DESTINATION ${ELASTIX_ARCHIVE_DIR}
   LIBRARY DESTINATION ${ELASTIX_LIBRARY_DIR}

--- a/Common/xout/xoutbase.cxx
+++ b/Common/xout/xoutbase.cxx
@@ -15,8 +15,6 @@
  *  limitations under the License.
  *
  *=========================================================================*/
-#ifndef xoutbase_hxx
-#define xoutbase_hxx
 
 #include "xoutbase.h"
 
@@ -32,16 +30,14 @@ using namespace std;
  * its declaration, in C++11, apparently.)
  */
 
-template <class charT, class traits>
-xoutbase<charT, traits>::~xoutbase() = default;
+xoutbase::~xoutbase() = default;
 
 
 /**
  * ********************* operator[] *****************************
  */
 
-template <class charT, class traits>
-xoutbase<charT, traits> & xoutbase<charT, traits>::operator[](const char * cellname)
+xoutbase & xoutbase::operator[](const char * cellname)
 {
   return this->SelectXCell(cellname);
 
@@ -56,9 +52,8 @@ xoutbase<charT, traits> & xoutbase<charT, traits>::operator[](const char * celln
  * cells are flushed.
  */
 
-template <class charT, class traits>
 void
-xoutbase<charT, traits>::WriteBufferedData(void)
+xoutbase::WriteBufferedData(void)
 {
   /** Update the target c-streams. */
   for (const auto & cell : m_CTargetCells)
@@ -76,12 +71,11 @@ xoutbase<charT, traits>::WriteBufferedData(void)
 
 
 /**
- * **************** AddTargetCell (ostream_type) ****************
+ * **************** AddTargetCell (std::ostream) ****************
  */
 
-template <class charT, class traits>
 int
-xoutbase<charT, traits>::AddTargetCell(const char * name, ostream_type * cell)
+xoutbase::AddTargetCell(const char * name, std::ostream * cell)
 {
   int returndummy = 1;
 
@@ -105,9 +99,8 @@ xoutbase<charT, traits>::AddTargetCell(const char * name, ostream_type * cell)
  * **************** AddTargetCell (xoutbase) ********************
  */
 
-template <class charT, class traits>
 int
-xoutbase<charT, traits>::AddTargetCell(const char * name, Self * cell)
+xoutbase::AddTargetCell(const char * name, Self * cell)
 {
   int returndummy = 1;
 
@@ -131,9 +124,8 @@ xoutbase<charT, traits>::AddTargetCell(const char * name, Self * cell)
  * ***************** RemoveTargetCell ***************************
  */
 
-template <class charT, class traits>
 int
-xoutbase<charT, traits>::RemoveTargetCell(const char * name)
+xoutbase::RemoveTargetCell(const char * name)
 {
   int returndummy = 1;
 
@@ -153,12 +145,11 @@ xoutbase<charT, traits>::RemoveTargetCell(const char * name)
 
 
 /**
- * **************** SetTargetCells (ostream_types) **************
+ * **************** SetTargetCells (std::ostreams) **************
  */
 
-template <class charT, class traits>
 void
-xoutbase<charT, traits>::SetTargetCells(const CStreamMapType & cellmap)
+xoutbase::SetTargetCells(const CStreamMapType & cellmap)
 {
   this->m_CTargetCells = cellmap;
 
@@ -168,9 +159,9 @@ xoutbase<charT, traits>::SetTargetCells(const CStreamMapType & cellmap)
 /**
  * **************** SetTargetCells (xout objects) ***************
  */
-template <class charT, class traits>
+
 void
-xoutbase<charT, traits>::SetTargetCells(const XStreamMapType & cellmap)
+xoutbase::SetTargetCells(const XStreamMapType & cellmap)
 {
   this->m_XTargetCells = cellmap;
 
@@ -178,12 +169,11 @@ xoutbase<charT, traits>::SetTargetCells(const XStreamMapType & cellmap)
 
 
 /**
- * **************** AddOutput (ostream_type) ********************
+ * **************** AddOutput (std::ostream) ********************
  */
 
-template <class charT, class traits>
 int
-xoutbase<charT, traits>::AddOutput(const char * name, ostream_type * output)
+xoutbase::AddOutput(const char * name, std::ostream * output)
 {
   int returndummy = 1;
 
@@ -206,9 +196,8 @@ xoutbase<charT, traits>::AddOutput(const char * name, ostream_type * output)
  * **************** AddOutput (xoutbase) ************************
  */
 
-template <class charT, class traits>
 int
-xoutbase<charT, traits>::AddOutput(const char * name, Self * output)
+xoutbase::AddOutput(const char * name, Self * output)
 {
   int returndummy = 1;
 
@@ -231,9 +220,8 @@ xoutbase<charT, traits>::AddOutput(const char * name, Self * output)
  * *********************** RemoveOutput *************************
  */
 
-template <class charT, class traits>
 int
-xoutbase<charT, traits>::RemoveOutput(const char * name)
+xoutbase::RemoveOutput(const char * name)
 {
   int returndummy = 1;
 
@@ -255,12 +243,11 @@ xoutbase<charT, traits>::RemoveOutput(const char * name)
 
 
 /**
- * ******************* SetOutputs (ostream_types) ***************
+ * ******************* SetOutputs (std::ostreams) ***************
  */
 
-template <class charT, class traits>
 void
-xoutbase<charT, traits>::SetOutputs(const CStreamMapType & outputmap)
+xoutbase::SetOutputs(const CStreamMapType & outputmap)
 {
   this->m_COutputs = outputmap;
 
@@ -271,9 +258,8 @@ xoutbase<charT, traits>::SetOutputs(const CStreamMapType & outputmap)
  * **************** SetOutputs (xoutobjects) ********************
  */
 
-template <class charT, class traits>
 void
-xoutbase<charT, traits>::SetOutputs(const XStreamMapType & outputmap)
+xoutbase::SetOutputs(const XStreamMapType & outputmap)
 {
   this->m_XOutputs = outputmap;
 
@@ -286,9 +272,8 @@ xoutbase<charT, traits>::SetOutputs(const XStreamMapType & outputmap)
  * Returns a target cell.
  */
 
-template <class charT, class traits>
-xoutbase<charT, traits> &
-xoutbase<charT, traits>::SelectXCell(const char * name)
+xoutbase &
+xoutbase::SelectXCell(const char * name)
 {
   const auto found = m_XTargetCells.find(name);
   return (found == m_XTargetCells.end()) ? *this : *(found->second);
@@ -300,9 +285,8 @@ xoutbase<charT, traits>::SelectXCell(const char * name)
  * **************** GetOutputs (map of xoutobjects) *************
  */
 
-template <class charT, class traits>
-const typename xoutbase<charT, traits>::XStreamMapType &
-xoutbase<charT, traits>::GetXOutputs(void)
+const xoutbase::XStreamMapType &
+xoutbase::GetXOutputs(void)
 {
   return this->m_XOutputs;
 
@@ -312,14 +296,11 @@ xoutbase<charT, traits>::GetXOutputs(void)
  * **************** GetOutputs (map of c-streams) ***************
  */
 
-template <class charT, class traits>
-const typename xoutbase<charT, traits>::CStreamMapType &
-xoutbase<charT, traits>::GetCOutputs(void)
+const xoutbase::CStreamMapType &
+xoutbase::GetCOutputs(void)
 {
   return this->m_COutputs;
 
 } // end GetOutputs
 
 } // end namespace xoutlibrary
-
-#endif // end #ifndef xoutbase_hxx

--- a/Common/xout/xoutbase.h
+++ b/Common/xout/xoutbase.h
@@ -37,41 +37,23 @@ using namespace std;
  * \ingroup xout
  */
 
-template <class charT, class traits = char_traits<charT>>
 class xoutbase
 {
 public:
   /** Typedef's.*/
   typedef xoutbase Self;
 
-  typedef traits                       traits_type;
-  typedef charT                        char_type;
-  typedef typename traits::int_type    int_type;
-  typedef typename traits::pos_type    pos_type;
-  typedef typename traits::off_type    off_type;
-  typedef basic_ostream<charT, traits> ostream_type;
-  typedef basic_ios<charT, traits>     ios_type;
-
-  typedef std::map<std::string, ostream_type *> CStreamMapType;
+  typedef std::map<std::string, std::ostream *> CStreamMapType;
   typedef std::map<std::string, Self *>         XStreamMapType;
-  typedef typename CStreamMapType::value_type   CStreamMapEntryType;
-  typedef typename XStreamMapType::value_type   XStreamMapEntryType;
+  typedef CStreamMapType::value_type            CStreamMapEntryType;
+  typedef XStreamMapType::value_type            XStreamMapEntryType;
 
   /** Destructor */
-  virtual ~xoutbase()
-#if !defined(_MSC_VER) || (_MSC_VER >= 1920)
-    // Preferably declare the destructor pure virtual, to ensure that this is an
-    // abstract base class. Unfortunately, doing so appears to trigger a weird
-    // compilation error with old Visual C++ versions (before Visual Studio 2019),
-    // specifically when having an `#include <valarray>`, saying:
-    // > error C2259: 'xoutlibrary::xoutbase<char,std::char_traits<char>>': cannot instantiate abstract class
-    = 0
-#endif
-    ;
+  virtual ~xoutbase() = 0;
 
   /** The operator [] simply calls this->SelectXCell(cellname).
    * It returns an x-cell */
-  inline Self & operator[](const char * cellname);
+  Self & operator[](const char * cellname);
 
   /**
    * the << operator. A templated member function, and some overloads.
@@ -96,14 +78,14 @@ public:
 
 
   Self &
-  operator<<(ostream_type & (*pf)(ostream_type &))
+  operator<<(std::ostream & (*pf)(std::ostream &))
   {
     return this->SendToTargets(pf);
   }
 
 
   Self &
-  operator<<(ios_type & (*pf)(ios_type &))
+  operator<<(std::ios & (*pf)(std::ios &))
   {
     return this->SendToTargets(pf);
   }
@@ -123,7 +105,7 @@ public:
    * Methods to Add and Remove target cells. They return 0 when successful.
    */
   virtual int
-  AddTargetCell(const char * name, ostream_type * cell);
+  AddTargetCell(const char * name, std::ostream * cell);
 
   virtual int
   AddTargetCell(const char * name, Self * cell);
@@ -144,7 +126,7 @@ public:
 
   /** Add/Remove an output stream (like cout, or an fstream, or an xout-object).  */
   virtual int
-  AddOutput(const char * name, ostream_type * output);
+  AddOutput(const char * name, std::ostream * output);
 
   virtual int
   AddOutput(const char * name, Self * output);
@@ -204,7 +186,5 @@ private:
 };
 
 } // end namespace xoutlibrary
-
-#include "xoutbase.hxx"
 
 #endif // end #ifndef xoutbase_h

--- a/Common/xout/xoutcell.cxx
+++ b/Common/xout/xoutcell.cxx
@@ -15,8 +15,6 @@
  *  limitations under the License.
  *
  *=========================================================================*/
-#ifndef xoutcell_hxx
-#define xoutcell_hxx
 
 #include "xoutcell.h"
 
@@ -27,8 +25,7 @@ namespace xoutlibrary
  * ************************ Constructor *************************
  */
 
-template <class charT, class traits>
-xoutcell<charT, traits>::xoutcell()
+xoutcell::xoutcell()
 {
   this->AddTargetCell("InternalBuffer", &(this->m_InternalBuffer));
 
@@ -41,9 +38,8 @@ xoutcell<charT, traits>::xoutcell()
  * The buffered data is sent to the outputs.
  */
 
-template <class charT, class traits>
 void
-xoutcell<charT, traits>::WriteBufferedData(void)
+xoutcell::WriteBufferedData(void)
 {
   const std::string strbuf = this->m_InternalBuffer.str();
 
@@ -67,5 +63,3 @@ xoutcell<charT, traits>::WriteBufferedData(void)
 
 
 } // end namespace xoutlibrary
-
-#endif // end #ifndef xoutcell_hxx

--- a/Common/xout/xoutcell.h
+++ b/Common/xout/xoutcell.h
@@ -35,13 +35,12 @@ using namespace std;
  * \ingroup xout
  */
 
-template <class charT, class traits = char_traits<charT>>
-class xoutcell : public xoutbase<charT, traits>
+class xoutcell : public xoutbase
 {
 public:
   /** Typdef's. */
-  typedef xoutcell                Self;
-  typedef xoutbase<charT, traits> Superclass;
+  typedef xoutcell Self;
+  typedef xoutbase Superclass;
 
   /** Constructors */
   xoutcell();
@@ -54,13 +53,11 @@ public:
   WriteBufferedData(void) override;
 
 private:
-  typedef std::basic_ostringstream<charT, traits> InternalBufferType;
+  typedef std::ostringstream InternalBufferType;
 
   InternalBufferType m_InternalBuffer;
 };
 
 } // end namespace xoutlibrary
-
-#include "xoutcell.hxx"
 
 #endif // end #ifndef xoutcell_h

--- a/Common/xout/xoutmain.h
+++ b/Common/xout/xoutmain.h
@@ -32,13 +32,9 @@ namespace xl = xoutlibrary;
 /** Typedefs for the most common use of xout */
 namespace xoutlibrary
 {
-typedef xoutbase<char>   xoutbase_type;
-typedef xoutsimple<char> xoutsimple_type;
-typedef xoutrow<char>    xoutrow_type;
-typedef xoutcell<char>   xoutcell_type;
 
 /** The main xout class */
-class xoutmain : public xoutbase_type
+class xoutmain : public xoutbase
 {};
 
 xoutmain &

--- a/Common/xout/xoutrow.cxx
+++ b/Common/xout/xoutrow.cxx
@@ -15,8 +15,6 @@
  *  limitations under the License.
  *
  *=========================================================================*/
-#ifndef xoutrow_hxx
-#define xoutrow_hxx
 
 #include "xoutrow.h"
 
@@ -33,9 +31,8 @@ using namespace std;
  * cells are flushed.
  */
 
-template <class charT, class traits>
 void
-xoutrow<charT, traits>::WriteBufferedData(void)
+xoutrow::WriteBufferedData(void)
 {
   /** Write the cell-data to the outputs, separated by tabs. */
   auto xit = this->m_XTargetCells.begin();
@@ -65,15 +62,14 @@ xoutrow<charT, traits>::WriteBufferedData(void)
  * ******************** AddTargetCell ***************************
  */
 
-template <class charT, class traits>
 int
-xoutrow<charT, traits>::AddTargetCell(const char * name)
+xoutrow::AddTargetCell(const char * name)
 {
   if (this->m_CellMap.count(name) == 0)
   {
     /** A new cell (type xoutcell) is created. */
-    std::unique_ptr<XOutCellType> cell{ new XOutCellType };
-    auto &                        cellReference = *cell;
+    std::unique_ptr<xoutcell> cell{ new xoutcell };
+    auto &                    cellReference = *cell;
 
     /** Set the outputs equal to the outputs of this object. */
     cell->SetOutputs(this->m_COutputs);
@@ -99,9 +95,8 @@ xoutrow<charT, traits>::AddTargetCell(const char * name)
  * ********************* RemoveTargetCell ***********************
  */
 
-template <class charT, class traits>
 int
-xoutrow<charT, traits>::RemoveTargetCell(const char * name)
+xoutrow::RemoveTargetCell(const char * name)
 {
   int returndummy = 1;
 
@@ -124,9 +119,8 @@ xoutrow<charT, traits>::RemoveTargetCell(const char * name)
  * **************** SetTargetCells (xout objects) ***************
  */
 
-template <class charT, class traits>
 void
-xoutrow<charT, traits>::SetTargetCells(const XStreamMapType & cellmap)
+xoutrow::SetTargetCells(const XStreamMapType & cellmap)
 {
   /** Clean the this->m_CellMap (cells that are created using the
    * AddTarget(const char *) method.
@@ -143,12 +137,11 @@ xoutrow<charT, traits>::SetTargetCells(const XStreamMapType & cellmap)
 
 
 /**
- * ****************** AddOutput (ostream_type) ******************
+ * ****************** AddOutput (std::ostream) ******************
  */
 
-template <class charT, class traits>
 int
-xoutrow<charT, traits>::AddOutput(const char * name, ostream_type * output)
+xoutrow::AddOutput(const char * name, std::ostream * output)
 {
   int returndummy = 0;
 
@@ -169,9 +162,8 @@ xoutrow<charT, traits>::AddOutput(const char * name, ostream_type * output)
  * ********************** AddOutput (xoutbase) ******************
  */
 
-template <class charT, class traits>
 int
-xoutrow<charT, traits>::AddOutput(const char * name, Superclass * output)
+xoutrow::AddOutput(const char * name, Superclass * output)
 {
   int returndummy = 0;
 
@@ -192,9 +184,8 @@ xoutrow<charT, traits>::AddOutput(const char * name, Superclass * output)
  * ******************** RemoveOutput ****************************
  */
 
-template <class charT, class traits>
 int
-xoutrow<charT, traits>::RemoveOutput(const char * name)
+xoutrow::RemoveOutput(const char * name)
 {
   int returndummy = 0;
   /** Set the output in all cells. */
@@ -211,12 +202,11 @@ xoutrow<charT, traits>::RemoveOutput(const char * name)
 
 
 /**
- * ******************* SetOutputs (ostream_types) ***************
+ * ******************* SetOutputs (std::ostreams) ***************
  */
 
-template <class charT, class traits>
 void
-xoutrow<charT, traits>::SetOutputs(const CStreamMapType & outputmap)
+xoutrow::SetOutputs(const CStreamMapType & outputmap)
 {
   /** Set the output in all cells. */
   for (const auto & cell : this->m_XTargetCells)
@@ -234,9 +224,8 @@ xoutrow<charT, traits>::SetOutputs(const CStreamMapType & outputmap)
  * ******************* SetOutputs (xoutobjects) *****************
  */
 
-template <class charT, class traits>
 void
-xoutrow<charT, traits>::SetOutputs(const XStreamMapType & outputmap)
+xoutrow::SetOutputs(const XStreamMapType & outputmap)
 {
   /** Set the output in all cells. */
   for (const auto & cell : this->m_XTargetCells)
@@ -254,9 +243,8 @@ xoutrow<charT, traits>::SetOutputs(const XStreamMapType & outputmap)
  * ******************** WriteHeaders ****************************
  */
 
-template <class charT, class traits>
 void
-xoutrow<charT, traits>::WriteHeaders(void)
+xoutrow::WriteHeaders(void)
 {
   /** Copy '*this'. */
   Self headerwriter;
@@ -282,9 +270,8 @@ xoutrow<charT, traits>::WriteHeaders(void)
  * Returns a target cell.
  */
 
-template <class charT, class traits>
-xoutbase<charT, traits> &
-xoutrow<charT, traits>::SelectXCell(const char * name)
+xoutbase &
+xoutrow::SelectXCell(const char * name)
 {
   std::string cellname(name);
 
@@ -306,5 +293,3 @@ xoutrow<charT, traits>::SelectXCell(const char * name)
 
 
 } // end namespace xoutlibrary
-
-#endif // end #ifndef xoutrow_hxx

--- a/Common/xout/xoutrow.h
+++ b/Common/xout/xoutrow.h
@@ -40,21 +40,11 @@ using namespace std;
  * \ingroup xout
  */
 
-template <class charT, class traits = char_traits<charT>>
-class xoutrow : public xoutbase<charT, traits>
+class xoutrow : public xoutbase
 {
 public:
-  typedef xoutrow                 Self;
-  typedef xoutbase<charT, traits> Superclass;
-
-  /** Typedefs of Superclass */
-  using typename Superclass::ostream_type;
-  using typename Superclass::CStreamMapType;
-  using typename Superclass::XStreamMapType;
-
-
-  /** Extra typedefs */
-  typedef xoutcell<charT, traits> XOutCellType;
+  typedef xoutrow  Self;
+  typedef xoutbase Superclass;
 
   /** Constructor */
   xoutrow() = default;
@@ -94,7 +84,7 @@ public:
    * set the outputs of the TargetCells as well.
    */
   int
-  AddOutput(const char * name, ostream_type * output) override;
+  AddOutput(const char * name, std::ostream * output) override;
 
   int
   AddOutput(const char * name, Superclass * output) override;
@@ -117,11 +107,9 @@ protected:
   SelectXCell(const char * name) override;
 
 private:
-  std::map<std::string, std::unique_ptr<xoutbase<charT, traits>>> m_CellMap;
+  std::map<std::string, std::unique_ptr<xoutbase>> m_CellMap;
 };
 
 } // end namespace xoutlibrary
-
-#include "xoutrow.hxx"
 
 #endif // end #ifndef xoutrow_h

--- a/Common/xout/xoutsimple.cxx
+++ b/Common/xout/xoutsimple.cxx
@@ -15,8 +15,6 @@
  *  limitations under the License.
  *
  *=========================================================================*/
-#ifndef xoutsimple_hxx
-#define xoutsimple_hxx
 
 #include "xoutsimple.h"
 
@@ -25,12 +23,11 @@ namespace xoutlibrary
 using namespace std;
 
 /**
- * **************** AddOutput (ostream_type) ********************
+ * **************** AddOutput (std::ostream) ********************
  */
 
-template <class charT, class traits>
 int
-xoutsimple<charT, traits>::AddOutput(const char * name, ostream_type * output)
+xoutsimple::AddOutput(const char * name, std::ostream * output)
 {
   return this->AddTargetCell(name, output);
 
@@ -41,9 +38,8 @@ xoutsimple<charT, traits>::AddOutput(const char * name, ostream_type * output)
  * **************** AddOutput (xoutsimple) **********************
  */
 
-template <class charT, class traits>
 int
-xoutsimple<charT, traits>::AddOutput(const char * name, Superclass * output)
+xoutsimple::AddOutput(const char * name, Superclass * output)
 {
   return this->AddTargetCell(name, output);
 
@@ -54,9 +50,8 @@ xoutsimple<charT, traits>::AddOutput(const char * name, Superclass * output)
  * ***************** RemoveOutput *******************************
  */
 
-template <class charT, class traits>
 int
-xoutsimple<charT, traits>::RemoveOutput(const char * name)
+xoutsimple::RemoveOutput(const char * name)
 {
   return this->RemoveTargetCell(name);
 
@@ -64,12 +59,11 @@ xoutsimple<charT, traits>::RemoveOutput(const char * name)
 
 
 /**
- * **************** SetOutputs (ostream_types) ******************
+ * **************** SetOutputs (std::ostreams) ******************
  */
 
-template <class charT, class traits>
 void
-xoutsimple<charT, traits>::SetOutputs(const CStreamMapType & outputmap)
+xoutsimple::SetOutputs(const CStreamMapType & outputmap)
 {
   this->SetTargetCells(outputmap);
 
@@ -80,9 +74,8 @@ xoutsimple<charT, traits>::SetOutputs(const CStreamMapType & outputmap)
  * **************** SetOutputs (xoutobjects) ********************
  */
 
-template <class charT, class traits>
 void
-xoutsimple<charT, traits>::SetOutputs(const XStreamMapType & outputmap)
+xoutsimple::SetOutputs(const XStreamMapType & outputmap)
 {
   this->SetTargetCells(outputmap);
 
@@ -93,9 +86,8 @@ xoutsimple<charT, traits>::SetOutputs(const XStreamMapType & outputmap)
  * **************** GetOutputs (map of xoutobjects) *************
  */
 
-template <class charT, class traits>
 auto
-xoutsimple<charT, traits>::GetXOutputs(void) -> const XStreamMapType &
+xoutsimple::GetXOutputs(void) -> const XStreamMapType &
 {
   return this->m_XTargetCells;
 
@@ -105,14 +97,11 @@ xoutsimple<charT, traits>::GetXOutputs(void) -> const XStreamMapType &
  * **************** GetOutputs (map of c-streams) ***************
  */
 
-template <class charT, class traits>
 auto
-xoutsimple<charT, traits>::GetCOutputs(void) -> const CStreamMapType &
+xoutsimple::GetCOutputs(void) -> const CStreamMapType &
 {
   return this->m_CTargetCells;
 
 } // end GetCOutputs()
 
 } // end namespace xoutlibrary
-
-#endif // end #ifndef xoutsimple_hxx

--- a/Common/xout/xoutsimple.h
+++ b/Common/xout/xoutsimple.h
@@ -33,18 +33,12 @@ using namespace std;
  * \ingroup xout
  */
 
-template <class charT, class traits = char_traits<charT>>
-class xoutsimple : public xoutbase<charT, traits>
+class xoutsimple : public xoutbase
 {
 public:
   /** Typedef's.*/
-  typedef xoutsimple              Self;
-  typedef xoutbase<charT, traits> Superclass;
-
-  /** Typedefs of Superclass */
-  using typename Superclass::ostream_type;
-  using typename Superclass::CStreamMapType;
-  using typename Superclass::XStreamMapType;
+  typedef xoutsimple Self;
+  typedef xoutbase   Superclass;
 
   /** Constructors */
   xoutsimple() = default;
@@ -54,7 +48,7 @@ public:
 
   /** Add/Remove an output stream (like cout, or an fstream, or an xout-object).  */
   int
-  AddOutput(const char * name, ostream_type * output) override;
+  AddOutput(const char * name, std::ostream * output) override;
 
   int
   AddOutput(const char * name, Superclass * output) override;
@@ -77,7 +71,5 @@ public:
 };
 
 } // end namespace xoutlibrary
-
-#include "xoutsimple.hxx"
 
 #endif // end #ifndef xoutsimple_h

--- a/Core/Kernel/elxElastixBase.h
+++ b/Core/Kernel/elxElastixBase.h
@@ -498,7 +498,7 @@ private:
   void
   operator=(const Self &) = delete;
 
-  xl::xoutrow_type m_IterationInfo;
+  xl::xoutrow m_IterationInfo;
 
   int m_DefaultOutputPrecision;
 

--- a/Core/Kernel/elxElastixMain.cxx
+++ b/Core/Kernel/elxElastixMain.cxx
@@ -47,13 +47,13 @@ namespace
 struct Data
 {
   /** xout TargetCells. */
-  xl::xoutmain        Xout;
-  xl::xoutsimple_type WarningXout;
-  xl::xoutsimple_type ErrorXout;
-  xl::xoutsimple_type StandardXout;
-  xl::xoutsimple_type CoutOnlyXout;
-  xl::xoutsimple_type LogOnlyXout;
-  std::ofstream       LogFileStream;
+  xl::xoutmain   Xout;
+  xl::xoutsimple WarningXout;
+  xl::xoutsimple ErrorXout;
+  xl::xoutsimple StandardXout;
+  xl::xoutsimple CoutOnlyXout;
+  xl::xoutsimple LogOnlyXout;
+  std::ofstream  LogFileStream;
 };
 
 Data g_data;

--- a/Core/Kernel/elxElastixTemplate.hxx
+++ b/Core/Kernel/elxElastixTemplate.hxx
@@ -762,8 +762,8 @@ ElastixTemplate<TFixedImage, TMovingImage>::CreateTransformParameterFile(const s
   this->m_CurrentTransformParameterFileName = fileName;
 
   /** Create transformParameterFile and xout["transpar"]. */
-  xl::xoutsimple_type transformationParameterInfo;
-  std::ofstream       transformParameterFile;
+  xl::xoutsimple transformationParameterInfo;
+  std::ofstream  transformParameterFile;
 
   /** Set up the "TransformationParameters" writing field. */
   transformationParameterInfo.SetOutputs(xl::xout.GetCOutputs());


### PR DESCRIPTION
It does not appear necessary to support template arguments (charT and traits) for the xout classes, as elastix always only uses 8-bits `char` as character type of output streams.

Removing those template arguments significantly reduces compilation time (especially when adjusting the implementation of xout) and code complexity.

Discussed at our internal SuperElastix/elastix slack channel.