### PR TITLE
ENH: Move FillImageRegion to elxCoreMainGTestUtilities.h

### DIFF
--- a/Core/Main/GTesting/CMakeLists.txt
+++ b/Core/Main/GTesting/CMakeLists.txt
@@ -1,4 +1,5 @@
 add_executable(ElastixLibGTest
+  elxCoreMainGTestUtilities.h
   ElastixFilterGTest.cxx
   ElastixLibGTest.cxx
   itkElastixRegistrationMethodGTest.cxx

--- a/Core/Main/GTesting/ElastixFilterGTest.cxx
+++ b/Core/Main/GTesting/ElastixFilterGTest.cxx
@@ -19,8 +19,11 @@
 
 // First include the header file to be tested:
 #include <elxElastixFilter.h>
+
+#include "elxCoreMainGTestUtilities.h"
+
+// ITK header file:
 #include <itkImage.h>
-#include <itkImageRegionRange.h>
 
 // GoogleTest header file:
 #include <gtest/gtest.h>
@@ -40,7 +43,6 @@ GTEST_TEST(ElastixFilter, Translation)
   using SizeType = itk::Size<ImageDimension>;
   using IndexType = itk::Index<ImageDimension>;
   using OffsetType = itk::Offset<ImageDimension>;
-  using RegionRangeType = itk::Experimental::ImageRegionRange<ImageType>;
 
   const OffsetType translationOffset{ { 1, -2 } };
   const auto       regionSize = SizeType::Filled(2);
@@ -50,16 +52,12 @@ GTEST_TEST(ElastixFilter, Translation)
   const auto fixedImage = ImageType::New();
   fixedImage->SetRegions(imageSize);
   fixedImage->Allocate(true);
-  const RegionType      fixedImageRegion{ fixedImageRegionIndex, regionSize };
-  const RegionRangeType fixedImageRegionRange{ *fixedImage, fixedImageRegion };
-  std::fill(std::begin(fixedImageRegionRange), std::end(fixedImageRegionRange), 1.0f);
+  elx::CoreMainGTestUtilities::FillImageRegion(*fixedImage, fixedImageRegionIndex, regionSize);
 
   const auto movingImage = ImageType::New();
   movingImage->SetRegions(imageSize);
   movingImage->Allocate(true);
-  const RegionType      movingImageRegion{ fixedImageRegionIndex + translationOffset, regionSize };
-  const RegionRangeType movingImageRegionRange{ *movingImage, movingImageRegion };
-  std::fill(std::begin(movingImageRegionRange), std::end(movingImageRegionRange), 1.0f);
+  elx::CoreMainGTestUtilities::FillImageRegion(*movingImage, fixedImageRegionIndex + translationOffset, regionSize);
 
   const auto parameterObject = elastix::ParameterObject::New();
 

--- a/Core/Main/GTesting/ElastixLibGTest.cxx
+++ b/Core/Main/GTesting/ElastixLibGTest.cxx
@@ -20,9 +20,10 @@
 // First include the header file to be tested:
 #include "elastixlib.h"
 
+#include "elxCoreMainGTestUtilities.h"
+
 // ITK header files:
 #include <itkImage.h>
-#include <itkImageRegionRange.h>
 
 // GoogleTest header file:
 #include <gtest/gtest.h>
@@ -122,17 +123,6 @@ ExpectRoundedTransformParametersEqualOffset(const elastix::ELASTIX &        elas
 }
 
 
-template <typename TPixel, unsigned int VImageDimension>
-void
-FillImageRegion(itk::Image<TPixel, VImageDimension> & image,
-                const itk::Index<VImageDimension> &   regionIndex,
-                const itk::Size<VImageDimension> &    regionSize)
-{
-  using ImageRegionRangeType = itk::Experimental::ImageRegionRange<itk::Image<TPixel, VImageDimension>>;
-  const ImageRegionRangeType imageRegionRange{ image, itk::ImageRegion<VImageDimension>{ regionIndex, regionSize } };
-  std::fill(std::begin(imageRegionRange), std::end(imageRegionRange), 1);
-}
-
 template <unsigned VImageDimension>
 std::map<std::string, std::vector<std::string>>
 CreateParameterMap(std::initializer_list<std::pair<std::string, std::string>> initializerList)
@@ -170,7 +160,8 @@ Expect_TransformParameters_are_zero_when_fixed_image_is_moving_image()
   const auto image = ImageType::New();
   image->SetRegions(SizeType::Filled(imageSizeValue));
   image->Allocate(true);
-  FillImageRegion(*image, itk::Index<VImageDimension>::Filled(1), SizeType::Filled(regionSizeValue));
+  elx::CoreMainGTestUtilities::FillImageRegion(
+    *image, itk::Index<VImageDimension>::Filled(1), SizeType::Filled(regionSizeValue));
 
   elastix::ELASTIX elastixObject;
   ASSERT_EQ(elastixObject.RegisterImages(image, image, parameterMap, ".", false, false), 0);
@@ -258,12 +249,12 @@ GTEST_TEST(ElastixLib, ExampleFromManualRunningElastix)
   const auto fixed_image = ITKImageType::New();
   fixed_image->SetRegions(imageSize);
   fixed_image->Allocate(true);
-  FillImageRegion(*fixed_image, fixedImageRegionIndex, regionSize);
+  elx::CoreMainGTestUtilities::FillImageRegion(*fixed_image, fixedImageRegionIndex, regionSize);
 
   const auto moving_image = ITKImageType::New();
   moving_image->SetRegions(imageSize);
   moving_image->Allocate(true);
-  FillImageRegion(*moving_image, fixedImageRegionIndex + translationOffset, regionSize);
+  elx::CoreMainGTestUtilities::FillImageRegion(*moving_image, fixedImageRegionIndex + translationOffset, regionSize);
 
   const std::string output_directory(".");
   const bool        write_log_file{ false };
@@ -360,12 +351,12 @@ GTEST_TEST(ElastixLib, Translation3D)
   const auto fixedImage = ImageType::New();
   fixedImage->SetRegions(imageSize);
   fixedImage->Allocate(true);
-  FillImageRegion(*fixedImage, fixedImageRegionIndex, regionSize);
+  elx::CoreMainGTestUtilities::FillImageRegion(*fixedImage, fixedImageRegionIndex, regionSize);
 
   const auto movingImage = ImageType::New();
   movingImage->SetRegions(imageSize);
   movingImage->Allocate(true);
-  FillImageRegion(*movingImage, fixedImageRegionIndex + translationOffset, regionSize);
+  elx::CoreMainGTestUtilities::FillImageRegion(*movingImage, fixedImageRegionIndex + translationOffset, regionSize);
 
   elastix::ELASTIX elastixObject;
 

--- a/Core/Main/GTesting/elxCoreMainGTestUtilities.h
+++ b/Core/Main/GTesting/elxCoreMainGTestUtilities.h
@@ -1,0 +1,67 @@
+/*=========================================================================
+ *
+ *  Copyright UMC Utrecht and contributors
+ *
+ *  Licensed under the Apache License, Version 2.0 (the "License");
+ *  you may not use this file except in compliance with the License.
+ *  You may obtain a copy of the License at
+ *
+ *        http://www.apache.org/licenses/LICENSE-2.0.txt
+ *
+ *  Unless required by applicable law or agreed to in writing, software
+ *  distributed under the License is distributed on an "AS IS" BASIS,
+ *  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *  See the License for the specific language governing permissions and
+ *  limitations under the License.
+ *
+ *=========================================================================*/
+
+#ifndef elxCoreMainGTestUtilities_h
+#define elxCoreMainGTestUtilities_h
+
+#include <itkImage.h>
+#include <itkImageRegionRange.h>
+#include <itkIndex.h>
+#include <itkSize.h>
+
+#include <algorithm> // For fill.
+#include <iterator>  // For begin and end.
+
+namespace itk
+{
+namespace Experimental
+{
+// Workaround to allow using things that may be either in itk or in itk::Experimental.
+}
+} // namespace itk
+
+
+namespace elastix
+{
+namespace CoreMainGTestUtilities
+{
+
+/// Fills the specified image region with pixel values 1.
+template <typename TPixel, unsigned int VImageDimension>
+void
+FillImageRegion(itk::Image<TPixel, VImageDimension> & image,
+                const itk::Index<VImageDimension> &   regionIndex,
+                const itk::Size<VImageDimension> &    regionSize)
+{
+  // ImageRegionRange is to be moved from namespace itk::Experimental
+  // to namespace itk with ITK version 5.2.
+  using namespace itk;
+  using namespace itk::Experimental;
+
+  const ImageRegionRange<Image<TPixel, VImageDimension>> imageRegionRange{
+    image, ImageRegion<VImageDimension>{ regionIndex, regionSize }
+  };
+  std::fill(std::begin(imageRegionRange), std::end(imageRegionRange), 1);
+}
+
+
+} // namespace CoreMainGTestUtilities
+} // namespace elastix
+
+
+#endif

--- a/Core/Main/GTesting/itkElastixRegistrationMethodGTest.cxx
+++ b/Core/Main/GTesting/itkElastixRegistrationMethodGTest.cxx
@@ -19,8 +19,11 @@
 
 // First include the header file to be tested:
 #include <itkElastixRegistrationMethod.h>
+
+#include "elxCoreMainGTestUtilities.h"
+
+// ITK header file:
 #include <itkImage.h>
-#include <itkImageRegionRange.h>
 
 // GoogleTest header file:
 #include <gtest/gtest.h>
@@ -40,7 +43,6 @@ GTEST_TEST(itkElastixRegistrationMethod, Translation)
   using SizeType = itk::Size<ImageDimension>;
   using IndexType = itk::Index<ImageDimension>;
   using OffsetType = itk::Offset<ImageDimension>;
-  using RegionRangeType = itk::Experimental::ImageRegionRange<ImageType>;
 
   const OffsetType translationOffset{ { 1, -2 } };
   const auto       regionSize = SizeType::Filled(2);
@@ -50,16 +52,12 @@ GTEST_TEST(itkElastixRegistrationMethod, Translation)
   const auto fixedImage = ImageType::New();
   fixedImage->SetRegions(imageSize);
   fixedImage->Allocate(true);
-  const RegionType      fixedImageRegion{ fixedImageRegionIndex, regionSize };
-  const RegionRangeType fixedImageRegionRange{ *fixedImage, fixedImageRegion };
-  std::fill(std::begin(fixedImageRegionRange), std::end(fixedImageRegionRange), 1.0f);
+  elx::CoreMainGTestUtilities::FillImageRegion(*fixedImage, fixedImageRegionIndex, regionSize);
 
   const auto movingImage = ImageType::New();
   movingImage->SetRegions(imageSize);
   movingImage->Allocate(true);
-  const RegionType      movingImageRegion{ fixedImageRegionIndex + translationOffset, regionSize };
-  const RegionRangeType movingImageRegionRange{ *movingImage, movingImageRegion };
-  std::fill(std::begin(movingImageRegionRange), std::end(movingImageRegionRange), 1.0f);
+  elx::CoreMainGTestUtilities::FillImageRegion(*movingImage, fixedImageRegionIndex + translationOffset, regionSize);
 
   const auto parameterObject = elastix::ParameterObject::New();
 


### PR DESCRIPTION
Aims to support both ITK 5.1 and ITK 5.2, by allowing `ImageRegionRange` to be either in `namespace itk` or in `namespace itk::Experimental`.