### PR TITLE
BUG: Fix Conversion::ToString(float) itk::NumberToString specialization

### DIFF
--- a/Common/GTesting/elxConversionGTest.cxx
+++ b/Common/GTesting/elxConversionGTest.cxx
@@ -415,6 +415,12 @@ GTEST_TEST(Conversion, ToString)
   EXPECT_EQ(Conversion::ToString(-DoubleLimits::infinity()), "-Infinity");
   EXPECT_EQ(Conversion::ToString(DoubleLimits::denorm_min()), "5e-324");
   EXPECT_EQ(Conversion::ToString(-DoubleLimits::denorm_min()), "-5e-324");
+
+  // Even though the IEEE float and double representations of 0.1 both have a
+  // small rounding error, we would rather not have 0.1 converted to a string
+  // like "0.10000000000000001", or even "0.10000000149011612".
+  EXPECT_EQ(Conversion::ToString(0.1), "0.1");
+  EXPECT_EQ(Conversion::ToString(0.1f), "0.1");
 }
 
 

--- a/Core/Install/elxConversion.cxx
+++ b/Core/Install/elxConversion.cxx
@@ -161,7 +161,7 @@ Conversion::ToString(const double scalar)
 std::string
 Conversion::ToString(const float scalar)
 {
-  return itk::NumberToString<double>{}(scalar);
+  return itk::NumberToString<float>{}(scalar);
 }
 
 


### PR DESCRIPTION
Accidentally, `ToString(float)` called the "double" specialization of `itk::NumberToString`, which led to a sub-optimal string representation. For example, 0.1f would yield "0.10000000149011612", instead of simply "0.1".

Fixed by calling the "float" specialization of `itk::NumberToString` instead.