### PR TITLE
Modernize ElastixMain::GetElastixBase(void)

### DIFF
--- a/Core/Kernel/elxElastixMain.cxx
+++ b/Core/Kernel/elxElastixMain.cxx
@@ -348,7 +348,7 @@ ElastixMain::Run(void)
   /** Create a log file. */
   itk::CreateOpenCLLogger("elastix", this->m_Configuration->GetCommandLineArgument("-out"));
 #endif
-  auto & elastixBase = *(this->GetElastixBase());
+  auto & elastixBase = this->GetElastixBase();
 
   /** Set some information in the ElastixBase. */
   elastixBase.SetConfiguration(this->m_Configuration);
@@ -729,19 +729,17 @@ ElastixMain::GetTotalNumberOfElastixLevels(void)
  * ************************* GetElastixBase ***************************
  */
 
-ElastixMain::ElastixBaseType *
+ElastixMain::ElastixBaseType &
 ElastixMain::GetElastixBase(void) const
 {
-  ElastixBaseType * testpointer;
-
   /** Convert ElastixAsObject to a pointer to an ElastixBaseType. */
-  testpointer = dynamic_cast<ElastixBaseType *>(this->m_Elastix.GetPointer());
-  if (!testpointer)
+  const auto testpointer = dynamic_cast<ElastixBaseType *>(this->m_Elastix.GetPointer());
+  if (testpointer == nullptr)
   {
     itkExceptionMacro(<< "Probably GetElastixBase() is called before having called Run()");
   }
 
-  return testpointer;
+  return *testpointer;
 
 } // end GetElastixBase()
 

--- a/Core/Kernel/elxElastixMain.cxx
+++ b/Core/Kernel/elxElastixMain.cxx
@@ -348,39 +348,39 @@ ElastixMain::Run(void)
   /** Create a log file. */
   itk::CreateOpenCLLogger("elastix", this->m_Configuration->GetCommandLineArgument("-out"));
 #endif
+  auto & elastixBase = *(this->GetElastixBase());
 
   /** Set some information in the ElastixBase. */
-  this->GetElastixBase()->SetConfiguration(this->m_Configuration);
-  this->GetElastixBase()->SetDBIndex(this->m_DBIndex);
+  elastixBase.SetConfiguration(this->m_Configuration);
+  elastixBase.SetDBIndex(this->m_DBIndex);
 
   /** Populate the component containers. ImageSampler is not mandatory.
    * No defaults are specified for ImageSampler, Metric, Transform
    * and Optimizer.
    */
-  this->GetElastixBase()->SetRegistrationContainer(
+  elastixBase.SetRegistrationContainer(
     this->CreateComponents("Registration", "MultiResolutionRegistration", errorCode));
 
-  this->GetElastixBase()->SetFixedImagePyramidContainer(
+  elastixBase.SetFixedImagePyramidContainer(
     this->CreateComponents("FixedImagePyramid", "FixedSmoothingImagePyramid", errorCode));
 
-  this->GetElastixBase()->SetMovingImagePyramidContainer(
+  elastixBase.SetMovingImagePyramidContainer(
     this->CreateComponents("MovingImagePyramid", "MovingSmoothingImagePyramid", errorCode));
 
-  this->GetElastixBase()->SetImageSamplerContainer(this->CreateComponents("ImageSampler", "", errorCode, false));
+  elastixBase.SetImageSamplerContainer(this->CreateComponents("ImageSampler", "", errorCode, false));
 
-  this->GetElastixBase()->SetInterpolatorContainer(
-    this->CreateComponents("Interpolator", "BSplineInterpolator", errorCode));
+  elastixBase.SetInterpolatorContainer(this->CreateComponents("Interpolator", "BSplineInterpolator", errorCode));
 
-  this->GetElastixBase()->SetMetricContainer(this->CreateComponents("Metric", "", errorCode));
+  elastixBase.SetMetricContainer(this->CreateComponents("Metric", "", errorCode));
 
-  this->GetElastixBase()->SetOptimizerContainer(this->CreateComponents("Optimizer", "", errorCode));
+  elastixBase.SetOptimizerContainer(this->CreateComponents("Optimizer", "", errorCode));
 
-  this->GetElastixBase()->SetResampleInterpolatorContainer(
+  elastixBase.SetResampleInterpolatorContainer(
     this->CreateComponents("ResampleInterpolator", "FinalBSplineInterpolator", errorCode));
 
-  this->GetElastixBase()->SetResamplerContainer(this->CreateComponents("Resampler", "DefaultResampler", errorCode));
+  elastixBase.SetResamplerContainer(this->CreateComponents("Resampler", "DefaultResampler", errorCode));
 
-  this->GetElastixBase()->SetTransformContainer(this->CreateComponents("Transform", "", errorCode));
+  elastixBase.SetTransformContainer(this->CreateComponents("Transform", "", errorCode));
 
   /** Check if all component could be created. */
   if (errorCode != 0)
@@ -393,24 +393,24 @@ ElastixMain::Run(void)
   /** Set the images and masks. If not set by the user, it is not a problem.
    * ElastixTemplate will try to load them from disk.
    */
-  this->GetElastixBase()->SetFixedImageContainer(this->GetModifiableFixedImageContainer());
-  this->GetElastixBase()->SetMovingImageContainer(this->GetModifiableMovingImageContainer());
-  this->GetElastixBase()->SetFixedMaskContainer(this->GetModifiableFixedMaskContainer());
-  this->GetElastixBase()->SetMovingMaskContainer(this->GetModifiableMovingMaskContainer());
-  this->GetElastixBase()->SetResultImageContainer(this->GetModifiableResultImageContainer());
+  elastixBase.SetFixedImageContainer(this->GetModifiableFixedImageContainer());
+  elastixBase.SetMovingImageContainer(this->GetModifiableMovingImageContainer());
+  elastixBase.SetFixedMaskContainer(this->GetModifiableFixedMaskContainer());
+  elastixBase.SetMovingMaskContainer(this->GetModifiableMovingMaskContainer());
+  elastixBase.SetResultImageContainer(this->GetModifiableResultImageContainer());
 
   /** Set the initial transform, if it happens to be there. */
-  this->GetElastixBase()->SetInitialTransform(this->GetModifiableInitialTransform());
+  elastixBase.SetInitialTransform(this->GetModifiableInitialTransform());
 
   /** Set the original fixed image direction cosines (relevant in case the
    * UseDirectionCosines parameter was set to false.
    */
-  this->GetElastixBase()->SetOriginalFixedImageDirectionFlat(this->GetOriginalFixedImageDirectionFlat());
+  elastixBase.SetOriginalFixedImageDirectionFlat(this->GetOriginalFixedImageDirectionFlat());
 
   /** Run elastix! */
   try
   {
-    errorCode = this->GetElastixBase()->Run();
+    errorCode = elastixBase.Run();
   }
   catch (itk::ExceptionObject & excp1)
   {
@@ -433,21 +433,21 @@ ElastixMain::Run(void)
   }
 
   /** Return the final transform. */
-  this->m_FinalTransform = this->GetElastixBase()->GetFinalTransform();
+  this->m_FinalTransform = elastixBase.GetFinalTransform();
 
   /** Get the transformation parameter map */
-  this->m_TransformParametersMap = this->GetElastixBase()->GetTransformParametersMap();
+  this->m_TransformParametersMap = elastixBase.GetTransformParametersMap();
 
   /** Store the images in ElastixMain. */
-  this->SetFixedImageContainer(this->GetElastixBase()->GetFixedImageContainer());
-  this->SetMovingImageContainer(this->GetElastixBase()->GetMovingImageContainer());
-  this->SetFixedMaskContainer(this->GetElastixBase()->GetFixedMaskContainer());
-  this->SetMovingMaskContainer(this->GetElastixBase()->GetMovingMaskContainer());
-  this->SetResultImageContainer(this->GetElastixBase()->GetResultImageContainer());
+  this->SetFixedImageContainer(elastixBase.GetFixedImageContainer());
+  this->SetMovingImageContainer(elastixBase.GetMovingImageContainer());
+  this->SetFixedMaskContainer(elastixBase.GetFixedMaskContainer());
+  this->SetMovingMaskContainer(elastixBase.GetMovingMaskContainer());
+  this->SetResultImageContainer(elastixBase.GetResultImageContainer());
 
   /** Store the original fixed image direction cosines (relevant in case the
    * UseDirectionCosines parameter was set to false. */
-  this->SetOriginalFixedImageDirectionFlat(this->GetElastixBase()->GetOriginalFixedImageDirectionFlat());
+  this->SetOriginalFixedImageDirectionFlat(elastixBase.GetOriginalFixedImageDirectionFlat());
 
   /** Return a value. */
   return errorCode;

--- a/Core/Kernel/elxElastixMain.h
+++ b/Core/Kernel/elxElastixMain.h
@@ -222,7 +222,7 @@ public:
   /** Convenience function that returns the elastix component as
    * a pointer to an ElastixBaseType. Use only after having called run()!
    */
-  virtual ElastixBaseType *
+  ElastixBaseType &
   GetElastixBase(void) const;
 
   /** Get the final transform (the result of running elastix).

--- a/Core/Kernel/elxTransformixMain.cxx
+++ b/Core/Kernel/elxTransformixMain.cxx
@@ -96,7 +96,7 @@ TransformixMain::Run(void)
   /** Create a log file. */
   itk::CreateOpenCLLogger("transformix", this->m_Configuration->GetCommandLineArgument("-out"));
 #endif
-  auto & elastixBase = *(this->GetElastixBase());
+  auto & elastixBase = this->GetElastixBase();
 
   if (BaseComponent::IsElastixLibrary())
   {

--- a/Core/Kernel/elxTransformixMain.cxx
+++ b/Core/Kernel/elxTransformixMain.cxx
@@ -96,23 +96,24 @@ TransformixMain::Run(void)
   /** Create a log file. */
   itk::CreateOpenCLLogger("transformix", this->m_Configuration->GetCommandLineArgument("-out"));
 #endif
+  auto & elastixBase = *(this->GetElastixBase());
 
   if (BaseComponent::IsElastixLibrary())
   {
-    this->GetElastixBase()->SetConfigurations(this->m_Configurations);
+    elastixBase.SetConfigurations(this->m_Configurations);
   }
 
   /** Set some information in the ElastixBase. */
-  this->GetElastixBase()->SetConfiguration(this->m_Configuration);
-  this->GetElastixBase()->SetDBIndex(this->m_DBIndex);
+  elastixBase.SetConfiguration(this->m_Configuration);
+  elastixBase.SetDBIndex(this->m_DBIndex);
 
   /** Populate the component containers. No default is specified for the Transform. */
-  this->GetElastixBase()->SetResampleInterpolatorContainer(
+  elastixBase.SetResampleInterpolatorContainer(
     this->CreateComponents("ResampleInterpolator", "FinalBSplineInterpolator", errorCode));
 
-  this->GetElastixBase()->SetResamplerContainer(this->CreateComponents("Resampler", "DefaultResampler", errorCode));
+  elastixBase.SetResamplerContainer(this->CreateComponents("Resampler", "DefaultResampler", errorCode));
 
-  this->GetElastixBase()->SetTransformContainer(this->CreateComponents("Transform", "", errorCode));
+  elastixBase.SetTransformContainer(this->CreateComponents("Transform", "", errorCode));
 
   /** Check if all components could be created. */
   if (errorCode != 0)
@@ -125,17 +126,17 @@ TransformixMain::Run(void)
   /** Set the images. If not set by the user, it is not a problem.
    * ElastixTemplate will try to load them from disk.
    */
-  this->GetElastixBase()->SetMovingImageContainer(this->GetModifiableMovingImageContainer());
+  elastixBase.SetMovingImageContainer(this->GetModifiableMovingImageContainer());
 
   /** Set the initial transform, if it happens to be there
    * \todo: Does this make sense for transformix?
    */
-  this->GetElastixBase()->SetInitialTransform(this->GetModifiableInitialTransform());
+  elastixBase.SetInitialTransform(this->GetModifiableInitialTransform());
 
   /** ApplyTransform! */
   try
   {
-    errorCode = this->GetElastixBase()->ApplyTransform();
+    errorCode = elastixBase.ApplyTransform();
   }
   catch (itk::ExceptionObject & excp)
   {
@@ -147,9 +148,9 @@ TransformixMain::Run(void)
   }
 
   /** Save the image container. */
-  this->SetMovingImageContainer(this->GetElastixBase()->GetMovingImageContainer());
-  this->SetResultImageContainer(this->GetElastixBase()->GetResultImageContainer());
-  this->SetResultDeformationFieldContainer(this->GetElastixBase()->GetResultDeformationFieldContainer());
+  this->SetMovingImageContainer(elastixBase.GetMovingImageContainer());
+  this->SetResultImageContainer(elastixBase.GetResultImageContainer());
+  this->SetResultDeformationFieldContainer(elastixBase.GetResultDeformationFieldContainer());
 
   return errorCode;
 


### PR DESCRIPTION
Two little commits to modernize the implementation, interface, and calls to `ElastixMain::GetElastixBase(void)`.