### PR TITLE
BUG: Remove unreachable code in Common\OpenCL, after `itkExceptionMacro`

### DIFF
--- a/Common/OpenCL/ITKimprovements/itkGPUDataManager.cxx
+++ b/Common/OpenCL/ITKimprovements/itkGPUDataManager.cxx
@@ -271,7 +271,6 @@ GPUDataManager::Update()
   if (m_IsGPUBufferDirty && m_IsCPUBufferDirty)
   {
     itkExceptionMacro("Cannot make up-to-date buffer because both CPU and GPU buffers are dirty");
-    return false;
   }
 
   this->UpdateGPUBuffer();

--- a/Common/OpenCL/ITKimprovements/itkOpenCLLogger.cxx
+++ b/Common/OpenCL/ITKimprovements/itkOpenCLLogger.cxx
@@ -104,10 +104,6 @@ OpenCLLogger::Initialize()
   if (this->m_FileStream->fail())
   {
     itkExceptionMacro(<< "Unable to open file: " << logFileName);
-    delete this->m_FileStream;
-    this->m_FileStream = nullptr;
-    this->m_Created = false;
-    return;
   }
 
   // Create an ITK Logger


### PR DESCRIPTION
Removed the unreachable code after `itkExceptionMacro` calls (which throw an exception), from two cxx files in Common\OpenCL\ITKimprovements.

Fixed Visual C++ Warning Level 4 warning C4702, "unreachable code".