### PR TITLE
Add `HasParameter(const std::string &)` member functions, add `const` to `Configuration::ReadParameter` overloads

### DIFF
--- a/Common/GTesting/itkParameterMapInterfaceTest.cxx
+++ b/Common/GTesting/itkParameterMapInterfaceTest.cxx
@@ -110,3 +110,20 @@ GTEST_TEST(ParameterMapInterface, RetrieveValuesThrowsExceptionWhenConversionFai
   parameterMapInterface->SetParameterMap({ { parameterName, { "2,375" } } });
   EXPECT_THROW(parameterMapInterface->RetrieveValues<double>(parameterName), itk::ExceptionObject);
 }
+
+
+GTEST_TEST(ParameterMapInterface, HasParameter)
+{
+  const auto        parameterMapInterface = ParameterMapInterface::New();
+  const std::string parameterName("Key");
+
+  EXPECT_FALSE(parameterMapInterface->HasParameter(parameterName));
+
+  parameterMapInterface->SetParameterMap({ { parameterName, {} } });
+  EXPECT_TRUE(parameterMapInterface->HasParameter(parameterName));
+
+  parameterMapInterface->SetParameterMap({ { parameterName, { "a", "b", "c" } } });
+  EXPECT_TRUE(parameterMapInterface->HasParameter(parameterName));
+
+  EXPECT_FALSE(parameterMapInterface->HasParameter("This-is-not-a-key-from-this-map-" + parameterName));
+}

--- a/Common/ParameterFileParser/itkParameterMapInterface.h
+++ b/Common/ParameterFileParser/itkParameterMapInterface.h
@@ -104,6 +104,13 @@ public:
   itkSetMacro(PrintErrorMessages, bool);
   itkGetConstMacro(PrintErrorMessages, bool);
 
+  /** Tells whether this parameter map has the parameter with the given name. */
+  bool
+  HasParameter(const std::string & parameterName) const
+  {
+    return this->m_ParameterMap.count(parameterName) > 0;
+  }
+
   /** Get the number of entries for a given parameter. */
   std::size_t
   CountNumberOfParameterEntries(const std::string & parameterName) const;

--- a/Core/Configuration/elxConfiguration.h
+++ b/Core/Configuration/elxConfiguration.h
@@ -154,7 +154,7 @@ public:
   ReadParameter(T &                 parameterValue,
                 const std::string & parameterName,
                 const unsigned int  entry_nr,
-                const bool          printThisErrorMessage)
+                const bool          printThisErrorMessage) const
   {
     std::string errorMessage = "";
     bool        found = this->m_ParameterMapInterface->ReadParameter(
@@ -171,7 +171,7 @@ public:
   /** Read a parameter from the parameter file. */
   template <class T>
   bool
-  ReadParameter(T & parameterValue, const std::string & parameterName, const unsigned int entry_nr)
+  ReadParameter(T & parameterValue, const std::string & parameterName, const unsigned int entry_nr) const
   {
     std::string errorMessage = "";
     bool found = this->m_ParameterMapInterface->ReadParameter(parameterValue, parameterName, entry_nr, errorMessage);

--- a/Core/Configuration/elxConfiguration.h
+++ b/Core/Configuration/elxConfiguration.h
@@ -227,6 +227,14 @@ public:
   }
 
 
+  /** Tells whether its parameter map has the parameter with the given name. */
+  bool
+  HasParameter(const std::string & parameterName) const
+  {
+    return m_ParameterMapInterface->HasParameter(parameterName);
+  }
+
+
   /** Returns the values of the specified parameter (from the parameter file). */
   std::vector<std::string>
   GetValuesOfParameter(const std::string & parameterName) const


### PR DESCRIPTION
Small commits in preparation of extended support of transform parameters from ITK.


