### PR TITLE
COMP: Remove duplicated elxOverrideGetSelfMacro from OpenCLResampler

### DIFF
--- a/Components/Resamplers/OpenCLResampler/elxOpenCLResampler.h
+++ b/Components/Resamplers/OpenCLResampler/elxOpenCLResampler.h
@@ -155,7 +155,7 @@ protected:
 
 private:
   elxOverrideGetSelfMacro;
-  elxOverrideGetSelfMacro;
+
   /** Creates a map of the parameters specific for this (derived) resampler type. */
   ParameterMapType
   CreateDerivedTransformParametersMap(void) const override;


### PR DESCRIPTION
Fixed compilation errors like:

> Components\Resamplers\OpenCLResampler\elxOpenCLResampler.h(158,1): error C2535: 'const elastix::OpenCLResampler<TElastix> &elastix::OpenCLResampler<TElastix>::GetSelf(void) const': member function already defined or declared
> Components\Resamplers\OpenCLResampler\elxOpenCLResampler.h(157): message : see declaration of 'elastix::OpenCLResampler<TElastix>::GetSelf'