### PR TITLE
Allow disabling all output from `xout`, to ease multi-threading support

### DIFF
--- a/Common/xout/xoutmain.cxx
+++ b/Common/xout/xoutmain.cxx
@@ -20,26 +20,14 @@
 
 namespace xoutlibrary
 {
-static xoutmain * local_xout = nullptr;
-
 xoutmain &
 get_xout(void)
 {
-  return *local_xout;
+  // Note: C++11 "magic statics" ensures that the construction of a local
+  // static variable like this is thread-safe.
+  static xoutmain local_xout;
+
+  return local_xout;
 }
-
-
-void
-set_xout(xoutmain * arg)
-{
-  local_xout = arg;
-}
-
-bool
-xout_valid()
-{
-  return local_xout != nullptr;
-}
-
 
 } // namespace xoutlibrary

--- a/Common/xout/xoutmain.h
+++ b/Common/xout/xoutmain.h
@@ -40,12 +40,6 @@ class xoutmain : public xoutbase
 xoutmain &
 get_xout(void);
 
-void
-set_xout(xoutmain * arg);
-
-bool
-xout_valid();
-
 } // end namespace xoutlibrary
 
 #endif // end #ifndef xoutmain_h

--- a/Core/Kernel/elxElastixMain.cxx
+++ b/Core/Kernel/elxElastixMain.cxx
@@ -47,7 +47,6 @@ namespace
 struct Data
 {
   /** xout TargetCells. */
-  xl::xoutmain   Xout;
   xl::xoutsimple WarningXout;
   xl::xoutsimple ErrorXout;
   xl::xoutsimple StandardXout;
@@ -71,7 +70,6 @@ int
 elastix::xoutSetup(const char * logfilename, bool setupLogging, bool setupCout)
 {
   int returndummy = 0;
-  set_xout(&g_data.Xout);
 
   if (setupLogging)
   {
@@ -141,6 +139,7 @@ xoutManager::xoutManager(const std::string & logFileName, const bool setupLoggin
 
 xoutManager::Guard::~Guard()
 {
+  xl::get_xout() = {};
   g_data = {};
 }
 

--- a/Core/Main/elxElastixFilter.h
+++ b/Core/Main/elxElastixFilter.h
@@ -206,6 +206,13 @@ public:
   itkGetConstReferenceMacro(LogToFile, bool);
   itkBooleanMacro(LogToFile);
 
+  /** Disables output to log and standard output. */
+  void
+  DisableOutput(void)
+  {
+    m_EnableOutput = false;
+  }
+
   itkSetMacro(NumberOfThreads, int);
   itkGetMacro(NumberOfThreads, int);
 
@@ -243,6 +250,7 @@ private:
   std::string m_OutputDirectory;
   std::string m_LogFileName;
 
+  bool m_EnableOutput{ true };
   bool m_LogToConsole;
   bool m_LogToFile;
 

--- a/Core/Main/elxElastixFilter.hxx
+++ b/Core/Main/elxElastixFilter.hxx
@@ -18,6 +18,8 @@
 #ifndef elxElastixFilter_hxx
 #define elxElastixFilter_hxx
 
+#include <memory> // For unique_ptr.
+
 namespace elastix
 {
 
@@ -197,7 +199,8 @@ ElastixFilter<TFixedImage, TMovingImage>::GenerateData(void)
   }
 
   // Setup xout
-  const elx::xoutManager manager(logFileName, this->GetLogToFile(), this->GetLogToConsole());
+  const std::unique_ptr<const elx::xoutManager> manager(
+    m_EnableOutput ? new elx::xoutManager(logFileName, this->GetLogToFile(), this->GetLogToConsole()) : nullptr);
 
   // Run the (possibly multiple) registration(s)
   for (unsigned int i = 0; i < parameterMapVector.size(); ++i)

--- a/Core/Main/elxTransformixFilter.h
+++ b/Core/Main/elxTransformixFilter.h
@@ -150,6 +150,13 @@ public:
   itkGetConstMacro(LogToFile, bool);
   itkBooleanMacro(LogToFile);
 
+  /** Disables output to log and standard output. */
+  void
+  DisableOutput(void)
+  {
+    m_EnableOutput = false;
+  }
+
   /** To support outputs of different types (i.e. ResultImage and ResultDeformationField)
    * MakeOutput from itk::ImageSource< TOutputImage > needs to be overridden.
    */
@@ -190,6 +197,7 @@ private:
   std::string m_OutputDirectory;
   std::string m_LogFileName;
 
+  bool m_EnableOutput{ true };
   bool m_LogToConsole;
   bool m_LogToFile;
 };

--- a/Core/Main/elxTransformixFilter.hxx
+++ b/Core/Main/elxTransformixFilter.hxx
@@ -18,6 +18,8 @@
 #ifndef elxTransformixFilter_hxx
 #define elxTransformixFilter_hxx
 
+#include <memory> // For unique_ptr.
+
 namespace elastix
 {
 
@@ -147,7 +149,8 @@ TransformixFilter<TMovingImage>::GenerateData(void)
   }
 
   // Setup xout
-  const elx::xoutManager manager(logFileName, this->GetLogToFile(), this->GetLogToConsole());
+  const std::unique_ptr<const elx::xoutManager> manager(
+    m_EnableOutput ? new elx::xoutManager(logFileName, this->GetLogToFile(), this->GetLogToConsole()) : nullptr);
 
   // Instantiate transformix
   TransformixMainPointer transformix = TransformixMainType::New();


### PR DESCRIPTION
Added `DisableOutput(void)` member function to both `elx::ElastixFilter` and  `elx::TransformixFilter`, which allows skipping an internal `xoutSetup` call, during `GenerateData()`. Effectively suppressed the output that is otherwise produced, when doing `xl::xout["some-stream"] << "some-output"`.

Aims to ease multi-threading support, as discussed with Konstantinos Ntatsis (@ntatsisk) .