### PR TITLE
Restore char pixel type support, work around Clang denormal bug, improve DefaultPixelValue I/O

### DIFF
--- a/Common/GTesting/elxConversionGTest.cxx
+++ b/Common/GTesting/elxConversionGTest.cxx
@@ -248,6 +248,11 @@ GTEST_TEST(Conversion, ToString)
   EXPECT_EQ(Conversion::ToString(1), "1");
   EXPECT_EQ(Conversion::ToString(-1), "-1");
 
+  EXPECT_EQ(Conversion::ToString(char{}), "0");
+  EXPECT_EQ(Conversion::ToString(char{ 2 }), "2");
+  EXPECT_EQ(Conversion::ToString(std::numeric_limits<signed char>::min()), "-128");
+  EXPECT_EQ(Conversion::ToString(std::numeric_limits<unsigned char>::max()), "255");
+
   EXPECT_EQ(Conversion::ToString(std::numeric_limits<std::int64_t>::min()), "-9223372036854775808");
   EXPECT_EQ(Conversion::ToString(std::numeric_limits<std::uint64_t>::max()), "18446744073709551615");
 

--- a/Common/GTesting/elxConversionGTest.cxx
+++ b/Common/GTesting/elxConversionGTest.cxx
@@ -433,12 +433,22 @@ GTEST_TEST(Conversion, IsNumberReturnsTrueOnNumericString)
 GTEST_TEST(Conversion, LosslessRoundTripOfParameterValue)
 {
   Expect_lossless_round_trip_of_unsigned_parameter_values<unsigned>();
+  Expect_lossless_round_trip_of_unsigned_parameter_values<std::uint8_t>();
   Expect_lossless_round_trip_of_unsigned_parameter_values<std::uint16_t>();
   Expect_lossless_round_trip_of_unsigned_parameter_values<std::uintmax_t>();
 
   Expect_lossless_round_trip_of_signed_integer_parameter_values<int>();
+  Expect_lossless_round_trip_of_signed_integer_parameter_values<std::int8_t>();
   Expect_lossless_round_trip_of_signed_integer_parameter_values<std::int16_t>();
   Expect_lossless_round_trip_of_signed_integer_parameter_values<std::intmax_t>();
+
+  // Note that the C++ Standard (C++11) does not specify whether `char` is a
+  // signed or an unsigned type, so it is tested here separately from
+  // `signed char` (int8_t) and `unsigned char` (uint8_t).
+  for (const char parameterValue : { std::numeric_limits<char>::min(), '\0', '\1', std::numeric_limits<char>::max() })
+  {
+    Expect_lossless_round_trip_of_parameter_value<char>(parameterValue);
+  }
 
   Expect_lossless_round_trip_of_floating_point_parameter_values<float>();
   Expect_lossless_round_trip_of_floating_point_parameter_values<double>();

--- a/Common/GTesting/elxConversionGTest.cxx
+++ b/Common/GTesting/elxConversionGTest.cxx
@@ -149,15 +149,7 @@ Expect_lossless_round_trip_of_floating_point_parameter_values()
   using NumericLimits = std::numeric_limits<TFloatingPoint>;
 
   Expect_lossless_round_trip_of_positive_and_negative_parameter_values<TFloatingPoint>({ 0,
-  // Note: For Clang (tested on AppleClang 12.0.0.12000032 macos-10.15), the round trip
-  // appears troublesome for denorm_min, as std::istream::fail() appears to return true.
-  // See also LLVM Bug 39012 "ostream writes a double that istream can't read", reported
-  // by Daniel Cooke, 2018-09-20: "It appears libc++ incorrectly sets input stream
-  // failbit when reading subnormal floating point numbers."
-  // https://bugs.llvm.org/show_bug.cgi?id=39012
-#ifndef __clang__
                                                                                          NumericLimits::denorm_min(),
-#endif
                                                                                          NumericLimits::min(),
                                                                                          NumericLimits::epsilon(),
                                                                                          1,

--- a/Common/ParameterFileParser/itkParameterMapInterface.cxx
+++ b/Common/ParameterFileParser/itkParameterMapInterface.cxx
@@ -22,7 +22,7 @@ namespace
 {
 template <typename TFloatingPoint>
 bool
-StringCastNaN(const std::string parameterValue, TFloatingPoint & casted)
+StringCastNaN(const std::string & parameterValue, TFloatingPoint & casted)
 {
   static_assert(std::is_floating_point<TFloatingPoint>::value,
                 "This function template only supports floating point types.");
@@ -38,7 +38,7 @@ StringCastNaN(const std::string parameterValue, TFloatingPoint & casted)
 
 template <typename TFloatingPoint>
 bool
-StringCastInfinity(const std::string parameterValue, TFloatingPoint & casted)
+StringCastInfinity(const std::string & parameterValue, TFloatingPoint & casted)
 {
   static_assert(std::is_floating_point<TFloatingPoint>::value,
                 "This function template only supports floating point types.");
@@ -172,7 +172,7 @@ ParameterMapInterface::StringCast(const std::string & parameterValue, std::strin
 
 
 bool
-ParameterMapInterface::StringCast(const std::string parameterValue, float & casted)
+ParameterMapInterface::StringCast(const std::string & parameterValue, float & casted)
 {
   return StringCastNaN(parameterValue, casted) || StringCastInfinity(parameterValue, casted) ||
          Self::StringCast<float>(parameterValue, casted);
@@ -181,7 +181,7 @@ ParameterMapInterface::StringCast(const std::string parameterValue, float & cast
 
 
 bool
-ParameterMapInterface::StringCast(const std::string parameterValue, double & casted)
+ParameterMapInterface::StringCast(const std::string & parameterValue, double & casted)
 {
   return StringCastNaN(parameterValue, casted) || StringCastInfinity(parameterValue, casted) ||
          Self::StringCast<double>(parameterValue, casted);

--- a/Common/ParameterFileParser/itkParameterMapInterface.cxx
+++ b/Common/ParameterFileParser/itkParameterMapInterface.cxx
@@ -19,7 +19,8 @@
 #include "itkParameterMapInterface.h"
 
 // Standard C++ header files:
-#include <cmath>       // For fpclassify and FP_SUBNORMAL.
+#include <cmath> // For fpclassify and FP_SUBNORMAL.
+#include <limits>
 #include <type_traits> // For is_floating_point.
 
 
@@ -202,6 +203,49 @@ bool
 ParameterMapInterface::StringCast(const std::string & parameterValue, double & casted)
 {
   return Self::StringCastToFloatingPoint(parameterValue, casted);
+}
+
+
+template <typename TChar>
+bool
+ParameterMapInterface::StringCastToCharType(const std::string & parameterValue, TChar & casted)
+{
+  static_assert(sizeof(TChar) < sizeof(int), "StringCastCharType only supports character types smaller than int");
+
+  int temp{};
+
+  if (Self::StringCast<int>(parameterValue, temp))
+  {
+    // Check that `temp` can be copied losslessly to `casted`.
+    if ((temp >= std::numeric_limits<TChar>::lowest()) && (temp <= std::numeric_limits<TChar>::max()))
+    {
+      casted = static_cast<TChar>(temp);
+      return true;
+    }
+  }
+  return false;
+
+} // end StringCastCharType()
+
+
+bool
+ParameterMapInterface::StringCast(const std::string & parameterValue, char & casted)
+{
+  return StringCastToCharType(parameterValue, casted);
+}
+
+
+bool
+ParameterMapInterface::StringCast(const std::string & parameterValue, signed char & casted)
+{
+  return StringCastToCharType(parameterValue, casted);
+}
+
+
+bool
+ParameterMapInterface::StringCast(const std::string & parameterValue, unsigned char & casted)
+{
+  return StringCastToCharType(parameterValue, casted);
 }
 
 

--- a/Common/ParameterFileParser/itkParameterMapInterface.h
+++ b/Common/ParameterFileParser/itkParameterMapInterface.h
@@ -425,10 +425,10 @@ private:
   /** Provide specializations for floating point types, to support NaN and infinity.
    */
   static bool
-  StringCast(const std::string parameterValue, double & casted);
+  StringCast(const std::string & parameterValue, double & casted);
 
   static bool
-  StringCast(const std::string parameterValue, float & casted);
+  StringCast(const std::string & parameterValue, float & casted);
 };
 
 } // end of namespace itk

--- a/Common/ParameterFileParser/itkParameterMapInterface.h
+++ b/Common/ParameterFileParser/itkParameterMapInterface.h
@@ -399,11 +399,9 @@ private:
 
     std::stringstream ss(parameterValue);
 
-    /** We do not support (signed/unsigned) char, because does not appear
-     * necessary. Moreover the result of ">>" may be counter-intuitive.
-     * It takes the first digit and thinks it is a char. For example:
-     * 84 becomes '8', which is ASCII number 56. */
-    static_assert(sizeof(T) > 1, "StringCast does not support (signed/unsigned) char!");
+    // 8-bits (signed/unsigned) char types are supported by other StringCast
+    // overloads.
+    static_assert(sizeof(T) > 1, "This StringCast<T> overload does not support (signed/unsigned) char!");
 
     ss >> casted;
 
@@ -433,6 +431,22 @@ private:
 
   static bool
   StringCast(const std::string & parameterValue, float & casted);
+
+  /** Provide specializations for signed/unsigned char types, in order to
+   * process them as 8-bits integer types, rather than as character types.
+   */
+  template <typename TChar>
+  static bool
+  StringCastToCharType(const std::string & parameterValue, TChar & casted);
+
+  static bool
+  StringCast(const std::string & parameterValue, char & casted);
+
+  static bool
+  StringCast(const std::string & parameterValue, signed char & casted);
+
+  static bool
+  StringCast(const std::string & parameterValue, unsigned char & casted);
 };
 
 } // end of namespace itk

--- a/Common/ParameterFileParser/itkParameterMapInterface.h
+++ b/Common/ParameterFileParser/itkParameterMapInterface.h
@@ -424,6 +424,10 @@ private:
 
   /** Provide specializations for floating point types, to support NaN and infinity.
    */
+  template <typename TFloatingPoint>
+  static bool
+  StringCastToFloatingPoint(const std::string & parameterValue, TFloatingPoint & casted);
+
   static bool
   StringCast(const std::string & parameterValue, double & casted);
 

--- a/Core/ComponentBaseClasses/elxResamplerBase.hxx
+++ b/Core/ComponentBaseClasses/elxResamplerBase.hxx
@@ -69,11 +69,11 @@ ResamplerBase<TElastix>::BeforeRegistrationBase(void)
   /** Set the DefaultPixelValue (for pixels in the resampled image
    * that come from outside the original (moving) image.
    */
-  double defaultPixelValue = itk::NumericTraits<double>::Zero;
+  OutputPixelType defaultPixelValue{};
   this->m_Configuration->ReadParameter(defaultPixelValue, "DefaultPixelValue", 0, false);
 
   /** Set the defaultPixelValue. */
-  this->GetAsITKBaseType()->SetDefaultPixelValue(static_cast<OutputPixelType>(defaultPixelValue));
+  this->GetAsITKBaseType()->SetDefaultPixelValue(defaultPixelValue);
 
 } // end BeforeRegistrationBase()
 

--- a/Core/Install/elxConversion.h
+++ b/Core/Install/elxConversion.h
@@ -99,7 +99,6 @@ public:
   {
     static_assert(std::is_integral<TInteger>::value, "An integer type expected!");
     static_assert(!std::is_same<TInteger, bool>::value, "No bool expected!");
-    static_assert(sizeof(TInteger) > 1, "ToString does not support (signed/unsigned) char!");
     return std::to_string(integerValue);
   }
 

--- a/Core/Main/elxParameterObject.cxx
+++ b/Core/Main/elxParameterObject.cxx
@@ -409,7 +409,7 @@ ParameterObject::GetDefaultParameterMap(const std::string &  transformName,
 
   // Optimizer
   parameterMap["NumberOfSamplesForExactGradient"] = ParameterValueVectorType(1, "4096");
-  parameterMap["DefaultPixelValue"] = ParameterValueVectorType(1, "0.0");
+  parameterMap["DefaultPixelValue"] = ParameterValueVectorType(1, "0");
   parameterMap["AutomaticParameterEstimation"] = ParameterValueVectorType(1, "true");
 
   // Output


### PR DESCRIPTION
Follow-up to pull request  #403, "ParameterMapInterface style improvements, round trip tests, Infinity and NaN support"

Including: 

- a more useful workaround for the LLVM Bug 39012, [ostream writes a double that istream can't read](https://bugs.llvm.org/show_bug.cgi?id=39012)
- restored and improved support for (signed/unsigned) char pixel types
- improved I/O for `DefaultPixelValue` parameter value, taking the pixel type into account