### PR TITLE
Fix warnings: '!=' on address of string, 'argv', 'argc' unreferenced parameter

### DIFF
--- a/Core/Main/GTesting/elxCoreMainGTestUtilities.cxx
+++ b/Core/Main/GTesting/elxCoreMainGTestUtilities.cxx
@@ -21,15 +21,23 @@
 // GoogleTest header file:
 #include <gtest/gtest.h>
 
+#include <cassert>
+#include <type_traits> // For is_same.
+
+
 namespace elastix
 {
 std::string
 CoreMainGTestUtilities::GetDataDirectoryPath()
 {
-  static_assert(ELX_CMAKE_SOURCE_DIR != nullptr, "The CMAKE_SOURCE_DIR must not be null");
-  const std::string sourceDirectoryPath = ELX_CMAKE_SOURCE_DIR;
-  [&sourceDirectoryPath] { ASSERT_FALSE(sourceDirectoryPath.empty()); }();
-  return sourceDirectoryPath + (sourceDirectoryPath.back() == '/' ? "" : "/") + "Testing/Data";
+  constexpr auto sourceDirectoryPath = ELX_CMAKE_SOURCE_DIR;
+  static_assert(std::is_same<decltype(sourceDirectoryPath), const char * const>(),
+                "CMAKE_SOURCE_DIR must be a character string!");
+  static_assert(sourceDirectoryPath != nullptr, "CMAKE_SOURCE_DIR must not be null!");
+  static_assert(*sourceDirectoryPath != '\0', "CMAKE_SOURCE_DIR must not be empty!");
+
+  const std::string str = sourceDirectoryPath;
+  return str + ((str.back() == '/') ? "" : "/") + "Testing/Data";
 }
 
 } // namespace elastix

--- a/Testing/itkAccumulateDerivativesParallellizationTest.cxx
+++ b/Testing/itkAccumulateDerivativesParallellizationTest.cxx
@@ -183,7 +183,7 @@ public:
 //-------------------------------------------------------------------------------------
 
 int
-main(int argc, char * argv[])
+main(void)
 {
   // Declare and setup
   std::cout << std::fixed << std::showpoint << std::setprecision(8);

--- a/Testing/itkAdvanceOneStepParallellizationTest.cxx
+++ b/Testing/itkAdvanceOneStepParallellizationTest.cxx
@@ -241,7 +241,7 @@ public:
 //-------------------------------------------------------------------------------------
 
 int
-main(int argc, char * argv[])
+main(void)
 {
   // Declare and setup
   std::cout << std::fixed << std::showpoint << std::setprecision(8);

--- a/Testing/itkAdvancedLinearInterpolatorTest.cxx
+++ b/Testing/itkAdvancedLinearInterpolatorTest.cxx
@@ -274,7 +274,7 @@ TestInterpolators(void)
 
 
 int
-main(int argc, char ** argv)
+main(void)
 {
   // 2D tests
   bool success = TestInterpolators<2>();

--- a/Testing/itkBSplineDerivativeKernelFunctionTest.cxx
+++ b/Testing/itkBSplineDerivativeKernelFunctionTest.cxx
@@ -25,7 +25,7 @@
 //-------------------------------------------------------------------------------------
 
 int
-main(int argc, char * argv[])
+main(void)
 {
   /** Some basic type definitions. */
   std::vector<unsigned int> splineOrders;

--- a/Testing/itkBSplineInterpolationDerivativeWeightFunctionTest.cxx
+++ b/Testing/itkBSplineInterpolationDerivativeWeightFunctionTest.cxx
@@ -23,7 +23,7 @@
 //-------------------------------------------------------------------------------------
 
 int
-main(int argc, char * argv[])
+main(void)
 {
   /** Some basic type definitions.
    * NOTE: don't change the dimension or the spline order, since the

--- a/Testing/itkBSplineInterpolationSODerivativeWeightFunctionTest.cxx
+++ b/Testing/itkBSplineInterpolationSODerivativeWeightFunctionTest.cxx
@@ -23,7 +23,7 @@
 //-------------------------------------------------------------------------------------
 
 int
-main(int argc, char * argv[])
+main(void)
 {
   /** Some basic type definitions.
    * NOTE: don't change the dimension or the spline order, since the

--- a/Testing/itkBSplineInterpolationWeightFunctionTest.cxx
+++ b/Testing/itkBSplineInterpolationWeightFunctionTest.cxx
@@ -28,7 +28,7 @@
 // Also the PrintSelf()-functions are called.
 
 int
-main(int argc, char * argv[])
+main(void)
 {
   /** Some basic type definitions. */
   const unsigned int SplineOrder = 3;

--- a/Testing/itkBSplineSODerivativeKernelFunctionTest.cxx
+++ b/Testing/itkBSplineSODerivativeKernelFunctionTest.cxx
@@ -24,7 +24,7 @@
 //-------------------------------------------------------------------------------------
 
 int
-main(int argc, char * argv[])
+main(void)
 {
   /** Some basic type definitions.
    * NOTE: don't change the dimension or the spline order, since the

--- a/Testing/itkCompareCompositeTransformsTest.cxx
+++ b/Testing/itkCompareCompositeTransformsTest.cxx
@@ -31,7 +31,7 @@
 
 //-------------------------------------------------------------------------------------
 int
-main(int argc, char * argv[])
+main(void)
 {
   const unsigned int Dimension = 3;
   typedef float      ScalarType;

--- a/Testing/itkGPUFactoriesTest.cxx
+++ b/Testing/itkGPUFactoriesTest.cxx
@@ -507,7 +507,7 @@ TestGPUAdvancedTransformFactories()
 //------------------------------------------------------------------------------
 // This test validates GPU factory create process
 int
-main(int argc, char * argv[])
+main(void)
 {
   // Setup for debugging
   itk::SetupForDebugging();

--- a/Testing/itkMevisDicomTiffImageIOTest.cxx
+++ b/Testing/itkMevisDicomTiffImageIOTest.cxx
@@ -218,7 +218,7 @@ testMevis(void)
 
 
 int
-main(int argc, char * argv[])
+main(void)
 {
 
   /** Support Mevis Dicom Tiff (if selected in cmake) */

--- a/Testing/itkOpenCLBufferTest.cxx
+++ b/Testing/itkOpenCLBufferTest.cxx
@@ -38,7 +38,7 @@ std_all_of(const std::vector<type> & v, const type value)
 
 //------------------------------------------------------------------------------
 int
-main(int argc, char * argv[])
+main(void)
 {
   itk::OpenCLBuffer bufferNull;
 

--- a/Testing/itkOpenCLContextTest.cxx
+++ b/Testing/itkOpenCLContextTest.cxx
@@ -19,7 +19,7 @@
 #include "itkTestHelper.h"
 
 int
-main(int argc, char * argv[])
+main(void)
 {
   itk::OpenCLContext::Pointer contextNull = itk::OpenCLContext::New();
 

--- a/Testing/itkOpenCLDeviceTest.cxx
+++ b/Testing/itkOpenCLDeviceTest.cxx
@@ -20,7 +20,7 @@
 #include "itkOpenCLProgram.h"
 
 int
-main(int argc, char * argv[])
+main(void)
 {
   itk::OpenCLDevice device;
 

--- a/Testing/itkOpenCLEventTest.cxx
+++ b/Testing/itkOpenCLEventTest.cxx
@@ -19,7 +19,7 @@
 #include "itkOpenCLEventTest.h"
 
 int
-main(int argc, char * argv[])
+main(void)
 {
   itk::OpenCLEvent eventNull;
 

--- a/Testing/itkOpenCLImageTest.cxx
+++ b/Testing/itkOpenCLImageTest.cxx
@@ -21,7 +21,7 @@
 #include <algorithm>
 
 int
-main(int argc, char * argv[])
+main(void)
 {
   itk::OpenCLImage imageNull;
 

--- a/Testing/itkOpenCLKernelManagerTest.cxx
+++ b/Testing/itkOpenCLKernelManagerTest.cxx
@@ -19,7 +19,7 @@
 #include "itkTestHelper.h"
 
 int
-main(int argc, char * argv[])
+main(void)
 {
   itk::OpenCLContext::Pointer context = itk::OpenCLContext::GetInstance();
   context->Create(itk::OpenCLContext::DevelopmentSingleMaximumFlopsDevice);

--- a/Testing/itkOpenCLKernelTest.cxx
+++ b/Testing/itkOpenCLKernelTest.cxx
@@ -18,7 +18,7 @@
 #include "itkOpenCLKernel.h"
 
 int
-main(int argc, char * argv[])
+main(void)
 {
   itk::OpenCLKernel kernel;
 

--- a/Testing/itkOpenCLKernelToImageBridgeTest.cxx
+++ b/Testing/itkOpenCLKernelToImageBridgeTest.cxx
@@ -20,7 +20,7 @@
 #include "itkOpenCLKernelToImageBridge.h"
 
 int
-main(int argc, char * argv[])
+main(void)
 {
   try
   {

--- a/Testing/itkOpenCLPlatformTest.cxx
+++ b/Testing/itkOpenCLPlatformTest.cxx
@@ -19,7 +19,7 @@
 #include "itkOpenCLPlatform.h"
 
 int
-main(int argc, char * argv[])
+main(void)
 {
   itk::OpenCLPlatform platform;
 

--- a/Testing/itkOpenCLProfilingTimeProbeTest.cxx
+++ b/Testing/itkOpenCLProfilingTimeProbeTest.cxx
@@ -18,7 +18,7 @@
 #include "itkOpenCLProfilingTimeProbe.h"
 
 int
-main(int argc, char * argv[])
+main(void)
 {
   {
     itk::OpenCLProfilingTimeProbe timer("Hello ITK OpenCL!");

--- a/Testing/itkOpenCLSamplerTest.cxx
+++ b/Testing/itkOpenCLSamplerTest.cxx
@@ -19,7 +19,7 @@
 #include "itkOpenCLSampler.h"
 
 int
-main(int argc, char * argv[])
+main(void)
 {
   itk::OpenCLSampler samplerNull;
 

--- a/Testing/itkOpenCLSimpleTest.cxx
+++ b/Testing/itkOpenCLSimpleTest.cxx
@@ -23,7 +23,7 @@
 // This test is mainly to test CMake generating process when two kernels are
 // merged into one source code see OpenCLSimpleTestKernel.cxx
 int
-main(int argc, char * argv[])
+main(void)
 {
   try
   {

--- a/Testing/itkOpenCLSizeTest.cxx
+++ b/Testing/itkOpenCLSizeTest.cxx
@@ -20,7 +20,7 @@
 #include "itkTestHelper.h"
 
 int
-main(int argc, char * argv[])
+main(void)
 {
   itk::OpenCLSize size(itk::OpenCLSize::null);
 


### PR DESCRIPTION
Fixed various Visual C++ 2019 Warning Level 4 warnings, saying:
> warning C4130: '!=': logical operation on address of string constant
> warning C4100: 'argc': unreferenced formal parameter
> warning C4100: 'argv': unreferenced formal parameter