### PR TITLE
Replace xout["iteration"] by access to IterationInfo via ElastixBase and BaseComponentSE 

### DIFF
--- a/Components/Metrics/RigidityPenalty/elxTransformRigidityPenaltyTerm.hxx
+++ b/Components/Metrics/RigidityPenalty/elxTransformRigidityPenaltyTerm.hxx
@@ -143,21 +143,21 @@ TransformRigidityPenalty<TElastix>::BeforeRegistration(void)
                         << "transform domain." << std::endl;
   }
 
-  /** Add target cells to xout["iteration"]. */
-  xl::xout["iteration"].AddTargetCell("Metric-LC");
-  xl::xout["iteration"].AddTargetCell("Metric-OC");
-  xl::xout["iteration"].AddTargetCell("Metric-PC");
-  xl::xout["iteration"].AddTargetCell("||Gradient-LC||");
-  xl::xout["iteration"].AddTargetCell("||Gradient-OC||");
-  xl::xout["iteration"].AddTargetCell("||Gradient-PC||");
+  /** Add target cells to IterationInfo. */
+  this->AddTargetCellToIterationInfo("Metric-LC");
+  this->AddTargetCellToIterationInfo("Metric-OC");
+  this->AddTargetCellToIterationInfo("Metric-PC");
+  this->AddTargetCellToIterationInfo("||Gradient-LC||");
+  this->AddTargetCellToIterationInfo("||Gradient-OC||");
+  this->AddTargetCellToIterationInfo("||Gradient-PC||");
 
   /** Format the metric as floats. */
-  xl::xout["iteration"]["Metric-LC"] << std::showpoint << std::fixed << std::setprecision(10);
-  xl::xout["iteration"]["Metric-OC"] << std::showpoint << std::fixed << std::setprecision(10);
-  xl::xout["iteration"]["Metric-PC"] << std::showpoint << std::fixed << std::setprecision(10);
-  xl::xout["iteration"]["||Gradient-LC||"] << std::showpoint << std::fixed << std::setprecision(10);
-  xl::xout["iteration"]["||Gradient-OC||"] << std::showpoint << std::fixed << std::setprecision(10);
-  xl::xout["iteration"]["||Gradient-PC||"] << std::showpoint << std::fixed << std::setprecision(10);
+  this->GetIterationInfoAt("Metric-LC") << std::showpoint << std::fixed << std::setprecision(10);
+  this->GetIterationInfoAt("Metric-OC") << std::showpoint << std::fixed << std::setprecision(10);
+  this->GetIterationInfoAt("Metric-PC") << std::showpoint << std::fixed << std::setprecision(10);
+  this->GetIterationInfoAt("||Gradient-LC||") << std::showpoint << std::fixed << std::setprecision(10);
+  this->GetIterationInfoAt("||Gradient-OC||") << std::showpoint << std::fixed << std::setprecision(10);
+  this->GetIterationInfoAt("||Gradient-PC||") << std::showpoint << std::fixed << std::setprecision(10);
 
 } // end BeforeRegistration()
 
@@ -272,13 +272,13 @@ void
 TransformRigidityPenalty<TElastix>::AfterEachIteration(void)
 {
   /** Print some information. */
-  xl::xout["iteration"]["Metric-LC"] << this->GetLinearityConditionValue();
-  xl::xout["iteration"]["Metric-OC"] << this->GetOrthonormalityConditionValue();
-  xl::xout["iteration"]["Metric-PC"] << this->GetPropernessConditionValue();
+  this->GetIterationInfoAt("Metric-LC") << this->GetLinearityConditionValue();
+  this->GetIterationInfoAt("Metric-OC") << this->GetOrthonormalityConditionValue();
+  this->GetIterationInfoAt("Metric-PC") << this->GetPropernessConditionValue();
 
-  xl::xout["iteration"]["||Gradient-LC||"] << this->GetLinearityConditionGradientMagnitude();
-  xl::xout["iteration"]["||Gradient-OC||"] << this->GetOrthonormalityConditionGradientMagnitude();
-  xl::xout["iteration"]["||Gradient-PC||"] << this->GetPropernessConditionGradientMagnitude();
+  this->GetIterationInfoAt("||Gradient-LC||") << this->GetLinearityConditionGradientMagnitude();
+  this->GetIterationInfoAt("||Gradient-OC||") << this->GetOrthonormalityConditionGradientMagnitude();
+  this->GetIterationInfoAt("||Gradient-PC||") << this->GetPropernessConditionGradientMagnitude();
 
 } // end AfterEachIteration()
 

--- a/Components/Optimizers/AdaGrad/elxAdaGrad.hxx
+++ b/Components/Optimizers/AdaGrad/elxAdaGrad.hxx
@@ -80,19 +80,19 @@ template <class TElastix>
 void
 AdaGrad<TElastix>::BeforeRegistration(void)
 {
-  /** Add the target cell "stepsize" to xout["iteration"]. */
-  xl::xout["iteration"].AddTargetCell("2:Metric");
-  xl::xout["iteration"].AddTargetCell("3a:Time");
-  xl::xout["iteration"].AddTargetCell("3b:StepSize");
-  xl::xout["iteration"].AddTargetCell("4a:||Gradient||");
-  xl::xout["iteration"].AddTargetCell("4b:||SearchDirection||");
+  /** Add the target cell "stepsize" to IterationInfo. */
+  this->AddTargetCellToIterationInfo("2:Metric");
+  this->AddTargetCellToIterationInfo("3a:Time");
+  this->AddTargetCellToIterationInfo("3b:StepSize");
+  this->AddTargetCellToIterationInfo("4a:||Gradient||");
+  this->AddTargetCellToIterationInfo("4b:||SearchDirection||");
 
   /** Format the metric and stepsize as floats. */
-  xl::xout["iteration"]["2:Metric"] << std::showpoint << std::fixed;
-  xl::xout["iteration"]["3a:Time"] << std::showpoint << std::fixed;
-  xl::xout["iteration"]["3b:StepSize"] << std::showpoint << std::fixed;
-  xl::xout["iteration"]["4:||Gradient||"] << std::showpoint << std::fixed;
-  xl::xout["iteration"]["4b:||SearchDirection||"] << std::showpoint << std::fixed;
+  this->GetIterationInfoAt("2:Metric") << std::showpoint << std::fixed;
+  this->GetIterationInfoAt("3a:Time") << std::showpoint << std::fixed;
+  this->GetIterationInfoAt("3b:StepSize") << std::showpoint << std::fixed;
+  this->GetIterationInfoAt("4:||Gradient||") << std::showpoint << std::fixed;
+  this->GetIterationInfoAt("4b:||SearchDirection||") << std::showpoint << std::fixed;
 
   this->m_SettingsVector.clear();
 
@@ -287,20 +287,20 @@ void
 AdaGrad<TElastix>::AfterEachIteration(void)
 {
   /** Print some information. */
-  xl::xout["iteration"]["2:Metric"] << this->GetValue();
-  xl::xout["iteration"]["3a:Time"] << this->GetCurrentTime();
-  xl::xout["iteration"]["3b:StepSize"] << this->GetLearningRate() * this->m_NoiseFactor;
+  this->GetIterationInfoAt("2:Metric") << this->GetValue();
+  this->GetIterationInfoAt("3a:Time") << this->GetCurrentTime();
+  this->GetIterationInfoAt("3b:StepSize") << this->GetLearningRate() * this->m_NoiseFactor;
 
   bool asFastAsPossible = false;
   if (asFastAsPossible)
   {
-    xl::xout["iteration"]["4a:||Gradient||"] << "---";
-    xl::xout["iteration"]["4b:||SearchDirection||"] << "---";
+    this->GetIterationInfoAt("4a:||Gradient||") << "---";
+    this->GetIterationInfoAt("4b:||SearchDirection||") << "---";
   }
   else
   {
-    xl::xout["iteration"]["4a:||Gradient||"] << this->GetGradient().magnitude();
-    xl::xout["iteration"]["4b:||SearchDirection||"] << this->GetSearchDirection().magnitude();
+    this->GetIterationInfoAt("4a:||Gradient||") << this->GetGradient().magnitude();
+    this->GetIterationInfoAt("4b:||SearchDirection||") << this->GetSearchDirection().magnitude();
   }
 
   /** Select new spatial samples for the computation of the metric. */

--- a/Components/Optimizers/AdaptiveStochasticGradientDescent/elxAdaptiveStochasticGradientDescent.hxx
+++ b/Components/Optimizers/AdaptiveStochasticGradientDescent/elxAdaptiveStochasticGradientDescent.hxx
@@ -70,17 +70,17 @@ template <class TElastix>
 void
 AdaptiveStochasticGradientDescent<TElastix>::BeforeRegistration(void)
 {
-  /** Add the target cell "stepsize" to xout["iteration"]. */
-  xl::xout["iteration"].AddTargetCell("2:Metric");
-  xl::xout["iteration"].AddTargetCell("3a:Time");
-  xl::xout["iteration"].AddTargetCell("3b:StepSize");
-  xl::xout["iteration"].AddTargetCell("4:||Gradient||");
+  /** Add the target cell "stepsize" to IterationInfo. */
+  this->AddTargetCellToIterationInfo("2:Metric");
+  this->AddTargetCellToIterationInfo("3a:Time");
+  this->AddTargetCellToIterationInfo("3b:StepSize");
+  this->AddTargetCellToIterationInfo("4:||Gradient||");
 
   /** Format the metric and stepsize as floats. */
-  xl::xout["iteration"]["2:Metric"] << std::showpoint << std::fixed;
-  xl::xout["iteration"]["3a:Time"] << std::showpoint << std::fixed;
-  xl::xout["iteration"]["3b:StepSize"] << std::showpoint << std::fixed;
-  xl::xout["iteration"]["4:||Gradient||"] << std::showpoint << std::fixed;
+  this->GetIterationInfoAt("2:Metric") << std::showpoint << std::fixed;
+  this->GetIterationInfoAt("3a:Time") << std::showpoint << std::fixed;
+  this->GetIterationInfoAt("3b:StepSize") << std::showpoint << std::fixed;
+  this->GetIterationInfoAt("4:||Gradient||") << std::showpoint << std::fixed;
 
   this->m_SettingsVector.clear();
 
@@ -266,17 +266,17 @@ void
 AdaptiveStochasticGradientDescent<TElastix>::AfterEachIteration(void)
 {
   /** Print some information. */
-  xl::xout["iteration"]["2:Metric"] << this->GetValue();
-  xl::xout["iteration"]["3a:Time"] << this->GetCurrentTime();
-  xl::xout["iteration"]["3b:StepSize"] << this->GetLearningRate();
+  this->GetIterationInfoAt("2:Metric") << this->GetValue();
+  this->GetIterationInfoAt("3a:Time") << this->GetCurrentTime();
+  this->GetIterationInfoAt("3b:StepSize") << this->GetLearningRate();
   bool asFastAsPossible = false;
   if (asFastAsPossible)
   {
-    xl::xout["iteration"]["4:||Gradient||"] << "---";
+    this->GetIterationInfoAt("4:||Gradient||") << "---";
   }
   else
   {
-    xl::xout["iteration"]["4:||Gradient||"] << this->GetGradient().magnitude();
+    this->GetIterationInfoAt("4:||Gradient||") << this->GetGradient().magnitude();
   }
 
   /** Select new spatial samples for the computation of the metric. */

--- a/Components/Optimizers/AdaptiveStochasticLBFGS/elxAdaptiveStochasticLBFGS.hxx
+++ b/Components/Optimizers/AdaptiveStochasticLBFGS/elxAdaptiveStochasticLBFGS.hxx
@@ -97,19 +97,19 @@ template <class TElastix>
 void
 AdaptiveStochasticLBFGS<TElastix>::BeforeRegistration(void)
 {
-  /** Add the target cell "stepsize" to xout["iteration"]. */
-  xl::xout["iteration"].AddTargetCell("2:Metric");
-  xl::xout["iteration"].AddTargetCell("3a:Time");
-  xl::xout["iteration"].AddTargetCell("3b:StepSize");
-  xl::xout["iteration"].AddTargetCell("4a:||Gradient||");
-  xl::xout["iteration"].AddTargetCell("4b:||SearchDir||");
+  /** Add the target cell "stepsize" to IterationInfo. */
+  this->AddTargetCellToIterationInfo("2:Metric");
+  this->AddTargetCellToIterationInfo("3a:Time");
+  this->AddTargetCellToIterationInfo("3b:StepSize");
+  this->AddTargetCellToIterationInfo("4a:||Gradient||");
+  this->AddTargetCellToIterationInfo("4b:||SearchDir||");
 
   /** Format the metric and stepsize as floats. */
-  xl::xout["iteration"]["2:Metric"] << std::showpoint << std::fixed;
-  xl::xout["iteration"]["3a:Time"] << std::showpoint << std::fixed;
-  xl::xout["iteration"]["3b:StepSize"] << std::showpoint << std::fixed;
-  xl::xout["iteration"]["4a:||Gradient||"] << std::showpoint << std::fixed;
-  xl::xout["iteration"]["4b:||SearchDir||"] << std::showpoint << std::fixed;
+  this->GetIterationInfoAt("2:Metric") << std::showpoint << std::fixed;
+  this->GetIterationInfoAt("3a:Time") << std::showpoint << std::fixed;
+  this->GetIterationInfoAt("3b:StepSize") << std::showpoint << std::fixed;
+  this->GetIterationInfoAt("4a:||Gradient||") << std::showpoint << std::fixed;
+  this->GetIterationInfoAt("4b:||SearchDir||") << std::showpoint << std::fixed;
 
   this->m_SettingsVector.clear();
 
@@ -350,11 +350,11 @@ void
 AdaptiveStochasticLBFGS<TElastix>::AfterEachIteration(void)
 {
   /** Print some information. */
-  xl::xout["iteration"]["2:Metric"] << this->GetValue();
-  xl::xout["iteration"]["3a:Time"] << this->GetCurrentTime();
-  xl::xout["iteration"]["3b:StepSize"] << this->GetLearningRate();
-  xl::xout["iteration"]["4a:||Gradient||"] << this->GetGradient().magnitude();
-  xl::xout["iteration"]["4b:||SearchDir||"] << this->m_SearchDir.magnitude();
+  this->GetIterationInfoAt("2:Metric") << this->GetValue();
+  this->GetIterationInfoAt("3a:Time") << this->GetCurrentTime();
+  this->GetIterationInfoAt("3b:StepSize") << this->GetLearningRate();
+  this->GetIterationInfoAt("4a:||Gradient||") << this->GetGradient().magnitude();
+  this->GetIterationInfoAt("4b:||SearchDir||") << this->m_SearchDir.magnitude();
 
   /** Select new spatial samples for the computation of the metric. */
   if (this->GetNewSamplesEveryIteration())

--- a/Components/Optimizers/AdaptiveStochasticVarianceReducedGradient/elxAdaptiveStochasticVarianceReducedGradient.hxx
+++ b/Components/Optimizers/AdaptiveStochasticVarianceReducedGradient/elxAdaptiveStochasticVarianceReducedGradient.hxx
@@ -91,17 +91,17 @@ template <class TElastix>
 void
 AdaptiveStochasticVarianceReducedGradient<TElastix>::BeforeRegistration(void)
 {
-  /** Add the target cell "stepsize" to xout["iteration"]. */
-  xl::xout["iteration"].AddTargetCell("2:Metric");
-  xl::xout["iteration"].AddTargetCell("3a:Time");
-  xl::xout["iteration"].AddTargetCell("3b:StepSize");
-  xl::xout["iteration"].AddTargetCell("4:||Gradient||");
+  /** Add the target cell "stepsize" to IterationInfo. */
+  this->AddTargetCellToIterationInfo("2:Metric");
+  this->AddTargetCellToIterationInfo("3a:Time");
+  this->AddTargetCellToIterationInfo("3b:StepSize");
+  this->AddTargetCellToIterationInfo("4:||Gradient||");
 
   /** Format the metric and stepsize as floats. */
-  xl::xout["iteration"]["2:Metric"] << std::showpoint << std::fixed;
-  xl::xout["iteration"]["3a:Time"] << std::showpoint << std::fixed;
-  xl::xout["iteration"]["3b:StepSize"] << std::showpoint << std::fixed;
-  xl::xout["iteration"]["4:||Gradient||"] << std::showpoint << std::fixed;
+  this->GetIterationInfoAt("2:Metric") << std::showpoint << std::fixed;
+  this->GetIterationInfoAt("3a:Time") << std::showpoint << std::fixed;
+  this->GetIterationInfoAt("3b:StepSize") << std::showpoint << std::fixed;
+  this->GetIterationInfoAt("4:||Gradient||") << std::showpoint << std::fixed;
 
   this->m_SettingsVector.clear();
 
@@ -295,17 +295,17 @@ void
 AdaptiveStochasticVarianceReducedGradient<TElastix>::AfterEachIteration(void)
 {
   /** Print some information. */
-  xl::xout["iteration"]["2:Metric"] << this->GetValue();
-  xl::xout["iteration"]["3a:Time"] << this->GetCurrentTime();
-  xl::xout["iteration"]["3b:StepSize"] << this->GetLearningRate();
+  this->GetIterationInfoAt("2:Metric") << this->GetValue();
+  this->GetIterationInfoAt("3a:Time") << this->GetCurrentTime();
+  this->GetIterationInfoAt("3b:StepSize") << this->GetLearningRate();
   bool asFastAsPossible = false;
   if (asFastAsPossible)
   {
-    xl::xout["iteration"]["4:||Gradient||"] << "---";
+    this->GetIterationInfoAt("4:||Gradient||") << "---";
   }
   else
   {
-    xl::xout["iteration"]["4:||Gradient||"] << this->GetGradient().magnitude();
+    this->GetIterationInfoAt("4:||Gradient||") << this->GetGradient().magnitude();
   }
 
   /** Select new spatial samples for the computation of the metric. */

--- a/Components/Optimizers/CMAEvolutionStrategy/elxCMAEvolutionStrategy.hxx
+++ b/Components/Optimizers/CMAEvolutionStrategy/elxCMAEvolutionStrategy.hxx
@@ -84,21 +84,21 @@ template <class TElastix>
 void
 CMAEvolutionStrategy<TElastix>::BeforeRegistration(void)
 {
-  /** Add target cells to xout["iteration"].*/
-  xl::xout["iteration"].AddTargetCell("2:Metric");
-  xl::xout["iteration"].AddTargetCell("3:StepLength");
-  xl::xout["iteration"].AddTargetCell("4:||Step||");
-  xl::xout["iteration"].AddTargetCell("5a:Sigma");
-  xl::xout["iteration"].AddTargetCell("5b:MaximumD");
-  xl::xout["iteration"].AddTargetCell("5c:MinimumD");
+  /** Add target cells to xout[IterationInfo.*/
+  this->AddTargetCellToIterationInfo("2:Metric");
+  this->AddTargetCellToIterationInfo("3:StepLength");
+  this->AddTargetCellToIterationInfo("4:||Step||");
+  this->AddTargetCellToIterationInfo("5a:Sigma");
+  this->AddTargetCellToIterationInfo("5b:MaximumD");
+  this->AddTargetCellToIterationInfo("5c:MinimumD");
 
   /** Format the metric and stepsize as floats */
-  xl::xout["iteration"]["2:Metric"] << std::showpoint << std::fixed;
-  xl::xout["iteration"]["3:StepLength"] << std::showpoint << std::fixed;
-  xl::xout["iteration"]["4:||Step||"] << std::showpoint << std::fixed;
-  xl::xout["iteration"]["5a:Sigma"] << std::showpoint << std::fixed;
-  xl::xout["iteration"]["5b:MaximumD"] << std::showpoint << std::fixed;
-  xl::xout["iteration"]["5c:MinimumD"] << std::showpoint << std::fixed;
+  this->GetIterationInfoAt("2:Metric") << std::showpoint << std::fixed;
+  this->GetIterationInfoAt("3:StepLength") << std::showpoint << std::fixed;
+  this->GetIterationInfoAt("4:||Step||") << std::showpoint << std::fixed;
+  this->GetIterationInfoAt("5a:Sigma") << std::showpoint << std::fixed;
+  this->GetIterationInfoAt("5b:MaximumD") << std::showpoint << std::fixed;
+  this->GetIterationInfoAt("5c:MinimumD") << std::showpoint << std::fixed;
 
 } // end BeforeRegistration
 
@@ -206,12 +206,12 @@ void
 CMAEvolutionStrategy<TElastix>::AfterEachIteration(void)
 {
   /** Print some information. */
-  xl::xout["iteration"]["2:Metric"] << this->GetCurrentValue();
-  xl::xout["iteration"]["3:StepLength"] << this->GetCurrentStepLength();
-  xl::xout["iteration"]["4:||Step||"] << this->GetCurrentScaledStep().magnitude();
-  xl::xout["iteration"]["5a:Sigma"] << this->GetCurrentSigma();
-  xl::xout["iteration"]["5b:MaximumD"] << this->GetCurrentMaximumD();
-  xl::xout["iteration"]["5c:MinimumD"] << this->GetCurrentMinimumD();
+  this->GetIterationInfoAt("2:Metric") << this->GetCurrentValue();
+  this->GetIterationInfoAt("3:StepLength") << this->GetCurrentStepLength();
+  this->GetIterationInfoAt("4:||Step||") << this->GetCurrentScaledStep().magnitude();
+  this->GetIterationInfoAt("5a:Sigma") << this->GetCurrentSigma();
+  this->GetIterationInfoAt("5b:MaximumD") << this->GetCurrentMaximumD();
+  this->GetIterationInfoAt("5c:MinimumD") << this->GetCurrentMinimumD();
 
   /** Select new samples if desired. These
    * will be used in the next iteration */

--- a/Components/Optimizers/ConjugateGradient/elxConjugateGradient.hxx
+++ b/Components/Optimizers/ConjugateGradient/elxConjugateGradient.hxx
@@ -177,25 +177,25 @@ template <class TElastix>
 void
 ConjugateGradient<TElastix>::BeforeRegistration(void)
 {
-  /** Add target cells to xout["iteration"].*/
-  xl::xout["iteration"].AddTargetCell("1a:SrchDirNr");
-  xl::xout["iteration"].AddTargetCell("1b:LineItNr");
-  xl::xout["iteration"].AddTargetCell("2:Metric");
-  xl::xout["iteration"].AddTargetCell("3:StepLength");
-  xl::xout["iteration"].AddTargetCell("4a:||Gradient||");
-  xl::xout["iteration"].AddTargetCell("4b:||SearchDir||");
-  xl::xout["iteration"].AddTargetCell("4c:DirGradient");
-  xl::xout["iteration"].AddTargetCell("5:Phase");
-  xl::xout["iteration"].AddTargetCell("6a:Wolfe1");
-  xl::xout["iteration"].AddTargetCell("6b:Wolfe2");
-  xl::xout["iteration"].AddTargetCell("7:LinSrchStopCondition");
+  /** Add target cells to IterationInfo.*/
+  this->AddTargetCellToIterationInfo("1a:SrchDirNr");
+  this->AddTargetCellToIterationInfo("1b:LineItNr");
+  this->AddTargetCellToIterationInfo("2:Metric");
+  this->AddTargetCellToIterationInfo("3:StepLength");
+  this->AddTargetCellToIterationInfo("4a:||Gradient||");
+  this->AddTargetCellToIterationInfo("4b:||SearchDir||");
+  this->AddTargetCellToIterationInfo("4c:DirGradient");
+  this->AddTargetCellToIterationInfo("5:Phase");
+  this->AddTargetCellToIterationInfo("6a:Wolfe1");
+  this->AddTargetCellToIterationInfo("6b:Wolfe2");
+  this->AddTargetCellToIterationInfo("7:LinSrchStopCondition");
 
   /** Format the metric and stepsize as floats */
-  xl::xout["iteration"]["2:Metric"] << std::showpoint << std::fixed;
-  xl::xout["iteration"]["3:StepLength"] << std::showpoint << std::fixed;
-  xl::xout["iteration"]["4a:||Gradient||"] << std::showpoint << std::fixed;
-  xl::xout["iteration"]["4b:||SearchDir||"] << std::showpoint << std::fixed;
-  xl::xout["iteration"]["4c:DirGradient"] << std::showpoint << std::fixed;
+  this->GetIterationInfoAt("2:Metric") << std::showpoint << std::fixed;
+  this->GetIterationInfoAt("3:StepLength") << std::showpoint << std::fixed;
+  this->GetIterationInfoAt("4a:||Gradient||") << std::showpoint << std::fixed;
+  this->GetIterationInfoAt("4b:||SearchDir||") << std::showpoint << std::fixed;
+  this->GetIterationInfoAt("4c:DirGradient") << std::showpoint << std::fixed;
 
   /** Check in the parameter file whether line search iterations should
    * be generated */
@@ -298,7 +298,7 @@ ConjugateGradient<TElastix>::AfterEachIteration(void)
 
   if (this->GetStartLineSearch())
   {
-    xl::xout["iteration"]["1b:LineItNr"] << "start";
+    this->GetIterationInfoAt("1b:LineItNr") << "start";
   }
   else
   {
@@ -309,45 +309,45 @@ ConjugateGradient<TElastix>::AfterEachIteration(void)
      * line search iteration number (so the number of line search
      * iterations minus one) is printed out.
      */
-    xl::xout["iteration"]["1b:LineItNr"] << this->m_LineOptimizer->GetCurrentIteration();
+    this->GetIterationInfoAt("1b:LineItNr") << this->m_LineOptimizer->GetCurrentIteration();
   }
 
   if (this->GetInLineSearch())
   {
-    xl::xout["iteration"]["2:Metric"] << this->m_LineOptimizer->GetCurrentValue();
-    xl::xout["iteration"]["3:StepLength"] << this->m_LineOptimizer->GetCurrentStepLength();
+    this->GetIterationInfoAt("2:Metric") << this->m_LineOptimizer->GetCurrentValue();
+    this->GetIterationInfoAt("3:StepLength") << this->m_LineOptimizer->GetCurrentStepLength();
     LineOptimizerType::DerivativeType cd;
     this->m_LineOptimizer->GetCurrentDerivative(cd);
-    xl::xout["iteration"]["4a:||Gradient||"] << cd.magnitude();
-    xl::xout["iteration"]["7:LinSrchStopCondition"] << "---";
+    this->GetIterationInfoAt("4a:||Gradient||") << cd.magnitude();
+    this->GetIterationInfoAt("7:LinSrchStopCondition") << "---";
   } // end if in line search
   else
   {
-    xl::xout["iteration"]["2:Metric"] << this->GetCurrentValue();
-    xl::xout["iteration"]["3:StepLength"] << this->GetCurrentStepLength();
-    xl::xout["iteration"]["4a:||Gradient||"] << this->GetCurrentGradient().magnitude();
-    xl::xout["iteration"]["7:LinSrchStopCondition"] << this->GetLineSearchStopCondition();
+    this->GetIterationInfoAt("2:Metric") << this->GetCurrentValue();
+    this->GetIterationInfoAt("3:StepLength") << this->GetCurrentStepLength();
+    this->GetIterationInfoAt("4a:||Gradient||") << this->GetCurrentGradient().magnitude();
+    this->GetIterationInfoAt("7:LinSrchStopCondition") << this->GetLineSearchStopCondition();
   } // end else (not in line search)
 
-  xl::xout["iteration"]["1a:SrchDirNr"] << this->GetCurrentIteration();
-  xl::xout["iteration"]["5:Phase"] << this->DeterminePhase();
-  xl::xout["iteration"]["4b:||SearchDir||"] << this->m_SearchDirectionMagnitude;
-  xl::xout["iteration"]["4c:DirGradient"] << this->m_LineOptimizer->GetCurrentDirectionalDerivative();
+  this->GetIterationInfoAt("1a:SrchDirNr") << this->GetCurrentIteration();
+  this->GetIterationInfoAt("5:Phase") << this->DeterminePhase();
+  this->GetIterationInfoAt("4b:||SearchDir||") << this->m_SearchDirectionMagnitude;
+  this->GetIterationInfoAt("4c:DirGradient") << this->m_LineOptimizer->GetCurrentDirectionalDerivative();
   if (this->m_LineOptimizer->GetSufficientDecreaseConditionSatisfied())
   {
-    xl::xout["iteration"]["6a:Wolfe1"] << "true";
+    this->GetIterationInfoAt("6a:Wolfe1") << "true";
   }
   else
   {
-    xl::xout["iteration"]["6a:Wolfe1"] << "false";
+    this->GetIterationInfoAt("6a:Wolfe1") << "false";
   }
   if (this->m_LineOptimizer->GetCurvatureConditionSatisfied())
   {
-    xl::xout["iteration"]["6b:Wolfe2"] << "true";
+    this->GetIterationInfoAt("6b:Wolfe2") << "true";
   }
   else
   {
-    xl::xout["iteration"]["6b:Wolfe2"] << "false";
+    this->GetIterationInfoAt("6b:Wolfe2") << "false";
   }
 
   if (!(this->GetInLineSearch()))

--- a/Components/Optimizers/ConjugateGradientFRPR/elxConjugateGradientFRPR.hxx
+++ b/Components/Optimizers/ConjugateGradientFRPR/elxConjugateGradientFRPR.hxx
@@ -79,20 +79,20 @@ void
 ConjugateGradientFRPR<TElastix>::BeforeRegistration(void)
 {
 
-  /** Add target cells to xout["iteration"].*/
-  xl::xout["iteration"].AddTargetCell("1a:SrchDirNr");
-  xl::xout["iteration"].AddTargetCell("1b:LineItNr");
-  xl::xout["iteration"].AddTargetCell("2:Metric");
-  xl::xout["iteration"].AddTargetCell("3:StepLength");
-  xl::xout["iteration"].AddTargetCell("4a:||Gradient||");
-  xl::xout["iteration"].AddTargetCell("4b:||SearchDir||");
-  xl::xout["iteration"].AddTargetCell("5:Phase");
+  /** Add target cells to IterationInfo.*/
+  this->AddTargetCellToIterationInfo("1a:SrchDirNr");
+  this->AddTargetCellToIterationInfo("1b:LineItNr");
+  this->AddTargetCellToIterationInfo("2:Metric");
+  this->AddTargetCellToIterationInfo("3:StepLength");
+  this->AddTargetCellToIterationInfo("4a:||Gradient||");
+  this->AddTargetCellToIterationInfo("4b:||SearchDir||");
+  this->AddTargetCellToIterationInfo("5:Phase");
 
   /** Format some fields as floats */
-  xl::xout["iteration"]["2:Metric"] << std::showpoint << std::fixed;
-  xl::xout["iteration"]["3:StepLength"] << std::showpoint << std::fixed;
-  xl::xout["iteration"]["4a:||Gradient||"] << std::showpoint << std::fixed;
-  xl::xout["iteration"]["4b:||SearchDir||"] << std::showpoint << std::fixed;
+  this->GetIterationInfoAt("2:Metric") << std::showpoint << std::fixed;
+  this->GetIterationInfoAt("3:StepLength") << std::showpoint << std::fixed;
+  this->GetIterationInfoAt("4a:||Gradient||") << std::showpoint << std::fixed;
+  this->GetIterationInfoAt("4b:||SearchDir||") << std::showpoint << std::fixed;
 
   /** \todo: call the correct functions */
 
@@ -159,30 +159,30 @@ ConjugateGradientFRPR<TElastix>::AfterEachIteration(void)
 {
 
   /** Print some information. */
-  xl::xout["iteration"]["1a:SrchDirNr"] << this->GetCurrentIteration();
-  xl::xout["iteration"]["1b:LineItNr"] << this->GetCurrentLineIteration();
-  xl::xout["iteration"]["2:Metric"] << this->GetValue();
-  xl::xout["iteration"]["4b:||SearchDir||"] << this->GetCurrentSearchDirectionMagnitude();
-  xl::xout["iteration"]["5:Phase"] << this->DeterminePhase();
+  this->GetIterationInfoAt("1a:SrchDirNr") << this->GetCurrentIteration();
+  this->GetIterationInfoAt("1b:LineItNr") << this->GetCurrentLineIteration();
+  this->GetIterationInfoAt("2:Metric") << this->GetValue();
+  this->GetIterationInfoAt("4b:||SearchDir||") << this->GetCurrentSearchDirectionMagnitude();
+  this->GetIterationInfoAt("5:Phase") << this->DeterminePhase();
 
   /** If main iteration (NewDirection) */
   if ((!(this->GetLineBracketing())) && (!(this->GetLineOptimizing())))
   {
-    xl::xout["iteration"]["3:StepLength"] << this->GetCurrentStepLength();
-    xl::xout["iteration"]["4a:||Gradient||"] << this->GetCurrentDerivativeMagnitude();
+    this->GetIterationInfoAt("3:StepLength") << this->GetCurrentStepLength();
+    this->GetIterationInfoAt("4a:||Gradient||") << this->GetCurrentDerivativeMagnitude();
   }
   else
   {
     if (this->GetLineBracketing())
     {
-      xl::xout["iteration"]["3:StepLength"] << this->GetCurrentStepLength();
+      this->GetIterationInfoAt("3:StepLength") << this->GetCurrentStepLength();
     }
     else
     {
       /** No step length known now */
-      xl::xout["iteration"]["3:StepLength"] << "---";
+      this->GetIterationInfoAt("3:StepLength") << "---";
     }
-    xl::xout["iteration"]["4a:||Gradient||"] << "---";
+    this->GetIterationInfoAt("4a:||Gradient||") << "---";
   } // end if main iteration
 
 } // end AfterEachIteration

--- a/Components/Optimizers/FiniteDifferenceGradientDescent/elxFiniteDifferenceGradientDescent.hxx
+++ b/Components/Optimizers/FiniteDifferenceGradientDescent/elxFiniteDifferenceGradientDescent.hxx
@@ -59,15 +59,15 @@ FiniteDifferenceGradientDescent<TElastix>::BeforeRegistration(void)
     this->SetComputeCurrentValue(this->m_ShowMetricValues);
   }
 
-  /** Add some target cells to xout["iteration"].*/
-  xl::xout["iteration"].AddTargetCell("2:Metric");
-  xl::xout["iteration"].AddTargetCell("3:Gain a_k");
-  xl::xout["iteration"].AddTargetCell("4:||Gradient||");
+  /** Add some target cells to IterationInfo.*/
+  this->AddTargetCellToIterationInfo("2:Metric");
+  this->AddTargetCellToIterationInfo("3:Gain a_k");
+  this->AddTargetCellToIterationInfo("4:||Gradient||");
 
   /** Format them as floats */
-  xl::xout["iteration"]["2:Metric"] << std::showpoint << std::fixed;
-  xl::xout["iteration"]["3:Gain a_k"] << std::showpoint << std::fixed;
-  xl::xout["iteration"]["4:||Gradient||"] << std::showpoint << std::fixed;
+  this->GetIterationInfoAt("2:Metric") << std::showpoint << std::fixed;
+  this->GetIterationInfoAt("3:Gain a_k") << std::showpoint << std::fixed;
+  this->GetIterationInfoAt("4:||Gradient||") << std::showpoint << std::fixed;
 
 } // end BeforeRegistration
 
@@ -123,14 +123,14 @@ FiniteDifferenceGradientDescent<TElastix>::AfterEachIteration(void)
 
   if (this->m_ShowMetricValues)
   {
-    xl::xout["iteration"]["2:Metric"] << this->GetValue();
+    this->GetIterationInfoAt("2:Metric") << this->GetValue();
   }
   else
   {
-    xl::xout["iteration"]["2:Metric"] << "---";
+    this->GetIterationInfoAt("2:Metric") << "---";
   }
-  xl::xout["iteration"]["3:Gain a_k"] << this->GetLearningRate();
-  xl::xout["iteration"]["4:||Gradient||"] << this->GetGradientMagnitude();
+  this->GetIterationInfoAt("3:Gain a_k") << this->GetLearningRate();
+  this->GetIterationInfoAt("4:||Gradient||") << this->GetGradientMagnitude();
 
   /** Select new spatial samples for the computation of the metric
    * \todo You may also choose to select new samples after evaluation

--- a/Components/Optimizers/FullSearch/elxFullSearchOptimizer.hxx
+++ b/Components/Optimizers/FullSearch/elxFullSearchOptimizer.hxx
@@ -47,11 +47,11 @@ template <class TElastix>
 void
 FullSearch<TElastix>::BeforeRegistration(void)
 {
-  /** Add the target cells "ItNr" and "Metric" to xout["iteration"]. */
-  xl::xout["iteration"].AddTargetCell("2:Metric");
+  /** Add the target cells "ItNr" and "Metric" to IterationInfo. */
+  this->AddTargetCellToIterationInfo("2:Metric");
 
   /** Format the metric as floats. */
-  xl::xout["iteration"]["2:Metric"] << std::showpoint << std::fixed;
+  this->GetIterationInfoAt("2:Metric") << std::showpoint << std::fixed;
 
 } // end BeforeRegistration
 
@@ -133,12 +133,12 @@ FullSearch<TElastix>::BeforeEachResolution(void)
       makeString.str("");
       makeString << prefix << ((entry_nr / 5) - 1) << ":" << name << ":" << param_nr;
 
-      /** Store the name and create a column in xout["iteration"]. */
+      /** Store the name and create a column in IterationInfo. */
       this->m_SearchSpaceDimensionNames[param_nr] = makeString.str();
-      xl::xout["iteration"].AddTargetCell(makeString.str().c_str());
+      this->AddTargetCellToIterationInfo(makeString.str().c_str());
 
       /** Format this xout iteration column as float. */
-      xl::xout["iteration"][makeString.str().c_str()] << std::showpoint << std::fixed;
+      this->GetIterationInfoAt(makeString.str().c_str()) << std::showpoint << std::fixed;
     }
   } // end while
 
@@ -186,7 +186,7 @@ void
 FullSearch<TElastix>::AfterEachIteration(void)
 {
   /** Print some information. */
-  xl::xout["iteration"]["2:Metric"] << this->GetValue();
+  this->GetIterationInfoAt("2:Metric") << this->GetValue();
 
   this->m_OptimizationSurface->SetPixel(this->GetCurrentIndexInSearchSpace(), this->GetValue());
 
@@ -196,7 +196,7 @@ FullSearch<TElastix>::AfterEachIteration(void)
 
   for (unsigned int dim = 0; dim < nrOfSSDims; dim++)
   {
-    xl::xout["iteration"][name_it->second.c_str()] << currentPoint[dim];
+    this->GetIterationInfoAt(name_it->second.c_str()) << currentPoint[dim];
     name_it++;
   }
 
@@ -276,11 +276,11 @@ FullSearch<TElastix>::AfterEachResolution(void)
   }
   elxout << "]\n" << std::endl;
 
-  /** Remove the columns from xout["iteration"]. */
+  /** Remove the columns from IterationInfo. */
   NameIteratorType name_it = this->m_SearchSpaceDimensionNames.begin();
   for (unsigned int dim = 0; dim < nrOfSSDims; dim++)
   {
-    xl::xout["iteration"].RemoveTargetCell(name_it->second.c_str());
+    this->RemoveTargetCellFromIterationInfo(name_it->second.c_str());
     name_it++;
   }
 

--- a/Components/Optimizers/Powell/elxPowell.hxx
+++ b/Components/Optimizers/Powell/elxPowell.hxx
@@ -35,15 +35,15 @@ template <class TElastix>
 void
 Powell<TElastix>::BeforeRegistration(void)
 {
-  /** Add the target cell "stepsize" to xout["iteration"].*/
-  xl::xout["iteration"].AddTargetCell("2:Metric");
-  xl::xout["iteration"].AddTargetCell("3:StepSize");
-  xl::xout["iteration"].AddTargetCell("4:||Gradient||");
+  /** Add the target cell "stepsize" to IterationInfo.*/
+  this->AddTargetCellToIterationInfo("2:Metric");
+  this->AddTargetCellToIterationInfo("3:StepSize");
+  this->AddTargetCellToIterationInfo("4:||Gradient||");
 
   /** Format the metric and stepsize as floats */
-  xl::xout["iteration"]["2:Metric"] << std::showpoint << std::fixed;
-  xl::xout["iteration"]["3:StepSize"] << std::showpoint << std::fixed;
-  xl::xout["iteration"]["4:||Gradient||"] << std::showpoint << std::fixed;
+  this->GetIterationInfoAt("2:Metric") << std::showpoint << std::fixed;
+  this->GetIterationInfoAt("3:StepSize") << std::showpoint << std::fixed;
+  this->GetIterationInfoAt("4:||Gradient||") << std::showpoint << std::fixed;
 
 } // end BeforeRegistration
 
@@ -92,8 +92,8 @@ void
 Powell<TElastix>::AfterEachIteration(void)
 {
   /** Print some information */
-  xl::xout["iteration"]["2:Metric"] << this->GetValue();
-  xl::xout["iteration"]["3:StepSize"] << this->GetStepLength();
+  this->GetIterationInfoAt("2:Metric") << this->GetValue();
+  this->GetIterationInfoAt("3:StepSize") << this->GetStepLength();
 } // end AfterEachIteration
 
 

--- a/Components/Optimizers/PreconditionedGradientDescent/elxPreconditionedGradientDescent.hxx
+++ b/Components/Optimizers/PreconditionedGradientDescent/elxPreconditionedGradientDescent.hxx
@@ -57,19 +57,19 @@ template <class TElastix>
 void
 PreconditionedGradientDescent<TElastix>::BeforeRegistration(void)
 {
-  /** Add the target cell "stepsize" to xout["iteration"].*/
-  xl::xout["iteration"].AddTargetCell("2:Metric");
-  xl::xout["iteration"].AddTargetCell("3a:Time");
-  xl::xout["iteration"].AddTargetCell("3b:StepSize");
-  xl::xout["iteration"].AddTargetCell("4a:||Gradient||");
-  xl::xout["iteration"].AddTargetCell("4b:||SearchDir||");
+  /** Add the target cell "stepsize" to IterationInfo.*/
+  this->AddTargetCellToIterationInfo("2:Metric");
+  this->AddTargetCellToIterationInfo("3a:Time");
+  this->AddTargetCellToIterationInfo("3b:StepSize");
+  this->AddTargetCellToIterationInfo("4a:||Gradient||");
+  this->AddTargetCellToIterationInfo("4b:||SearchDir||");
 
   /** Format the metric and stepsize as floats */
-  xl::xout["iteration"]["2:Metric"] << std::showpoint << std::fixed;
-  xl::xout["iteration"]["3a:Time"] << std::showpoint << std::fixed;
-  xl::xout["iteration"]["3b:StepSize"] << std::showpoint << std::fixed;
-  xl::xout["iteration"]["4a:||Gradient||"] << std::showpoint << std::fixed;
-  xl::xout["iteration"]["4b:||SearchDir||"] << std::showpoint << std::fixed;
+  this->GetIterationInfoAt("2:Metric") << std::showpoint << std::fixed;
+  this->GetIterationInfoAt("3a:Time") << std::showpoint << std::fixed;
+  this->GetIterationInfoAt("3b:StepSize") << std::showpoint << std::fixed;
+  this->GetIterationInfoAt("4a:||Gradient||") << std::showpoint << std::fixed;
+  this->GetIterationInfoAt("4b:||SearchDir||") << std::showpoint << std::fixed;
 
 } // end BeforeRegistration()
 
@@ -204,11 +204,11 @@ void
 PreconditionedGradientDescent<TElastix>::AfterEachIteration(void)
 {
   /** Print some information. */
-  xl::xout["iteration"]["2:Metric"] << this->GetValue();
-  xl::xout["iteration"]["3a:Time"] << this->GetCurrentTime();
-  xl::xout["iteration"]["3b:StepSize"] << this->GetLearningRate();
-  xl::xout["iteration"]["4a:||Gradient||"] << this->GetGradient().magnitude();
-  xl::xout["iteration"]["4b:||SearchDir||"] << this->GetSearchDirection().magnitude();
+  this->GetIterationInfoAt("2:Metric") << this->GetValue();
+  this->GetIterationInfoAt("3a:Time") << this->GetCurrentTime();
+  this->GetIterationInfoAt("3b:StepSize") << this->GetLearningRate();
+  this->GetIterationInfoAt("4a:||Gradient||") << this->GetGradient().magnitude();
+  this->GetIterationInfoAt("4b:||SearchDir||") << this->GetSearchDirection().magnitude();
 
   /** Select new spatial samples for the computation of the metric. */
   if (this->GetNewSamplesEveryIteration())

--- a/Components/Optimizers/PreconditionedStochasticGradientDescent/elxPreconditionedStochasticGradientDescent.hxx
+++ b/Components/Optimizers/PreconditionedStochasticGradientDescent/elxPreconditionedStochasticGradientDescent.hxx
@@ -80,19 +80,19 @@ template <class TElastix>
 void
 PreconditionedStochasticGradientDescent<TElastix>::BeforeRegistration(void)
 {
-  /** Add the target cell "stepsize" to xout["iteration"]. */
-  xl::xout["iteration"].AddTargetCell("2:Metric");
-  xl::xout["iteration"].AddTargetCell("3a:Time");
-  xl::xout["iteration"].AddTargetCell("3b:StepSize");
-  xl::xout["iteration"].AddTargetCell("4a:||Gradient||");
-  xl::xout["iteration"].AddTargetCell("4b:||SearchDirection||");
+  /** Add the target cell "stepsize" to IterationInfo. */
+  this->AddTargetCellToIterationInfo("2:Metric");
+  this->AddTargetCellToIterationInfo("3a:Time");
+  this->AddTargetCellToIterationInfo("3b:StepSize");
+  this->AddTargetCellToIterationInfo("4a:||Gradient||");
+  this->AddTargetCellToIterationInfo("4b:||SearchDirection||");
 
   /** Format the metric and stepsize as floats. */
-  xl::xout["iteration"]["2:Metric"] << std::showpoint << std::fixed;
-  xl::xout["iteration"]["3a:Time"] << std::showpoint << std::fixed;
-  xl::xout["iteration"]["3b:StepSize"] << std::showpoint << std::fixed;
-  xl::xout["iteration"]["4:||Gradient||"] << std::showpoint << std::fixed;
-  xl::xout["iteration"]["4b:||SearchDirection||"] << std::showpoint << std::fixed;
+  this->GetIterationInfoAt("2:Metric") << std::showpoint << std::fixed;
+  this->GetIterationInfoAt("3a:Time") << std::showpoint << std::fixed;
+  this->GetIterationInfoAt("3b:StepSize") << std::showpoint << std::fixed;
+  this->GetIterationInfoAt("4:||Gradient||") << std::showpoint << std::fixed;
+  this->GetIterationInfoAt("4b:||SearchDirection||") << std::showpoint << std::fixed;
 
   this->m_SettingsVector.clear();
 
@@ -291,20 +291,20 @@ void
 PreconditionedStochasticGradientDescent<TElastix>::AfterEachIteration(void)
 {
   /** Print some information. */
-  xl::xout["iteration"]["2:Metric"] << this->GetValue();
-  xl::xout["iteration"]["3a:Time"] << this->GetCurrentTime();
-  xl::xout["iteration"]["3b:StepSize"] << this->GetLearningRate() * this->m_NoiseFactor;
+  this->GetIterationInfoAt("2:Metric") << this->GetValue();
+  this->GetIterationInfoAt("3a:Time") << this->GetCurrentTime();
+  this->GetIterationInfoAt("3b:StepSize") << this->GetLearningRate() * this->m_NoiseFactor;
 
   bool asFastAsPossible = false;
   if (asFastAsPossible)
   {
-    xl::xout["iteration"]["4a:||Gradient||"] << "---";
-    xl::xout["iteration"]["4b:||SearchDirection||"] << "---";
+    this->GetIterationInfoAt("4a:||Gradient||") << "---";
+    this->GetIterationInfoAt("4b:||SearchDirection||") << "---";
   }
   else
   {
-    xl::xout["iteration"]["4a:||Gradient||"] << this->GetGradient().magnitude();
-    xl::xout["iteration"]["4b:||SearchDirection||"] << this->GetSearchDirection().magnitude();
+    this->GetIterationInfoAt("4a:||Gradient||") << this->GetGradient().magnitude();
+    this->GetIterationInfoAt("4b:||SearchDirection||") << this->GetSearchDirection().magnitude();
   }
 
   /** Select new spatial samples for the computation of the metric. */

--- a/Components/Optimizers/QuasiNewtonLBFGS/elxQuasiNewtonLBFGS.hxx
+++ b/Components/Optimizers/QuasiNewtonLBFGS/elxQuasiNewtonLBFGS.hxx
@@ -177,25 +177,25 @@ template <class TElastix>
 void
 QuasiNewtonLBFGS<TElastix>::BeforeRegistration(void)
 {
-  /** Add target cells to xout["iteration"].*/
-  xl::xout["iteration"].AddTargetCell("1a:SrchDirNr");
-  xl::xout["iteration"].AddTargetCell("1b:LineItNr");
-  xl::xout["iteration"].AddTargetCell("2:Metric");
-  xl::xout["iteration"].AddTargetCell("3:StepLength");
-  xl::xout["iteration"].AddTargetCell("4a:||Gradient||");
-  xl::xout["iteration"].AddTargetCell("4b:||SearchDir||");
-  xl::xout["iteration"].AddTargetCell("4c:DirGradient");
-  xl::xout["iteration"].AddTargetCell("5:Phase");
-  xl::xout["iteration"].AddTargetCell("6a:Wolfe1");
-  xl::xout["iteration"].AddTargetCell("6b:Wolfe2");
-  xl::xout["iteration"].AddTargetCell("7:LinSrchStopCondition");
+  /** Add target cells to IterationInfo.*/
+  this->AddTargetCellToIterationInfo("1a:SrchDirNr");
+  this->AddTargetCellToIterationInfo("1b:LineItNr");
+  this->AddTargetCellToIterationInfo("2:Metric");
+  this->AddTargetCellToIterationInfo("3:StepLength");
+  this->AddTargetCellToIterationInfo("4a:||Gradient||");
+  this->AddTargetCellToIterationInfo("4b:||SearchDir||");
+  this->AddTargetCellToIterationInfo("4c:DirGradient");
+  this->AddTargetCellToIterationInfo("5:Phase");
+  this->AddTargetCellToIterationInfo("6a:Wolfe1");
+  this->AddTargetCellToIterationInfo("6b:Wolfe2");
+  this->AddTargetCellToIterationInfo("7:LinSrchStopCondition");
 
   /** Format the metric and stepsize as floats */
-  xl::xout["iteration"]["2:Metric"] << std::showpoint << std::fixed;
-  xl::xout["iteration"]["3:StepLength"] << std::showpoint << std::fixed;
-  xl::xout["iteration"]["4a:||Gradient||"] << std::showpoint << std::fixed;
-  xl::xout["iteration"]["4b:||SearchDir||"] << std::showpoint << std::fixed;
-  xl::xout["iteration"]["4c:DirGradient"] << std::showpoint << std::fixed;
+  this->GetIterationInfoAt("2:Metric") << std::showpoint << std::fixed;
+  this->GetIterationInfoAt("3:StepLength") << std::showpoint << std::fixed;
+  this->GetIterationInfoAt("4a:||Gradient||") << std::showpoint << std::fixed;
+  this->GetIterationInfoAt("4b:||SearchDir||") << std::showpoint << std::fixed;
+  this->GetIterationInfoAt("4c:DirGradient") << std::showpoint << std::fixed;
 
   /** Check in the parameter file whether line search iterations should
    * be generated */
@@ -290,7 +290,7 @@ QuasiNewtonLBFGS<TElastix>::AfterEachIteration(void)
 
   if (this->GetStartLineSearch())
   {
-    xl::xout["iteration"]["1b:LineItNr"] << "start";
+    this->GetIterationInfoAt("1b:LineItNr") << "start";
   }
   else
   {
@@ -301,45 +301,45 @@ QuasiNewtonLBFGS<TElastix>::AfterEachIteration(void)
      * line search iteration number (so the number of line search
      * iterations minus one) is printed out.
      */
-    xl::xout["iteration"]["1b:LineItNr"] << this->m_LineOptimizer->GetCurrentIteration();
+    this->GetIterationInfoAt("1b:LineItNr") << this->m_LineOptimizer->GetCurrentIteration();
   }
 
   if (this->GetInLineSearch())
   {
-    xl::xout["iteration"]["2:Metric"] << this->m_LineOptimizer->GetCurrentValue();
-    xl::xout["iteration"]["3:StepLength"] << this->m_LineOptimizer->GetCurrentStepLength();
+    this->GetIterationInfoAt("2:Metric") << this->m_LineOptimizer->GetCurrentValue();
+    this->GetIterationInfoAt("3:StepLength") << this->m_LineOptimizer->GetCurrentStepLength();
     LineOptimizerType::DerivativeType cd;
     this->m_LineOptimizer->GetCurrentDerivative(cd);
-    xl::xout["iteration"]["4a:||Gradient||"] << cd.magnitude();
-    xl::xout["iteration"]["7:LinSrchStopCondition"] << "---";
+    this->GetIterationInfoAt("4a:||Gradient||") << cd.magnitude();
+    this->GetIterationInfoAt("7:LinSrchStopCondition") << "---";
   } // end if in line search
   else
   {
-    xl::xout["iteration"]["2:Metric"] << this->GetCurrentValue();
-    xl::xout["iteration"]["3:StepLength"] << this->GetCurrentStepLength();
-    xl::xout["iteration"]["4a:||Gradient||"] << this->GetCurrentGradient().magnitude();
-    xl::xout["iteration"]["7:LinSrchStopCondition"] << this->GetLineSearchStopCondition();
+    this->GetIterationInfoAt("2:Metric") << this->GetCurrentValue();
+    this->GetIterationInfoAt("3:StepLength") << this->GetCurrentStepLength();
+    this->GetIterationInfoAt("4a:||Gradient||") << this->GetCurrentGradient().magnitude();
+    this->GetIterationInfoAt("7:LinSrchStopCondition") << this->GetLineSearchStopCondition();
   } // end else (not in line search)
 
-  xl::xout["iteration"]["1a:SrchDirNr"] << this->GetCurrentIteration();
-  xl::xout["iteration"]["5:Phase"] << this->DeterminePhase();
-  xl::xout["iteration"]["4b:||SearchDir||"] << this->m_SearchDirectionMagnitude;
-  xl::xout["iteration"]["4c:DirGradient"] << this->m_LineOptimizer->GetCurrentDirectionalDerivative();
+  this->GetIterationInfoAt("1a:SrchDirNr") << this->GetCurrentIteration();
+  this->GetIterationInfoAt("5:Phase") << this->DeterminePhase();
+  this->GetIterationInfoAt("4b:||SearchDir||") << this->m_SearchDirectionMagnitude;
+  this->GetIterationInfoAt("4c:DirGradient") << this->m_LineOptimizer->GetCurrentDirectionalDerivative();
   if (this->m_LineOptimizer->GetSufficientDecreaseConditionSatisfied())
   {
-    xl::xout["iteration"]["6a:Wolfe1"] << "true";
+    this->GetIterationInfoAt("6a:Wolfe1") << "true";
   }
   else
   {
-    xl::xout["iteration"]["6a:Wolfe1"] << "false";
+    this->GetIterationInfoAt("6a:Wolfe1") << "false";
   }
   if (this->m_LineOptimizer->GetCurvatureConditionSatisfied())
   {
-    xl::xout["iteration"]["6b:Wolfe2"] << "true";
+    this->GetIterationInfoAt("6b:Wolfe2") << "true";
   }
   else
   {
-    xl::xout["iteration"]["6b:Wolfe2"] << "false";
+    this->GetIterationInfoAt("6b:Wolfe2") << "false";
   }
 
   if (!(this->GetInLineSearch()))

--- a/Components/Optimizers/RSGDEachParameterApart/elxRSGDEachParameterApart.hxx
+++ b/Components/Optimizers/RSGDEachParameterApart/elxRSGDEachParameterApart.hxx
@@ -35,15 +35,15 @@ template <class TElastix>
 void
 RSGDEachParameterApart<TElastix>::BeforeRegistration(void)
 {
-  /** Add the target cell "stepsize" to xout["iteration"].*/
-  xl::xout["iteration"].AddTargetCell("2:Metric");
-  xl::xout["iteration"].AddTargetCell("3:StepSize");
-  xl::xout["iteration"].AddTargetCell("4:||Gradient||");
+  /** Add the target cell "stepsize" to IterationInfo.*/
+  this->AddTargetCellToIterationInfo("2:Metric");
+  this->AddTargetCellToIterationInfo("3:StepSize");
+  this->AddTargetCellToIterationInfo("4:||Gradient||");
 
   /** Format the metric and stepsize as floats */
-  xl::xout["iteration"]["2:Metric"] << std::showpoint << std::fixed;
-  xl::xout["iteration"]["3:StepSize"] << std::showpoint << std::fixed;
-  xl::xout["iteration"]["4:||Gradient||"] << std::showpoint << std::fixed;
+  this->GetIterationInfoAt("2:Metric") << std::showpoint << std::fixed;
+  this->GetIterationInfoAt("3:StepSize") << std::showpoint << std::fixed;
+  this->GetIterationInfoAt("4:||Gradient||") << std::showpoint << std::fixed;
 
 } // end BeforeRegistration
 
@@ -105,9 +105,9 @@ void
 RSGDEachParameterApart<TElastix>::AfterEachIteration(void)
 {
   /** Print some information */
-  xl::xout["iteration"]["2:Metric"] << this->GetValue();
-  xl::xout["iteration"]["3:StepSize"] << this->GetCurrentStepLength();
-  xl::xout["iteration"]["4:||Gradient||"] << this->GetGradientMagnitude();
+  this->GetIterationInfoAt("2:Metric") << this->GetValue();
+  this->GetIterationInfoAt("3:StepSize") << this->GetCurrentStepLength();
+  this->GetIterationInfoAt("4:||Gradient||") << this->GetGradientMagnitude();
 
 } // end AfterEachIteration
 

--- a/Components/Optimizers/RegularStepGradientDescent/elxRegularStepGradientDescent.hxx
+++ b/Components/Optimizers/RegularStepGradientDescent/elxRegularStepGradientDescent.hxx
@@ -35,15 +35,15 @@ template <class TElastix>
 void
 RegularStepGradientDescent<TElastix>::BeforeRegistration(void)
 {
-  /** Add the target cell "stepsize" to xout["iteration"].*/
-  xl::xout["iteration"].AddTargetCell("2:Metric");
-  xl::xout["iteration"].AddTargetCell("3:StepSize");
-  xl::xout["iteration"].AddTargetCell("4:||Gradient||");
+  /** Add the target cell "stepsize" to IterationInfo.*/
+  this->AddTargetCellToIterationInfo("2:Metric");
+  this->AddTargetCellToIterationInfo("3:StepSize");
+  this->AddTargetCellToIterationInfo("4:||Gradient||");
 
   /** Format the metric and stepsize as floats */
-  xl::xout["iteration"]["2:Metric"] << std::showpoint << std::fixed;
-  xl::xout["iteration"]["3:StepSize"] << std::showpoint << std::fixed;
-  xl::xout["iteration"]["4:||Gradient||"] << std::showpoint << std::fixed;
+  this->GetIterationInfoAt("2:Metric") << std::showpoint << std::fixed;
+  this->GetIterationInfoAt("3:StepSize") << std::showpoint << std::fixed;
+  this->GetIterationInfoAt("4:||Gradient||") << std::showpoint << std::fixed;
 
 } // end BeforeRegistration
 
@@ -101,9 +101,9 @@ void
 RegularStepGradientDescent<TElastix>::AfterEachIteration(void)
 {
   /** Print some information */
-  xl::xout["iteration"]["2:Metric"] << this->GetValue();
-  xl::xout["iteration"]["3:StepSize"] << this->GetCurrentStepLength();
-  xl::xout["iteration"]["4:||Gradient||"] << this->GetGradient().magnitude();
+  this->GetIterationInfoAt("2:Metric") << this->GetValue();
+  this->GetIterationInfoAt("3:StepSize") << this->GetCurrentStepLength();
+  this->GetIterationInfoAt("4:||Gradient||") << this->GetGradient().magnitude();
 } // end AfterEachIteration
 
 

--- a/Components/Optimizers/Simplex/elxSimplex.hxx
+++ b/Components/Optimizers/Simplex/elxSimplex.hxx
@@ -35,15 +35,15 @@ template <class TElastix>
 void
 Simplex<TElastix>::BeforeRegistration(void)
 {
-  /** Add the target cell "stepsize" to xout["iteration"].*/
-  xl::xout["iteration"].AddTargetCell("2:Metric");
-  xl::xout["iteration"].AddTargetCell("3:StepSize");
-  xl::xout["iteration"].AddTargetCell("4:||Gradient||");
+  /** Add the target cell "stepsize" to IterationInfo.*/
+  this->AddTargetCellToIterationInfo("2:Metric");
+  this->AddTargetCellToIterationInfo("3:StepSize");
+  this->AddTargetCellToIterationInfo("4:||Gradient||");
 
   /** Format the metric and stepsize as floats */
-  xl::xout["iteration"]["2:Metric"] << std::showpoint << std::fixed;
-  xl::xout["iteration"]["3:StepSize"] << std::showpoint << std::fixed;
-  xl::xout["iteration"]["4:||Gradient||"] << std::showpoint << std::fixed;
+  this->GetIterationInfoAt("2:Metric") << std::showpoint << std::fixed;
+  this->GetIterationInfoAt("3:StepSize") << std::showpoint << std::fixed;
+  this->GetIterationInfoAt("4:||Gradient||") << std::showpoint << std::fixed;
 
 } // end BeforeRegistration()
 
@@ -104,8 +104,8 @@ void
 Simplex<TElastix>::AfterEachIteration(void)
 {
   /** Print some information */
-  xl::xout["iteration"]["2:Metric"] << this->GetCachedValue();
-  // xl::xout["iteration"]["3:StepSize"] << this->GetStepLength();
+  this->GetIterationInfoAt("2:Metric") << this->GetCachedValue();
+  // this->GetIterationInfoAt("3:StepSize") << this->GetStepLength();
 
 } // end AfterEachIteration()
 

--- a/Components/Optimizers/SimultaneousPerturbation/elxSimultaneousPerturbation.hxx
+++ b/Components/Optimizers/SimultaneousPerturbation/elxSimultaneousPerturbation.hxx
@@ -57,15 +57,15 @@ SimultaneousPerturbation<TElastix>::BeforeRegistration(void)
     this->m_ShowMetricValues = true;
   }
 
-  /** Add the target cell "stepsize" to xout["iteration"].*/
-  xl::xout["iteration"].AddTargetCell("2:Metric");
-  xl::xout["iteration"].AddTargetCell("3:Gain a_k");
-  xl::xout["iteration"].AddTargetCell("4:||Gradient||");
+  /** Add the target cell "stepsize" to IterationInfo.*/
+  this->AddTargetCellToIterationInfo("2:Metric");
+  this->AddTargetCellToIterationInfo("3:Gain a_k");
+  this->AddTargetCellToIterationInfo("4:||Gradient||");
 
   /** Format the metric and stepsize as floats */
-  xl::xout["iteration"]["2:Metric"] << std::showpoint << std::fixed;
-  xl::xout["iteration"]["3:Gain a_k"] << std::showpoint << std::fixed;
-  xl::xout["iteration"]["4:||Gradient||"] << std::showpoint << std::fixed;
+  this->GetIterationInfoAt("2:Metric") << std::showpoint << std::fixed;
+  this->GetIterationInfoAt("3:Gain a_k") << std::showpoint << std::fixed;
+  this->GetIterationInfoAt("4:||Gradient||") << std::showpoint << std::fixed;
 
 } // end BeforeRegistration
 
@@ -130,15 +130,15 @@ SimultaneousPerturbation<TElastix>::AfterEachIteration(void)
 
   if (this->m_ShowMetricValues)
   {
-    xl::xout["iteration"]["2:Metric"] << this->GetValue();
+    this->GetIterationInfoAt("2:Metric") << this->GetValue();
   }
   else
   {
-    xl::xout["iteration"]["2:Metric"] << "---";
+    this->GetIterationInfoAt("2:Metric") << "---";
   }
 
-  xl::xout["iteration"]["3:Gain a_k"] << this->GetLearningRate();
-  xl::xout["iteration"]["4:||Gradient||"] << this->GetGradientMagnitude();
+  this->GetIterationInfoAt("3:Gain a_k") << this->GetLearningRate();
+  this->GetIterationInfoAt("4:||Gradient||") << this->GetGradientMagnitude();
 
   /** Select new spatial samples for the computation of the metric
    * \todo You may also choose to select new samples upon every evaluation

--- a/Components/Optimizers/StandardGradientDescent/elxStandardGradientDescent.hxx
+++ b/Components/Optimizers/StandardGradientDescent/elxStandardGradientDescent.hxx
@@ -47,15 +47,15 @@ template <class TElastix>
 void
 StandardGradientDescent<TElastix>::BeforeRegistration(void)
 {
-  /** Add the target cell "stepsize" to xout["iteration"].*/
-  xl::xout["iteration"].AddTargetCell("2:Metric");
-  xl::xout["iteration"].AddTargetCell("3:StepSize");
-  xl::xout["iteration"].AddTargetCell("4:||Gradient||");
+  /** Add the target cell "stepsize" to IterationInfo.*/
+  this->AddTargetCellToIterationInfo("2:Metric");
+  this->AddTargetCellToIterationInfo("3:StepSize");
+  this->AddTargetCellToIterationInfo("4:||Gradient||");
 
   /** Format the metric and stepsize as floats */
-  xl::xout["iteration"]["2:Metric"] << std::showpoint << std::fixed;
-  xl::xout["iteration"]["3:StepSize"] << std::showpoint << std::fixed;
-  xl::xout["iteration"]["4:||Gradient||"] << std::showpoint << std::fixed;
+  this->GetIterationInfoAt("2:Metric") << std::showpoint << std::fixed;
+  this->GetIterationInfoAt("3:StepSize") << std::showpoint << std::fixed;
+  this->GetIterationInfoAt("4:||Gradient||") << std::showpoint << std::fixed;
 
 } // end BeforeRegistration()
 
@@ -117,9 +117,9 @@ void
 StandardGradientDescent<TElastix>::AfterEachIteration(void)
 {
   /** Print some information */
-  xl::xout["iteration"]["2:Metric"] << this->GetValue();
-  xl::xout["iteration"]["3:StepSize"] << this->GetLearningRate();
-  xl::xout["iteration"]["4:||Gradient||"] << this->GetGradient().magnitude();
+  this->GetIterationInfoAt("2:Metric") << this->GetValue();
+  this->GetIterationInfoAt("3:StepSize") << this->GetLearningRate();
+  this->GetIterationInfoAt("4:||Gradient||") << this->GetGradient().magnitude();
 
   /** Select new spatial samples for the computation of the metric */
   if (this->GetNewSamplesEveryIteration())

--- a/Components/Registrations/MultiMetricMultiResolutionRegistration/elxMultiMetricMultiResolutionRegistration.hxx
+++ b/Components/Registrations/MultiMetricMultiResolutionRegistration/elxMultiMetricMultiResolutionRegistration.hxx
@@ -75,7 +75,7 @@ MultiMetricMultiResolutionRegistration<TElastix>::BeforeRegistration(void)
     this->SetFixedImageRegion(this->GetElastix()->GetFixedImage(i)->GetBufferedRegion(), i);
   }
 
-  /** Add the target cells "Metric<i>" and "||Gradient<i>||" to xout["iteration"]
+  /** Add the target cells "Metric<i>" and "||Gradient<i>||" to IterationInfo
    * and format as floats.
    */
   const unsigned int nrOfMetrics = this->GetCombinationMetric()->GetNumberOfMetrics();
@@ -88,18 +88,18 @@ MultiMetricMultiResolutionRegistration<TElastix>::BeforeRegistration(void)
   {
     std::ostringstream makestring1;
     makestring1 << "2:Metric" << std::setfill('0') << std::setw(width) << i;
-    xl::xout["iteration"].AddTargetCell(makestring1.str().c_str());
-    xl::xout["iteration"][makestring1.str().c_str()] << std::showpoint << std::fixed;
+    this->AddTargetCellToIterationInfo(makestring1.str().c_str());
+    this->GetIterationInfoAt(makestring1.str().c_str()) << std::showpoint << std::fixed;
 
     std::ostringstream makestring2;
     makestring2 << "4:||Gradient" << std::setfill('0') << std::setw(width) << i << "||";
-    xl::xout["iteration"].AddTargetCell(makestring2.str().c_str());
-    xl::xout["iteration"][makestring2.str().c_str()] << std::showpoint << std::fixed;
+    this->AddTargetCellToIterationInfo(makestring2.str().c_str());
+    this->GetIterationInfoAt(makestring2.str().c_str()) << std::showpoint << std::fixed;
 
     std::ostringstream makestring3;
     makestring3 << "Time" << std::setfill('0') << std::setw(width) << i << "[ms]";
-    xl::xout["iteration"].AddTargetCell(makestring3.str().c_str());
-    xl::xout["iteration"][makestring3.str().c_str()] << std::showpoint << std::fixed << std::setprecision(1);
+    this->AddTargetCellToIterationInfo(makestring3.str().c_str());
+    this->GetIterationInfoAt(makestring3.str().c_str()) << std::showpoint << std::fixed << std::setprecision(1);
   }
 
   /** Temporary? Use the multi-threaded version or not. */
@@ -124,7 +124,7 @@ template <class TElastix>
 void
 MultiMetricMultiResolutionRegistration<TElastix>::AfterEachIteration(void)
 {
-  /** Print the submetric values and gradients to xout["iteration"]. */
+  /** Print the submetric values and gradients to IterationInfo. */
   const unsigned int nrOfMetrics = this->GetCombinationMetric()->GetNumberOfMetrics();
   unsigned int       width = 0;
   for (unsigned int i = nrOfMetrics; i > 0; i /= 10)
@@ -135,15 +135,16 @@ MultiMetricMultiResolutionRegistration<TElastix>::AfterEachIteration(void)
   {
     std::ostringstream makestring1;
     makestring1 << "2:Metric" << std::setfill('0') << std::setw(width) << i;
-    xl::xout["iteration"][makestring1.str().c_str()] << this->GetCombinationMetric()->GetMetricValue(i);
+    this->GetIterationInfoAt(makestring1.str().c_str()) << this->GetCombinationMetric()->GetMetricValue(i);
 
     std::ostringstream makestring2;
     makestring2 << "4:||Gradient" << std::setfill('0') << std::setw(width) << i << "||";
-    xl::xout["iteration"][makestring2.str().c_str()] << this->GetCombinationMetric()->GetMetricDerivativeMagnitude(i);
+    this->GetIterationInfoAt(makestring2.str().c_str())
+      << this->GetCombinationMetric()->GetMetricDerivativeMagnitude(i);
 
     std::ostringstream makestring3;
     makestring3 << "Time" << std::setfill('0') << std::setw(width) << i << "[ms]";
-    xl::xout["iteration"][makestring3.str().c_str()] << this->GetCombinationMetric()->GetMetricComputationTime(i);
+    this->GetIterationInfoAt(makestring3.str().c_str()) << this->GetCombinationMetric()->GetMetricComputationTime(i);
   }
 
   if (this->m_ShowExactMetricValue)
@@ -162,7 +163,7 @@ MultiMetricMultiResolutionRegistration<TElastix>::AfterEachIteration(void)
       }
     }
 
-    xl::xout["iteration"]["ExactMetric"] << currentExactMetricValue;
+    this->GetIterationInfoAt("ExactMetric") << currentExactMetricValue;
   }
 
 } // end AfterEachIteration()
@@ -247,11 +248,11 @@ MultiMetricMultiResolutionRegistration<TElastix>::BeforeEachResolution(void)
     std::string exactMetricColumn = "ExactMetric";
 
     /** Remove the ExactMetric-column, if it already existed. */
-    xl::xout["iteration"].RemoveTargetCell(exactMetricColumn.c_str());
+    this->RemoveTargetCellFromIterationInfo(exactMetricColumn.c_str());
 
     /** Create a new column in the iteration info table */
-    xl::xout["iteration"].AddTargetCell(exactMetricColumn.c_str());
-    xl::xout["iteration"][exactMetricColumn.c_str()] << std::showpoint << std::fixed;
+    this->AddTargetCellToIterationInfo(exactMetricColumn.c_str());
+    this->GetIterationInfoAt(exactMetricColumn.c_str()) << std::showpoint << std::fixed;
   }
 
 } // end BeforeEachResolution()

--- a/Core/ComponentBaseClasses/elxMetricBase.hxx
+++ b/Core/ComponentBaseClasses/elxMetricBase.hxx
@@ -58,7 +58,7 @@ MetricBase<TElastix>::BeforeEachResolutionBase(void)
   exactMetricColumn += this->GetComponentLabel();
 
   /** Remove the ExactMetric-column, if it already existed. */
-  xl::xout["iteration"].RemoveTargetCell(exactMetricColumn.c_str());
+  this->RemoveTargetCellFromIterationInfo(exactMetricColumn.c_str());
 
   /** Read the parameter file: Show the exact metric in every iteration? */
   bool showExactMetricValue = false;
@@ -68,8 +68,8 @@ MetricBase<TElastix>::BeforeEachResolutionBase(void)
   if (showExactMetricValue)
   {
     /** Create a new column in the iteration info table */
-    xl::xout["iteration"].AddTargetCell(exactMetricColumn.c_str());
-    xl::xout["iteration"][exactMetricColumn.c_str()] << std::showpoint << std::fixed;
+    this->AddTargetCellToIterationInfo(exactMetricColumn.c_str());
+    this->GetIterationInfoAt(exactMetricColumn.c_str()) << std::showpoint << std::fixed;
   }
 
   /** Read the sample grid spacing for computing the "exact" metric */
@@ -194,7 +194,7 @@ MetricBase<TElastix>::AfterEachIterationBase(void)
     this->m_CurrentExactMetricValue =
       this->GetExactValue(this->GetElastix()->GetElxOptimizerBase()->GetAsITKBaseType()->GetCurrentPosition());
 
-    xl::xout["iteration"][exactMetricColumn.c_str()] << this->m_CurrentExactMetricValue;
+    this->GetIterationInfoAt(exactMetricColumn.c_str()) << this->m_CurrentExactMetricValue;
   }
 
 } // end AfterEachIterationBase()

--- a/Core/Install/elxBaseComponentSE.h
+++ b/Core/Install/elxBaseComponentSE.h
@@ -91,6 +91,23 @@ public:
     return this->m_Elastix.GetPointer();
   }
 
+  int
+  RemoveTargetCellFromIterationInfo(const char * const name)
+  {
+    return this->m_Elastix->GetIterationInfo().xl::xoutrow::RemoveTargetCell(name);
+  }
+
+  xl::xoutbase &
+  GetIterationInfoAt(const char * const name)
+  {
+    return this->m_Elastix->GetIterationInfoAt(name);
+  }
+
+  void
+  AddTargetCellToIterationInfo(const char * const name)
+  {
+    return this->m_Elastix->AddTargetCellToIterationInfo(name);
+  }
 
   /** itkGetModifiableObjectMacro(Configuration, ConfigurationType);
    * The configuration object provides functionality to

--- a/Core/Kernel/elxElastixBase.cxx
+++ b/Core/Kernel/elxElastixBase.cxx
@@ -456,22 +456,8 @@ ElastixBase::BeforeRegistrationBase(void)
   this->m_IterationInfo.SetOutputs(xl::xout.GetCOutputs());
   this->m_IterationInfo.SetOutputs(xl::xout.GetXOutputs());
 
-  xl::xout.AddTargetCell("iteration", &this->m_IterationInfo);
-
 } // end BeforeRegistrationBase()
 
-
-/**
- * **************** AfterRegistrationBase ***********************
- */
-
-void
-ElastixBase::AfterRegistrationBase(void)
-{
-  /** Remove the "iteration" writing field. */
-  xl::xout.RemoveTargetCell("iteration");
-
-} // end AfterRegistrationBase()
 
 /**
  * ********************** GetResultImage *************************

--- a/Core/Kernel/elxElastixBase.h
+++ b/Core/Kernel/elxElastixBase.h
@@ -385,6 +385,24 @@ public:
   ConfigurationPointer
   GetConfiguration(const size_t index) const;
 
+  xl::xoutrow &
+  GetIterationInfo(void)
+  {
+    return m_IterationInfo;
+  }
+
+  xl::xoutbase &
+  GetIterationInfoAt(const char * const name)
+  {
+    return m_IterationInfo[name];
+  }
+
+  void
+  AddTargetCellToIterationInfo(const char * const name)
+  {
+    m_IterationInfo.xl::xoutrow::AddTargetCell(name);
+  }
+
 protected:
   ElastixBase();
   ~ElastixBase() override = default;

--- a/Core/Kernel/elxElastixBase.h
+++ b/Core/Kernel/elxElastixBase.h
@@ -322,14 +322,11 @@ public:
   int
   BeforeAllTransformixBase(void);
 
-  /** Functions called before and after registration.
-   * They install/uninstall the xout["iteration"] field.
+  /** Function called before registration.
+   * It installs the IterationInfo field.
    */
   void
   BeforeRegistrationBase(void) override;
-
-  void
-  AfterRegistrationBase(void) override;
 
   ResultImageType *
   GetResultImage(const unsigned int idx = 0) const;
@@ -400,7 +397,7 @@ public:
   void
   AddTargetCellToIterationInfo(const char * const name)
   {
-    m_IterationInfo.xl::xoutrow::AddTargetCell(name);
+    m_IterationInfo.AddTargetCell(name);
   }
 
 protected:

--- a/Core/Kernel/elxElastixTemplate.hxx
+++ b/Core/Kernel/elxElastixTemplate.hxx
@@ -211,12 +211,6 @@ ElastixTemplate<TFixedImage, TMovingImage>::Run(void)
     err_str += "\n\nError occurred during actual registration.";
     excp.SetDescription(err_str);
 
-    /** Clean up before returning - very important for exception safety of the xout global static object */
-    if (xl::xout_valid())
-    {
-      xl::xout.RemoveTargetCell("iteration");
-    }
-
     /** Pass the exception to a higher level. */
     throw excp;
   }

--- a/Core/Kernel/elxElastixTemplate.hxx
+++ b/Core/Kernel/elxElastixTemplate.hxx
@@ -489,11 +489,11 @@ ElastixTemplate<TFixedImage, TMovingImage>::BeforeRegistration(void)
   CallInEachComponent(&BaseComponentType::BeforeRegistration);
 
   /** Add a column to iteration with the iteration number. */
-  xl::xout["iteration"].AddTargetCell("1:ItNr");
+  this->AddTargetCellToIterationInfo("1:ItNr");
 
   /** Add a column to iteration with timing information. */
-  xl::xout["iteration"].AddTargetCell("Time[ms]");
-  xl::xout["iteration"]["Time[ms]"] << std::showpoint << std::fixed << std::setprecision(1);
+  this->AddTargetCellToIterationInfo("Time[ms]");
+  this->GetIterationInfoAt("Time[ms]") << std::showpoint << std::fixed << std::setprecision(1);
 
   /** Print time for initializing. */
   this->m_Timer0.Stop();
@@ -627,7 +627,7 @@ ElastixTemplate<TFixedImage, TMovingImage>::AfterEachIteration(void)
   /** Write the headers of the columns that are printed each iteration. */
   if (this->m_IterationCounter == 0)
   {
-    xl::xout["iteration"]["WriteHeaders"];
+    this->GetIterationInfoAt("WriteHeaders");
   }
 
   /** Call all the AfterEachIteration() functions. */
@@ -636,14 +636,14 @@ ElastixTemplate<TFixedImage, TMovingImage>::AfterEachIteration(void)
   CallInEachComponent(&BaseComponentType::AfterEachIteration);
 
   /** Write the iteration number to the table. */
-  xl::xout["iteration"]["1:ItNr"] << m_IterationCounter;
+  this->GetIterationInfoAt("1:ItNr") << m_IterationCounter;
 
   /** Time in this iteration. */
   this->m_IterationTimer.Stop();
-  xl::xout["iteration"]["Time[ms]"] << this->m_IterationTimer.GetMean() * 1000.0;
+  this->GetIterationInfoAt("Time[ms]") << this->m_IterationTimer.GetMean() * 1000.0;
 
   /** Write the iteration info of this iteration. */
-  xl::xout["iteration"].WriteBufferedData();
+  this->GetIterationInfo().WriteBufferedData();
 
   /** Create a TransformParameter-file for the current iteration. */
   bool writeTansformParametersThisIteration = false;
@@ -1016,7 +1016,7 @@ void
 ElastixTemplate<TFixedImage, TMovingImage>::OpenIterationInfoFile(void)
 {
   /** Remove the current iteration info output file, if any. */
-  xl::xout["iteration"].RemoveOutput("IterationInfoFile");
+  this->GetIterationInfo().RemoveOutput("IterationInfoFile");
 
   if (this->m_IterationInfoFile.is_open())
   {
@@ -1038,8 +1038,8 @@ ElastixTemplate<TFixedImage, TMovingImage>::OpenIterationInfoFile(void)
   }
   else
   {
-    /** Add this file to the list of outputs of xout["iteration"]. */
-    xl::xout["iteration"].AddOutput("IterationInfoFile", &(this->m_IterationInfoFile));
+    /** Add this file to the list of outputs of IterationInfo. */
+    this->GetIterationInfo().AddOutput("IterationInfoFile", &(this->m_IterationInfoFile));
   }
 
 } // end OpenIterationInfoFile()


### PR DESCRIPTION
No longer added `ElastixBase::m_IterationInfo` to `xout["iteration"]`. Accessed `IterationInfo` via newly added member functions of `ElastixBase` and `BaseComponentSE`, instead. 

Aims to improve thread-safety, as discussed at our internal weekly elastix sprint.

Related to issue #174 "elastix 4.9 static library version not thread safe"