### PR TITLE
STYLE: Remove xout["WriteHeaders"] logic, simply call WriteHeaders()

### DIFF
--- a/Common/xout/xoutbase.cxx
+++ b/Common/xout/xoutbase.cxx
@@ -39,7 +39,8 @@ xoutbase::~xoutbase() = default;
 
 xoutbase & xoutbase::operator[](const char * cellname)
 {
-  return this->SelectXCell(cellname);
+  const auto found = m_XTargetCells.find(cellname);
+  return (found == m_XTargetCells.end()) ? *this : *(found->second);
 
 } // end operator[]
 
@@ -264,21 +265,6 @@ xoutbase::SetOutputs(const XStreamMapType & outputmap)
   this->m_XOutputs = outputmap;
 
 } // end SetOutputs
-
-
-/**
- * ************************ SelectXCell *************************
- *
- * Returns a target cell.
- */
-
-xoutbase &
-xoutbase::SelectXCell(const char * name)
-{
-  const auto found = m_XTargetCells.find(name);
-  return (found == m_XTargetCells.end()) ? *this : *(found->second);
-
-} // end SelectXCell
 
 
 /**

--- a/Common/xout/xoutbase.h
+++ b/Common/xout/xoutbase.h
@@ -51,8 +51,7 @@ public:
   /** Destructor */
   virtual ~xoutbase() = 0;
 
-  /** The operator [] simply calls this->SelectXCell(cellname).
-   * It returns an x-cell */
+  /** The operator [] returns an x-cell */
   Self & operator[](const char * cellname);
 
   /**
@@ -150,10 +149,6 @@ public:
 protected:
   /** Default-constructor. Only to be used by its derived classes. */
   xoutbase() = default;
-
-  /** Returns a target cell. */
-  virtual Self &
-  SelectXCell(const char * name);
 
   /** Maps that contain the outputs. */
   CStreamMapType m_COutputs;

--- a/Common/xout/xoutrow.cxx
+++ b/Common/xout/xoutrow.cxx
@@ -263,33 +263,4 @@ xoutrow::WriteHeaders(void)
 
 } // end WriteHeaders()
 
-
-/**
- * ********************* SelectXCell ****************************
- *
- * Returns a target cell.
- */
-
-xoutbase &
-xoutrow::SelectXCell(const char * name)
-{
-  std::string cellname(name);
-
-  /** Check if the name is "WriteHeaders". Then the method
-   * this->WriteHeaders() is invoked.
-   */
-  if (cellname == "WriteHeaders")
-  {
-    this->WriteHeaders();
-    return *this;
-  }
-  else
-  {
-    /** Call the Superclass's implementation. */
-    return this->Superclass::SelectXCell(name);
-  }
-
-} // end SelectXCell()
-
-
 } // end namespace xoutlibrary

--- a/Common/xout/xoutrow.h
+++ b/Common/xout/xoutrow.h
@@ -58,9 +58,7 @@ public:
   void
   WriteBufferedData(void) override;
 
-  /** Writes the names of the target cells to the outputs;
-   * This method can also be executed by selecting the
-   * "WriteHeaders" target: xout["WriteHeaders"]
+  /** Writes the names of the target cells to the outputs.
    */
   virtual void
   WriteHeaders(void);
@@ -97,14 +95,6 @@ public:
 
   void
   SetOutputs(const XStreamMapType & outputmap) override;
-
-protected:
-  /** Returns a target cell.
-   * Extension: if input = "WriteHeaders" it calls
-   * this->WriteHeaders() and returns 'this'.
-   */
-  Superclass &
-  SelectXCell(const char * name) override;
 
 private:
   std::map<std::string, std::unique_ptr<xoutbase>> m_CellMap;

--- a/Core/Kernel/elxElastixTemplate.hxx
+++ b/Core/Kernel/elxElastixTemplate.hxx
@@ -621,7 +621,7 @@ ElastixTemplate<TFixedImage, TMovingImage>::AfterEachIteration(void)
   /** Write the headers of the columns that are printed each iteration. */
   if (this->m_IterationCounter == 0)
   {
-    this->GetIterationInfoAt("WriteHeaders");
+    this->GetIterationInfo().WriteHeaders();
   }
 
   /** Call all the AfterEachIteration() functions. */


### PR DESCRIPTION
Dropped "WriteHeaders" as special case for `xout[name]`.

Replaced "WriteHeaders" by a direct call to `xoutrow::WriteHeaders()`.

Aims to just simplify the code.