### PR TITLE
STYLE: Remove 14 unnecessary dynamic_casts from T* tot T*

### DIFF
--- a/Components/Metrics/MissingStructurePenalty/elxMissingStructurePenalty.hxx
+++ b/Components/Metrics/MissingStructurePenalty/elxMissingStructurePenalty.hxx
@@ -154,7 +154,7 @@ MissingStructurePenalty<TElastix>::BeforeRegistration(void)
       this->ReadMesh(fixedMeshName, fixedMesh);
     }
 
-    meshPointerContainer->SetElement(meshNumber, dynamic_cast<MeshType *>(fixedMesh.GetPointer()));
+    meshPointerContainer->SetElement(meshNumber, fixedMesh.GetPointer());
   }
 
   this->SetFixedMeshContainer(meshPointerContainer);

--- a/Components/Metrics/PolydataDummyPenalty/elxPolydataDummyPenalty.hxx
+++ b/Components/Metrics/PolydataDummyPenalty/elxPolydataDummyPenalty.hxx
@@ -141,7 +141,7 @@ PolydataDummyPenalty<TElastix>::BeforeRegistration(void)
       this->ReadMesh(fixedMeshName, fixedMesh);
     }
 
-    meshPointerContainer->SetElement(meshNumber, dynamic_cast<MeshType *>(fixedMesh.GetPointer()));
+    meshPointerContainer->SetElement(meshNumber, fixedMesh.GetPointer());
   }
 
   this->SetFixedMeshContainer(meshPointerContainer);

--- a/Components/Optimizers/AdaGrad/elxAdaGrad.h
+++ b/Components/Optimizers/AdaGrad/elxAdaGrad.h
@@ -381,10 +381,6 @@ protected:
   double m_RegularizationKappa;
   double m_ConditionNumber;
 
-  /** Check if the transform is an advanced transform. Called by Initialize. */
-  virtual void
-  CheckForAdvancedTransform(void);
-
   /** Print the contents of the settings vector to elxout. */
   virtual void
   PrintSettingsVector(const SettingsVectorType & settings) const;

--- a/Components/Optimizers/AdaGrad/elxAdaGrad.hxx
+++ b/Components/Optimizers/AdaGrad/elxAdaGrad.hxx
@@ -541,7 +541,7 @@ AdaGrad<TElastix>::AutomaticPreconditionerEstimation(void)
   for (unsigned int m = 0; m < M; ++m)
   {
     ImageSamplerBasePointer sampler = this->GetElastix()->GetElxMetricBase(m)->GetAdvancedMetricImageSampler();
-    originalSampler[m] = dynamic_cast<ImageSamplerBaseType *>(sampler.GetPointer());
+    originalSampler[m] = sampler.GetPointer();
   }
 
 #if 0

--- a/Components/Optimizers/AdaGrad/elxAdaGrad.hxx
+++ b/Components/Optimizers/AdaGrad/elxAdaGrad.hxx
@@ -943,33 +943,6 @@ AdaGrad<TElastix>::PrintSettingsVector(const SettingsVectorType & settings) cons
 
 
 /**
- * ****************** CheckForAdvancedTransform **********************
- */
-
-template <class TElastix>
-void
-AdaGrad<TElastix>::CheckForAdvancedTransform(void)
-{
-  typename TransformType::Pointer transform = this->GetRegistration()->GetAsITKBaseType()->GetModifiableTransform();
-
-  AdvancedTransformType * testPtr = dynamic_cast<AdvancedTransformType *>(transform.GetPointer());
-  if (!testPtr)
-  {
-    this->m_AdvancedTransform = nullptr;
-    itkDebugMacro("Transform is not Advanced");
-    itkExceptionMacro(<< "The automatic parameter estimation of the ASGD "
-                      << "optimizer works only with advanced transforms");
-  }
-  else
-  {
-    this->m_AdvancedTransform = testPtr;
-    itkDebugMacro("Transform is Advanced");
-  }
-
-} // end CheckForAdvancedTransform()
-
-
-/**
  * *************** GetScaledDerivativeWithExceptionHandling ***************
  */
 

--- a/Components/Optimizers/AdaptiveStochasticGradientDescent/elxAdaptiveStochasticGradientDescent.h
+++ b/Components/Optimizers/AdaptiveStochasticGradientDescent/elxAdaptiveStochasticGradientDescent.h
@@ -359,10 +359,6 @@ protected:
 
   double m_SigmoidScaleFactor;
 
-  /** Check if the transform is an advanced transform. Called by Initialize. */
-  virtual void
-  CheckForAdvancedTransform(void);
-
   /** Print the contents of the settings vector to elxout. */
   virtual void
   PrintSettingsVector(const SettingsVectorType & settings) const;

--- a/Components/Optimizers/AdaptiveStochasticGradientDescent/elxAdaptiveStochasticGradientDescent.hxx
+++ b/Components/Optimizers/AdaptiveStochasticGradientDescent/elxAdaptiveStochasticGradientDescent.hxx
@@ -1004,33 +1004,6 @@ AdaptiveStochasticGradientDescent<TElastix>::PrintSettingsVector(const SettingsV
 
 
 /**
- * ****************** CheckForAdvancedTransform **********************
- */
-
-template <class TElastix>
-void
-AdaptiveStochasticGradientDescent<TElastix>::CheckForAdvancedTransform(void)
-{
-  typename TransformType::Pointer transform = this->GetRegistration()->GetAsITKBaseType()->GetModifiableTransform();
-
-  AdvancedTransformType * testPtr = dynamic_cast<AdvancedTransformType *>(transform.GetPointer());
-  if (!testPtr)
-  {
-    this->m_AdvancedTransform = nullptr;
-    itkDebugMacro("Transform is not Advanced");
-    itkExceptionMacro(<< "The automatic parameter estimation of the ASGD "
-                      << "optimizer works only with advanced transforms");
-  }
-  else
-  {
-    this->m_AdvancedTransform = testPtr;
-    itkDebugMacro("Transform is Advanced");
-  }
-
-} // end CheckForAdvancedTransform()
-
-
-/**
  * *************** GetScaledDerivativeWithExceptionHandling ***************
  */
 

--- a/Components/Optimizers/AdaptiveStochasticLBFGS/elxAdaptiveStochasticLBFGS.h
+++ b/Components/Optimizers/AdaptiveStochasticLBFGS/elxAdaptiveStochasticLBFGS.h
@@ -315,10 +315,6 @@ protected:
 
   double m_SigmoidScaleFactor;
 
-  /** Check if the transform is an advanced transform. Called by Initialize. */
-  virtual void
-  CheckForAdvancedTransform(void);
-
   /** Print the contents of the settings vector to elxout. */
   virtual void
   PrintSettingsVector(const SettingsVectorType & settings) const;

--- a/Components/Optimizers/AdaptiveStochasticLBFGS/elxAdaptiveStochasticLBFGS.hxx
+++ b/Components/Optimizers/AdaptiveStochasticLBFGS/elxAdaptiveStochasticLBFGS.hxx
@@ -1477,33 +1477,6 @@ AdaptiveStochasticLBFGS<TElastix>::PrintSettingsVector(const SettingsVectorType 
 
 
 /**
- * ****************** CheckForAdvancedTransform **********************
- */
-
-template <class TElastix>
-void
-AdaptiveStochasticLBFGS<TElastix>::CheckForAdvancedTransform(void)
-{
-  typename TransformType::Pointer transform = this->GetRegistration()->GetAsITKBaseType()->GetModifiableTransform();
-
-  AdvancedTransformType * testPtr = dynamic_cast<AdvancedTransformType *>(transform.GetPointer());
-  if (!testPtr)
-  {
-    this->m_AdvancedTransform = nullptr;
-    itkDebugMacro("Transform is not Advanced");
-    itkExceptionMacro(<< "The automatic parameter estimation of the ASGD "
-                      << "optimizer works only with advanced transforms");
-  }
-  else
-  {
-    this->m_AdvancedTransform = testPtr;
-    itkDebugMacro("Transform is Advanced");
-  }
-
-} // end CheckForAdvancedTransform()
-
-
-/**
  * *************** GetScaledDerivativeWithExceptionHandling ***************
  */
 

--- a/Components/Optimizers/AdaptiveStochasticLBFGS/elxAdaptiveStochasticLBFGS.hxx
+++ b/Components/Optimizers/AdaptiveStochasticLBFGS/elxAdaptiveStochasticLBFGS.hxx
@@ -638,7 +638,7 @@ AdaptiveStochasticLBFGS<TElastix>::ResumeOptimization(void)
   for (unsigned int m = 0; m < M; ++m)
   {
     ImageSamplerBasePointer sampler = this->GetElastix()->GetElxMetricBase(m)->GetAdvancedMetricImageSampler();
-    originalSampler[m] = dynamic_cast<ImageSamplerBaseType *>(sampler.GetPointer());
+    originalSampler[m] = sampler.GetPointer();
   }
 
   /** Get the sampler that is used for the curvature pair update. */
@@ -653,7 +653,7 @@ AdaptiveStochasticLBFGS<TElastix>::ResumeOptimization(void)
   for (unsigned int m = 0; m < M; ++m)
   {
     ImageSamplerBasePointer sampler = this->GetElastix()->GetElxMetricBase(m)->GetAdvancedMetricImageSampler();
-    curvatureSamplers[m] = dynamic_cast<ImageSamplerBaseType *>(sampler.GetPointer());
+    curvatureSamplers[m] = sampler.GetPointer();
     curvatureSamplers[m]->SetNumberOfSamples(this->m_NumberOfInnerLoopSamples);
   }
 

--- a/Components/Optimizers/AdaptiveStochasticVarianceReducedGradient/elxAdaptiveStochasticVarianceReducedGradient.h
+++ b/Components/Optimizers/AdaptiveStochasticVarianceReducedGradient/elxAdaptiveStochasticVarianceReducedGradient.h
@@ -384,10 +384,6 @@ protected:
 
   double m_SigmoidScaleFactor;
 
-  /** Check if the transform is an advanced transform. Called by Initialize. */
-  virtual void
-  CheckForAdvancedTransform(void);
-
   /** Print the contents of the settings vector to elxout. */
   virtual void
   PrintSettingsVector(const SettingsVectorType & settings) const;

--- a/Components/Optimizers/AdaptiveStochasticVarianceReducedGradient/elxAdaptiveStochasticVarianceReducedGradient.hxx
+++ b/Components/Optimizers/AdaptiveStochasticVarianceReducedGradient/elxAdaptiveStochasticVarianceReducedGradient.hxx
@@ -1270,33 +1270,6 @@ AdaptiveStochasticVarianceReducedGradient<TElastix>::PrintSettingsVector(const S
 
 
 /**
- * ****************** CheckForAdvancedTransform **********************
- */
-
-template <class TElastix>
-void
-AdaptiveStochasticVarianceReducedGradient<TElastix>::CheckForAdvancedTransform(void)
-{
-  typename TransformType::Pointer transform = this->GetRegistration()->GetAsITKBaseType()->GetModifiableTransform();
-
-  AdvancedTransformType * testPtr = dynamic_cast<AdvancedTransformType *>(transform.GetPointer());
-  if (!testPtr)
-  {
-    this->m_AdvancedTransform = nullptr;
-    itkDebugMacro("Transform is not Advanced");
-    itkExceptionMacro(<< "The automatic parameter estimation of the ASGD "
-                      << "optimizer works only with advanced transforms");
-  }
-  else
-  {
-    this->m_AdvancedTransform = testPtr;
-    itkDebugMacro("Transform is Advanced");
-  }
-
-} // end CheckForAdvancedTransform()
-
-
-/**
  * *************** GetScaledDerivativeWithExceptionHandling ***************
  */
 

--- a/Components/Optimizers/PreconditionedStochasticGradientDescent/elxPreconditionedStochasticGradientDescent.h
+++ b/Components/Optimizers/PreconditionedStochasticGradientDescent/elxPreconditionedStochasticGradientDescent.h
@@ -368,10 +368,6 @@ protected:
   double m_RegularizationKappa;
   double m_ConditionNumber;
 
-  /** Check if the transform is an advanced transform. Called by Initialize. */
-  virtual void
-  CheckForAdvancedTransform(void);
-
   /** Print the contents of the settings vector to elxout. */
   virtual void
   PrintSettingsVector(const SettingsVectorType & settings) const;

--- a/Components/Optimizers/PreconditionedStochasticGradientDescent/elxPreconditionedStochasticGradientDescent.hxx
+++ b/Components/Optimizers/PreconditionedStochasticGradientDescent/elxPreconditionedStochasticGradientDescent.hxx
@@ -956,33 +956,6 @@ PreconditionedStochasticGradientDescent<TElastix>::PrintSettingsVector(const Set
 
 
 /**
- * ****************** CheckForAdvancedTransform **********************
- */
-
-template <class TElastix>
-void
-PreconditionedStochasticGradientDescent<TElastix>::CheckForAdvancedTransform(void)
-{
-  typename TransformType::Pointer transform = this->GetRegistration()->GetAsITKBaseType()->GetModifiableTransform();
-
-  AdvancedTransformType * testPtr = dynamic_cast<AdvancedTransformType *>(transform.GetPointer());
-  if (!testPtr)
-  {
-    this->m_AdvancedTransform = nullptr;
-    itkDebugMacro("Transform is not Advanced");
-    itkExceptionMacro(<< "The automatic parameter estimation of the ASGD "
-                      << "optimizer works only with advanced transforms");
-  }
-  else
-  {
-    this->m_AdvancedTransform = testPtr;
-    itkDebugMacro("Transform is Advanced");
-  }
-
-} // end CheckForAdvancedTransform()
-
-
-/**
  * *************** GetScaledDerivativeWithExceptionHandling ***************
  */
 

--- a/Components/Optimizers/PreconditionedStochasticGradientDescent/elxPreconditionedStochasticGradientDescent.hxx
+++ b/Components/Optimizers/PreconditionedStochasticGradientDescent/elxPreconditionedStochasticGradientDescent.hxx
@@ -542,7 +542,7 @@ PreconditionedStochasticGradientDescent<TElastix>::AutomaticPreconditionerEstima
   for (unsigned int m = 0; m < M; ++m)
   {
     ImageSamplerBasePointer sampler = this->GetElastix()->GetElxMetricBase(m)->GetAdvancedMetricImageSampler();
-    originalSampler[m] = dynamic_cast<ImageSamplerBaseType *>(sampler.GetPointer());
+    originalSampler[m] = sampler.GetPointer();
   }
 
   /** Create a random sampler with more samples that can be used for the pre-conditioner computation. */

--- a/Components/Transforms/BSplineDeformableTransformWithDiffusion/elxBSplineTransformWithDiffusion.hxx
+++ b/Components/Transforms/BSplineDeformableTransformWithDiffusion/elxBSplineTransformWithDiffusion.hxx
@@ -352,7 +352,7 @@ BSplineTransformWithDiffusion<TElastix>::BeforeRegistration(void)
   }
   else
   {
-    this->m_Resampler1->SetInput(dynamic_cast<MovingImageELXType *>(this->m_Elastix->GetMovingImage()));
+    this->m_Resampler1->SetInput(this->m_Elastix->GetMovingImage());
   }
 
   /** Get the default pixel value. */
@@ -1140,7 +1140,7 @@ BSplineTransformWithDiffusion<TElastix>::DiffuseDeformationField(void)
     {
       maximumImageFilter = MaximumImageFilterType::New();
       maximumImageFilter->SetInput(0, this->m_GrayValueImage1);
-      maximumImageFilter->SetInput(1, dynamic_cast<FixedImageELXType *>(this->m_Elastix->GetFixedImage()));
+      maximumImageFilter->SetInput(1, this->m_Elastix->GetFixedImage());
       this->m_GrayValueImage2 = maximumImageFilter->GetOutput();
 
       /** Do the maximum (OR filter). */

--- a/Core/ComponentBaseClasses/elxResamplerBase.hxx
+++ b/Core/ComponentBaseClasses/elxResamplerBase.hxx
@@ -283,7 +283,7 @@ ResamplerBase<TElastix>::SetComponents(void)
   this->GetAsITKBaseType()->SetInterpolator(
     BaseComponent::AsITKBaseType(this->m_Elastix->GetElxResampleInterpolatorBase()));
 
-  this->GetAsITKBaseType()->SetInput(dynamic_cast<InputImageType *>(this->m_Elastix->GetMovingImage()));
+  this->GetAsITKBaseType()->SetInput(this->m_Elastix->GetMovingImage());
 
 } // end SetComponents()
 


### PR DESCRIPTION
Removed "no-op" dynamic_casts, that just cast a pointer to its own compile-time type.

Remove unused `CheckForAdvancedTransform(void)` member functions, which have such "no-op" dynamic_casts.

Removal of dynamic_casts could ease avoiding the MacOS segfaults that we observed.