### PR TITLE
STYLE: Move CreateParameterMap function to elx::CoreMainGTestUtilities

### DIFF
--- a/Core/Main/GTesting/ElastixFilterGTest.cxx
+++ b/Core/Main/GTesting/ElastixFilterGTest.cxx
@@ -60,25 +60,12 @@ GTEST_TEST(ElastixFilter, Translation)
   elx::CoreMainGTestUtilities::FillImageRegion(*movingImage, fixedImageRegionIndex + translationOffset, regionSize);
 
   const auto parameterObject = elastix::ParameterObject::New();
-
-  const std::pair<std::string, std::string> parameterArray[] = { // Parameters in alphabetic order:
-                                                                 { "ImageSampler", "Full" },
-                                                                 { "MaximumNumberOfIterations", "2" },
-                                                                 { "Metric", "AdvancedNormalizedCorrelation" },
-                                                                 { "Optimizer", "AdaptiveStochasticGradientDescent" },
-                                                                 { "Transform", "TranslationTransform" }
-  };
-
-  std::map<std::string, std::vector<std::string>> parameterMap;
-
-  for (const auto & pair : parameterArray)
-  {
-    const auto result = parameterMap.insert({ pair.first, { pair.second } });
-
-    ASSERT_EQ(std::make_pair(pair, result.second), std::make_pair(pair, true));
-  }
-
-  parameterObject->SetParameterMap(parameterMap);
+  parameterObject->SetParameterMap(
+    elx::CoreMainGTestUtilities::CreateParameterMap({ { "ImageSampler", "Full" },
+                                                      { "MaximumNumberOfIterations", "2" },
+                                                      { "Metric", "AdvancedNormalizedCorrelation" },
+                                                      { "Optimizer", "AdaptiveStochasticGradientDescent" },
+                                                      { "Transform", "TranslationTransform" } }));
 
   const auto filter = elastix::ElastixFilter<ImageType, ImageType>::New();
   ASSERT_NE(filter, nullptr);

--- a/Core/Main/GTesting/ElastixLibGTest.cxx
+++ b/Core/Main/GTesting/ElastixLibGTest.cxx
@@ -30,7 +30,6 @@
 
 #include <algorithm> // For transform.
 #include <array>
-#include <initializer_list>
 #include <limits>
 #include <vector>
 
@@ -123,22 +122,6 @@ ExpectRoundedTransformParametersEqualOffset(const elastix::ELASTIX &        elas
 }
 
 
-template <unsigned VImageDimension>
-std::map<std::string, std::vector<std::string>>
-CreateParameterMap(std::initializer_list<std::pair<std::string, std::string>> initializerList)
-{
-  const std::vector<std::string> imageDimensionVector = { std::to_string(VImageDimension) };
-
-  std::map<std::string, std::vector<std::string>> result{ { "FixedImageDimension", imageDimensionVector },
-                                                          { "MovingImageDimension", imageDimensionVector } };
-
-  for (const auto & pair : initializerList)
-  {
-    [&pair, &result] { ASSERT_TRUE(result.insert({ pair.first, { pair.second } }).second); }();
-  }
-  return result;
-}
-
 template <unsigned VImageDimension, typename TPixel = float>
 void
 Expect_TransformParameters_are_zero_when_fixed_image_is_moving_image()
@@ -146,13 +129,13 @@ Expect_TransformParameters_are_zero_when_fixed_image_is_moving_image()
   using ImageType = itk::Image<TPixel, VImageDimension>;
   using SizeType = itk::Size<VImageDimension>;
 
-  const auto parameterMap =
-    CreateParameterMap<VImageDimension>({ { "ImageSampler", "Full" },
-                                          { "FixedInternalImagePixelType", GetPixelTypeName<TPixel>() },
-                                          { "Metric", "AdvancedNormalizedCorrelation" },
-                                          { "MovingInternalImagePixelType", GetPixelTypeName<TPixel>() },
-                                          { "Optimizer", "AdaptiveStochasticGradientDescent" },
-                                          { "Transform", "TranslationTransform" } });
+  const auto parameterMap = elx::CoreMainGTestUtilities::CreateParameterMap<VImageDimension>(
+    { { "ImageSampler", "Full" },
+      { "FixedInternalImagePixelType", GetPixelTypeName<TPixel>() },
+      { "Metric", "AdvancedNormalizedCorrelation" },
+      { "MovingInternalImagePixelType", GetPixelTypeName<TPixel>() },
+      { "Optimizer", "AdaptiveStochasticGradientDescent" },
+      { "Transform", "TranslationTransform" } });
 
   const auto regionSizeValue = 2;
   const auto imageSizeValue = 4;
@@ -197,7 +180,7 @@ GTEST_TEST(ElastixLib, ExampleFromManualRunningElastix)
   using ITKImageType = itk::Image<float>;
   constexpr auto ImageDimension = ITKImageType::ImageDimension;
 
-  const auto parameters = CreateParameterMap<ImageDimension>({
+  const auto parameters = elx::CoreMainGTestUtilities::CreateParameterMap<ImageDimension>({
     // Parameters with non-default values (A-Z):
     { "ImageSampler", "Full" },
     { "MaximumNumberOfIterations", "2" }, // Default value: 500
@@ -337,11 +320,12 @@ GTEST_TEST(ElastixLib, Translation3D)
   constexpr auto ImageDimension = 3;
   using ImageType = itk::Image<float, ImageDimension>;
 
-  const auto parameterMap = CreateParameterMap<ImageDimension>({ { "ImageSampler", "Full" },
-                                                                 { "MaximumNumberOfIterations", "3" },
-                                                                 { "Metric", "AdvancedNormalizedCorrelation" },
-                                                                 { "Optimizer", "AdaptiveStochasticGradientDescent" },
-                                                                 { "Transform", "TranslationTransform" } });
+  const auto parameterMap = elx::CoreMainGTestUtilities::CreateParameterMap<ImageDimension>(
+    { { "ImageSampler", "Full" },
+      { "MaximumNumberOfIterations", "3" },
+      { "Metric", "AdvancedNormalizedCorrelation" },
+      { "Optimizer", "AdaptiveStochasticGradientDescent" },
+      { "Transform", "TranslationTransform" } });
 
   const itk::Size<ImageDimension>   imageSize{ { 5, 7, 9 } };
   const itk::Size<ImageDimension>   regionSize = itk::Size<ImageDimension>::Filled(2);

--- a/Core/Main/GTesting/elxCoreMainGTestUtilities.h
+++ b/Core/Main/GTesting/elxCoreMainGTestUtilities.h
@@ -25,7 +25,14 @@
 #include <itkSize.h>
 
 #include <algorithm> // For fill.
-#include <iterator>  // For begin and end.
+#include <map>
+#include <initializer_list>
+#include <iterator> // For begin and end.
+#include <vector>
+
+// GoogleTest header file:
+#include <gtest/gtest.h>
+
 
 namespace itk
 {
@@ -59,6 +66,32 @@ FillImageRegion(itk::Image<TPixel, VImageDimension> & image,
   std::fill(std::begin(imageRegionRange), std::end(imageRegionRange), 1);
 }
 
+
+std::map<std::string, std::vector<std::string>> inline CreateParameterMap(
+  std::initializer_list<std::pair<std::string, std::string>> initializerList)
+{
+  std::map<std::string, std::vector<std::string>> result;
+
+  for (const auto & pair : initializerList)
+  {
+    [&pair, &result] { ASSERT_TRUE(result.insert({ pair.first, { pair.second } }).second); }();
+  }
+  return result;
+}
+
+
+template <unsigned VImageDimension>
+std::map<std::string, std::vector<std::string>>
+CreateParameterMap(std::initializer_list<std::pair<std::string, std::string>> initializerList)
+{
+  std::map<std::string, std::vector<std::string>> result = CreateParameterMap(initializerList);
+
+  for (const auto & key : { "FixedImageDimension", "MovingImageDimension" })
+  {
+    [&key, &result] { ASSERT_TRUE(result.insert({ key, { std::to_string(VImageDimension) } }).second); }();
+  }
+  return result;
+}
 
 } // namespace CoreMainGTestUtilities
 } // namespace elastix

--- a/Core/Main/GTesting/itkElastixRegistrationMethodGTest.cxx
+++ b/Core/Main/GTesting/itkElastixRegistrationMethodGTest.cxx
@@ -60,25 +60,12 @@ GTEST_TEST(itkElastixRegistrationMethod, Translation)
   elx::CoreMainGTestUtilities::FillImageRegion(*movingImage, fixedImageRegionIndex + translationOffset, regionSize);
 
   const auto parameterObject = elastix::ParameterObject::New();
-
-  const std::pair<std::string, std::string> parameterArray[] = { // Parameters in alphabetic order:
-                                                                 { "ImageSampler", "Full" },
-                                                                 { "MaximumNumberOfIterations", "2" },
-                                                                 { "Metric", "AdvancedNormalizedCorrelation" },
-                                                                 { "Optimizer", "AdaptiveStochasticGradientDescent" },
-                                                                 { "Transform", "TranslationTransform" }
-  };
-
-  std::map<std::string, std::vector<std::string>> parameterMap;
-
-  for (const auto & pair : parameterArray)
-  {
-    const auto result = parameterMap.insert({ pair.first, { pair.second } });
-
-    ASSERT_EQ(std::make_pair(pair, result.second), std::make_pair(pair, true));
-  }
-
-  parameterObject->SetParameterMap(parameterMap);
+  parameterObject->SetParameterMap(
+    elx::CoreMainGTestUtilities::CreateParameterMap({ { "ImageSampler", "Full" },
+                                                      { "MaximumNumberOfIterations", "2" },
+                                                      { "Metric", "AdvancedNormalizedCorrelation" },
+                                                      { "Optimizer", "AdaptiveStochasticGradientDescent" },
+                                                      { "Transform", "TranslationTransform" } }));
 
   const auto filter = itk::ElastixRegistrationMethod<ImageType, ImageType>::New();
   ASSERT_NE(filter, nullptr);


### PR DESCRIPTION
Preparing to add more unit tests, for example for https://github.com/SuperElastix/elastix/pull/438 (ENH: Read data from an external transform file into the parameter map)