### PR TITLE
COMP: Fix OpenCLResampler ParameterMapType build error

### DIFF
--- a/Components/Resamplers/OpenCLResampler/elxOpenCLResampler.h
+++ b/Components/Resamplers/OpenCLResampler/elxOpenCLResampler.h
@@ -98,6 +98,8 @@ public:
                                              GPUResamplerType;
   typedef typename GPUResamplerType::Pointer GPUResamplerPointer;
 
+  typedef typename Superclass2::ParameterMapType ParameterMapType;
+
   /** Set the transform. */
   virtual void
   SetTransform(const TransformType * _arg);


### PR DESCRIPTION
Addressed issue https://github.com/SuperElastix/elastix/issues/414 "OpenCLResampler build error: 'ParameterMapType does not name a type'", reported by @1989HD.