### PR TITLE
COMP: Fix GetJacobianOfSpatialHessian warnings on jsh_tmp buffer overrun

### DIFF
--- a/Common/Transforms/itkRecursiveBSplineTransformImplementation.h
+++ b/Common/Transforms/itkRecursiveBSplineTransformImplementation.h
@@ -20,6 +20,10 @@
 
 #include "itkRecursiveBSplineInterpolationWeightFunction.h"
 
+// Standard C++ header files:
+#include <cassert>
+#include <cstring> // For memcpy.
+
 namespace itk
 {
 
@@ -533,22 +537,13 @@ public:
      */
     if (OutputDimension == 3)
     {
-      jsh_tmp[0] = jsh[9];
-      jsh_tmp[1] = jsh[8];
-      jsh_tmp[2] = jsh[7];
-      jsh_tmp[3] = jsh_tmp[1];
-      jsh_tmp[4] = jsh[5];
-      jsh_tmp[5] = jsh[4];
-      jsh_tmp[6] = jsh_tmp[2];
-      jsh_tmp[7] = jsh_tmp[5];
-      jsh_tmp[8] = jsh[2];
+      const double tmp[] = { jsh[9], jsh[8], jsh[7], jsh[8], jsh[5], jsh[4], jsh[7], jsh[4], jsh[2] };
+      FastBitwiseCopy(jsh_tmp, tmp);
     }
     else if (OutputDimension == 2)
     {
-      jsh_tmp[0] = jsh[5];
-      jsh_tmp[1] = jsh[4];
-      jsh_tmp[2] = jsh_tmp[1];
-      jsh_tmp[3] = jsh[2];
+      const double tmp[] = { jsh[5], jsh[4], jsh[4], jsh[2] };
+      FastBitwiseCopy(jsh_tmp, tmp);
     }
     else // the general case
     {
@@ -609,6 +604,22 @@ public:
     jsh_out += OutputDimension * OutputDimension * OutputDimension;
 
   } // end GetJacobianOfSpatialHessian()
+
+
+private:
+  template <typename T>
+  static void
+  FastBitwiseCopy(T & destination, const T & source)
+  {
+    std::memcpy(&destination, &source, sizeof(T));
+  }
+
+  template <typename T1, typename T2>
+  static void
+  FastBitwiseCopy(const T1 &, const T2 &)
+  {
+    assert(!"This FastBitwiseCopy overload should not be called!");
+  }
 };
 
 


### PR DESCRIPTION
Solved fifteen Visual C++ warnings from `RecursiveBSplineTransformImplementation::GetJacobianOfSpatialHessian`, which said:

> warning C4789: buffer 'jsh_tmp' of size 32 bytes will be overrun; 8 bytes will be written starting at offset 64

Note that the buffer overrun would not occur in practice, as the size of `jsh_tmp` depends on `OutputDimension`, which was checked at runtime. But the compiler still issued those warnings. Which are fixed by this commit.