### PR TITLE
ENH: Test ability to use special chars in external transform file paths

### DIFF
--- a/Core/Main/GTesting/itkElastixRegistrationMethodGTest.cxx
+++ b/Core/Main/GTesting/itkElastixRegistrationMethodGTest.cxx
@@ -219,7 +219,9 @@ GTEST_TEST(itkElastixRegistrationMethod, InitialTransformParameterFileLinkToTran
   const auto filter1 = createFilter("TransformParameters.txt");
 
   for (const auto transformParameterFileName :
-       { "TransformParameters-link-to-ITK-tfm-file.txt", "TransformParameters-link-to-ITK-HDF5-file.txt" })
+       { "TransformParameters-link-to-ITK-tfm-file.txt",
+         "TransformParameters-link-to-ITK-HDF5-file.txt",
+         "TransformParameters-link-to-file-with-special-chars-in-path-name.txt" })
   {
     const auto filter2 = createFilter(transformParameterFileName);
 

--- a/Testing/Data/Translation(1,-2)/Special characters [(0-9,;!@#$%&)]/ITK-Transform.tfm
+++ b/Testing/Data/Translation(1,-2)/Special characters [(0-9,;!@#$%&)]/ITK-Transform.tfm
@@ -1,0 +1,5 @@
+#Insight Transform File V1.0
+#Transform 0
+Transform: TranslationTransform_double_2_2
+Parameters: 1 -2
+FixedParameters:

--- a/Testing/Data/Translation(1,-2)/TransformParameters-link-to-file-with-special-chars-in-path-name.txt
+++ b/Testing/Data/Translation(1,-2)/TransformParameters-link-to-file-with-special-chars-in-path-name.txt
@@ -1,0 +1,2 @@
+(Transform "File")
+(TransformFileName "Special characters [(0-9,;!@#$%&)]/ITK-Transform.tfm")


### PR DESCRIPTION
Follow-up to commit 0a962b866dd8a1f15ca1a1eee11ca84a170534ab "ENH: Lift ParameterFileParser restrictions on chars of parameter values".