### PR TITLE
ENH: Add DeformationFieldFileName from two transforms to ParameterMap

### DIFF
--- a/Common/GTesting/elxTransformIOGTest.cxx
+++ b/Common/GTesting/elxTransformIOGTest.cxx
@@ -373,6 +373,7 @@ struct WithDimension
     const auto expectedMatrixTranslation = toVectorOfStrings(times(NDimension, '1' + std::string(NDimension, '0')));
     const auto expectedGridDirection =
       toVectorOfStrings(times(NDimension - 1, '1' + std::string(NDimension, '0')) + '1');
+    const std::string expectedDeformationFieldFileName("DeformationFieldImage.mhd");
 
     using namespace elx;
 
@@ -403,12 +404,14 @@ struct WithDimension
     (void)skippedTest;
 
     WithElastixTransform<BSplineTransformWithDiffusion>::Test_CreateTransformParametersMap_for_default_transform(
-      { { "GridIndex", expectedZeros },
+      { { "DeformationFieldFileName", { expectedDeformationFieldFileName } },
+        { "GridIndex", expectedZeros },
         { "GridOrigin", expectedZeros },
         { "GridSize", expectedZeros },
         { "GridSpacing", expectedOnes } });
     WithElastixTransform<DeformationFieldTransform>::Test_CreateTransformParametersMap_for_default_transform(
-      { { "DeformationFieldInterpolationOrder", { expectedZero } } });
+      { { "DeformationFieldFileName", { expectedDeformationFieldFileName } },
+        { "DeformationFieldInterpolationOrder", { expectedZero } } });
     WithElastixTransform<EulerStackTransform>::Test_CreateTransformParametersMap_for_default_transform(
       { { "CenterOfRotationPoint", ParameterValuesType(NDimension - 1, expectedZero) },
         { "NumberOfSubTransforms", { expectedZero } },

--- a/Common/Transforms/elxTransformIO.cxx
+++ b/Common/Transforms/elxTransformIO.cxx
@@ -18,6 +18,7 @@
 #include "elxTransformIO.h"
 
 #include "elxBaseComponent.h"
+#include "elxConfiguration.h"
 
 #include "xoutmain.h"
 
@@ -75,4 +76,27 @@ elastix::TransformIO::Write(const itk::TransformBaseTemplate<double> & itkTransf
   {
     xl::xout["error"] << "Error trying to write " << fileName << ":\n" << stdException.what() << std::endl;
   }
+}
+
+
+std::string
+elastix::TransformIO::MakeDeformationFieldFileName(Configuration &     configuration,
+                                                   const std::string & transformParameterFileName)
+{
+  // Get the last part of the filename of the transformParameter-file,
+  // which is going to be part of the filename of the deformationField image.
+  const std::string            transformParameterBaseName = "TransformParameters";
+  const auto                   transformParameterBaseNameSize = transformParameterBaseName.size();
+  const std::string::size_type pos = transformParameterFileName.rfind(transformParameterBaseName + '.');
+  const std::string            lastpart =
+    (pos == std::string::npos)
+      ? ""
+      : transformParameterFileName.substr(pos + transformParameterBaseNameSize,
+                                          transformParameterFileName.size() - pos - transformParameterBaseNameSize - 4);
+
+  // Create the filename of the deformationField image.
+  std::string resultImageFormat = "mhd";
+  configuration.ReadParameter(resultImageFormat, "ResultImageFormat", 0, false);
+
+  return configuration.GetCommandLineArgument("-out") + "DeformationFieldImage" + lastpart + "." + resultImageFormat;
 }

--- a/Common/Transforms/elxTransformIO.h
+++ b/Common/Transforms/elxTransformIO.h
@@ -24,6 +24,7 @@
 namespace elastix
 {
 class BaseComponent;
+class Configuration;
 
 class TransformIO
 {
@@ -54,11 +55,23 @@ public:
   static void
   Write(const itk::TransformBaseTemplate<double> & itkTransform, const std::string & fileName);
 
+
+  /// Makes the deformation field file name, as used by BSplineTransformWithDiffusion and DeformationFieldTransform.
+  template <typename TElastixTransform>
+  static std::string
+  MakeDeformationFieldFileName(const TElastixTransform & elxTransform)
+  {
+    return MakeDeformationFieldFileName(*(elxTransform.GetConfiguration()),
+                                        elxTransform.GetElastix()->GetCurrentTransformParameterFileName());
+  }
+
 private:
   static itk::TransformBaseTemplate<double>::Pointer
   CreateCorrespondingItkTransform(const BaseComponent & elxTransform,
                                   const unsigned        fixedImageDimension,
                                   const unsigned        movingImageDimension);
+  static std::string
+  MakeDeformationFieldFileName(Configuration & configuration, const std::string & transformParameterFileName);
 };
 } // namespace elastix
 


### PR DESCRIPTION
Adds "DeformationFieldFileName" to the parameter maps of both `DeformationFieldTransform` and `BSplineTransformWithDiffusion`.

Reduced code duplication by adding a helper function, `TransformIO::MakeDeformationFieldFileName`.

Adjusted GTest `CreateTransformParametersMap` unit tests by expecting the added parameter for those two transform types.