### PR TITLE
BUG: Replace dynamic_cast's TransformBase by GetAsCombinationTransform()

### DIFF
--- a/Components/Transforms/AdvancedAffineTransform/elxAdvancedAffineTransform.h
+++ b/Components/Transforms/AdvancedAffineTransform/elxAdvancedAffineTransform.h
@@ -214,6 +214,18 @@ protected:
   ReadCenterOfRotationPoint(InputPointType & rotationPoint) const;
 
 private:
+  const Self &
+  GetAsCombinationTransform(void) const override
+  {
+    return *this;
+  }
+
+  Self &
+  GetAsCombinationTransform(void) override
+  {
+    return *this;
+  }
+
   /** Creates a map of the parameters specific for this (derived) transform type. */
   ParameterMapType
   CreateDerivedTransformParametersMap(void) const override;

--- a/Components/Transforms/AdvancedBSplineTransform/elxAdvancedBSplineTransform.h
+++ b/Components/Transforms/AdvancedBSplineTransform/elxAdvancedBSplineTransform.h
@@ -285,6 +285,18 @@ protected:
   PreComputeGridInformation(void);
 
 private:
+  const Self &
+  GetAsCombinationTransform(void) const override
+  {
+    return *this;
+  }
+
+  Self &
+  GetAsCombinationTransform(void) override
+  {
+    return *this;
+  }
+
   /** Creates a map of the parameters specific for this (derived) transform type. */
   ParameterMapType
   CreateDerivedTransformParametersMap(void) const override;

--- a/Components/Transforms/AffineDTITransform/elxAffineDTITransform.h
+++ b/Components/Transforms/AffineDTITransform/elxAffineDTITransform.h
@@ -215,6 +215,18 @@ protected:
   ReadCenterOfRotationPoint(InputPointType & rotationPoint) const;
 
 private:
+  const Self &
+  GetAsCombinationTransform(void) const override
+  {
+    return *this;
+  }
+
+  Self &
+  GetAsCombinationTransform(void) override
+  {
+    return *this;
+  }
+
   /** Creates a map of the parameters specific for this (derived) transform type. */
   ParameterMapType
   CreateDerivedTransformParametersMap(void) const override;

--- a/Components/Transforms/AffineLogStackTransform/elxAffineLogStackTransform.h
+++ b/Components/Transforms/AffineLogStackTransform/elxAffineLogStackTransform.h
@@ -180,6 +180,18 @@ protected:
   ReadCenterOfRotationPoint(ReducedDimensionInputPointType & rotationPoint) const;
 
 private:
+  const Self &
+  GetAsCombinationTransform(void) const override
+  {
+    return *this;
+  }
+
+  Self &
+  GetAsCombinationTransform(void) override
+  {
+    return *this;
+  }
+
   /** Creates a map of the parameters specific for this (derived) transform type. */
   ParameterMapType
   CreateDerivedTransformParametersMap(void) const override;

--- a/Components/Transforms/AffineLogTransform/elxAffineLogTransform.h
+++ b/Components/Transforms/AffineLogTransform/elxAffineLogTransform.h
@@ -179,6 +179,18 @@ protected:
   ReadCenterOfRotationPoint(InputPointType & rotationPoint) const;
 
 private:
+  const Self &
+  GetAsCombinationTransform(void) const override
+  {
+    return *this;
+  }
+
+  Self &
+  GetAsCombinationTransform(void) override
+  {
+    return *this;
+  }
+
   /** Creates a map of the parameters specific for this (derived) transform type. */
   ParameterMapType
   CreateDerivedTransformParametersMap(void) const override;

--- a/Components/Transforms/BSplineDeformableTransformWithDiffusion/elxBSplineTransformWithDiffusion.h
+++ b/Components/Transforms/BSplineDeformableTransformWithDiffusion/elxBSplineTransformWithDiffusion.h
@@ -360,6 +360,18 @@ protected:
   SpacingType m_GridSpacingFactor;
 
 private:
+  const Self &
+  GetAsCombinationTransform(void) const override
+  {
+    return *this;
+  }
+
+  Self &
+  GetAsCombinationTransform(void) override
+  {
+    return *this;
+  }
+
   /** Creates a map of the parameters specific for this (derived) transform type. */
   ParameterMapType
   CreateDerivedTransformParametersMap(void) const override;

--- a/Components/Transforms/BSplineStackTransform/elxBSplineStackTransform.h
+++ b/Components/Transforms/BSplineStackTransform/elxBSplineStackTransform.h
@@ -291,6 +291,18 @@ protected:
   PreComputeGridInformation(void);
 
 private:
+  const Self &
+  GetAsCombinationTransform(void) const override
+  {
+    return *this;
+  }
+
+  Self &
+  GetAsCombinationTransform(void) override
+  {
+    return *this;
+  }
+
   /** Creates a map of the parameters specific for this (derived) transform type. */
   ParameterMapType
   CreateDerivedTransformParametersMap(void) const override;

--- a/Components/Transforms/DeformationFieldTransform/elxDeformationFieldTransform.h
+++ b/Components/Transforms/DeformationFieldTransform/elxDeformationFieldTransform.h
@@ -136,6 +136,18 @@ protected:
   ~DeformationFieldTransform() override = default;
 
 private:
+  const Self &
+  GetAsCombinationTransform(void) const override
+  {
+    return *this;
+  }
+
+  Self &
+  GetAsCombinationTransform(void) override
+  {
+    return *this;
+  }
+
   /** Creates a map of the parameters specific for this (derived) transform type. */
   ParameterMapType
   CreateDerivedTransformParametersMap(void) const override;

--- a/Components/Transforms/EulerStackTransform/elxEulerStackTransform.h
+++ b/Components/Transforms/EulerStackTransform/elxEulerStackTransform.h
@@ -227,6 +227,18 @@ protected:
   ReadCenterOfRotationPoint(ReducedDimensionInputPointType & rotationPoint) const;
 
 private:
+  const Self &
+  GetAsCombinationTransform(void) const override
+  {
+    return *this;
+  }
+
+  Self &
+  GetAsCombinationTransform(void) override
+  {
+    return *this;
+  }
+
   /** Creates a map of the parameters specific for this (derived) transform type. */
   ParameterMapType
   CreateDerivedTransformParametersMap(void) const override;

--- a/Components/Transforms/EulerTransform/elxEulerTransform.h
+++ b/Components/Transforms/EulerTransform/elxEulerTransform.h
@@ -218,6 +218,18 @@ protected:
   ReadCenterOfRotationPoint(InputPointType & rotationPoint) const;
 
 private:
+  const Self &
+  GetAsCombinationTransform(void) const override
+  {
+    return *this;
+  }
+
+  Self &
+  GetAsCombinationTransform(void) override
+  {
+    return *this;
+  }
+
   /** Creates a map of the parameters specific for this (derived) transform type. */
   ParameterMapType
   CreateDerivedTransformParametersMap(void) const override;

--- a/Components/Transforms/MultiBSplineTransformWithNormal/elxMultiBSplineTransformWithNormal.h
+++ b/Components/Transforms/MultiBSplineTransformWithNormal/elxMultiBSplineTransformWithNormal.h
@@ -255,6 +255,18 @@ protected:
   PreComputeGridInformation(void);
 
 private:
+  const Self &
+  GetAsCombinationTransform(void) const override
+  {
+    return *this;
+  }
+
+  Self &
+  GetAsCombinationTransform(void) override
+  {
+    return *this;
+  }
+
   /** Creates a map of the parameters specific for this (derived) transform type. */
   ParameterMapType
   CreateDerivedTransformParametersMap(void) const override;

--- a/Components/Transforms/RecursiveBSplineTransform/elxRecursiveBSplineTransform.h
+++ b/Components/Transforms/RecursiveBSplineTransform/elxRecursiveBSplineTransform.h
@@ -285,6 +285,18 @@ protected:
   PreComputeGridInformation(void);
 
 private:
+  const Self &
+  GetAsCombinationTransform(void) const override
+  {
+    return *this;
+  }
+
+  Self &
+  GetAsCombinationTransform(void) override
+  {
+    return *this;
+  }
+
   /** Creates a map of the parameters specific for this (derived) transform type. */
   ParameterMapType
   CreateDerivedTransformParametersMap(void) const override;

--- a/Components/Transforms/SimilarityTransform/elxSimilarityTransform.h
+++ b/Components/Transforms/SimilarityTransform/elxSimilarityTransform.h
@@ -228,6 +228,18 @@ protected:
   ReadCenterOfRotationPoint(InputPointType & rotationPoint) const;
 
 private:
+  const Self &
+  GetAsCombinationTransform(void) const override
+  {
+    return *this;
+  }
+
+  Self &
+  GetAsCombinationTransform(void) override
+  {
+    return *this;
+  }
+
   /** Creates a map of the parameters specific for this (derived) transform type. */
   ParameterMapType
   CreateDerivedTransformParametersMap(void) const override;

--- a/Components/Transforms/SplineKernelTransform/elxSplineKernelTransform.h
+++ b/Components/Transforms/SplineKernelTransform/elxSplineKernelTransform.h
@@ -247,6 +247,18 @@ protected:
   KernelTransformPointer m_KernelTransform;
 
 private:
+  const Self &
+  GetAsCombinationTransform(void) const override
+  {
+    return *this;
+  }
+
+  Self &
+  GetAsCombinationTransform(void) override
+  {
+    return *this;
+  }
+
   /** Creates a map of the parameters specific for this (derived) transform type. */
   ParameterMapType
   CreateDerivedTransformParametersMap(void) const override;

--- a/Components/Transforms/TranslationStackTransform/elxTranslationStackTransform.h
+++ b/Components/Transforms/TranslationStackTransform/elxTranslationStackTransform.h
@@ -153,6 +153,18 @@ protected:
   ~TranslationStackTransform() override = default;
 
 private:
+  const Self &
+  GetAsCombinationTransform(void) const override
+  {
+    return *this;
+  }
+
+  Self &
+  GetAsCombinationTransform(void) override
+  {
+    return *this;
+  }
+
   /** Creates a map of the parameters specific for this (derived) transform type. */
   ParameterMapType
   CreateDerivedTransformParametersMap(void) const override;

--- a/Components/Transforms/TranslationTransform/elxTranslationTransform.h
+++ b/Components/Transforms/TranslationTransform/elxTranslationTransform.h
@@ -144,6 +144,18 @@ protected:
   TranslationTransformPointer m_TranslationTransform;
 
 private:
+  const Self &
+  GetAsCombinationTransform(void) const override
+  {
+    return *this;
+  }
+
+  Self &
+  GetAsCombinationTransform(void) override
+  {
+    return *this;
+  }
+
   /** Creates a map of the parameters specific for this (derived) transform type. */
   ParameterMapType
   CreateDerivedTransformParametersMap(void) const override;

--- a/Components/Transforms/WeightedCombinationTransform/elxWeightedCombinationTransform.h
+++ b/Components/Transforms/WeightedCombinationTransform/elxWeightedCombinationTransform.h
@@ -208,6 +208,18 @@ protected:
   std::vector<std::string>            m_SubTransformFileNames;
 
 private:
+  const Self &
+  GetAsCombinationTransform(void) const override
+  {
+    return *this;
+  }
+
+  Self &
+  GetAsCombinationTransform(void) override
+  {
+    return *this;
+  }
+
   /** Creates a map of the parameters specific for this (derived) transform type. */
   ParameterMapType
   CreateDerivedTransformParametersMap(void) const override;

--- a/Core/ComponentBaseClasses/elxTransformBase.h
+++ b/Core/ComponentBaseClasses/elxTransformBase.h
@@ -201,7 +201,7 @@ public:
   ITKBaseType *
   GetAsITKBaseType(void)
   {
-    return dynamic_cast<ITKBaseType *>(this);
+    return &(this->GetAsCombinationTransform());
   }
 
 
@@ -209,7 +209,7 @@ public:
   const ITKBaseType *
   GetAsITKBaseType(void) const
   {
-    return dynamic_cast<const ITKBaseType *>(this);
+    return &(this->GetAsCombinationTransform());
   }
 
   /** Execute stuff before the actual transformation:
@@ -301,18 +301,11 @@ private:
   void
   ReadInitialTransformFromConfiguration(const Configuration::Pointer);
 
-  const CombinationTransformType *
-  GetAsCombinationTransform(void) const
-  {
-    return dynamic_cast<const CombinationTransformType *>(this);
-  }
+  virtual const CombinationTransformType &
+  GetAsCombinationTransform(void) const = 0;
 
-
-  CombinationTransformType *
-  GetAsCombinationTransform(void)
-  {
-    return dynamic_cast<CombinationTransformType *>(this);
-  }
+  virtual CombinationTransformType &
+  GetAsCombinationTransform(void) = 0;
 
   /** Execute stuff before everything else:
    * \li Check the appearance of an initial transform.

--- a/Core/ComponentBaseClasses/elxTransformBase.hxx
+++ b/Core/ComponentBaseClasses/elxTransformBase.hxx
@@ -217,19 +217,7 @@ TransformBase<TElastix>::BeforeRegistrationBase(void)
   std::string howToCombineTransforms = "Compose";
   this->m_Configuration->ReadParameter(howToCombineTransforms, "HowToCombineTransforms", 0, false);
 
-  /** Check if this is a CombinationTransform. */
-  CombinationTransformType * thisAsGrouper = dynamic_cast<CombinationTransformType *>(this);
-  if (thisAsGrouper)
-  {
-    if (howToCombineTransforms == "Compose")
-    {
-      thisAsGrouper->SetUseComposition(true);
-    }
-    else
-    {
-      thisAsGrouper->SetUseComposition(false);
-    }
-  }
+  this->GetAsCombinationTransform().SetUseComposition(howToCombineTransforms == "Compose");
 
   /** Set the initial transform. Elastix returns an itk::Object, so try to
    * cast it to an InitialTransformType, which is of type itk::Transform.
@@ -271,16 +259,7 @@ template <class TElastix>
 const typename TransformBase<TElastix>::InitialTransformType *
 TransformBase<TElastix>::GetInitialTransform(void) const
 {
-  /** Cast to a(n Advanced)CombinationTransform. */
-  const CombinationTransformType * thisAsGrouper = dynamic_cast<const CombinationTransformType *>(this);
-
-  /** Set the initial transform. */
-  if (thisAsGrouper)
-  {
-    return thisAsGrouper->GetInitialTransform();
-  }
-
-  return nullptr;
+  return this->GetAsCombinationTransform().GetInitialTransform();
 
 } // end GetInitialTransform()
 
@@ -293,14 +272,8 @@ template <class TElastix>
 void
 TransformBase<TElastix>::SetInitialTransform(InitialTransformType * _arg)
 {
-  /** Cast to a(n Advanced)CombinationTransform. */
-  CombinationTransformType * thisAsGrouper = dynamic_cast<CombinationTransformType *>(this);
-
   /** Set initial transform. */
-  if (thisAsGrouper)
-  {
-    thisAsGrouper->SetInitialTransform(_arg);
-  }
+  this->GetAsCombinationTransform().SetInitialTransform(_arg);
 
   // \todo AdvancedCombinationTransformType
 
@@ -477,18 +450,7 @@ TransformBase<TElastix>::ReadFromFile(void)
   /** Convert 'this' to a pointer to a CombinationTransform and set how
    * to combine the current transform with the initial transform.
    */
-  CombinationTransformType * thisAsGrouper = dynamic_cast<CombinationTransformType *>(this);
-  if (thisAsGrouper)
-  {
-    if (howToCombineTransforms == "Compose")
-    {
-      thisAsGrouper->SetUseComposition(true);
-    }
-    else
-    {
-      thisAsGrouper->SetUseComposition(false);
-    }
-  }
+  this->GetAsCombinationTransform().SetUseComposition(howToCombineTransforms == "Compose");
 
   /** Task 4 - Remember the name of the TransformParametersFileName.
    * This will be needed when another transform will use this transform
@@ -659,10 +621,7 @@ TransformBase<TElastix>::CreateTransformParametersMap(const ParametersType & par
   const auto & elastixObject = *(this->GetElastix());
 
   /** The way Transforms are combined. */
-  const auto combinationMethod = [this] {
-    const auto combinationTransform = dynamic_cast<const CombinationTransformType *>(this);
-    return ((combinationTransform != nullptr) && combinationTransform->GetUseAddition()) ? "Add" : "Compose";
-  }();
+  const auto combinationMethod = this->GetAsCombinationTransform().GetUseAddition() ? "Add" : "Compose";
 
   /** Write image pixel types. */
   std::string fixpix = "float";
@@ -1050,7 +1009,7 @@ TransformBase<TElastix>::TransformPointsSomePointsVTK(const std::string & filena
   /** Apply the transform. */
   elxout << "  The input points are transformed." << std::endl;
   const auto meshTransformer = TransformMeshFilterType::New();
-  meshTransformer->SetTransform(const_cast<CombinationTransformType *>(this->GetAsCombinationTransform()));
+  meshTransformer->SetTransform(&const_cast<CombinationTransformType &>(this->GetAsCombinationTransform()));
   meshTransformer->SetInput(meshReader->GetOutput());
   try
   {
@@ -1414,8 +1373,7 @@ TransformBase<TElastix>::SetTransformParametersFileName(const char * filename)
   {
     this->m_TransformParametersFileName = "";
   }
-  ObjectType * thisAsObject = dynamic_cast<ObjectType *>(this);
-  thisAsObject->Modified();
+  this->GetAsCombinationTransform().Modified();
 
 } // end SetTransformParametersFileName()
 
@@ -1432,8 +1390,7 @@ TransformBase<TElastix>::SetReadWriteTransformParameters(const bool _arg)
   if (this->m_ReadWriteTransformParameters != _arg)
   {
     this->m_ReadWriteTransformParameters = _arg;
-    ObjectType * thisAsObject = dynamic_cast<ObjectType *>(this);
-    thisAsObject->Modified();
+    this->GetAsCombinationTransform().Modified();
   }
 
 } // end SetReadWriteTransformParameters()


### PR DESCRIPTION
Replaced 11 `dynamic_cast`'s from the implementation of `elx::TransformBase` by calls to `this->GetAsCombinationTransform()`, which is now pure `virtual`. Did override `TransformBase::GetAsCombinationTransform()` in all of its 17 derived transform classes.

Aims to fix MacOS segfaults, mentioned by Matt McCormick (@thewtex), issue https://github.com/SuperElastix/elastix/issues/411, "elastix::TransformBase itk::Object casting".