### PR TITLE
Replace dynamic_cast from all GetAsITKBaseType() member functions by this->GetSelf()

### DIFF
--- a/Components/FixedImagePyramids/FixedGenericPyramid/elxFixedGenericPyramid.h
+++ b/Components/FixedImagePyramids/FixedGenericPyramid/elxFixedGenericPyramid.h
@@ -131,6 +131,8 @@ protected:
   ~FixedGenericPyramid() override = default;
 
 private:
+  elxOverrideGetSelfMacro;
+
   /** The deleted copy constructor. */
   FixedGenericPyramid(const Self &) = delete;
   /** The deleted assignment operator. */

--- a/Components/FixedImagePyramids/FixedRecursivePyramid/elxFixedRecursivePyramid.h
+++ b/Components/FixedImagePyramids/FixedRecursivePyramid/elxFixedRecursivePyramid.h
@@ -90,6 +90,8 @@ protected:
   ~FixedRecursivePyramid() override = default;
 
 private:
+  elxOverrideGetSelfMacro;
+
   /** The deleted copy constructor. */
   FixedRecursivePyramid(const Self &) = delete;
   /** The deleted assignment operator. */

--- a/Components/FixedImagePyramids/FixedShrinkingPyramid/elxFixedShrinkingPyramid.h
+++ b/Components/FixedImagePyramids/FixedShrinkingPyramid/elxFixedShrinkingPyramid.h
@@ -90,6 +90,8 @@ protected:
   ~FixedShrinkingPyramid() override = default;
 
 private:
+  elxOverrideGetSelfMacro;
+
   /** The deleted copy constructor. */
   FixedShrinkingPyramid(const Self &) = delete;
   /** The deleted assignment operator. */

--- a/Components/FixedImagePyramids/FixedSmoothingPyramid/elxFixedSmoothingPyramid.h
+++ b/Components/FixedImagePyramids/FixedSmoothingPyramid/elxFixedSmoothingPyramid.h
@@ -92,6 +92,8 @@ protected:
   ~FixedSmoothingPyramid() override = default;
 
 private:
+  elxOverrideGetSelfMacro;
+
   /** The deleted copy constructor. */
   FixedSmoothingPyramid(const Self &) = delete;
   /** The deleted assignment operator. */

--- a/Components/FixedImagePyramids/OpenCLFixedGenericPyramid/elxOpenCLFixedGenericPyramid.h
+++ b/Components/FixedImagePyramids/OpenCLFixedGenericPyramid/elxOpenCLFixedGenericPyramid.h
@@ -111,6 +111,8 @@ protected:
   virtual ~OpenCLFixedGenericPyramid() = default;
 
 private:
+  elxOverrideGetSelfMacro;
+
   /** The deleted copy constructor. */
   OpenCLFixedGenericPyramid(const Self &) = delete;
   /** The deleted assignment operator. */

--- a/Components/ImageSamplers/Full/elxFullSampler.h
+++ b/Components/ImageSamplers/Full/elxFullSampler.h
@@ -99,6 +99,8 @@ protected:
   ~FullSampler() override = default;
 
 private:
+  elxOverrideGetSelfMacro;
+
   /** The deleted copy constructor. */
   FullSampler(const Self &) = delete;
   /** The deleted assignment operator. */

--- a/Components/ImageSamplers/Grid/elxGridSampler.h
+++ b/Components/ImageSamplers/Grid/elxGridSampler.h
@@ -112,6 +112,8 @@ protected:
   ~GridSampler() override = default;
 
 private:
+  elxOverrideGetSelfMacro;
+
   /** The deleted copy constructor. */
   GridSampler(const Self &) = delete;
   /** The deleted assignment operator. */

--- a/Components/ImageSamplers/MultInputRandomCoordinate/elxMultiInputRandomCoordinateSampler.h
+++ b/Components/ImageSamplers/MultInputRandomCoordinate/elxMultiInputRandomCoordinateSampler.h
@@ -158,6 +158,8 @@ protected:
   ~MultiInputRandomCoordinateSampler() override = default;
 
 private:
+  elxOverrideGetSelfMacro;
+
   /** The deleted copy constructor. */
   MultiInputRandomCoordinateSampler(const Self &) = delete;
   /** The deleted assignment operator. */

--- a/Components/ImageSamplers/Random/elxRandomSampler.h
+++ b/Components/ImageSamplers/Random/elxRandomSampler.h
@@ -113,6 +113,8 @@ protected:
   ~RandomSampler() override = default;
 
 private:
+  elxOverrideGetSelfMacro;
+
   /** The deleted copy constructor. */
   RandomSampler(const Self &) = delete;
   /** The deleted assignment operator. */

--- a/Components/ImageSamplers/RandomCoordinate/elxRandomCoordinateSampler.h
+++ b/Components/ImageSamplers/RandomCoordinate/elxRandomCoordinateSampler.h
@@ -151,6 +151,8 @@ protected:
   ~RandomCoordinateSampler() override = default;
 
 private:
+  elxOverrideGetSelfMacro;
+
   /** The deleted copy constructor. */
   RandomCoordinateSampler(const Self &) = delete;
   /** The deleted assignment operator. */

--- a/Components/ImageSamplers/RandomSparseMask/elxRandomSamplerSparseMask.h
+++ b/Components/ImageSamplers/RandomSparseMask/elxRandomSamplerSparseMask.h
@@ -115,6 +115,8 @@ protected:
   ~RandomSamplerSparseMask() override = default;
 
 private:
+  elxOverrideGetSelfMacro;
+
   /** The deleted copy constructor. */
   RandomSamplerSparseMask(const Self &) = delete;
   /** The deleted assignment operator. */

--- a/Components/Interpolators/BSplineInterpolator/elxBSplineInterpolator.h
+++ b/Components/Interpolators/BSplineInterpolator/elxBSplineInterpolator.h
@@ -115,6 +115,8 @@ protected:
   ~BSplineInterpolator() override = default;
 
 private:
+  elxOverrideGetSelfMacro;
+
   /** The deleted copy constructor. */
   BSplineInterpolator(const Self &) = delete;
   /** The deleted assignment operator. */

--- a/Components/Interpolators/BSplineInterpolatorFloat/elxBSplineInterpolatorFloat.h
+++ b/Components/Interpolators/BSplineInterpolatorFloat/elxBSplineInterpolatorFloat.h
@@ -115,6 +115,8 @@ protected:
   ~BSplineInterpolatorFloat() override = default;
 
 private:
+  elxOverrideGetSelfMacro;
+
   /** The deleted copy constructor. */
   BSplineInterpolatorFloat(const Self &) = delete;
   /** The deleted assignment operator. */

--- a/Components/Interpolators/LinearInterpolator/elxLinearInterpolator.h
+++ b/Components/Interpolators/LinearInterpolator/elxLinearInterpolator.h
@@ -94,6 +94,8 @@ protected:
   ~LinearInterpolator() override = default;
 
 private:
+  elxOverrideGetSelfMacro;
+
   /** The deleted copy constructor. */
   LinearInterpolator(const Self &) = delete;
   /** The deleted assignment operator. */

--- a/Components/Interpolators/NearestNeighborInterpolator/elxNearestNeighborInterpolator.h
+++ b/Components/Interpolators/NearestNeighborInterpolator/elxNearestNeighborInterpolator.h
@@ -92,6 +92,8 @@ protected:
   ~NearestNeighborInterpolator() override = default;
 
 private:
+  elxOverrideGetSelfMacro;
+
   /** The deleted copy constructor. */
   NearestNeighborInterpolator(const Self &) = delete;
   /** The deleted assignment operator. */

--- a/Components/Interpolators/RayCastInterpolator/elxRayCastInterpolator.h
+++ b/Components/Interpolators/RayCastInterpolator/elxRayCastInterpolator.h
@@ -121,6 +121,8 @@ protected:
   BeforeEachResolution(void) override;
 
 private:
+  elxOverrideGetSelfMacro;
+
   /** The deleted copy constructor. */
   RayCastInterpolator(const Self &) = delete;
 

--- a/Components/Interpolators/ReducedDimensionBSplineInterpolator/elxReducedDimensionBSplineInterpolator.h
+++ b/Components/Interpolators/ReducedDimensionBSplineInterpolator/elxReducedDimensionBSplineInterpolator.h
@@ -113,6 +113,8 @@ protected:
   ~ReducedDimensionBSplineInterpolator() override = default;
 
 private:
+  elxOverrideGetSelfMacro;
+
   /** The deleted copy constructor. */
   ReducedDimensionBSplineInterpolator(const Self &) = delete;
   /** The deleted assignment operator. */

--- a/Components/Metrics/AdvancedKappaStatistic/elxAdvancedKappaStatisticMetric.h
+++ b/Components/Metrics/AdvancedKappaStatistic/elxAdvancedKappaStatisticMetric.h
@@ -150,6 +150,8 @@ protected:
   ~AdvancedKappaStatisticMetric() override = default;
 
 private:
+  elxOverrideGetSelfMacro;
+
   /** The deleted copy constructor. */
   AdvancedKappaStatisticMetric(const Self &) = delete;
   /** The deleted assignment operator. */

--- a/Components/Metrics/AdvancedMattesMutualInformation/elxAdvancedMattesMutualInformationMetric.h
+++ b/Components/Metrics/AdvancedMattesMutualInformation/elxAdvancedMattesMutualInformationMetric.h
@@ -225,6 +225,8 @@ protected:
   Compute_c(unsigned long k) const;
 
 private:
+  elxOverrideGetSelfMacro;
+
   /** The deleted copy constructor. */
   AdvancedMattesMutualInformationMetric(const Self &) = delete;
   /** The deleted assignment operator. */

--- a/Components/Metrics/AdvancedMeanSquares/elxAdvancedMeanSquaresMetric.h
+++ b/Components/Metrics/AdvancedMeanSquares/elxAdvancedMeanSquaresMetric.h
@@ -146,6 +146,8 @@ protected:
   ~AdvancedMeanSquaresMetric() override = default;
 
 private:
+  elxOverrideGetSelfMacro;
+
   /** The deleted copy constructor. */
   AdvancedMeanSquaresMetric(const Self &) = delete;
   /** The deleted assignment operator. */

--- a/Components/Metrics/AdvancedNormalizedCorrelation/elxAdvancedNormalizedCorrelationMetric.h
+++ b/Components/Metrics/AdvancedNormalizedCorrelation/elxAdvancedNormalizedCorrelationMetric.h
@@ -144,6 +144,8 @@ protected:
   ~AdvancedNormalizedCorrelationMetric() override = default;
 
 private:
+  elxOverrideGetSelfMacro;
+
   /** The deleted copy constructor. */
   AdvancedNormalizedCorrelationMetric(const Self &) = delete;
   /** The deleted assignment operator. */

--- a/Components/Metrics/BendingEnergyPenalty/elxTransformBendingEnergyPenaltyTerm.h
+++ b/Components/Metrics/BendingEnergyPenalty/elxTransformBendingEnergyPenaltyTerm.h
@@ -145,6 +145,8 @@ protected:
   ~TransformBendingEnergyPenalty() override = default;
 
 private:
+  elxOverrideGetSelfMacro;
+
   /** The deleted copy constructor. */
   TransformBendingEnergyPenalty(const Self &) = delete;
   /** The deleted assignment operator. */

--- a/Components/Metrics/CorrespondingPointsEuclideanDistanceMetric/elxCorrespondingPointsEuclideanDistanceMetric.h
+++ b/Components/Metrics/CorrespondingPointsEuclideanDistanceMetric/elxCorrespondingPointsEuclideanDistanceMetric.h
@@ -149,6 +149,8 @@ protected:
   ~CorrespondingPointsEuclideanDistanceMetric() override = default;
 
 private:
+  elxOverrideGetSelfMacro;
+
   /** The deleted copy constructor. */
   CorrespondingPointsEuclideanDistanceMetric(const Self &) = delete;
   /** The deleted assignment operator. */

--- a/Components/Metrics/DisplacementMagnitudePenalty/elxDisplacementMagnitudePenalty.h
+++ b/Components/Metrics/DisplacementMagnitudePenalty/elxDisplacementMagnitudePenalty.h
@@ -135,6 +135,8 @@ protected:
   ~DisplacementMagnitudePenalty() override = default;
 
 private:
+  elxOverrideGetSelfMacro;
+
   /** The deleted copy constructor. */
   DisplacementMagnitudePenalty(const Self &) = delete;
   /** The deleted assignment operator. */

--- a/Components/Metrics/DistancePreservingRigidityPenalty/elxDistancePreservingRigidityPenaltyTerm.h
+++ b/Components/Metrics/DistancePreservingRigidityPenalty/elxDistancePreservingRigidityPenaltyTerm.h
@@ -168,6 +168,8 @@ protected:
   ~DistancePreservingRigidityPenalty() override = default;
 
 private:
+  elxOverrideGetSelfMacro;
+
   /** The deleted copy constructor. */
   DistancePreservingRigidityPenalty(const Self &) = delete;
   /** The deleted assignment operator. */

--- a/Components/Metrics/GradientDifference/elxGradientDifferenceMetric.h
+++ b/Components/Metrics/GradientDifference/elxGradientDifferenceMetric.h
@@ -143,6 +143,8 @@ protected:
   ~GradientDifferenceMetric() override = default;
 
 private:
+  elxOverrideGetSelfMacro;
+
   /** The deleted copy constructor. */
   GradientDifferenceMetric(const Self &) = delete;
   /** The deleted assignment operator. */

--- a/Components/Metrics/KNNGraphAlphaMutualInformation/elxKNNGraphAlphaMutualInformationMetric.h
+++ b/Components/Metrics/KNNGraphAlphaMutualInformation/elxKNNGraphAlphaMutualInformationMetric.h
@@ -175,6 +175,8 @@ protected:
   ~KNNGraphAlphaMutualInformationMetric() override = default;
 
 private:
+  elxOverrideGetSelfMacro;
+
   /** The deleted copy constructor. */
   KNNGraphAlphaMutualInformationMetric(const Self &) = delete;
   /** The deleted assignment operator. */

--- a/Components/Metrics/MissingStructurePenalty/elxMissingStructurePenalty.h
+++ b/Components/Metrics/MissingStructurePenalty/elxMissingStructurePenalty.h
@@ -186,6 +186,8 @@ protected:
   ~MissingStructurePenalty() override = default;
 
 private:
+  elxOverrideGetSelfMacro;
+
   /** The deleted copy constructor. */
   MissingStructurePenalty(const Self &) = delete;
   /** The deleted assignment operator. */

--- a/Components/Metrics/NormalizedGradientCorrelation/elxNormalizedGradientCorrelationMetric.h
+++ b/Components/Metrics/NormalizedGradientCorrelation/elxNormalizedGradientCorrelationMetric.h
@@ -141,6 +141,8 @@ protected:
   ~NormalizedGradientCorrelationMetric() override = default;
 
 private:
+  elxOverrideGetSelfMacro;
+
   /** The deleted copy constructor. */
   NormalizedGradientCorrelationMetric(const Self &) = delete;
 

--- a/Components/Metrics/NormalizedMutualInformation/elxNormalizedMutualInformationMetric.h
+++ b/Components/Metrics/NormalizedMutualInformation/elxNormalizedMutualInformationMetric.h
@@ -176,6 +176,8 @@ protected:
   ~NormalizedMutualInformationMetric() override = default;
 
 private:
+  elxOverrideGetSelfMacro;
+
   /** The deleted copy constructor. */
   NormalizedMutualInformationMetric(const Self &) = delete;
   /** The deleted assignment operator. */

--- a/Components/Metrics/PCAMetric/elxPCAMetric.h
+++ b/Components/Metrics/PCAMetric/elxPCAMetric.h
@@ -171,6 +171,8 @@ protected:
   ~PCAMetric() override = default;
 
 private:
+  elxOverrideGetSelfMacro;
+
   /** The deleted copy constructor. */
   PCAMetric(const Self &) = delete;
   /** The deleted assignment operator. */

--- a/Components/Metrics/PCAMetric2/elxPCAMetric2.h
+++ b/Components/Metrics/PCAMetric2/elxPCAMetric2.h
@@ -172,6 +172,8 @@ protected:
   ~PCAMetric2() override = default;
 
 private:
+  elxOverrideGetSelfMacro;
+
   /** The deleted copy constructor. */
   PCAMetric2(const Self &) = delete;
   /** The deleted assignment operator. */

--- a/Components/Metrics/PatternIntensity/elxPatternIntensityMetric.h
+++ b/Components/Metrics/PatternIntensity/elxPatternIntensityMetric.h
@@ -141,6 +141,8 @@ protected:
   ~PatternIntensityMetric() override = default;
 
 private:
+  elxOverrideGetSelfMacro;
+
   /** The deleted copy constructor. */
   PatternIntensityMetric(const Self &) = delete;
   /** The deleted assignment operator. */

--- a/Components/Metrics/PolydataDummyPenalty/elxPolydataDummyPenalty.h
+++ b/Components/Metrics/PolydataDummyPenalty/elxPolydataDummyPenalty.h
@@ -204,6 +204,8 @@ protected:
   ~PolydataDummyPenalty() override = default;
 
 private:
+  elxOverrideGetSelfMacro;
+
   /** The deleted copy constructor. */
   PolydataDummyPenalty(const Self &) = delete;
   /** The deleted assignment operator. */

--- a/Components/Metrics/RigidityPenalty/elxTransformRigidityPenaltyTerm.h
+++ b/Components/Metrics/RigidityPenalty/elxTransformRigidityPenaltyTerm.h
@@ -233,6 +233,8 @@ protected:
   ~TransformRigidityPenalty() override = default;
 
 private:
+  elxOverrideGetSelfMacro;
+
   /** The deleted copy constructor. */
   TransformRigidityPenalty(const Self &) = delete;
   /** The deleted assignment operator. */

--- a/Components/Metrics/StatisticalShapePenalty/elxStatisticalShapePenalty.h
+++ b/Components/Metrics/StatisticalShapePenalty/elxStatisticalShapePenalty.h
@@ -181,6 +181,8 @@ protected:
   ~StatisticalShapePenalty() override = default;
 
 private:
+  elxOverrideGetSelfMacro;
+
   /** The deleted copy constructor. */
   StatisticalShapePenalty(const Self &) = delete;
   /** The deleted assignment operator. */

--- a/Components/Metrics/SumOfPairwiseCorrelationsMetric/elxSumOfPairwiseCorrelationCoefficientsMetric.h
+++ b/Components/Metrics/SumOfPairwiseCorrelationsMetric/elxSumOfPairwiseCorrelationCoefficientsMetric.h
@@ -174,6 +174,8 @@ protected:
   ~SumOfPairwiseCorrelationCoefficientsMetric() override = default;
 
 private:
+  elxOverrideGetSelfMacro;
+
   /** The deleted copy constructor. */
   SumOfPairwiseCorrelationCoefficientsMetric(const Self &) = delete;
 

--- a/Components/Metrics/SumSquaredTissueVolumeDifferenceMetric/elxSumSquaredTissueVolumeDifferenceMetric.h
+++ b/Components/Metrics/SumSquaredTissueVolumeDifferenceMetric/elxSumSquaredTissueVolumeDifferenceMetric.h
@@ -152,6 +152,8 @@ protected:
   ~SumSquaredTissueVolumeDifferenceMetric() override = default;
 
 private:
+  elxOverrideGetSelfMacro;
+
   /** The deleted copy constructor. */
   SumSquaredTissueVolumeDifferenceMetric(const Self &) = delete;
   /** The deleted assignment operator. */

--- a/Components/Metrics/VarianceOverLastDimension/elxVarianceOverLastDimensionMetric.h
+++ b/Components/Metrics/VarianceOverLastDimension/elxVarianceOverLastDimensionMetric.h
@@ -184,6 +184,8 @@ protected:
   ~VarianceOverLastDimensionMetric() override = default;
 
 private:
+  elxOverrideGetSelfMacro;
+
   /** The deleted copy constructor. */
   VarianceOverLastDimensionMetric(const Self &) = delete;
   /** The deleted assignment operator. */

--- a/Components/MovingImagePyramids/MovingGenericPyramid/elxMovingGenericPyramid.h
+++ b/Components/MovingImagePyramids/MovingGenericPyramid/elxMovingGenericPyramid.h
@@ -131,6 +131,8 @@ protected:
   ~MovingGenericPyramid() override = default;
 
 private:
+  elxOverrideGetSelfMacro;
+
   /** The deleted copy constructor. */
   MovingGenericPyramid(const Self &) = delete;
   /** The deleted assignment operator. */

--- a/Components/MovingImagePyramids/MovingRecursivePyramid/elxMovingRecursivePyramid.h
+++ b/Components/MovingImagePyramids/MovingRecursivePyramid/elxMovingRecursivePyramid.h
@@ -89,6 +89,8 @@ protected:
   ~MovingRecursivePyramid() override = default;
 
 private:
+  elxOverrideGetSelfMacro;
+
   /** The deleted copy constructor. */
   MovingRecursivePyramid(const Self &) = delete;
   /** The deleted assignment operator. */

--- a/Components/MovingImagePyramids/MovingShrinkingPyramid/elxMovingShrinkingPyramid.h
+++ b/Components/MovingImagePyramids/MovingShrinkingPyramid/elxMovingShrinkingPyramid.h
@@ -90,6 +90,8 @@ protected:
   ~MovingShrinkingPyramid() override = default;
 
 private:
+  elxOverrideGetSelfMacro;
+
   /** The deleted copy constructor. */
   MovingShrinkingPyramid(const Self &) = delete;
   /** The deleted assignment operator. */

--- a/Components/MovingImagePyramids/MovingSmoothingPyramid/elxMovingSmoothingPyramid.h
+++ b/Components/MovingImagePyramids/MovingSmoothingPyramid/elxMovingSmoothingPyramid.h
@@ -91,6 +91,8 @@ protected:
   ~MovingSmoothingPyramid() override = default;
 
 private:
+  elxOverrideGetSelfMacro;
+
   /** The deleted copy constructor. */
   MovingSmoothingPyramid(const Self &) = delete;
   /** The deleted assignment operator. */

--- a/Components/MovingImagePyramids/OpenCLMovingGenericPyramid/elxOpenCLMovingGenericPyramid.h
+++ b/Components/MovingImagePyramids/OpenCLMovingGenericPyramid/elxOpenCLMovingGenericPyramid.h
@@ -111,6 +111,8 @@ protected:
   virtual ~OpenCLMovingGenericPyramid() = default;
 
 private:
+  elxOverrideGetSelfMacro;
+
   /** The deleted copy constructor. */
   OpenCLMovingGenericPyramid(const Self &) = delete;
   /** The deleted assignment operator. */

--- a/Components/Optimizers/AdaGrad/elxAdaGrad.h
+++ b/Components/Optimizers/AdaGrad/elxAdaGrad.h
@@ -419,6 +419,8 @@ protected:
   AddRandomPerturbation(ParametersType & parameters, double sigma);
 
 private:
+  elxOverrideGetSelfMacro;
+
   AdaGrad(const Self &) = delete;
   void
   operator=(const Self &) = delete;

--- a/Components/Optimizers/AdaptiveStochasticGradientDescent/elxAdaptiveStochasticGradientDescent.h
+++ b/Components/Optimizers/AdaptiveStochasticGradientDescent/elxAdaptiveStochasticGradientDescent.h
@@ -410,6 +410,8 @@ protected:
   AddRandomPerturbation(ParametersType & parameters, double sigma);
 
 private:
+  elxOverrideGetSelfMacro;
+
   AdaptiveStochasticGradientDescent(const Self &) = delete;
   void
   operator=(const Self &) = delete;

--- a/Components/Optimizers/AdaptiveStochasticLBFGS/elxAdaptiveStochasticLBFGS.h
+++ b/Components/Optimizers/AdaptiveStochasticLBFGS/elxAdaptiveStochasticLBFGS.h
@@ -408,6 +408,8 @@ protected:
   double  m_WindowScale;
 
 private:
+  elxOverrideGetSelfMacro;
+
   AdaptiveStochasticLBFGS(const Self &) = delete;
   void
   operator=(const Self &) = delete;

--- a/Components/Optimizers/AdaptiveStochasticVarianceReducedGradient/elxAdaptiveStochasticVarianceReducedGradient.h
+++ b/Components/Optimizers/AdaptiveStochasticVarianceReducedGradient/elxAdaptiveStochasticVarianceReducedGradient.h
@@ -440,6 +440,8 @@ protected:
   double m_NoiseFactor;
 
 private:
+  elxOverrideGetSelfMacro;
+
   AdaptiveStochasticVarianceReducedGradient(const Self &) = delete;
   void
   operator=(const Self &) = delete;

--- a/Components/Optimizers/CMAEvolutionStrategy/elxCMAEvolutionStrategy.h
+++ b/Components/Optimizers/CMAEvolutionStrategy/elxCMAEvolutionStrategy.h
@@ -184,6 +184,8 @@ protected:
   InitializeProgressVariables(void) override;
 
 private:
+  elxOverrideGetSelfMacro;
+
   CMAEvolutionStrategy(const Self &) = delete;
   void
   operator=(const Self &) = delete;

--- a/Components/Optimizers/ConjugateGradient/elxConjugateGradient.h
+++ b/Components/Optimizers/ConjugateGradient/elxConjugateGradient.h
@@ -189,6 +189,8 @@ protected:
     override;
 
 private:
+  elxOverrideGetSelfMacro;
+
   ConjugateGradient(const Self &) = delete;
   void
   operator=(const Self &) = delete;

--- a/Components/Optimizers/ConjugateGradientFRPR/elxConjugateGradientFRPR.h
+++ b/Components/Optimizers/ConjugateGradientFRPR/elxConjugateGradientFRPR.h
@@ -212,6 +212,8 @@ protected:
   LineOptimize(ParametersType * p, ParametersType xi, double * val);
 
 private:
+  elxOverrideGetSelfMacro;
+
   ConjugateGradientFRPR(const Self &) = delete;
   void
   operator=(const Self &) = delete;

--- a/Components/Optimizers/FiniteDifferenceGradientDescent/elxFiniteDifferenceGradientDescent.h
+++ b/Components/Optimizers/FiniteDifferenceGradientDescent/elxFiniteDifferenceGradientDescent.h
@@ -146,6 +146,8 @@ protected:
   bool m_ShowMetricValues;
 
 private:
+  elxOverrideGetSelfMacro;
+
   FiniteDifferenceGradientDescent(const Self &) = delete;
   void
   operator=(const Self &) = delete;

--- a/Components/Optimizers/FullSearch/elxFullSearchOptimizer.h
+++ b/Components/Optimizers/FullSearch/elxFullSearchOptimizer.h
@@ -151,6 +151,8 @@ protected:
                                   const unsigned int  entry_nr) const;
 
 private:
+  elxOverrideGetSelfMacro;
+
   FullSearch(const Self &) = delete;
   void
   operator=(const Self &) = delete;

--- a/Components/Optimizers/Powell/elxPowell.h
+++ b/Components/Optimizers/Powell/elxPowell.h
@@ -107,6 +107,8 @@ protected:
   ~Powell() override = default;
 
 private:
+  elxOverrideGetSelfMacro;
+
   Powell(const Self &) = delete;
   void
   operator=(const Self &) = delete;

--- a/Components/Optimizers/PreconditionedGradientDescent/elxPreconditionedGradientDescent.h
+++ b/Components/Optimizers/PreconditionedGradientDescent/elxPreconditionedGradientDescent.h
@@ -254,6 +254,8 @@ protected:
   AddRandomPerturbation(const ParametersType & initialParameters, ParametersType & perturbedParameters, double sigma);
 
 private:
+  elxOverrideGetSelfMacro;
+
   PreconditionedGradientDescent(const Self &) = delete;
   void
   operator=(const Self &) = delete;

--- a/Components/Optimizers/PreconditionedStochasticGradientDescent/elxPreconditionedStochasticGradientDescent.h
+++ b/Components/Optimizers/PreconditionedStochasticGradientDescent/elxPreconditionedStochasticGradientDescent.h
@@ -406,6 +406,8 @@ protected:
   AddRandomPerturbation(ParametersType & parameters, double sigma);
 
 private:
+  elxOverrideGetSelfMacro;
+
   PreconditionedStochasticGradientDescent(const Self &) = delete;
   void
   operator=(const Self &) = delete;

--- a/Components/Optimizers/QuasiNewtonLBFGS/elxQuasiNewtonLBFGS.h
+++ b/Components/Optimizers/QuasiNewtonLBFGS/elxQuasiNewtonLBFGS.h
@@ -186,6 +186,8 @@ protected:
     override;
 
 private:
+  elxOverrideGetSelfMacro;
+
   QuasiNewtonLBFGS(const Self &) = delete;
   void
   operator=(const Self &) = delete;

--- a/Components/Optimizers/RSGDEachParameterApart/elxRSGDEachParameterApart.h
+++ b/Components/Optimizers/RSGDEachParameterApart/elxRSGDEachParameterApart.h
@@ -137,6 +137,8 @@ protected:
   ~RSGDEachParameterApart() override = default;
 
 private:
+  elxOverrideGetSelfMacro;
+
   RSGDEachParameterApart(const Self &) = delete;
   void
   operator=(const Self &) = delete;

--- a/Components/Optimizers/RegularStepGradientDescent/elxRegularStepGradientDescent.h
+++ b/Components/Optimizers/RegularStepGradientDescent/elxRegularStepGradientDescent.h
@@ -131,6 +131,8 @@ protected:
   ~RegularStepGradientDescent() override = default;
 
 private:
+  elxOverrideGetSelfMacro;
+
   RegularStepGradientDescent(const Self &) = delete;
   void
   operator=(const Self &) = delete;

--- a/Components/Optimizers/Simplex/elxSimplex.h
+++ b/Components/Optimizers/Simplex/elxSimplex.h
@@ -107,6 +107,8 @@ protected:
   ~Simplex() override = default;
 
 private:
+  elxOverrideGetSelfMacro;
+
   Simplex(const Self &) = delete;
   void
   operator=(const Self &) = delete;

--- a/Components/Optimizers/SimultaneousPerturbation/elxSimultaneousPerturbation.h
+++ b/Components/Optimizers/SimultaneousPerturbation/elxSimultaneousPerturbation.h
@@ -150,6 +150,8 @@ protected:
   bool m_ShowMetricValues;
 
 private:
+  elxOverrideGetSelfMacro;
+
   SimultaneousPerturbation(const Self &) = delete;
   void
   operator=(const Self &) = delete;

--- a/Components/Optimizers/StandardGradientDescent/elxStandardGradientDescent.h
+++ b/Components/Optimizers/StandardGradientDescent/elxStandardGradientDescent.h
@@ -153,6 +153,8 @@ protected:
   ~StandardGradientDescent() override = default;
 
 private:
+  elxOverrideGetSelfMacro;
+
   StandardGradientDescent(const Self &) = delete;
   void
   operator=(const Self &) = delete;

--- a/Components/Registrations/MultiMetricMultiResolutionRegistration/elxMultiMetricMultiResolutionRegistration.h
+++ b/Components/Registrations/MultiMetricMultiResolutionRegistration/elxMultiMetricMultiResolutionRegistration.h
@@ -235,6 +235,8 @@ protected:
   bool m_ShowExactMetricValue;
 
 private:
+  elxOverrideGetSelfMacro;
+
   /** The deleted copy constructor. */
   MultiMetricMultiResolutionRegistration(const Self &) = delete;
   /** The deleted assignment operator. */

--- a/Components/Registrations/MultiResolutionRegistration/elxMultiResolutionRegistration.h
+++ b/Components/Registrations/MultiResolutionRegistration/elxMultiResolutionRegistration.h
@@ -158,6 +158,8 @@ protected:
   SetComponents(void);
 
 private:
+  elxOverrideGetSelfMacro;
+
   /** The deleted copy constructor. */
   MultiResolutionRegistration(const Self &) = delete;
   /** The deleted assignment operator. */

--- a/Components/Registrations/MultiResolutionRegistrationWithFeatures/elxMultiResolutionRegistrationWithFeatures.h
+++ b/Components/Registrations/MultiResolutionRegistrationWithFeatures/elxMultiResolutionRegistrationWithFeatures.h
@@ -191,6 +191,8 @@ protected:
   GetAndSetFixedImageInterpolators(void);
 
 private:
+  elxOverrideGetSelfMacro;
+
   /** The deleted copy constructor. */
   MultiResolutionRegistrationWithFeatures(const Self &) = delete;
   /** The deleted assignment operator. */

--- a/Components/ResampleInterpolators/BSplineResampleInterpolator/elxBSplineResampleInterpolator.h
+++ b/Components/ResampleInterpolators/BSplineResampleInterpolator/elxBSplineResampleInterpolator.h
@@ -126,6 +126,8 @@ protected:
   ~BSplineResampleInterpolator() override = default;
 
 private:
+  elxOverrideGetSelfMacro;
+
   /** Creates a map of the parameters specific for this (derived) interpolator type. */
   ParameterMapType
   CreateDerivedTransformParametersMap() const override;

--- a/Components/ResampleInterpolators/BSplineResampleInterpolatorFloat/elxBSplineResampleInterpolatorFloat.h
+++ b/Components/ResampleInterpolators/BSplineResampleInterpolatorFloat/elxBSplineResampleInterpolatorFloat.h
@@ -124,6 +124,8 @@ protected:
   ~BSplineResampleInterpolatorFloat() override = default;
 
 private:
+  elxOverrideGetSelfMacro;
+
   /** Creates a map of the parameters specific for this (derived) interpolator type. */
   ParameterMapType
   CreateDerivedTransformParametersMap() const override;

--- a/Components/ResampleInterpolators/LinearResampleInterpolator/elxLinearResampleInterpolator.h
+++ b/Components/ResampleInterpolators/LinearResampleInterpolator/elxLinearResampleInterpolator.h
@@ -93,6 +93,8 @@ protected:
   ~LinearResampleInterpolator() override = default;
 
 private:
+  elxOverrideGetSelfMacro;
+
   /** The deleted copy constructor. */
   LinearResampleInterpolator(const Self &) = delete;
   /** The deleted assignment operator. */

--- a/Components/ResampleInterpolators/NearestNeighborResampleInterpolator/elxNearestNeighborResampleInterpolator.h
+++ b/Components/ResampleInterpolators/NearestNeighborResampleInterpolator/elxNearestNeighborResampleInterpolator.h
@@ -93,6 +93,8 @@ protected:
   ~NearestNeighborResampleInterpolator() override = default;
 
 private:
+  elxOverrideGetSelfMacro;
+
   /** The deleted copy constructor. */
   NearestNeighborResampleInterpolator(const Self &) = delete;
   /** The deleted assignment operator. */

--- a/Components/ResampleInterpolators/RDBSplineResampleInterpolator/elxRDBSplineResampleInterpolator.h
+++ b/Components/ResampleInterpolators/RDBSplineResampleInterpolator/elxRDBSplineResampleInterpolator.h
@@ -125,6 +125,8 @@ protected:
   ~ReducedDimensionBSplineResampleInterpolator() override = default;
 
 private:
+  elxOverrideGetSelfMacro;
+
   /** Creates a map of the parameters specific for this (derived) interpolator type. */
   ParameterMapType
   CreateDerivedTransformParametersMap() const override;

--- a/Components/ResampleInterpolators/RayCastResampleInterpolator/elxRayCastResampleInterpolator.h
+++ b/Components/ResampleInterpolators/RayCastResampleInterpolator/elxRayCastResampleInterpolator.h
@@ -124,6 +124,8 @@ protected:
   InitializeRayCastInterpolator(void);
 
 private:
+  elxOverrideGetSelfMacro;
+
   /** Creates a map of the parameters specific for this (derived) interpolator type. */
   ParameterMapType
   CreateDerivedTransformParametersMap() const override;

--- a/Components/Resamplers/MyStandardResampler/elxMyStandardResampler.h
+++ b/Components/Resamplers/MyStandardResampler/elxMyStandardResampler.h
@@ -95,6 +95,8 @@ protected:
   ~MyStandardResampler() override = default;
 
 private:
+  elxOverrideGetSelfMacro;
+
   /** The deleted copy constructor. */
   MyStandardResampler(const Self &) = delete;
   /** The deleted assignment operator. */

--- a/Components/Resamplers/OpenCLResampler/elxOpenCLResampler.h
+++ b/Components/Resamplers/OpenCLResampler/elxOpenCLResampler.h
@@ -154,6 +154,8 @@ protected:
   typedef typename InterpolateCopierType::GPUExplicitInterpolatorPointer GPUExplicitInterpolatorPointer;
 
 private:
+  elxOverrideGetSelfMacro;
+  elxOverrideGetSelfMacro;
   /** Creates a map of the parameters specific for this (derived) resampler type. */
   ParameterMapType
   CreateDerivedTransformParametersMap(void) const override;

--- a/Components/Transforms/AdvancedAffineTransform/elxAdvancedAffineTransform.h
+++ b/Components/Transforms/AdvancedAffineTransform/elxAdvancedAffineTransform.h
@@ -214,6 +214,8 @@ protected:
   ReadCenterOfRotationPoint(InputPointType & rotationPoint) const;
 
 private:
+  elxOverrideGetSelfMacro;
+
   const Self &
   GetAsCombinationTransform(void) const override
   {

--- a/Components/Transforms/AdvancedAffineTransform/elxAdvancedAffineTransform.h
+++ b/Components/Transforms/AdvancedAffineTransform/elxAdvancedAffineTransform.h
@@ -216,18 +216,6 @@ protected:
 private:
   elxOverrideGetSelfMacro;
 
-  const Self &
-  GetAsCombinationTransform(void) const override
-  {
-    return *this;
-  }
-
-  Self &
-  GetAsCombinationTransform(void) override
-  {
-    return *this;
-  }
-
   /** Creates a map of the parameters specific for this (derived) transform type. */
   ParameterMapType
   CreateDerivedTransformParametersMap(void) const override;

--- a/Components/Transforms/AdvancedBSplineTransform/elxAdvancedBSplineTransform.h
+++ b/Components/Transforms/AdvancedBSplineTransform/elxAdvancedBSplineTransform.h
@@ -287,18 +287,6 @@ protected:
 private:
   elxOverrideGetSelfMacro;
 
-  const Self &
-  GetAsCombinationTransform(void) const override
-  {
-    return *this;
-  }
-
-  Self &
-  GetAsCombinationTransform(void) override
-  {
-    return *this;
-  }
-
   /** Creates a map of the parameters specific for this (derived) transform type. */
   ParameterMapType
   CreateDerivedTransformParametersMap(void) const override;

--- a/Components/Transforms/AdvancedBSplineTransform/elxAdvancedBSplineTransform.h
+++ b/Components/Transforms/AdvancedBSplineTransform/elxAdvancedBSplineTransform.h
@@ -285,6 +285,8 @@ protected:
   PreComputeGridInformation(void);
 
 private:
+  elxOverrideGetSelfMacro;
+
   const Self &
   GetAsCombinationTransform(void) const override
   {

--- a/Components/Transforms/AffineDTITransform/elxAffineDTITransform.h
+++ b/Components/Transforms/AffineDTITransform/elxAffineDTITransform.h
@@ -215,6 +215,8 @@ protected:
   ReadCenterOfRotationPoint(InputPointType & rotationPoint) const;
 
 private:
+  elxOverrideGetSelfMacro;
+
   const Self &
   GetAsCombinationTransform(void) const override
   {

--- a/Components/Transforms/AffineDTITransform/elxAffineDTITransform.h
+++ b/Components/Transforms/AffineDTITransform/elxAffineDTITransform.h
@@ -217,18 +217,6 @@ protected:
 private:
   elxOverrideGetSelfMacro;
 
-  const Self &
-  GetAsCombinationTransform(void) const override
-  {
-    return *this;
-  }
-
-  Self &
-  GetAsCombinationTransform(void) override
-  {
-    return *this;
-  }
-
   /** Creates a map of the parameters specific for this (derived) transform type. */
   ParameterMapType
   CreateDerivedTransformParametersMap(void) const override;

--- a/Components/Transforms/AffineLogStackTransform/elxAffineLogStackTransform.h
+++ b/Components/Transforms/AffineLogStackTransform/elxAffineLogStackTransform.h
@@ -182,18 +182,6 @@ protected:
 private:
   elxOverrideGetSelfMacro;
 
-  const Self &
-  GetAsCombinationTransform(void) const override
-  {
-    return *this;
-  }
-
-  Self &
-  GetAsCombinationTransform(void) override
-  {
-    return *this;
-  }
-
   /** Creates a map of the parameters specific for this (derived) transform type. */
   ParameterMapType
   CreateDerivedTransformParametersMap(void) const override;

--- a/Components/Transforms/AffineLogStackTransform/elxAffineLogStackTransform.h
+++ b/Components/Transforms/AffineLogStackTransform/elxAffineLogStackTransform.h
@@ -180,6 +180,8 @@ protected:
   ReadCenterOfRotationPoint(ReducedDimensionInputPointType & rotationPoint) const;
 
 private:
+  elxOverrideGetSelfMacro;
+
   const Self &
   GetAsCombinationTransform(void) const override
   {

--- a/Components/Transforms/AffineLogTransform/elxAffineLogTransform.h
+++ b/Components/Transforms/AffineLogTransform/elxAffineLogTransform.h
@@ -181,18 +181,6 @@ protected:
 private:
   elxOverrideGetSelfMacro;
 
-  const Self &
-  GetAsCombinationTransform(void) const override
-  {
-    return *this;
-  }
-
-  Self &
-  GetAsCombinationTransform(void) override
-  {
-    return *this;
-  }
-
   /** Creates a map of the parameters specific for this (derived) transform type. */
   ParameterMapType
   CreateDerivedTransformParametersMap(void) const override;

--- a/Components/Transforms/AffineLogTransform/elxAffineLogTransform.h
+++ b/Components/Transforms/AffineLogTransform/elxAffineLogTransform.h
@@ -179,6 +179,8 @@ protected:
   ReadCenterOfRotationPoint(InputPointType & rotationPoint) const;
 
 private:
+  elxOverrideGetSelfMacro;
+
   const Self &
   GetAsCombinationTransform(void) const override
   {

--- a/Components/Transforms/BSplineDeformableTransformWithDiffusion/elxBSplineTransformWithDiffusion.h
+++ b/Components/Transforms/BSplineDeformableTransformWithDiffusion/elxBSplineTransformWithDiffusion.h
@@ -360,6 +360,8 @@ protected:
   SpacingType m_GridSpacingFactor;
 
 private:
+  elxOverrideGetSelfMacro;
+
   const Self &
   GetAsCombinationTransform(void) const override
   {

--- a/Components/Transforms/BSplineDeformableTransformWithDiffusion/elxBSplineTransformWithDiffusion.h
+++ b/Components/Transforms/BSplineDeformableTransformWithDiffusion/elxBSplineTransformWithDiffusion.h
@@ -362,18 +362,6 @@ protected:
 private:
   elxOverrideGetSelfMacro;
 
-  const Self &
-  GetAsCombinationTransform(void) const override
-  {
-    return *this;
-  }
-
-  Self &
-  GetAsCombinationTransform(void) override
-  {
-    return *this;
-  }
-
   /** Creates a map of the parameters specific for this (derived) transform type. */
   ParameterMapType
   CreateDerivedTransformParametersMap(void) const override;

--- a/Components/Transforms/BSplineStackTransform/elxBSplineStackTransform.h
+++ b/Components/Transforms/BSplineStackTransform/elxBSplineStackTransform.h
@@ -293,18 +293,6 @@ protected:
 private:
   elxOverrideGetSelfMacro;
 
-  const Self &
-  GetAsCombinationTransform(void) const override
-  {
-    return *this;
-  }
-
-  Self &
-  GetAsCombinationTransform(void) override
-  {
-    return *this;
-  }
-
   /** Creates a map of the parameters specific for this (derived) transform type. */
   ParameterMapType
   CreateDerivedTransformParametersMap(void) const override;

--- a/Components/Transforms/BSplineStackTransform/elxBSplineStackTransform.h
+++ b/Components/Transforms/BSplineStackTransform/elxBSplineStackTransform.h
@@ -291,6 +291,8 @@ protected:
   PreComputeGridInformation(void);
 
 private:
+  elxOverrideGetSelfMacro;
+
   const Self &
   GetAsCombinationTransform(void) const override
   {

--- a/Components/Transforms/DeformationFieldTransform/elxDeformationFieldTransform.h
+++ b/Components/Transforms/DeformationFieldTransform/elxDeformationFieldTransform.h
@@ -138,18 +138,6 @@ protected:
 private:
   elxOverrideGetSelfMacro;
 
-  const Self &
-  GetAsCombinationTransform(void) const override
-  {
-    return *this;
-  }
-
-  Self &
-  GetAsCombinationTransform(void) override
-  {
-    return *this;
-  }
-
   /** Creates a map of the parameters specific for this (derived) transform type. */
   ParameterMapType
   CreateDerivedTransformParametersMap(void) const override;

--- a/Components/Transforms/DeformationFieldTransform/elxDeformationFieldTransform.h
+++ b/Components/Transforms/DeformationFieldTransform/elxDeformationFieldTransform.h
@@ -136,6 +136,8 @@ protected:
   ~DeformationFieldTransform() override = default;
 
 private:
+  elxOverrideGetSelfMacro;
+
   const Self &
   GetAsCombinationTransform(void) const override
   {

--- a/Components/Transforms/EulerStackTransform/elxEulerStackTransform.h
+++ b/Components/Transforms/EulerStackTransform/elxEulerStackTransform.h
@@ -229,18 +229,6 @@ protected:
 private:
   elxOverrideGetSelfMacro;
 
-  const Self &
-  GetAsCombinationTransform(void) const override
-  {
-    return *this;
-  }
-
-  Self &
-  GetAsCombinationTransform(void) override
-  {
-    return *this;
-  }
-
   /** Creates a map of the parameters specific for this (derived) transform type. */
   ParameterMapType
   CreateDerivedTransformParametersMap(void) const override;

--- a/Components/Transforms/EulerStackTransform/elxEulerStackTransform.h
+++ b/Components/Transforms/EulerStackTransform/elxEulerStackTransform.h
@@ -227,6 +227,8 @@ protected:
   ReadCenterOfRotationPoint(ReducedDimensionInputPointType & rotationPoint) const;
 
 private:
+  elxOverrideGetSelfMacro;
+
   const Self &
   GetAsCombinationTransform(void) const override
   {

--- a/Components/Transforms/EulerTransform/elxEulerTransform.h
+++ b/Components/Transforms/EulerTransform/elxEulerTransform.h
@@ -218,6 +218,8 @@ protected:
   ReadCenterOfRotationPoint(InputPointType & rotationPoint) const;
 
 private:
+  elxOverrideGetSelfMacro;
+
   const Self &
   GetAsCombinationTransform(void) const override
   {

--- a/Components/Transforms/EulerTransform/elxEulerTransform.h
+++ b/Components/Transforms/EulerTransform/elxEulerTransform.h
@@ -220,18 +220,6 @@ protected:
 private:
   elxOverrideGetSelfMacro;
 
-  const Self &
-  GetAsCombinationTransform(void) const override
-  {
-    return *this;
-  }
-
-  Self &
-  GetAsCombinationTransform(void) override
-  {
-    return *this;
-  }
-
   /** Creates a map of the parameters specific for this (derived) transform type. */
   ParameterMapType
   CreateDerivedTransformParametersMap(void) const override;

--- a/Components/Transforms/MultiBSplineTransformWithNormal/elxMultiBSplineTransformWithNormal.h
+++ b/Components/Transforms/MultiBSplineTransformWithNormal/elxMultiBSplineTransformWithNormal.h
@@ -257,18 +257,6 @@ protected:
 private:
   elxOverrideGetSelfMacro;
 
-  const Self &
-  GetAsCombinationTransform(void) const override
-  {
-    return *this;
-  }
-
-  Self &
-  GetAsCombinationTransform(void) override
-  {
-    return *this;
-  }
-
   /** Creates a map of the parameters specific for this (derived) transform type. */
   ParameterMapType
   CreateDerivedTransformParametersMap(void) const override;

--- a/Components/Transforms/MultiBSplineTransformWithNormal/elxMultiBSplineTransformWithNormal.h
+++ b/Components/Transforms/MultiBSplineTransformWithNormal/elxMultiBSplineTransformWithNormal.h
@@ -255,6 +255,8 @@ protected:
   PreComputeGridInformation(void);
 
 private:
+  elxOverrideGetSelfMacro;
+
   const Self &
   GetAsCombinationTransform(void) const override
   {

--- a/Components/Transforms/RecursiveBSplineTransform/elxRecursiveBSplineTransform.h
+++ b/Components/Transforms/RecursiveBSplineTransform/elxRecursiveBSplineTransform.h
@@ -287,18 +287,6 @@ protected:
 private:
   elxOverrideGetSelfMacro;
 
-  const Self &
-  GetAsCombinationTransform(void) const override
-  {
-    return *this;
-  }
-
-  Self &
-  GetAsCombinationTransform(void) override
-  {
-    return *this;
-  }
-
   /** Creates a map of the parameters specific for this (derived) transform type. */
   ParameterMapType
   CreateDerivedTransformParametersMap(void) const override;

--- a/Components/Transforms/RecursiveBSplineTransform/elxRecursiveBSplineTransform.h
+++ b/Components/Transforms/RecursiveBSplineTransform/elxRecursiveBSplineTransform.h
@@ -285,6 +285,8 @@ protected:
   PreComputeGridInformation(void);
 
 private:
+  elxOverrideGetSelfMacro;
+
   const Self &
   GetAsCombinationTransform(void) const override
   {

--- a/Components/Transforms/SimilarityTransform/elxSimilarityTransform.h
+++ b/Components/Transforms/SimilarityTransform/elxSimilarityTransform.h
@@ -230,18 +230,6 @@ protected:
 private:
   elxOverrideGetSelfMacro;
 
-  const Self &
-  GetAsCombinationTransform(void) const override
-  {
-    return *this;
-  }
-
-  Self &
-  GetAsCombinationTransform(void) override
-  {
-    return *this;
-  }
-
   /** Creates a map of the parameters specific for this (derived) transform type. */
   ParameterMapType
   CreateDerivedTransformParametersMap(void) const override;

--- a/Components/Transforms/SimilarityTransform/elxSimilarityTransform.h
+++ b/Components/Transforms/SimilarityTransform/elxSimilarityTransform.h
@@ -228,6 +228,8 @@ protected:
   ReadCenterOfRotationPoint(InputPointType & rotationPoint) const;
 
 private:
+  elxOverrideGetSelfMacro;
+
   const Self &
   GetAsCombinationTransform(void) const override
   {

--- a/Components/Transforms/SplineKernelTransform/elxSplineKernelTransform.h
+++ b/Components/Transforms/SplineKernelTransform/elxSplineKernelTransform.h
@@ -247,6 +247,8 @@ protected:
   KernelTransformPointer m_KernelTransform;
 
 private:
+  elxOverrideGetSelfMacro;
+
   const Self &
   GetAsCombinationTransform(void) const override
   {

--- a/Components/Transforms/SplineKernelTransform/elxSplineKernelTransform.h
+++ b/Components/Transforms/SplineKernelTransform/elxSplineKernelTransform.h
@@ -249,18 +249,6 @@ protected:
 private:
   elxOverrideGetSelfMacro;
 
-  const Self &
-  GetAsCombinationTransform(void) const override
-  {
-    return *this;
-  }
-
-  Self &
-  GetAsCombinationTransform(void) override
-  {
-    return *this;
-  }
-
   /** Creates a map of the parameters specific for this (derived) transform type. */
   ParameterMapType
   CreateDerivedTransformParametersMap(void) const override;

--- a/Components/Transforms/TranslationStackTransform/elxTranslationStackTransform.h
+++ b/Components/Transforms/TranslationStackTransform/elxTranslationStackTransform.h
@@ -155,18 +155,6 @@ protected:
 private:
   elxOverrideGetSelfMacro;
 
-  const Self &
-  GetAsCombinationTransform(void) const override
-  {
-    return *this;
-  }
-
-  Self &
-  GetAsCombinationTransform(void) override
-  {
-    return *this;
-  }
-
   /** Creates a map of the parameters specific for this (derived) transform type. */
   ParameterMapType
   CreateDerivedTransformParametersMap(void) const override;

--- a/Components/Transforms/TranslationStackTransform/elxTranslationStackTransform.h
+++ b/Components/Transforms/TranslationStackTransform/elxTranslationStackTransform.h
@@ -153,6 +153,8 @@ protected:
   ~TranslationStackTransform() override = default;
 
 private:
+  elxOverrideGetSelfMacro;
+
   const Self &
   GetAsCombinationTransform(void) const override
   {

--- a/Components/Transforms/TranslationTransform/elxTranslationTransform.h
+++ b/Components/Transforms/TranslationTransform/elxTranslationTransform.h
@@ -146,18 +146,6 @@ protected:
 private:
   elxOverrideGetSelfMacro;
 
-  const Self &
-  GetAsCombinationTransform(void) const override
-  {
-    return *this;
-  }
-
-  Self &
-  GetAsCombinationTransform(void) override
-  {
-    return *this;
-  }
-
   /** Creates a map of the parameters specific for this (derived) transform type. */
   ParameterMapType
   CreateDerivedTransformParametersMap(void) const override;

--- a/Components/Transforms/TranslationTransform/elxTranslationTransform.h
+++ b/Components/Transforms/TranslationTransform/elxTranslationTransform.h
@@ -144,6 +144,8 @@ protected:
   TranslationTransformPointer m_TranslationTransform;
 
 private:
+  elxOverrideGetSelfMacro;
+
   const Self &
   GetAsCombinationTransform(void) const override
   {

--- a/Components/Transforms/WeightedCombinationTransform/elxWeightedCombinationTransform.h
+++ b/Components/Transforms/WeightedCombinationTransform/elxWeightedCombinationTransform.h
@@ -210,18 +210,6 @@ protected:
 private:
   elxOverrideGetSelfMacro;
 
-  const Self &
-  GetAsCombinationTransform(void) const override
-  {
-    return *this;
-  }
-
-  Self &
-  GetAsCombinationTransform(void) override
-  {
-    return *this;
-  }
-
   /** Creates a map of the parameters specific for this (derived) transform type. */
   ParameterMapType
   CreateDerivedTransformParametersMap(void) const override;

--- a/Components/Transforms/WeightedCombinationTransform/elxWeightedCombinationTransform.h
+++ b/Components/Transforms/WeightedCombinationTransform/elxWeightedCombinationTransform.h
@@ -208,6 +208,8 @@ protected:
   std::vector<std::string>            m_SubTransformFileNames;
 
 private:
+  elxOverrideGetSelfMacro;
+
   const Self &
   GetAsCombinationTransform(void) const override
   {

--- a/Core/ComponentBaseClasses/elxFixedImagePyramidBase.h
+++ b/Core/ComponentBaseClasses/elxFixedImagePyramidBase.h
@@ -83,19 +83,19 @@ public:
   /** Typedef's from ITKBaseType. */
   typedef typename ITKBaseType::ScheduleType ScheduleType;
 
-  /** Cast to ITKBaseType. */
-  virtual ITKBaseType *
+  /** Retrieves this object as ITKBaseType. */
+  ITKBaseType *
   GetAsITKBaseType(void)
   {
-    return dynamic_cast<ITKBaseType *>(this);
+    return &(this->GetSelf());
   }
 
 
-  /** Cast to ITKBaseType, to use in const functions. */
-  virtual const ITKBaseType *
+  /** Retrieves this object as ITKBaseType, to use in const functions. */
+  const ITKBaseType *
   GetAsITKBaseType(void) const
   {
-    return dynamic_cast<const ITKBaseType *>(this);
+    return &(this->GetSelf());
   }
 
 

--- a/Core/ComponentBaseClasses/elxFixedImagePyramidBase.h
+++ b/Core/ComponentBaseClasses/elxFixedImagePyramidBase.h
@@ -127,6 +127,8 @@ protected:
   ~FixedImagePyramidBase() override = default;
 
 private:
+  elxDeclarePureVirtualGetSelfMacro(ITKBaseType);
+
   /** The deleted copy constructor. */
   FixedImagePyramidBase(const Self &) = delete;
   /** The deleted assignment operator. */

--- a/Core/ComponentBaseClasses/elxImageSamplerBase.h
+++ b/Core/ComponentBaseClasses/elxImageSamplerBase.h
@@ -95,6 +95,8 @@ protected:
   ~ImageSamplerBase() override = default;
 
 private:
+  elxDeclarePureVirtualGetSelfMacro(ITKBaseType);
+
   /** The deleted copy constructor. */
   ImageSamplerBase(const Self &) = delete;
   /** The deleted assignment operator. */

--- a/Core/ComponentBaseClasses/elxImageSamplerBase.h
+++ b/Core/ComponentBaseClasses/elxImageSamplerBase.h
@@ -65,19 +65,19 @@ public:
   /** ITKBaseType. */
   typedef itk::ImageSamplerBase<InputImageType> ITKBaseType;
 
-  /** Cast to ITKBaseType. */
-  virtual ITKBaseType *
+  /** Retrieves this object as ITKBaseType. */
+  ITKBaseType *
   GetAsITKBaseType(void)
   {
-    return dynamic_cast<ITKBaseType *>(this);
+    return &(this->GetSelf());
   }
 
 
-  /** Cast to ITKBaseType, to use in const functions. */
-  virtual const ITKBaseType *
+  /** Retrieves this object as ITKBaseType, to use in const functions. */
+  const ITKBaseType *
   GetAsITKBaseType(void) const
   {
-    return dynamic_cast<const ITKBaseType *>(this);
+    return &(this->GetSelf());
   }
 
 

--- a/Core/ComponentBaseClasses/elxInterpolatorBase.h
+++ b/Core/ComponentBaseClasses/elxInterpolatorBase.h
@@ -89,6 +89,8 @@ protected:
   ~InterpolatorBase() override = default;
 
 private:
+  elxDeclarePureVirtualGetSelfMacro(ITKBaseType);
+
   /** The deleted copy constructor. */
   InterpolatorBase(const Self &) = delete;
   /** The deleted assignment operator. */

--- a/Core/ComponentBaseClasses/elxInterpolatorBase.h
+++ b/Core/ComponentBaseClasses/elxInterpolatorBase.h
@@ -66,19 +66,19 @@ public:
   /** ITKBaseType. */
   typedef itk::InterpolateImageFunction<InputImageType, CoordRepType> ITKBaseType;
 
-  /** Cast to ITKBaseType. */
-  virtual ITKBaseType *
+  /** Retrieves this object as ITKBaseType. */
+  ITKBaseType *
   GetAsITKBaseType(void)
   {
-    return dynamic_cast<ITKBaseType *>(this);
+    return &(this->GetSelf());
   }
 
 
-  /** Cast to ITKBaseType, to use in const functions. */
-  virtual const ITKBaseType *
+  /** Retrieves this object as ITKBaseType, to use in const functions. */
+  const ITKBaseType *
   GetAsITKBaseType(void) const
   {
-    return dynamic_cast<const ITKBaseType *>(this);
+    return &(this->GetSelf());
   }
 
 

--- a/Core/ComponentBaseClasses/elxMetricBase.h
+++ b/Core/ComponentBaseClasses/elxMetricBase.h
@@ -132,19 +132,19 @@ public:
   /** Return type of GetValue */
   typedef typename ITKBaseType::MeasureType MeasureType;
 
-  /** Cast to ITKBaseType. */
-  virtual ITKBaseType *
+  /** Retrieves this object as ITKBaseType. */
+  ITKBaseType *
   GetAsITKBaseType(void)
   {
-    return dynamic_cast<ITKBaseType *>(this);
+    return &(this->GetSelf());
   }
 
 
-  /** Cast to ITKBaseType, to use in const functions. */
-  virtual const ITKBaseType *
+  /** Retrieves this object as ITKBaseType, to use in const functions. */
+  const ITKBaseType *
   GetAsITKBaseType(void) const
   {
-    return dynamic_cast<const ITKBaseType *>(this);
+    return &(this->GetSelf());
   }
 
 

--- a/Core/ComponentBaseClasses/elxMetricBase.h
+++ b/Core/ComponentBaseClasses/elxMetricBase.h
@@ -236,6 +236,8 @@ protected:
   unsigned int                     m_ExactMetricEachXNumberOfIterations;
 
 private:
+  elxDeclarePureVirtualGetSelfMacro(ITKBaseType);
+
   /** The deleted copy constructor. */
   MetricBase(const Self &) = delete;
   /** The deleted assignment operator. */

--- a/Core/ComponentBaseClasses/elxMovingImagePyramidBase.h
+++ b/Core/ComponentBaseClasses/elxMovingImagePyramidBase.h
@@ -129,6 +129,8 @@ protected:
   ~MovingImagePyramidBase() override = default;
 
 private:
+  elxDeclarePureVirtualGetSelfMacro(ITKBaseType);
+
   /** The deleted copy constructor. */
   MovingImagePyramidBase(const Self &) = delete;
   /** The deleted assignment operator. */

--- a/Core/ComponentBaseClasses/elxMovingImagePyramidBase.h
+++ b/Core/ComponentBaseClasses/elxMovingImagePyramidBase.h
@@ -85,19 +85,19 @@ public:
   /** Typedef's from ITKBaseType. */
   typedef typename ITKBaseType::ScheduleType ScheduleType;
 
-  /** Cast to ITKBaseType. */
-  virtual ITKBaseType *
+  /** Retrieves this object as ITKBaseType. */
+  ITKBaseType *
   GetAsITKBaseType(void)
   {
-    return dynamic_cast<ITKBaseType *>(this);
+    return &(this->GetSelf());
   }
 
 
-  /** Cast to ITKBaseType, to use in const functions. */
-  virtual const ITKBaseType *
+  /** Retrieves this object as ITKBaseType, to use in const functions. */
+  const ITKBaseType *
   GetAsITKBaseType(void) const
   {
-    return dynamic_cast<const ITKBaseType *>(this);
+    return &(this->GetSelf());
   }
 
 

--- a/Core/ComponentBaseClasses/elxOptimizerBase.h
+++ b/Core/ComponentBaseClasses/elxOptimizerBase.h
@@ -74,19 +74,19 @@ public:
   /** Typedef needed for the SetCurrentPositionPublic function. */
   typedef typename ITKBaseType::ParametersType ParametersType;
 
-  /** Cast to ITKBaseType. */
-  virtual ITKBaseType *
+  /** Retrieves this object as ITKBaseType. */
+  ITKBaseType *
   GetAsITKBaseType(void)
   {
-    return dynamic_cast<ITKBaseType *>(this);
+    return &(this->GetSelf());
   }
 
 
-  /** Cast to ITKBaseType, to use in const functions. */
-  virtual const ITKBaseType *
+  /** Retrieves this object as ITKBaseType, to use in const functions. */
+  const ITKBaseType *
   GetAsITKBaseType(void) const
   {
-    return dynamic_cast<const ITKBaseType *>(this);
+    return &(this->GetSelf());
   }
 
 

--- a/Core/ComponentBaseClasses/elxOptimizerBase.h
+++ b/Core/ComponentBaseClasses/elxOptimizerBase.h
@@ -129,6 +129,8 @@ protected:
   GetNewSamplesEveryIteration(void) const;
 
 private:
+  elxDeclarePureVirtualGetSelfMacro(ITKBaseType);
+
   /** The deleted copy constructor. */
   OptimizerBase(const Self &) = delete;
   /** The deleted assignment operator. */

--- a/Core/ComponentBaseClasses/elxRegistrationBase.h
+++ b/Core/ComponentBaseClasses/elxRegistrationBase.h
@@ -105,19 +105,19 @@ public:
   /** Typedef for mask erosion options */
   typedef std::vector<bool> UseMaskErosionArrayType;
 
-  /** Cast to ITKBaseType. */
-  virtual ITKBaseType *
+  /** Retrieves this object as ITKBaseType. */
+  ITKBaseType *
   GetAsITKBaseType(void)
   {
-    return dynamic_cast<ITKBaseType *>(this);
+    return &(this->GetSelf());
   }
 
 
-  /** Cast to ITKBaseType, to use in const functions. */
-  virtual const ITKBaseType *
+  /** Retrieves this object as ITKBaseType, to use in const functions. */
+  const ITKBaseType *
   GetAsITKBaseType(void) const
   {
-    return dynamic_cast<const ITKBaseType *>(this);
+    return &(this->GetSelf());
   }
 
 

--- a/Core/ComponentBaseClasses/elxRegistrationBase.h
+++ b/Core/ComponentBaseClasses/elxRegistrationBase.h
@@ -210,6 +210,8 @@ protected:
                                   unsigned int                   level) const;
 
 private:
+  elxDeclarePureVirtualGetSelfMacro(ITKBaseType);
+
   /** The deleted copy constructor. */
   RegistrationBase(const Self &) = delete;
   /** The deleted assignment operator. */

--- a/Core/ComponentBaseClasses/elxResampleInterpolatorBase.h
+++ b/Core/ComponentBaseClasses/elxResampleInterpolatorBase.h
@@ -68,19 +68,19 @@ public:
   /** Typedef that is used in the elastix dll version. */
   typedef typename ElastixType::ParameterMapType ParameterMapType;
 
-  /** Cast ti ITKBaseType. */
-  virtual ITKBaseType *
+  /** Retrieves this object as ITKBaseType. */
+  ITKBaseType *
   GetAsITKBaseType(void)
   {
-    return dynamic_cast<ITKBaseType *>(this);
+    return &(this->GetSelf());
   }
 
 
-  /** Cast to ITKBaseType, to use in const functions. */
-  virtual const ITKBaseType *
+  /** Retrieves this object as ITKBaseType, to use in const functions. */
+  const ITKBaseType *
   GetAsITKBaseType(void) const
   {
-    return dynamic_cast<const ITKBaseType *>(this);
+    return &(this->GetSelf());
   }
 
 

--- a/Core/ComponentBaseClasses/elxResampleInterpolatorBase.h
+++ b/Core/ComponentBaseClasses/elxResampleInterpolatorBase.h
@@ -112,6 +112,8 @@ protected:
   ~ResampleInterpolatorBase() override = default;
 
 private:
+  elxDeclarePureVirtualGetSelfMacro(ITKBaseType);
+
   virtual ParameterMapType
   CreateDerivedTransformParametersMap() const
   {

--- a/Core/ComponentBaseClasses/elxResamplerBase.h
+++ b/Core/ComponentBaseClasses/elxResamplerBase.h
@@ -117,19 +117,19 @@ public:
   /** Get the ImageDimension. */
   itkStaticConstMacro(ImageDimension, unsigned int, OutputImageType::ImageDimension);
 
-  /** Cast to ITKBaseType. */
-  virtual ITKBaseType *
+  /** Retrieves this object as ITKBaseType. */
+  ITKBaseType *
   GetAsITKBaseType(void)
   {
-    return dynamic_cast<ITKBaseType *>(this);
+    return &(this->GetSelf());
   }
 
 
-  /** Cast to ITKBaseType, to use in const functions. */
-  virtual const ITKBaseType *
+  /** Retrieves this object as ITKBaseType, to use in const functions. */
+  const ITKBaseType *
   GetAsITKBaseType(void) const
   {
-    return dynamic_cast<const ITKBaseType *>(this);
+    return &(this->GetSelf());
   }
 
 

--- a/Core/ComponentBaseClasses/elxResamplerBase.h
+++ b/Core/ComponentBaseClasses/elxResamplerBase.h
@@ -207,6 +207,8 @@ protected:
   bool m_ShowProgress;
 
 private:
+  elxDeclarePureVirtualGetSelfMacro(ITKBaseType);
+
   virtual ParameterMapType
   CreateDerivedTransformParametersMap() const
   {

--- a/Core/ComponentBaseClasses/elxTransformBase.h
+++ b/Core/ComponentBaseClasses/elxTransformBase.h
@@ -300,12 +300,6 @@ private:
   void
   ReadInitialTransformFromConfiguration(const Configuration::Pointer);
 
-  virtual const CombinationTransformType &
-  GetAsCombinationTransform(void) const = 0;
-
-  virtual CombinationTransformType &
-  GetAsCombinationTransform(void) = 0;
-
   /** Execute stuff before everything else:
    * \li Check the appearance of an initial transform.
    */

--- a/Core/ComponentBaseClasses/elxTransformBase.h
+++ b/Core/ComponentBaseClasses/elxTransformBase.h
@@ -296,6 +296,8 @@ protected:
   AutomaticScalesEstimationStackTransform(const unsigned int & numSubTransforms, ScalesType & scales) const;
 
 private:
+  elxDeclarePureVirtualGetSelfMacro(ITKBaseType);
+
   /** Function to read the initial transform parameters from the specified configuration object.
    */
   void

--- a/Core/ComponentBaseClasses/elxTransformBase.h
+++ b/Core/ComponentBaseClasses/elxTransformBase.h
@@ -169,12 +169,9 @@ public:
 
   /** Other typedef's. */
   typedef itk::Object ObjectType;
-  typedef itk::AdvancedTransform<CoordRepType,
-                                 itkGetStaticConstMacro(FixedImageDimension),
-                                 itkGetStaticConstMacro(MovingImageDimension)>
-    ITKBaseType;
   typedef itk::AdvancedCombinationTransform<CoordRepType, itkGetStaticConstMacro(FixedImageDimension)>
                                                                   CombinationTransformType;
+  typedef CombinationTransformType                                ITKBaseType;
   typedef typename CombinationTransformType::InitialTransformType InitialTransformType;
 
   /** Typedef's for parameters. */

--- a/Core/ComponentBaseClasses/elxTransformBase.h
+++ b/Core/ComponentBaseClasses/elxTransformBase.h
@@ -197,19 +197,19 @@ public:
   /** Typedef that is used in the elastix dll version. */
   typedef typename TElastix::ParameterMapType ParameterMapType;
 
-  /** Cast to ITKBaseType. */
+  /** Retrieves this object as ITKBaseType. */
   ITKBaseType *
   GetAsITKBaseType(void)
   {
-    return &(this->GetAsCombinationTransform());
+    return &(this->GetSelf());
   }
 
 
-  /** Cast to ITKBaseType, to use in const functions. */
+  /** Retrieves this object as ITKBaseType, to use in const functions. */
   const ITKBaseType *
   GetAsITKBaseType(void) const
   {
-    return &(this->GetAsCombinationTransform());
+    return &(this->GetSelf());
   }
 
   /** Execute stuff before the actual transformation:

--- a/Core/ComponentBaseClasses/elxTransformBase.hxx
+++ b/Core/ComponentBaseClasses/elxTransformBase.hxx
@@ -217,7 +217,7 @@ TransformBase<TElastix>::BeforeRegistrationBase(void)
   std::string howToCombineTransforms = "Compose";
   this->m_Configuration->ReadParameter(howToCombineTransforms, "HowToCombineTransforms", 0, false);
 
-  this->GetAsCombinationTransform().SetUseComposition(howToCombineTransforms == "Compose");
+  this->GetAsITKBaseType()->SetUseComposition(howToCombineTransforms == "Compose");
 
   /** Set the initial transform. Elastix returns an itk::Object, so try to
    * cast it to an InitialTransformType, which is of type itk::Transform.
@@ -259,7 +259,7 @@ template <class TElastix>
 const typename TransformBase<TElastix>::InitialTransformType *
 TransformBase<TElastix>::GetInitialTransform(void) const
 {
-  return this->GetAsCombinationTransform().GetInitialTransform();
+  return this->GetAsITKBaseType()->GetInitialTransform();
 
 } // end GetInitialTransform()
 
@@ -273,7 +273,7 @@ void
 TransformBase<TElastix>::SetInitialTransform(InitialTransformType * _arg)
 {
   /** Set initial transform. */
-  this->GetAsCombinationTransform().SetInitialTransform(_arg);
+  this->GetAsITKBaseType()->SetInitialTransform(_arg);
 
   // \todo AdvancedCombinationTransformType
 
@@ -450,7 +450,7 @@ TransformBase<TElastix>::ReadFromFile(void)
   /** Convert 'this' to a pointer to a CombinationTransform and set how
    * to combine the current transform with the initial transform.
    */
-  this->GetAsCombinationTransform().SetUseComposition(howToCombineTransforms == "Compose");
+  this->GetAsITKBaseType()->SetUseComposition(howToCombineTransforms == "Compose");
 
   /** Task 4 - Remember the name of the TransformParametersFileName.
    * This will be needed when another transform will use this transform
@@ -621,7 +621,7 @@ TransformBase<TElastix>::CreateTransformParametersMap(const ParametersType & par
   const auto & elastixObject = *(this->GetElastix());
 
   /** The way Transforms are combined. */
-  const auto combinationMethod = this->GetAsCombinationTransform().GetUseAddition() ? "Add" : "Compose";
+  const auto combinationMethod = this->GetAsITKBaseType()->GetUseAddition() ? "Add" : "Compose";
 
   /** Write image pixel types. */
   std::string fixpix = "float";
@@ -1009,7 +1009,7 @@ TransformBase<TElastix>::TransformPointsSomePointsVTK(const std::string & filena
   /** Apply the transform. */
   elxout << "  The input points are transformed." << std::endl;
   const auto meshTransformer = TransformMeshFilterType::New();
-  meshTransformer->SetTransform(&const_cast<CombinationTransformType &>(this->GetAsCombinationTransform()));
+  meshTransformer->SetTransform(const_cast<CombinationTransformType *>(this->GetAsITKBaseType()));
   meshTransformer->SetInput(meshReader->GetOutput());
   try
   {
@@ -1373,7 +1373,7 @@ TransformBase<TElastix>::SetTransformParametersFileName(const char * filename)
   {
     this->m_TransformParametersFileName = "";
   }
-  this->GetAsCombinationTransform().Modified();
+  this->GetAsITKBaseType()->Modified();
 
 } // end SetTransformParametersFileName()
 
@@ -1390,7 +1390,7 @@ TransformBase<TElastix>::SetReadWriteTransformParameters(const bool _arg)
   if (this->m_ReadWriteTransformParameters != _arg)
   {
     this->m_ReadWriteTransformParameters = _arg;
-    this->GetAsCombinationTransform().Modified();
+    this->GetAsITKBaseType()->Modified();
   }
 
 } // end SetReadWriteTransformParameters()

--- a/Core/Install/elxMacro.h
+++ b/Core/Install/elxMacro.h
@@ -302,6 +302,22 @@
 #define elxOverrideGetConstMacro(name, type)                                                                           \
   type Get##name() const override { return this->m_##name; }
 
+/** Declares a pair of pure virtual member functions (overloaded for const
+ * and non-const) to get a reference to itself, of the specified type.
+ */
+#define elxDeclarePureVirtualGetSelfMacro(type)                                                                        \
+  virtual const type & GetSelf(void) const = 0;                                                                        \
+  virtual type &       GetSelf(void) = 0
+
+/** Defines a pair of overrides of GetSelf(void) (overloaded for const and
+ * non-const), which return a reference to itself. Declares a deleted static
+ * member function overload, just to allow macro calls to end with a semicolon.
+ */
+#define elxOverrideGetSelfMacro                                                                                        \
+  auto GetSelf(void) const->decltype(*this) override { return *this; }                                                 \
+  auto GetSelf(void)->decltype(*this) override { return *this; }                                                       \
+  static void                         GetSelf(const void *) = delete
+
 
 /**
  *  elxout


### PR DESCRIPTION
Added pure virtual `GetSelf()` member functions to each of the ten component base classes, returning a reference to their `ITKBaseType`. Implemented by the added macro's, `elxDeclarePureVirtualGetSelfMacro(type)` and `elxOverrideGetSelfMacro`.

Replaced `dynamic_cast`s from all `GetAsITKBaseType()` member functions by `this->GetSelf()` calls.

The main aim of this pull request is to avoid MacOS segfaults like the ones mentioned by Matt McCormick (@thewtex), issue #411, "elastix::TransformBase itk::Object casting".

This pull request supersedes pull request https://github.com/SuperElastix/elastix/pull/420 commit 6fcd90348664c4a477a73552194592de014c02a5 ("BUG: Replace dynamic_cast's TransformBase by GetAsCombinationTransform()"), which only addressed the issue for `TransformBase` (whereas this new pull request addresses the issue for all of the elastix component base classes). 