### PR TITLE
STYLE: Pass parameter map "by reference" to CreateTransformParametersMap

### DIFF
--- a/Common/GTesting/elxResampleInterpolatorGTest.cxx
+++ b/Common/GTesting/elxResampleInterpolatorGTest.cxx
@@ -68,7 +68,7 @@ struct WithDimension
       const elx::ResampleInterpolatorBase<ElastixType<NDimension>> & interpolator = *newInterpolator;
 
       ParameterMapType actualParameterMap;
-      interpolator.CreateTransformParametersMap(&actualParameterMap);
+      interpolator.CreateTransformParametersMap(actualParameterMap);
 
       const ParameterMapType expectedBaseParameterMap = { { "ResampleInterpolator",
                                                             { interpolator.elxGetClassName() } } };

--- a/Common/GTesting/elxResamplerGTest.cxx
+++ b/Common/GTesting/elxResamplerGTest.cxx
@@ -71,7 +71,7 @@ struct WithDimension
       resampler.SetElastix(elastixObject);
 
       ParameterMapType actualParameterMap;
-      resampler.CreateTransformParametersMap(&actualParameterMap);
+      resampler.CreateTransformParametersMap(actualParameterMap);
 
       const ParameterMapType expectedBaseParameterMap = { { "Resampler", { resampler.elxGetClassName() } },
                                                           { "DefaultPixelValue", { "0" } },

--- a/Common/GTesting/elxTransformIOGTest.cxx
+++ b/Common/GTesting/elxTransformIOGTest.cxx
@@ -212,7 +212,7 @@ struct WithDimension
       elxTransform->SetReadWriteTransformParameters(true);
 
       ParameterMapType actualParameterMap;
-      elxTransform->CreateTransformParametersMap(itk::OptimizerParameters<double>{}, &actualParameterMap);
+      elxTransform->CreateTransformParametersMap(itk::OptimizerParameters<double>{}, actualParameterMap);
 
       const std::string expectedImageDimension{ char{ '0' + NDimension } };
       const std::string expectedInternalImagePixelType = "float";
@@ -272,7 +272,7 @@ struct WithDimension
 
       ParameterMapType                       parameterMap;
       const itk::OptimizerParameters<double> optimizerParameters(itk::Array<double>(vnl_vector<double>(2U, testValue)));
-      elxTransform->CreateTransformParametersMap(optimizerParameters, &parameterMap);
+      elxTransform->CreateTransformParametersMap(optimizerParameters, parameterMap);
 
       for (const auto key : { "TransformParameters", "Origin", "Spacing" })
       {
@@ -301,7 +301,7 @@ struct WithDimension
 
       const auto expectHowToCombineTransforms = [&elxTransform](const char * const expectedParameterValue) {
         ParameterMapType parameterMap;
-        elxTransform->CreateTransformParametersMap({}, &parameterMap);
+        elxTransform->CreateTransformParametersMap({}, parameterMap);
 
         const auto found = parameterMap.find("HowToCombineTransforms");
         ASSERT_NE(found, end(parameterMap));

--- a/Core/ComponentBaseClasses/elxResampleInterpolatorBase.h
+++ b/Core/ComponentBaseClasses/elxResampleInterpolatorBase.h
@@ -103,7 +103,7 @@ public:
 
   /** Function to create transform-parameters map. */
   void
-  CreateTransformParametersMap(ParameterMapType * paramsMap) const;
+  CreateTransformParametersMap(ParameterMapType & parameterMap) const;
 
 protected:
   /** The constructor. */

--- a/Core/ComponentBaseClasses/elxResampleInterpolatorBase.hxx
+++ b/Core/ComponentBaseClasses/elxResampleInterpolatorBase.hxx
@@ -46,7 +46,7 @@ void
 ResampleInterpolatorBase<TElastix>::WriteToFile(xl::xoutsimple & transformationParameterInfo) const
 {
   ParameterMapType parameterMap;
-  this->CreateTransformParametersMap(&parameterMap);
+  this->CreateTransformParametersMap(parameterMap);
 
   /** Write ResampleInterpolator specific things. */
   transformationParameterInfo << ("\n// ResampleInterpolator specific\n" +
@@ -61,10 +61,8 @@ ResampleInterpolatorBase<TElastix>::WriteToFile(xl::xoutsimple & transformationP
 
 template <class TElastix>
 void
-ResampleInterpolatorBase<TElastix>::CreateTransformParametersMap(ParameterMapType * paramsMap) const
+ResampleInterpolatorBase<TElastix>::CreateTransformParametersMap(ParameterMapType & parameterMap) const
 {
-  auto & parameterMap = *paramsMap;
-
   /** Store the name of this transform. */
   parameterMap["ResampleInterpolator"] = { this->elxGetClassName() };
 

--- a/Core/ComponentBaseClasses/elxResamplerBase.h
+++ b/Core/ComponentBaseClasses/elxResamplerBase.h
@@ -179,7 +179,7 @@ public:
 
   /** Function to create transform-parameters map. */
   void
-  CreateTransformParametersMap(ParameterMapType * paramsMap) const;
+  CreateTransformParametersMap(ParameterMapType & parameterMap) const;
 
   /** Function to perform resample and write the result output image to a file. */
   virtual void

--- a/Core/ComponentBaseClasses/elxResamplerBase.hxx
+++ b/Core/ComponentBaseClasses/elxResamplerBase.hxx
@@ -690,7 +690,7 @@ void
 ResamplerBase<TElastix>::WriteToFile(xl::xoutsimple & transformationParameterInfo) const
 {
   ParameterMapType parameterMap;
-  Self::CreateTransformParametersMap(&parameterMap);
+  Self::CreateTransformParametersMap(parameterMap);
 
   /** Write resampler specific things. */
   transformationParameterInfo << ("\n// Resampler specific\n" + Conversion::ParameterMapToString(parameterMap));
@@ -704,10 +704,8 @@ ResamplerBase<TElastix>::WriteToFile(xl::xoutsimple & transformationParameterInf
 
 template <class TElastix>
 void
-ResamplerBase<TElastix>::CreateTransformParametersMap(ParameterMapType * paramsMap) const
+ResamplerBase<TElastix>::CreateTransformParametersMap(ParameterMapType & parameterMap) const
 {
-  auto & parameterMap = *paramsMap;
-
   /** Store the name of this transform. */
   parameterMap["Resampler"] = { this->elxGetClassName() };
 

--- a/Core/ComponentBaseClasses/elxTransformBase.h
+++ b/Core/ComponentBaseClasses/elxTransformBase.h
@@ -232,7 +232,7 @@ public:
 
   /** Function to create transform-parameters map. */
   void
-  CreateTransformParametersMap(const ParametersType & param, ParameterMapType * paramsMap) const;
+  CreateTransformParametersMap(const ParametersType & param, ParameterMapType & parameterMap) const;
 
   /** Function to write transform-parameters to a file. */
   void

--- a/Core/ComponentBaseClasses/elxTransformBase.hxx
+++ b/Core/ComponentBaseClasses/elxTransformBase.hxx
@@ -585,7 +585,7 @@ TransformBase<TElastix>::WriteToFile(xl::xoutsimple & transformationParameterInf
 {
   ParameterMapType parameterMap;
 
-  this->CreateTransformParametersMap(param, &parameterMap);
+  this->CreateTransformParametersMap(param, parameterMap);
 
   /** Write the parameters of this transform. */
   if (this->m_ReadWriteTransformParameters)
@@ -653,9 +653,9 @@ TransformBase<TElastix>::WriteToFile(xl::xoutsimple & transformationParameterInf
 
 template <class TElastix>
 void
-TransformBase<TElastix>::CreateTransformParametersMap(const ParametersType & param, ParameterMapType * paramsMap) const
+TransformBase<TElastix>::CreateTransformParametersMap(const ParametersType & param,
+                                                      ParameterMapType &     parameterMap) const
 {
-  auto &       parameterMap = *paramsMap;
   const auto & elastixObject = *(this->GetElastix());
 
   /** The way Transforms are combined. */

--- a/Core/Kernel/elxElastixTemplate.hxx
+++ b/Core/Kernel/elxElastixTemplate.hxx
@@ -812,9 +812,9 @@ void
 ElastixTemplate<TFixedImage, TMovingImage>::CreateTransformParametersMap(void)
 {
   this->GetElxTransformBase()->CreateTransformParametersMap(
-    this->GetElxOptimizerBase()->GetAsITKBaseType()->GetCurrentPosition(), &this->m_TransformParametersMap);
-  this->GetElxResampleInterpolatorBase()->CreateTransformParametersMap(&this->m_TransformParametersMap);
-  this->GetElxResamplerBase()->CreateTransformParametersMap(&this->m_TransformParametersMap);
+    this->GetElxOptimizerBase()->GetAsITKBaseType()->GetCurrentPosition(), this->m_TransformParametersMap);
+  this->GetElxResampleInterpolatorBase()->CreateTransformParametersMap(this->m_TransformParametersMap);
+  this->GetElxResamplerBase()->CreateTransformParametersMap(this->m_TransformParametersMap);
 
 } // end CreateTransformParametersMap()
 


### PR DESCRIPTION
Replaced `ParameterMapType *` by `ParameterMapType &` as parameter type, to express that `CreateTransformParametersMap` does not support `nullptr` as argument.

Follows C++ Core Guidelines section "Parameter passing expression rules" from https://isocpp.github.io/CppCoreGuidelines/CppCoreGuidelines#S-functions (August 3, 2020)