### PR TITLE
BUG: TransformBase call Modified when itk::Object dynamic_cast succeeds

### DIFF
--- a/Core/ComponentBaseClasses/elxTransformBase.hxx
+++ b/Core/ComponentBaseClasses/elxTransformBase.hxx
@@ -1415,7 +1415,10 @@ TransformBase<TElastix>::SetTransformParametersFileName(const char * filename)
     this->m_TransformParametersFileName = "";
   }
   ObjectType * thisAsObject = dynamic_cast<ObjectType *>(this);
-  thisAsObject->Modified();
+  if (thisAsObject != nullptr)
+  {
+    thisAsObject->Modified();
+  }
 
 } // end SetTransformParametersFileName()
 
@@ -1433,7 +1436,10 @@ TransformBase<TElastix>::SetReadWriteTransformParameters(const bool _arg)
   {
     this->m_ReadWriteTransformParameters = _arg;
     ObjectType * thisAsObject = dynamic_cast<ObjectType *>(this);
-    thisAsObject->Modified();
+    if (thisAsObject != nullptr)
+    {
+      thisAsObject->Modified();
+    }
   }
 
 } // end SetReadWriteTransformParameters()


### PR DESCRIPTION
This fails in the wrapping with the type of `this`:

  `elastix::TransfromBase<elastix::ElastixTemplate<itk::Image<float,
  2u>, itk::Image<float, 2u> > >`

This is currently necessary on macOS to prevent segfaults in ITKElastix
Python wrapping.
