### PR TITLE
STYLE: Remove `using namespace std` from Common/xout

### DIFF
--- a/Common/xout/xoutbase.cxx
+++ b/Common/xout/xoutbase.cxx
@@ -20,7 +20,6 @@
 
 namespace xoutlibrary
 {
-using namespace std;
 
 /**
  * ********************* Destructor *****************************
@@ -59,7 +58,7 @@ xoutbase::WriteBufferedData(void)
   /** Update the target c-streams. */
   for (const auto & cell : m_CTargetCells)
   {
-    *(cell.second) << flush;
+    *(cell.second) << std::flush;
   }
 
   /** WriteBufferedData of the target xout-objects. */

--- a/Common/xout/xoutbase.h
+++ b/Common/xout/xoutbase.h
@@ -25,7 +25,6 @@
 
 namespace xoutlibrary
 {
-using namespace std;
 
 /**
  * \class xoutbase
@@ -91,7 +90,7 @@ public:
 
 
   Self &
-  operator<<(ios_base & (*pf)(ios_base &))
+  operator<<(std::ios_base & (*pf)(std::ios_base &))
   {
     return this->SendToTargets(pf);
   }

--- a/Common/xout/xoutcell.cxx
+++ b/Common/xout/xoutcell.cxx
@@ -57,7 +57,7 @@ xoutcell::WriteBufferedData(void)
   }
 
   /** Empty the internal buffer */
-  this->m_InternalBuffer.str(string(""));
+  this->m_InternalBuffer.str(std::string(""));
 
 } // end WriteBufferedData
 

--- a/Common/xout/xoutcell.h
+++ b/Common/xout/xoutcell.h
@@ -23,7 +23,6 @@
 
 namespace xoutlibrary
 {
-using namespace std;
 
 /**
  * \class xoutcell

--- a/Common/xout/xoutrow.cxx
+++ b/Common/xout/xoutrow.cxx
@@ -20,8 +20,6 @@
 
 namespace xoutlibrary
 {
-using namespace std;
-
 
 /**
  * ******************** WriteBufferedData ***********************

--- a/Common/xout/xoutrow.h
+++ b/Common/xout/xoutrow.h
@@ -26,7 +26,6 @@
 
 namespace xoutlibrary
 {
-using namespace std;
 
 /**
  * \class xoutrow

--- a/Common/xout/xoutsimple.cxx
+++ b/Common/xout/xoutsimple.cxx
@@ -20,7 +20,6 @@
 
 namespace xoutlibrary
 {
-using namespace std;
 
 /**
  * **************** AddOutput (std::ostream) ********************

--- a/Common/xout/xoutsimple.h
+++ b/Common/xout/xoutsimple.h
@@ -22,7 +22,6 @@
 
 namespace xoutlibrary
 {
-using namespace std;
 
 /**
  * \class xoutsimple


### PR DESCRIPTION
Followed "Coding Standards" FAQ, "Should I use using namespace std in my code?" (Answer: "Probably not.")
https://isocpp.org/wiki/faq/coding-standards#using-namespace-std