### PR TITLE
STYLE: Use itk::TransformBase for itk::TransformBaseTemplate<double>

### DIFF
--- a/Common/Transforms/elxTransformIO.cxx
+++ b/Common/Transforms/elxTransformIO.cxx
@@ -28,7 +28,7 @@
 
 #include <string>
 
-itk::TransformBaseTemplate<double>::Pointer
+itk::TransformBase::Pointer
 elastix::TransformIO::CreateCorrespondingItkTransform(const elx::BaseComponent & elxTransform,
                                                       const unsigned             fixedImageDimension,
                                                       const unsigned             movingImageDimension)
@@ -58,11 +58,11 @@ elastix::TransformIO::CreateCorrespondingItkTransform(const elx::BaseComponent &
                             "_double_" + std::to_string(fixedImageDimension) + '_' +
                             std::to_string(movingImageDimension);
   const auto instance = itk::ObjectFactoryBase::CreateInstance(instanceName.c_str());
-  return dynamic_cast<itk::TransformBaseTemplate<double> *>(instance.GetPointer());
+  return dynamic_cast<itk::TransformBase *>(instance.GetPointer());
 }
 
 void
-elastix::TransformIO::Write(const itk::TransformBaseTemplate<double> & itkTransform, const std::string & fileName)
+elastix::TransformIO::Write(const itk::TransformBase & itkTransform, const std::string & fileName)
 {
   try
   {

--- a/Common/Transforms/elxTransformIO.h
+++ b/Common/Transforms/elxTransformIO.h
@@ -30,22 +30,20 @@ class TransformIO
 {
 public:
   static itk::OptimizerParameters<double>
-  GetParameters(const bool fixed, const itk::TransformBaseTemplate<double> & transform)
+  GetParameters(const bool fixed, const itk::TransformBase & transform)
   {
     return fixed ? transform.GetFixedParameters() : transform.GetParameters();
   }
 
   static void
-  SetParameters(const bool                               fixed,
-                itk::TransformBaseTemplate<double> &     transform,
-                const itk::OptimizerParameters<double> & parameters)
+  SetParameters(const bool fixed, itk::TransformBase & transform, const itk::OptimizerParameters<double> & parameters)
   {
     fixed ? transform.SetFixedParameters(parameters) : transform.SetParameters(parameters);
   }
 
 
   template <typename TElastixTransform>
-  static itk::TransformBaseTemplate<double>::Pointer
+  static itk::TransformBase::Pointer
   CreateCorrespondingItkTransform(const TElastixTransform & elxTransform)
   {
     return CreateCorrespondingItkTransform(
@@ -53,7 +51,7 @@ public:
   }
 
   static void
-  Write(const itk::TransformBaseTemplate<double> & itkTransform, const std::string & fileName);
+  Write(const itk::TransformBase & itkTransform, const std::string & fileName);
 
 
   /// Makes the deformation field file name, as used by BSplineTransformWithDiffusion and DeformationFieldTransform.
@@ -66,7 +64,7 @@ public:
   }
 
 private:
-  static itk::TransformBaseTemplate<double>::Pointer
+  static itk::TransformBase::Pointer
   CreateCorrespondingItkTransform(const BaseComponent & elxTransform,
                                   const unsigned        fixedImageDimension,
                                   const unsigned        movingImageDimension);

--- a/Core/ComponentBaseClasses/elxTransformBase.hxx
+++ b/Core/ComponentBaseClasses/elxTransformBase.hxx
@@ -574,7 +574,7 @@ TransformBase<TElastix>::WriteToFile(xl::xoutsimple & transformationParameterInf
               "Transform files stored by this feature may still be incomplete or incorrect!"
            << std::endl;
 
-    const itk::TransformBaseTemplate<double> * const thisAsITKBase = this->GetAsITKBaseType();
+    const itk::TransformBase * const thisAsITKBase = this->GetAsITKBaseType();
     assert(thisAsITKBase != nullptr);
 
     const auto correspondingItkTransform = TransformIO::CreateCorrespondingItkTransform(*this);
@@ -584,7 +584,7 @@ TransformBase<TElastix>::WriteToFile(xl::xoutsimple & transformationParameterInf
       correspondingItkTransform->SetParameters(thisAsITKBase->GetParameters());
       correspondingItkTransform->SetFixedParameters(thisAsITKBase->GetFixedParameters());
     }
-    const itk::TransformBaseTemplate<double> & transformObject =
+    const itk::TransformBase & transformObject =
       (correspondingItkTransform == nullptr) ? *thisAsITKBase : *correspondingItkTransform;
     const auto fileNameWithoutExtension =
       std::string(m_TransformParametersFileName, 0, m_TransformParametersFileName.rfind('.')) + "-experimental";


### PR DESCRIPTION
Just to reduce the noise, just like using `std::string` for `std::basic_string<char>`.