### PR TITLE
Support ITK Parameters and FixedParameters from itk::AffineTransform

### DIFF
--- a/Core/ComponentBaseClasses/elxTransformBase.hxx
+++ b/Core/ComponentBaseClasses/elxTransformBase.hxx
@@ -402,7 +402,7 @@ TransformBase<TElastix>::ReadFromFile(void)
       m_TransformParametersPointer.reset(new ParametersType(Conversion::ToOptimizerParameters(*itkParameterValues)));
 
       const auto itkFixedParameterValues =
-        this->m_Configuration->template RetrieveValuesOfParameter<double>("ITKTransformParameters");
+        this->m_Configuration->template RetrieveValuesOfParameter<double>("ITKTransformFixedParameters");
 
       if (itkFixedParameterValues != nullptr)
       {


### PR DESCRIPTION
Also fixed a bug in `TransformBase::ReadFromFile()` that I introduced last month, with "ENH: Read data from an external transform file into the parameter map" pull request #438 commit 1c294607e55e18018874005e57aac458b6f4e013