### PR TITLE
ENH: Add RetrieveValues to ParameterMapInterface and elx::Configuration

### DIFF
--- a/Common/GTesting/CMakeLists.txt
+++ b/Common/GTesting/CMakeLists.txt
@@ -6,6 +6,7 @@ add_executable(CommonGTest
   elxResamplerGTest.cxx
   elxTransformIOGTest.cxx
   itkComputeImageExtremaFilterGTest.cxx
+  itkParameterMapInterfaceTest.cxx
   )
 target_link_libraries(CommonGTest
   GTest::GTest GTest::Main

--- a/Common/GTesting/itkParameterMapInterfaceTest.cxx
+++ b/Common/GTesting/itkParameterMapInterfaceTest.cxx
@@ -1,0 +1,104 @@
+/*=========================================================================
+ *
+ *  Copyright UMC Utrecht and contributors
+ *
+ *  Licensed under the Apache License, Version 2.0 (the "License");
+ *  you may not use this file except in compliance with the License.
+ *  You may obtain a copy of the License at
+ *
+ *        http://www.apache.org/licenses/LICENSE-2.0.txt
+ *
+ *  Unless required by applicable law or agreed to in writing, software
+ *  distributed under the License is distributed on an "AS IS" BASIS,
+ *  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *  See the License for the specific language governing permissions and
+ *  limitations under the License.
+ *
+ *=========================================================================*/
+
+// First include the header file to be tested:
+#include "itkParameterMapInterface.h"
+
+#include <itkNumberToString.h>
+
+#include <gtest/gtest.h>
+
+
+// The class to be tested.
+using itk::ParameterMapInterface;
+
+
+GTEST_TEST(ParameterMapInterface, RetrieveValuesReturnsNullWhenParameterMapIsEmpty)
+{
+  const auto parameterMapInterface = ParameterMapInterface::New();
+  EXPECT_EQ(parameterMapInterface->RetrieveValues<double>("parameterName"), nullptr);
+}
+
+
+GTEST_TEST(ParameterMapInterface, RetrieveValuesReturnsNullWhenParameterNameIsMissing)
+{
+  const auto parameterMapInterface = ParameterMapInterface::New();
+  parameterMapInterface->SetParameterMap({ { "ParameterName", { "0", "1" } } });
+
+  EXPECT_EQ(parameterMapInterface->RetrieveValues<double>("MissingParameterName"), nullptr);
+}
+
+
+GTEST_TEST(ParameterMapInterface, RetrieveValuesSupportsZeroValues)
+{
+  const auto        parameterMapInterface = ParameterMapInterface::New();
+  const std::string parameterName("Key");
+  parameterMapInterface->SetParameterMap({ { parameterName, {} } });
+
+  const auto retrievedValues = parameterMapInterface->RetrieveValues<double>(parameterName);
+  ASSERT_NE(retrievedValues, nullptr);
+  EXPECT_EQ(*retrievedValues, std::vector<double>{});
+}
+
+
+GTEST_TEST(ParameterMapInterface, RetrieveValuesSupportsSingleValue)
+{
+  const auto        parameterMapInterface = ParameterMapInterface::New();
+  const std::string parameterName("Key");
+
+  for (const double testValue : { -1.0, 0.0, 1.0 })
+  {
+    parameterMapInterface->SetParameterMap({ { parameterName, { itk::NumberToString<double>{}(testValue) } } });
+
+    const auto retrievedValues = parameterMapInterface->RetrieveValues<double>(parameterName);
+    ASSERT_NE(retrievedValues, nullptr);
+    EXPECT_EQ(*retrievedValues, std::vector<double>{ testValue });
+  }
+}
+
+
+GTEST_TEST(ParameterMapInterface, RetrieveValuesSupportsMultipleValues)
+{
+  const auto        parameterMapInterface = ParameterMapInterface::New();
+  const std::string parameterName("Key");
+  using NumberToString = itk::NumberToString<double>;
+
+  for (const double testValue1 : { 0.0, 1.0 })
+  {
+    for (const double testValue2 : { 0.0, 1.0 })
+    {
+      parameterMapInterface->SetParameterMap(
+        { { parameterName, { NumberToString{}(testValue1), NumberToString{}(testValue2) } } });
+
+      const auto retrievedValues = parameterMapInterface->RetrieveValues<double>(parameterName);
+      ASSERT_NE(retrievedValues, nullptr);
+      const std::vector<double> expectedValues{ testValue1, testValue2 };
+      EXPECT_EQ(*retrievedValues, expectedValues);
+    }
+  }
+}
+
+
+GTEST_TEST(ParameterMapInterface, RetrieveValuesThrowsExceptionWhenConversionFails)
+{
+  const auto        parameterMapInterface = ParameterMapInterface::New();
+  const std::string parameterName("Key");
+  parameterMapInterface->SetParameterMap({ { parameterName, { "not-a-valid-floating-point-value" } } });
+
+  EXPECT_THROW(parameterMapInterface->RetrieveValues<double>(parameterName), itk::ExceptionObject);
+}

--- a/Core/Configuration/elxConfiguration.h
+++ b/Core/Configuration/elxConfiguration.h
@@ -235,6 +235,19 @@ public:
   }
 
 
+  /** Retrieves the values of the specified parameter (from the parameter file).
+   * Returns null when the parameter map does not contain the specified
+   * parameter. Throws an exception when it fails to convert each of the
+   * parameter values to the specified type `T`.
+   */
+  template <typename T>
+  std::unique_ptr<std::vector<T>>
+  RetrieveValuesOfParameter(const std::string & parameterName) const
+  {
+    return m_ParameterMapInterface->RetrieveValues<T>(parameterName);
+  }
+
+
   /** Read a range of parameters from the parameter file. */
   template <class T>
   bool


### PR DESCRIPTION
Added convenience member functions, `itk::ParameterMapInterface::RetrieveValues(parameterName)` and `elx::Configuration::RetrieveValuesOfParameter(parameterName)`.

Included six `ParameterMapInterface` GoogleTest unit tests.