### PR TITLE
BUG: Use double-conversion instead of std::istringstream in ParameterMap

### DIFF
--- a/Common/GTesting/itkParameterMapInterfaceTest.cxx
+++ b/Common/GTesting/itkParameterMapInterfaceTest.cxx
@@ -98,7 +98,15 @@ GTEST_TEST(ParameterMapInterface, RetrieveValuesThrowsExceptionWhenConversionFai
 {
   const auto        parameterMapInterface = ParameterMapInterface::New();
   const std::string parameterName("Key");
-  parameterMapInterface->SetParameterMap({ { parameterName, { "not-a-valid-floating-point-value" } } });
 
+  parameterMapInterface->SetParameterMap({ { parameterName, { "not-a-valid-floating-point-value" } } });
+  EXPECT_THROW(parameterMapInterface->RetrieveValues<double>(parameterName), itk::ExceptionObject);
+
+  // A typical input error where floating point value 1.25 might have been intended:
+  parameterMapInterface->SetParameterMap({ { parameterName, { "1,25" } } });
+  EXPECT_THROW(parameterMapInterface->RetrieveValues<double>(parameterName), itk::ExceptionObject);
+
+  // Either 2375 (using comma as thousands separator) or 2.375 might have been intended:
+  parameterMapInterface->SetParameterMap({ { parameterName, { "2,375" } } });
   EXPECT_THROW(parameterMapInterface->RetrieveValues<double>(parameterName), itk::ExceptionObject);
 }


### PR DESCRIPTION
Replaced `std::istringstream` by `StringToDoubleConverter` from Google's double-conversion library <https://github.com/google/double-conversion>, inside the implementation of `ParameterMapInterface::StringCastToFloatingPoint`.

`double_conversion::StringToDoubleConverter` is not affected by locale settings (specifically the decimal separator), so this commit should fix issue https://github.com/SuperElastix/elastix/issues/454 "elastix crash when LANG=fr_FR.UTF-8".

The new `StringCastToFloatingPoint` implementation detects more types of user input errors, for example when a user tries to use a comma as decimal separator (as in "2,375").

This commit also cleans up, by removing code which is no longer necessary now, from "BUG: ParameterMapInterface::StringCast workaround Clang denormal bug", pull request https://github.com/SuperElastix/elastix/pull/404 commit a06e2323166d2ce3119ebcb650fe8ac80fe9b26b

Note that elastix already uses Google's double-conversion library for double-to-string conversion, indirectly, via `itk::NumberToString`.