### PR TITLE
COMP: Replace string::find_last_of("/") calls by using string::back()

### DIFF
--- a/Core/Kernel/elxElastixBase.cxx
+++ b/Core/Kernel/elxElastixBase.cxx
@@ -405,11 +405,9 @@ ElastixBase::BeforeAllTransformixBase(void)
   else
   {
     /** Make sure that last character of -out equals a '/'. */
-    std::string folder(check);
-    if (folder.find_last_of("/") != folder.size() - 1)
+    if (check.back() != '/')
     {
-      folder.append("/");
-      this->GetConfiguration()->SetCommandLineArgument("-out", folder.c_str());
+      this->GetConfiguration()->SetCommandLineArgument("-out", check + '/');
     }
     elxout << "-out      " << check << std::endl;
   }

--- a/Core/Main/elastixlib.cxx
+++ b/Core/Main/elastixlib.cxx
@@ -160,7 +160,7 @@ ELASTIX::RegisterImages(ImagePointer                          fixedImage,
     value = outputPath;
 
     /** Make sure that last character of the output folder equals a '/'. */
-    if (value.find_last_of("/") != value.size() - 1)
+    if (outputPath.back() != '/')
     {
       value.append("/");
     }

--- a/Core/Main/transformixlib.cxx
+++ b/Core/Main/transformixlib.cxx
@@ -120,7 +120,7 @@ TRANSFORMIX::TransformImage(ImagePointer                    inputImage,
     value = outputPath;
 
     /** Make sure that last character of the output folder equals a '/'. */
-    if (value.find_last_of("/") != value.size() - 1)
+    if (outputPath.back() != '/')
     {
       value.append("/");
     }


### PR DESCRIPTION
Addressed warnings from LLVM 11.1.0 Clang Power Tools, saying:

> 'find_last_of' called with a string literal consisting of a single character; consider using the more effective overload accepting a character [performance-faster-string-find]