### PR TITLE
Small fixes based on Clang-Tidy performance-unnecessary-value-param

### DIFF
--- a/Common/GTesting/elxResampleInterpolatorGTest.cxx
+++ b/Common/GTesting/elxResampleInterpolatorGTest.cxx
@@ -51,7 +51,7 @@ using ElastixType = elx::ElastixTemplate<itk::Image<float, NDimension>, itk::Ima
 template <unsigned NDimension>
 struct WithDimension
 {
-  template <template <typename> typename TInterpolatorTemplate>
+  template <template <typename> class TInterpolatorTemplate>
   struct WithInterpolator
   {
     using InterpolatorType = TInterpolatorTemplate<ElastixType<NDimension>>;

--- a/Common/GTesting/elxResamplerGTest.cxx
+++ b/Common/GTesting/elxResamplerGTest.cxx
@@ -49,7 +49,7 @@ using ElastixType = elx::ElastixTemplate<itk::Image<float, NDimension>, itk::Ima
 template <unsigned NDimension>
 struct WithDimension
 {
-  template <template <typename> typename TResamplerTemplate>
+  template <template <typename> class TResamplerTemplate>
   struct WithResampler
   {
     using ResamplerType = TResamplerTemplate<ElastixType<NDimension>>;

--- a/Common/GTesting/elxTransformIOGTest.cxx
+++ b/Common/GTesting/elxTransformIOGTest.cxx
@@ -72,7 +72,7 @@ using ExpectedParameters = std::array<double, N>;
 template <unsigned NDimension>
 struct WithDimension
 {
-  template <template <typename> typename TElastixTransform>
+  template <template <typename> class TElastixTransform>
   struct WithElastixTransform
   {
     using ElastixTransformType = TElastixTransform<ElastixType<NDimension>>;
@@ -325,7 +325,7 @@ struct WithDimension
   }
 
 
-  template <template <typename> typename TElastixTransform, std::size_t NExpectedParameters>
+  template <template <typename> class TElastixTransform, std::size_t NExpectedParameters>
   static void
   Expect_default_elastix_Parameters_equal(const ExpectedParameters<NExpectedParameters> & expectedParameters)
   {
@@ -467,7 +467,7 @@ struct WithDimension
 };
 
 
-template <template <typename> typename TElastixTransform>
+template <template <typename> class TElastixTransform>
 void
 Expect_default_elastix_FixedParameters_are_all_zero()
 {
@@ -477,7 +477,7 @@ Expect_default_elastix_FixedParameters_are_all_zero()
 }
 
 
-template <template <typename> typename TElastixTransform>
+template <template <typename> class TElastixTransform>
 void
 Expect_default_elastix_FixedParameters_empty()
 {
@@ -487,7 +487,7 @@ Expect_default_elastix_FixedParameters_empty()
 }
 
 
-template <template <typename> typename TElastixTransform>
+template <template <typename> class TElastixTransform>
 void
 Expect_default_elastix_Parameters_remain_the_same_when_set(const bool fixed)
 {

--- a/Components/Metrics/KNNGraphAlphaMutualInformation/KNN/itkANNbdTree.h
+++ b/Components/Metrics/KNNGraphAlphaMutualInformation/KNN/itkANNbdTree.h
@@ -64,7 +64,7 @@ public:
   itkSetMacro(ShrinkingRule, ShrinkingRuleType);
   itkGetConstMacro(ShrinkingRule, ShrinkingRuleType);
   void
-  SetShrinkingRule(std::string rule);
+  SetShrinkingRule(const std::string & rule);
 
   std::string
   GetShrinkingRule(void);

--- a/Components/Metrics/KNNGraphAlphaMutualInformation/KNN/itkANNbdTree.hxx
+++ b/Components/Metrics/KNNGraphAlphaMutualInformation/KNN/itkANNbdTree.hxx
@@ -41,7 +41,7 @@ ANNbdTree<TListSample>::ANNbdTree()
 
 template <class TListSample>
 void
-ANNbdTree<TListSample>::SetShrinkingRule(std::string rule)
+ANNbdTree<TListSample>::SetShrinkingRule(const std::string & rule)
 {
   if (rule == "ANN_BD_NONE")
   {

--- a/Components/Metrics/KNNGraphAlphaMutualInformation/KNN/itkANNkDTree.h
+++ b/Components/Metrics/KNNGraphAlphaMutualInformation/KNN/itkANNkDTree.h
@@ -68,7 +68,7 @@ public:
   itkSetMacro(SplittingRule, SplittingRuleType);
   itkGetConstMacro(SplittingRule, SplittingRuleType);
   void
-  SetSplittingRule(std::string rule);
+  SetSplittingRule(const std::string & rule);
 
   std::string
   GetSplittingRule(void);

--- a/Components/Metrics/KNNGraphAlphaMutualInformation/KNN/itkANNkDTree.hxx
+++ b/Components/Metrics/KNNGraphAlphaMutualInformation/KNN/itkANNkDTree.hxx
@@ -56,7 +56,7 @@ ANNkDTree<TListSample>::~ANNkDTree()
 
 template <class TListSample>
 void
-ANNkDTree<TListSample>::SetSplittingRule(std::string rule)
+ANNkDTree<TListSample>::SetSplittingRule(const std::string & rule)
 {
   if (rule == "ANN_KD_STD")
   {

--- a/Core/ComponentBaseClasses/elxTransformBase.h
+++ b/Core/ComponentBaseClasses/elxTransformBase.h
@@ -345,11 +345,11 @@ private:
 
   /** Function to transform coordinates from fixed to moving image. */
   void
-  TransformPointsSomePoints(const std::string filename) const;
+  TransformPointsSomePoints(const std::string & filename) const;
 
   /** Function to transform coordinates from fixed to moving image, given as VTK file. */
   void
-  TransformPointsSomePointsVTK(const std::string filename) const;
+  TransformPointsSomePointsVTK(const std::string & filename) const;
 
   /** Deprecation note: The plan is to split all Compute* and TransformPoints* functions
    *  into Generate* and Write* functions, since that would facilitate a proper library

--- a/Core/ComponentBaseClasses/elxTransformBase.hxx
+++ b/Core/ComponentBaseClasses/elxTransformBase.hxx
@@ -805,7 +805,7 @@ TransformBase<TElastix>::TransformPoints(void) const
 
 template <class TElastix>
 void
-TransformBase<TElastix>::TransformPointsSomePoints(const std::string filename) const
+TransformBase<TElastix>::TransformPointsSomePoints(const std::string & filename) const
 {
   /** Typedef's. */
   typedef typename FixedImageType::RegionType                FixedImageRegionType;
@@ -1029,7 +1029,7 @@ TransformBase<TElastix>::TransformPointsSomePoints(const std::string filename) c
 
 template <class TElastix>
 void
-TransformBase<TElastix>::TransformPointsSomePointsVTK(const std::string filename) const
+TransformBase<TElastix>::TransformPointsSomePointsVTK(const std::string & filename) const
 {
   /** Typedef's. \todo test DummyIPPPixelType=bool. */
   typedef float DummyIPPPixelType;

--- a/Core/Kernel/elxElastixTemplate.h
+++ b/Core/Kernel/elxElastixTemplate.h
@@ -266,7 +266,7 @@ private:
 
   /** CreateTransformParameterFile. */
   void
-  CreateTransformParameterFile(const std::string FileName, const bool ToLog);
+  CreateTransformParameterFile(const std::string & FileName, const bool ToLog);
 
   /** CreateTransformParametersMap. */
   void

--- a/Core/Kernel/elxElastixTemplate.hxx
+++ b/Core/Kernel/elxElastixTemplate.hxx
@@ -754,7 +754,7 @@ ElastixTemplate<TFixedImage, TMovingImage>::AfterRegistration(void)
 
 template <class TFixedImage, class TMovingImage>
 void
-ElastixTemplate<TFixedImage, TMovingImage>::CreateTransformParameterFile(const std::string fileName, const bool toLog)
+ElastixTemplate<TFixedImage, TMovingImage>::CreateTransformParameterFile(const std::string & fileName, const bool toLog)
 {
   /** Store CurrentTransformParameterFileName. */
   this->m_CurrentTransformParameterFileName = fileName;

--- a/Core/Main/elxElastixFilter.h
+++ b/Core/Main/elxElastixFilter.h
@@ -226,7 +226,7 @@ private:
 
   /** IsInputOfType. */
   bool
-  IsInputOfType(const DataObjectIdentifierType & InputOfType, DataObjectIdentifierType inputName);
+  IsInputOfType(const DataObjectIdentifierType & InputOfType, const DataObjectIdentifierType & inputName);
 
   /** GetNumberOfInputsOfType */
   unsigned int

--- a/Core/Main/elxElastixFilter.hxx
+++ b/Core/Main/elxElastixFilter.hxx
@@ -756,7 +756,7 @@ ElastixFilter<TFixedImage, TMovingImage>::MakeUniqueName(const DataObjectIdentif
 template <typename TFixedImage, typename TMovingImage>
 bool
 ElastixFilter<TFixedImage, TMovingImage>::IsInputOfType(const DataObjectIdentifierType & inputType,
-                                                        DataObjectIdentifierType         inputName)
+                                                        const DataObjectIdentifierType & inputName)
 {
   return std::strncmp(inputType.c_str(), inputName.c_str(), std::min(inputType.size(), inputName.size())) == 0;
 } // end IsInputOfType()

--- a/Core/Main/itkElastixRegistrationMethod.h
+++ b/Core/Main/itkElastixRegistrationMethod.h
@@ -263,7 +263,7 @@ private:
 
   /** IsInputOfType. */
   bool
-  IsInputOfType(const DataObjectIdentifierType & InputOfType, DataObjectIdentifierType inputName) const;
+  IsInputOfType(const DataObjectIdentifierType & InputOfType, const DataObjectIdentifierType & inputName) const;
 
   /** GetNumberOfInputsOfType */
   unsigned int

--- a/Core/Main/itkElastixRegistrationMethod.hxx
+++ b/Core/Main/itkElastixRegistrationMethod.hxx
@@ -743,7 +743,7 @@ ElastixRegistrationMethod<TFixedImage, TMovingImage>::MakeUniqueName(const DataO
 template <typename TFixedImage, typename TMovingImage>
 bool
 ElastixRegistrationMethod<TFixedImage, TMovingImage>::IsInputOfType(const DataObjectIdentifierType & inputType,
-                                                                    DataObjectIdentifierType         inputName) const
+                                                                    const DataObjectIdentifierType & inputName) const
 {
   return std::strncmp(inputType.c_str(), inputName.c_str(), std::min(inputType.size(), inputName.size())) == 0;
 }

--- a/Core/Main/transformixlib.cxx
+++ b/Core/Main/transformixlib.cxx
@@ -84,7 +84,7 @@ TRANSFORMIX::GetResultImage(void)
 int
 TRANSFORMIX::TransformImage(ImagePointer                    inputImage,
                             std::vector<ParameterMapType> & parameterMaps,
-                            std::string                     outputPath,
+                            const std::string &             outputPath,
                             bool                            performLogging,
                             bool                            performCout)
 {

--- a/Core/Main/transformixlib.h
+++ b/Core/Main/transformixlib.h
@@ -70,7 +70,7 @@ public:
   int
   TransformImage(ImagePointer                    inputImage,
                  std::vector<ParameterMapType> & parameterMaps,
-                 std::string                     outputPath,
+                 const std::string &             outputPath,
                  bool                            performLogging,
                  bool                            performCout);
 


### PR DESCRIPTION
See also https://clang.llvm.org/extra/clang-tidy/checks/performance-unnecessary-value-param.html

(Clang-Tidy also found the template template parameter issue, which is fixed as well.)
