### PR TITLE
ENH: Replace itkGPUKernelClassMacro calls by GetOpenCLSourceOf functions

### DIFF
--- a/CMake/elastixOpenCL.cmake
+++ b/CMake/elastixOpenCL.cmake
@@ -73,7 +73,7 @@ macro(write_opencl_kernel_to_file _opencl_file _src_var _group_name)
   set(${kernel_cxx_class_name}_KernelString
     "${${kernel_cxx_class_name}_KernelString}{\n\n")
   set(${kernel_cxx_class_name}_KernelString
-    "${${kernel_cxx_class_name}_KernelString}const char* ${kernel_cxx_class_name}::GetOpenCLSource()\n")
+    "${${kernel_cxx_class_name}_KernelString}const char* GetOpenCLSourceOf${kernel_cxx_class_name}()\n")
   set(${kernel_cxx_class_name}_KernelString
     "${${kernel_cxx_class_name}_KernelString}{\n")
 
@@ -142,7 +142,7 @@ macro(write_opencl_kernels_to_file _opencl_files _merge_to _src_var _group_name)
 
     # add const char* ${kernel_cxx_class_name}::GetOpenCLSource() here
     set(${OpenCLFileName}_KernelString
-      "${${OpenCLFileName}_KernelString}const char* ${OpenCLFileName}Kernel::GetOpenCLSource()\n")
+      "${${OpenCLFileName}_KernelString}const char* GetOpenCLSourceOf${kernel_cxx_class_name}()\n")
     set(${OpenCLFileName}_KernelString
       "${${OpenCLFileName}_KernelString}{\n")
 

--- a/Common/OpenCL/Filters/itkGPUBSplineBaseTransform.h
+++ b/Common/OpenCL/Filters/itkGPUBSplineBaseTransform.h
@@ -24,8 +24,9 @@
 
 namespace itk
 {
-/** Create a helper GPU Kernel class for GPUBSplineTransform */
-itkGPUKernelClassMacro(GPUBSplineTransformKernel);
+/** Returns the OpenCL source code for GPUBSplineTransform */
+const char *
+GetOpenCLSourceOfGPUBSplineTransformKernel();
 
 /** \class GPUBSplineBaseTransform
  * \brief GPU base class for the BSplineTransform.

--- a/Common/OpenCL/Filters/itkGPUBSplineBaseTransform.hxx
+++ b/Common/OpenCL/Filters/itkGPUBSplineBaseTransform.hxx
@@ -31,7 +31,7 @@ GPUBSplineBaseTransform<TScalarType, NDimensions>::GPUBSplineBaseTransform()
   this->m_SplineOrder = 3;
 
   // Add GPUBSplineTransform source
-  const std::string sourcePath(GPUBSplineTransformKernel::GetOpenCLSource());
+  const std::string sourcePath(GetOpenCLSourceOfGPUBSplineTransformKernel());
   this->m_Sources.push_back(sourcePath);
 }
 

--- a/Common/OpenCL/Filters/itkGPUBSplineDecompositionImageFilter.h
+++ b/Common/OpenCL/Filters/itkGPUBSplineDecompositionImageFilter.h
@@ -23,8 +23,9 @@
 
 namespace itk
 {
-/** Create a helper GPU Kernel class for GPUBSplineDecompositionImageFilter */
-itkGPUKernelClassMacro(GPUBSplineDecompositionImageFilterKernel);
+/** Returns the OpenCL source code for GPUBSplineDecompositionImageFilter */
+const char *
+GetOpenCLSourceOfGPUBSplineDecompositionImageFilterKernel();
 
 /** \class GPUBSplineDecompositionImageFilter
  * \brief GPU version of BSplineDecompositionImageFilter.

--- a/Common/OpenCL/Filters/itkGPUBSplineDecompositionImageFilter.hxx
+++ b/Common/OpenCL/Filters/itkGPUBSplineDecompositionImageFilter.hxx
@@ -64,7 +64,7 @@ GPUBSplineDecompositionImageFilter<TInputImage, TOutputImage>::GPUBSplineDecompo
   GetTypenameInString(typeid(typename TOutputImage::PixelType), defines);
 
   // OpenCL kernel source
-  const char * GPUSource = GPUBSplineDecompositionImageFilterKernel::GetOpenCLSource();
+  const char * GPUSource = GetOpenCLSourceOfGPUBSplineDecompositionImageFilterKernel();
   // Build and create kernel
   OpenCLProgram program = this->m_GPUKernelManager->BuildProgramFromSourceCode(GPUSource, defines.str());
   if (!program.IsNull())

--- a/Common/OpenCL/Filters/itkGPUBSplineInterpolateImageFunction.h
+++ b/Common/OpenCL/Filters/itkGPUBSplineInterpolateImageFunction.h
@@ -27,8 +27,9 @@
 
 namespace itk
 {
-/** Create a helper GPU Kernel class for GPUBSplineInterpolateImageFunction */
-itkGPUKernelClassMacro(GPUBSplineInterpolateImageFunctionKernel);
+/** Returns the OpenCL source code for GPUBSplineInterpolateImageFunction */
+const char *
+GetOpenCLSourceOfGPUBSplineInterpolateImageFunctionKernel();
 
 /** \class GPUBSplineInterpolateImageFunction
  * \brief GPU version of BSplineInterpolateImageFunction.

--- a/Common/OpenCL/Filters/itkGPUBSplineInterpolateImageFunction.hxx
+++ b/Common/OpenCL/Filters/itkGPUBSplineInterpolateImageFunction.hxx
@@ -32,11 +32,11 @@ GPUBSplineInterpolateImageFunction<TInputImage, TCoordRep, TCoefficientType>::GP
   this->m_GPUCoefficientsImageBase = GPUDataManager::New();
 
   // Add GPUImageFunction implementation
-  const std::string sourcePath0(GPUImageFunctionKernel::GetOpenCLSource());
+  const std::string sourcePath0(GetOpenCLSourceOfGPUImageFunctionKernel());
   this->m_Sources.push_back(sourcePath0);
 
   // Add GPUBSplineInterpolateImageFunction implementation
-  const std::string sourcePath1(GPUBSplineInterpolateImageFunctionKernel::GetOpenCLSource());
+  const std::string sourcePath1(GetOpenCLSourceOfGPUBSplineInterpolateImageFunctionKernel());
   this->m_Sources.push_back(sourcePath1);
 }
 

--- a/Common/OpenCL/Filters/itkGPUCastImageFilter.h
+++ b/Common/OpenCL/Filters/itkGPUCastImageFilter.h
@@ -27,8 +27,9 @@
 
 namespace itk
 {
-/** Create a helper GPU Kernel class for GPUCastImageFilter */
-itkGPUKernelClassMacro(GPUCastImageFilterKernel);
+/** Returns the OpenCL source code for GPUCastImageFilter */
+const char *
+GetOpenCLSourceOfGPUCastImageFilterKernel();
 
 /** \class GPUCastImageFilter
  * \brief GPU version of CastImageFilter.

--- a/Common/OpenCL/Filters/itkGPUCastImageFilter.hxx
+++ b/Common/OpenCL/Filters/itkGPUCastImageFilter.hxx
@@ -43,7 +43,7 @@ GPUCastImageFilter<TInputImage, TOutputImage>::GPUCastImageFilter()
   GetTypenameInString(typeid(typename TOutputImage::PixelType), defines);
 
   // OpenCL kernel source
-  const char * GPUSource = GPUCastImageFilterKernel::GetOpenCLSource();
+  const char * GPUSource = GetOpenCLSourceOfGPUCastImageFilterKernel();
   // Build and create kernel
   const OpenCLProgram program = this->m_GPUKernelManager->BuildProgramFromSourceCode(GPUSource, defines.str());
   if (!program.IsNull())

--- a/Common/OpenCL/Filters/itkGPUIdentityTransform.h
+++ b/Common/OpenCL/Filters/itkGPUIdentityTransform.h
@@ -25,8 +25,9 @@
 
 namespace itk
 {
-/** Create a helper GPU Kernel class for GPUIdentityTransform */
-itkGPUKernelClassMacro(GPUIdentityTransformKernel);
+/** Returns the OpenCL source code for GPUIdentityTransform */
+const char *
+GetOpenCLSourceOfGPUIdentityTransformKernel();
 
 /** \class GPUIdentityTransform
  * \brief GPU version of IdentityTransform.

--- a/Common/OpenCL/Filters/itkGPUIdentityTransform.hxx
+++ b/Common/OpenCL/Filters/itkGPUIdentityTransform.hxx
@@ -28,7 +28,7 @@ template <typename TScalarType, unsigned int NDimensions, typename TParentTransf
 GPUIdentityTransform<TScalarType, NDimensions, TParentTransform>::GPUIdentityTransform()
 {
   // Add GPUIdentityTransform source
-  const std::string sourcePath(GPUIdentityTransformKernel::GetOpenCLSource());
+  const std::string sourcePath(GetOpenCLSourceOfGPUIdentityTransformKernel());
   this->m_Sources.push_back(sourcePath);
 }
 

--- a/Common/OpenCL/Filters/itkGPUImageBase.h
+++ b/Common/OpenCL/Filters/itkGPUImageBase.h
@@ -34,8 +34,9 @@ namespace itk
  * \ingroup GPUCommon
  */
 
-/** Create a helper GPU Kernel class for itkGPUImageBase */
-itkGPUKernelClassMacro(GPUImageBaseKernel);
+/** Returns the OpenCL source code for itkGPUImageBase */
+const char *
+GetOpenCLSourceOfGPUImageBaseKernel();
 } // end namespace itk
 
 #endif /* itkGPUImageBase_h */

--- a/Common/OpenCL/Filters/itkGPUImageFunction.h
+++ b/Common/OpenCL/Filters/itkGPUImageFunction.h
@@ -34,8 +34,9 @@ namespace itk
  * \ingroup GPUCommon
  */
 
-/** Create a helper GPU Kernel class for itkGPUImageFunction */
-itkGPUKernelClassMacro(GPUImageFunctionKernel);
+/** Returns the OpenCL source code for itkGPUImageFunction */
+const char *
+GetOpenCLSourceOfGPUImageFunctionKernel();
 } // end namespace itk
 
 #endif /* itkGPUImageFunction_h */

--- a/Common/OpenCL/Filters/itkGPULinearInterpolateImageFunction.h
+++ b/Common/OpenCL/Filters/itkGPULinearInterpolateImageFunction.h
@@ -26,8 +26,9 @@
 
 namespace itk
 {
-/** Create a helper GPU Kernel class for GPULinearInterpolateImageFunction */
-itkGPUKernelClassMacro(GPULinearInterpolateImageFunctionKernel);
+/** Returns the OpenCL source code for GPULinearInterpolateImageFunction */
+const char *
+GetOpenCLSourceOfGPULinearInterpolateImageFunctionKernel();
 
 /** \class GPULinearInterpolateImageFunction
  * \brief GPU version of LinearInterpolateImageFunction.

--- a/Common/OpenCL/Filters/itkGPULinearInterpolateImageFunction.hxx
+++ b/Common/OpenCL/Filters/itkGPULinearInterpolateImageFunction.hxx
@@ -28,11 +28,11 @@ template <typename TInputImage, typename TCoordRep>
 GPULinearInterpolateImageFunction<TInputImage, TCoordRep>::GPULinearInterpolateImageFunction()
 {
   // Add GPUImageFunction implementation
-  const std::string sourcePath0(GPUImageFunctionKernel::GetOpenCLSource());
+  const std::string sourcePath0(GetOpenCLSourceOfGPUImageFunctionKernel());
   this->m_Sources.push_back(sourcePath0);
 
   // Add GPULinearInterpolateImageFunction implementation
-  const std::string sourcePath1(GPULinearInterpolateImageFunctionKernel::GetOpenCLSource());
+  const std::string sourcePath1(GetOpenCLSourceOfGPULinearInterpolateImageFunctionKernel());
   this->m_Sources.push_back(sourcePath1);
 }
 

--- a/Common/OpenCL/Filters/itkGPUMath.h
+++ b/Common/OpenCL/Filters/itkGPUMath.h
@@ -34,8 +34,9 @@ namespace itk
  * \ingroup GPUCommon
  */
 
-/** Create a helper GPU Kernel class for itkGPUMath */
-itkGPUKernelClassMacro(GPUMathKernel);
+/** Returns the OpenCL source code for itkGPUMath */
+const char *
+GetOpenCLSourceOfGPUMathKernel();
 } // end namespace itk
 
 #endif /* itkGPUMath_h */

--- a/Common/OpenCL/Filters/itkGPUMatrixOffsetTransformBase.h
+++ b/Common/OpenCL/Filters/itkGPUMatrixOffsetTransformBase.h
@@ -23,8 +23,9 @@
 
 namespace itk
 {
-/** Create a helper GPU Kernel class for itkGPUMatrixOffsetTransformBase */
-itkGPUKernelClassMacro(GPUMatrixOffsetTransformBaseKernel);
+/** Returns the OpenCL source code for itkGPUMatrixOffsetTransformBase */
+const char *
+GetOpenCLSourceOfGPUMatrixOffsetTransformBaseKernel();
 
 /** \class GPUMatrixOffsetTransformBase
  * \brief Base version of the GPU MatrixOffsetTransform.

--- a/Common/OpenCL/Filters/itkGPUMatrixOffsetTransformBase.hxx
+++ b/Common/OpenCL/Filters/itkGPUMatrixOffsetTransformBase.hxx
@@ -190,7 +190,7 @@ template <typename TScalarType, unsigned int NInputDimensions, unsigned int NOut
 GPUMatrixOffsetTransformBase<TScalarType, NInputDimensions, NOutputDimensions>::GPUMatrixOffsetTransformBase()
 {
   // Add GPUMatrixOffsetTransformBase source
-  const std::string sourcePath(GPUMatrixOffsetTransformBaseKernel::GetOpenCLSource());
+  const std::string sourcePath(GetOpenCLSourceOfGPUMatrixOffsetTransformBaseKernel());
   this->m_Sources.push_back(sourcePath);
 
   this->m_ParametersDataManager->Initialize();

--- a/Common/OpenCL/Filters/itkGPUNearestNeighborInterpolateImageFunction.h
+++ b/Common/OpenCL/Filters/itkGPUNearestNeighborInterpolateImageFunction.h
@@ -26,8 +26,9 @@
 
 namespace itk
 {
-/** Create a helper GPU Kernel class for GPUNearestNeighborInterpolateImageFunction */
-itkGPUKernelClassMacro(GPUNearestNeighborInterpolateImageFunctionKernel);
+/** Returns the OpenCL source code for GPUNearestNeighborInterpolateImageFunction */
+const char *
+GetOpenCLSourceOfGPUNearestNeighborInterpolateImageFunctionKernel();
 
 /** \class GPUNearestNeighborInterpolateImageFunction
  * \brief GPU version of NearestNeighborInterpolateImageFunction.

--- a/Common/OpenCL/Filters/itkGPUNearestNeighborInterpolateImageFunction.hxx
+++ b/Common/OpenCL/Filters/itkGPUNearestNeighborInterpolateImageFunction.hxx
@@ -28,11 +28,11 @@ template <typename TInputImage, typename TCoordRep>
 GPUNearestNeighborInterpolateImageFunction<TInputImage, TCoordRep>::GPUNearestNeighborInterpolateImageFunction()
 {
   // Add GPUImageFunction implementation
-  const std::string sourcePath0(GPUImageFunctionKernel::GetOpenCLSource());
+  const std::string sourcePath0(GetOpenCLSourceOfGPUImageFunctionKernel());
   this->m_Sources.push_back(sourcePath0);
 
   // Add GPUNearestNeighborInterpolateImageFunction implementation
-  const std::string sourcePath1(GPUNearestNeighborInterpolateImageFunctionKernel::GetOpenCLSource());
+  const std::string sourcePath1(GetOpenCLSourceOfGPUNearestNeighborInterpolateImageFunctionKernel());
   this->m_Sources.push_back(sourcePath1);
 }
 

--- a/Common/OpenCL/Filters/itkGPURecursiveGaussianImageFilter.h
+++ b/Common/OpenCL/Filters/itkGPURecursiveGaussianImageFilter.h
@@ -23,8 +23,9 @@
 
 namespace itk
 {
-/** Create a helper GPU Kernel class for GPURecursiveGaussianImageFilter */
-itkGPUKernelClassMacro(GPURecursiveGaussianImageFilterKernel);
+/** Returns the OpenCL source code for GPURecursiveGaussianImageFilter */
+const char *
+GetOpenCLSourceOfGPURecursiveGaussianImageFilterKernel();
 
 /** \class GPURecursiveGaussianImageFilter
  * \brief GPU version of RecursiveGaussianImageFilter.

--- a/Common/OpenCL/Filters/itkGPURecursiveGaussianImageFilter.hxx
+++ b/Common/OpenCL/Filters/itkGPURecursiveGaussianImageFilter.hxx
@@ -59,7 +59,7 @@ GPURecursiveGaussianImageFilter<TInputImage, TOutputImage>::GPURecursiveGaussian
   GetTypenameInString(typeid(typename TOutputImage::PixelType), defines);
 
   // OpenCL kernel source
-  const char * GPUSource = GPURecursiveGaussianImageFilterKernel::GetOpenCLSource();
+  const char * GPUSource = GetOpenCLSourceOfGPURecursiveGaussianImageFilterKernel();
   // Build and create kernel
   OpenCLProgram program = this->m_GPUKernelManager->BuildProgramFromSourceCode(GPUSource, defines.str());
   if (!program.IsNull())

--- a/Common/OpenCL/Filters/itkGPUResampleImageFilter.h
+++ b/Common/OpenCL/Filters/itkGPUResampleImageFilter.h
@@ -29,8 +29,9 @@
 
 namespace itk
 {
-/** Create a helper GPU Kernel class for GPUResampleImageFilter */
-itkGPUKernelClassMacro(GPUResampleImageFilterKernel);
+/** Returns the OpenCL source code for GPUResampleImageFilter */
+const char *
+GetOpenCLSourceOfGPUResampleImageFilterKernel();
 
 /** \class GPUResampleImageFilter
  * \brief GPU version of ResampleImageFilter.

--- a/Common/OpenCL/Filters/itkGPUResampleImageFilter.hxx
+++ b/Common/OpenCL/Filters/itkGPUResampleImageFilter.hxx
@@ -108,15 +108,15 @@ GPUResampleImageFilter<TInputImage, TOutputImage, TInterpolatorPrecisionType>::G
   this->m_Sources[this->m_SourceIndex++] = defines.str();
 
   // Get GPUMath source
-  const std::string oclMathSource(GPUMathKernel::GetOpenCLSource());
+  const std::string oclMathSource(GetOpenCLSourceOfGPUMathKernel());
   this->m_Sources[this->m_SourceIndex++] = oclMathSource;
 
   // Get GPUImageBase source
-  const std::string oclImageBaseSource(GPUImageBaseKernel::GetOpenCLSource());
+  const std::string oclImageBaseSource(GetOpenCLSourceOfGPUImageBaseKernel());
   this->m_Sources[this->m_SourceIndex++] = oclImageBaseSource;
 
   // Get GPUResampleImageFilter source
-  const std::string oclResampleImageFilterSource(GPUResampleImageFilterKernel::GetOpenCLSource());
+  const std::string oclResampleImageFilterSource(GetOpenCLSourceOfGPUResampleImageFilterKernel());
   this->m_Sources[this->m_SourceIndex++] = oclResampleImageFilterSource;
 
   // Construct ResampleImageFilter Pre code

--- a/Common/OpenCL/Filters/itkGPUShrinkImageFilter.h
+++ b/Common/OpenCL/Filters/itkGPUShrinkImageFilter.h
@@ -26,8 +26,9 @@
 
 namespace itk
 {
-/** Create a helper GPU Kernel class for GPUShrinkImageFilter */
-itkGPUKernelClassMacro(GPUShrinkImageFilterKernel);
+/** Returns the OpenCL source code for GPUShrinkImageFilter */
+const char *
+GetOpenCLSourceOfGPUShrinkImageFilterKernel();
 
 /** \class GPUShrinkImageFilter
  * \brief GPU version of ShrinkImageFilter.

--- a/Common/OpenCL/Filters/itkGPUShrinkImageFilter.hxx
+++ b/Common/OpenCL/Filters/itkGPUShrinkImageFilter.hxx
@@ -44,7 +44,7 @@ GPUShrinkImageFilter<TInputImage, TOutputImage>::GPUShrinkImageFilter()
   GetTypenameInString(typeid(typename TOutputImage::PixelType), defines);
 
   // OpenCL kernel source
-  const char * GPUSource = GPUShrinkImageFilterKernel::GetOpenCLSource();
+  const char * GPUSource = GetOpenCLSourceOfGPUShrinkImageFilterKernel();
   // Build and create kernel
   OpenCLProgram program = this->m_GPUKernelManager->BuildProgramFromSourceCode(GPUSource, defines.str());
   if (!program.IsNull())

--- a/Common/OpenCL/Filters/itkGPUTranslationTransformBase.h
+++ b/Common/OpenCL/Filters/itkGPUTranslationTransformBase.h
@@ -22,8 +22,9 @@
 
 namespace itk
 {
-/** Create a helper GPU Kernel class for itkGPUTranslationTransformBase */
-itkGPUKernelClassMacro(GPUTranslationTransformBaseKernel);
+/** Returns the OpenCL source code for itkGPUTranslationTransformBase */
+const char *
+GetOpenCLSourceOfGPUTranslationTransformBaseKernel();
 
 /** \class GPUTranslationTransformBase
  * \brief Base class for all GPU translation transforms.

--- a/Common/OpenCL/Filters/itkGPUTranslationTransformBase.hxx
+++ b/Common/OpenCL/Filters/itkGPUTranslationTransformBase.hxx
@@ -105,7 +105,7 @@ template <typename TScalarType, unsigned int NDimensions>
 GPUTranslationTransformBase<TScalarType, NDimensions>::GPUTranslationTransformBase()
 {
   // Add GPUTranslationTransformBase source
-  const std::string sourcePath(GPUTranslationTransformBaseKernel::GetOpenCLSource());
+  const std::string sourcePath(GetOpenCLSourceOfGPUTranslationTransformBaseKernel());
   m_Sources.push_back(sourcePath);
 
   this->m_ParametersDataManager->Initialize();

--- a/Testing/itkOpenCLBufferTest.cxx
+++ b/Testing/itkOpenCLBufferTest.cxx
@@ -54,7 +54,7 @@ main(int argc, char * argv[])
     const std::list<itk::OpenCLDevice> devices = context->GetDevices();
 
     itk::OpenCLProgram program =
-      context->BuildProgramFromSourceCode(devices, itk::OpenCLBufferTestKernel::GetOpenCLSource());
+      context->BuildProgramFromSourceCode(devices, itk::GetOpenCLSourceOfOpenCLBufferTestKernel());
 
     if (program.IsNull())
     {

--- a/Testing/itkOpenCLBufferTest.h
+++ b/Testing/itkOpenCLBufferTest.h
@@ -22,8 +22,9 @@
 
 namespace itk
 {
-/** Create a helper GPU Kernel class for OpenCLBufferTest.cl kernel */
-itkGPUKernelClassMacro(OpenCLBufferTestKernel);
+/** Returns the OpenCL source code for OpenCLBufferTest.cl kernel */
+const char *
+GetOpenCLSourceOfOpenCLBufferTestKernel();
 } // end namespace itk
 
 #endif /* itkOpenCLBufferTest_h */

--- a/Testing/itkOpenCLEventTest.cxx
+++ b/Testing/itkOpenCLEventTest.cxx
@@ -58,7 +58,7 @@ main(int argc, char * argv[])
 
     // Create program
     itk::OpenCLProgram program =
-      context->BuildProgramFromSourceCode(context->GetDevices(), itk::OpenCLEventTestKernel::GetOpenCLSource());
+      context->BuildProgramFromSourceCode(context->GetDevices(), itk::GetOpenCLSourceOfOpenCLEventTestKernel());
     if (program.IsNull())
     {
       if (context->GetDefaultDevice().HasCompiler())

--- a/Testing/itkOpenCLEventTest.h
+++ b/Testing/itkOpenCLEventTest.h
@@ -22,8 +22,9 @@
 
 namespace itk
 {
-/** Create a helper GPU Kernel class for OpenCLEventTest.cl kernel */
-itkGPUKernelClassMacro(OpenCLEventTestKernel);
+/** Returns the OpenCL source code for OpenCLEventTest.cl kernel */
+const char *
+GetOpenCLSourceOfOpenCLEventTestKernel();
 } // end namespace itk
 
 #endif /* itkOpenCLEventTest_h */

--- a/Testing/itkOpenCLImageTest.cxx
+++ b/Testing/itkOpenCLImageTest.cxx
@@ -46,7 +46,7 @@ main(int argc, char * argv[])
     const std::list<itk::OpenCLDevice> devices = context->GetDevices();
 
     itk::OpenCLProgram program =
-      context->BuildProgramFromSourceCode(devices, itk::OpenCLImageTestKernel::GetOpenCLSource());
+      context->BuildProgramFromSourceCode(devices, itk::GetOpenCLSourceOfOpenCLImageTestKernel());
 
     if (program.IsNull())
     {

--- a/Testing/itkOpenCLImageTest.h
+++ b/Testing/itkOpenCLImageTest.h
@@ -22,8 +22,9 @@
 
 namespace itk
 {
-/** Create a helper GPU Kernel class for OpenCLImageTest.cl kernel */
-itkGPUKernelClassMacro(OpenCLImageTestKernel);
+/** Returns the OpenCL source code for OpenCLImageTest.cl kernel */
+const char *
+GetOpenCLSourceOfOpenCLImageTestKernel();
 } // end namespace itk
 
 #endif /* itkOpenCLImageTest_h */

--- a/Testing/itkOpenCLKernelToImageBridgeTest.cxx
+++ b/Testing/itkOpenCLKernelToImageBridgeTest.cxx
@@ -29,7 +29,7 @@ main(int argc, char * argv[])
     const std::list<itk::OpenCLDevice> devices = context->GetDevices();
 
     itk::OpenCLProgram program =
-      context->BuildProgramFromSourceCode(devices, itk::OpenCLKernelToImageBridgeTestKernel::GetOpenCLSource());
+      context->BuildProgramFromSourceCode(devices, itk::GetOpenCLSourceOfOpenCLKernelToImageBridgeTestKernel());
 
     if (program.IsNull())
     {

--- a/Testing/itkOpenCLKernelToImageBridgeTest.h
+++ b/Testing/itkOpenCLKernelToImageBridgeTest.h
@@ -22,9 +22,10 @@
 
 namespace itk
 {
-/** Create a helper GPU Kernel class for OpenCLKernelToImageBridgeTest.cl kernel
+/** Returns the OpenCL source code for OpenCLKernelToImageBridgeTest.cl kernel
  */
-itkGPUKernelClassMacro(OpenCLKernelToImageBridgeTestKernel);
+const char *
+GetOpenCLSourceOfOpenCLKernelToImageBridgeTestKernel();
 } // end namespace itk
 
 #endif /* itkOpenCLKernelToImageBridgeTest_h */

--- a/Testing/itkOpenCLSimpleTest.cxx
+++ b/Testing/itkOpenCLSimpleTest.cxx
@@ -33,7 +33,7 @@ main(int argc, char * argv[])
     devices = context->GetDevices();
 
     itk::OpenCLProgram programAllGPU =
-      context->BuildProgramFromSourceCode(devices, itk::OpenCLSimpleTest1Kernel::GetOpenCLSource());
+      context->BuildProgramFromSourceCode(devices, itk::GetOpenCLSourceOfOpenCLSimpleTest1Kernel());
 
     if (context.IsNull())
     {
@@ -52,7 +52,7 @@ main(int argc, char * argv[])
     context->Create(itk::OpenCLContext::SingleMaximumFlopsDevice);
     devices = context->GetDevices();
     itk::OpenCLProgram programMaxFlops =
-      context->BuildProgramFromSourceCode(devices, itk::OpenCLSimpleTest2Kernel::GetOpenCLSource());
+      context->BuildProgramFromSourceCode(devices, itk::GetOpenCLSourceOfOpenCLSimpleTest2Kernel());
 
     if (programMaxFlops.IsNull())
     {

--- a/Testing/itkOpenCLSimpleTest.h
+++ b/Testing/itkOpenCLSimpleTest.h
@@ -22,11 +22,13 @@
 
 namespace itk
 {
-/** Create a helper GPU Kernel class for OpenCLSimpleTest1.cl kernel */
-itkGPUKernelClassMacro(OpenCLSimpleTest1Kernel);
+/** Returns the OpenCL source code for OpenCLSimpleTest1.cl kernel */
+const char *
+GetOpenCLSourceOfOpenCLSimpleTest1Kernel();
 
-/** Create a helper GPU Kernel class for OpenCLSimpleTest2.cl kernel */
-itkGPUKernelClassMacro(OpenCLSimpleTest2Kernel);
+/** Returns the OpenCL source code for OpenCLSimpleTest2.cl kernel */
+const char *
+GetOpenCLSourceOfOpenCLSimpleTest2Kernel();
 } // end namespace itk
 
 #endif /* itkOpenCLSimpleTest_h */

--- a/Testing/itkOpenCLVectorTest.cxx
+++ b/Testing/itkOpenCLVectorTest.cxx
@@ -74,7 +74,7 @@ main(int argc, char * argv[])
     const std::list<itk::OpenCLDevice> devices = context->GetDevices();
 
     itk::OpenCLProgram program =
-      context->BuildProgramFromSourceCode(devices, itk::OpenCLVectorTestKernel::GetOpenCLSource());
+      context->BuildProgramFromSourceCode(devices, itk::GetOpenCLSourceOfOpenCLVectorTestKernel());
 
     if (program.IsNull())
     {

--- a/Testing/itkOpenCLVectorTest.h
+++ b/Testing/itkOpenCLVectorTest.h
@@ -22,8 +22,9 @@
 
 namespace itk
 {
-/** Create a helper GPU Kernel class for OpenCLVectorTest.cl kernel */
-itkGPUKernelClassMacro(OpenCLVectorTestKernel);
+/** Returns the OpenCL source code for OpenCLVectorTest.cl kernel */
+const char *
+GetOpenCLSourceOfOpenCLVectorTestKernel();
 } // end namespace itk
 
 #endif /* itkOpenCLVectorTest_h */


### PR DESCRIPTION
Removed all (n = 22) `itkGPUKernelClassMacro` macro calls, as there is an upcoming breaking change of the macro definition with ITK 5.2 (introduced with ITK v5.2rc01).

Replaced the class definitions that were created by the macro by simple functions of the form `GetOpenCLSourceOf...Kernel()`, which just return the OpenCL source code as a string.

Allows compilation on ITK 5.1.1 and 5.1.2, as well as ITK 5.2.0 (release candidate 1 or 2).