### PR TITLE
CI: Elastix docker image build and push to docker hub

### DIFF
--- a/.github/workflows/ElastixGitHubActions.yml
+++ b/.github/workflows/ElastixGitHubActions.yml
@@ -46,6 +46,7 @@ jobs:
         mv ${items[*]} Elastix-source
         mv .editorconfig Elastix-source
         mv .clang-format Elastix-source
+        mv Elastix-source/Dockerfile .
       shell: bash
       
     - uses: actions/cache@v2
@@ -54,8 +55,8 @@ jobs:
         path: |
           ITK-build
           ITK-source
-        key: ${{ matrix.itk-git-tag }}-${{ matrix.os }}-${{ matrix.cmake-build-type }}
-      
+        key: ${{ matrix.itk-git-tag }}-${{ matrix.os }}-${{ matrix.cmake-build-type }} 
+        
     - name: Set up Python 3.7
       uses: actions/setup-python@v1
       with:
@@ -93,7 +94,6 @@ jobs:
     
     - name: Build Elastix Unix
       if: matrix.os != 'windows-2019'
-
       run: |
         mkdir Elastix-build
         cd Elastix-build
@@ -154,5 +154,20 @@ jobs:
       with: 
         name: "${{ matrix.os }}"
         path: uploads
+        
+    - name: Login to Docker Hub
+      if: github.event_name == 'push' && startsWith(github.event.ref, 'refs/tags') && matrix.os == 'ubuntu-18.04'
+      uses: docker/login-action@v1
+      with:
+        username: ${{ secrets.DOCKER_HUB_USERNAME }}
+        password: ${{ secrets.DOCKER_HUB_ACCESS_TOKEN }}
+
+    - name: Build and push
+      if: github.event_name == 'push' && startsWith(github.event.ref, 'refs/tags') && matrix.os == 'ubuntu-18.04'     
+      run: |
+        mkdir output
+        docker build -t superelastix/elastix:${GITHUB_REF#refs/tags/} .
+        docker run -u $UID:$GROUPS --mount type=bind,source="$(pwd)"/output,target=/out -v "$(pwd)"/Elastix-source/Testing/Data:/elastix/ superelastix/elastix:${GITHUB_REF#refs/tags/} elastix -out /out/ -p /elastix/parameters.3D.NC.euler.ASGD.001.txt -f /elastix/3DCT_lung_baseline.mha -m /elastix/3DCT_lung_followup.mha
+        docker push superelastix/elastix:${GITHUB_REF#refs/tags/}
 
 

--- a/.gitignore
+++ b/.gitignore
@@ -37,3 +37,4 @@ Makefile
 CMakeFiles/
 CTestTestfile.cmake
 .idea/
+.githooks/clangFormatMac

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,0 +1,18 @@
+FROM ubuntu:20.04
+
+# Add labels to image
+LABEL documentation="https://github.com/SuperElastix/elastix/wiki"
+LABEL license="Apache License Version 2.0"
+LABEL modelzoo="https://elastix.lumc.nl/modelzoo/"
+
+# Prepare system packages, libgomp1 is required by elastix
+RUN apt-get update && apt-get -qq install libgomp1 -y
+
+# Copy necessary files
+COPY uploads/bin/* /usr/local/bin/
+COPY uploads/lib/* /usr/lib/
+
+COPY uploads/LICENSE /
+COPY uploads/NOTICE /
+
+CMD elastix

--- a/README.md
+++ b/README.md
@@ -6,7 +6,7 @@
 
 Welcome to elastix: a toolbox for rigid and nonrigid registration of images.
 
-elastix is open source software, based on the well-known [Insight Segmentation and Registration Toolkit (ITK)](https://itk.org/). The software consists of a collection of algorithms that are commonly used to solve (medical) image registration problems. The modular design of elastix allows the user to quickly configure, test, and compare different registration methods for a specific application. A command-line interface enables automated processing of large numbers of data sets, by means of scripting. Nowadays elastix is accompanied by [SimpleElastix](http://simpleelastix.github.io/), making it available in languages like C++, Python, Java, R, Ruby, C# and Lua.
+elastix is open source software, based on the well-known [Insight Segmentation and Registration Toolkit (ITK)](https://itk.org/). The software consists of a collection of algorithms that are commonly used to solve (medical) image registration problems. The modular design of elastix allows the user to quickly configure, test, and compare different registration methods for a specific application. A command-line interface enables automated processing of large numbers of data sets, by means of scripting. Nowadays elastix is accompanied by [SimpleElastix](http://simpleelastix.github.io/), making it available in languages like C++, Python, Java, R, Ruby, C# and Lua. A docker image of the latest elastix build is available as well on [dockerhub](https://hub.docker.com/repository/docker/superelastix/elastix).
 
 ## Authors ##
 


### PR DESCRIPTION
The CI now builds a docker image of every tagged elastix commit. The docker image is uploaded to [dockerhub](https://hub.docker.com/repository/docker/superelastix/elastix) and labeled by it's tag.