### PR TITLE
STYLE: Replace postfix by prefix increment in `for` loops

### DIFF
--- a/Common/CostFunctions/itkAdvancedImageToImageMetric.hxx
+++ b/Common/CostFunctions/itkAdvancedImageToImageMetric.hxx
@@ -610,7 +610,7 @@ AdvancedImageToImageMetric<TFixedImage, TMovingImage>::EvaluateMovingImageValueA
          */
         movingImageValue = this->m_Interpolator->EvaluateAtContinuousIndex(cindex);
         MovingImageIndexType index;
-        for (unsigned int j = 0; j < MovingImageDimension; j++)
+        for (unsigned int j = 0; j < MovingImageDimension; ++j)
         {
           index[j] = static_cast<long>(Math::Round<double>(cindex[j]));
         }

--- a/Common/CostFunctions/itkImageToImageMetricWithFeatures.hxx
+++ b/Common/CostFunctions/itkImageToImageMetricWithFeatures.hxx
@@ -49,7 +49,7 @@ ImageToImageMetricWithFeatures<TFixedImage, TMovingImage, TFixedFeatureImage, TM
   this->Superclass::Initialize();
 
   /** Check the fixed stuff. */
-  for (unsigned int i = 0; i < m_NumberOfFixedFeatureImages; i++)
+  for (unsigned int i = 0; i < m_NumberOfFixedFeatureImages; ++i)
   {
     /** Check if all the fixed feature images are set. */
     if (!this->m_FixedFeatureImages[i])
@@ -66,7 +66,7 @@ ImageToImageMetricWithFeatures<TFixedImage, TMovingImage, TFixedFeatureImage, TM
   }
 
   /** Check the moving stuff. */
-  for (unsigned int i = 0; i < m_NumberOfMovingFeatureImages; i++)
+  for (unsigned int i = 0; i < m_NumberOfMovingFeatureImages; ++i)
   {
     /** Check if all the moving feature images are set. */
     if (!this->m_MovingFeatureImages[i])
@@ -344,22 +344,22 @@ ImageToImageMetricWithFeatures<TFixedImage, TMovingImage, TFixedFeatureImage, TM
   os << indent << "NumberOfMovingFeatureImages: " << this->m_NumberOfMovingFeatureImages << std::endl;
 
   /** Print the feature image pointers. */
-  for (unsigned int i = 0; i < this->m_NumberOfFixedFeatureImages; i++)
+  for (unsigned int i = 0; i < this->m_NumberOfFixedFeatureImages; ++i)
   {
     os << indent << "FixedFeatureImages[" << i << "]: " << this->m_FixedFeatureImages[i].GetPointer() << std::endl;
   }
-  for (unsigned int i = 0; i < this->m_NumberOfMovingFeatureImages; i++)
+  for (unsigned int i = 0; i < this->m_NumberOfMovingFeatureImages; ++i)
   {
     os << indent << "MovingFeatureImages[" << i << "]: " << this->m_MovingFeatureImages[i].GetPointer() << std::endl;
   }
 
   /** Print the feature interpolators pointers. */
-  for (unsigned int i = 0; i < this->m_NumberOfFixedFeatureImages; i++)
+  for (unsigned int i = 0; i < this->m_NumberOfFixedFeatureImages; ++i)
   {
     os << indent << "FixedFeatureInterpolators[" << i << "]: " << this->m_FixedFeatureInterpolators[i].GetPointer()
        << std::endl;
   }
-  for (unsigned int i = 0; i < this->m_NumberOfMovingFeatureImages; i++)
+  for (unsigned int i = 0; i < this->m_NumberOfMovingFeatureImages; ++i)
   {
     os << indent << "MovingFeatureInterpolators[" << i << "]: " << this->m_MovingFeatureInterpolators[i].GetPointer()
        << std::endl;

--- a/Common/ImageSamplers/itkImageGridSampler.hxx
+++ b/Common/ImageSamplers/itkImageGridSampler.hxx
@@ -84,7 +84,7 @@ ImageGridSampler<TInputImage>::GenerateData(void)
   SampleGridIndexType        sampleGridIndex = this->GetCroppedInputImageRegion().GetIndex();
   const InputImageSizeType & inputImageSize = this->GetCroppedInputImageRegion().GetSize();
   unsigned long              numberOfSamplesOnGrid = 1;
-  for (unsigned int dim = 0; dim < InputImageDimension; dim++)
+  for (unsigned int dim = 0; dim < InputImageDimension; ++dim)
   {
     /** The number of sample point along one dimension. */
     sampleGridSize[dim] = 1 + ((inputImageSize[dim] - 1) / this->GetSampleGridSpacing()[dim]);
@@ -115,13 +115,13 @@ ImageGridSampler<TInputImage>::GenerateData(void)
   if (mask.IsNull())
   {
     /** Ugly loop over the grid. */
-    for (unsigned int t = 0; t < dim_t; t++)
+    for (unsigned int t = 0; t < dim_t; ++t)
     {
-      for (unsigned int z = 0; z < dim_z; z++)
+      for (unsigned int z = 0; z < dim_z; ++z)
       {
-        for (unsigned int y = 0; y < sampleGridSize[1]; y++)
+        for (unsigned int y = 0; y < sampleGridSize[1]; ++y)
         {
-          for (unsigned int x = 0; x < sampleGridSize[0]; x++)
+          for (unsigned int x = 0; x < sampleGridSize[0]; ++x)
           {
             ImageSampleType tempsample;
 
@@ -163,13 +163,13 @@ ImageGridSampler<TInputImage>::GenerateData(void)
       mask->GetSource()->Update();
     }
     /* Ugly loop over the grid; checks also if a sample falls within the mask. */
-    for (unsigned int t = 0; t < dim_t; t++)
+    for (unsigned int t = 0; t < dim_t; ++t)
     {
-      for (unsigned int z = 0; z < dim_z; z++)
+      for (unsigned int z = 0; z < dim_z; ++z)
       {
-        for (unsigned int y = 0; y < sampleGridSize[1]; y++)
+        for (unsigned int y = 0; y < sampleGridSize[1]; ++y)
         {
-          for (unsigned int x = 0; x < sampleGridSize[0]; x++)
+          for (unsigned int x = 0; x < sampleGridSize[0]; ++x)
           {
             ImageSampleType tempsample;
 

--- a/Common/ImageSamplers/itkImageRandomCoordinateSampler.hxx
+++ b/Common/ImageSamplers/itkImageRandomCoordinateSampler.hxx
@@ -186,7 +186,7 @@ ImageRandomCoordinateSampler<TInputImage>::BeforeThreadedGenerateData(void)
   this->GenerateSampleRegion(smallestImageCIndex, largestImageCIndex, smallestCIndex, largestCIndex);
 
   /** Fill the list with random numbers. */
-  for (unsigned long i = 0; i < this->m_NumberOfSamples; i++)
+  for (unsigned long i = 0; i < this->m_NumberOfSamples; ++i)
   {
     this->GenerateRandomCoordinate(smallestCIndex, largestCIndex, randomCIndex);
     for (unsigned int j = 0; j < InputImageDimension; ++j)
@@ -198,7 +198,7 @@ ImageRandomCoordinateSampler<TInputImage>::BeforeThreadedGenerateData(void)
   /** Initialize variables needed for threads. */
   this->m_ThreaderSampleContainer.clear();
   this->m_ThreaderSampleContainer.resize(this->GetNumberOfWorkUnits());
-  for (std::size_t i = 0; i < this->GetNumberOfWorkUnits(); i++)
+  for (std::size_t i = 0; i < this->GetNumberOfWorkUnits(); ++i)
   {
     this->m_ThreaderSampleContainer[i] = ImageSampleContainerType::New();
   }

--- a/Common/ImageSamplers/itkImageRandomSampler.hxx
+++ b/Common/ImageSamplers/itkImageRandomSampler.hxx
@@ -175,7 +175,7 @@ ImageRandomSampler<TInputImage>::ThreadedGenerateData(const InputImageRegionType
     /** Translate randomPosition to an index, copied from ImageRandomConstIteratorWithIndex. */
     unsigned long       residual;
     InputImageIndexType positionIndex;
-    for (unsigned int dim = 0; dim < InputImageDimension; dim++)
+    for (unsigned int dim = 0; dim < InputImageDimension; ++dim)
     {
       const unsigned long sizeInThisDimension = regionSize[dim];
       residual = randomPosition % sizeInThisDimension;

--- a/Common/ImageSamplers/itkImageRandomSamplerBase.hxx
+++ b/Common/ImageSamplers/itkImageRandomSamplerBase.hxx
@@ -58,7 +58,7 @@ ImageRandomSamplerBase<TInputImage>::BeforeThreadedGenerateData(void)
   /** Fill the list with random numbers. */
   const double numPixels = static_cast<double>(this->GetCroppedInputImageRegion().GetNumberOfPixels());
   localGenerator->GetVariateWithOpenRange(numPixels - 0.5); // dummy jump
-  for (unsigned long i = 0; i < this->m_NumberOfSamples; i++)
+  for (unsigned long i = 0; i < this->m_NumberOfSamples; ++i)
   {
     const double randomPosition = localGenerator->GetVariateWithOpenRange(numPixels - 0.5);
     this->m_RandomNumberList.push_back(randomPosition);

--- a/Common/ImageSamplers/itkImageRandomSamplerSparseMask.hxx
+++ b/Common/ImageSamplers/itkImageRandomSamplerSparseMask.hxx
@@ -139,7 +139,7 @@ ImageRandomSamplerSparseMask<TInputImage>::BeforeThreadedGenerateData(void)
   /** Initialize variables needed for threads. */
   this->m_ThreaderSampleContainer.clear();
   this->m_ThreaderSampleContainer.resize(this->GetNumberOfWorkUnits());
-  for (std::size_t i = 0; i < this->GetNumberOfWorkUnits(); i++)
+  for (std::size_t i = 0; i < this->GetNumberOfWorkUnits(); ++i)
   {
     this->m_ThreaderSampleContainer[i] = ImageSampleContainerType::New();
   }

--- a/Common/ImageSamplers/itkImageSamplerBase.hxx
+++ b/Common/ImageSamplers/itkImageSamplerBase.hxx
@@ -400,7 +400,7 @@ ImageSamplerBase<TInputImage>::BeforeThreadedGenerateData(void)
   /** Initialize variables needed for threads. */
   this->m_ThreaderSampleContainer.clear();
   this->m_ThreaderSampleContainer.resize(this->GetNumberOfWorkUnits());
-  for (std::size_t i = 0; i < this->GetNumberOfWorkUnits(); i++)
+  for (std::size_t i = 0; i < this->GetNumberOfWorkUnits(); ++i)
   {
     this->m_ThreaderSampleContainer[i] = ImageSampleContainerType::New();
   }
@@ -418,7 +418,7 @@ ImageSamplerBase<TInputImage>::AfterThreadedGenerateData(void)
 {
   /** Get the combined number of samples. */
   this->m_NumberOfSamples = 0;
-  for (std::size_t i = 0; i < this->GetNumberOfWorkUnits(); i++)
+  for (std::size_t i = 0; i < this->GetNumberOfWorkUnits(); ++i)
   {
     this->m_NumberOfSamples += this->m_ThreaderSampleContainer[i]->Size();
   }
@@ -429,7 +429,7 @@ ImageSamplerBase<TInputImage>::AfterThreadedGenerateData(void)
   sampleContainer->reserve(this->m_NumberOfSamples);
 
   /** Combine the results of all threads. */
-  for (std::size_t i = 0; i < this->GetNumberOfWorkUnits(); i++)
+  for (std::size_t i = 0; i < this->GetNumberOfWorkUnits(); ++i)
   {
     sampleContainer->insert(
       sampleContainer->end(), this->m_ThreaderSampleContainer[i]->begin(), this->m_ThreaderSampleContainer[i]->end());

--- a/Common/MevisDicomTiff/itkMevisDicomTiffImageIO.cxx
+++ b/Common/MevisDicomTiff/itkMevisDicomTiffImageIO.cxx
@@ -871,7 +871,7 @@ MevisDicomTiffImageIO::Read(void * buffer)
       // case one both x,y is larger
       if (m_TileLength >= m_Length && m_TileWidth >= m_Width)
       {
-        for (unsigned int z0 = 0; z0 < (m_TIFFDimension == 3 ? m_Depth : 1); z0++)
+        for (unsigned int z0 = 0; z0 < (m_TIFFDimension == 3 ? m_Depth : 1); ++z0)
         {
           if (TIFFReadTile(m_TIFFImage, tilebuf, 0, 0, z0, 0) < 0)
           {
@@ -909,7 +909,7 @@ MevisDicomTiffImageIO::Read(void * buffer)
         const unsigned int tilexbytes = lenx * bytespersample;
 
         const bool my = (m_Length % m_TileLength == 0) ? true : false;
-        for (unsigned int z0 = 0; z0 < (m_TIFFDimension == 3 ? m_Depth : 1); z0++)
+        for (unsigned int z0 = 0; z0 < (m_TIFFDimension == 3 ? m_Depth : 1); ++z0)
         {
           for (unsigned int y0 = 0; y0 < (my ? m_Length : m_Length - m_TileLength); y0 += m_TileLength)
           {
@@ -973,7 +973,7 @@ MevisDicomTiffImageIO::Read(void * buffer)
         const unsigned leny = m_Length;
         const bool     mx = (m_Width % m_TileWidth == 0) ? true : false;
 
-        for (unsigned int z0 = 0; z0 < (m_TIFFDimension == 3 ? m_Depth : 1); z0++)
+        for (unsigned int z0 = 0; z0 < (m_TIFFDimension == 3 ? m_Depth : 1); ++z0)
         {
           for (unsigned int x0 = 0; x0 < (mx ? m_Width : m_Width - m_TileWidth); x0 += m_TileWidth)
           {
@@ -1043,7 +1043,7 @@ MevisDicomTiffImageIO::Read(void * buffer)
       const bool my = (m_Length % m_TileLength == 0) ? true : false;
 
       // fill everything inside ie from topleft
-      for (unsigned int z0 = 0; z0 < (m_TIFFDimension == 3 ? m_Depth : 1); z0++)
+      for (unsigned int z0 = 0; z0 < (m_TIFFDimension == 3 ? m_Depth : 1); ++z0)
       {
         for (unsigned int y0 = 0; y0 < (my ? m_Length : m_Length - m_TileLength); y0 += m_TileLength)
         {
@@ -2002,7 +2002,7 @@ MevisDicomTiffImageIO ::Write(const void * buffer)
     const bool mx = (m_Width % m_TileWidth == 0) ? true : false;
     const bool my = (m_Length % m_TileLength == 0) ? true : false;
 
-    for (unsigned int z0 = 0; z0 < (m_TIFFDimension == 3 ? m_Depth : 1); z0++)
+    for (unsigned int z0 = 0; z0 < (m_TIFFDimension == 3 ? m_Depth : 1); ++z0)
     {
       for (unsigned int y0 = 0; y0 < (my ? m_Length : m_Length - m_TileLength); y0 += m_TileLength)
       {

--- a/Common/OpenCL/Filters/itkGPUBSplineBaseTransform.hxx
+++ b/Common/OpenCL/Filters/itkGPUBSplineBaseTransform.hxx
@@ -80,7 +80,7 @@ GPUBSplineBaseTransform<TScalarType, NDimensions>::GetSourceCode(std::string & s
   std::ostringstream sources;
 
   // Add other sources
-  for (std::size_t i = 0; i < this->m_Sources.size(); i++)
+  for (std::size_t i = 0; i < this->m_Sources.size(); ++i)
   {
     sources << this->m_Sources[i] << std::endl;
   }

--- a/Common/OpenCL/Filters/itkGPUBSplineDecompositionImageFilter.hxx
+++ b/Common/OpenCL/Filters/itkGPUBSplineDecompositionImageFilter.hxx
@@ -110,7 +110,7 @@ GPUBSplineDecompositionImageFilter<TInputImage, TOutputImage>::GPUGenerateData(v
   const typename GPUInputImage::SizeType  dataLength = inPtr->GetLargestPossibleRegion().GetSize();
   typename GPUOutputImage::SizeValueType  maxLength = 0;
 
-  for (std::size_t n = 0; n < InputImageDimension; n++)
+  for (std::size_t n = 0; n < InputImageDimension; ++n)
   {
     if (dataLength[n] > maxLength)
     {
@@ -134,7 +134,7 @@ GPUBSplineDecompositionImageFilter<TInputImage, TOutputImage>::GPUGenerateData(v
   caster->Update();
 
   typename GPUInputImage::SizeType localSize, globalSize;
-  for (std::size_t i = 0; i < InputImageDimension; i++)
+  for (std::size_t i = 0; i < InputImageDimension; ++i)
   {
     localSize[i] = OpenCLGetLocalBlockSize(InputImageDimension);
     // total # of threads
@@ -153,7 +153,7 @@ GPUBSplineDecompositionImageFilter<TInputImage, TOutputImage>::GPUGenerateData(v
 
   // set image size
   unsigned int imageSize[InputImageDimension];
-  for (std::size_t i = 0; i < InputImageDimension; i++)
+  for (std::size_t i = 0; i < InputImageDimension; ++i)
   {
     imageSize[i] = outSize[i];
   }
@@ -199,7 +199,7 @@ GPUBSplineDecompositionImageFilter<TInputImage, TOutputImage>::GPUGenerateData(v
 
   // Loop over directions
   OpenCLEventList eventList;
-  for (std::size_t n = 0; n < InputImageDimension; n++)
+  for (std::size_t n = 0; n < InputImageDimension; ++n)
   {
     this->m_GPUKernelManager->SetKernelArg(this->m_FilterGPUKernelHandle, argidx, sizeof(cl_uint), &n);
 

--- a/Common/OpenCL/Filters/itkGPUBSplineInterpolateImageFunction.hxx
+++ b/Common/OpenCL/Filters/itkGPUBSplineInterpolateImageFunction.hxx
@@ -84,7 +84,7 @@ GPUBSplineInterpolateImageFunction<TInputImage, TCoordRep, TCoefficientType>::Ge
   std::ostringstream sources;
 
   // Add other sources
-  for (std::size_t i = 0; i < this->m_Sources.size(); i++)
+  for (std::size_t i = 0; i < this->m_Sources.size(); ++i)
   {
     sources << this->m_Sources[i] << std::endl;
   }

--- a/Common/OpenCL/Filters/itkGPUCompositeTransformBase.hxx
+++ b/Common/OpenCL/Filters/itkGPUCompositeTransformBase.hxx
@@ -73,7 +73,7 @@ GPUCompositeTransformBase<TScalarType, NDimensions>::GetSourceCode(std::string &
   bool bsplineLoaded = false;
 
   // Add sources based on Transform type
-  for (std::size_t i = 0; i < this->GetNumberOfTransforms(); i++)
+  for (std::size_t i = 0; i < this->GetNumberOfTransforms(); ++i)
   {
     if (this->IsIdentityTransform(i, true, source_i) && !identityLoaded)
     {
@@ -111,7 +111,7 @@ template <typename TScalarType, unsigned int NDimensions>
 bool
 GPUCompositeTransformBase<TScalarType, NDimensions>::HasIdentityTransform(void) const
 {
-  for (std::size_t i = 0; i < this->GetNumberOfTransforms(); i++)
+  for (std::size_t i = 0; i < this->GetNumberOfTransforms(); ++i)
   {
     if (this->IsIdentityTransform(i))
     {
@@ -128,7 +128,7 @@ template <typename TScalarType, unsigned int NDimensions>
 bool
 GPUCompositeTransformBase<TScalarType, NDimensions>::HasMatrixOffsetTransform(void) const
 {
-  for (std::size_t i = 0; i < this->GetNumberOfTransforms(); i++)
+  for (std::size_t i = 0; i < this->GetNumberOfTransforms(); ++i)
   {
     if (this->IsMatrixOffsetTransform(i))
     {
@@ -145,7 +145,7 @@ template <typename TScalarType, unsigned int NDimensions>
 bool
 GPUCompositeTransformBase<TScalarType, NDimensions>::HasTranslationTransform(void) const
 {
-  for (std::size_t i = 0; i < this->GetNumberOfTransforms(); i++)
+  for (std::size_t i = 0; i < this->GetNumberOfTransforms(); ++i)
   {
     if (this->IsTranslationTransform(i))
     {
@@ -162,7 +162,7 @@ template <typename TScalarType, unsigned int NDimensions>
 bool
 GPUCompositeTransformBase<TScalarType, NDimensions>::HasBSplineTransform(void) const
 {
-  for (std::size_t i = 0; i < this->GetNumberOfTransforms(); i++)
+  for (std::size_t i = 0; i < this->GetNumberOfTransforms(); ++i)
   {
     if (this->IsBSplineTransform(i))
     {

--- a/Common/OpenCL/Filters/itkGPUIdentityTransform.hxx
+++ b/Common/OpenCL/Filters/itkGPUIdentityTransform.hxx
@@ -45,7 +45,7 @@ GPUIdentityTransform<TScalarType, NDimensions, TParentTransform>::GetSourceCode(
 
   // Create the final source code
   std::ostringstream sources;
-  for (std::size_t i = 0; i < this->m_Sources.size(); i++)
+  for (std::size_t i = 0; i < this->m_Sources.size(); ++i)
   {
     sources << this->m_Sources[i] << std::endl;
   }

--- a/Common/OpenCL/Filters/itkGPUInterpolateImageFunction.hxx
+++ b/Common/OpenCL/Filters/itkGPUInterpolateImageFunction.hxx
@@ -65,7 +65,7 @@ SetIndex(const typename ImageType::IndexType index, cl_uint2 & oclindex)
 {
   unsigned int id = 0;
 
-  for (unsigned int i = 0; i < 2; i++)
+  for (unsigned int i = 0; i < 2; ++i)
   {
     oclindex.s[id++] = index[i];
   }
@@ -78,7 +78,7 @@ SetIndex(const typename ImageType::IndexType index, cl_uint4 & oclindex)
 {
   unsigned int id = 0;
 
-  for (unsigned int i = 0; i < 3; i++)
+  for (unsigned int i = 0; i < 3; ++i)
   {
     oclindex.s[id++] = index[i];
   }
@@ -110,7 +110,7 @@ SetContinuousIndex(const TContinuousIndex & cindex, cl_float4 & oclindex)
 {
   unsigned int id = 0;
 
-  for (unsigned int i = 0; i < 3; i++)
+  for (unsigned int i = 0; i < 3; ++i)
   {
     oclindex.s[id++] = cindex[i];
   }

--- a/Common/OpenCL/Filters/itkGPULinearInterpolateImageFunction.hxx
+++ b/Common/OpenCL/Filters/itkGPULinearInterpolateImageFunction.hxx
@@ -49,7 +49,7 @@ GPULinearInterpolateImageFunction<TInputImage, TCoordRep>::GetSourceCode(std::st
 
   // Create the source code
   std::ostringstream sources;
-  for (std::size_t i = 0; i < this->m_Sources.size(); i++)
+  for (std::size_t i = 0; i < this->m_Sources.size(); ++i)
   {
     sources << this->m_Sources[i] << std::endl;
   }

--- a/Common/OpenCL/Filters/itkGPUMatrixOffsetTransformBase.hxx
+++ b/Common/OpenCL/Filters/itkGPUMatrixOffsetTransformBase.hxx
@@ -81,7 +81,7 @@ SetOffset2(const itk::Vector<TScalarType, 2> & offset, cl_float2 & ocloffset, Sp
 {
   unsigned int id = 0;
 
-  for (unsigned int i = 0; i < 2; i++)
+  for (unsigned int i = 0; i < 2; ++i)
   {
     ocloffset.s[id++] = offset[i];
   }
@@ -94,7 +94,7 @@ SetOffset3(const itk::Vector<TScalarType, 3> & offset, cl_float3 & ocloffset, Sp
 {
   unsigned int id = 0;
 
-  for (unsigned int i = 0; i < 3; i++)
+  for (unsigned int i = 0; i < 3; ++i)
   {
     ocloffset.s[id++] = offset[i];
   }
@@ -148,9 +148,9 @@ SetMatrix2(const itk::Matrix<TScalarType, 2, 2> & matrix,
 {
   unsigned int id = 0;
 
-  for (unsigned int i = 0; i < 2; i++)
+  for (unsigned int i = 0; i < 2; ++i)
   {
-    for (unsigned int j = 0; j < 2; j++)
+    for (unsigned int j = 0; j < 2; ++j)
     {
       oclmatrix.s[id++] = matrix[i][j];
     }
@@ -167,14 +167,14 @@ SetMatrix3(const itk::Matrix<TScalarType, 3, 3> & matrix,
 {
   unsigned int id = 0;
 
-  for (unsigned int i = 0; i < 3; i++)
+  for (unsigned int i = 0; i < 3; ++i)
   {
-    for (unsigned int j = 0; j < 3; j++)
+    for (unsigned int j = 0; j < 3; ++j)
     {
       oclmatrix.s[id++] = matrix[i][j];
     }
   }
-  for (unsigned int i = 9; i < 16; i++)
+  for (unsigned int i = 9; i < 16; ++i)
   {
     oclmatrix.s[i] = 0.0;
   }
@@ -282,7 +282,7 @@ GPUMatrixOffsetTransformBase<TScalarType, NInputDimensions, NOutputDimensions>::
   // Create the final source code
   std::ostringstream sources;
   // Add other sources
-  for (std::size_t i = 0; i < this->m_Sources.size(); i++)
+  for (std::size_t i = 0; i < this->m_Sources.size(); ++i)
   {
     sources << this->m_Sources[i] << std::endl;
   }

--- a/Common/OpenCL/Filters/itkGPUNearestNeighborInterpolateImageFunction.hxx
+++ b/Common/OpenCL/Filters/itkGPUNearestNeighborInterpolateImageFunction.hxx
@@ -49,7 +49,7 @@ GPUNearestNeighborInterpolateImageFunction<TInputImage, TCoordRep>::GetSourceCod
 
   // Create the source code
   std::ostringstream sources;
-  for (std::size_t i = 0; i < this->m_Sources.size(); i++)
+  for (std::size_t i = 0; i < this->m_Sources.size(); ++i)
   {
     sources << this->m_Sources[i] << std::endl;
   }

--- a/Common/OpenCL/Filters/itkGPURecursiveGaussianImageFilter.hxx
+++ b/Common/OpenCL/Filters/itkGPURecursiveGaussianImageFilter.hxx
@@ -110,13 +110,13 @@ GPURecursiveGaussianImageFilter<TInputImage, TOutputImage>::GPUGenerateData()
   }
 
   int imgSize[TInputImage::ImageDimension];
-  for (unsigned int i = 0; i < ImageDim; i++)
+  for (unsigned int i = 0; i < ImageDim; ++i)
   {
     imgSize[i] = outSize[i];
   }
 
   std::size_t globalSize1D = 0, globalSize2D[2];
-  for (unsigned int i = 0; i < 2; i++)
+  for (unsigned int i = 0; i < 2; ++i)
   {
     globalSize2D[i] = 0;
   }
@@ -204,7 +204,7 @@ GPURecursiveGaussianImageFilter<TInputImage, TOutputImage>::GPUGenerateData()
   this->m_GPUKernelManager->SetKernelArg(this->m_FilterGPUKernelHandle, argidx++, sizeof(cl_float4), (void *)&BM);
 
   // Set image size
-  for (unsigned int i = 0; i < ImageDim; i++)
+  for (unsigned int i = 0; i < ImageDim; ++i)
   {
     this->m_GPUKernelManager->SetKernelArg(this->m_FilterGPUKernelHandle, argidx++, sizeof(cl_uint), &(imgSize[i]));
   }

--- a/Common/OpenCL/Filters/itkGPUResampleImageFilter.hxx
+++ b/Common/OpenCL/Filters/itkGPUResampleImageFilter.hxx
@@ -467,7 +467,7 @@ GPUResampleImageFilter<TInputImage, TOutputImage, TInterpolatorPrecisionType>::G
   // Create and allocate the deformation field buffer
   // The deformation field size equals the maximum chunk size
   std::size_t totalDFSize = 1;
-  for (unsigned int i = 0; i < InputImageDimension; i++)
+  for (unsigned int i = 0; i < InputImageDimension; ++i)
   {
     totalDFSize *= maxChunkSize[i];
   }
@@ -559,7 +559,7 @@ GPUResampleImageFilter<TInputImage, TOutputImage, TInterpolatorPrecisionType>::G
       break;
       case 2:
       {
-        for (unsigned int i = 0; i < 2; i++)
+        for (unsigned int i = 0; i < 2; ++i)
         {
           dfsize2D.s[i] = currentChunkRegion.GetSize(i);
           global2D[i] = local2D[i] * (unsigned int)ceil((float)dfsize2D.s[i] / (float)local2D[i]);
@@ -579,7 +579,7 @@ GPUResampleImageFilter<TInputImage, TOutputImage, TInterpolatorPrecisionType>::G
       break;
       case 3:
       {
-        for (unsigned int i = 0; i < 3; i++)
+        for (unsigned int i = 0; i < 3; ++i)
         {
           dfsize3D.s[i] = currentChunkRegion.GetSize(i);
           global3D[i] = local3D[i] * (unsigned int)ceil((float)dfsize3D.s[i] / (float)local3D[i]);
@@ -840,7 +840,7 @@ GPUResampleImageFilter<TInputImage, TOutputImage, TInterpolatorPrecisionType>::S
                                                  true);
 
   // Set the B-spline coefficient images to the kernel.
-  for (unsigned int i = 0; i < InputImageDimension; i++)
+  for (unsigned int i = 0; i < InputImageDimension; ++i)
   {
     coefficient = gpuCoefficientImages[i];
     coefficientbase = gpuCoefficientImagesBases[i];

--- a/Common/OpenCL/Filters/itkGPUShrinkImageFilter.hxx
+++ b/Common/OpenCL/Filters/itkGPUShrinkImageFilter.hxx
@@ -89,7 +89,7 @@ GPUShrinkImageFilter<TInputImage, TOutputImage>::GPUGenerateData(void)
   // Convert the factor for convenient multiplication
   typename TOutputImage::SizeType factorSize;
   const ShrinkFactorsType         shrinkFactors = this->GetShrinkFactors();
-  for (std::size_t i = 0; i < InputImageDimension; i++)
+  for (std::size_t i = 0; i < InputImageDimension; ++i)
   {
     factorSize[i] = shrinkFactors[i];
   }
@@ -114,7 +114,7 @@ GPUShrinkImageFilter<TInputImage, TOutputImage>::GPUGenerateData(void)
   // inputIndex = outputIndex * factorSize
   // is equivalent up to a fixed offset which we now compute
   OffsetValueType zeroOffset = 0;
-  for (std::size_t i = 0; i < InputImageDimension; i++)
+  for (std::size_t i = 0; i < InputImageDimension; ++i)
   {
     offsetIndex[i] = inputIndex[i] - outputIndex[i] * shrinkFactors[i];
     // It is plausible that due to small amounts of loss of numerical
@@ -129,7 +129,7 @@ GPUShrinkImageFilter<TInputImage, TOutputImage>::GPUGenerateData(void)
   const OpenCLSize localSize = OpenCLSize::GetLocalWorkSize(this->m_GPUKernelManager->GetContext()->GetDefaultDevice());
 
   typename GPUInputImage::SizeType globalSize;
-  for (std::size_t i = 0; i < InputImageDimension; i++)
+  for (std::size_t i = 0; i < InputImageDimension; ++i)
   {
     // total # of threads
     globalSize[i] =
@@ -145,7 +145,7 @@ GPUShrinkImageFilter<TInputImage, TOutputImage>::GPUGenerateData(void)
   // set arguments for image size/offset/shrinkfactors
   unsigned int inImageSize[InputImageDimension];
   unsigned int outImageSize[InputImageDimension];
-  for (unsigned int i = 0; i < InputImageDimension; i++)
+  for (unsigned int i = 0; i < InputImageDimension; ++i)
   {
     inImageSize[i] = inSize[i];
     outImageSize[i] = outSize[i];
@@ -154,7 +154,7 @@ GPUShrinkImageFilter<TInputImage, TOutputImage>::GPUGenerateData(void)
   unsigned int offset[InputImageDimension];
   unsigned int shrinkfactors[InputImageDimension];
 
-  for (std::size_t i = 0; i < InputImageDimension; i++)
+  for (std::size_t i = 0; i < InputImageDimension; ++i)
   {
     offset[i] = offsetIndex[i];
     shrinkfactors[i] = factorSize[i];

--- a/Common/OpenCL/Filters/itkGPUTranslationTransformBase.hxx
+++ b/Common/OpenCL/Filters/itkGPUTranslationTransformBase.hxx
@@ -75,7 +75,7 @@ SetOffset2(const itk::Vector<TScalarType, 2> & offset, cl_float2 & ocloffset, Sp
 {
   unsigned int id = 0;
 
-  for (unsigned int i = 0; i < 2; i++)
+  for (unsigned int i = 0; i < 2; ++i)
   {
     ocloffset.s[id++] = offset[i];
   }
@@ -88,7 +88,7 @@ SetOffset3(const itk::Vector<TScalarType, 3> & offset, cl_float4 & ocloffset, Sp
 {
   unsigned int id = 0;
 
-  for (unsigned int i = 0; i < 3; i++)
+  for (unsigned int i = 0; i < 3; ++i)
   {
     ocloffset.s[id++] = offset[i];
   }
@@ -189,7 +189,7 @@ GPUTranslationTransformBase<TScalarType, NDimensions>::GetSourceCode(std::string
   // Create the final source code
   std::ostringstream sources;
   // Add other sources
-  for (std::size_t i = 0; i < this->m_Sources.size(); i++)
+  for (std::size_t i = 0; i < this->m_Sources.size(); ++i)
   {
     sources << this->m_Sources[i] << std::endl;
   }

--- a/Common/OpenCL/ITKimprovements/itkGPUInPlaceImageFilter.hxx
+++ b/Common/OpenCL/ITKimprovements/itkGPUInPlaceImageFilter.hxx
@@ -89,7 +89,7 @@ GPUInPlaceImageFilter<TInputImage, TOutputImage, TParentImageFilter>::AllocateOu
       typename ImageBaseType::Pointer         outputPtr;
 
       // If there are more than one outputs, allocate the remaining outputs
-      for (unsigned int i = 1; i < this->GetNumberOfOutputs(); i++)
+      for (unsigned int i = 1; i < this->GetNumberOfOutputs(); ++i)
       {
         // Check whether the output is an image of the appropriate
         // dimension (use ProcessObject's version of the GetInput()

--- a/Common/OpenCL/ITKimprovements/itkGPUUnaryFunctorImageFilter.hxx
+++ b/Common/OpenCL/ITKimprovements/itkGPUUnaryFunctorImageFilter.hxx
@@ -79,13 +79,13 @@ GPUUnaryFunctorImageFilter<TInputImage, TOutputImage, TFunction, TParentImageFil
 
   const unsigned int ImageDim = (unsigned int)TInputImage::ImageDimension;
 
-  for (std::size_t i = 0; i < ImageDim; i++)
+  for (std::size_t i = 0; i < ImageDim; ++i)
   {
     imgSize[i] = outSize[i];
   }
 
   typename GPUInputImage::SizeType localSize, globalSize;
-  for (std::size_t i = 0; i < ImageDim; i++)
+  for (std::size_t i = 0; i < ImageDim; ++i)
   {
     localSize[i] = OpenCLGetLocalBlockSize(InputImageDimension);
     // total # of threads
@@ -104,7 +104,7 @@ GPUUnaryFunctorImageFilter<TInputImage, TOutputImage, TFunction, TParentImageFil
   this->m_GPUKernelManager->SetKernelArgWithImage(
     m_UnaryFunctorImageFilterGPUKernelHandle, argidx++, otPtr->GetGPUDataManager());
 
-  for (std::size_t i = 0; i < ImageDim; i++)
+  for (std::size_t i = 0; i < ImageDim; ++i)
   {
     this->m_GPUKernelManager->SetKernelArg(
       m_UnaryFunctorImageFilterGPUKernelHandle, argidx++, sizeof(cl_uint), &(imgSize[i]));

--- a/Common/OpenCL/ITKimprovements/itkOpenCLKernel.cxx
+++ b/Common/OpenCL/ITKimprovements/itkOpenCLKernel.cxx
@@ -1118,9 +1118,9 @@ OpenCLKernel::SetArg(const cl_uint index, const MatrixFloat2x2Type & value)
   const unsigned int nRows = MatrixFloat2x2Type::RowDimensions;
   const unsigned int nColumns = MatrixFloat2x2Type::ColumnDimensions;
 
-  for (unsigned int i = 0; i < nRows; i++)
+  for (unsigned int i = 0; i < nRows; ++i)
   {
-    for (unsigned int j = 0; j < nColumns; j++)
+    for (unsigned int j = 0; j < nColumns; ++j)
     {
       values.s[id] = value[i][j];
       id++;
@@ -1141,9 +1141,9 @@ OpenCLKernel::SetArg(const cl_uint index, const MatrixDouble2x2Type & value)
   if (!this->m_DoubleAsFloat)
   {
     cl_double4 values;
-    for (unsigned int i = 0; i < nRows; i++)
+    for (unsigned int i = 0; i < nRows; ++i)
     {
-      for (unsigned int j = 0; j < nColumns; j++)
+      for (unsigned int j = 0; j < nColumns; ++j)
       {
         values.s[id] = value[i][j];
         id++;
@@ -1154,9 +1154,9 @@ OpenCLKernel::SetArg(const cl_uint index, const MatrixDouble2x2Type & value)
   else
   {
     cl_float4 values;
-    for (unsigned int i = 0; i < nRows; i++)
+    for (unsigned int i = 0; i < nRows; ++i)
     {
-      for (unsigned int j = 0; j < nColumns; j++)
+      for (unsigned int j = 0; j < nColumns; ++j)
       {
         values.s[id] = static_cast<float>(value[i][j]);
         id++;
@@ -1177,9 +1177,9 @@ OpenCLKernel::SetArg(const cl_uint index, const MatrixFloat3x3Type & value)
   const unsigned int nRows = MatrixFloat3x3Type::RowDimensions;
   const unsigned int nColumns = MatrixFloat3x3Type::ColumnDimensions;
 
-  for (unsigned int i = 0; i < nRows; i++)
+  for (unsigned int i = 0; i < nRows; ++i)
   {
-    for (unsigned int j = 0; j < nColumns; j++)
+    for (unsigned int j = 0; j < nColumns; ++j)
     {
       values.s[id] = value[i][j];
       id++;
@@ -1201,9 +1201,9 @@ OpenCLKernel::SetArg(const cl_uint index, const MatrixDouble3x3Type & value)
   {
     // OpenCL does not support double9 therefore we are using double16
     cl_double16 values;
-    for (unsigned int i = 0; i < nRows; i++)
+    for (unsigned int i = 0; i < nRows; ++i)
     {
-      for (unsigned int j = 0; j < nColumns; j++)
+      for (unsigned int j = 0; j < nColumns; ++j)
       {
         values.s[id] = value[i][j];
         id++;
@@ -1215,9 +1215,9 @@ OpenCLKernel::SetArg(const cl_uint index, const MatrixDouble3x3Type & value)
   {
     // OpenCL does not support float9 therefore we are using float16
     cl_float16 values;
-    for (unsigned int i = 0; i < nRows; i++)
+    for (unsigned int i = 0; i < nRows; ++i)
     {
-      for (unsigned int j = 0; j < nColumns; j++)
+      for (unsigned int j = 0; j < nColumns; ++j)
       {
         values.s[id] = static_cast<float>(value[i][j]);
         id++;
@@ -1238,9 +1238,9 @@ OpenCLKernel::SetArg(const cl_uint index, const MatrixFloat4x4Type & value)
   const unsigned int nRows = MatrixFloat4x4Type::RowDimensions;
   const unsigned int nColumns = MatrixFloat4x4Type::ColumnDimensions;
 
-  for (unsigned int i = 0; i < nRows; i++)
+  for (unsigned int i = 0; i < nRows; ++i)
   {
-    for (unsigned int j = 0; j < nColumns; j++)
+    for (unsigned int j = 0; j < nColumns; ++j)
     {
       values.s[id] = value[i][j];
       id++;
@@ -1262,9 +1262,9 @@ OpenCLKernel::SetArg(const cl_uint index, const MatrixDouble4x4Type & value)
   {
     // OpenCL does not support double9 therefore we are using double16
     cl_double16 values;
-    for (unsigned int i = 0; i < nRows; i++)
+    for (unsigned int i = 0; i < nRows; ++i)
     {
-      for (unsigned int j = 0; j < nColumns; j++)
+      for (unsigned int j = 0; j < nColumns; ++j)
       {
         values.s[id] = value[i][j];
         id++;
@@ -1276,9 +1276,9 @@ OpenCLKernel::SetArg(const cl_uint index, const MatrixDouble4x4Type & value)
   {
     // OpenCL does not support float9 therefore we are using float16
     cl_float16 values;
-    for (unsigned int i = 0; i < nRows; i++)
+    for (unsigned int i = 0; i < nRows; ++i)
     {
-      for (unsigned int j = 0; j < nColumns; j++)
+      for (unsigned int j = 0; j < nColumns; ++j)
       {
         values.s[id] = static_cast<float>(value[i][j]);
         id++;

--- a/Common/OpenCL/ITKimprovements/itkOpenCLKernelManager.cxx
+++ b/Common/OpenCL/ITKimprovements/itkOpenCLKernelManager.cxx
@@ -233,7 +233,7 @@ OpenCLKernelManager::CheckArgumentReady(const std::size_t kernelId)
 {
   const std::size_t nArg = this->m_KernelArgumentReady[kernelId].size();
 
-  for (std::size_t i = 0; i < nArg; i++)
+  for (std::size_t i = 0; i < nArg; ++i)
   {
     if (!(this->m_KernelArgumentReady[kernelId][i].m_IsReady))
     {
@@ -256,7 +256,7 @@ OpenCLKernelManager::ResetArguments(const std::size_t kernelIdx)
 {
   const std::size_t nArg = this->m_KernelArgumentReady[kernelIdx].size();
 
-  for (std::size_t i = 0; i < nArg; i++)
+  for (std::size_t i = 0; i < nArg; ++i)
   {
     this->m_KernelArgumentReady[kernelIdx][i].m_IsReady = false;
     this->m_KernelArgumentReady[kernelIdx][i].m_GPUDataManager = (GPUDataManager::Pointer) nullptr;

--- a/Common/OpenCL/ITKimprovements/itkOpenCLKernelToImageBridge.hxx
+++ b/Common/OpenCL/ITKimprovements/itkOpenCLKernelToImageBridge.hxx
@@ -207,7 +207,7 @@ OpenCLKernelToImageBridge<TImage>::SetImageMetaData(OpenCLKernel &              
         const typename ImageType::DirectionType & pp2i = image->GetPhysicalPointToIndex();
 
         // Set Size, Spacing, Origin
-        for (unsigned int i = 0; i < ImageDimension; i++)
+        for (unsigned int i = 0; i < ImageDimension; ++i)
         {
           imageBase2D.Size.s[i] = size[i];
           imageBase2D.Spacing.s[i] = spacing[i];
@@ -216,9 +216,9 @@ OpenCLKernelToImageBridge<TImage>::SetImageMetaData(OpenCLKernel &              
 
         // Set Directions
         unsigned int index = 0;
-        for (unsigned int i = 0; i < ImageDimension; i++)
+        for (unsigned int i = 0; i < ImageDimension; ++i)
         {
-          for (unsigned int j = 0; j < ImageDimension; j++)
+          for (unsigned int j = 0; j < ImageDimension; ++j)
           {
             imageBase2D.Direction.s[index] = static_cast<float>(direction[i][j]);
             imageBase2D.IndexToPhysicalPoint.s[index] = static_cast<float>(i2pp[i][j]);
@@ -230,14 +230,14 @@ OpenCLKernelToImageBridge<TImage>::SetImageMetaData(OpenCLKernel &              
       else
       {
         // Set Size, Spacing, Origin to zero
-        for (unsigned int i = 0; i < ImageDimension; i++)
+        for (unsigned int i = 0; i < ImageDimension; ++i)
         {
           imageBase2D.Size.s[i] = 0;
           imageBase2D.Spacing.s[i] = 0.0f;
           imageBase2D.Origin.s[i] = 0.0f;
         }
         // Set Directions to zero
-        for (unsigned int i = 0; i < 4; i++)
+        for (unsigned int i = 0; i < 4; ++i)
         {
           imageBase2D.Direction.s[i] = 0.0f;
           imageBase2D.IndexToPhysicalPoint.s[i] = 0.0f;
@@ -264,7 +264,7 @@ OpenCLKernelToImageBridge<TImage>::SetImageMetaData(OpenCLKernel &              
         const typename ImageType::DirectionType & pp2i = image->GetPhysicalPointToIndex();
 
         // Set Size, Spacing, Origin
-        for (unsigned int i = 0; i < ImageDimension; i++)
+        for (unsigned int i = 0; i < ImageDimension; ++i)
         {
           imageBase3D.Size.s[i] = size[i];
           imageBase3D.Spacing.s[i] = spacing[i];
@@ -273,9 +273,9 @@ OpenCLKernelToImageBridge<TImage>::SetImageMetaData(OpenCLKernel &              
 
         // Set Directions
         unsigned int index = 0;
-        for (unsigned int i = 0; i < ImageDimension; i++)
+        for (unsigned int i = 0; i < ImageDimension; ++i)
         {
-          for (unsigned int j = 0; j < ImageDimension; j++)
+          for (unsigned int j = 0; j < ImageDimension; ++j)
           {
             imageBase3D.Direction.s[index] = static_cast<float>(direction[i][j]);
             imageBase3D.IndexToPhysicalPoint.s[index] = static_cast<float>(i2pp[i][j]);
@@ -283,7 +283,7 @@ OpenCLKernelToImageBridge<TImage>::SetImageMetaData(OpenCLKernel &              
             index++;
           }
         }
-        for (unsigned int i = 9; i < 16; i++)
+        for (unsigned int i = 9; i < 16; ++i)
         {
           imageBase3D.Direction.s[i] = 0.0f;
           imageBase3D.IndexToPhysicalPoint.s[i] = 0.0f;
@@ -293,14 +293,14 @@ OpenCLKernelToImageBridge<TImage>::SetImageMetaData(OpenCLKernel &              
       else
       {
         // Set Size, Spacing, Origin to zero
-        for (unsigned int i = 0; i < ImageDimension; i++)
+        for (unsigned int i = 0; i < ImageDimension; ++i)
         {
           imageBase3D.Size.s[i] = 0;
           imageBase3D.Spacing.s[i] = 0.0f;
           imageBase3D.Origin.s[i] = 0.0f;
         }
         // Set Directions to zero
-        for (unsigned int i = 0; i < 16; i++)
+        for (unsigned int i = 0; i < 16; ++i)
         {
           imageBase3D.Direction.s[i] = 0.0f;
           imageBase3D.IndexToPhysicalPoint.s[i] = 0.0f;

--- a/Common/OpenCL/itkGPUKernelManagerHelperFunctions.h
+++ b/Common/OpenCL/itkGPUKernelManagerHelperFunctions.h
@@ -88,15 +88,15 @@ SetKernelWithDirection(const typename ImageType::DirectionType & dir,
   {
     float        direction[4];
     unsigned int index = 0;
-    for (unsigned int i = 0; i < ImageDim; i++)
+    for (unsigned int i = 0; i < ImageDim; ++i)
     {
-      for (unsigned int j = 0; j < ImageDim; j++)
+      for (unsigned int j = 0; j < ImageDim; ++j)
       {
         direction[index] = static_cast<float>(dir[i][j]);
         index++;
       }
     }
-    for (unsigned int i = 0; i < 4; i++)
+    for (unsigned int i = 0; i < 4; ++i)
     {
       direction2d.s[i] = direction[i];
     }
@@ -106,19 +106,19 @@ SetKernelWithDirection(const typename ImageType::DirectionType & dir,
     // OpenCL does not support float9 therefore we are using float16
     float        direction[16];
     unsigned int index = 0;
-    for (unsigned int i = 0; i < ImageDim; i++)
+    for (unsigned int i = 0; i < ImageDim; ++i)
     {
-      for (unsigned int j = 0; j < ImageDim; j++)
+      for (unsigned int j = 0; j < ImageDim; ++j)
       {
         direction[index] = static_cast<float>(dir[i][j]);
         index++;
       }
     }
-    for (unsigned int i = 9; i < 16; i++)
+    for (unsigned int i = 9; i < 16; ++i)
     {
       direction[i] = 0.0f;
     }
-    for (unsigned int i = 0; i < 16; i++)
+    for (unsigned int i = 0; i < 16; ++i)
     {
       direction3d.s[i] = direction[i];
     }
@@ -177,7 +177,7 @@ SetKernelWithITKImage(OpenCLKernelManager::Pointer &      kernelManager,
 
     typedef unsigned int size_type;
     size_type            size[ImageType::ImageDimension];
-    for (unsigned int i = 0; i < ImageDim; i++)
+    for (unsigned int i = 0; i < ImageDim; ++i)
     {
       if (image.IsNotNull())
       {
@@ -194,14 +194,14 @@ SetKernelWithITKImage(OpenCLKernelManager::Pointer &      kernelManager,
     }
     else if (ImageDim == 2)
     {
-      for (unsigned int i = 0; i < ImageDim; i++)
+      for (unsigned int i = 0; i < ImageDim; ++i)
       {
         imageBase2D.Size.s[i] = size[i];
       }
     }
     else if (ImageDim == 3)
     {
-      for (unsigned int i = 0; i < ImageDim; i++)
+      for (unsigned int i = 0; i < ImageDim; ++i)
       {
         imageBase3D.Size.s[i] = size[i];
       }
@@ -209,7 +209,7 @@ SetKernelWithITKImage(OpenCLKernelManager::Pointer &      kernelManager,
 
     // Set spacing
     float spacing[ImageType::ImageDimension];
-    for (unsigned int i = 0; i < ImageDim; i++)
+    for (unsigned int i = 0; i < ImageDim; ++i)
     {
       if (image.IsNotNull())
       {
@@ -226,14 +226,14 @@ SetKernelWithITKImage(OpenCLKernelManager::Pointer &      kernelManager,
     }
     else if (ImageDim == 2)
     {
-      for (unsigned int i = 0; i < ImageDim; i++)
+      for (unsigned int i = 0; i < ImageDim; ++i)
       {
         imageBase2D.Spacing.s[i] = spacing[i];
       }
     }
     else if (ImageDim == 3)
     {
-      for (unsigned int i = 0; i < ImageDim; i++)
+      for (unsigned int i = 0; i < ImageDim; ++i)
       {
         imageBase3D.Spacing.s[i] = spacing[i];
       }
@@ -241,7 +241,7 @@ SetKernelWithITKImage(OpenCLKernelManager::Pointer &      kernelManager,
 
     // Set origin
     float origin[ImageType::ImageDimension];
-    for (unsigned int i = 0; i < ImageDim; i++)
+    for (unsigned int i = 0; i < ImageDim; ++i)
     {
       if (image.IsNotNull())
       {
@@ -258,14 +258,14 @@ SetKernelWithITKImage(OpenCLKernelManager::Pointer &      kernelManager,
     }
     else if (ImageDim == 2)
     {
-      for (unsigned int i = 0; i < ImageDim; i++)
+      for (unsigned int i = 0; i < ImageDim; ++i)
       {
         imageBase2D.Origin.s[i] = origin[i];
       }
     }
     else if (ImageDim == 3)
     {
-      for (unsigned int i = 0; i < ImageDim; i++)
+      for (unsigned int i = 0; i < ImageDim; ++i)
       {
         imageBase3D.Origin.s[i] = origin[i];
       }

--- a/Common/Transforms/itkAdvancedBSplineDeformableTransform.hxx
+++ b/Common/Transforms/itkAdvancedBSplineDeformableTransform.hxx
@@ -87,7 +87,7 @@ AdvancedBSplineDeformableTransform<TScalarType, NDimensions, VSplineOrder>::Adva
   this->m_InputParametersPointer = &(this->m_InternalParametersBuffer);
 
   // Initialize coefficient images
-  for (unsigned int j = 0; j < SpaceDimension; j++)
+  for (unsigned int j = 0; j < SpaceDimension; ++j)
   {
     this->m_WrappedImage[j] = ImageType::New();
     this->m_WrappedImage[j]->SetRegions(this->m_GridRegion);
@@ -118,13 +118,13 @@ AdvancedBSplineDeformableTransform<TScalarType, NDimensions, VSplineOrder>::Adva
    */
   this->m_FixedParameters.SetSize(NDimensions * (NDimensions + 3));
   this->m_FixedParameters.Fill(0.0);
-  for (unsigned int i = 0; i < NDimensions; i++)
+  for (unsigned int i = 0; i < NDimensions; ++i)
   {
     this->m_FixedParameters[2 * NDimensions + i] = this->m_GridSpacing[i];
   }
-  for (unsigned int di = 0; di < NDimensions; di++)
+  for (unsigned int di = 0; di < NDimensions; ++di)
   {
-    for (unsigned int dj = 0; dj < NDimensions; dj++)
+    for (unsigned int dj = 0; dj < NDimensions; ++dj)
     {
       this->m_FixedParameters[3 * NDimensions + (di * NDimensions + dj)] = this->m_GridDirection[di][dj];
     }
@@ -157,7 +157,7 @@ AdvancedBSplineDeformableTransform<TScalarType, NDimensions, VSplineOrder>::SetG
     this->m_GridRegion = region;
 
     // set regions for each coefficient and Jacobian image
-    for (unsigned int j = 0; j < SpaceDimension; j++)
+    for (unsigned int j = 0; j < SpaceDimension; ++j)
     {
       this->m_WrappedImage[j]->SetRegions(this->m_GridRegion);
     }
@@ -175,7 +175,7 @@ AdvancedBSplineDeformableTransform<TScalarType, NDimensions, VSplineOrder>::SetG
     typename RegionType::SizeType                   size = this->m_GridRegion.GetSize();
     typename RegionType::IndexType                  index = this->m_GridRegion.GetIndex();
     typedef typename ContinuousIndexType::ValueType CValueType;
-    for (unsigned int j = 0; j < SpaceDimension; j++)
+    for (unsigned int j = 0; j < SpaceDimension; ++j)
     {
       this->m_ValidRegionBegin[j] =
         static_cast<CValueType>(index[j]) + (static_cast<CValueType>(SplineOrder) - 1.0) / 2.0;
@@ -227,7 +227,7 @@ AdvancedBSplineDeformableTransform<TScalarType, NDimensions, VSplineOrder>::Tran
   if (!this->m_CoefficientImages[0])
   {
     itkWarningMacro(<< "B-spline coefficients have not been set");
-    for (unsigned int j = 0; j < SpaceDimension; j++)
+    for (unsigned int j = 0; j < SpaceDimension; ++j)
     {
       outputPoint[j] = transformedPoint[j];
     }
@@ -265,7 +265,7 @@ AdvancedBSplineDeformableTransform<TScalarType, NDimensions, VSplineOrder>::Tran
   unsigned long                                 counter = 0;
   const PixelType *                             basePointer = this->m_CoefficientImages[0]->GetBufferPointer();
 
-  for (unsigned int j = 0; j < SpaceDimension; j++)
+  for (unsigned int j = 0; j < SpaceDimension; ++j)
   {
     iterator[j] = IteratorType(this->m_CoefficientImages[j], supportRegion);
   }
@@ -279,7 +279,7 @@ AdvancedBSplineDeformableTransform<TScalarType, NDimensions, VSplineOrder>::Tran
       indices[counter] = &(iterator[0].Value()) - basePointer;
 
       // multiply weight with coefficient to compute displacement
-      for (unsigned int j = 0; j < SpaceDimension; j++)
+      for (unsigned int j = 0; j < SpaceDimension; ++j)
       {
         outputPoint[j] += static_cast<ScalarType>(weights[counter] * iterator[j].Value());
         ++iterator[j];
@@ -287,7 +287,7 @@ AdvancedBSplineDeformableTransform<TScalarType, NDimensions, VSplineOrder>::Tran
       ++counter;
     } // end of scanline
 
-    for (unsigned int j = 0; j < SpaceDimension; j++)
+    for (unsigned int j = 0; j < SpaceDimension; ++j)
     {
       iterator[j].NextLine();
     }
@@ -295,7 +295,7 @@ AdvancedBSplineDeformableTransform<TScalarType, NDimensions, VSplineOrder>::Tran
   } // end while
 
   // The output point is the start point + displacement.
-  for (unsigned int j = 0; j < SpaceDimension; j++)
+  for (unsigned int j = 0; j < SpaceDimension; ++j)
   {
     outputPoint[j] += transformedPoint[j];
   }

--- a/Common/Transforms/itkAdvancedBSplineDeformableTransformBase.hxx
+++ b/Common/Transforms/itkAdvancedBSplineDeformableTransformBase.hxx
@@ -49,7 +49,7 @@ AdvancedBSplineDeformableTransformBase<TScalarType, NDimensions>::AdvancedBSplin
   this->m_InputParametersPointer = &(this->m_InternalParametersBuffer);
 
   // Initialize coeffient images
-  for (unsigned int j = 0; j < SpaceDimension; j++)
+  for (unsigned int j = 0; j < SpaceDimension; ++j)
   {
     this->m_WrappedImage[j] = ImageType::New();
     this->m_WrappedImage[j]->SetRegions(this->m_GridRegion);
@@ -80,13 +80,13 @@ AdvancedBSplineDeformableTransformBase<TScalarType, NDimensions>::AdvancedBSplin
    */
   this->m_FixedParameters.SetSize(NDimensions * (NDimensions + 3));
   this->m_FixedParameters.Fill(0.0);
-  for (unsigned int i = 0; i < NDimensions; i++)
+  for (unsigned int i = 0; i < NDimensions; ++i)
   {
     this->m_FixedParameters[2 * NDimensions + i] = this->m_GridSpacing[i];
   }
-  for (unsigned int di = 0; di < NDimensions; di++)
+  for (unsigned int di = 0; di < NDimensions; ++di)
   {
-    for (unsigned int dj = 0; dj < NDimensions; dj++)
+    for (unsigned int dj = 0; dj < NDimensions; ++dj)
     {
       this->m_FixedParameters[3 * NDimensions + (di * NDimensions + dj)] = this->m_GridDirection[di][dj];
     }
@@ -174,7 +174,7 @@ AdvancedBSplineDeformableTransformBase<TScalarType, NDimensions>::UpdateGridOffs
 {
   SizeType gridSize = this->m_GridRegion.GetSize();
   this->m_GridOffsetTable.Fill(1);
-  for (unsigned int j = 1; j < SpaceDimension; j++)
+  for (unsigned int j = 1; j < SpaceDimension; ++j)
   {
     this->m_GridOffsetTable[j] = this->m_GridOffsetTable[j - 1] * gridSize[j - 1];
   }
@@ -192,7 +192,7 @@ AdvancedBSplineDeformableTransformBase<TScalarType, NDimensions>::SetGridSpacing
     this->m_GridSpacing = spacing;
 
     // set spacing for each coefficient and Jacobian image
-    for (unsigned int j = 0; j < SpaceDimension; j++)
+    for (unsigned int j = 0; j < SpaceDimension; ++j)
     {
       this->m_WrappedImage[j]->SetSpacing(this->m_GridSpacing.GetDataPointer());
     }
@@ -214,7 +214,7 @@ AdvancedBSplineDeformableTransformBase<TScalarType, NDimensions>::SetGridDirecti
     this->m_GridDirection = direction;
 
     // set direction for each coefficient and Jacobian image
-    for (unsigned int j = 0; j < SpaceDimension; j++)
+    for (unsigned int j = 0; j < SpaceDimension; ++j)
     {
       this->m_WrappedImage[j]->SetDirection(this->m_GridDirection);
     }
@@ -236,7 +236,7 @@ AdvancedBSplineDeformableTransformBase<TScalarType, NDimensions>::SetGridOrigin(
     this->m_GridOrigin = origin;
 
     // set spacing for each coefficient and jacobianimage
-    for (unsigned int j = 0; j < SpaceDimension; j++)
+    for (unsigned int j = 0; j < SpaceDimension; ++j)
     {
       this->m_WrappedImage[j]->SetOrigin(this->m_GridOrigin.GetDataPointer());
     }
@@ -307,11 +307,11 @@ AdvancedBSplineDeformableTransformBase<TScalarType, NDimensions>::SetFixedParame
   if (passedParameters.Size() == NDimensions * 3)
   {
     parameters.Fill(0.0);
-    for (unsigned int i = 0; i < 3 * NDimensions; i++)
+    for (unsigned int i = 0; i < 3 * NDimensions; ++i)
     {
       parameters[i] = passedParameters[i];
     }
-    for (unsigned int di = 0; di < NDimensions; di++)
+    for (unsigned int di = 0; di < NDimensions; ++di)
     {
       parameters[3 * NDimensions + (di * NDimensions + di)] = 1;
     }
@@ -323,7 +323,7 @@ AdvancedBSplineDeformableTransformBase<TScalarType, NDimensions>::SetFixedParame
   }
   else
   {
-    for (unsigned int i = 0; i < NDimensions * (3 + NDimensions); i++)
+    for (unsigned int i = 0; i < NDimensions * (3 + NDimensions); ++i)
     {
       parameters[i] = passedParameters[i];
     }
@@ -340,7 +340,7 @@ AdvancedBSplineDeformableTransformBase<TScalarType, NDimensions>::SetFixedParame
 
   /** Set the Grid Parameters */
   SizeType gridSize;
-  for (unsigned int i = 0; i < NDimensions; i++)
+  for (unsigned int i = 0; i < NDimensions; ++i)
   {
     gridSize[i] = static_cast<int>(parameters[i]);
   }
@@ -349,23 +349,23 @@ AdvancedBSplineDeformableTransformBase<TScalarType, NDimensions>::SetFixedParame
 
   /** Set the Origin Parameters */
   OriginType origin;
-  for (unsigned int i = 0; i < NDimensions; i++)
+  for (unsigned int i = 0; i < NDimensions; ++i)
   {
     origin[i] = parameters[NDimensions + i];
   }
 
   /** Set the Spacing Parameters */
   SpacingType spacing;
-  for (unsigned int i = 0; i < NDimensions; i++)
+  for (unsigned int i = 0; i < NDimensions; ++i)
   {
     spacing[i] = parameters[2 * NDimensions + i];
   }
 
   /** Set the Direction Parameters */
   DirectionType direction;
-  for (unsigned int di = 0; di < NDimensions; di++)
+  for (unsigned int di = 0; di < NDimensions; ++di)
   {
-    for (unsigned int dj = 0; dj < NDimensions; dj++)
+    for (unsigned int dj = 0; dj < NDimensions; ++dj)
     {
       direction[di][dj] = parameters[3 * NDimensions + (di * NDimensions + dj)];
     }
@@ -394,7 +394,7 @@ AdvancedBSplineDeformableTransformBase<TScalarType, NDimensions>::WrapAsImages(v
   PixelType *  dataPointer = const_cast<PixelType *>((this->m_InputParametersPointer->data_block()));
   unsigned int numberOfPixels = this->m_GridRegion.GetNumberOfPixels();
 
-  for (unsigned int j = 0; j < SpaceDimension; j++)
+  for (unsigned int j = 0; j < SpaceDimension; ++j)
   {
     this->m_WrappedImage[j]->GetPixelContainer()->SetImportPointer(dataPointer, numberOfPixels);
     dataPointer += numberOfPixels;
@@ -454,21 +454,21 @@ AdvancedBSplineDeformableTransformBase<TScalarType, NDimensions>::GetFixedParame
 {
   RegionType resRegion = this->GetGridRegion();
 
-  for (unsigned int i = 0; i < NDimensions; i++)
+  for (unsigned int i = 0; i < NDimensions; ++i)
   {
     this->m_FixedParameters[i] = (resRegion.GetSize())[i];
   }
-  for (unsigned int i = 0; i < NDimensions; i++)
+  for (unsigned int i = 0; i < NDimensions; ++i)
   {
     this->m_FixedParameters[NDimensions + i] = (this->GetGridOrigin())[i];
   }
-  for (unsigned int i = 0; i < NDimensions; i++)
+  for (unsigned int i = 0; i < NDimensions; ++i)
   {
     this->m_FixedParameters[2 * NDimensions + i] = (this->GetGridSpacing())[i];
   }
-  for (unsigned int di = 0; di < NDimensions; di++)
+  for (unsigned int di = 0; di < NDimensions; ++di)
   {
-    for (unsigned int dj = 0; dj < NDimensions; dj++)
+    for (unsigned int dj = 0; dj < NDimensions; ++dj)
     {
       this->m_FixedParameters[3 * NDimensions + (di * NDimensions + dj)] = (this->GetGridDirection())[di][dj];
     }
@@ -490,7 +490,7 @@ AdvancedBSplineDeformableTransformBase<TScalarType, NDimensions>::SetCoefficient
     this->SetGridOrigin(images[0]->GetOrigin());
     this->UpdateGridOffsetTable();
 
-    for (unsigned int j = 0; j < SpaceDimension; j++)
+    for (unsigned int j = 0; j < SpaceDimension; ++j)
     {
       this->m_CoefficientImages[j] = images[j];
     }
@@ -521,14 +521,14 @@ AdvancedBSplineDeformableTransformBase<TScalarType, NDimensions>::PrintSelf(std:
   os << indent << "PointToIndexTransposed2:\n" << this->m_PointToIndexMatrixTransposed2 << std::endl;
 
   os << indent << "CoefficientImage: [ " << this->m_CoefficientImages[0].GetPointer();
-  for (unsigned int j = 1; j < SpaceDimension; j++)
+  for (unsigned int j = 1; j < SpaceDimension; ++j)
   {
     os << ", " << this->m_CoefficientImages[j].GetPointer();
   }
   os << " ]" << std::endl;
 
   os << indent << "WrappedImage: [ " << this->m_WrappedImage[0].GetPointer();
-  for (unsigned int j = 1; j < SpaceDimension; j++)
+  for (unsigned int j = 1; j < SpaceDimension; ++j)
   {
     os << ", " << this->m_WrappedImage[j].GetPointer();
   }
@@ -549,7 +549,7 @@ AdvancedBSplineDeformableTransformBase<TScalarType, NDimensions>::InsideValidReg
   bool inside = true;
 
   /** Check if index can be evaluated given the current grid. */
-  for (unsigned int j = 0; j < SpaceDimension; j++)
+  for (unsigned int j = 0; j < SpaceDimension; ++j)
   {
     if (index[j] < this->m_ValidRegionBegin[j] || index[j] >= this->m_ValidRegionEnd[j])
     {
@@ -570,14 +570,14 @@ AdvancedBSplineDeformableTransformBase<TScalarType, NDimensions>::TransformPoint
 {
   Vector<double, SpaceDimension> tvector;
 
-  for (unsigned int j = 0; j < SpaceDimension; j++)
+  for (unsigned int j = 0; j < SpaceDimension; ++j)
   {
     tvector[j] = point[j] - this->m_GridOrigin[j];
   }
 
   Vector<double, SpaceDimension> cvector = this->m_PointToIndexMatrix * tvector;
 
-  for (unsigned int j = 0; j < SpaceDimension; j++)
+  for (unsigned int j = 0; j < SpaceDimension; ++j)
   {
     cindex[j] = static_cast<typename ContinuousIndexType::CoordRepType>(cvector[j]);
   }

--- a/Common/Transforms/itkAdvancedCombinationTransform.hxx
+++ b/Common/Transforms/itkAdvancedCombinationTransform.hxx
@@ -710,7 +710,7 @@ AdvancedCombinationTransform<TScalarType, NDimensions>::TransformPointUseAdditio
   OutputPointType out = this->m_CurrentTransform->TransformPoint(point);
 
   /** Add them. */
-  for (unsigned int i = 0; i < SpaceDimension; i++)
+  for (unsigned int i = 0; i < SpaceDimension; ++i)
   {
     out[i] += (out0[i] - point[i]);
   }

--- a/Common/Transforms/itkAdvancedImageMomentsCalculator.hxx
+++ b/Common/Transforms/itkAdvancedImageMomentsCalculator.hxx
@@ -151,20 +151,20 @@ AdvancedImageMomentsCalculator<TImage>::ComputeSingleThreaded()
     {
       m_M0 += value;
 
-      for (unsigned int i = 0; i < ImageDimension; i++)
+      for (unsigned int i = 0; i < ImageDimension; ++i)
       {
         m_M1[i] += static_cast<double>(indexPosition[i]) * value;
-        for (unsigned int j = 0; j < ImageDimension; j++)
+        for (unsigned int j = 0; j < ImageDimension; ++j)
         {
           double weight = value * static_cast<double>(indexPosition[i]) * static_cast<double>(indexPosition[j]);
           m_M2[i][j] += weight;
         }
       }
 
-      for (unsigned int i = 0; i < ImageDimension; i++)
+      for (unsigned int i = 0; i < ImageDimension; ++i)
       {
         m_Cg[i] += physicalPosition[i] * value;
-        for (unsigned int j = 0; j < ImageDimension; j++)
+        for (unsigned int j = 0; j < ImageDimension; ++j)
         {
           double weight = value * physicalPosition[i] * physicalPosition[j];
           m_Cm[i][j] += weight;
@@ -324,10 +324,10 @@ AdvancedImageMomentsCalculator<TImage>::ThreadedCompute(ThreadIdType threadId)
     {
       M0 += value;
 
-      for (unsigned int i = 0; i < ImageDimension; i++)
+      for (unsigned int i = 0; i < ImageDimension; ++i)
       {
         Cg[i] += physicalPosition[i] * value;
-        for (unsigned int j = 0; j < ImageDimension; j++)
+        for (unsigned int j = 0; j < ImageDimension; ++j)
         {
           double weight = value * physicalPosition[i] * physicalPosition[j];
           Cm[i][j] += weight;
@@ -391,11 +391,11 @@ AdvancedImageMomentsCalculator<TImage>::DoPostProcessing()
   }
 
   // Normalize using the total mass
-  for (unsigned int i = 0; i < ImageDimension; i++)
+  for (unsigned int i = 0; i < ImageDimension; ++i)
   {
     m_Cg[i] /= m_M0;
     m_M1[i] /= m_M0;
-    for (unsigned int j = 0; j < ImageDimension; j++)
+    for (unsigned int j = 0; j < ImageDimension; ++j)
     {
       m_M2[i][j] /= m_M0;
       m_Cm[i][j] /= m_M0;
@@ -403,9 +403,9 @@ AdvancedImageMomentsCalculator<TImage>::DoPostProcessing()
   }
 
   // Center the second order moments
-  for (unsigned int i = 0; i < ImageDimension; i++)
+  for (unsigned int i = 0; i < ImageDimension; ++i)
   {
-    for (unsigned int j = 0; j < ImageDimension; j++)
+    for (unsigned int j = 0; j < ImageDimension; ++j)
     {
       m_M2[i][j] -= m_M1[i] * m_M1[j];
       m_Cm[i][j] -= m_Cg[i] * m_Cg[j];
@@ -415,7 +415,7 @@ AdvancedImageMomentsCalculator<TImage>::DoPostProcessing()
   // Compute principal moments and axes
   vnl_symmetric_eigensystem<double> eigen(m_Cm.GetVnlMatrix().as_ref());
   vnl_diag_matrix<double>           pm = eigen.D;
-  for (unsigned int i = 0; i < ImageDimension; i++)
+  for (unsigned int i = 0; i < ImageDimension; ++i)
   {
     m_Pm[i] = pm(i) * m_M0;
   }
@@ -427,12 +427,12 @@ AdvancedImageMomentsCalculator<TImage>::DoPostProcessing()
   vnl_diag_matrix<std::complex<double>> eigenval = eigenrot.D;
   std::complex<double>                  det(1.0, 0.0);
 
-  for (unsigned int i = 0; i < ImageDimension; i++)
+  for (unsigned int i = 0; i < ImageDimension; ++i)
   {
     det *= eigenval(i);
   }
 
-  for (unsigned int i = 0; i < ImageDimension; i++)
+  for (unsigned int i = 0; i < ImageDimension; ++i)
   {
     m_Pa[ImageDimension - 1][i] *= std::real(det);
   }
@@ -541,10 +541,10 @@ AdvancedImageMomentsCalculator<TImage>::GetPrincipalAxesToPhysicalAxesTransform(
 {
   typename AffineTransformType::MatrixType matrix;
   typename AffineTransformType::OffsetType offset;
-  for (unsigned int i = 0; i < ImageDimension; i++)
+  for (unsigned int i = 0; i < ImageDimension; ++i)
   {
     offset[i] = m_Cg[i];
-    for (unsigned int j = 0; j < ImageDimension; j++)
+    for (unsigned int j = 0; j < ImageDimension; ++j)
     {
       matrix[j][i] = m_Pa[i][j]; // Note the transposition
     }
@@ -567,10 +567,10 @@ AdvancedImageMomentsCalculator<TImage>::GetPhysicalAxesToPrincipalAxesTransform(
 {
   typename AffineTransformType::MatrixType matrix;
   typename AffineTransformType::OffsetType offset;
-  for (unsigned int i = 0; i < ImageDimension; i++)
+  for (unsigned int i = 0; i < ImageDimension; ++i)
   {
     offset[i] = m_Cg[i];
-    for (unsigned int j = 0; j < ImageDimension; j++)
+    for (unsigned int j = 0; j < ImageDimension; ++j)
     {
       matrix[j][i] = m_Pa[i][j]; // Note the transposition
     }

--- a/Common/Transforms/itkAdvancedMatrixOffsetTransformBase.hxx
+++ b/Common/Transforms/itkAdvancedMatrixOffsetTransformBase.hxx
@@ -92,7 +92,7 @@ AdvancedMatrixOffsetTransformBase<TScalarType, NInputDimensions, NOutputDimensio
   this->m_Offset = offset;
   this->m_Center.Fill(0);
   this->m_Translation.Fill(0);
-  for (unsigned int i = 0; i < NOutputDimensions; i++)
+  for (unsigned int i = 0; i < NOutputDimensions; ++i)
   {
     this->m_Translation[i] = offset[i];
   }
@@ -119,9 +119,9 @@ AdvancedMatrixOffsetTransformBase<TScalarType, NInputDimensions, NOutputDimensio
    * such as the RigidTransform. */
   this->m_JacobianOfSpatialJacobian.resize(paramDims);
   unsigned int par = 0;
-  for (unsigned int row = 0; row < OutputSpaceDimension; row++)
+  for (unsigned int row = 0; row < OutputSpaceDimension; ++row)
   {
-    for (unsigned int col = 0; col < InputSpaceDimension; col++)
+    for (unsigned int col = 0; col < InputSpaceDimension; ++col)
     {
       if (par < paramDims)
       {
@@ -170,10 +170,10 @@ AdvancedMatrixOffsetTransformBase<TScalarType, NInputDimensions, NOutputDimensio
   unsigned int i, j;
 
   os << indent << "Matrix: " << std::endl;
-  for (i = 0; i < NInputDimensions; i++)
+  for (i = 0; i < NInputDimensions; ++i)
   {
     os << indent.GetNextIndent();
-    for (j = 0; j < NOutputDimensions; j++)
+    for (j = 0; j < NOutputDimensions; ++j)
     {
       os << m_Matrix[i][j] << " ";
     }
@@ -185,10 +185,10 @@ AdvancedMatrixOffsetTransformBase<TScalarType, NInputDimensions, NOutputDimensio
   os << indent << "Translation: " << m_Translation << std::endl;
 
   os << indent << "Inverse: " << std::endl;
-  for (i = 0; i < NInputDimensions; i++)
+  for (i = 0; i < NInputDimensions; ++i)
   {
     os << indent.GetNextIndent();
-    for (j = 0; j < NOutputDimensions; j++)
+    for (j = 0; j < NOutputDimensions; ++j)
     {
       os << this->GetInverseMatrix()[i][j] << " ";
     }
@@ -280,10 +280,10 @@ AdvancedMatrixOffsetTransformBase<TScalarType, NInputDimensions, NOutputDimensio
 {
   OutputCovariantVectorType result; // Converted vector
 
-  for (unsigned int i = 0; i < NOutputDimensions; i++)
+  for (unsigned int i = 0; i < NOutputDimensions; ++i)
   {
     result[i] = NumericTraits<ScalarType>::Zero;
-    for (unsigned int j = 0; j < NInputDimensions; j++)
+    for (unsigned int j = 0; j < NInputDimensions; ++j)
     {
       result[i] += this->GetInverseMatrix()[j][i] * vec[j]; // Inverse transposed
     }
@@ -349,7 +349,7 @@ AdvancedMatrixOffsetTransformBase<TScalarType, NInputDimensions, NOutputDimensio
 {
   this->m_FixedParameters = fp;
   InputPointType c;
-  for (unsigned int i = 0; i < NInputDimensions; i++)
+  for (unsigned int i = 0; i < NInputDimensions; ++i)
   {
     c[i] = this->m_FixedParameters[i];
   }
@@ -364,7 +364,7 @@ const typename AdvancedMatrixOffsetTransformBase<TScalarType, NInputDimensions, 
   AdvancedMatrixOffsetTransformBase<TScalarType, NInputDimensions, NOutputDimensions>::GetFixedParameters(void) const
 {
   this->m_FixedParameters.SetSize(NInputDimensions);
-  for (unsigned int i = 0; i < NInputDimensions; i++)
+  for (unsigned int i = 0; i < NInputDimensions; ++i)
   {
     this->m_FixedParameters[i] = this->m_Center[i];
   }
@@ -379,9 +379,9 @@ AdvancedMatrixOffsetTransformBase<TScalarType, NInputDimensions, NOutputDimensio
   // Transfer the linear part
   unsigned int par = 0;
 
-  for (unsigned int row = 0; row < NOutputDimensions; row++)
+  for (unsigned int row = 0; row < NOutputDimensions; ++row)
   {
-    for (unsigned int col = 0; col < NInputDimensions; col++)
+    for (unsigned int col = 0; col < NInputDimensions; ++col)
     {
       this->m_Parameters[par] = m_Matrix[row][col];
       ++par;
@@ -389,7 +389,7 @@ AdvancedMatrixOffsetTransformBase<TScalarType, NInputDimensions, NOutputDimensio
   }
 
   // Transfer the constant part
-  for (unsigned int i = 0; i < NOutputDimensions; i++)
+  for (unsigned int i = 0; i < NOutputDimensions; ++i)
   {
     this->m_Parameters[par] = m_Translation[i];
     ++par;
@@ -417,9 +417,9 @@ AdvancedMatrixOffsetTransformBase<TScalarType, NInputDimensions, NOutputDimensio
 
   this->m_Parameters = parameters;
 
-  for (unsigned int row = 0; row < NOutputDimensions; row++)
+  for (unsigned int row = 0; row < NOutputDimensions; ++row)
   {
-    for (unsigned int col = 0; col < NInputDimensions; col++)
+    for (unsigned int col = 0; col < NInputDimensions; ++col)
     {
       m_Matrix[row][col] = this->m_Parameters[par];
       ++par;
@@ -427,7 +427,7 @@ AdvancedMatrixOffsetTransformBase<TScalarType, NInputDimensions, NOutputDimensio
   }
 
   // Transfer the constant part
-  for (unsigned int i = 0; i < NOutputDimensions; i++)
+  for (unsigned int i = 0; i < NOutputDimensions; ++i)
   {
     m_Translation[i] = this->m_Parameters[par];
     ++par;
@@ -453,10 +453,10 @@ AdvancedMatrixOffsetTransformBase<TScalarType, NInputDimensions, NOutputDimensio
   const MatrixType & matrix = this->GetMatrix();
 
   OffsetType offset;
-  for (unsigned int i = 0; i < NOutputDimensions; i++)
+  for (unsigned int i = 0; i < NOutputDimensions; ++i)
   {
     offset[i] = m_Translation[i] + m_Center[i];
-    for (unsigned int j = 0; j < NInputDimensions; j++)
+    for (unsigned int j = 0; j < NInputDimensions; ++j)
     {
       offset[i] -= matrix[i][j] * m_Center[j];
     }
@@ -474,10 +474,10 @@ AdvancedMatrixOffsetTransformBase<TScalarType, NInputDimensions, NOutputDimensio
   const MatrixType & matrix = this->GetMatrix();
 
   OffsetType translation;
-  for (unsigned int i = 0; i < NOutputDimensions; i++)
+  for (unsigned int i = 0; i < NOutputDimensions; ++i)
   {
     translation[i] = m_Offset[i] - m_Center[i];
-    for (unsigned int j = 0; j < NInputDimensions; j++)
+    for (unsigned int j = 0; j < NInputDimensions; ++j)
     {
       translation[i] += matrix[i][j] * m_Center[j];
     }

--- a/Common/Transforms/itkAdvancedRigid2DTransform.hxx
+++ b/Common/Transforms/itkAdvancedRigid2DTransform.hxx
@@ -238,7 +238,7 @@ AdvancedRigid2DTransform<TScalarType>::SetParameters(const ParametersType & para
 
   // Set translation
   OutputVectorType translation;
-  for (unsigned int i = 0; i < OutputSpaceDimension; i++)
+  for (unsigned int i = 0; i < OutputSpaceDimension; ++i)
   {
     translation[i] = parameters[i + 1];
   }
@@ -267,7 +267,7 @@ AdvancedRigid2DTransform<TScalarType>::GetParameters(void) const
   this->m_Parameters[0] = this->GetAngle();
 
   // Get the translation
-  for (unsigned int i = 0; i < OutputSpaceDimension; i++)
+  for (unsigned int i = 0; i < OutputSpaceDimension; ++i)
   {
     this->m_Parameters[i + 1] = this->GetTranslation()[i];
   }

--- a/Common/Transforms/itkAdvancedRigid3DTransform.hxx
+++ b/Common/Transforms/itkAdvancedRigid3DTransform.hxx
@@ -113,16 +113,16 @@ AdvancedRigid3DTransform<TScalarType>::SetParameters(const ParametersType & para
   MatrixType       matrix;
   OutputVectorType translation;
 
-  for (unsigned int row = 0; row < 3; row++)
+  for (unsigned int row = 0; row < 3; ++row)
   {
-    for (unsigned int col = 0; col < 3; col++)
+    for (unsigned int col = 0; col < 3; ++col)
     {
       matrix[row][col] = this->m_Parameters[par];
       ++par;
     }
   }
 
-  for (unsigned int dim = 0; dim < 3; dim++)
+  for (unsigned int dim = 0; dim < 3; ++dim)
   {
     translation[dim] = this->m_Parameters[par];
     ++par;

--- a/Common/Transforms/itkAdvancedSimilarity2DTransform.hxx
+++ b/Common/Transforms/itkAdvancedSimilarity2DTransform.hxx
@@ -76,7 +76,7 @@ AdvancedSimilarity2DTransform<TScalarType>::SetParameters(const ParametersType &
 
   // Set translation
   OffsetType translation;
-  for (unsigned int i = 0; i < SpaceDimension; i++)
+  for (unsigned int i = 0; i < SpaceDimension; ++i)
   {
     translation[i] = parameters[i + 2];
   }
@@ -105,7 +105,7 @@ AdvancedSimilarity2DTransform<TScalarType>::GetParameters(void) const
 
   // Get the translation
   OffsetType translation = this->GetTranslation();
-  for (unsigned int i = 0; i < SpaceDimension; i++)
+  for (unsigned int i = 0; i < SpaceDimension; ++i)
   {
     this->m_Parameters[i + 2] = translation[i];
   }

--- a/Common/Transforms/itkAdvancedTranslationTransform.hxx
+++ b/Common/Transforms/itkAdvancedTranslationTransform.hxx
@@ -52,7 +52,7 @@ AdvancedTranslationTransform<TScalarType, NDimensions>::AdvancedTranslationTrans
   this->m_LocalJacobian.SetSize(SpaceDimension, ParametersDimension);
   this->m_LocalJacobian.Fill(0.0);
 
-  for (unsigned int i = 0; i < NDimensions; i++)
+  for (unsigned int i = 0; i < NDimensions; ++i)
   {
     this->m_LocalJacobian(i, i) = 1.0;
   }
@@ -91,7 +91,7 @@ void
 AdvancedTranslationTransform<TScalarType, NDimensions>::SetParameters(const ParametersType & parameters)
 {
   bool modified = false;
-  for (unsigned int i = 0; i < SpaceDimension; i++)
+  for (unsigned int i = 0; i < SpaceDimension; ++i)
   {
     if (m_Offset[i] != parameters[i])
     {
@@ -111,7 +111,7 @@ template <class TScalarType, unsigned int NDimensions>
 const typename AdvancedTranslationTransform<TScalarType, NDimensions>::ParametersType &
 AdvancedTranslationTransform<TScalarType, NDimensions>::GetParameters(void) const
 {
-  for (unsigned int i = 0; i < SpaceDimension; i++)
+  for (unsigned int i = 0; i < SpaceDimension; ++i)
   {
     this->m_Parameters[i] = this->m_Offset[i];
   }
@@ -145,7 +145,7 @@ void
 AdvancedTranslationTransform<TScalarType, NDimensions>::Translate(const OutputVectorType & offset, bool)
 {
   ParametersType newOffset(SpaceDimension);
-  for (unsigned int i = 0; i < SpaceDimension; i++)
+  for (unsigned int i = 0; i < SpaceDimension; ++i)
   {
     newOffset[i] = m_Offset[i] + offset[i];
   }

--- a/Common/Transforms/itkBSplineInterpolationWeightFunctionBase.hxx
+++ b/Common/Transforms/itkBSplineInterpolationWeightFunctionBase.hxx
@@ -185,11 +185,11 @@ BSplineInterpolationWeightFunctionBase<TCoordRep, VSpaceDimension, VSplineOrder>
   this->Compute1DWeights(cindex, startIndex, weights1D);
 
   /** Compute the vector of weights. */
-  for (unsigned int k = 0; k < this->m_NumberOfWeights; k++)
+  for (unsigned int k = 0; k < this->m_NumberOfWeights; ++k)
   {
     double                tmp1 = 1.0;
     const unsigned long * tmp2 = this->m_OffsetToIndexTable[k];
-    for (unsigned int j = 0; j < SpaceDimension; j++)
+    for (unsigned int j = 0; j < SpaceDimension; ++j)
     {
       tmp1 *= weights1D[j][tmp2[j]];
     }

--- a/Common/Transforms/itkCyclicBSplineDeformableTransform.hxx
+++ b/Common/Transforms/itkCyclicBSplineDeformableTransform.hxx
@@ -65,7 +65,7 @@ CyclicBSplineDeformableTransform<TScalarType, NDimensions, VSplineOrder>::Inside
   bool inside = true;
 
   /** Check if index can be evaluated given the current grid. */
-  for (unsigned int j = 0; j < SpaceDimension - 1; j++)
+  for (unsigned int j = 0; j < SpaceDimension - 1; ++j)
   {
     if (index[j] < this->m_ValidRegionBegin[j] || index[j] >= this->m_ValidRegionEnd[j])
     {
@@ -154,7 +154,7 @@ CyclicBSplineDeformableTransform<TScalarType, NDimensions, VSplineOrder>::Transf
   if (!this->m_CoefficientImages[0])
   {
     itkWarningMacro(<< "B-spline coefficients have not been set");
-    for (unsigned int j = 0; j < SpaceDimension; j++)
+    for (unsigned int j = 0; j < SpaceDimension; ++j)
     {
       outputPoint[j] = transformedPoint[j];
     }
@@ -204,7 +204,7 @@ CyclicBSplineDeformableTransform<TScalarType, NDimensions, VSplineOrder>::Transf
 
     const PixelType * basePointer = this->m_CoefficientImages[0]->GetBufferPointer();
 
-    for (unsigned int j = 0; j < SpaceDimension - 1; j++)
+    for (unsigned int j = 0; j < SpaceDimension - 1; ++j)
     {
       iterator[j] = IteratorType(this->m_CoefficientImages[j], supportRegions[r]);
     }
@@ -216,7 +216,7 @@ CyclicBSplineDeformableTransform<TScalarType, NDimensions, VSplineOrder>::Transf
       indices[counter] = &(iterator[0].Value()) - basePointer;
 
       /** Multiply weigth with coefficient to compute displacement. */
-      for (unsigned int j = 0; j < SpaceDimension - 1; j++)
+      for (unsigned int j = 0; j < SpaceDimension - 1; ++j)
       {
         outputPoint[j] += static_cast<ScalarType>(weights[counter] * iterator[j].Value());
         ++iterator[j];
@@ -227,7 +227,7 @@ CyclicBSplineDeformableTransform<TScalarType, NDimensions, VSplineOrder>::Transf
   }
 
   /** The output point is the start point + displacement. */
-  for (unsigned int j = 0; j < SpaceDimension; j++)
+  for (unsigned int j = 0; j < SpaceDimension; ++j)
   {
     outputPoint[j] += transformedPoint[j];
   }

--- a/Common/Transforms/itkGridScheduleComputer.hxx
+++ b/Common/Transforms/itkGridScheduleComputer.hxx
@@ -300,7 +300,7 @@ GridScheduleComputer<TTransformScalarType, VImageDimension>::ApplyInitialTransfo
 
   /** Compute the new "ImageSpacing" in each dimension. */
   const double smallnumber = NumericTraits<double>::epsilon();
-  for (unsigned int i = 0; i < Dimension; i++)
+  for (unsigned int i = 0; i < Dimension; ++i)
   {
     /** Compute the length of the fixed image (in mm) for dimension i. */
     double oldLength_i = this->m_ImageSpacing[i] * static_cast<double>(this->m_ImageRegion.GetSize()[i] - 1);

--- a/Common/Transforms/itkUpsampleBSplineParametersFilter.hxx
+++ b/Common/Transforms/itkUpsampleBSplineParametersFilter.hxx
@@ -86,7 +86,7 @@ UpsampleBSplineParametersFilter<TArray, TImage>::UpsampleParameters(const ArrayT
   coeffs_in->SetRegions(this->m_CurrentGridRegion);
 
   /** Loop over dimension: each direction is upsampled separately. */
-  for (unsigned int j = 0; j < Dimension; j++)
+  for (unsigned int j = 0; j < Dimension; ++j)
   {
     /** Fill the coefficient image with parameter data. */
     coeffs_in->GetPixelContainer()->SetImportPointer(inputDataPointer, currentNumberOfPixels);

--- a/Common/itkAdvancedLinearInterpolateImageFunction.hxx
+++ b/Common/itkAdvancedLinearInterpolateImageFunction.hxx
@@ -88,7 +88,7 @@ AdvancedLinearInterpolateImageFunction<TInputImage, TCoordRep>::EvaluateValueAnd
   /** Create a possibly mirrored version of x. */
   ContinuousIndexType xm = x;
   double              deriv_sign[ImageDimension];
-  for (unsigned int dim = 0; dim < ImageDimension; dim++)
+  for (unsigned int dim = 0; dim < ImageDimension; ++dim)
   {
     deriv_sign[dim] = 1.0 / spacing[dim];
     if (x[dim] < this->m_StartIndex[dim])
@@ -117,7 +117,7 @@ AdvancedLinearInterpolateImageFunction<TInputImage, TCoordRep>::EvaluateValueAnd
   IndexType baseIndex;
   double    dist[ImageDimension];
   double    dinv[ImageDimension];
-  for (unsigned int dim = 0; dim < ImageDimension; dim++)
+  for (unsigned int dim = 0; dim < ImageDimension; ++dim)
   {
     baseIndex[dim] = Math::Floor<IndexValueType>(xm[dim]);
 
@@ -170,7 +170,7 @@ AdvancedLinearInterpolateImageFunction<TInputImage, TCoordRep>::EvaluateValueAnd
   /** Create a possibly mirrored version of x. */
   ContinuousIndexType xm = x;
   double              deriv_sign[ImageDimension];
-  for (unsigned int dim = 0; dim < ImageDimension; dim++)
+  for (unsigned int dim = 0; dim < ImageDimension; ++dim)
   {
     deriv_sign[dim] = 1.0 / spacing[dim];
     if (x[dim] < this->m_StartIndex[dim])
@@ -199,7 +199,7 @@ AdvancedLinearInterpolateImageFunction<TInputImage, TCoordRep>::EvaluateValueAnd
   IndexType baseIndex;
   double    dist[ImageDimension];
   double    dinv[ImageDimension];
-  for (unsigned int dim = 0; dim < ImageDimension; dim++)
+  for (unsigned int dim = 0; dim < ImageDimension; ++dim)
   {
     baseIndex[dim] = Math::Floor<IndexValueType>(xm[dim]);
 

--- a/Common/itkAdvancedRayCastInterpolateImageFunction.hxx
+++ b/Common/itkAdvancedRayCastInterpolateImageFunction.hxx
@@ -426,7 +426,7 @@ RayCastHelper<TInputImage, TCoordRep>::CalcPlanesAndCorners(void)
 
   int c1 = 0, c2 = 0, c3 = 0;
 
-  for (j = 0; j < 6; j++)
+  for (j = 0; j < 6; ++j)
   { // loop around for planes
     switch (j)
     { // which corners to take
@@ -527,7 +527,7 @@ RayCastHelper<TInputImage, TCoordRep>::CalcRayIntercepts()
   double interceptx[6], intercepty[6], interceptz[6];
   double d[6];
 
-  for (j = 0; j < NoSides; j++)
+  for (j = 0; j < NoSides; ++j)
   {
 
     denom = (m_BoundingPlane[j][0] * m_RayDirectionInMM[0] + m_BoundingPlane[j][1] * m_RayDirectionInMM[1] +
@@ -553,7 +553,7 @@ RayCastHelper<TInputImage, TCoordRep>::CalcRayIntercepts()
   }
 
   nSidesCrossed = 0;
-  for (j = 0; j < NoSides; j++)
+  for (j = 0; j < NoSides; ++j)
   {
 
     // Work out which corners to use
@@ -602,7 +602,7 @@ RayCastHelper<TInputImage, TCoordRep>::CalcRayIntercepts()
     }
 
     // Calculate vectors from corner of ct volume to intercept.
-    for (i = 0; i < 4; i++)
+    for (i = 0; i < 4; ++i)
     {
       if (noInterFlag[j] == 1)
       {
@@ -619,7 +619,7 @@ RayCastHelper<TInputImage, TCoordRep>::CalcRayIntercepts()
     }
 
     // Do cross product with these vectors
-    for (i = 0; i < 4; i++)
+    for (i = 0; i < 4; ++i)
     {
       if (i == 3)
       {
@@ -651,7 +651,7 @@ RayCastHelper<TInputImage, TCoordRep>::CalcRayIntercepts()
     // if not, then the ray went through this plane
 
     crossFlag = 0;
-    for (i = 0; i < 3; i++)
+    for (i = 0; i < 3; ++i)
     {
       if ((cross[0][i] <= 0 && cross[1][i] <= 0 && cross[2][i] <= 0 && cross[3][i] <= 0)
 
@@ -693,12 +693,12 @@ RayCastHelper<TInputImage, TCoordRep>::CalcRayIntercepts()
   if (nSidesCrossed >= 3)
   {
     maxInterDist = 0;
-    for (j = 0; j < nSidesCrossed - 1; j++)
+    for (j = 0; j < nSidesCrossed - 1; ++j)
     {
-      for (k = j + 1; k < nSidesCrossed; k++)
+      for (k = j + 1; k < nSidesCrossed; ++k)
       {
         interDist = 0;
-        for (i = 0; i < 3; i++)
+        for (i = 0; i < 3; ++i)
         {
           interDist += (cubeInter[j][i] - cubeInter[k][i]) * (cubeInter[j][i] - cubeInter[k][i]);
         }
@@ -1075,7 +1075,7 @@ RayCastHelper<TInputImage, TCoordRep>::Reset(void)
 
   if (m_ValidRay)
   {
-    for (i = 0; i < 3; i++)
+    for (i = 0; i < 3; ++i)
     {
       m_Position3Dvox[i] = m_RayVoxelStartPosition[i];
     }
@@ -1086,15 +1086,15 @@ RayCastHelper<TInputImage, TCoordRep>::Reset(void)
 
   else
   {
-    for (i = 0; i < 3; i++)
+    for (i = 0; i < 3; ++i)
     {
       m_RayVoxelStartPosition[i] = 0.;
     }
-    for (i = 0; i < 3; i++)
+    for (i = 0; i < 3; ++i)
     {
       m_RayVoxelEndPosition[i] = 0.;
     }
-    for (i = 0; i < 3; i++)
+    for (i = 0; i < 3; ++i)
     {
       m_VoxelIncrement[i] = 0.;
     }
@@ -1102,11 +1102,11 @@ RayCastHelper<TInputImage, TCoordRep>::Reset(void)
 
     m_TotalRayVoxelPlanes = 0;
 
-    for (i = 0; i < 4; i++)
+    for (i = 0; i < 4; ++i)
     {
       m_RayIntersectionVoxels[i] = nullptr;
     }
-    for (i = 0; i < 3; i++)
+    for (i = 0; i < 3; ++i)
     {
       m_RayIntersectionVoxelIndex[i] = 0;
     }
@@ -1388,7 +1388,7 @@ RayCastHelper<TInputImage, TCoordRep>::IntegrateAboveThreshold(double & integral
   /* Step along the ray as quickly as possible
      integrating the interpolated intensities. */
 
-  for (m_NumVoxelPlanesTraversed = 0; m_NumVoxelPlanesTraversed < m_TotalRayVoxelPlanes; m_NumVoxelPlanesTraversed++)
+  for (m_NumVoxelPlanesTraversed = 0; m_NumVoxelPlanesTraversed < m_TotalRayVoxelPlanes; ++m_NumVoxelPlanesTraversed)
   {
     intensity = this->GetCurrentIntensity();
 
@@ -1429,23 +1429,23 @@ RayCastHelper<TInputImage, TCoordRep>::ZeroState()
   m_VoxelDimensionInY = 0;
   m_VoxelDimensionInZ = 0;
 
-  for (i = 0; i < 3; i++)
+  for (i = 0; i < 3; ++i)
   {
     m_CurrentRayPositionInMM[i] = 0.;
   }
-  for (i = 0; i < 3; i++)
+  for (i = 0; i < 3; ++i)
   {
     m_RayDirectionInMM[i] = 0.;
   }
-  for (i = 0; i < 3; i++)
+  for (i = 0; i < 3; ++i)
   {
     m_RayVoxelStartPosition[i] = 0.;
   }
-  for (i = 0; i < 3; i++)
+  for (i = 0; i < 3; ++i)
   {
     m_RayVoxelEndPosition[i] = 0.;
   }
-  for (i = 0; i < 3; i++)
+  for (i = 0; i < 3; ++i)
   {
     m_VoxelIncrement[i] = 0.;
   }
@@ -1454,11 +1454,11 @@ RayCastHelper<TInputImage, TCoordRep>::ZeroState()
   m_TotalRayVoxelPlanes = 0;
   m_NumVoxelPlanesTraversed = -1;
 
-  for (i = 0; i < 4; i++)
+  for (i = 0; i < 4; ++i)
   {
     m_RayIntersectionVoxels[i] = nullptr;
   }
-  for (i = 0; i < 3; i++)
+  for (i = 0; i < 3; ++i)
   {
     m_RayIntersectionVoxelIndex[i] = 0;
   }

--- a/Common/itkGenericMultiResolutionPyramidImageFilter.hxx
+++ b/Common/itkGenericMultiResolutionPyramidImageFilter.hxx
@@ -213,9 +213,9 @@ GenericMultiResolutionPyramidImageFilter<TInputImage, TOutputImage, TPrecisionTy
     return;
   }
 
-  for (unsigned int level = 0; level < this->m_NumberOfLevels; level++)
+  for (unsigned int level = 0; level < this->m_NumberOfLevels; ++level)
   {
-    for (unsigned int dim = 0; dim < ImageDimension; dim++)
+    for (unsigned int dim = 0; dim < ImageDimension; ++dim)
     {
       this->m_SmoothingSchedule[level][dim] = schedule[level][dim];
 
@@ -627,7 +627,7 @@ GenericMultiResolutionPyramidImageFilter<TInputImage, TOutputImage, TPrecisionTy
   }
 
   // We have to set requestedRegion properly
-  for (unsigned int level = 0; level < this->m_NumberOfLevels; level++)
+  for (unsigned int level = 0; level < this->m_NumberOfLevels; ++level)
   {
     this->GetOutput(level)->SetRequestedRegionToLargestPossibleRegion();
   }
@@ -683,7 +683,7 @@ void
 GenericMultiResolutionPyramidImageFilter<TInputImage, TOutputImage, TPrecisionType>::ReleaseOutputs(void)
 {
   // release the memories if already has been allocated
-  for (unsigned int level = 0; level < this->m_NumberOfLevels; level++)
+  for (unsigned int level = 0; level < this->m_NumberOfLevels; ++level)
   {
     if (this->m_ComputeOnlyForCurrentLevel && level != this->m_CurrentLevel)
     {
@@ -756,9 +756,9 @@ GenericMultiResolutionPyramidImageFilter<TInputImage, TOutputImage, TPrecisionTy
   this->m_SmoothingSchedule = temp;
 
   unsigned int factors[ImageDimension];
-  for (unsigned int level = 0; level < this->m_NumberOfLevels; level++)
+  for (unsigned int level = 0; level < this->m_NumberOfLevels; ++level)
   {
-    for (unsigned int dim = 0; dim < ImageDimension; dim++)
+    for (unsigned int dim = 0; dim < ImageDimension; ++dim)
     {
       factors[dim] = this->m_Schedule[level][dim];
       this->m_SmoothingSchedule[level][dim] = this->GetDefaultSigma(level, dim, factors, spacing);
@@ -778,7 +778,7 @@ GenericMultiResolutionPyramidImageFilter<TInputImage, TOutputImage, TPrecisionTy
   SigmaArrayType &   sigmaArray) const
 {
   sigmaArray.Fill(0);
-  for (unsigned int dim = 0; dim < ImageDimension; dim++)
+  for (unsigned int dim = 0; dim < ImageDimension; ++dim)
   {
     sigmaArray[dim] = this->m_SmoothingSchedule[level][dim];
   }
@@ -796,7 +796,7 @@ GenericMultiResolutionPyramidImageFilter<TInputImage, TOutputImage, TPrecisionTy
   RescaleFactorArrayType & shrinkFactors) const
 {
   shrinkFactors.Fill(0);
-  for (unsigned int dim = 0; dim < ImageDimension; dim++)
+  for (unsigned int dim = 0; dim < ImageDimension; ++dim)
   {
     /** Here we would prefer to use m_RescaleSchedule.
      * Although it would require copying most of the methods
@@ -818,7 +818,7 @@ GenericMultiResolutionPyramidImageFilter<TInputImage, TOutputImage, TPrecisionTy
   const SigmaArrayType & sigmaArray) const
 {
   const ScalarRealType zero = NumericTraits<ScalarRealType>::Zero;
-  for (unsigned int dim = 0; dim < ImageDimension; dim++)
+  for (unsigned int dim = 0; dim < ImageDimension; ++dim)
   {
     if (sigmaArray[dim] != zero)
     {
@@ -840,7 +840,7 @@ GenericMultiResolutionPyramidImageFilter<TInputImage, TOutputImage, TPrecisionTy
   const RescaleFactorArrayType & rescaleFactors) const
 {
   const ScalarRealType one = NumericTraits<ScalarRealType>::One;
-  for (unsigned int dim = 0; dim < ImageDimension; dim++)
+  for (unsigned int dim = 0; dim < ImageDimension; ++dim)
   {
     if (rescaleFactors[dim] != one)
     {
@@ -862,7 +862,7 @@ GenericMultiResolutionPyramidImageFilter<TInputImage, TOutputImage, TPrecisionTy
 {
   // If for any level all sigma elements are not zeros then smooth are used in pipeline
   SigmaArrayType sigmaArray;
-  for (unsigned int level = 0; level < this->m_NumberOfLevels; level++)
+  for (unsigned int level = 0; level < this->m_NumberOfLevels; ++level)
   {
     this->GetSigma(level, sigmaArray);
     if (!this->AreSigmasAllZeros(sigmaArray))
@@ -884,7 +884,7 @@ GenericMultiResolutionPyramidImageFilter<TInputImage, TOutputImage, TPrecisionTy
 {
   // If for any level all rescale factors are not ones then rescale are used in pipeline
   RescaleFactorArrayType rescaleFactors;
-  for (unsigned int level = 0; level < this->m_NumberOfLevels; level++)
+  for (unsigned int level = 0; level < this->m_NumberOfLevels; ++level)
   {
     this->GetShrinkFactors(level, rescaleFactors);
     if (!this->AreRescaleFactorsAllOnes(rescaleFactors))

--- a/Common/itkMultiOrderBSplineDecompositionImageFilter.hxx
+++ b/Common/itkMultiOrderBSplineDecompositionImageFilter.hxx
@@ -96,25 +96,25 @@ MultiOrderBSplineDecompositionImageFilter<TInputImage, TOutputImage>::DataToCoef
   }
 
   // Compute overall gain
-  for (int k = 0; k < m_NumberOfPoles; k++)
+  for (int k = 0; k < m_NumberOfPoles; ++k)
   {
     // Note for cubic splines lambda = 6
     c0 = c0 * (1.0 - m_SplinePoles[k]) * (1.0 - 1.0 / m_SplinePoles[k]);
   }
 
   // apply the gain
-  for (unsigned int n = 0; n < m_DataLength[m_IteratorDirection]; n++)
+  for (unsigned int n = 0; n < m_DataLength[m_IteratorDirection]; ++n)
   {
     m_Scratch[n] *= c0;
   }
 
   // loop over all poles
-  for (int k = 0; k < m_NumberOfPoles; k++)
+  for (int k = 0; k < m_NumberOfPoles; ++k)
   {
     // causal initialization
     this->SetInitialCausalCoefficient(m_SplinePoles[k]);
     // causal recursion
-    for (unsigned int n = 1; n < m_DataLength[m_IteratorDirection]; n++)
+    for (unsigned int n = 1; n < m_DataLength[m_IteratorDirection]; ++n)
     {
       m_Scratch[n] += m_SplinePoles[k] * m_Scratch[n - 1];
     }
@@ -233,7 +233,7 @@ MultiOrderBSplineDecompositionImageFilter<TInputImage, TOutputImage>::SetInitial
   {
     /* accelerated loop */
     sum = m_Scratch[0]; // verify this
-    for (unsigned int n = 1; n < horizon; n++)
+    for (unsigned int n = 1; n < horizon; ++n)
     {
       sum += zn * m_Scratch[n];
       zn *= z;
@@ -247,7 +247,7 @@ MultiOrderBSplineDecompositionImageFilter<TInputImage, TOutputImage>::SetInitial
     z2n = std::pow(z, (double)(m_DataLength[m_IteratorDirection] - 1L));
     sum = m_Scratch[0] + z2n * m_Scratch[m_DataLength[m_IteratorDirection] - 1L];
     z2n *= z2n * iz;
-    for (unsigned int n = 1; n <= (m_DataLength[m_IteratorDirection] - 2); n++)
+    for (unsigned int n = 1; n <= (m_DataLength[m_IteratorDirection] - 2); ++n)
     {
       sum += (zn + z2n) * m_Scratch[n];
       zn *= z;
@@ -286,7 +286,7 @@ MultiOrderBSplineDecompositionImageFilter<TInputImage, TOutputImage>::DataToCoef
   // Initialize coeffient array
   this->CopyImageToImage(); // Coefficients are initialized to the input data
 
-  for (unsigned int n = 0; n < ImageDimension; n++)
+  for (unsigned int n = 0; n < ImageDimension; ++n)
   {
     m_IteratorDirection = n;
     // Loop through each dimension
@@ -428,7 +428,7 @@ MultiOrderBSplineDecompositionImageFilter<TInputImage, TOutputImage>::GenerateDa
   m_DataLength = inputPtr->GetBufferedRegion().GetSize();
 
   unsigned long maxLength = 0;
-  for (unsigned int n = 0; n < ImageDimension; n++)
+  for (unsigned int n = 0; n < ImageDimension; ++n)
   {
     if (m_DataLength[n] > maxLength)
     {

--- a/Common/itkMultiResolutionGaussianSmoothingPyramidImageFilter.hxx
+++ b/Common/itkMultiResolutionGaussianSmoothingPyramidImageFilter.hxx
@@ -76,9 +76,9 @@ MultiResolutionGaussianSmoothingPyramidImageFilter<TInputImage, TOutputImage>::S
 
   this->Modified();
   unsigned int level, dim;
-  for (level = 0; level < this->m_NumberOfLevels; level++)
+  for (level = 0; level < this->m_NumberOfLevels; ++level)
   {
-    for (dim = 0; dim < ImageDimension; dim++)
+    for (dim = 0; dim < ImageDimension; ++dim)
     {
       this->m_Schedule[level][dim] = schedule[level][dim];
     }
@@ -136,7 +136,7 @@ MultiResolutionGaussianSmoothingPyramidImageFilter<TInputImage, TOutputImage>::G
   double       stdev[ImageDimension];
   SpacingType  spacing = inputPtr->GetSpacing();
 
-  for (ilevel = 0; ilevel < this->m_NumberOfLevels; ilevel++)
+  for (ilevel = 0; ilevel < this->m_NumberOfLevels; ++ilevel)
   {
 
     this->UpdateProgress(static_cast<float>(ilevel) / static_cast<float>(this->m_NumberOfLevels));
@@ -153,7 +153,7 @@ MultiResolutionGaussianSmoothingPyramidImageFilter<TInputImage, TOutputImage>::G
     caster->Modified();
 
     // compute shrink factors and variances
-    for (idim = 0; idim < ImageDimension; idim++)
+    for (idim = 0; idim < ImageDimension; ++idim)
     {
       factors[idim] = this->m_Schedule[ilevel][idim];
       /** Compute the standard deviation: 0.5 * factor * spacing
@@ -238,7 +238,7 @@ MultiResolutionGaussianSmoothingPyramidImageFilter<TInputImage, TOutputImage>::G
   OutputImagePointer outputPtr;
 
   unsigned int ilevel;
-  for (ilevel = 0; ilevel < this->m_NumberOfLevels; ilevel++)
+  for (ilevel = 0; ilevel < this->m_NumberOfLevels; ++ilevel)
   {
     /** The same as the input image for each resolution
      * \todo: is this not already done in the supersuperclass?  */
@@ -287,7 +287,7 @@ MultiResolutionGaussianSmoothingPyramidImageFilter<TInputImage, TOutputImage>::G
     // set the requested regions for the other outputs to their
     // requested region
 
-    for (ilevel = 0; ilevel < this->m_NumberOfLevels; ilevel++)
+    for (ilevel = 0; ilevel < this->m_NumberOfLevels; ++ilevel)
     {
       if (ilevel == refLevel)
       {
@@ -309,7 +309,7 @@ MultiResolutionGaussianSmoothingPyramidImageFilter<TInputImage, TOutputImage>::G
     /** Set them all to the same region */
     RegionType outputRegion = ptr->GetRequestedRegion();
 
-    for (ilevel = 0; ilevel < this->m_NumberOfLevels; ilevel++)
+    for (ilevel = 0; ilevel < this->m_NumberOfLevels; ++ilevel)
     {
       if (ilevel == refLevel)
       {

--- a/Common/itkMultiResolutionImageRegistrationMethod2.hxx
+++ b/Common/itkMultiResolutionImageRegistrationMethod2.hxx
@@ -210,7 +210,7 @@ MultiResolutionImageRegistrationMethod2<TFixedImage, TMovingImage>::PreparePyram
   SizeType  inputSize = this->m_FixedImageRegion.GetSize();
   IndexType inputStart = this->m_FixedImageRegion.GetIndex();
   IndexType inputEnd = inputStart;
-  for (unsigned int dim = 0; dim < TFixedImage::ImageDimension; dim++)
+  for (unsigned int dim = 0; dim < TFixedImage::ImageDimension; ++dim)
   {
     inputEnd[dim] += (inputSize[dim] - 1);
   }
@@ -237,7 +237,7 @@ MultiResolutionImageRegistrationMethod2<TFixedImage, TMovingImage>::PreparePyram
   this->m_FixedImage->TransformIndexToPhysicalPoint(inputStart, inputStartPoint);
   this->m_FixedImage->TransformIndexToPhysicalPoint(inputEnd, inputEndPoint);
 
-  for (unsigned int level = 0; level < this->m_NumberOfLevels; level++)
+  for (unsigned int level = 0; level < this->m_NumberOfLevels; ++level)
   {
     SizeType         size;
     IndexType        start;
@@ -250,7 +250,7 @@ MultiResolutionImageRegistrationMethod2<TFixedImage, TMovingImage>::PreparePyram
      * floored. To see why, consider an image of 4 by 4, and its downsampled version of 2 by 2. */
     fixedImageAtLevel->TransformPhysicalPointToContinuousIndex(inputStartPoint, startcindex);
     fixedImageAtLevel->TransformPhysicalPointToContinuousIndex(inputEndPoint, endcindex);
-    for (unsigned int dim = 0; dim < TFixedImage::ImageDimension; dim++)
+    for (unsigned int dim = 0; dim < TFixedImage::ImageDimension; ++dim)
     {
       start[dim] = static_cast<IndexValueType>(std::ceil(startcindex[dim]));
       size[dim] =
@@ -378,7 +378,7 @@ MultiResolutionImageRegistrationMethod2<TFixedImage, TMovingImage>::PrintSelf(st
   os << indent << "LastTransformParameters: " << this->m_LastTransformParameters << std::endl;
   os << indent << "FixedImageRegion: " << this->m_FixedImageRegion << std::endl;
 
-  for (unsigned int level = 0; level < this->m_FixedImageRegionPyramid.size(); level++)
+  for (unsigned int level = 0; level < this->m_FixedImageRegionPyramid.size(); ++level)
   {
     os << indent << "FixedImageRegion at level " << level << ": " << this->m_FixedImageRegionPyramid[level]
        << std::endl;

--- a/Common/itkMultiResolutionShrinkPyramidImageFilter.hxx
+++ b/Common/itkMultiResolutionShrinkPyramidImageFilter.hxx
@@ -40,7 +40,7 @@ MultiResolutionShrinkPyramidImageFilter<TInputImage, TOutputImage>::GenerateData
 
   /** Loop over all resolution levels. */
   unsigned int factors[ImageDimension];
-  for (unsigned int ilevel = 0; ilevel < this->m_NumberOfLevels; ilevel++)
+  for (unsigned int ilevel = 0; ilevel < this->m_NumberOfLevels; ++ilevel)
   {
     this->UpdateProgress(static_cast<float>(ilevel) / static_cast<float>(this->m_NumberOfLevels));
 
@@ -50,7 +50,7 @@ MultiResolutionShrinkPyramidImageFilter<TInputImage, TOutputImage>::GenerateData
     outputPtr->Allocate();
 
     // compute and set shrink factors
-    for (unsigned int idim = 0; idim < ImageDimension; idim++)
+    for (unsigned int idim = 0; idim < ImageDimension; ++idim)
     {
       factors[idim] = this->m_Schedule[ilevel][idim];
     }

--- a/Common/itkNDImageTemplate.h
+++ b/Common/itkNDImageTemplate.h
@@ -244,7 +244,7 @@ protected:
     {
       TOut out(VDimension);
 
-      for (unsigned int i = 0; i < VDimension; i++)
+      for (unsigned int i = 0; i < VDimension; ++i)
       {
         out[i] = in[i];
       }
@@ -261,7 +261,7 @@ protected:
     {
       TOut out;
 
-      for (unsigned int i = 0; i < VDimension; i++)
+      for (unsigned int i = 0; i < VDimension; ++i)
       {
         out[i] = in[i];
       }

--- a/Common/itkParabolicErodeDilateImageFilter.hxx
+++ b/Common/itkParabolicErodeDilateImageFilter.hxx
@@ -184,7 +184,7 @@ ParabolicErodeDilateImageFilter<TInputImage, doDilate, TOutputImage>::GenerateDa
   this->GetMultiThreader()->SetSingleMethod(this->ThreaderCallback, &str);
 
   // multithread the execution
-  for (unsigned int d = 0; d < ImageDimension; d++)
+  for (unsigned int d = 0; d < ImageDimension; ++d)
   {
     m_CurrentDimension = d;
     this->GetMultiThreader()->SingleMethodExecute();
@@ -202,10 +202,10 @@ ParabolicErodeDilateImageFilter<TInputImage, doDilate, TOutputImage>::ThreadedGe
   typename std::vector<unsigned int> NumberOfRows;
   InputSizeType                      size = outputRegionForThread.GetSize();
 
-  for (unsigned int i = 0; i < InputImageDimension; i++)
+  for (unsigned int i = 0; i < InputImageDimension; ++i)
   {
     NumberOfRows.push_back(1);
-    for (unsigned int d = 0; d < InputImageDimension; d++)
+    for (unsigned int d = 0; d < InputImageDimension; ++d)
     {
       if (d != i)
       {
@@ -243,7 +243,7 @@ ParabolicErodeDilateImageFilter<TInputImage, doDilate, TOutputImage>::ThreadedGe
 
   // setup the progress reporting
   //   unsigned int numberOfLinesToProcess = 0;
-  //   for (unsigned  dd = 0; dd < imageDimension; dd++)
+  //   for (unsigned  dd = 0; dd < imageDimension; ++dd)
   //     {
   //     numberOfLinesToProcess += region.GetSize()[dd];
   //     }

--- a/Common/itkParabolicMorphUtils.h
+++ b/Common/itkParabolicMorphUtils.h
@@ -32,11 +32,11 @@ DoLine(LineBufferType & LineBuf, LineBufferType & tmpLineBuf, const RealType mag
 
   const long LineLength = LineBuf.size();
   // negative half of the parabola
-  for (long pos = 0; pos < LineLength; pos++)
+  for (long pos = 0; pos < LineLength; ++pos)
   {
     RealType BaseVal = (RealType)m_Extreme; // the base value for
     // comparison
-    for (long krange = koffset; krange <= 0; krange++)
+    for (long krange = koffset; krange <= 0; ++krange)
     {
       // difference needs to be paramaterised
       RealType T = LineBuf[pos + krange] - magnitude * krange * krange;

--- a/Common/itkReducedDimensionBSplineInterpolateImageFunction.hxx
+++ b/Common/itkReducedDimensionBSplineInterpolateImageFunction.hxx
@@ -130,7 +130,7 @@ ReducedDimensionBSplineInterpolateImageFunction<TImageType, TCoordRep, TCoeffici
 
   // this->SetPoles();
   m_MaxNumberInterpolationPoints = 1;
-  for (unsigned int n = 0; n < ImageDimension - 1; n++)
+  for (unsigned int n = 0; n < ImageDimension - 1; ++n)
   {
     m_MaxNumberInterpolationPoints *= (m_SplineOrder + 1);
   }
@@ -168,13 +168,13 @@ ReducedDimensionBSplineInterpolateImageFunction<TImageType, TCoordRep, TCoeffici
   coefficientIndex[ImageDimension - 1] = vnl_math::rnd(x[ImageDimension - 1]);
 
   // Step through eachpoint in the N-dimensional interpolation cube.
-  for (unsigned int p = 0; p < m_MaxNumberInterpolationPoints; p++)
+  for (unsigned int p = 0; p < m_MaxNumberInterpolationPoints; ++p)
   {
     // translate each step into the N-dimensional index.
     //      IndexType pointIndex = PointToIndex( p );
 
     double w = 1.0;
-    for (unsigned int n = 0; n < ImageDimension - 1; n++)
+    for (unsigned int n = 0; n < ImageDimension - 1; ++n)
     {
       w *= weights[n][m_PointsToIndex[p][n]];
       coefficientIndex[n] = EvaluateIndex[n][m_PointsToIndex[p][n]]; // Build up ND index for coefficients.
@@ -225,13 +225,13 @@ ReducedDimensionBSplineInterpolateImageFunction<TImageType, TCoordRep, TCoeffici
   double    tempValue;
   IndexType coefficientIndex;
   coefficientIndex[ImageDimension - 1] = vnl_math::rnd(x[ImageDimension - 1]);
-  for (unsigned int n = 0; n < ImageDimension - 1; n++)
+  for (unsigned int n = 0; n < ImageDimension - 1; ++n)
   {
     derivativeValue[n] = 0.0;
-    for (unsigned int p = 0; p < m_MaxNumberInterpolationPoints; p++)
+    for (unsigned int p = 0; p < m_MaxNumberInterpolationPoints; ++p)
     {
       tempValue = 1.0;
-      for (unsigned int n1 = 0; n1 < ImageDimension - 1; n1++)
+      for (unsigned int n1 = 0; n1 < ImageDimension - 1; ++n1)
       {
         coefficientIndex[n1] = EvaluateIndex[n1][m_PointsToIndex[p][n1]];
 
@@ -277,7 +277,7 @@ ReducedDimensionBSplineInterpolateImageFunction<TImageType, TCoordRep, TCoeffici
   switch (splineOrder)
   {
     case 3:
-      for (unsigned int n = 0; n < ImageDimension - 1; n++)
+      for (unsigned int n = 0; n < ImageDimension - 1; ++n)
       {
         w = x[n] - (double)EvaluateIndex[n][1];
         weights[n][3] = (1.0 / 6.0) * w * w * w;
@@ -287,13 +287,13 @@ ReducedDimensionBSplineInterpolateImageFunction<TImageType, TCoordRep, TCoeffici
       }
       break;
     case 0:
-      for (unsigned int n = 0; n < ImageDimension - 1; n++)
+      for (unsigned int n = 0; n < ImageDimension - 1; ++n)
       {
         weights[n][0] = 1; // implements nearest neighbor
       }
       break;
     case 1:
-      for (unsigned int n = 0; n < ImageDimension - 1; n++)
+      for (unsigned int n = 0; n < ImageDimension - 1; ++n)
       {
         w = x[n] - (double)EvaluateIndex[n][0];
         weights[n][1] = w;
@@ -301,7 +301,7 @@ ReducedDimensionBSplineInterpolateImageFunction<TImageType, TCoordRep, TCoeffici
       }
       break;
     case 2:
-      for (unsigned int n = 0; n < ImageDimension - 1; n++)
+      for (unsigned int n = 0; n < ImageDimension - 1; ++n)
       {
         /* x */
         w = x[n] - (double)EvaluateIndex[n][1];
@@ -311,7 +311,7 @@ ReducedDimensionBSplineInterpolateImageFunction<TImageType, TCoordRep, TCoeffici
       }
       break;
     case 4:
-      for (unsigned int n = 0; n < ImageDimension - 1; n++)
+      for (unsigned int n = 0; n < ImageDimension - 1; ++n)
       {
         /* x */
         w = x[n] - (double)EvaluateIndex[n][2];
@@ -329,7 +329,7 @@ ReducedDimensionBSplineInterpolateImageFunction<TImageType, TCoordRep, TCoeffici
       }
       break;
     case 5:
-      for (unsigned int n = 0; n < ImageDimension - 1; n++)
+      for (unsigned int n = 0; n < ImageDimension - 1; ++n)
       {
         /* x */
         w = x[n] - (double)EvaluateIndex[n][2];
@@ -383,20 +383,20 @@ ReducedDimensionBSplineInterpolateImageFunction<TImageType, TCoordRep, TCoeffici
     // Calculates B(splineOrder) ( (x + 1/2) - xi) - B(splineOrder -1) ( (x - 1/2) - xi)
     case -1:
       // Why would we want to do this?
-      for (unsigned int n = 0; n < ImageDimension - 1; n++)
+      for (unsigned int n = 0; n < ImageDimension - 1; ++n)
       {
         weights[n][0] = 0.0;
       }
       break;
     case 0:
-      for (unsigned int n = 0; n < ImageDimension - 1; n++)
+      for (unsigned int n = 0; n < ImageDimension - 1; ++n)
       {
         weights[n][0] = -1.0;
         weights[n][1] = 1.0;
       }
       break;
     case 1:
-      for (unsigned int n = 0; n < ImageDimension - 1; n++)
+      for (unsigned int n = 0; n < ImageDimension - 1; ++n)
       {
         w = x[n] + 0.5 - (double)EvaluateIndex[n][1];
         // w2 = w;
@@ -409,7 +409,7 @@ ReducedDimensionBSplineInterpolateImageFunction<TImageType, TCoordRep, TCoeffici
       break;
     case 2:
 
-      for (unsigned int n = 0; n < ImageDimension - 1; n++)
+      for (unsigned int n = 0; n < ImageDimension - 1; ++n)
       {
         w = x[n] + .5 - (double)EvaluateIndex[n][2];
         w2 = 0.75 - w * w;
@@ -424,7 +424,7 @@ ReducedDimensionBSplineInterpolateImageFunction<TImageType, TCoordRep, TCoeffici
       break;
     case 3:
 
-      for (unsigned int n = 0; n < ImageDimension - 1; n++)
+      for (unsigned int n = 0; n < ImageDimension - 1; ++n)
       {
         w = x[n] + 0.5 - (double)EvaluateIndex[n][2];
         w4 = (1.0 / 6.0) * w * w * w;
@@ -440,7 +440,7 @@ ReducedDimensionBSplineInterpolateImageFunction<TImageType, TCoordRep, TCoeffici
       }
       break;
     case 4:
-      for (unsigned int n = 0; n < ImageDimension - 1; n++)
+      for (unsigned int n = 0; n < ImageDimension - 1; ++n)
       {
         w = x[n] + .5 - (double)EvaluateIndex[n][3];
         t2 = w * w;
@@ -484,12 +484,12 @@ ReducedDimensionBSplineInterpolateImageFunction<TImageType, TCoordRep, TCoeffici
   // m_PointsToIndex is used to convert a sequential location to an N-dimension
   // index vector.  This is precomputed to save time during the interpolation routine.
   m_PointsToIndex.resize(m_MaxNumberInterpolationPoints);
-  for (unsigned int p = 0; p < m_MaxNumberInterpolationPoints; p++)
+  for (unsigned int p = 0; p < m_MaxNumberInterpolationPoints; ++p)
   {
     int           pp = p;
     unsigned long indexFactor[ImageDimension - 1];
     indexFactor[0] = 1;
-    for (int j = 1; j < static_cast<int>(ImageDimension - 1); j++)
+    for (int j = 1; j < static_cast<int>(ImageDimension - 1); ++j)
     {
       indexFactor[j] = indexFactor[j - 1] * (m_SplineOrder + 1);
     }
@@ -512,12 +512,12 @@ ReducedDimensionBSplineInterpolateImageFunction<TImageType, TCoordRep, TCoeffici
   long indx;
 
   // compute the interpolation indexes
-  for (unsigned int n = 0; n < ImageDimension - 1; n++)
+  for (unsigned int n = 0; n < ImageDimension - 1; ++n)
   {
     if (splineOrder & 1) // Use this index calculation for odd splineOrder
     {
       indx = (long)std::floor((float)x[n]) - splineOrder / 2;
-      for (unsigned int k = 0; k <= splineOrder; k++)
+      for (unsigned int k = 0; k <= splineOrder; ++k)
       {
         evaluateIndex[n][k] = indx++;
       }
@@ -525,7 +525,7 @@ ReducedDimensionBSplineInterpolateImageFunction<TImageType, TCoordRep, TCoeffici
     else // Use this index calculation for even splineOrder
     {
       indx = (long)std::floor((float)(x[n] + 0.5)) - splineOrder / 2;
-      for (unsigned int k = 0; k <= splineOrder; k++)
+      for (unsigned int k = 0; k <= splineOrder; ++k)
       {
         evaluateIndex[n][k] = indx++;
       }
@@ -540,7 +540,7 @@ ReducedDimensionBSplineInterpolateImageFunction<TImageType, TCoordRep, TCoeffici
   vnl_matrix<long> & evaluateIndex,
   unsigned int       splineOrder) const
 {
-  for (unsigned int n = 0; n < ImageDimension - 1; n++)
+  for (unsigned int n = 0; n < ImageDimension - 1; ++n)
   {
     long dataLength2 = 2 * m_DataLength[n] - 2;
 
@@ -548,14 +548,14 @@ ReducedDimensionBSplineInterpolateImageFunction<TImageType, TCoordRep, TCoeffici
     // TODO:  We could implement other boundary options beside mirror
     if (m_DataLength[n] == 1)
     {
-      for (unsigned int k = 0; k <= splineOrder; k++)
+      for (unsigned int k = 0; k <= splineOrder; ++k)
       {
         evaluateIndex[n][k] = 0;
       }
     }
     else
     {
-      for (unsigned int k = 0; k <= splineOrder; k++)
+      for (unsigned int k = 0; k <= splineOrder; ++k)
       {
         // btw - Think about this couldn't this be replaced with a more elagent modulus method?
         evaluateIndex[n][k] = (evaluateIndex[n][k] < 0L)

--- a/Common/itkTransformixInputPointFileReader.hxx
+++ b/Common/itkTransformixInputPointFileReader.hxx
@@ -120,7 +120,7 @@ TransformixInputPointFileReader<TOutputMesh>::GenerateData(void)
     {
       // read point from textfile
       PointType point;
-      for (unsigned int j = 0; j < dimension; j++)
+      for (unsigned int j = 0; j < dimension; ++j)
       {
         if (!this->m_Reader.eof())
         {

--- a/Components/FixedImagePyramids/FixedGenericPyramid/elxFixedGenericPyramid.hxx
+++ b/Components/FixedImagePyramids/FixedGenericPyramid/elxFixedGenericPyramid.hxx
@@ -55,9 +55,9 @@ FixedGenericPyramid<TElastix>::SetFixedSchedule(void)
    * - FixedImagePyramidSchedule
    */
   bool foundRescale = true;
-  for (unsigned int i = 0; i < numberOfResolutions; i++)
+  for (unsigned int i = 0; i < numberOfResolutions; ++i)
   {
-    for (unsigned int j = 0; j < FixedImageDimension; j++)
+    for (unsigned int j = 0; j < FixedImageDimension; ++j)
     {
       bool               ijfound = false;
       const unsigned int entrynr = i * FixedImageDimension + j;
@@ -92,9 +92,9 @@ FixedGenericPyramid<TElastix>::SetFixedSchedule(void)
    * - FixedImagePyramidSmoothingSchedule
    */
   bool foundSmoothing = true;
-  for (unsigned int i = 0; i < numberOfResolutions; i++)
+  for (unsigned int i = 0; i < numberOfResolutions; ++i)
   {
-    for (unsigned int j = 0; j < FixedImageDimension; j++)
+    for (unsigned int j = 0; j < FixedImageDimension; ++j)
     {
       bool               ijfound = false;
       const unsigned int entrynr = i * FixedImageDimension + j;

--- a/Components/ImageSamplers/Grid/elxGridSampler.hxx
+++ b/Components/ImageSamplers/Grid/elxGridSampler.hxx
@@ -38,7 +38,7 @@ GridSampler<TElastix>::BeforeEachResolution(void)
 
   /** Read the desired grid spacing of the samples. */
   unsigned int spacing_dim;
-  for (unsigned int dim = 0; dim < InputImageDimension; dim++)
+  for (unsigned int dim = 0; dim < InputImageDimension; ++dim)
   {
     spacing_dim = 2;
     this->GetConfiguration()->ReadParameter(

--- a/Components/Interpolators/RayCastInterpolator/elxRayCastInterpolator.hxx
+++ b/Components/Interpolators/RayCastInterpolator/elxRayCastInterpolator.hxx
@@ -63,7 +63,7 @@ RayCastInterpolator<TElastix>::BeforeRegistration(void)
   TransformParametersType preParameters(numberofparameters);
   preParameters.Fill(0.0);
 
-  for (unsigned int i = 0; i < numberofparameters; i++)
+  for (unsigned int i = 0; i < numberofparameters; ++i)
   {
     bool ret =
       this->GetConfiguration()->ReadParameter(preParameters[i], "PreParameters", this->GetComponentLabel(), i, 0);
@@ -83,7 +83,7 @@ RayCastInterpolator<TElastix>::BeforeRegistration(void)
   PointType focalPoint;
   focalPoint.Fill(0.);
 
-  for (unsigned int i = 0; i < this->m_Elastix->GetFixedImage()->GetImageDimension(); i++)
+  for (unsigned int i = 0; i < this->m_Elastix->GetFixedImage()->GetImageDimension(); ++i)
   {
     bool ret = this->GetConfiguration()->ReadParameter(focalPoint[i], "FocalPoint", this->GetComponentLabel(), i, 0);
     if (!ret)

--- a/Components/Metrics/AdvancedKappaStatistic/itkAdvancedKappaStatisticImageToImageMetric.hxx
+++ b/Components/Metrics/AdvancedKappaStatistic/itkAdvancedKappaStatisticImageToImageMetric.hxx
@@ -705,7 +705,7 @@ AdvancedKappaStatisticImageToImageMetric<TFixedImage, TMovingImage>::AccumulateD
 
   const DerivativeValueType zero = NumericTraits<DerivativeValueType>::Zero;
   DerivativeValueType       sum1, sum2;
-  for (unsigned int j = jmin; j < jmax; j++)
+  for (unsigned int j = jmin; j < jmax; ++j)
   {
     sum1 = sum2 = zero;
     for (ThreadIdType i = 0; i < nrOfThreads; ++i)
@@ -854,7 +854,7 @@ AdvancedKappaStatisticImageToImageMetric<TFixedImage, TMovingImage>::ComputeGrad
     currIndex = mit.GetIndex();
     minusIndex = currIndex;
     plusIndex = currIndex;
-    for (unsigned int i = 0; i < MovingImageDimension; i++)
+    for (unsigned int i = 0; i < MovingImageDimension; ++i)
     {
       /** Check for being on the edge of the moving image. */
       if (currIndex[i] == movingIndex[i] || currIndex[i] == static_cast<int>(movingIndex[i] + movingSize[i] - 1))

--- a/Components/Metrics/AdvancedMeanSquares/itkAdvancedMeanSquaresImageToImageMetric.hxx
+++ b/Components/Metrics/AdvancedMeanSquares/itkAdvancedMeanSquaresImageToImageMetric.hxx
@@ -760,7 +760,7 @@ AdvancedMeanSquaresImageToImageMetric<TFixedImage, TMovingImage>::AfterThreadedG
   if (!this->m_UseMultiThread && false) // force multi-threaded
   {
     derivative = this->m_GetValueAndDerivativePerThreadVariables[0].st_Derivative * normal_sum;
-    for (ThreadIdType i = 1; i < numberOfThreads; i++)
+    for (ThreadIdType i = 1; i < numberOfThreads; ++i)
     {
       derivative += this->m_GetValueAndDerivativePerThreadVariables[i].st_Derivative * normal_sum;
     }

--- a/Components/Metrics/AdvancedNormalizedCorrelation/itkAdvancedNormalizedCorrelationImageToImageMetric.hxx
+++ b/Components/Metrics/AdvancedNormalizedCorrelation/itkAdvancedNormalizedCorrelationImageToImageMetric.hxx
@@ -446,7 +446,7 @@ AdvancedNormalizedCorrelationImageToImageMetric<TFixedImage, TMovingImage>::GetV
     smm -= (sm * sm / N);
     sfm -= (sf * sm / N);
 
-    for (unsigned int i = 0; i < this->GetNumberOfParameters(); i++)
+    for (unsigned int i = 0; i < this->GetNumberOfParameters(); ++i)
     {
       derivativeF[i] -= sf * differential[i] / N;
       derivativeM[i] -= sm * differential[i] / N;
@@ -460,7 +460,7 @@ AdvancedNormalizedCorrelationImageToImageMetric<TFixedImage, TMovingImage>::GetV
   if (this->m_NumberOfPixelsCounted > 0 && denom < -1e-14)
   {
     value = sfm / denom;
-    for (unsigned int i = 0; i < this->GetNumberOfParameters(); i++)
+    for (unsigned int i = 0; i < this->GetNumberOfParameters(); ++i)
     {
       derivative[i] = (derivativeF[i] - (sfm / smm) * derivativeM[i]) / denom;
     }

--- a/Components/Metrics/DistancePreservingRigidityPenalty/itkDistancePreservingRigidityPenaltyTerm.hxx
+++ b/Components/Metrics/DistancePreservingRigidityPenalty/itkDistancePreservingRigidityPenaltyTerm.hxx
@@ -441,7 +441,7 @@ DistancePreservingRigidityPenaltyTerm<TFixedImage, TScalarType>::GetValueAndDeri
               ty_neighbor = tindex_neighbor[1];
               tz_neighbor = tindex_neighbor[2];
 
-              for (unsigned dd = 0; dd < ImageDimension; dd++)
+              for (unsigned dd = 0; dd < ImageDimension; ++dd)
               {
                 ntindex_start[dd] = static_cast<ContinuousIndexValueType>(floor(tindex[dd])) - 1.0;
                 ntindex_neighbor_start[dd] = static_cast<ContinuousIndexValueType>(floor(tindex_neighbor[dd])) - 1.0;

--- a/Components/Metrics/GradientDifference/itkGradientDifferenceImageToImageMetric2.hxx
+++ b/Components/Metrics/GradientDifference/itkGradientDifferenceImageToImageMetric2.hxx
@@ -62,14 +62,14 @@ GradientDifferenceImageToImageMetric<TFixedImage, TMovingImage>::GradientDiffere
   this->m_CombinationTransform = CombinationTransformType::New();
   this->m_TransformMovingImageFilter = TransformMovingImageFilterType::New();
 
-  for (iDimension = 0; iDimension < FixedImageDimension; iDimension++)
+  for (iDimension = 0; iDimension < FixedImageDimension; ++iDimension)
   {
     this->m_MinFixedGradient[iDimension] = 0;
     this->m_MaxFixedGradient[iDimension] = 0;
     this->m_Variance[iDimension] = 0;
   }
 
-  for (iDimension = 0; iDimension < MovedImageDimension; iDimension++)
+  for (iDimension = 0; iDimension < MovedImageDimension; ++iDimension)
   {
     this->m_MinMovedGradient[iDimension] = 0;
     this->m_MaxMovedGradient[iDimension] = 0;
@@ -97,7 +97,7 @@ GradientDifferenceImageToImageMetric<TFixedImage, TMovingImage>::Initialize(void
   this->m_CastFixedImageFilter->SetInput(this->m_FixedImage);
   this->m_CastFixedImageFilter->Update();
 
-  for (iFilter = 0; iFilter < FixedImageDimension; iFilter++)
+  for (iFilter = 0; iFilter < FixedImageDimension; ++iFilter)
   {
     this->m_FixedSobelOperators[iFilter].SetDirection(iFilter);
     this->m_FixedSobelOperators[iFilter].CreateDirectional();
@@ -131,7 +131,7 @@ GradientDifferenceImageToImageMetric<TFixedImage, TMovingImage>::Initialize(void
 
   this->m_CastMovedImageFilter->SetInput(this->m_TransformMovingImageFilter->GetOutput());
 
-  for (iFilter = 0; iFilter < MovedImageDimension; iFilter++)
+  for (iFilter = 0; iFilter < MovedImageDimension; ++iFilter)
   {
     this->m_MovedSobelOperators[iFilter].SetDirection(iFilter);
     this->m_MovedSobelOperators[iFilter].CreateDirectional();
@@ -180,7 +180,7 @@ GradientDifferenceImageToImageMetric<TFixedImage, TMovingImage>::ComputeMovedGra
   unsigned int           iDimension;
   MovedGradientPixelType gradient;
 
-  for (iDimension = 0; iDimension < FixedImageDimension; iDimension++)
+  for (iDimension = 0; iDimension < FixedImageDimension; ++iDimension)
   {
     typedef itk::ImageRegionConstIteratorWithIndex<MovedGradientImageType> IteratorType;
 
@@ -223,7 +223,7 @@ GradientDifferenceImageToImageMetric<TFixedImage, TMovingImage>::ComputeVariance
   FixedGradientPixelType mean[FixedImageDimension];
   FixedGradientPixelType gradient;
 
-  for (iDimension = 0; iDimension < FixedImageDimension; iDimension++)
+  for (iDimension = 0; iDimension < FixedImageDimension; ++iDimension)
   {
     typedef itk::ImageRegionConstIteratorWithIndex<FixedGradientImageType> IteratorType;
 
@@ -365,7 +365,7 @@ GradientDifferenceImageToImageMetric<TFixedImage, TMovingImage>::ComputeMeasure(
   typename FixedImageType::IndexType currentIndex;
   typename FixedImageType::PointType point;
 
-  for (iDimension = 0; iDimension < FixedImageDimension; iDimension++)
+  for (iDimension = 0; iDimension < FixedImageDimension; ++iDimension)
   {
 
     if (this->m_Variance[iDimension] == NumericTraits<MovedGradientPixelType>::ZeroValue())
@@ -455,7 +455,7 @@ GradientDifferenceImageToImageMetric<TFixedImage, TMovingImage>::GetValue(
   this->m_TransformMovingImageFilter->UpdateLargestPossibleRegion();
 
   /** Update the gradient images */
-  for (iFilter = 0; iFilter < MovedImageDimension; iFilter++)
+  for (iFilter = 0; iFilter < MovedImageDimension; ++iFilter)
   {
     this->m_MovedSobelFilters[iFilter]->UpdateLargestPossibleRegion();
   }
@@ -466,7 +466,7 @@ GradientDifferenceImageToImageMetric<TFixedImage, TMovingImage>::GetValue(
   MovedGradientPixelType subtractionFactor[FixedImageDimension];
   MeasureType            currentMeasure;
 
-  for (iDimension = 0; iDimension < FixedImageDimension; iDimension++)
+  for (iDimension = 0; iDimension < FixedImageDimension; ++iDimension)
   {
     subtractionFactor[iDimension] = this->m_MaxFixedGradient[iDimension] / this->m_MaxMovedGradient[iDimension];
   }
@@ -493,7 +493,7 @@ GradientDifferenceImageToImageMetric<TFixedImage, TMovingImage>::GetDerivative(
   const unsigned int numberOfParameters = this->GetNumberOfParameters();
   derivative = DerivativeType(numberOfParameters);
 
-  for (unsigned int i = 0; i < numberOfParameters; i++)
+  for (unsigned int i = 0; i < numberOfParameters; ++i)
   {
     testPoint[i] -= this->m_DerivativeDelta / std::sqrt(this->m_Scales[i]);
     const MeasureType valuep0 = this->GetValue(testPoint);

--- a/Components/Metrics/KNNGraphAlphaMutualInformation/KNN/itkANNFixedRadiusTreeSearch.hxx
+++ b/Components/Metrics/KNNGraphAlphaMutualInformation/KNN/itkANNFixedRadiusTreeSearch.hxx
@@ -67,7 +67,7 @@ ANNFixedRadiusTreeSearch<TBinaryTree>::Search(const MeasurementVectorType & qp,
 
   /** Alocate memory for ANN query point and copy qp to it. */
   ANNPointType ANNQueryPoint = annAllocPt(dim);
-  for (int i = 0; i < dim; i++)
+  for (int i = 0; i < dim; ++i)
   {
     ANNQueryPoint[i] = qp[i];
   }
@@ -116,7 +116,7 @@ ANNFixedRadiusTreeSearch<TBinaryTree>::Search(const MeasurementVectorType & qp,
 
   /** Alocate memory for ANN query point and copy qp to it. */
   ANNPointType ANNQueryPoint = annAllocPt(dim);
-  for (int i = 0; i < dim; i++)
+  for (int i = 0; i < dim; ++i)
   {
     ANNQueryPoint[i] = qp[i];
   }

--- a/Components/Metrics/KNNGraphAlphaMutualInformation/KNN/itkANNPriorityTreeSearch.hxx
+++ b/Components/Metrics/KNNGraphAlphaMutualInformation/KNN/itkANNPriorityTreeSearch.hxx
@@ -112,7 +112,7 @@ ANNPriorityTreeSearch<TBinaryTree>::Search(const MeasurementVectorType & qp,
 
   /** Alocate memory for ANN query point and copy qp to it. */
   ANNPointType ANNQueryPoint = annAllocPt(dim);
-  for (int i = 0; i < dim; i++)
+  for (int i = 0; i < dim; ++i)
   {
     ANNQueryPoint[i] = qp[i];
   }

--- a/Components/Metrics/KNNGraphAlphaMutualInformation/KNN/itkANNStandardTreeSearch.hxx
+++ b/Components/Metrics/KNNGraphAlphaMutualInformation/KNN/itkANNStandardTreeSearch.hxx
@@ -65,7 +65,7 @@ ANNStandardTreeSearch<TBinaryTree>::Search(const MeasurementVectorType & qp,
 
   /** Alocate memory for ANN query point and copy qp to it. */
   ANNPointType ANNQueryPoint = annAllocPt(dim);
-  for (int i = 0; i < dim; i++)
+  for (int i = 0; i < dim; ++i)
   {
     ANNQueryPoint[i] = qp[i];
   }

--- a/Components/Metrics/KNNGraphAlphaMutualInformation/KNN/itkListSampleCArray.hxx
+++ b/Components/Metrics/KNNGraphAlphaMutualInformation/KNN/itkListSampleCArray.hxx
@@ -118,7 +118,7 @@ ListSampleCArray<TMeasurementVector, TInternalValue>::SetMeasurementVector(Insta
   unsigned int dim = this->GetMeasurementVectorSize();
   if (id < this->m_InternalContainerSize)
   {
-    for (unsigned int i = 0; i < dim; i++)
+    for (unsigned int i = 0; i < dim; ++i)
     {
       this->m_InternalContainer[id][i] = mv[i];
     }
@@ -207,7 +207,7 @@ ListSampleCArray<TMeasurementVector, TInternalValue>::AllocateInternalContainer(
 {
   this->m_InternalContainer = new InternalDataType[size];
   InternalDataType p = new InternalValueType[size * dim];
-  for (unsigned long i = 0; i < size; i++)
+  for (unsigned long i = 0; i < size; ++i)
   {
     this->m_InternalContainer[i] = &(p[i * dim]);
   }

--- a/Components/Metrics/KNNGraphAlphaMutualInformation/itkKNNGraphAlphaMutualInformationImageToImageMetric.hxx
+++ b/Components/Metrics/KNNGraphAlphaMutualInformation/itkKNNGraphAlphaMutualInformationImageToImageMetric.hxx
@@ -394,7 +394,7 @@ KNNGraphAlphaMutualInformationImageToImageMetric<TFixedImage, TMovingImage>::Get
   double       twoGamma = jointSize * (1.0 - this->m_Alpha);
 
   /** Loop over all query points, i.e. all samples. */
-  for (unsigned long i = 0; i < this->m_NumberOfPixelsCounted; i++)
+  for (unsigned long i = 0; i < this->m_NumberOfPixelsCounted; ++i)
   {
     /** Get the i-th query point. */
     listSampleFixed->GetMeasurementVector(i, z_F);
@@ -430,7 +430,7 @@ KNNGraphAlphaMutualInformationImageToImageMetric<TFixedImage, TMovingImage>::Get
     AccumulateType Gamma_J = NumericTraits<AccumulateType>::Zero;
 
     /** Loop over the neighbours. */
-    for (unsigned int p = 0; p < k; p++)
+    for (unsigned int p = 0; p < k; ++p)
     {
       Gamma_F += std::sqrt(distances_F[p]);
       Gamma_M += std::sqrt(distances_M[p]);
@@ -624,7 +624,7 @@ KNNGraphAlphaMutualInformationImageToImageMetric<TFixedImage, TMovingImage>::Get
   double       twoGamma = jointSize * (1.0 - this->m_Alpha);
 
   /** Loop over all query points, i.e. all samples. */
-  for (unsigned long i = 0; i < this->m_NumberOfPixelsCounted; i++)
+  for (unsigned long i = 0; i < this->m_NumberOfPixelsCounted; ++i)
   {
     /** Get the i-th query point. */
     listSampleFixed->GetMeasurementVector(i, z_F);
@@ -648,7 +648,7 @@ KNNGraphAlphaMutualInformationImageToImageMetric<TFixedImage, TMovingImage>::Get
     dGamma_J.Fill(NumericTraits<DerivativeValueType>::ZeroValue());
 
     /** Loop over the neighbours. */
-    for (unsigned int p = 0; p < k; p++)
+    for (unsigned int p = 0; p < k; ++p)
     {
       /** Get the neighbour point z_ip^M. */
       listSampleMoving->GetMeasurementVector(indices_M[p], z_M_ip);
@@ -830,7 +830,7 @@ KNNGraphAlphaMutualInformationImageToImageMetric<TFixedImage, TMovingImage>::
       listSampleJoint->SetMeasurement(this->m_NumberOfPixelsCounted, this->GetNumberOfFixedImages(), movingImageValue);
 
       /** Get and set the values of the fixed feature images. */
-      for (unsigned int j = 1; j < this->GetNumberOfFixedImages(); j++)
+      for (unsigned int j = 1; j < this->GetNumberOfFixedImages(); ++j)
       {
         fixedFeatureValue = this->m_FixedImageInterpolatorVector[j]->Evaluate(fixedPoint);
         listSampleFixed->SetMeasurement(this->m_NumberOfPixelsCounted, j, fixedFeatureValue);
@@ -838,7 +838,7 @@ KNNGraphAlphaMutualInformationImageToImageMetric<TFixedImage, TMovingImage>::
       }
 
       /** Get and set the values of the moving feature images. */
-      for (unsigned int j = 1; j < this->GetNumberOfMovingImages(); j++)
+      for (unsigned int j = 1; j < this->GetNumberOfMovingImages(); ++j)
       {
         movingFeatureValue = this->m_InterpolatorVector[j]->Evaluate(mappedPoint);
         listSampleMoving->SetMeasurement(this->m_NumberOfPixelsCounted, j, movingFeatureValue);

--- a/Components/Metrics/MissingStructurePenalty/elxMissingStructurePenalty.hxx
+++ b/Components/Metrics/MissingStructurePenalty/elxMissingStructurePenalty.hxx
@@ -100,7 +100,7 @@ MissingStructurePenalty<TElastix>::BeforeAllBase(void)
 
   this->m_NumberOfMeshes = 0;
 
-  for (char ch = 'A'; ch <= 'Z'; ch++)
+  for (char ch = 'A'; ch <= 'Z'; ++ch)
   {
     std::ostringstream fmeshArgument("-fmesh", std::ios_base::ate);
     fmeshArgument << ch << metricNumber;
@@ -493,7 +493,7 @@ the sequence of points to form a 2d connected polydata contour.
   /** Read the input points, as index or as point. */
   if (!(ippReader->GetPointsAreIndices()))
   {
-    for (unsigned int j = 0; j < nrofpoints; j++)
+    for (unsigned int j = 0; j < nrofpoints; ++j)
     {
       /** Compute index of nearest voxel in fixed image. */
       InputPointType point;
@@ -501,7 +501,7 @@ the sequence of points to form a 2d connected polydata contour.
       inputPointSet->GetPoint(j, &point);
       inputpointvec[j] = point;
       dummyImage->TransformPhysicalPointToContinuousIndex(point, fixedcindex);
-      for (unsigned int i = 0; i < FixedImageDimension; i++)
+      for (unsigned int i = 0; i < FixedImageDimension; ++i)
       {
         inputindexvec[j][i] = static_cast<FixedImageIndexValueType>(vnl_math::rnd(fixedcindex[i]));
       }
@@ -509,7 +509,7 @@ the sequence of points to form a 2d connected polydata contour.
   }
   else // so: inputasindex
   {
-    for (unsigned int j = 0; j < nrofpoints; j++)
+    for (unsigned int j = 0; j < nrofpoints; ++j)
     {
       /** The read point from the inutPointSet is actually an index
        * Cast to the proper type.
@@ -517,7 +517,7 @@ the sequence of points to form a 2d connected polydata contour.
       InputPointType point;
       point.Fill(0.0f);
       inputPointSet->GetPoint(j, &point);
-      for (unsigned int i = 0; i < FixedImageDimension; i++)
+      for (unsigned int i = 0; i < FixedImageDimension; ++i)
       {
         inputindexvec[j][i] = static_cast<FixedImageIndexValueType>(vnl_math::rnd(point[i]));
       }

--- a/Components/Metrics/NormalizedGradientCorrelation/itkNormalizedGradientCorrelationImageToImageMetric.hxx
+++ b/Components/Metrics/NormalizedGradientCorrelation/itkNormalizedGradientCorrelationImageToImageMetric.hxx
@@ -44,7 +44,7 @@ NormalizedGradientCorrelationImageToImageMetric<TFixedImage,
   this->m_TransformMovingImageFilter = TransformMovingImageFilterType::New();
   this->m_DerivativeDelta = 0.001;
 
-  for (unsigned int iDimension = 0; iDimension < MovedImageDimension; iDimension++)
+  for (unsigned int iDimension = 0; iDimension < MovedImageDimension; ++iDimension)
   {
     this->m_MeanFixedGradient[iDimension] = 0;
     this->m_MeanMovedGradient[iDimension] = 0;
@@ -70,7 +70,7 @@ NormalizedGradientCorrelationImageToImageMetric<TFixedImage, TMovingImage>::Init
   this->m_CastFixedImageFilter->SetInput(this->m_FixedImage);
   this->m_CastFixedImageFilter->Update();
 
-  for (iFilter = 0; iFilter < FixedImageDimension; iFilter++)
+  for (iFilter = 0; iFilter < FixedImageDimension; ++iFilter)
   {
     this->m_FixedSobelOperators[iFilter].SetDirection(iFilter);
     this->m_FixedSobelOperators[iFilter].CreateDirectional();
@@ -106,7 +106,7 @@ NormalizedGradientCorrelationImageToImageMetric<TFixedImage, TMovingImage>::Init
 
   this->m_CastMovedImageFilter->SetInput(this->m_TransformMovingImageFilter->GetOutput());
 
-  for (iFilter = 0; iFilter < MovedImageDimension; iFilter++)
+  for (iFilter = 0; iFilter < MovedImageDimension; ++iFilter)
   {
     this->m_MovedSobelOperators[iFilter].SetDirection(iFilter);
     this->m_MovedSobelOperators[iFilter].CreateDirectional();
@@ -145,7 +145,7 @@ NormalizedGradientCorrelationImageToImageMetric<TFixedImage, TMovingImage>::Comp
   typename FixedGradientImageType::IndexType currentIndex;
   typename FixedGradientImageType::PointType point;
 
-  for (int iDimension = 0; iDimension < FixedImageDimension; iDimension++)
+  for (int iDimension = 0; iDimension < FixedImageDimension; ++iDimension)
   {
     this->m_FixedSobelFilters[iDimension]->UpdateLargestPossibleRegion();
   }
@@ -159,7 +159,7 @@ NormalizedGradientCorrelationImageToImageMetric<TFixedImage, TMovingImage>::Comp
 
   bool                   sampleOK = false;
   FixedGradientPixelType fixedGradient[FixedImageDimension];
-  for (int i = 0; i < FixedImageDimension; i++)
+  for (int i = 0; i < FixedImageDimension; ++i)
   {
     fixedGradient[i] = 0.0;
   }
@@ -218,7 +218,7 @@ NormalizedGradientCorrelationImageToImageMetric<TFixedImage, TMovingImage>::Comp
   typename MovedGradientImageType::IndexType currentIndex;
   typename MovedGradientImageType::PointType point;
 
-  for (int iDimension = 0; iDimension < MovedImageDimension; iDimension++)
+  for (int iDimension = 0; iDimension < MovedImageDimension; ++iDimension)
   {
     this->m_MovedSobelFilters[iDimension]->UpdateLargestPossibleRegion();
   }
@@ -240,7 +240,7 @@ NormalizedGradientCorrelationImageToImageMetric<TFixedImage, TMovingImage>::Comp
 
   MovedGradientPixelType movedGradient[MovedImageDimension];
 
-  for (int i = 0; i < MovedImageDimension; i++)
+  for (int i = 0; i < MovedImageDimension; ++i)
   {
     movedGradient[i] = 0.0;
   }
@@ -309,7 +309,7 @@ NormalizedGradientCorrelationImageToImageMetric<TFixedImage, TMovingImage>::Comp
   MeasureType NGautocorrelationmoving = NumericTraits<MeasureType>::Zero;
 
   /** Make sure all is updated */
-  for (int iDimension = 0; iDimension < FixedImageDimension; iDimension++)
+  for (int iDimension = 0; iDimension < FixedImageDimension; ++iDimension)
   {
     this->m_FixedSobelFilters[iDimension]->UpdateLargestPossibleRegion();
     this->m_MovedSobelFilters[iDimension]->UpdateLargestPossibleRegion();
@@ -411,7 +411,7 @@ NormalizedGradientCorrelationImageToImageMetric<TFixedImage, TMovingImage>::GetV
   this->m_TransformMovingImageFilter->Modified();
   this->m_TransformMovingImageFilter->UpdateLargestPossibleRegion();
 
-  for (iFilter = 0; iFilter < MovedImageDimension; iFilter++)
+  for (iFilter = 0; iFilter < MovedImageDimension; ++iFilter)
   {
     this->m_MovedSobelFilters[iFilter]->UpdateLargestPossibleRegion();
   }
@@ -457,7 +457,7 @@ NormalizedGradientCorrelationImageToImageMetric<TFixedImage, TMovingImage>::GetD
   const unsigned int numberOfParameters = this->GetNumberOfParameters();
   derivative = DerivativeType(numberOfParameters);
 
-  for (unsigned int i = 0; i < numberOfParameters; i++)
+  for (unsigned int i = 0; i < numberOfParameters; ++i)
   {
     testPoint[i] -= this->m_DerivativeDelta / std::sqrt(this->m_Scales[i]);
     const MeasureType valuep0 = this->GetValue(testPoint);

--- a/Components/Metrics/PCAMetric/itkPCAMetric.hxx
+++ b/Components/Metrics/PCAMetric/itkPCAMetric.hxx
@@ -141,12 +141,12 @@ PCAMetric<TFixedImage, TMovingImage>::EvaluateTransformJacobianInnerProduct(
   JacobianIteratorType                                   jac = jacobian.begin();
   imageJacobian.Fill(0.0);
   const unsigned int sizeImageJacobian = imageJacobian.GetSize();
-  for (unsigned int dim = 0; dim < FixedImageDimension; dim++)
+  for (unsigned int dim = 0; dim < FixedImageDimension; ++dim)
   {
     const double           imDeriv = movingImageDerivative[dim];
     DerivativeIteratorType imjac = imageJacobian.begin();
 
-    for (unsigned int mu = 0; mu < sizeImageJacobian; mu++)
+    for (unsigned int mu = 0; mu < sizeImageJacobian; ++mu)
     {
       (*imjac) += (*jac) * imDeriv;
       ++imjac;
@@ -298,9 +298,9 @@ PCAMetric<TFixedImage, TMovingImage>::GetValue(const TransformParametersType & p
   /** Calculate mean of from columns */
   vnl_vector<RealType> mean(G);
   mean.fill(NumericTraits<RealType>::Zero);
-  for (int i = 0; i < N; i++)
+  for (int i = 0; i < N; ++i)
   {
-    for (int j = 0; j < G; j++)
+    for (int j = 0; j < G; ++j)
     {
       mean(j) += A(i, j);
     }
@@ -310,9 +310,9 @@ PCAMetric<TFixedImage, TMovingImage>::GetValue(const TransformParametersType & p
   MatrixType Amm(N, G);
   Amm.fill(NumericTraits<RealType>::Zero);
 
-  for (int i = 0; i < N; i++)
+  for (int i = 0; i < N; ++i)
   {
-    for (int j = 0; j < G; j++)
+    for (int j = 0; j < G; ++j)
     {
       Amm(i, j) = A(i, j) - mean(j);
     }
@@ -338,7 +338,7 @@ PCAMetric<TFixedImage, TMovingImage>::GetValue(const TransformParametersType & p
   /** Calculate variance of columns */
   vnl_vector<RealType> var(G);
   var.fill(NumericTraits<RealType>::Zero);
-  for (int j = 0; j < G; j++)
+  for (int j = 0; j < G; ++j)
   {
     var(j) = C(j, j);
   }
@@ -346,12 +346,12 @@ PCAMetric<TFixedImage, TMovingImage>::GetValue(const TransformParametersType & p
 
   MatrixType S(G, G);
   S.fill(NumericTraits<RealType>::Zero);
-  for (int j = 0; j < G; j++)
+  for (int j = 0; j < G; ++j)
   {
     S(j, j) = 1.0 / sqrt(var(j));
   }
 
-  for (int j = 0; j < G; j++)
+  for (int j = 0; j < G; ++j)
   {
     C(j, j) -= varNoise;
   }
@@ -373,7 +373,7 @@ PCAMetric<TFixedImage, TMovingImage>::GetValue(const TransformParametersType & p
   const unsigned int L = this->m_NumEigenValues;
 
   RealType sumEigenValuesUsed = itk::NumericTraits<RealType>::Zero;
-  for (unsigned int i = 1; i < L + 1; i++)
+  for (unsigned int i = 1; i < L + 1; ++i)
   {
     sumEigenValuesUsed += eig.get_eigenvalue(G - i);
   }
@@ -547,9 +547,9 @@ PCAMetric<TFixedImage, TMovingImage>::GetValueAndDerivative(const TransformParam
   /** Calculate mean of from columns */
   vnl_vector<RealType> mean(G);
   mean.fill(NumericTraits<RealType>::Zero);
-  for (int i = 0; i < N; i++)
+  for (int i = 0; i < N; ++i)
   {
-    for (int j = 0; j < G; j++)
+    for (int j = 0; j < G; ++j)
     {
       mean(j) += A(i, j);
     }
@@ -559,9 +559,9 @@ PCAMetric<TFixedImage, TMovingImage>::GetValueAndDerivative(const TransformParam
   /** Calculate standard deviation from columns */
   MatrixType Amm(N, G);
   Amm.fill(NumericTraits<RealType>::Zero);
-  for (int i = 0; i < N; i++)
+  for (int i = 0; i < N; ++i)
   {
-    for (int j = 0; j < G; j++)
+    for (int j = 0; j < G; ++j)
     {
       Amm(i, j) = A(i, j) - mean(j);
     }
@@ -584,7 +584,7 @@ PCAMetric<TFixedImage, TMovingImage>::GetValueAndDerivative(const TransformParam
   /** Calculate standard deviation from columns */
   vnl_vector<RealType> var(G);
   var.fill(NumericTraits<RealType>::Zero);
-  for (int j = 0; j < G; j++)
+  for (int j = 0; j < G; ++j)
   {
     var(j) = C(j, j);
   }
@@ -592,12 +592,12 @@ PCAMetric<TFixedImage, TMovingImage>::GetValueAndDerivative(const TransformParam
 
   vnl_diag_matrix<RealType> S(G);
   S.fill(NumericTraits<RealType>::Zero);
-  for (int j = 0; j < G; j++)
+  for (int j = 0; j < G; ++j)
   {
     S(j, j) = 1.0 / sqrt(var(j));
   }
 
-  for (int j = 0; j < G; j++)
+  for (int j = 0; j < G; ++j)
   {
     C(j, j) -= varNoise;
   }
@@ -618,13 +618,13 @@ PCAMetric<TFixedImage, TMovingImage>::GetValueAndDerivative(const TransformParam
   const unsigned int L = this->m_NumEigenValues;
 
   RealType sumEigenValuesUsed = itk::NumericTraits<RealType>::Zero;
-  for (unsigned int i = 1; i < L + 1; i++)
+  for (unsigned int i = 1; i < L + 1; ++i)
   {
     sumEigenValuesUsed += eig.get_eigenvalue(G - i);
   }
 
   MatrixType eigenVectorMatrix(G, L);
-  for (unsigned int i = 1; i < L + 1; i++)
+  for (unsigned int i = 1; i < L + 1; ++i)
   {
     eigenVectorMatrix.set_column(i - 1, (eig.get_eigenvector(G - i)).normalize());
   }
@@ -677,7 +677,7 @@ PCAMetric<TFixedImage, TMovingImage>::GetValueAndDerivative(const TransformParam
   unsigned int startSamplesOK;
   startSamplesOK = 0;
 
-  for (unsigned int d = 0; d < G; d++)
+  for (unsigned int d = 0; d < G; ++d)
   {
     dSdmu_part1[d] = -pow(S(d, d), 3.0);
   }
@@ -731,7 +731,7 @@ PCAMetric<TFixedImage, TMovingImage>::GetValueAndDerivative(const TransformParam
         meandAdmu[nzjis[d][p]] += (dMTdmu[p]) / double(N);
         v_GAtmmdAdmu[d][nzjis[d][p]] += v_GAtmm[pixelIndex] * dMTdmu[p];
         dSdmu[d][nzjis[d][p]] += Atmm[d][pixelIndex] * dSdmu_part1[d] * dMTdmu[p];
-        for (unsigned int z = 0; z < L; z++)
+        for (unsigned int z = 0; z < L; ++z)
         {
           vSAtmmdAdmu[z][d + nzjis[d][p] * G] += vSAtmm[z][pixelIndex] * dMTdmu[p];
         }
@@ -741,7 +741,7 @@ PCAMetric<TFixedImage, TMovingImage>::GetValueAndDerivative(const TransformParam
 
   if (this->m_UseDerivativeOfMean)
   {
-    for (unsigned int i = 0; i < N; i++)
+    for (unsigned int i = 0; i < N; ++i)
     {
       for (unsigned int d = 0; d < G; ++d)
       {
@@ -749,7 +749,7 @@ PCAMetric<TFixedImage, TMovingImage>::GetValueAndDerivative(const TransformParam
         {
           v_GAtmmmeandAdmu[d][p] += v_GAtmm[i] * meandAdmu[p];
           meandSdmu[d][p] += Atmm[d][i] * dSdmu_part1[d] * meandAdmu[p];
-          for (unsigned int z = 0; z < L; z++)
+          for (unsigned int z = 0; z < L; ++z)
           {
             vSAtmmmeandAdmu[z][d + G * p] += vSAtmm[z][i] * meandAdmu[p];
           }
@@ -758,7 +758,7 @@ PCAMetric<TFixedImage, TMovingImage>::GetValueAndDerivative(const TransformParam
     }
   }
 
-  for (unsigned int p = 0; p < P; p++)
+  for (unsigned int p = 0; p < P; ++p)
   {
     dvarNoisedmu[p] = dot_product((v_GAtmmdAdmu - v_GAtmmmeandAdmu).get_column(p), v_G);
   }
@@ -768,13 +768,13 @@ PCAMetric<TFixedImage, TMovingImage>::GetValueAndDerivative(const TransformParam
     dvarNoisedmu.fill(itk::NumericTraits<DerivativeValueType>::Zero);
   }
 
-  for (unsigned int p = 0; p < P; p++)
+  for (unsigned int p = 0; p < P; ++p)
   {
     vnl_diag_matrix<DerivativeValueType> diagonaldvarNoisedmu(G);
     diagonaldvarNoisedmu.fill(0.0);
     vnl_diag_matrix<DerivativeValueType> diagonaldSdmu(G);
     diagonaldSdmu.fill(0.0);
-    for (unsigned int d = 0; d < G; d++)
+    for (unsigned int d = 0; d < G; ++d)
     {
       diagonaldvarNoisedmu(d, d) = dSdmu_part1[d] * dvarNoisedmu[p];
       diagonaldSdmu(d, d) = (dSdmu - meandSdmu).get_column(p)[d] - diagonaldvarNoisedmu(d, d);

--- a/Components/Metrics/PCAMetric/itkPCAMetric_F_multithreaded.hxx
+++ b/Components/Metrics/PCAMetric/itkPCAMetric_F_multithreaded.hxx
@@ -158,12 +158,12 @@ PCAMetric<TFixedImage, TMovingImage>::EvaluateTransformJacobianInnerProduct(
   JacobianIteratorType                                   jac = jacobian.begin();
   imageJacobian.Fill(0.0);
   const unsigned int sizeImageJacobian = imageJacobian.GetSize();
-  for (unsigned int dim = 0; dim < FixedImageDimension; dim++)
+  for (unsigned int dim = 0; dim < FixedImageDimension; ++dim)
   {
     const double           imDeriv = movingImageDerivative[dim];
     DerivativeIteratorType imjac = imageJacobian.begin();
 
-    for (unsigned int mu = 0; mu < sizeImageJacobian; mu++)
+    for (unsigned int mu = 0; mu < sizeImageJacobian; ++mu)
     {
       (*imjac) += (*jac) * imDeriv;
       ++imjac;
@@ -281,9 +281,9 @@ PCAMetric<TFixedImage, TMovingImage>::GetValue(const TransformParametersType & p
   /** Calculate mean of from columns */
   vnl_vector<RealType> mean(this->m_G);
   mean.fill(NumericTraits<RealType>::Zero);
-  for (unsigned int i = 0; i < this->m_NumberOfPixelsCounted; i++)
+  for (unsigned int i = 0; i < this->m_NumberOfPixelsCounted; ++i)
   {
-    for (unsigned int j = 0; j < this->m_G; j++)
+    for (unsigned int j = 0; j < this->m_G; ++j)
     {
       mean(j) += A(i, j);
     }
@@ -293,9 +293,9 @@ PCAMetric<TFixedImage, TMovingImage>::GetValue(const TransformParametersType & p
   MatrixType Amm(this->m_NumberOfPixelsCounted, this->m_G);
   Amm.fill(NumericTraits<RealType>::Zero);
 
-  for (unsigned int i = 0; i < this->m_NumberOfPixelsCounted; i++)
+  for (unsigned int i = 0; i < this->m_NumberOfPixelsCounted; ++i)
   {
-    for (unsigned int j = 0; j < this->m_G; j++)
+    for (unsigned int j = 0; j < this->m_G; ++j)
     {
       Amm(i, j) = A(i, j) - mean(j);
     }
@@ -307,7 +307,7 @@ PCAMetric<TFixedImage, TMovingImage>::GetValue(const TransformParametersType & p
 
   vnl_diag_matrix<RealType> S(this->m_G);
   S.fill(NumericTraits<RealType>::Zero);
-  for (unsigned int j = 0; j < this->m_G; j++)
+  for (unsigned int j = 0; j < this->m_G; ++j)
   {
     S(j, j) = 1.0 / sqrt(C(j, j));
   }
@@ -319,7 +319,7 @@ PCAMetric<TFixedImage, TMovingImage>::GetValue(const TransformParametersType & p
   vnl_symmetric_eigensystem<RealType> eig(K);
 
   RealType sumEigenValuesUsed = itk::NumericTraits<RealType>::Zero;
-  for (unsigned int i = 1; i < this->m_NumEigenValues + 1; i++)
+  for (unsigned int i = 1; i < this->m_NumEigenValues + 1; ++i)
   {
     sumEigenValuesUsed += eig.get_eigenvalue(this->m_G - i);
   }
@@ -466,9 +466,9 @@ PCAMetric<TFixedImage, TMovingImage>::GetValueAndDerivativeSingleThreaded(const 
   /** Calculate mean of from columns */
   vnl_vector<RealType> mean(this->m_G);
   mean.fill(NumericTraits<RealType>::Zero);
-  for (unsigned int i = 0; i < this->m_NumberOfPixelsCounted; i++)
+  for (unsigned int i = 0; i < this->m_NumberOfPixelsCounted; ++i)
   {
-    for (unsigned int j = 0; j < this->m_G; j++)
+    for (unsigned int j = 0; j < this->m_G; ++j)
     {
       mean(j) += A(i, j);
     }
@@ -478,9 +478,9 @@ PCAMetric<TFixedImage, TMovingImage>::GetValueAndDerivativeSingleThreaded(const 
   /** Calculate standard deviation from columns */
   MatrixType Amm(this->m_NumberOfPixelsCounted, this->m_G);
   Amm.fill(NumericTraits<RealType>::Zero);
-  for (unsigned int i = 0; i < this->m_NumberOfPixelsCounted; i++)
+  for (unsigned int i = 0; i < this->m_NumberOfPixelsCounted; ++i)
   {
-    for (unsigned int j = 0; j < this->m_G; j++)
+    for (unsigned int j = 0; j < this->m_G; ++j)
     {
       Amm(i, j) = A(i, j) - mean(j);
     }
@@ -493,7 +493,7 @@ PCAMetric<TFixedImage, TMovingImage>::GetValueAndDerivativeSingleThreaded(const 
 
   vnl_diag_matrix<RealType> S(this->m_G);
   S.fill(NumericTraits<RealType>::Zero);
-  for (unsigned int j = 0; j < this->m_G; j++)
+  for (unsigned int j = 0; j < this->m_G; ++j)
   {
     S(j, j) = 1.0 / sqrt(C(j, j));
   }
@@ -504,13 +504,13 @@ PCAMetric<TFixedImage, TMovingImage>::GetValueAndDerivativeSingleThreaded(const 
   vnl_symmetric_eigensystem<RealType> eig(K);
 
   RealType sumEigenValuesUsed = itk::NumericTraits<RealType>::Zero;
-  for (unsigned int i = 1; i < this->m_NumEigenValues + 1; i++)
+  for (unsigned int i = 1; i < this->m_NumEigenValues + 1; ++i)
   {
     sumEigenValuesUsed += eig.get_eigenvalue(this->m_G - i);
   }
 
   MatrixType eigenVectorMatrix(this->m_G, this->m_NumEigenValues);
-  for (unsigned int i = 1; i < this->m_NumEigenValues + 1; i++)
+  for (unsigned int i = 1; i < this->m_NumEigenValues + 1; ++i)
   {
     eigenVectorMatrix.set_column(i - 1, (eig.get_eigenvector(this->m_G - i)).normalize());
   }
@@ -529,7 +529,7 @@ PCAMetric<TFixedImage, TMovingImage>::GetValueAndDerivativeSingleThreaded(const 
   /** initialize */
   dSdmu_part1.fill(itk::NumericTraits<DerivativeValueType>::Zero);
 
-  for (unsigned int d = 0; d < this->m_G; d++)
+  for (unsigned int d = 0; d < this->m_G; ++d)
   {
     double S_sqr = S(d, d) * S(d, d);
     double S_qub = S_sqr * S(d, d);
@@ -578,7 +578,7 @@ PCAMetric<TFixedImage, TMovingImage>::GetValueAndDerivativeSingleThreaded(const 
       /** build metric derivative components */
       for (unsigned int p = 0; p < nzjis[d].size(); ++p)
       {
-        for (unsigned int z = 0; z < this->m_NumEigenValues; z++)
+        for (unsigned int z = 0; z < this->m_NumEigenValues; ++z)
         {
           derivative[nzjis[d][p]] += vSAtmm[z][pixelIndex] * dMTdmu[p] * Sv[d][z] +
                                      vdSdmu_part1[z][d] * Atmm[d][pixelIndex] * dMTdmu[p] * CSv[d][z];
@@ -841,9 +841,9 @@ PCAMetric<TFixedImage, TMovingImage>::AfterThreadedGetSamples(MeasureType & valu
   /** Calculate mean of from columns */
   vnl_vector<RealType> mean(this->m_G);
   mean.fill(NumericTraits<RealType>::Zero);
-  for (unsigned int i = 0; i < this->m_NumberOfPixelsCounted; i++)
+  for (unsigned int i = 0; i < this->m_NumberOfPixelsCounted; ++i)
   {
-    for (unsigned int j = 0; j < this->m_G; j++)
+    for (unsigned int j = 0; j < this->m_G; ++j)
     {
       mean(j) += A(i, j);
     }
@@ -853,9 +853,9 @@ PCAMetric<TFixedImage, TMovingImage>::AfterThreadedGetSamples(MeasureType & valu
   /** Calculate standard deviation from columns */
   MatrixType Amm(this->m_NumberOfPixelsCounted, this->m_G);
   Amm.fill(NumericTraits<RealType>::Zero);
-  for (unsigned int i = 0; i < this->m_NumberOfPixelsCounted; i++)
+  for (unsigned int i = 0; i < this->m_NumberOfPixelsCounted; ++i)
   {
-    for (unsigned int j = 0; j < this->m_G; j++)
+    for (unsigned int j = 0; j < this->m_G; ++j)
     {
       Amm(i, j) = A(i, j) - mean(j);
     }
@@ -868,7 +868,7 @@ PCAMetric<TFixedImage, TMovingImage>::AfterThreadedGetSamples(MeasureType & valu
 
   vnl_diag_matrix<RealType> S(this->m_G);
   S.fill(NumericTraits<RealType>::Zero);
-  for (unsigned int j = 0; j < this->m_G; j++)
+  for (unsigned int j = 0; j < this->m_G; ++j)
   {
     S(j, j) = 1.0 / sqrt(C(j, j));
   }
@@ -880,7 +880,7 @@ PCAMetric<TFixedImage, TMovingImage>::AfterThreadedGetSamples(MeasureType & valu
 
   RealType   sumEigenValuesUsed = itk::NumericTraits<RealType>::Zero;
   MatrixType eigenVectorMatrix(this->m_G, this->m_NumEigenValues);
-  for (unsigned int i = 1; i < this->m_NumEigenValues + 1; i++)
+  for (unsigned int i = 1; i < this->m_NumEigenValues + 1; ++i)
   {
     sumEigenValuesUsed += eig.get_eigenvalue(this->m_G - i);
     eigenVectorMatrix.set_column(i - 1, (eig.get_eigenvector(this->m_G - i)).normalize());
@@ -893,7 +893,7 @@ PCAMetric<TFixedImage, TMovingImage>::AfterThreadedGetSamples(MeasureType & valu
   /** Sub components of metric derivative */
   vnl_diag_matrix<DerivativeValueType> dSdmu_part1(this->m_G);
 
-  for (unsigned int d = 0; d < this->m_G; d++)
+  for (unsigned int d = 0; d < this->m_G; ++d)
   {
     double S_sqr = S(d, d) * S(d, d);
     double S_qub = S_sqr * S(d, d);
@@ -1006,7 +1006,7 @@ PCAMetric<TFixedImage, TMovingImage>::ThreadedComputeDerivative(ThreadIdType thr
       for (unsigned int p = 0; p < nzjis.size(); ++p)
       {
         DerivativeValueType tmp = 0.0;
-        for (unsigned int z = 0; z < this->m_NumEigenValues; z++)
+        for (unsigned int z = 0; z < this->m_NumEigenValues; ++z)
         {
           tmp += this->m_vSAtmm[z][pixelIndex] * imageJacobian[p] * this->m_Sv[d][z] +
                  this->m_vdSdmu_part1[z][d] * this->m_Atmm[d][pixelIndex] * imageJacobian[p] * this->m_CSv[d][z];

--- a/Components/Metrics/PCAMetric2/itkPCAMetric2.hxx
+++ b/Components/Metrics/PCAMetric2/itkPCAMetric2.hxx
@@ -126,12 +126,12 @@ PCAMetric2<TFixedImage, TMovingImage>::EvaluateTransformJacobianInnerProduct(
   JacobianIteratorType                                   jac = jacobian.begin();
   imageJacobian.Fill(0.0);
   const unsigned int sizeImageJacobian = imageJacobian.GetSize();
-  for (unsigned int dim = 0; dim < FixedImageDimension; dim++)
+  for (unsigned int dim = 0; dim < FixedImageDimension; ++dim)
   {
     const double           imDeriv = movingImageDerivative[dim];
     DerivativeIteratorType imjac = imageJacobian.begin();
 
-    for (unsigned int mu = 0; mu < sizeImageJacobian; mu++)
+    for (unsigned int mu = 0; mu < sizeImageJacobian; ++mu)
     {
       (*imjac) += (*jac) * imDeriv;
       ++imjac;
@@ -267,9 +267,9 @@ PCAMetric2<TFixedImage, TMovingImage>::GetValue(const TransformParametersType & 
   /** Calculate mean of from columns */
   vnl_vector<RealType> mean(G);
   mean.fill(NumericTraits<RealType>::Zero);
-  for (unsigned int i = 0; i < N; i++)
+  for (unsigned int i = 0; i < N; ++i)
   {
-    for (unsigned int j = 0; j < G; j++)
+    for (unsigned int j = 0; j < G; ++j)
     {
       mean(j) += A(i, j);
     }
@@ -279,9 +279,9 @@ PCAMetric2<TFixedImage, TMovingImage>::GetValue(const TransformParametersType & 
   MatrixType Amm(N, G);
   Amm.fill(NumericTraits<RealType>::Zero);
 
-  for (unsigned int i = 0; i < N; i++)
+  for (unsigned int i = 0; i < N; ++i)
   {
-    for (unsigned int j = 0; j < G; j++)
+    for (unsigned int j = 0; j < G; ++j)
     {
       Amm(i, j) = A(i, j) - mean(j);
     }
@@ -293,7 +293,7 @@ PCAMetric2<TFixedImage, TMovingImage>::GetValue(const TransformParametersType & 
 
   MatrixType S(G, G);
   S.fill(NumericTraits<RealType>::Zero);
-  for (unsigned int j = 0; j < G; j++)
+  for (unsigned int j = 0; j < G; ++j)
   {
     S(j, j) = 1.0 / sqrt(C(j, j));
   }
@@ -318,7 +318,7 @@ PCAMetric2<TFixedImage, TMovingImage>::GetValue(const TransformParametersType & 
   // eigenvalue 29 has a weight of 1 and eigenvalue 0 has a weight of 30
 
   RealType sumWeightedEigenValues = itk::NumericTraits<RealType>::Zero;
-  for (unsigned int i = 0; i < G; i++)
+  for (unsigned int i = 0; i < G; ++i)
   {
     sumWeightedEigenValues += (i + 1) * eig.get_eigenvalue(G - i - 1);
   }
@@ -477,9 +477,9 @@ PCAMetric2<TFixedImage, TMovingImage>::GetValueAndDerivative(const TransformPara
   /** Calculate mean of columns */
   vnl_vector<RealType> mean(G);
   mean.fill(NumericTraits<RealType>::Zero);
-  for (unsigned int i = 0; i < N; i++)
+  for (unsigned int i = 0; i < N; ++i)
   {
-    for (unsigned int j = 0; j < G; j++)
+    for (unsigned int j = 0; j < G; ++j)
     {
       mean(j) += A(i, j);
     }
@@ -489,9 +489,9 @@ PCAMetric2<TFixedImage, TMovingImage>::GetValueAndDerivative(const TransformPara
   /** Calculate standard deviation of columns */
   MatrixType Amm(N, G);
   Amm.fill(NumericTraits<RealType>::Zero);
-  for (unsigned int i = 0; i < N; i++)
+  for (unsigned int i = 0; i < N; ++i)
   {
-    for (unsigned int j = 0; j < G; j++)
+    for (unsigned int j = 0; j < G; ++j)
     {
       Amm(i, j) = A(i, j) - mean(j);
     }
@@ -504,7 +504,7 @@ PCAMetric2<TFixedImage, TMovingImage>::GetValueAndDerivative(const TransformPara
 
   vnl_diag_matrix<RealType> S(G);
   S.fill(NumericTraits<RealType>::Zero);
-  for (unsigned int j = 0; j < G; j++)
+  for (unsigned int j = 0; j < G; ++j)
   {
     S(j, j) = 1.0 / sqrt(C(j, j));
   }
@@ -516,13 +516,13 @@ PCAMetric2<TFixedImage, TMovingImage>::GetValueAndDerivative(const TransformPara
   vnl_symmetric_eigensystem<RealType> eig(K);
 
   RealType sumWeightedEigenValues = itk::NumericTraits<RealType>::Zero;
-  for (unsigned int i = 0; i < G; i++)
+  for (unsigned int i = 0; i < G; ++i)
   {
     sumWeightedEigenValues += (i + 1) * eig.get_eigenvalue(G - i - 1);
   }
 
   MatrixType eigenVectorMatrix(G, G);
-  for (unsigned int i = 0; i < G; i++)
+  for (unsigned int i = 0; i < G; ++i)
   {
     eigenVectorMatrix.set_column(i, (eig.get_eigenvector(G - i - 1)).normalize());
   }
@@ -541,7 +541,7 @@ PCAMetric2<TFixedImage, TMovingImage>::GetValueAndDerivative(const TransformPara
   unsigned int startSamplesOK;
   startSamplesOK = 0;
 
-  for (unsigned int d = 0; d < G; d++)
+  for (unsigned int d = 0; d < G; ++d)
   {
     double S_sqr = S(d, d) * S(d, d);
     double S_qub = S_sqr * S(d, d);
@@ -594,7 +594,7 @@ PCAMetric2<TFixedImage, TMovingImage>::GetValueAndDerivative(const TransformPara
       /** build metric derivative components */
       for (unsigned int p = 0; p < nzjis[d].size(); ++p)
       {
-        for (unsigned int z = 0; z < G; z++)
+        for (unsigned int z = 0; z < G; ++z)
         {
           derivative[nzjis[d][p]] += z * (vSAtmm[z][pixelIndex] * dMTdmu[p] * Sv[d][z] +
                                           vdSdmu_part1[z][d] * Atmm[d][pixelIndex] * dMTdmu[p] * CSv[d][z]);

--- a/Components/Metrics/PatternIntensity/itkPatternIntensityImageToImageMetric.hxx
+++ b/Components/Metrics/PatternIntensity/itkPatternIntensityImageToImageMetric.hxx
@@ -401,7 +401,7 @@ PatternIntensityImageToImageMetric<TFixedImage, TMovingImage>::GetDerivative(con
   const unsigned int numberOfParameters = this->GetNumberOfParameters();
   derivative = DerivativeType(numberOfParameters);
 
-  for (unsigned int i = 0; i < numberOfParameters; i++)
+  for (unsigned int i = 0; i < numberOfParameters; ++i)
   {
     testPoint[i] -= this->m_DerivativeDelta / std::sqrt(this->m_Scales[i]);
     const MeasureType valuep0 = this->GetValue(testPoint);

--- a/Components/Metrics/PolydataDummyPenalty/elxPolydataDummyPenalty.hxx
+++ b/Components/Metrics/PolydataDummyPenalty/elxPolydataDummyPenalty.hxx
@@ -87,7 +87,7 @@ PolydataDummyPenalty<TElastix>::BeforeAllBase(void)
 
   this->m_NumberOfMeshes = 0;
 
-  for (char ch = 'A'; ch <= 'Z'; ch++)
+  for (char ch = 'A'; ch <= 'Z'; ++ch)
   {
     std::ostringstream fmeshArgument("-fmesh", std::ios_base::ate);
     /** Check for appearance of "-fmesh<[A-Z]><Metric>". */
@@ -463,7 +463,7 @@ PolydataDummyPenalty<TElastix>::ReadTransformixPoints(const std::string &       
   /** Read the input points, as index or as point. */
   if (!(ippReader->GetPointsAreIndices()))
   {
-    for (unsigned int j = 0; j < nrofpoints; j++)
+    for (unsigned int j = 0; j < nrofpoints; ++j)
     {
       /** Compute index of nearest voxel in fixed image. */
       InputPointType point;
@@ -471,7 +471,7 @@ PolydataDummyPenalty<TElastix>::ReadTransformixPoints(const std::string &       
       inputPointSet->GetPoint(j, &point);
       inputpointvec[j] = point;
       dummyImage->TransformPhysicalPointToContinuousIndex(point, fixedcindex);
-      for (unsigned int i = 0; i < FixedImageDimension; i++)
+      for (unsigned int i = 0; i < FixedImageDimension; ++i)
       {
         inputindexvec[j][i] = static_cast<FixedImageIndexValueType>(vnl_math::rnd(fixedcindex[i]));
       }
@@ -479,7 +479,7 @@ PolydataDummyPenalty<TElastix>::ReadTransformixPoints(const std::string &       
   }
   else // so: inputasindex
   {
-    for (unsigned int j = 0; j < nrofpoints; j++)
+    for (unsigned int j = 0; j < nrofpoints; ++j)
     {
       /** The read point from the inutPointSet is actually an index
        * Cast to the proper type.
@@ -487,7 +487,7 @@ PolydataDummyPenalty<TElastix>::ReadTransformixPoints(const std::string &       
       InputPointType point;
       point.Fill(0.0f);
       inputPointSet->GetPoint(j, &point);
-      for (unsigned int i = 0; i < FixedImageDimension; i++)
+      for (unsigned int i = 0; i < FixedImageDimension; ++i)
       {
         inputindexvec[j][i] = static_cast<FixedImageIndexValueType>(vnl_math::rnd(point[i]));
       }

--- a/Components/Metrics/RigidityPenalty/itkTransformRigidityPenaltyTerm.hxx
+++ b/Components/Metrics/RigidityPenalty/itkTransformRigidityPenaltyTerm.hxx
@@ -71,7 +71,7 @@ TransformRigidityPenaltyTerm<TFixedImage, TScalarType>::TransformRigidityPenalty
   /** Initialize dilation filter for the rigidity images. */
   this->m_FixedRigidityImageDilation.resize(FixedImageDimension);
   this->m_MovingRigidityImageDilation.resize(MovingImageDimension);
-  for (unsigned int i = 0; i < FixedImageDimension; i++)
+  for (unsigned int i = 0; i < FixedImageDimension; ++i)
   {
     this->m_FixedRigidityImageDilation[i] = nullptr;
     this->m_MovingRigidityImageDilation[i] = nullptr;
@@ -186,7 +186,7 @@ TransformRigidityPenaltyTerm<TFixedImage, TScalarType>::DilateRigidityImages(voi
     if (this->m_UseFixedRigidityImage)
     {
       /** Create the dilation filters for the fixedRigidityImage. */
-      for (unsigned int i = 0; i < FixedImageDimension; i++)
+      for (unsigned int i = 0; i < FixedImageDimension; ++i)
       {
         this->m_FixedRigidityImageDilation[i] = DilateFilterType::New();
       }
@@ -195,7 +195,7 @@ TransformRigidityPenaltyTerm<TFixedImage, TScalarType>::DilateRigidityImages(voi
     if (this->m_UseMovingRigidityImage)
     {
       /** Create the dilation filter for the movingRigidityImage. */
-      for (unsigned int i = 0; i < FixedImageDimension; i++)
+      for (unsigned int i = 0; i < FixedImageDimension; ++i)
       {
         this->m_MovingRigidityImageDilation[i] = DilateFilterType::New();
       }
@@ -210,7 +210,7 @@ TransformRigidityPenaltyTerm<TFixedImage, TScalarType>::DilateRigidityImages(voi
     }
 
     /** Set stuff for the separate dilation. */
-    for (unsigned int i = 0; i < FixedImageDimension; i++)
+    for (unsigned int i = 0; i < FixedImageDimension; ++i)
     {
       /** Create the structuring element. */
       radius.Fill(0);
@@ -485,7 +485,7 @@ TransformRigidityPenaltyTerm<TFixedImage, TScalarType>::GetValue(const Parameter
 
   /** Get a handle to the B-spline coefficient images. */
   std::vector<CoefficientImagePointer> inputImages(ImageDimension);
-  for (unsigned int i = 0; i < ImageDimension; i++)
+  for (unsigned int i = 0; i < ImageDimension; ++i)
   {
     inputImages[i] = this->m_BSplineTransform->GetCoefficientImages()[i];
   }
@@ -534,7 +534,7 @@ TransformRigidityPenaltyTerm<TFixedImage, TScalarType>::GetValue(const Parameter
     ui_FI(ImageDimension);
 
   /** For all dimensions ... */
-  for (unsigned int i = 0; i < ImageDimension; i++)
+  for (unsigned int i = 0; i < ImageDimension; ++i)
   {
     /** ... create the filtered images ... */
     ui_FA[i] = CoefficientImageType::New();
@@ -573,7 +573,7 @@ TransformRigidityPenaltyTerm<TFixedImage, TScalarType>::GetValue(const Parameter
    ************************************************************************* */
 
   /** Filter the inputImages. */
-  for (unsigned int i = 0; i < ImageDimension; i++)
+  for (unsigned int i = 0; i < ImageDimension; ++i)
   {
     ui_FA[i] = this->FilterSeparable(inputImages[i], Operators_A);
     ui_FB[i] = this->FilterSeparable(inputImages[i], Operators_B);
@@ -600,7 +600,7 @@ TransformRigidityPenaltyTerm<TFixedImage, TScalarType>::GetValue(const Parameter
     itI(ImageDimension);
 
   /** Create iterators. */
-  for (unsigned int i = 0; i < ImageDimension; i++)
+  for (unsigned int i = 0; i < ImageDimension; ++i)
   {
     /** Create iterators. */
     itA[i] = CoefficientImageIteratorType(ui_FA[i], ui_FA[i]->GetLargestPossibleRegion());
@@ -679,7 +679,7 @@ TransformRigidityPenaltyTerm<TFixedImage, TScalarType>::GetValue(const Parameter
       }
 
       /** Increase all iterators. */
-      for (unsigned int i = 0; i < ImageDimension; i++)
+      for (unsigned int i = 0; i < ImageDimension; ++i)
       {
         ++itA[i];
         ++itB[i];
@@ -699,7 +699,7 @@ TransformRigidityPenaltyTerm<TFixedImage, TScalarType>::GetValue(const Parameter
    ************************************************************************* */
 
   /** Reset all iterators. */
-  for (unsigned int i = 0; i < ImageDimension; i++)
+  for (unsigned int i = 0; i < ImageDimension; ++i)
   {
     itA[i].GoToBegin();
     itB[i].GoToBegin();
@@ -746,7 +746,7 @@ TransformRigidityPenaltyTerm<TFixedImage, TScalarType>::GetValue(const Parameter
       }
 
       /** Increase all iterators. */
-      for (unsigned int i = 0; i < ImageDimension; i++)
+      for (unsigned int i = 0; i < ImageDimension; ++i)
       {
         ++itA[i];
         ++itB[i];
@@ -774,7 +774,7 @@ TransformRigidityPenaltyTerm<TFixedImage, TScalarType>::GetValue(const Parameter
     while (!itD[0].IsAtEnd())
     {
       /** Linearity condition part. */
-      for (unsigned int i = 0; i < ImageDimension; i++)
+      for (unsigned int i = 0; i < ImageDimension; ++i)
       {
         this->m_LinearityConditionValue +=
           it_RCI.Get() * (+itD[i].Get() * itD[i].Get() + itE[i].Get() * itE[i].Get() + itG[i].Get() * itG[i].Get());
@@ -786,7 +786,7 @@ TransformRigidityPenaltyTerm<TFixedImage, TScalarType>::GetValue(const Parameter
       } // end loop over i
 
       /** Increase all iterators. */
-      for (unsigned int i = 0; i < ImageDimension; i++)
+      for (unsigned int i = 0; i < ImageDimension; ++i)
       {
         ++itD[i];
         ++itE[i];
@@ -928,7 +928,7 @@ TransformRigidityPenaltyTerm<TFixedImage, TScalarType>::GetValueAndDerivative(co
 
   /** Get a handle to the B-spline coefficient images. */
   std::vector<CoefficientImagePointer> inputImages(ImageDimension);
-  for (unsigned int i = 0; i < ImageDimension; i++)
+  for (unsigned int i = 0; i < ImageDimension; ++i)
   {
     inputImages[i] = this->m_BSplineTransform->GetCoefficientImages()[i];
   }
@@ -977,7 +977,7 @@ TransformRigidityPenaltyTerm<TFixedImage, TScalarType>::GetValueAndDerivative(co
     ui_FI(ImageDimension);
 
   /** For all dimensions ... */
-  for (unsigned int i = 0; i < ImageDimension; i++)
+  for (unsigned int i = 0; i < ImageDimension; ++i)
   {
     /** ... create the filtered images ... */
     ui_FA[i] = CoefficientImageType::New();
@@ -1016,7 +1016,7 @@ TransformRigidityPenaltyTerm<TFixedImage, TScalarType>::GetValueAndDerivative(co
    ************************************************************************* */
 
   /** Filter the inputImages. */
-  for (unsigned int i = 0; i < ImageDimension; i++)
+  for (unsigned int i = 0; i < ImageDimension; ++i)
   {
     ui_FA[i] = this->FilterSeparable(inputImages[i], Operators_A);
     ui_FB[i] = this->FilterSeparable(inputImages[i], Operators_B);
@@ -1043,7 +1043,7 @@ TransformRigidityPenaltyTerm<TFixedImage, TScalarType>::GetValueAndDerivative(co
     itI(ImageDimension);
 
   /** Create iterators. */
-  for (unsigned int i = 0; i < ImageDimension; i++)
+  for (unsigned int i = 0; i < ImageDimension; ++i)
   {
     /** Create iterators. */
     itA[i] = CoefficientImageIteratorType(ui_FA[i], ui_FA[i]->GetLargestPossibleRegion());
@@ -1076,11 +1076,11 @@ TransformRigidityPenaltyTerm<TFixedImage, TScalarType>::GetValueAndDerivative(co
   /** Create orthonormality and properness parts. */
   std::vector<std::vector<CoefficientImagePointer>> OCparts(ImageDimension);
   std::vector<std::vector<CoefficientImagePointer>> PCparts(ImageDimension);
-  for (unsigned int i = 0; i < ImageDimension; i++)
+  for (unsigned int i = 0; i < ImageDimension; ++i)
   {
     OCparts[i].resize(ImageDimension);
     PCparts[i].resize(ImageDimension);
-    for (unsigned int j = 0; j < ImageDimension; j++)
+    for (unsigned int j = 0; j < ImageDimension; ++j)
     {
       OCparts[i][j] = CoefficientImageType::New();
       OCparts[i][j]->SetRegions(inputImages[0]->GetLargestPossibleRegion());
@@ -1094,10 +1094,10 @@ TransformRigidityPenaltyTerm<TFixedImage, TScalarType>::GetValueAndDerivative(co
   /** Create linearity parts. */
   unsigned int                                      NofLParts = 3 * ImageDimension - 3;
   std::vector<std::vector<CoefficientImagePointer>> LCparts(ImageDimension);
-  for (unsigned int i = 0; i < ImageDimension; i++)
+  for (unsigned int i = 0; i < ImageDimension; ++i)
   {
     LCparts[i].resize(NofLParts);
-    for (unsigned int j = 0; j < NofLParts; j++)
+    for (unsigned int j = 0; j < NofLParts; ++j)
     {
       LCparts[i][j] = CoefficientImageType::New();
       LCparts[i][j]->SetRegions(inputImages[0]->GetLargestPossibleRegion());
@@ -1109,19 +1109,19 @@ TransformRigidityPenaltyTerm<TFixedImage, TScalarType>::GetValueAndDerivative(co
   std::vector<std::vector<CoefficientImageIteratorType>> itOCp(ImageDimension);
   std::vector<std::vector<CoefficientImageIteratorType>> itPCp(ImageDimension);
   std::vector<std::vector<CoefficientImageIteratorType>> itLCp(ImageDimension);
-  for (unsigned int i = 0; i < ImageDimension; i++)
+  for (unsigned int i = 0; i < ImageDimension; ++i)
   {
     itOCp[i].resize(ImageDimension);
     itPCp[i].resize(ImageDimension);
     itLCp[i].resize(NofLParts);
-    for (unsigned int j = 0; j < ImageDimension; j++)
+    for (unsigned int j = 0; j < ImageDimension; ++j)
     {
       itOCp[i][j] = CoefficientImageIteratorType(OCparts[i][j], OCparts[i][j]->GetLargestPossibleRegion());
       itOCp[i][j].GoToBegin();
       itPCp[i][j] = CoefficientImageIteratorType(PCparts[i][j], PCparts[i][j]->GetLargestPossibleRegion());
       itPCp[i][j].GoToBegin();
     }
-    for (unsigned int j = 0; j < NofLParts; j++)
+    for (unsigned int j = 0; j < NofLParts; ++j)
     {
       itLCp[i][j] = CoefficientImageIteratorType(LCparts[i][j], LCparts[i][j]->GetLargestPossibleRegion());
       itLCp[i][j].GoToBegin();
@@ -1251,7 +1251,7 @@ TransformRigidityPenaltyTerm<TFixedImage, TScalarType>::GetValueAndDerivative(co
       } // end if dim == 3
 
       /** Increase all iterators. */
-      for (unsigned int i = 0; i < ImageDimension; i++)
+      for (unsigned int i = 0; i < ImageDimension; ++i)
       {
         ++itA[i];
         ++itB[i];
@@ -1259,7 +1259,7 @@ TransformRigidityPenaltyTerm<TFixedImage, TScalarType>::GetValueAndDerivative(co
         {
           ++itC[i];
         }
-        for (unsigned int j = 0; j < ImageDimension; j++)
+        for (unsigned int j = 0; j < ImageDimension; ++j)
         {
           ++itOCp[i][j];
         }
@@ -1275,7 +1275,7 @@ TransformRigidityPenaltyTerm<TFixedImage, TScalarType>::GetValueAndDerivative(co
    ************************************************************************* */
 
   /** Reset all iterators. */
-  for (unsigned int i = 0; i < ImageDimension; i++)
+  for (unsigned int i = 0; i < ImageDimension; ++i)
   {
     itA[i].GoToBegin();
     itB[i].GoToBegin();
@@ -1432,7 +1432,7 @@ TransformRigidityPenaltyTerm<TFixedImage, TScalarType>::GetValueAndDerivative(co
       } // end if dim == 3
 
       /** Increase all iterators. */
-      for (unsigned int i = 0; i < ImageDimension; i++)
+      for (unsigned int i = 0; i < ImageDimension; ++i)
       {
         ++itA[i];
         ++itB[i];
@@ -1440,7 +1440,7 @@ TransformRigidityPenaltyTerm<TFixedImage, TScalarType>::GetValueAndDerivative(co
         {
           ++itC[i];
         }
-        for (unsigned int j = 0; j < ImageDimension; j++)
+        for (unsigned int j = 0; j < ImageDimension; ++j)
         {
           ++itPCp[i][j];
         }
@@ -1463,7 +1463,7 @@ TransformRigidityPenaltyTerm<TFixedImage, TScalarType>::GetValueAndDerivative(co
     while (!itLCp[0][0].IsAtEnd())
     {
       /** Linearity condition part. */
-      for (unsigned int i = 0; i < ImageDimension; i++)
+      for (unsigned int i = 0; i < ImageDimension; ++i)
       {
         /** Calculate the value of the linearity condition. */
         this->m_LinearityConditionValue +=
@@ -1508,7 +1508,7 @@ TransformRigidityPenaltyTerm<TFixedImage, TScalarType>::GetValueAndDerivative(co
       } // end if dim == 3
 
       /** Increase all iterators. */
-      for (unsigned int i = 0; i < ImageDimension; i++)
+      for (unsigned int i = 0; i < ImageDimension; ++i)
       {
         ++itD[i];
         ++itE[i];
@@ -1519,7 +1519,7 @@ TransformRigidityPenaltyTerm<TFixedImage, TScalarType>::GetValueAndDerivative(co
           ++itH[i];
           ++itI[i];
         }
-        for (unsigned int j = 0; j < NofLParts; j++)
+        for (unsigned int j = 0; j < NofLParts; ++j)
         {
           ++itLCp[i][j];
         }
@@ -1571,7 +1571,7 @@ TransformRigidityPenaltyTerm<TFixedImage, TScalarType>::GetValueAndDerivative(co
   std::vector<CoefficientImagePointer> OCpartsF(ImageDimension);
   std::vector<CoefficientImagePointer> PCpartsF(ImageDimension);
   std::vector<CoefficientImagePointer> LCpartsF(ImageDimension);
-  for (unsigned int i = 0; i < ImageDimension; i++)
+  for (unsigned int i = 0; i < ImageDimension; ++i)
   {
     OCpartsF[i] = CoefficientImageType::New();
     OCpartsF[i]->SetRegions(inputImages[0]->GetLargestPossibleRegion());
@@ -1590,19 +1590,19 @@ TransformRigidityPenaltyTerm<TFixedImage, TScalarType>::GetValueAndDerivative(co
   std::vector<std::vector<NeighborhoodIteratorType>> nitLCp(ImageDimension);
   RadiusType                                         radius;
   radius.Fill(1);
-  for (unsigned int i = 0; i < ImageDimension; i++)
+  for (unsigned int i = 0; i < ImageDimension; ++i)
   {
     nitOCp[i].resize(ImageDimension);
     nitPCp[i].resize(ImageDimension);
     nitLCp[i].resize(NofLParts);
-    for (unsigned int j = 0; j < ImageDimension; j++)
+    for (unsigned int j = 0; j < ImageDimension; ++j)
     {
       nitOCp[i][j] = NeighborhoodIteratorType(radius, OCparts[i][j], OCparts[i][j]->GetLargestPossibleRegion());
       nitOCp[i][j].GoToBegin();
       nitPCp[i][j] = NeighborhoodIteratorType(radius, PCparts[i][j], PCparts[i][j]->GetLargestPossibleRegion());
       nitPCp[i][j].GoToBegin();
     }
-    for (unsigned int j = 0; j < NofLParts; j++)
+    for (unsigned int j = 0; j < NofLParts; ++j)
     {
       nitLCp[i][j] = NeighborhoodIteratorType(radius, LCparts[i][j], LCparts[i][j]->GetLargestPossibleRegion());
       nitLCp[i][j].GoToBegin();
@@ -1613,7 +1613,7 @@ TransformRigidityPenaltyTerm<TFixedImage, TScalarType>::GetValueAndDerivative(co
   std::vector<CoefficientImageIteratorType> itOCpf(ImageDimension);
   std::vector<CoefficientImageIteratorType> itPCpf(ImageDimension);
   std::vector<CoefficientImageIteratorType> itLCpf(ImageDimension);
-  for (unsigned int i = 0; i < ImageDimension; i++)
+  for (unsigned int i = 0; i < ImageDimension; ++i)
   {
     itOCpf[i] = CoefficientImageIteratorType(OCpartsF[i], OCpartsF[i]->GetLargestPossibleRegion());
     itOCpf[i].GoToBegin();
@@ -1666,7 +1666,7 @@ TransformRigidityPenaltyTerm<TFixedImage, TScalarType>::GetValueAndDerivative(co
       std::vector<double> tmp(ImageDimension, 0.0);
 
       /** Loop over all dimensions. */
-      for (unsigned int i = 0; i < ImageDimension; i++)
+      for (unsigned int i = 0; i < ImageDimension; ++i)
       {
         /** Loop over the neighborhood. */
         for (unsigned int k = 0; k < neighborhoodSize; ++k)
@@ -1693,10 +1693,10 @@ TransformRigidityPenaltyTerm<TFixedImage, TScalarType>::GetValueAndDerivative(co
 
       /** Increase all iterators. */
       ++nit_RCI;
-      for (unsigned int i = 0; i < ImageDimension; i++)
+      for (unsigned int i = 0; i < ImageDimension; ++i)
       {
         ++itOCpf[i];
-        for (unsigned int j = 0; j < ImageDimension; j++)
+        for (unsigned int j = 0; j < ImageDimension; ++j)
         {
           ++nitOCp[i][j];
         }
@@ -1719,7 +1719,7 @@ TransformRigidityPenaltyTerm<TFixedImage, TScalarType>::GetValueAndDerivative(co
       std::vector<double> tmp(ImageDimension, 0.0);
 
       /** Loop over all dimensions. */
-      for (unsigned int i = 0; i < ImageDimension; i++)
+      for (unsigned int i = 0; i < ImageDimension; ++i)
       {
         /** Loop over the neighborhood. */
         for (unsigned int k = 0; k < neighborhoodSize; ++k)
@@ -1746,10 +1746,10 @@ TransformRigidityPenaltyTerm<TFixedImage, TScalarType>::GetValueAndDerivative(co
 
       /** Increase all iterators. */
       ++nit_RCI;
-      for (unsigned int i = 0; i < ImageDimension; i++)
+      for (unsigned int i = 0; i < ImageDimension; ++i)
       {
         ++itPCpf[i];
-        for (unsigned int j = 0; j < ImageDimension; j++)
+        for (unsigned int j = 0; j < ImageDimension; ++j)
         {
           ++nitPCp[i][j];
         }
@@ -1771,7 +1771,7 @@ TransformRigidityPenaltyTerm<TFixedImage, TScalarType>::GetValueAndDerivative(co
       std::vector<double> tmp(ImageDimension, 0.0);
 
       /** Loop over all dimensions. */
-      for (unsigned int i = 0; i < ImageDimension; i++)
+      for (unsigned int i = 0; i < ImageDimension; ++i)
       {
         /** Loop over the neighborhood. */
         for (unsigned int k = 0; k < neighborhoodSize; ++k)
@@ -1807,10 +1807,10 @@ TransformRigidityPenaltyTerm<TFixedImage, TScalarType>::GetValueAndDerivative(co
 
       /** Increase all iterators. */
       ++nit_RCI;
-      for (unsigned int i = 0; i < ImageDimension; i++)
+      for (unsigned int i = 0; i < ImageDimension; ++i)
       {
         ++itLCpf[i];
-        for (unsigned int j = 0; j < NofLParts; j++)
+        for (unsigned int j = 0; j < NofLParts; ++j)
         {
           ++nitLCp[i][j];
         }
@@ -1824,7 +1824,7 @@ TransformRigidityPenaltyTerm<TFixedImage, TScalarType>::GetValueAndDerivative(co
 
   /** Create derivative images, each holding a component of the vector field. */
   std::vector<CoefficientImagePointer> derivativeImages(ImageDimension);
-  for (unsigned int i = 0; i < ImageDimension; i++)
+  for (unsigned int i = 0; i < ImageDimension; ++i)
   {
     derivativeImages[i] = CoefficientImageType::New();
     derivativeImages[i]->SetRegions(inputImages[i]->GetLargestPossibleRegion());
@@ -1833,7 +1833,7 @@ TransformRigidityPenaltyTerm<TFixedImage, TScalarType>::GetValueAndDerivative(co
 
   /** Create iterators over the derivative images. */
   std::vector<CoefficientImageIteratorType> itDIs(ImageDimension);
-  for (unsigned int i = 0; i < ImageDimension; i++)
+  for (unsigned int i = 0; i < ImageDimension; ++i)
   {
     itDIs[i] = CoefficientImageIteratorType(derivativeImages[i], derivativeImages[i]->GetLargestPossibleRegion());
     itDIs[i].GoToBegin();
@@ -1850,7 +1850,7 @@ TransformRigidityPenaltyTerm<TFixedImage, TScalarType>::GetValueAndDerivative(co
   double      rigidityCoefficientSumSqr = rigidityCoefficientSum * rigidityCoefficientSum;
   while (!itDIs[0].IsAtEnd())
   {
-    for (unsigned int i = 0; i < ImageDimension; i++)
+    for (unsigned int i = 0; i < ImageDimension; ++i)
     {
       ScalarType tmpDIs = NumericTraits<ScalarType>::Zero;
 
@@ -1896,7 +1896,7 @@ TransformRigidityPenaltyTerm<TFixedImage, TScalarType>::GetValueAndDerivative(co
 
   /** Rearrange to create a derivative. */
   unsigned int j = 0;
-  for (unsigned int i = 0; i < ImageDimension; i++)
+  for (unsigned int i = 0; i < ImageDimension; ++i)
   {
     itDIs[i].GoToBegin();
     while (!itDIs[i].IsAtEnd())
@@ -1965,7 +1965,7 @@ TransformRigidityPenaltyTerm<TFixedImage, TScalarType>::Create1DOperator(
 
   /** Get the image spacing factors that we are going to use. */
   std::vector<double> s(ImageDimension);
-  for (unsigned int i = 0; i < ImageDimension; i++)
+  for (unsigned int i = 0; i < ImageDimension; ++i)
   {
     s[i] = spacing[i];
   }
@@ -2169,7 +2169,7 @@ TransformRigidityPenaltyTerm<TFixedImage, TScalarType>::FilterSeparable(
 {
   /** Create filters, supply them with boundary conditions and operators. */
   std::vector<typename NOIFType::Pointer> filters(ImageDimension);
-  for (unsigned int i = 0; i < ImageDimension; i++)
+  for (unsigned int i = 0; i < ImageDimension; ++i)
   {
     filters[i] = NOIFType::New();
     filters[i]->SetOperator(Operators[i]);
@@ -2177,7 +2177,7 @@ TransformRigidityPenaltyTerm<TFixedImage, TScalarType>::FilterSeparable(
 
   /** Set up the mini-pipline. */
   filters[0]->SetInput(image);
-  for (unsigned int i = 1; i < ImageDimension; i++)
+  for (unsigned int i = 1; i < ImageDimension; ++i)
   {
     filters[i]->SetInput(filters[i - 1]->GetOutput());
   }
@@ -2209,7 +2209,7 @@ TransformRigidityPenaltyTerm<TFixedImage, TScalarType>::CreateNDOperator(
 
   /** Get the image spacing factors that we are going to use. */
   std::vector<double> s(ImageDimension);
-  for (unsigned int i = 0; i < ImageDimension; i++)
+  for (unsigned int i = 0; i < ImageDimension; ++i)
   {
     s[i] = spacing[i];
   }

--- a/Components/Metrics/StatisticalShapePenalty/itkStatisticalShapePointPenalty.hxx
+++ b/Components/Metrics/StatisticalShapePenalty/itkStatisticalShapePointPenalty.hxx
@@ -706,7 +706,7 @@ StatisticalShapePointPenalty<TFixedPointSet, TMovingPointSet>::UpdateL2(const un
 
   // loop over all shape coordinates of the aligned shape
   l2norm = 0; // initialize l2norm to zero
-  for (unsigned int index = 0; index < shapeLength; index++)
+  for (unsigned int index = 0; index < shapeLength; ++index)
   {
     // accumulate squared distances
     l2norm += this->m_ProposalVector[index] * this->m_ProposalVector[index];
@@ -728,7 +728,7 @@ StatisticalShapePointPenalty<TFixedPointSet, TMovingPointSet>::NormalizeProposal
   double & l2norm = this->m_ProposalVector[shapeLength + Self::FixedPointSetDimension];
 
   // loop over all shape coordinates of the aligned shape
-  for (unsigned int index = 0; index < shapeLength; index++)
+  for (unsigned int index = 0; index < shapeLength; ++index)
   {
     // normalize shape size by l2-norm
     this->m_ProposalVector[index] /= l2norm;
@@ -758,14 +758,14 @@ StatisticalShapePointPenalty<TFixedPointSet, TMovingPointSet>::UpdateL2AndNormal
       double & l2normDerivative = (**proposalDerivativeIt)[shapeLength + Self::FixedPointSetDimension];
       l2normDerivative = 0; // initialize to zero
       // loop over all shape coordinates of the aligned shape
-      for (unsigned int index = 0; index < shapeLength; index++)
+      for (unsigned int index = 0; index < shapeLength; ++index)
       {
         l2normDerivative += this->m_ProposalVector[index] * (**proposalDerivativeIt)[index];
       }
       l2normDerivative /= (l2norm * sqrt((double)(this->GetFixedPointSet()->GetNumberOfPoints())));
 
       // loop over all shape coordinates of the aligned shape
-      for (unsigned int index = 0; index < shapeLength; index++)
+      for (unsigned int index = 0; index < shapeLength; ++index)
       {
         // update normalized shape derivatives
         (**proposalDerivativeIt)[index] = (**proposalDerivativeIt)[index] / l2norm -

--- a/Components/Metrics/SumOfPairwiseCorrelationsMetric/itkSumOfPairwiseCorrelationCoefficientsMetric.hxx
+++ b/Components/Metrics/SumOfPairwiseCorrelationsMetric/itkSumOfPairwiseCorrelationCoefficientsMetric.hxx
@@ -120,12 +120,12 @@ SumOfPairwiseCorrelationCoefficientsMetric<TFixedImage, TMovingImage>::EvaluateT
   JacobianIteratorType                                   jac = jacobian.begin();
   imageJacobian.Fill(0.0);
   const unsigned int sizeImageJacobian = imageJacobian.GetSize();
-  for (unsigned int dim = 0; dim < FixedImageDimension; dim++)
+  for (unsigned int dim = 0; dim < FixedImageDimension; ++dim)
   {
     const double           imDeriv = movingImageDerivative[dim];
     DerivativeIteratorType imjac = imageJacobian.begin();
 
-    for (unsigned int mu = 0; mu < sizeImageJacobian; mu++)
+    for (unsigned int mu = 0; mu < sizeImageJacobian; ++mu)
     {
       (*imjac) += (*jac) * imDeriv;
       ++imjac;
@@ -241,9 +241,9 @@ SumOfPairwiseCorrelationCoefficientsMetric<TFixedImage, TMovingImage>::GetValue(
   /** Calculate mean of from columns */
   vnl_vector<RealType> mean(G);
   mean.fill(NumericTraits<RealType>::Zero);
-  for (unsigned int i = 0; i < N; i++)
+  for (unsigned int i = 0; i < N; ++i)
   {
-    for (unsigned int j = 0; j < G; j++)
+    for (unsigned int j = 0; j < G; ++j)
     {
       mean(j) += A(i, j);
     }
@@ -252,9 +252,9 @@ SumOfPairwiseCorrelationCoefficientsMetric<TFixedImage, TMovingImage>::GetValue(
 
   MatrixType Amm(N, G);
   Amm.fill(NumericTraits<RealType>::Zero);
-  for (unsigned int i = 0; i < N; i++)
+  for (unsigned int i = 0; i < N; ++i)
   {
-    for (unsigned int j = 0; j < G; j++)
+    for (unsigned int j = 0; j < G; ++j)
     {
       Amm(i, j) = A(i, j) - mean(j);
     }
@@ -267,7 +267,7 @@ SumOfPairwiseCorrelationCoefficientsMetric<TFixedImage, TMovingImage>::GetValue(
 
   vnl_diag_matrix<RealType> S(G);
   S.fill(NumericTraits<RealType>::Zero);
-  for (unsigned int j = 0; j < G; j++)
+  for (unsigned int j = 0; j < G; ++j)
   {
     S(j, j) = 1.0 / sqrt(C(j, j));
   }
@@ -424,9 +424,9 @@ SumOfPairwiseCorrelationCoefficientsMetric<TFixedImage, TMovingImage>::GetValueA
   /** Calculate mean of from columns */
   vnl_vector<RealType> mean(G);
   mean.fill(NumericTraits<RealType>::Zero);
-  for (unsigned int i = 0; i < N; i++)
+  for (unsigned int i = 0; i < N; ++i)
   {
-    for (unsigned int j = 0; j < G; j++)
+    for (unsigned int j = 0; j < G; ++j)
     {
       mean(j) += A(i, j);
     }
@@ -435,9 +435,9 @@ SumOfPairwiseCorrelationCoefficientsMetric<TFixedImage, TMovingImage>::GetValueA
 
   MatrixType Amm(N, G);
   Amm.fill(NumericTraits<RealType>::Zero);
-  for (unsigned int i = 0; i < N; i++)
+  for (unsigned int i = 0; i < N; ++i)
   {
-    for (unsigned int j = 0; j < G; j++)
+    for (unsigned int j = 0; j < G; ++j)
     {
       Amm(i, j) = A(i, j) - mean(j);
     }
@@ -450,7 +450,7 @@ SumOfPairwiseCorrelationCoefficientsMetric<TFixedImage, TMovingImage>::GetValueA
 
   vnl_diag_matrix<RealType> S(G);
   S.fill(NumericTraits<RealType>::Zero);
-  for (unsigned int j = 0; j < G; j++)
+  for (unsigned int j = 0; j < G; ++j)
   {
     S(j, j) = 1.0 / sqrt(C(j, j));
   }
@@ -470,7 +470,7 @@ SumOfPairwiseCorrelationCoefficientsMetric<TFixedImage, TMovingImage>::GetValueA
   /** initialize */
   dSdmu_part1.fill(itk::NumericTraits<DerivativeValueType>::Zero);
 
-  for (unsigned int d = 0; d < G; d++)
+  for (unsigned int d = 0; d < G; ++d)
   {
     double S_sqr = S(d, d) * S(d, d);
     double S_qub = S_sqr * S(d, d);

--- a/Components/Metrics/SumSquaredTissueVolumeDifferenceMetric/itkSumSquaredTissueVolumeDifferenceImageToImageMetric.hxx
+++ b/Components/Metrics/SumSquaredTissueVolumeDifferenceMetric/itkSumSquaredTissueVolumeDifferenceImageToImageMetric.hxx
@@ -734,12 +734,12 @@ SumSquaredTissueVolumeDifferenceImageToImageMetric<TFixedImage, TMovingImage>::E
   JacobianIteratorType                                   jac = jacobian.begin();
   imageJacobian.Fill(0.0);
   const unsigned int sizeImageJacobian = imageJacobian.GetSize();
-  for (unsigned int dim = 0; dim < FixedImageDimension; dim++)
+  for (unsigned int dim = 0; dim < FixedImageDimension; ++dim)
   {
     const double           imDeriv = movingImageDerivative[dim] / (this->m_TissueValue - this->m_AirValue);
     DerivativeIteratorType imjac = imageJacobian.begin();
 
-    for (unsigned int mu = 0; mu < sizeImageJacobian; mu++)
+    for (unsigned int mu = 0; mu < sizeImageJacobian; ++mu)
     {
       (*imjac) += (*jac) * imDeriv;
       ++imjac;
@@ -848,11 +848,11 @@ SumSquaredTissueVolumeDifferenceImageToImageMetric<TFixedImage, TMovingImage>::
   const unsigned int sizejacobianOfSpatialJacobianDeterminant = jacobianOfSpatialJacobianDeterminant.GetSize();
 
   /** matrix product first, then trace. */
-  for (unsigned int mu = 0; mu < sizejacobianOfSpatialJacobianDeterminant; mu++)
+  for (unsigned int mu = 0; mu < sizejacobianOfSpatialJacobianDeterminant; ++mu)
   {
-    for (unsigned int diag = 0; diag < FixedImageDimension; diag++)
+    for (unsigned int diag = 0; diag < FixedImageDimension; ++diag)
     {
-      for (unsigned int idx = 0; idx < FixedImageDimension; idx++)
+      for (unsigned int idx = 0; idx < FixedImageDimension; ++idx)
       {
         (*jsjdit) += inverseSpatialJacobian(diag, idx) * (*jsjit)(idx, diag);
       }

--- a/Components/Metrics/VarianceOverLastDimension/itkVarianceOverLastDimensionImageMetric.hxx
+++ b/Components/Metrics/VarianceOverLastDimension/itkVarianceOverLastDimensionImageMetric.hxx
@@ -173,12 +173,12 @@ VarianceOverLastDimensionImageMetric<TFixedImage, TMovingImage>::EvaluateTransfo
   JacobianIteratorType                                   jac = jacobian.begin();
   imageJacobian.Fill(0.0);
   const unsigned int sizeImageJacobian = imageJacobian.GetSize();
-  for (unsigned int dim = 0; dim < FixedImageDimension; dim++)
+  for (unsigned int dim = 0; dim < FixedImageDimension; ++dim)
   {
     const double           imDeriv = movingImageDerivative[dim];
     DerivativeIteratorType imjac = imageJacobian.begin();
 
-    for (unsigned int mu = 0; mu < sizeImageJacobian; mu++)
+    for (unsigned int mu = 0; mu < sizeImageJacobian; ++mu)
     {
       (*imjac) += (*jac) * imDeriv;
       ++imjac;

--- a/Components/MovingImagePyramids/MovingGenericPyramid/elxMovingGenericPyramid.hxx
+++ b/Components/MovingImagePyramids/MovingGenericPyramid/elxMovingGenericPyramid.hxx
@@ -55,9 +55,9 @@ MovingGenericPyramid<TElastix>::SetMovingSchedule(void)
    * - MovingImagePyramidSchedule
    */
   bool foundRescale = true;
-  for (unsigned int i = 0; i < numberOfResolutions; i++)
+  for (unsigned int i = 0; i < numberOfResolutions; ++i)
   {
-    for (unsigned int j = 0; j < MovingImageDimension; j++)
+    for (unsigned int j = 0; j < MovingImageDimension; ++j)
     {
       bool               ijfound = false;
       const unsigned int entrynr = i * MovingImageDimension + j;
@@ -92,9 +92,9 @@ MovingGenericPyramid<TElastix>::SetMovingSchedule(void)
    * - MovingImagePyramidSmoothingSchedule
    */
   bool foundSmoothing = true;
-  for (unsigned int i = 0; i < numberOfResolutions; i++)
+  for (unsigned int i = 0; i < numberOfResolutions; ++i)
   {
-    for (unsigned int j = 0; j < MovingImageDimension; j++)
+    for (unsigned int j = 0; j < MovingImageDimension; ++j)
     {
       bool               ijfound = false;
       const unsigned int entrynr = i * MovingImageDimension + j;

--- a/Components/Optimizers/AdaptiveStochasticVarianceReducedGradient/elxAdaptiveStochasticVarianceReducedGradient.hxx
+++ b/Components/Optimizers/AdaptiveStochasticVarianceReducedGradient/elxAdaptiveStochasticVarianceReducedGradient.hxx
@@ -601,7 +601,7 @@ AdaptiveStochasticVarianceReducedGradient<TElastix>::ResumeOptimization(void)
 
     this->m_CurrentInnerIteration = 0;
 
-    for (unsigned i = 0; i < this->m_NumberOfInnerIterations; i++)
+    for (unsigned i = 0; i < this->m_NumberOfInnerIterations; ++i)
     {
       unsigned int itp = i;
 

--- a/Components/Optimizers/AdaptiveStochasticVarianceReducedGradient/itkStochasticVarianceReducedGradientDescentOptimizer.cxx
+++ b/Components/Optimizers/AdaptiveStochasticVarianceReducedGradient/itkStochasticVarianceReducedGradientDescentOptimizer.cxx
@@ -219,7 +219,7 @@ StochasticVarianceReducedGradientDescentOptimizer::AdvanceOneStep(void)
     const ParametersType & currentPosition = this->GetScaledCurrentPosition();
 
     /** Update the new position. */
-    for (unsigned int j = 0; j < spaceDimension; j++)
+    for (unsigned int j = 0; j < spaceDimension; ++j)
     {
       newPosition[j] = currentPosition[j] - this->m_LearningRate * this->m_Gradient[j];
     }
@@ -234,7 +234,7 @@ StochasticVarianceReducedGradientDescentOptimizer::AdvanceOneStep(void)
     const int nthreads = static_cast<int>(this->m_Threader->GetNumberOfWorkUnits());
     omp_set_num_threads(nthreads);
 #  pragma omp parallel for
-    for (int j = 0; j < static_cast<int>(spaceDimension); j++)
+    for (int j = 0; j < static_cast<int>(spaceDimension); ++j)
     {
       newPosition[j] = currentPosition[j] - this->m_LearningRate * this->m_Gradient[j];
     }
@@ -351,7 +351,7 @@ StochasticVarianceReducedGradientDescentOptimizer::ThreadedAdvanceOneStep(Thread
   const DerivativeType & gradient = this->m_Gradient;
 
   /** Advance one step: mu_{k+1} = mu_k - a_k * gradient_k */
-  for (unsigned int j = jmin; j < jmax; j++)
+  for (unsigned int j = jmin; j < jmax; ++j)
   {
     newPosition[j] = currentPosition[j] - learningRate * gradient[j];
   }

--- a/Components/Optimizers/FiniteDifferenceGradientDescent/itkFiniteDifferenceGradientDescentOptimizer.cxx
+++ b/Components/Optimizers/FiniteDifferenceGradientDescent/itkFiniteDifferenceGradientDescentOptimizer.cxx
@@ -156,7 +156,7 @@ FiniteDifferenceGradientDescentOptimizer::ResumeOptimization(void)
     /** Calculate the derivative; this may take a while... */
     try
     {
-      for (unsigned int j = 0; j < spaceDimension; j++)
+      for (unsigned int j = 0; j < spaceDimension; ++j)
       {
         param[j] += ck;
         valueplus = this->GetScaledValue(param);
@@ -242,7 +242,7 @@ FiniteDifferenceGradientDescentOptimizer::AdvanceOneStep(void)
   const ParametersType & currentPosition = this->GetScaledCurrentPosition();
 
   ParametersType newPosition(spaceDimension);
-  for (unsigned int j = 0; j < spaceDimension; j++)
+  for (unsigned int j = 0; j < spaceDimension; ++j)
   {
     newPosition[j] = currentPosition[j] - ak * this->m_Gradient[j];
   }

--- a/Components/Optimizers/FullSearch/elxFullSearchOptimizer.hxx
+++ b/Components/Optimizers/FullSearch/elxFullSearchOptimizer.hxx
@@ -194,7 +194,7 @@ FullSearch<TElastix>::AfterEachIteration(void)
   unsigned int         nrOfSSDims = currentPoint.GetSize();
   NameIteratorType     name_it = this->m_SearchSpaceDimensionNames.begin();
 
-  for (unsigned int dim = 0; dim < nrOfSSDims; dim++)
+  for (unsigned int dim = 0; dim < nrOfSSDims; ++dim)
   {
     this->GetIterationInfoAt(name_it->second.c_str()) << currentPoint[dim];
     name_it++;
@@ -263,14 +263,14 @@ FullSearch<TElastix>::AfterEachResolution(void)
 
   elxout << "Index of the point in the optimization surface image that has "
          << "the best metric value: [ ";
-  for (unsigned int dim = 0; dim < nrOfSSDims; dim++)
+  for (unsigned int dim = 0; dim < nrOfSSDims; ++dim)
   {
     elxout << bestIndex[dim] << " ";
   }
   elxout << "]" << std::endl;
 
   elxout << "The corresponding parameter values: [ ";
-  for (unsigned int dim = 0; dim < nrOfSSDims; dim++)
+  for (unsigned int dim = 0; dim < nrOfSSDims; ++dim)
   {
     elxout << bestPoint[dim] << " ";
   }
@@ -278,7 +278,7 @@ FullSearch<TElastix>::AfterEachResolution(void)
 
   /** Remove the columns from IterationInfo. */
   NameIteratorType name_it = this->m_SearchSpaceDimensionNames.begin();
-  for (unsigned int dim = 0; dim < nrOfSSDims; dim++)
+  for (unsigned int dim = 0; dim < nrOfSSDims; ++dim)
   {
     this->RemoveTargetCellFromIterationInfo(name_it->second.c_str());
     name_it++;

--- a/Components/Optimizers/FullSearch/itkFullSearchOptimizer.cxx
+++ b/Components/Optimizers/FullSearch/itkFullSearchOptimizer.cxx
@@ -191,7 +191,7 @@ FullSearchOptimizer::UpdateCurrentPosition(void)
 
   /** Derive the index of the next search space point */
   bool JustSetPreviousDimToZero = true;
-  for (unsigned int ssdim = 0; ssdim < searchSpaceDimension; ssdim++) // loop over all dimensions of the search space
+  for (unsigned int ssdim = 0; ssdim < searchSpaceDimension; ++ssdim) // loop over all dimensions of the search space
   {
     /** if the full range of ssdim-1 has been searched (so, if its
      * index has just been set back to 0) then increase index[ssdim] */
@@ -224,7 +224,7 @@ FullSearchOptimizer::UpdateCurrentPosition(void)
    * The IndexToPoint and PointToParameter functions are not used here,
    * because we edit directly in the currentPosition (faster).
    */
-  for (unsigned int ssdim = 0; ssdim < searchSpaceDimension; ssdim++)
+  for (unsigned int ssdim = 0; ssdim < searchSpaceDimension; ++ssdim)
   {
     /** Transform the index to a point; point = min + step*index */
     RangeType range = it.Value();
@@ -260,7 +260,7 @@ FullSearchOptimizer::ProcessSearchSpaceChanges(void)
     /** Initialise an iterator over the search space map. */
     SearchSpaceIteratorType it(m_SearchSpace->Begin());
 
-    for (unsigned int ssdim = 0; ssdim < m_NumberOfSearchSpaceDimensions; ssdim++)
+    for (unsigned int ssdim = 0; ssdim < m_NumberOfSearchSpaceDimensions; ++ssdim)
     {
       RangeType range = it.Value();
       m_SearchSpaceSize[ssdim] = static_cast<unsigned long>((range[1] - range[0]) / range[2]) + 1;
@@ -335,7 +335,7 @@ FullSearchOptimizer::GetNumberOfIterations(void)
   if (maxssdim > 0)
   {
     nr_it = sssize[0];
-    for (unsigned int ssdim = 1; ssdim < maxssdim; ssdim++)
+    for (unsigned int ssdim = 1; ssdim < maxssdim; ++ssdim)
     {
       nr_it *= sssize[ssdim];
     }
@@ -388,7 +388,7 @@ FullSearchOptimizer::PointToPosition(const SearchSpacePointType & point)
   SearchSpaceIteratorType it(m_SearchSpace->Begin());
 
   /** Transform the index to a point in search space. */
-  for (unsigned int ssdim = 0; ssdim < searchSpaceDimension; ssdim++)
+  for (unsigned int ssdim = 0; ssdim < searchSpaceDimension; ++ssdim)
   {
     /** Update the array of parameters. */
     param[it.Index()] = point[ssdim];
@@ -426,7 +426,7 @@ FullSearchOptimizer::IndexToPoint(const SearchSpaceIndexType & index)
   SearchSpaceIteratorType it(m_SearchSpace->Begin());
 
   /** Transform the index to a point in search space. */
-  for (unsigned int ssdim = 0; ssdim < searchSpaceDimension; ssdim++)
+  for (unsigned int ssdim = 0; ssdim < searchSpaceDimension; ++ssdim)
   {
     /** point = min + step*index */
     RangeType range = it.Value();

--- a/Components/Optimizers/RSGDEachParameterApart/itkRSGDEachParameterApartBaseOptimizer.cxx
+++ b/Components/Optimizers/RSGDEachParameterApart/itkRSGDEachParameterApartBaseOptimizer.cxx
@@ -177,14 +177,14 @@ RSGDEachParameterApartBaseOptimizer::AdvanceOneStep(void)
                       << ", but the NumberOfParameters for the CostFunction is " << spaceDimension << ".");
   }
 
-  for (unsigned int i = 0; i < spaceDimension; i++)
+  for (unsigned int i = 0; i < spaceDimension; ++i)
   {
     transformedGradient[i] = m_Gradient[i] / scales[i];
     previousTransformedGradient[i] = m_PreviousGradient[i] / scales[i];
   }
 
   double magnitudeSquare = 0;
-  for (unsigned int dim = 0; dim < spaceDimension; dim++)
+  for (unsigned int dim = 0; dim < spaceDimension; ++dim)
   {
     const double weighted = transformedGradient[dim];
     magnitudeSquare += weighted * weighted;
@@ -201,7 +201,7 @@ RSGDEachParameterApartBaseOptimizer::AdvanceOneStep(void)
 
   double sumOfCurrentStepLengths = 0.0;
   double biggestCurrentStepLength = 0.0;
-  for (unsigned int i = 0; i < spaceDimension; i++)
+  for (unsigned int i = 0; i < spaceDimension; ++i)
   {
     const bool signChange = (transformedGradient[i] * previousTransformedGradient[i]) < 0;
 
@@ -244,7 +244,7 @@ RSGDEachParameterApartBaseOptimizer::AdvanceOneStep(void)
 
   DerivativeType factor = DerivativeType(spaceDimension);
 
-  for (unsigned int i = 0; i < spaceDimension; i++)
+  for (unsigned int i = 0; i < spaceDimension; ++i)
   {
     factor[i] = direction * m_CurrentStepLengths[i] / m_GradientMagnitude;
   }

--- a/Components/Optimizers/RSGDEachParameterApart/itkRSGDEachParameterApartOptimizer.cxx
+++ b/Components/Optimizers/RSGDEachParameterApart/itkRSGDEachParameterApartOptimizer.cxx
@@ -39,7 +39,7 @@ RSGDEachParameterApartOptimizer::StepAlongGradient(const DerivativeType & factor
   ParametersType newPosition(spaceDimension);
   ParametersType currentPosition = this->GetCurrentPosition();
 
-  for (unsigned int j = 0; j < spaceDimension; j++)
+  for (unsigned int j = 0; j < spaceDimension; ++j)
   {
     /** Each parameters has its own factor! */
     newPosition[j] = currentPosition[j] + transformedGradient[j] * factor[j];

--- a/Components/Optimizers/Simplex/elxSimplex.hxx
+++ b/Components/Optimizers/Simplex/elxSimplex.hxx
@@ -84,7 +84,7 @@ Simplex<TElastix>::BeforeEachResolution(void)
     ParametersType initialsimplexdelta(numberofparameters);
     initialsimplexdelta.Fill(1);
 
-    for (unsigned int i = 0; i < numberofparameters; i++)
+    for (unsigned int i = 0; i < numberofparameters; ++i)
     {
       this->m_Configuration->ReadParameter(initialsimplexdelta[i], "InitialSimplexDelta", i);
     }

--- a/Components/Optimizers/StandardGradientDescent/itkGradientDescentOptimizer2.cxx
+++ b/Components/Optimizers/StandardGradientDescent/itkGradientDescentOptimizer2.cxx
@@ -217,7 +217,7 @@ GradientDescentOptimizer2 ::AdvanceOneStep(void)
   const int nthreads = static_cast<int>(this->m_Threader->GetNumberOfWorkUnits());
   omp_set_num_threads(nthreads);
 #  pragma omp parallel for
-  for (int j = 0; j < static_cast<int>(spaceDimension); j++)
+  for (int j = 0; j < static_cast<int>(spaceDimension); ++j)
   {
     newPosition[j] = currentPosition[j] - this->m_LearningRate * this->m_Gradient[j];
   }

--- a/Components/Optimizers/StandardStochasticGradientDescent/itkStochasticGradientDescentOptimizer.cxx
+++ b/Components/Optimizers/StandardStochasticGradientDescent/itkStochasticGradientDescentOptimizer.cxx
@@ -219,7 +219,7 @@ StochasticGradientDescentOptimizer::AdvanceOneStep(void)
     const ParametersType & currentPosition = this->GetScaledCurrentPosition();
 
     /** Update the new position. */
-    for (unsigned int j = 0; j < spaceDimension; j++)
+    for (unsigned int j = 0; j < spaceDimension; ++j)
     {
       newPosition[j] = currentPosition[j] - this->m_LearningRate * this->m_Gradient[j];
     }
@@ -234,7 +234,7 @@ StochasticGradientDescentOptimizer::AdvanceOneStep(void)
     const int nthreads = static_cast<int>(this->m_Threader->GetNumberOfWorkUnits());
     omp_set_num_threads(nthreads);
 #  pragma omp parallel for
-    for (int j = 0; j < static_cast<int>(spaceDimension); j++)
+    for (int j = 0; j < static_cast<int>(spaceDimension); ++j)
     {
       newPosition[j] = currentPosition[j] - this->m_LearningRate * this->m_Gradient[j];
     }
@@ -348,7 +348,7 @@ StochasticGradientDescentOptimizer::ThreadedAdvanceOneStep(ThreadIdType threadId
   const DerivativeType & gradient = this->m_Gradient;
 
   /** Advance one step: mu_{k+1} = mu_k - a_k * gradient_k */
-  for (unsigned int j = jmin; j < jmax; j++)
+  for (unsigned int j = jmin; j < jmax; ++j)
   {
     newPosition[j] = currentPosition[j] - learningRate * gradient[j];
   }

--- a/Components/Registrations/MultiMetricMultiResolutionRegistration/itkCombinationImageToImageMetric.hxx
+++ b/Components/Registrations/MultiMetricMultiResolutionRegistration/itkCombinationImageToImageMetric.hxx
@@ -52,7 +52,7 @@
   template <class TFixedImage, class TMovingImage>                                                                     \
   void CombinationImageToImageMetric<TFixedImage, TMovingImage>::Set##_name(_type1 _type2 * _arg)                      \
   {                                                                                                                    \
-    for (unsigned int i = 0; i < this->GetNumberOfMetrics(); i++)                                                      \
+    for (unsigned int i = 0; i < this->GetNumberOfMetrics(); ++i)                                                      \
     {                                                                                                                  \
       this->Set##_name(_arg, i);                                                                                       \
     }                                                                                                                  \
@@ -75,7 +75,7 @@
   template <class TFixedImage, class TMovingImage>                                                                     \
   void CombinationImageToImageMetric<TFixedImage, TMovingImage>::Set##_name(_type1 _type2 * _arg)                      \
   {                                                                                                                    \
-    for (unsigned int i = 0; i < this->GetNumberOfMetrics(); i++)                                                      \
+    for (unsigned int i = 0; i < this->GetNumberOfMetrics(); ++i)                                                      \
     {                                                                                                                  \
       this->Set##_name(_arg, i);                                                                                       \
     }                                                                                                                  \
@@ -164,7 +164,7 @@ CombinationImageToImageMetric<TFixedImage, TMovingImage>::PrintSelf(std::ostream
 
   /** Add debugging information. */
   os << "NumberOfMetrics: " << this->m_NumberOfMetrics << std::endl;
-  for (unsigned int i = 0; i < this->m_NumberOfMetrics; i++)
+  for (unsigned int i = 0; i < this->m_NumberOfMetrics; ++i)
   {
     os << "Metric " << i << ":\n";
     os << indent << "MetricPointer: " << this->m_Metrics[i].GetPointer() << "\n";
@@ -210,7 +210,7 @@ template <class TFixedImage, class TMovingImage>
 void
 CombinationImageToImageMetric<TFixedImage, TMovingImage>::SetFixedImageRegion(const FixedImageRegionType _arg)
 {
-  for (unsigned int i = 0; i < this->GetNumberOfMetrics(); i++)
+  for (unsigned int i = 0; i < this->GetNumberOfMetrics(); ++i)
   {
     this->SetFixedImageRegion(_arg, i);
   }
@@ -579,7 +579,7 @@ CombinationImageToImageMetric<TFixedImage, TMovingImage>::Initialize(void)
   }
 
   /** Call Initialize for all metrics. */
-  for (unsigned int i = 0; i < this->GetNumberOfMetrics(); i++)
+  for (unsigned int i = 0; i < this->GetNumberOfMetrics(); ++i)
   {
     SingleValuedCostFunctionType * costfunc = this->GetMetric(i);
     if (!costfunc)
@@ -665,7 +665,7 @@ CombinationImageToImageMetric<TFixedImage, TMovingImage>::GetValue(const Paramet
   MeasureType measure = NumericTraits<MeasureType>::Zero;
 
   /** Compute, store and combine all metric values. */
-  for (unsigned int i = 0; i < this->m_NumberOfMetrics; i++)
+  for (unsigned int i = 0; i < this->m_NumberOfMetrics; ++i)
   {
     /** Time the computation per metric. */
     itk::TimeProbe timer;
@@ -725,7 +725,7 @@ CombinationImageToImageMetric<TFixedImage, TMovingImage>::GetDerivative(const Pa
   derivative.Fill(NumericTraits<MeasureType>::ZeroValue());
 
   /** Compute, store and combine all metric derivatives. */
-  for (unsigned int i = 0; i < this->m_NumberOfMetrics; i++)
+  for (unsigned int i = 0; i < this->m_NumberOfMetrics; ++i)
   {
     /** Time the computation per metric. */
     itk::TimeProbe timer;
@@ -786,7 +786,7 @@ CombinationImageToImageMetric<TFixedImage, TMovingImage>::GetValueAndDerivative(
   /** This function must be called before the multi-threaded code.
    * It calls all the non thread-safe stuff.
    */
-  for (unsigned int i = 0; i < this->m_NumberOfMetrics; i++)
+  for (unsigned int i = 0; i < this->m_NumberOfMetrics; ++i)
   {
     ImageMetricType *    testPtr1 = dynamic_cast<ImageMetricType *>(this->GetMetric(i));
     PointSetMetricType * testPtr2 = dynamic_cast<PointSetMetricType *>(this->GetMetric(i));
@@ -808,7 +808,7 @@ CombinationImageToImageMetric<TFixedImage, TMovingImage>::GetValueAndDerivative(
   this->InitializeThreadingParameters();
 
   /** Compute all metric values and derivatives. */
-  for (unsigned int i = 0; i < this->m_NumberOfMetrics; i++)
+  for (unsigned int i = 0; i < this->m_NumberOfMetrics; ++i)
   {
     /** Compute ... */
     timer.Reset();
@@ -821,14 +821,14 @@ CombinationImageToImageMetric<TFixedImage, TMovingImage>::GetValueAndDerivative(
   }
 
   /** Compute the derivative magnitude. */
-  for (unsigned int i = 0; i < this->m_NumberOfMetrics; i++)
+  for (unsigned int i = 0; i < this->m_NumberOfMetrics; ++i)
   {
     this->m_MetricDerivativesMagnitude[i] = this->m_MetricDerivatives[i].magnitude();
   }
 
   /** Combine the metric values. */
   value = NumericTraits<MeasureType>::Zero;
-  for (unsigned int i = 0; i < this->m_NumberOfMetrics; i++)
+  for (unsigned int i = 0; i < this->m_NumberOfMetrics; ++i)
   {
     if (this->m_UseMetric[i])
     {
@@ -849,7 +849,7 @@ CombinationImageToImageMetric<TFixedImage, TMovingImage>::GetValueAndDerivative(
   }
 
   /** Then the remaining derivatives. */
-  for (unsigned int i = 1; i < this->m_NumberOfMetrics; i++)
+  for (unsigned int i = 1; i < this->m_NumberOfMetrics; ++i)
   {
     if (this->m_UseMetric[i])
     {
@@ -877,7 +877,7 @@ CombinationImageToImageMetric<TFixedImage, TMovingImage>::GetSelfHessian(const T
 
   /** Add all metrics' selfhessians. */
   bool initialized = false;
-  for (unsigned int i = 0; i < this->m_NumberOfMetrics; i++)
+  for (unsigned int i = 0; i < this->m_NumberOfMetrics; ++i)
   {
     if (this->m_UseMetric[i])
     {

--- a/Components/Registrations/MultiMetricMultiResolutionRegistration/itkMultiMetricMultiResolutionImageRegistrationMethod.hxx
+++ b/Components/Registrations/MultiMetricMultiResolutionRegistration/itkMultiMetricMultiResolutionImageRegistrationMethod.hxx
@@ -240,7 +240,7 @@ MultiMetricMultiResolutionImageRegistrationMethod<TFixedImage, TMovingImage>::Pr
       SizeType  inputSize = fixedImageRegion.GetSize();
       IndexType inputStart = fixedImageRegion.GetIndex();
       IndexType inputEnd = inputStart;
-      for (unsigned int dim = 0; dim < TFixedImage::ImageDimension; dim++)
+      for (unsigned int dim = 0; dim < TFixedImage::ImageDimension; ++dim)
       {
         inputEnd[dim] += (inputSize[dim] - 1);
       }
@@ -267,7 +267,7 @@ MultiMetricMultiResolutionImageRegistrationMethod<TFixedImage, TMovingImage>::Pr
       fixpyr->GetInput()->TransformIndexToPhysicalPoint(inputStart, inputStartPoint);
       fixpyr->GetInput()->TransformIndexToPhysicalPoint(inputEnd, inputEndPoint);
 
-      for (unsigned int level = 0; level < this->GetNumberOfLevels(); level++)
+      for (unsigned int level = 0; level < this->GetNumberOfLevels(); ++level)
       {
         SizeType         size;
         IndexType        start;
@@ -282,7 +282,7 @@ MultiMetricMultiResolutionImageRegistrationMethod<TFixedImage, TMovingImage>::Pr
          */
         fixedImageAtLevel->TransformPhysicalPointToContinuousIndex(inputStartPoint, startcindex);
         fixedImageAtLevel->TransformPhysicalPointToContinuousIndex(inputEndPoint, endcindex);
-        for (unsigned int dim = 0; dim < TFixedImage::ImageDimension; dim++)
+        for (unsigned int dim = 0; dim < TFixedImage::ImageDimension; ++dim)
         {
           start[dim] = static_cast<IndexValueType>(std::ceil(startcindex[dim]));
           size[dim] = std::max(
@@ -362,7 +362,7 @@ MultiMetricMultiResolutionImageRegistrationMethod<TFixedImage, TMovingImage>::Ge
   this->PrepareAllPyramids();
 
   /** Loop over the resolution levels. */
-  for (unsigned int currentLevel = 0; currentLevel < this->GetNumberOfLevels(); currentLevel++)
+  for (unsigned int currentLevel = 0; currentLevel < this->GetNumberOfLevels(); ++currentLevel)
   {
     this->SetCurrentLevel(currentLevel);
 

--- a/Components/Registrations/MultiResolutionRegistrationWithFeatures/elxMultiResolutionRegistrationWithFeatures.hxx
+++ b/Components/Registrations/MultiResolutionRegistrationWithFeatures/elxMultiResolutionRegistrationWithFeatures.hxx
@@ -202,7 +202,7 @@ MultiResolutionRegistrationWithFeatures<TElastix>::GetAndSetFixedImageInterpolat
   typedef itk::BSplineInterpolateImageFunction<FixedImageType>      FixedImageInterpolatorType;
   typedef std::vector<typename FixedImageInterpolatorType::Pointer> FixedImageInterpolatorVectorType;
   FixedImageInterpolatorVectorType                                  interpolators(noFixIm);
-  for (unsigned int i = 0; i < noFixIm; i++)
+  for (unsigned int i = 0; i < noFixIm; ++i)
   {
     interpolators[i] = FixedImageInterpolatorType::New();
     interpolators[i]->SetSplineOrder(soFII[i]);

--- a/Components/Registrations/MultiResolutionRegistrationWithFeatures/itkMultiInputMultiResolutionImageRegistrationMethodBase.hxx
+++ b/Components/Registrations/MultiResolutionRegistrationWithFeatures/itkMultiInputMultiResolutionImageRegistrationMethodBase.hxx
@@ -371,7 +371,7 @@ MultiInputMultiResolutionImageRegistrationMethodBase<TFixedImage, TMovingImage>:
       SizeType  inputSize = fixedImageRegion.GetSize();
       IndexType inputStart = fixedImageRegion.GetIndex();
       IndexType inputEnd = inputStart;
-      for (unsigned int dim = 0; dim < TFixedImage::ImageDimension; dim++)
+      for (unsigned int dim = 0; dim < TFixedImage::ImageDimension; ++dim)
       {
         inputEnd[dim] += (inputSize[dim] - 1);
       }
@@ -398,7 +398,7 @@ MultiInputMultiResolutionImageRegistrationMethodBase<TFixedImage, TMovingImage>:
       fixpyr->GetInput()->TransformIndexToPhysicalPoint(inputStart, inputStartPoint);
       fixpyr->GetInput()->TransformIndexToPhysicalPoint(inputEnd, inputEndPoint);
 
-      for (unsigned int level = 0; level < this->GetNumberOfLevels(); level++)
+      for (unsigned int level = 0; level < this->GetNumberOfLevels(); ++level)
       {
         SizeType         size;
         IndexType        start;
@@ -411,7 +411,7 @@ MultiInputMultiResolutionImageRegistrationMethodBase<TFixedImage, TMovingImage>:
          * floored. To see why, consider an image of 4 by 4, and its downsampled version of 2 by 2. */
         fixedImageAtLevel->TransformPhysicalPointToContinuousIndex(inputStartPoint, startcindex);
         fixedImageAtLevel->TransformPhysicalPointToContinuousIndex(inputEndPoint, endcindex);
-        for (unsigned int dim = 0; dim < TFixedImage::ImageDimension; dim++)
+        for (unsigned int dim = 0; dim < TFixedImage::ImageDimension; ++dim)
         {
           start[dim] = static_cast<IndexValueType>(std::ceil(startcindex[dim]));
           size[dim] =
@@ -457,7 +457,7 @@ MultiInputMultiResolutionImageRegistrationMethodBase<TFixedImage, TMovingImage>:
   this->PreparePyramids();
 
   /** Loop over the resolution levels. */
-  for (unsigned int currentLevel = 0; currentLevel < this->GetNumberOfLevels(); currentLevel++)
+  for (unsigned int currentLevel = 0; currentLevel < this->GetNumberOfLevels(); ++currentLevel)
   {
     this->SetCurrentLevel(currentLevel);
 

--- a/Components/ResampleInterpolators/RayCastResampleInterpolator/elxRayCastResampleInterpolator.hxx
+++ b/Components/ResampleInterpolators/RayCastResampleInterpolator/elxRayCastResampleInterpolator.hxx
@@ -42,7 +42,7 @@ RayCastResampleInterpolator<TElastix>::InitializeRayCastInterpolator(void)
   TransformParametersType preParameters(numberofparameters);
   preParameters.Fill(0.0);
 
-  for (unsigned int i = 0; i < numberofparameters; i++)
+  for (unsigned int i = 0; i < numberofparameters; ++i)
   {
     bool ret =
       this->GetConfiguration()->ReadParameter(preParameters[i], "PreParameters", this->GetComponentLabel(), i, 0);
@@ -55,7 +55,7 @@ RayCastResampleInterpolator<TElastix>::InitializeRayCastInterpolator(void)
   typename EulerTransformType::InputPointType centerofrotation;
   centerofrotation.Fill(0.0);
 
-  for (unsigned int i = 0; i < this->m_Elastix->GetMovingImage()->GetImageDimension(); i++)
+  for (unsigned int i = 0; i < this->m_Elastix->GetMovingImage()->GetImageDimension(); ++i)
   {
     this->GetConfiguration()->ReadParameter(
       centerofrotation[i], "CenterOfRotationPoint", this->GetComponentLabel(), i, 0);
@@ -71,7 +71,7 @@ RayCastResampleInterpolator<TElastix>::InitializeRayCastInterpolator(void)
   PointType focalPoint;
   focalPoint.Fill(0.0);
 
-  for (unsigned int i = 0; i < this->m_Elastix->GetFixedImage()->GetImageDimension(); i++)
+  for (unsigned int i = 0; i < this->m_Elastix->GetFixedImage()->GetImageDimension(); ++i)
   {
     bool ret = this->GetConfiguration()->ReadParameter(focalPoint[i], "FocalPoint", this->GetComponentLabel(), i, 0);
     if (!ret)

--- a/Components/Transforms/AdvancedAffineTransform/elxAdvancedAffineTransform.hxx
+++ b/Components/Transforms/AdvancedAffineTransform/elxAdvancedAffineTransform.hxx
@@ -155,7 +155,7 @@ AdvancedAffineTransformElastix<TElastix>::InitializeTransform(void)
 
   bool centerGivenAsIndex = true;
   bool centerGivenAsPoint = true;
-  for (unsigned int i = 0; i < SpaceDimension; i++)
+  for (unsigned int i = 0; i < SpaceDimension; ++i)
   {
     /** Initialize. */
     centerOfRotationIndex[i] = 0;
@@ -395,7 +395,7 @@ AdvancedAffineTransformElastix<TElastix>::SetScales(void)
     if (count == 0)
     {
       /** In this case the first option is used. */
-      for (unsigned int i = 0; i < rotationPart; i++)
+      for (unsigned int i = 0; i < rotationPart; ++i)
       {
         newscales[i] = defaultScalingvalue;
       }
@@ -405,7 +405,7 @@ AdvancedAffineTransformElastix<TElastix>::SetScales(void)
       /** In this case the second option is used. */
       double scale = defaultScalingvalue;
       this->m_Configuration->ReadParameter(scale, "Scales", 0);
-      for (unsigned int i = 0; i < rotationPart; i++)
+      for (unsigned int i = 0; i < rotationPart; ++i)
       {
         newscales[i] = scale;
       }
@@ -413,7 +413,7 @@ AdvancedAffineTransformElastix<TElastix>::SetScales(void)
     else if (count == this->GetNumberOfParameters())
     {
       /** In this case the third option is used. */
-      for (unsigned int i = 0; i < this->GetNumberOfParameters(); i++)
+      for (unsigned int i = 0; i < this->GetNumberOfParameters(); ++i)
       {
         this->m_Configuration->ReadParameter(newscales[i], "Scales", i);
       }
@@ -451,7 +451,7 @@ AdvancedAffineTransformElastix<TElastix>::ReadCenterOfRotationPoint(InputPointTy
    */
   InputPointType centerOfRotationPoint;
   bool           centerGivenAsPoint = true;
-  for (unsigned int i = 0; i < SpaceDimension; i++)
+  for (unsigned int i = 0; i < SpaceDimension; ++i)
   {
     centerOfRotationPoint[i] = 0.0;
 

--- a/Components/Transforms/AdvancedAffineTransform/itkCenteredTransformInitializer2.hxx
+++ b/Components/Transforms/AdvancedAffineTransform/itkCenteredTransformInitializer2.hxx
@@ -141,7 +141,7 @@ CenteredTransformInitializer2<TTransform, TFixedImage, TMovingImage>::Initialize
 
     typename MovingImageCalculatorType::VectorType movingCenter = m_MovingCalculator->GetCenterOfGravity();
 
-    for (unsigned int i = 0; i < InputSpaceDimension; i++)
+    for (unsigned int i = 0; i < InputSpaceDimension; ++i)
     {
       rotationCenter[i] = fixedCenter[i];
       translationVector[i] = movingCenter[i] - fixedCenter[i];
@@ -162,7 +162,7 @@ CenteredTransformInitializer2<TTransform, TFixedImage, TMovingImage>::Initialize
     InputPointType      centerMovingPoint;
     ContinuousIndexType centerMovingIndex;
 
-    for (unsigned int m = 0; m < InputSpaceDimension; m++)
+    for (unsigned int m = 0; m < InputSpaceDimension; ++m)
     {
       centerMovingIndex[m] = static_cast<ContinuousIndexValueType>(movingIndex[m]) +
                              static_cast<ContinuousIndexValueType>(movingSize[m] - 1) / 2.0;
@@ -179,7 +179,7 @@ CenteredTransformInitializer2<TTransform, TFixedImage, TMovingImage>::Initialize
     InputPointType                              originFixedPoint;
     m_FixedImage->TransformIndexToPhysicalPoint(fixedIndex, originFixedPoint);
 
-    for (unsigned int i = 0; i < InputSpaceDimension; i++)
+    for (unsigned int i = 0; i < InputSpaceDimension; ++i)
     {
       translationVector[i] = originMovingPoint[i] - originFixedPoint[i];
       rotationCenter[i] = centerMovingPoint[i] - translationVector[i];
@@ -309,7 +309,7 @@ CenteredTransformInitializer2<TTransform, TFixedImage, TMovingImage>::Initialize
 
     // Compute center of the fixed image (mask bounding box) in physical units
     ContinuousIndex<double, InputSpaceDimension> fixedCenterCI;
-    for (unsigned int k = 0; k < InputSpaceDimension; k++)
+    for (unsigned int k = 0; k < InputSpaceDimension; ++k)
     {
       fixedCenterCI[k] = fixedRegion.GetIndex()[k] + (fixedRegion.GetSize()[k] - 1.0) / 2.0;
     }
@@ -328,7 +328,7 @@ CenteredTransformInitializer2<TTransform, TFixedImage, TMovingImage>::Initialize
 
     // Compute center of the moving image (mask bounding box) in physical units
     ContinuousIndex<double, InputSpaceDimension> movingCenterCI;
-    for (unsigned int k = 0; k < InputSpaceDimension; k++)
+    for (unsigned int k = 0; k < InputSpaceDimension; ++k)
     {
       movingCenterCI[k] = movingRegion.GetIndex()[k] + (movingRegion.GetSize()[k] - 1.0) / 2.0;
     }
@@ -336,7 +336,7 @@ CenteredTransformInitializer2<TTransform, TFixedImage, TMovingImage>::Initialize
     this->m_MovingImage->TransformContinuousIndexToPhysicalPoint(movingCenterCI, centerMoving);
 
     // Compute the difference between the centers
-    for (unsigned int i = 0; i < InputSpaceDimension; i++)
+    for (unsigned int i = 0; i < InputSpaceDimension; ++i)
     {
       rotationCenter[i] = centerFixed[i];
       translationVector[i] = centerMoving[i] - centerFixed[i];

--- a/Components/Transforms/AdvancedBSplineTransform/elxAdvancedBSplineTransform.hxx
+++ b/Components/Transforms/AdvancedBSplineTransform/elxAdvancedBSplineTransform.hxx
@@ -481,13 +481,13 @@ AdvancedBSplineTransform<TElastix>::ReadFromFile(void)
   griddirection.SetIdentity();
 
   /** Get GridSize, GridIndex, GridSpacing and GridOrigin. */
-  for (unsigned int i = 0; i < SpaceDimension; i++)
+  for (unsigned int i = 0; i < SpaceDimension; ++i)
   {
     this->m_Configuration->ReadParameter(gridsize[i], "GridSize", i);
     this->m_Configuration->ReadParameter(gridindex[i], "GridIndex", i);
     this->m_Configuration->ReadParameter(gridspacing[i], "GridSpacing", i);
     this->m_Configuration->ReadParameter(gridorigin[i], "GridOrigin", i);
-    for (unsigned int j = 0; j < SpaceDimension; j++)
+    for (unsigned int j = 0; j < SpaceDimension; ++j)
     {
       this->m_Configuration->ReadParameter(griddirection(j, i), "GridDirection", i * SpaceDimension + j);
     }

--- a/Components/Transforms/AffineDTITransform/elxAffineDTITransform.hxx
+++ b/Components/Transforms/AffineDTITransform/elxAffineDTITransform.hxx
@@ -132,7 +132,7 @@ AffineDTITransformElastix<TElastix>::InitializeTransform(void)
   InputPointType centerOfRotationPoint;
   bool           centerGivenAsIndex = true;
   bool           centerGivenAsPoint = true;
-  for (unsigned int i = 0; i < SpaceDimension; i++)
+  for (unsigned int i = 0; i < SpaceDimension; ++i)
   {
     /** Initialize. */
     centerOfRotationIndex[i] = 0;
@@ -293,7 +293,7 @@ AffineDTITransformElastix<TElastix>::SetScales(void)
   {
     /** Overrule the automatically estimated scales with the user-specified
      * scales. Values <= 0 are not used; the default is kept then. */
-    for (unsigned int i = 0; i < this->GetNumberOfParameters(); i++)
+    for (unsigned int i = 0; i < this->GetNumberOfParameters(); ++i)
     {
       double scale_i = -1.0;
       this->m_Configuration->ReadParameter(scale_i, "Scales", i);
@@ -334,7 +334,7 @@ AffineDTITransformElastix<TElastix>::ReadCenterOfRotationPoint(InputPointType & 
    */
   InputPointType centerOfRotationPoint;
   bool           centerGivenAsPoint = true;
-  for (unsigned int i = 0; i < SpaceDimension; i++)
+  for (unsigned int i = 0; i < SpaceDimension; ++i)
   {
     centerOfRotationPoint[i] = 0;
 

--- a/Components/Transforms/AffineDTITransform/itkAffineDTI2DTransform.hxx
+++ b/Components/Transforms/AffineDTITransform/itkAffineDTI2DTransform.hxx
@@ -206,7 +206,7 @@ AffineDTI2DTransform<TScalarType>::GetJacobian(const InputPointType &       p,
 
   /** Compute dR/dmu * (p-c) */
   const InputVectorType pp = p - this->GetCenter();
-  for (unsigned int dim = 0; dim < 5; dim++)
+  for (unsigned int dim = 0; dim < 5; ++dim)
   {
     const InputVectorType column = jsj[dim] * pp;
     for (unsigned int i = 0; i < SpaceDimension; ++i)
@@ -217,7 +217,7 @@ AffineDTI2DTransform<TScalarType>::GetJacobian(const InputPointType &       p,
 
   // compute derivatives for the translation part
   const unsigned int blockOffset = 5;
-  for (unsigned int dim = 0; dim < SpaceDimension; dim++)
+  for (unsigned int dim = 0; dim < SpaceDimension; ++dim)
   {
     j[dim][blockOffset + dim] = 1.0;
   }

--- a/Components/Transforms/AffineDTITransform/itkAffineDTI3DTransform.hxx
+++ b/Components/Transforms/AffineDTITransform/itkAffineDTI3DTransform.hxx
@@ -291,7 +291,7 @@ AffineDTI3DTransform<TScalarType>::GetJacobian(const InputPointType &       p,
 
   /** Compute dR/dmu * (p-c) */
   const InputVectorType pp = p - this->GetCenter();
-  for (unsigned int dim = 0; dim < 9; dim++)
+  for (unsigned int dim = 0; dim < 9; ++dim)
   {
     const InputVectorType column = jsj[dim] * pp;
     for (unsigned int i = 0; i < SpaceDimension; ++i)
@@ -302,7 +302,7 @@ AffineDTI3DTransform<TScalarType>::GetJacobian(const InputPointType &       p,
 
   // compute derivatives for the translation part
   const unsigned int blockOffset = 9;
-  for (unsigned int dim = 0; dim < SpaceDimension; dim++)
+  for (unsigned int dim = 0; dim < SpaceDimension; ++dim)
   {
     j[dim][blockOffset + dim] = 1.0;
   }

--- a/Components/Transforms/AffineLogStackTransform/elxAffineLogStackTransform.hxx
+++ b/Components/Transforms/AffineLogStackTransform/elxAffineLogStackTransform.hxx
@@ -200,7 +200,7 @@ AffineLogStackTransform<TElastix>::InitializeTransform()
   SizeType fixedImageSize =
     this->m_Registration->GetAsITKBaseType()->GetFixedImage()->GetLargestPossibleRegion().GetSize();
 
-  for (unsigned int i = 0; i < ReducedSpaceDimension; i++)
+  for (unsigned int i = 0; i < ReducedSpaceDimension; ++i)
   {
     /** Initialize. */
     centerOfRotationIndex[i] = 0;
@@ -242,7 +242,7 @@ AffineLogStackTransform<TElastix>::InitializeTransform()
   if (!centerGiven)
   {
     /** Use center of image as default center of rotation */
-    for (unsigned int k = 0; k < SpaceDimension; k++)
+    for (unsigned int k = 0; k < SpaceDimension; ++k)
     {
       centerOfRotationIndex[k] = (fixedImageSize[k] - 1.0) / 2.0;
     }
@@ -250,7 +250,7 @@ AffineLogStackTransform<TElastix>::InitializeTransform()
     this->m_Registration->GetAsITKBaseType()->GetFixedImage()->TransformContinuousIndexToPhysicalPoint(
       centerOfRotationIndex, TransformedCenterOfRotation);
 
-    for (unsigned int k = 0; k < ReducedSpaceDimension; k++)
+    for (unsigned int k = 0; k < ReducedSpaceDimension; ++k)
     {
       RDTransformedCenterOfRotation[k] = TransformedCenterOfRotation[k];
     }
@@ -267,7 +267,7 @@ AffineLogStackTransform<TElastix>::InitializeTransform()
   {
     this->m_Registration->GetAsITKBaseType()->GetFixedImage()->TransformContinuousIndexToPhysicalPoint(
       centerOfRotationIndex, TransformedCenterOfRotation);
-    for (unsigned int k = 0; k < ReducedSpaceDimension; k++)
+    for (unsigned int k = 0; k < ReducedSpaceDimension; ++k)
     {
       RDTransformedCenterOfRotation[k] = TransformedCenterOfRotation[k];
     }
@@ -406,7 +406,7 @@ AffineLogStackTransform<TElastix>::SetScales(void)
     {
       newscales.Fill(1.0);
       /** In this case the third option is used. */
-      for (unsigned int i = 0; i < this->GetNumberOfParameters(); i++)
+      for (unsigned int i = 0; i < this->GetNumberOfParameters(); ++i)
       {
         this->m_Configuration->ReadParameter(newscales[i], "Scales", i);
       }
@@ -444,7 +444,7 @@ AffineLogStackTransform<TElastix>::ReadCenterOfRotationPoint(ReducedDimensionInp
    */
   ReducedDimensionInputPointType RDcenterOfRotationPoint;
   bool                           centerGivenAsPoint = true;
-  for (unsigned int i = 0; i < ReducedSpaceDimension; i++)
+  for (unsigned int i = 0; i < ReducedSpaceDimension; ++i)
   {
     RDcenterOfRotationPoint[i] = 0.0;
 

--- a/Components/Transforms/AffineLogTransform/elxAffineLogTransform.hxx
+++ b/Components/Transforms/AffineLogTransform/elxAffineLogTransform.hxx
@@ -134,7 +134,7 @@ AffineLogTransformElastix<TElastix>::InitializeTransform(void)
   bool           centerGivenAsPoint = true;
   // SizeType fixedImageSize = this->m_Registration->GetAsITKBaseType()
   //  ->GetFixedImage()->GetLargestPossibleRegion().GetSize();
-  for (unsigned int i = 0; i < SpaceDimension; i++)
+  for (unsigned int i = 0; i < SpaceDimension; ++i)
   {
     /** Initialize. */
     centerOfRotationIndex[i] = 0;
@@ -294,7 +294,7 @@ AffineLogTransformElastix<TElastix>::SetScales(void)
   {
     /** Overrule the automatically estimated scales with the user-specified
      * scales. Values <= 0 are not used; the default is kept then. */
-    for (unsigned int i = 0; i < this->GetNumberOfParameters(); i++)
+    for (unsigned int i = 0; i < this->GetNumberOfParameters(); ++i)
     {
       double scale_i = -1.0;
       this->m_Configuration->ReadParameter(scale_i, "Scales", i);
@@ -336,7 +336,7 @@ AffineLogTransformElastix<TElastix>::ReadCenterOfRotationPoint(InputPointType & 
    */
   InputPointType centerOfRotationPoint;
   bool           centerGivenAsPoint = true;
-  for (unsigned int i = 0; i < SpaceDimension; i++)
+  for (unsigned int i = 0; i < SpaceDimension; ++i)
   {
     centerOfRotationPoint[i] = 0;
 

--- a/Components/Transforms/AffineLogTransform/itkAffineLogTransform.hxx
+++ b/Components/Transforms/AffineLogTransform/itkAffineLogTransform.hxx
@@ -43,7 +43,7 @@ AffineLogTransform<TScalarType, Dimension>::AffineLogTransform(const MatrixType 
   this->SetMatrix(matrix);
 
   OffsetType off;
-  for (unsigned int i = 0; i < Dimension; i++)
+  for (unsigned int i = 0; i < Dimension; ++i)
   {
     off[i] = offset[i];
   }
@@ -74,9 +74,9 @@ AffineLogTransform<TScalarType, Dimension>::SetParameters(const ParametersType &
 
   MatrixType exponentMatrix;
 
-  for (unsigned int i = 0; i < Dimension; i++)
+  for (unsigned int i = 0; i < Dimension; ++i)
   {
-    for (unsigned int j = 0; j < Dimension; j++)
+    for (unsigned int j = 0; j < Dimension; ++j)
     {
       this->m_MatrixLogDomain(i, j) = parameters[k];
       k += 1;
@@ -91,7 +91,7 @@ AffineLogTransform<TScalarType, Dimension>::SetParameters(const ParametersType &
 
   OutputVectorType off;
 
-  for (unsigned int i = 0; i < Dimension; i++)
+  for (unsigned int i = 0; i < Dimension; ++i)
   {
     off[i] = parameters[k];
     k += 1;
@@ -115,16 +115,16 @@ AffineLogTransform<TScalarType, Dimension>::GetParameters(void) const
 {
   unsigned int k = 0; // Dummy loop index
 
-  for (unsigned int i = 0; i < Dimension; i++)
+  for (unsigned int i = 0; i < Dimension; ++i)
   {
-    for (unsigned int j = 0; j < Dimension; j++)
+    for (unsigned int j = 0; j < Dimension; ++j)
     {
       this->m_Parameters[k] = this->m_MatrixLogDomain(i, j);
       k += 1;
     }
   }
 
-  for (unsigned int j = 0; j < Dimension; j++)
+  for (unsigned int j = 0; j < Dimension; ++j)
   {
     this->m_Parameters[k] = this->GetTranslation()[j];
     k += 1;
@@ -158,7 +158,7 @@ AffineLogTransform<TScalarType, Dimension>::GetJacobian(const InputPointType &  
 
   const JacobianOfSpatialJacobianType & jsj = this->m_JacobianOfSpatialJacobian;
   const InputVectorType                 pp = p - this->GetCenter();
-  for (unsigned int dim = 0; dim < d * d; dim++)
+  for (unsigned int dim = 0; dim < d * d; ++dim)
   {
     const InputVectorType column = jsj[dim] * pp;
     for (unsigned int i = 0; i < d; ++i)
@@ -169,7 +169,7 @@ AffineLogTransform<TScalarType, Dimension>::GetJacobian(const InputPointType &  
 
   // compute derivatives for the translation part
   const unsigned int blockOffset = d * d;
-  for (unsigned int dim = 0; dim < Dimension; dim++)
+  for (unsigned int dim = 0; dim < Dimension; ++dim)
   {
     j[dim][blockOffset + dim] = 1.0;
   }
@@ -203,16 +203,16 @@ AffineLogTransform<TScalarType, Dimension>::PrecomputeJacobianOfSpatialJacobian(
   A_bar.fill(itk::NumericTraits<ScalarType>::Zero);
 
   // Fill A_bar top left and bottom right with A
-  for (unsigned int k = 0; k < d; k++)
+  for (unsigned int k = 0; k < d; ++k)
   {
-    for (unsigned int l = 0; l < d; l++)
+    for (unsigned int l = 0; l < d; ++l)
     {
       A_bar(k, l) = this->m_MatrixLogDomain(k, l);
     }
   }
-  for (unsigned int k = d; k < 2 * d; k++)
+  for (unsigned int k = d; k < 2 * d; ++k)
   {
-    for (unsigned int l = d; l < 2 * d; l++)
+    for (unsigned int l = d; l < 2 * d; ++l)
     {
       A_bar(k, l) = this->m_MatrixLogDomain(k - d, l - d);
     }
@@ -221,22 +221,22 @@ AffineLogTransform<TScalarType, Dimension>::PrecomputeJacobianOfSpatialJacobian(
   unsigned int m = 0; // Dummy loop index
 
   // Non-translation derivatives
-  for (unsigned int i = 0; i < d; i++)
+  for (unsigned int i = 0; i < d; ++i)
   {
-    for (unsigned int j = 0; j < d; j++)
+    for (unsigned int j = 0; j < d; ++j)
     {
       dA(i, j) = 1;
-      for (unsigned int k = 0; k < d; k++)
+      for (unsigned int k = 0; k < d; ++k)
       {
-        for (unsigned int l = d; l < 2 * d; l++)
+        for (unsigned int l = d; l < 2 * d; ++l)
         {
           A_bar(k, l) = dA(k, (l - d));
         }
       }
       B_bar = vnl_matrix_exp(A_bar);
-      for (unsigned int k = 0; k < d; k++)
+      for (unsigned int k = 0; k < d; ++k)
       {
-        for (unsigned int l = d; l < 2 * d; l++)
+        for (unsigned int l = d; l < 2 * d; ++l)
         {
           dummymatrix(k, (l - d)) = B_bar(k, l);
         }

--- a/Components/Transforms/BSplineDeformableTransformWithDiffusion/elxBSplineTransformWithDiffusion.hxx
+++ b/Components/Transforms/BSplineDeformableTransformWithDiffusion/elxBSplineTransformWithDiffusion.hxx
@@ -128,7 +128,7 @@ BSplineTransformWithDiffusion<TElastix>::BeforeRegistration(void)
   unsigned int radius1D = 1;
   this->m_Configuration->ReadParameter(radius1D, "Radius", 0);
   RadiusType radius;
-  for (unsigned int i = 0; i < this->FixedImageDimension; i++)
+  for (unsigned int i = 0; i < this->FixedImageDimension; ++i)
   {
     radius[i] = static_cast<long unsigned int>(radius1D);
   }
@@ -635,7 +635,7 @@ BSplineTransformWithDiffusion<TElastix>::SetInitialGrid(bool upsampleGridOption)
   this->m_GridSpacingFactor[0] = 8.0;
   this->m_Configuration->ReadParameter(this->m_GridSpacingFactor[0], "FinalGridSpacing", 0);
   this->m_GridSpacingFactor.Fill(this->m_GridSpacingFactor[0]);
-  for (unsigned int j = 1; j < SpaceDimension; j++)
+  for (unsigned int j = 1; j < SpaceDimension; ++j)
   {
     this->m_Configuration->ReadParameter(this->m_GridSpacingFactor[j], "FinalGridSpacing", j);
   }
@@ -648,7 +648,7 @@ BSplineTransformWithDiffusion<TElastix>::SetInitialGrid(bool upsampleGridOption)
   }
 
   /** Determine the correct grid size. */
-  for (unsigned int j = 0; j < SpaceDimension; j++)
+  for (unsigned int j = 0; j < SpaceDimension; ++j)
   {
     gridspacing[j] = gridspacing[j] * this->m_GridSpacingFactor[j];
     gridorigin[j] -= gridspacing[j] * std::floor(static_cast<double>(SplineOrder) / 2.0);
@@ -711,7 +711,7 @@ BSplineTransformWithDiffusion<TElastix>::IncreaseScale(void)
   this->m_GridSpacingFactor /= 2;
 
   /** Determine the correct grid size. */
-  for (unsigned int j = 0; j < SpaceDimension; j++)
+  for (unsigned int j = 0; j < SpaceDimension; ++j)
   {
     gridspacingHigh[j] = gridspacingHigh[j] * this->m_GridSpacingFactor[j];
     gridoriginHigh[j] -= gridspacingHigh[j] * std::floor(static_cast<double>(SplineOrder) / 2.0);
@@ -751,7 +751,7 @@ BSplineTransformWithDiffusion<TElastix>::IncreaseScale(void)
   unsigned int i = 0;
 
   /** Loop over dimension. */
-  for (unsigned int j = 0; j < SpaceDimension; j++)
+  for (unsigned int j = 0; j < SpaceDimension; ++j)
   {
     /** Fill the coefficient image with parameter data (displacements
      * of the control points in the direction of dimension j).
@@ -896,7 +896,7 @@ BSplineTransformWithDiffusion<TElastix>::ReadFromFile(void)
   gridorigin.Fill(0.0);
 
   /** Get GridSize, GridIndex, GridSpacing and GridOrigin. */
-  for (unsigned int i = 0; i < SpaceDimension; i++)
+  for (unsigned int i = 0; i < SpaceDimension; ++i)
   {
     this->m_Configuration->ReadParameter(gridsize[i], "GridSize", i);
     this->m_Configuration->ReadParameter(gridindex[i], "GridIndex", i);
@@ -1081,7 +1081,7 @@ BSplineTransformWithDiffusion<TElastix>::DiffuseDeformationField(void)
     /** Call TransformPoint. */
     outputPoint = this->TransformPoint(inputPoint);
     /** Calculate the difference. */
-    for (unsigned int i = 0; i < this->FixedImageDimension; i++)
+    for (unsigned int i = 0; i < this->FixedImageDimension; ++i)
     {
       diff_point[i] = outputPoint[i] - inputPoint[i];
     }

--- a/Components/Transforms/BSplineDeformableTransformWithDiffusion/itkDeformationFieldRegulizer.hxx
+++ b/Components/Transforms/BSplineDeformableTransformWithDiffusion/itkDeformationFieldRegulizer.hxx
@@ -101,7 +101,7 @@ DeformationFieldRegulizer<TAnyITKTransform>::TransformPoint(const InputPointType
   oppDF = this->m_IntermediaryDeformationFieldTransform->TransformPoint(inputPoint);
 
   /** Add them: don't forget to subtract ipp. */
-  for (unsigned int i = 0; i < OutputSpaceDimension; i++)
+  for (unsigned int i = 0; i < OutputSpaceDimension; ++i)
   {
     opp[i] = oppAnyT[i] + oppDF[i] - inputPoint[i];
   }

--- a/Components/Transforms/BSplineDeformableTransformWithDiffusion/itkDeformationVectorFieldTransform.hxx
+++ b/Components/Transforms/BSplineDeformableTransformWithDiffusion/itkDeformationVectorFieldTransform.hxx
@@ -34,7 +34,7 @@ template <class TScalarType, unsigned int NDimensions>
 DeformationVectorFieldTransform<TScalarType, NDimensions>::DeformationVectorFieldTransform()
 {
   /** Initialize m_Images. */
-  for (unsigned int i = 0; i < SpaceDimension; i++)
+  for (unsigned int i = 0; i < SpaceDimension; ++i)
   {
     this->m_Images[i] = nullptr;
   }
@@ -50,7 +50,7 @@ template <class TScalarType, unsigned int NDimensions>
 DeformationVectorFieldTransform<TScalarType, NDimensions>::~DeformationVectorFieldTransform()
 {
   /** Initialize m_Images. */
-  for (unsigned int i = 0; i < SpaceDimension; i++)
+  for (unsigned int i = 0; i < SpaceDimension; ++i)
   {
     this->m_Images[i] = nullptr;
   }
@@ -77,7 +77,7 @@ DeformationVectorFieldTransform<TScalarType, NDimensions>::SetCoefficientVectorI
   /** Create array of images representing the B-spline
    * coefficients in each dimension.
    */
-  for (unsigned int i = 0; i < SpaceDimension; i++)
+  for (unsigned int i = 0; i < SpaceDimension; ++i)
   {
     this->m_Images[i] = CoefficientImageType::New();
     this->m_Images[i]->SetRegions(vecImage->GetLargestPossibleRegion());
@@ -90,7 +90,7 @@ DeformationVectorFieldTransform<TScalarType, NDimensions>::SetCoefficientVectorI
   VectorIteratorType vecit(vecImage, vecImage->GetLargestPossibleRegion());
   vecit.GoToBegin();
   IteratorType it[SpaceDimension];
-  for (unsigned int i = 0; i < SpaceDimension; i++)
+  for (unsigned int i = 0; i < SpaceDimension; ++i)
   {
     it[i] = IteratorType(this->m_Images[i], this->m_Images[i]->GetLargestPossibleRegion());
     it[i].GoToBegin();
@@ -101,7 +101,7 @@ DeformationVectorFieldTransform<TScalarType, NDimensions>::SetCoefficientVectorI
   while (!vecit.IsAtEnd())
   {
     vect = vecit.Get();
-    for (unsigned int i = 0; i < SpaceDimension; i++)
+    for (unsigned int i = 0; i < SpaceDimension; ++i)
     {
       it[i].Set(static_cast<CoefficientPixelType>(vect[i]));
       ++it[i];
@@ -135,7 +135,7 @@ DeformationVectorFieldTransform<TScalarType, NDimensions>::GetCoefficientVectorI
 
   /** Combine the coefficient images to a vector image. */
   typename ScalarImageCombineType::Pointer combiner = ScalarImageCombineType::New();
-  for (unsigned int i = 0; i < SpaceDimension; i++)
+  for (unsigned int i = 0; i < SpaceDimension; ++i)
   {
     combiner->SetInput(i, coefImage[i]);
   }

--- a/Components/Transforms/BSplineDeformableTransformWithDiffusion/itkVectorMeanDiffusionImageFilter.hxx
+++ b/Components/Transforms/BSplineDeformableTransformWithDiffusion/itkVectorMeanDiffusionImageFilter.hxx
@@ -201,7 +201,7 @@ VectorMeanDiffusionImageFilter<TInputImage, TGrayValueImage>::GenerateData(void)
   double ci = 0.0;
 
   /** Loop over the number of iterations. */
-  for (unsigned int k = 0; k < this->GetNumberOfIterations(); k++)
+  for (unsigned int k = 0; k < this->GetNumberOfIterations(); ++k)
   {
     /** Reset the iterators. */
     nit.GoToBegin();
@@ -220,7 +220,7 @@ VectorMeanDiffusionImageFilter<TInputImage, TGrayValueImage>::GenerateData(void)
       else
       {
         /** Initialize the sum to 0. */
-        for (j = 0; j < InputImageDimension; j++)
+        for (j = 0; j < InputImageDimension; ++j)
         {
           sum[j] = NumericTraits<double>::Zero;
         }
@@ -241,7 +241,7 @@ VectorMeanDiffusionImageFilter<TInputImage, TGrayValueImage>::GenerateData(void)
 
           /** Calculate SUthis->m_i{ ci } and SUthis->m_i{ ci * x_i }. */
           sumc += ci;
-          for (j = 0; j < InputImageDimension; j++)
+          for (j = 0; j < InputImageDimension; ++j)
           {
             sum[j] += ci * static_cast<double>(pix[j]);
           }
@@ -249,7 +249,7 @@ VectorMeanDiffusionImageFilter<TInputImage, TGrayValueImage>::GenerateData(void)
 
         /** Get the mean value by dividing by sumc. */
         InputPixelType mean;
-        for (j = 0; j < InputImageDimension; j++)
+        for (j = 0; j < InputImageDimension; ++j)
         {
           if (sumc < 0.00001)
           {

--- a/Components/Transforms/BSplineStackTransform/elxBSplineStackTransform.hxx
+++ b/Components/Transforms/BSplineStackTransform/elxBSplineStackTransform.hxx
@@ -522,13 +522,13 @@ BSplineStackTransform<TElastix>::ReadFromFile(void)
   griddirection.SetIdentity();
 
   /** Get GridSize, GridIndex, GridSpacing and GridOrigin. */
-  for (unsigned int i = 0; i < ReducedSpaceDimension; i++)
+  for (unsigned int i = 0; i < ReducedSpaceDimension; ++i)
   {
     dummy |= this->m_Configuration->ReadParameter(gridsize[i], "GridSize", i);
     dummy |= this->m_Configuration->ReadParameter(gridindex[i], "GridIndex", i);
     dummy |= this->m_Configuration->ReadParameter(gridspacing[i], "GridSpacing", i);
     dummy |= this->m_Configuration->ReadParameter(gridorigin[i], "GridOrigin", i);
-    for (unsigned int j = 0; j < ReducedSpaceDimension; j++)
+    for (unsigned int j = 0; j < ReducedSpaceDimension; ++j)
     {
       this->m_Configuration->ReadParameter(griddirection(j, i), "GridDirection", i * ReducedSpaceDimension + j);
     }

--- a/Components/Transforms/EulerStackTransform/elxEulerStackTransform.hxx
+++ b/Components/Transforms/EulerStackTransform/elxEulerStackTransform.hxx
@@ -199,7 +199,7 @@ EulerStackTransform<TElastix>::InitializeTransform()
     this->m_Registration->GetAsITKBaseType()->GetFixedImage()->GetLargestPossibleRegion().GetSize();
 
   /** Try to read center of rotation point (COP) from parameter file. */
-  for (unsigned int i = 0; i < ReducedSpaceDimension; i++)
+  for (unsigned int i = 0; i < ReducedSpaceDimension; ++i)
   {
     /** Initialize. */
     centerOfRotationIndex[i] = 0;
@@ -228,7 +228,7 @@ EulerStackTransform<TElastix>::InitializeTransform()
   if (!centerGiven)
   {
     /** Use center of image as default center of rotation */
-    for (unsigned int k = 0; k < SpaceDimension; k++)
+    for (unsigned int k = 0; k < SpaceDimension; ++k)
     {
       centerOfRotationIndex[k] = (fixedImageSize[k] - 1.0f) / 2.0f;
     }
@@ -237,7 +237,7 @@ EulerStackTransform<TElastix>::InitializeTransform()
     this->m_Registration->GetAsITKBaseType()->GetFixedImage()->TransformContinuousIndexToPhysicalPoint(
       centerOfRotationIndex, centerOfRotationPoint);
 
-    for (unsigned int k = 0; k < ReducedSpaceDimension; k++)
+    for (unsigned int k = 0; k < ReducedSpaceDimension; ++k)
     {
       redDimCenterOfRotationPoint[k] = redDimCenterOfRotationPoint[k];
     }
@@ -258,7 +258,7 @@ EulerStackTransform<TElastix>::InitializeTransform()
     this->m_Registration->GetAsITKBaseType()->GetFixedImage()->TransformContinuousIndexToPhysicalPoint(
       centerOfRotationIndex, centerOfRotationPoint);
 
-    for (unsigned int k = 0; k < ReducedSpaceDimension; k++)
+    for (unsigned int k = 0; k < ReducedSpaceDimension; ++k)
     {
       redDimCenterOfRotationPoint[k] = centerOfRotationPoint[k];
     }
@@ -464,7 +464,7 @@ EulerStackTransform<TElastix>::SetScales(void)
     {
       newscales.Fill(1.0);
       /** In this case the third option is used. */
-      for (unsigned int i = 0; i < this->GetNumberOfParameters(); i++)
+      for (unsigned int i = 0; i < this->GetNumberOfParameters(); ++i)
       {
         this->m_Configuration->ReadParameter(newscales[i], "Scales", i);
       }
@@ -502,7 +502,7 @@ EulerStackTransform<TElastix>::ReadCenterOfRotationPoint(ReducedDimensionInputPo
    */
   ReducedDimensionInputPointType redDimCenterOfRotationPoint;
   bool                           centerGivenAsPoint = true;
-  for (unsigned int i = 0; i < ReducedSpaceDimension; i++)
+  for (unsigned int i = 0; i < ReducedSpaceDimension; ++i)
   {
     redDimCenterOfRotationPoint[i] = 0.0;
 

--- a/Components/Transforms/EulerTransform/elxEulerTransform.hxx
+++ b/Components/Transforms/EulerTransform/elxEulerTransform.hxx
@@ -144,7 +144,7 @@ EulerTransformElastix<TElastix>::InitializeTransform(void)
   InputPointType centerOfRotationPoint;
   bool           centerGivenAsIndex = true;
   bool           centerGivenAsPoint = true;
-  for (unsigned int i = 0; i < SpaceDimension; i++)
+  for (unsigned int i = 0; i < SpaceDimension; ++i)
   {
     /** Initialize. */
     centerOfRotationIndex[i] = 0;
@@ -359,7 +359,7 @@ EulerTransformElastix<TElastix>::SetScales(void)
     if (count == 0)
     {
       /** In this case the first option is used. */
-      for (unsigned int i = 0; i < RotationPart; i++)
+      for (unsigned int i = 0; i < RotationPart; ++i)
       {
         newscales[i] = defaultScalingvalue;
       }
@@ -369,7 +369,7 @@ EulerTransformElastix<TElastix>::SetScales(void)
       /** In this case the second option is used. */
       double scale = defaultScalingvalue;
       this->m_Configuration->ReadParameter(scale, "Scales", 0);
-      for (unsigned int i = 0; i < RotationPart; i++)
+      for (unsigned int i = 0; i < RotationPart; ++i)
       {
         newscales[i] = scale;
       }
@@ -377,7 +377,7 @@ EulerTransformElastix<TElastix>::SetScales(void)
     else if (count == this->GetNumberOfParameters())
     {
       /** In this case the third option is used. */
-      for (unsigned int i = 0; i < this->GetNumberOfParameters(); i++)
+      for (unsigned int i = 0; i < this->GetNumberOfParameters(); ++i)
       {
         this->m_Configuration->ReadParameter(newscales[i], "Scales", i);
       }
@@ -415,7 +415,7 @@ EulerTransformElastix<TElastix>::ReadCenterOfRotationPoint(InputPointType & rota
    */
   InputPointType centerOfRotationPoint;
   bool           centerGivenAsPoint = true;
-  for (unsigned int i = 0; i < SpaceDimension; i++)
+  for (unsigned int i = 0; i < SpaceDimension; ++i)
   {
     centerOfRotationPoint[i] = 0;
 

--- a/Components/Transforms/MultiBSplineTransformWithNormal/elxMultiBSplineTransformWithNormal.hxx
+++ b/Components/Transforms/MultiBSplineTransformWithNormal/elxMultiBSplineTransformWithNormal.hxx
@@ -526,7 +526,7 @@ MultiBSplineTransformWithNormal<TElastix>::IncreaseScale(void)
       {
         upsampledParameters.SetElement(i, tmp[0]);
       }
-      for (unsigned int k = 0; k < (SpaceDimension - 1); k++)
+      for (unsigned int k = 0; k < (SpaceDimension - 1); ++k)
       {
         upsampledParameters.SetElement(i + ((SpaceDimension - 1) * (l - 1) + 1 + k) * new_ParametersPerDimension,
                                        tmp[k + 1]);
@@ -576,13 +576,13 @@ MultiBSplineTransformWithNormal<TElastix>::ReadFromFile(void)
   griddirection.SetIdentity();
 
   /** Get GridSize, GridIndex, GridSpacing and GridOrigin. */
-  for (unsigned int i = 0; i < SpaceDimension; i++)
+  for (unsigned int i = 0; i < SpaceDimension; ++i)
   {
     this->m_Configuration->ReadParameter(gridsize[i], "GridSize", i);
     this->m_Configuration->ReadParameter(gridindex[i], "GridIndex", i);
     this->m_Configuration->ReadParameter(gridspacing[i], "GridSpacing", i);
     this->m_Configuration->ReadParameter(gridorigin[i], "GridOrigin", i);
-    for (unsigned int j = 0; j < SpaceDimension; j++)
+    for (unsigned int j = 0; j < SpaceDimension; ++j)
     {
       this->m_Configuration->ReadParameter(griddirection(j, i), "GridDirection", i * SpaceDimension + j);
     }

--- a/Components/Transforms/RecursiveBSplineTransform/elxRecursiveBSplineTransform.hxx
+++ b/Components/Transforms/RecursiveBSplineTransform/elxRecursiveBSplineTransform.hxx
@@ -480,13 +480,13 @@ RecursiveBSplineTransform<TElastix>::ReadFromFile(void)
   griddirection.SetIdentity();
 
   /** Get GridSize, GridIndex, GridSpacing and GridOrigin. */
-  for (unsigned int i = 0; i < SpaceDimension; i++)
+  for (unsigned int i = 0; i < SpaceDimension; ++i)
   {
     this->m_Configuration->ReadParameter(gridsize[i], "GridSize", i);
     this->m_Configuration->ReadParameter(gridindex[i], "GridIndex", i);
     this->m_Configuration->ReadParameter(gridspacing[i], "GridSpacing", i);
     this->m_Configuration->ReadParameter(gridorigin[i], "GridOrigin", i);
-    for (unsigned int j = 0; j < SpaceDimension; j++)
+    for (unsigned int j = 0; j < SpaceDimension; ++j)
     {
       this->m_Configuration->ReadParameter(griddirection(j, i), "GridDirection", i * SpaceDimension + j);
     }

--- a/Components/Transforms/SimilarityTransform/elxSimilarityTransform.hxx
+++ b/Components/Transforms/SimilarityTransform/elxSimilarityTransform.hxx
@@ -133,7 +133,7 @@ SimilarityTransformElastix<TElastix>::InitializeTransform(void)
   InputPointType centerOfRotationPoint;
   bool           centerGivenAsIndex = true;
   bool           centerGivenAsPoint = true;
-  for (unsigned int i = 0; i < SpaceDimension; i++)
+  for (unsigned int i = 0; i < SpaceDimension; ++i)
   {
     /** Initilialize. */
     centerOfRotationIndex[i] = 0;
@@ -308,14 +308,14 @@ SimilarityTransformElastix<TElastix>::SetScales(void)
     else if (SpaceDimension == 3)
     {
       newscales[6] = 10000.0;
-      for (unsigned int i = 0; i < 3; i++)
+      for (unsigned int i = 0; i < 3; ++i)
       {
         newscales[i] = 100000.0;
       }
     }
 
     /** Get the scales from the parameter file. */
-    for (unsigned int i = 0; i < N; i++)
+    for (unsigned int i = 0; i < N; ++i)
     {
       this->GetConfiguration()->ReadParameter(newscales[i], "Scales", this->GetComponentLabel(), i, -1);
     }
@@ -342,7 +342,7 @@ SimilarityTransformElastix<TElastix>::ReadCenterOfRotationIndex(InputPointType &
    */
   IndexType centerOfRotationIndex;
   bool      centerGivenAsIndex = true;
-  for (unsigned int i = 0; i < SpaceDimension; i++)
+  for (unsigned int i = 0; i < SpaceDimension; ++i)
   {
     centerOfRotationIndex[i] = 0;
 
@@ -369,7 +369,7 @@ SimilarityTransformElastix<TElastix>::ReadCenterOfRotationIndex(InputPointType &
   SizeType      size;
   DirectionType direction;
   direction.SetIdentity();
-  for (unsigned int i = 0; i < SpaceDimension; i++)
+  for (unsigned int i = 0; i < SpaceDimension; ++i)
   {
     /** Read size from the parameter file. Zero by default, which is illegal. */
     size[i] = 0;
@@ -388,7 +388,7 @@ SimilarityTransformElastix<TElastix>::ReadCenterOfRotationIndex(InputPointType &
     this->m_Configuration->ReadParameter(origin[i], "Origin", i);
 
     /** Read direction cosines. Default identity */
-    for (unsigned int j = 0; j < SpaceDimension; j++)
+    for (unsigned int j = 0; j < SpaceDimension; ++j)
     {
       this->m_Configuration->ReadParameter(direction(j, i), "Direction", i * SpaceDimension + j);
     }
@@ -396,7 +396,7 @@ SimilarityTransformElastix<TElastix>::ReadCenterOfRotationIndex(InputPointType &
 
   /** Check for image size. */
   bool illegalSize = false;
-  for (unsigned int i = 0; i < SpaceDimension; i++)
+  for (unsigned int i = 0; i < SpaceDimension; ++i)
   {
     if (size[i] == 0)
     {
@@ -445,7 +445,7 @@ SimilarityTransformElastix<TElastix>::ReadCenterOfRotationPoint(InputPointType &
    */
   InputPointType centerOfRotationPoint;
   bool           centerGivenAsPoint = true;
-  for (unsigned int i = 0; i < SpaceDimension; i++)
+  for (unsigned int i = 0; i < SpaceDimension; ++i)
   {
     centerOfRotationPoint[i] = 0;
 

--- a/Components/Transforms/SplineKernelTransform/itkElasticBodyReciprocalSplineKernelTransform2.hxx
+++ b/Components/Transforms/SplineKernelTransform/itkElasticBodyReciprocalSplineKernelTransform2.hxx
@@ -54,11 +54,11 @@ ElasticBodyReciprocalSplineKernelTransform2<TScalarType, NDimensions>::ComputeG(
   const TScalarType r = x.GetNorm();
   const TScalarType factor = (r > 1e-8) ? (-1.0 / r) : NumericTraits<TScalarType>::Zero;
   const TScalarType radial = this->m_Alpha * r;
-  for (unsigned int i = 0; i < NDimensions; i++)
+  for (unsigned int i = 0; i < NDimensions; ++i)
   {
     const typename InputVectorType::ValueType xi = x[i] * factor;
     // G is symmetric
-    for (unsigned int j = 0; j < i; j++)
+    for (unsigned int j = 0; j < i; ++j)
     {
       const TScalarType value = xi * x[j];
       GMatrix[i][j] = value;

--- a/Components/Transforms/SplineKernelTransform/itkElasticBodySplineKernelTransform2.hxx
+++ b/Components/Transforms/SplineKernelTransform/itkElasticBodySplineKernelTransform2.hxx
@@ -54,11 +54,11 @@ ElasticBodySplineKernelTransform2<TScalarType, NDimensions>::ComputeG(const Inpu
   const TScalarType r = x.GetNorm();
   const TScalarType factor = -3.0 * r;
   const TScalarType radial = this->m_Alpha * r * r * r;
-  for (unsigned int i = 0; i < NDimensions; i++)
+  for (unsigned int i = 0; i < NDimensions; ++i)
   {
     const typename InputVectorType::ValueType xi = x[i] * factor;
     // G is symmetric
-    for (unsigned int j = 0; j < i; j++)
+    for (unsigned int j = 0; j < i; ++j)
     {
       const TScalarType value = xi * x[j];
       GMatrix[i][j] = value;

--- a/Components/Transforms/SplineKernelTransform/itkKernelTransform2.hxx
+++ b/Components/Transforms/SplineKernelTransform/itkKernelTransform2.hxx
@@ -192,12 +192,12 @@ KernelTransform2<TScalarType, NDimensions>::ComputeDeformationContribution(const
   PointsIterator sp = this->m_SourceLandmarks->GetPoints()->Begin();
   GMatrixType    Gmatrix;
 
-  for (unsigned long lnd = 0; lnd < numberOfLandmarks; lnd++)
+  for (unsigned long lnd = 0; lnd < numberOfLandmarks; ++lnd)
   {
     this->ComputeG(thisPoint - sp->Value(), Gmatrix);
-    for (unsigned int dim = 0; dim < NDimensions; dim++)
+    for (unsigned int dim = 0; dim < NDimensions; ++dim)
     {
-      for (unsigned int odim = 0; odim < NDimensions; odim++)
+      for (unsigned int odim = 0; odim < NDimensions; ++odim)
       {
         opp[odim] += Gmatrix(dim, odim) * this->m_DMatrix(dim, lnd);
       }
@@ -423,10 +423,10 @@ KernelTransform2<TScalarType, NDimensions>::ComputeP(void)
   this->m_PMatrix.set_size(NDimensions * numberOfLandmarks, NDimensions * (NDimensions + 1));
   this->m_PMatrix.fill(0.0f);
 
-  for (unsigned long i = 0; i < numberOfLandmarks; i++)
+  for (unsigned long i = 0; i < numberOfLandmarks; ++i)
   {
     this->m_SourceLandmarks->GetPoint(i, &p);
-    for (unsigned int j = 0; j < NDimensions; j++)
+    for (unsigned int j = 0; j < NDimensions; ++j)
     {
       temp = I * p[j];
       this->m_PMatrix.update(temp_ref, i * NDimensions, j * NDimensions);
@@ -454,16 +454,16 @@ KernelTransform2<TScalarType, NDimensions>::ComputeY(void)
   this->m_YMatrix.set_size(NDimensions * (numberOfLandmarks + NDimensions + 1), 1);
   this->m_YMatrix.fill(0.0);
 
-  for (unsigned long i = 0; i < numberOfLandmarks; i++)
+  for (unsigned long i = 0; i < numberOfLandmarks; ++i)
   {
-    for (unsigned int j = 0; j < NDimensions; j++)
+    for (unsigned int j = 0; j < NDimensions; ++j)
     {
       this->m_YMatrix.put(i * NDimensions + j, 0, displacement.Value()[j]);
     }
     displacement++;
   }
 
-  for (unsigned int i = 0; i < NDimensions * (NDimensions + 1); i++)
+  for (unsigned int i = 0; i < NDimensions * (NDimensions + 1); ++i)
   {
     this->m_YMatrix.put(numberOfLandmarks * NDimensions + i, 0, 0);
   }
@@ -485,25 +485,25 @@ KernelTransform2<TScalarType, NDimensions>::ReorganizeW(void)
   this->m_DMatrix.set_size(NDimensions, numberOfLandmarks);
   unsigned int ci = 0;
 
-  for (unsigned long lnd = 0; lnd < numberOfLandmarks; lnd++)
+  for (unsigned long lnd = 0; lnd < numberOfLandmarks; ++lnd)
   {
-    for (unsigned int dim = 0; dim < NDimensions; dim++)
+    for (unsigned int dim = 0; dim < NDimensions; ++dim)
     {
       this->m_DMatrix(dim, lnd) = this->m_WMatrix(ci++, 0);
     }
   }
 
   // This matrix holds the rotational part of the Affine component
-  for (unsigned int j = 0; j < NDimensions; j++)
+  for (unsigned int j = 0; j < NDimensions; ++j)
   {
-    for (unsigned int i = 0; i < NDimensions; i++)
+    for (unsigned int i = 0; i < NDimensions; ++i)
     {
       this->m_AMatrix(i, j) = this->m_WMatrix(ci++, 0);
     }
   }
 
   // This vector holds the translational part of the Affine component
-  for (unsigned int k = 0; k < NDimensions; k++)
+  for (unsigned int k = 0; k < NDimensions; ++k)
   {
     this->m_BVector(k) = this->m_WMatrix(ci++, 0);
   }
@@ -528,16 +528,16 @@ KernelTransform2<TScalarType, NDimensions>::TransformPoint(const InputPointType 
   this->ComputeDeformationContribution(thisPoint, opp);
 
   // Add the rotational part of the Affine component
-  for (unsigned int j = 0; j < NDimensions; j++)
+  for (unsigned int j = 0; j < NDimensions; ++j)
   {
-    for (unsigned int i = 0; i < NDimensions; i++)
+    for (unsigned int i = 0; i < NDimensions; ++i)
     {
       opp[i] += this->m_AMatrix(i, j) * thisPoint[j];
     }
   }
 
   // This vector holds the translational part of the Affine component
-  for (unsigned int k = 0; k < NDimensions; k++)
+  for (unsigned int k = 0; k < NDimensions; ++k)
   {
     opp[k] += this->m_BVector(k) + thisPoint[k];
   }
@@ -588,7 +588,7 @@ KernelTransform2<TScalarType, NDimensions>::SetParameters(const ParametersType &
 
   while (itr != end)
   {
-    for (unsigned int dim = 0; dim < NDimensions; dim++)
+    for (unsigned int dim = 0; dim < NDimensions; ++dim)
     {
       landMark[dim] = parameters[pcounter];
       pcounter++;
@@ -633,7 +633,7 @@ KernelTransform2<TScalarType, NDimensions>::SetFixedParameters(const ParametersT
 
   while (itr != end)
   {
-    for (unsigned int dim = 0; dim < NDimensions; dim++)
+    for (unsigned int dim = 0; dim < NDimensions; ++dim)
     {
       landMark[dim] = parameters[pcounter];
       pcounter++;
@@ -673,7 +673,7 @@ KernelTransform2<TScalarType, NDimensions>::UpdateParameters(void)
   while (itr != end)
   {
     InputPointType landmark = itr.Value();
-    for (unsigned int dim = 0; dim < NDimensions; dim++)
+    for (unsigned int dim = 0; dim < NDimensions; ++dim)
     {
       this->m_Parameters[pcounter] = landmark[dim];
       pcounter++;
@@ -711,7 +711,7 @@ KernelTransform2<TScalarType, NDimensions>::GetFixedParameters(void) const
   while (itr != end)
   {
     InputPointType landmark = itr.Value();
-    for (unsigned int dim = 0; dim < NDimensions; dim++)
+    for (unsigned int dim = 0; dim < NDimensions; ++dim)
     {
       this->m_FixedParameters[pcounter] = landmark[dim];
       pcounter++;
@@ -742,14 +742,14 @@ KernelTransform2<TScalarType, NDimensions>::GetJacobian(const InputPointType &  
   // General route working for all kernels (but slow)
   if (!this->m_FastComputationPossible)
   {
-    for (unsigned int lnd = 0; lnd < numberOfLandmarks; lnd++)
+    for (unsigned int lnd = 0; lnd < numberOfLandmarks; ++lnd)
     {
       this->ComputeG(p - sp->Value(), Gmatrix);
-      for (unsigned int dim = 0; dim < NDimensions; dim++)
+      for (unsigned int dim = 0; dim < NDimensions; ++dim)
       {
-        for (unsigned int odim = 0; odim < NDimensions; odim++)
+        for (unsigned int odim = 0; odim < NDimensions; ++odim)
         {
-          for (unsigned int lidx = 0; lidx < numberOfLandmarks * NDimensions; lidx++)
+          for (unsigned int lidx = 0; lidx < numberOfLandmarks * NDimensions; ++lidx)
           {
             jac[odim][lidx] += Gmatrix(dim, odim) * this->m_LMatrixInverse[lnd * NDimensions + dim][lidx];
           }
@@ -758,11 +758,11 @@ KernelTransform2<TScalarType, NDimensions>::GetJacobian(const InputPointType &  
       ++sp;
     }
 
-    for (unsigned int odim = 0; odim < NDimensions; odim++)
+    for (unsigned int odim = 0; odim < NDimensions; ++odim)
     {
-      for (unsigned long lidx = 0; lidx < numberOfLandmarks * NDimensions; lidx++)
+      for (unsigned long lidx = 0; lidx < numberOfLandmarks * NDimensions; ++lidx)
       {
-        for (unsigned int dim = 0; dim < NDimensions; dim++)
+        for (unsigned int dim = 0; dim < NDimensions; ++dim)
         {
           jac[odim][lidx] += p[dim] * this->m_LMatrixInverse[(numberOfLandmarks + dim) * NDimensions + odim][lidx];
         }
@@ -795,7 +795,7 @@ KernelTransform2<TScalarType, NDimensions>::GetJacobian(const InputPointType &  
   {
     // Precompute G's.
     std::vector<ScalarType> gVector(numberOfLandmarks);
-    for (unsigned int lnd = 0; lnd < numberOfLandmarks; lnd++)
+    for (unsigned int lnd = 0; lnd < numberOfLandmarks; ++lnd)
     {
       // Property A: G = G(0,0) * I_d.
       this->ComputeG(p - sp->Value(), Gmatrix);
@@ -805,7 +805,7 @@ KernelTransform2<TScalarType, NDimensions>::GetJacobian(const InputPointType &  
 
     // Deformation part of the transform:
     sp = this->m_SourceLandmarks->GetPoints()->Begin();
-    for (unsigned int lnd = 0; lnd < numberOfLandmarks; lnd++)
+    for (unsigned int lnd = 0; lnd < numberOfLandmarks; ++lnd)
     {
       // Property A: G = G(0,0) * I_d.
       ScalarType g = gVector[lnd];
@@ -814,13 +814,13 @@ KernelTransform2<TScalarType, NDimensions>::GetJacobian(const InputPointType &  
       unsigned int lIdx = lnd * NDimensions;
       ScalarType   linv = this->m_LMatrixInverse[lIdx][lIdx];
       // Property B: only access non-zero values
-      for (unsigned int dim = 0; dim < NDimensions; dim++)
+      for (unsigned int dim = 0; dim < NDimensions; ++dim)
       {
         jac[dim][lIdx + dim] += g * linv;
       }
 
       // Property C: Then process right of diagonal
-      for (unsigned int lidx = lnd + 1; lidx < numberOfLandmarks; lidx++)
+      for (unsigned int lidx = lnd + 1; lidx < numberOfLandmarks; ++lidx)
       {
         // Property C: Get G value at mirrored position
         ScalarType gSym = gVector[lidx];
@@ -830,7 +830,7 @@ KernelTransform2<TScalarType, NDimensions>::GetJacobian(const InputPointType &  
         ScalarType   linv = this->m_LMatrixInverse[lnd * NDimensions][lIdx];
 
         // Property B: only access non-zero values
-        for (unsigned int dim = 0; dim < NDimensions; dim++)
+        for (unsigned int dim = 0; dim < NDimensions; ++dim)
         {
           jac[dim][lIdx + dim] += g * linv;
           // Property C: mirroring
@@ -843,14 +843,14 @@ KernelTransform2<TScalarType, NDimensions>::GetJacobian(const InputPointType &  
     }
 
     // Affine part of the transform:
-    for (unsigned int odim = 0; odim < NDimensions; odim++)
+    for (unsigned int odim = 0; odim < NDimensions; ++odim)
     {
       const unsigned long index = (numberOfLandmarks + NDimensions) * NDimensions + odim;
 
-      for (unsigned long lidx = 0; lidx < numberOfLandmarks * NDimensions; lidx++)
+      for (unsigned long lidx = 0; lidx < numberOfLandmarks * NDimensions; ++lidx)
       {
         ScalarType tmp = 0.0;
-        for (unsigned int dim = 0; dim < NDimensions; dim++)
+        for (unsigned int dim = 0; dim < NDimensions; ++dim)
         {
           unsigned int indtmp = (numberOfLandmarks + dim) * NDimensions + odim;
           tmp += p[dim] * this->m_LMatrixInverse[indtmp][lidx];

--- a/Components/Transforms/SplineKernelTransform/itkThinPlateR2LogRSplineKernelTransform2.hxx
+++ b/Components/Transforms/SplineKernelTransform/itkThinPlateR2LogRSplineKernelTransform2.hxx
@@ -62,12 +62,12 @@ ThinPlateR2LogRSplineKernelTransform2<TScalarType, NDimensions>::ComputeDeformat
 
   PointsIterator sp = this->m_SourceLandmarks->GetPoints()->Begin();
 
-  for (unsigned int lnd = 0; lnd < numberOfLandmarks; lnd++)
+  for (unsigned int lnd = 0; lnd < numberOfLandmarks; ++lnd)
   {
     InputVectorType   position = thisPoint - sp->Value();
     const TScalarType r = position.GetNorm();
     const TScalarType R2logR = (r > 1e-8) ? r * r * std::log(r) : NumericTraits<TScalarType>::Zero;
-    for (unsigned int odim = 0; odim < NDimensions; odim++)
+    for (unsigned int odim = 0; odim < NDimensions; ++odim)
     {
       result[odim] += R2logR * this->m_DMatrix(odim, lnd);
     }

--- a/Components/Transforms/SplineKernelTransform/itkThinPlateSplineKernelTransform2.hxx
+++ b/Components/Transforms/SplineKernelTransform/itkThinPlateSplineKernelTransform2.hxx
@@ -68,12 +68,12 @@ ThinPlateSplineKernelTransform2<TScalarType, NDimensions>::ComputeDeformationCon
   const unsigned long numberOfLandmarks = this->m_SourceLandmarks->GetNumberOfPoints();
   PointsIterator      sp = this->m_SourceLandmarks->GetPoints()->Begin();
 
-  for (unsigned long lnd = 0; lnd < numberOfLandmarks; lnd++)
+  for (unsigned long lnd = 0; lnd < numberOfLandmarks; ++lnd)
   {
     InputVectorType   position = thisPoint - sp->Value();
     const TScalarType r = position.GetNorm();
 
-    for (unsigned int odim = 0; odim < NDimensions; odim++)
+    for (unsigned int odim = 0; odim < NDimensions; ++odim)
     {
       opp[odim] += r * this->m_DMatrix(odim, lnd);
     }

--- a/Components/Transforms/SplineKernelTransform/itkVolumeSplineKernelTransform2.hxx
+++ b/Components/Transforms/SplineKernelTransform/itkVolumeSplineKernelTransform2.hxx
@@ -63,13 +63,13 @@ VolumeSplineKernelTransform2<TScalarType, NDimensions>::ComputeDeformationContri
   const unsigned long numberOfLandmarks = this->m_SourceLandmarks->GetNumberOfPoints();
   PointsIterator      sp = this->m_SourceLandmarks->GetPoints()->Begin();
 
-  for (unsigned int lnd = 0; lnd < numberOfLandmarks; lnd++)
+  for (unsigned int lnd = 0; lnd < numberOfLandmarks; ++lnd)
   {
     InputVectorType   position = thisPoint - sp->Value();
     const TScalarType r = position.GetNorm();
     const TScalarType r3 = r * r * r;
 
-    for (unsigned int odim = 0; odim < NDimensions; odim++)
+    for (unsigned int odim = 0; odim < NDimensions; ++odim)
     {
       opp[odim] += r3 * this->m_DMatrix(odim, lnd);
     }

--- a/Components/Transforms/TranslationTransform/itkTranslationTransformInitializer.hxx
+++ b/Components/Transforms/TranslationTransform/itkTranslationTransformInitializer.hxx
@@ -111,7 +111,7 @@ TranslationTransformInitializer<TTransform, TFixedImage, TMovingImage>::Initiali
     typename MovingImageCalculatorType::VectorType movingCenter = this->m_MovingCalculator->GetCenterOfGravity();
 
     // Compute the difference between the centers
-    for (unsigned int i = 0; i < InputSpaceDimension; i++)
+    for (unsigned int i = 0; i < InputSpaceDimension; ++i)
     {
       translationVector[i] = movingCenter[i] - fixedCenter[i];
     }
@@ -134,7 +134,7 @@ TranslationTransformInitializer<TTransform, TFixedImage, TMovingImage>::Initiali
 
     // Compute center of the fixed image (mask bounding box) in physical units
     ContinuousIndex<double, InputSpaceDimension> fixedCenterCI;
-    for (unsigned int k = 0; k < InputSpaceDimension; k++)
+    for (unsigned int k = 0; k < InputSpaceDimension; ++k)
     {
       fixedCenterCI[k] = fixedRegion.GetIndex()[k] + fixedRegion.GetSize()[k] / 2.0;
     }
@@ -153,7 +153,7 @@ TranslationTransformInitializer<TTransform, TFixedImage, TMovingImage>::Initiali
 
     // Compute center of the moving image (mask bounding box) in physical units
     ContinuousIndex<double, InputSpaceDimension> movingCenterCI;
-    for (unsigned int k = 0; k < InputSpaceDimension; k++)
+    for (unsigned int k = 0; k < InputSpaceDimension; ++k)
     {
       movingCenterCI[k] = movingRegion.GetIndex()[k] + movingRegion.GetSize()[k] / 2.0;
     }
@@ -161,7 +161,7 @@ TranslationTransformInitializer<TTransform, TFixedImage, TMovingImage>::Initiali
     this->m_MovingImage->TransformContinuousIndexToPhysicalPoint(movingCenterCI, centerMoving);
 
     // Compute the difference between the centers
-    for (unsigned int i = 0; i < InputSpaceDimension; i++)
+    for (unsigned int i = 0; i < InputSpaceDimension; ++i)
     {
       translationVector[i] = centerMoving[i] - centerFixed[i];
     }

--- a/Components/Transforms/WeightedCombinationTransform/elxWeightedCombinationTransform.hxx
+++ b/Components/Transforms/WeightedCombinationTransform/elxWeightedCombinationTransform.hxx
@@ -162,7 +162,7 @@ WeightedCombinationTransformElastix<TElastix>::SetScales(void)
       /** Read the user-supplied values/ */
       std::vector<double> newscalesvec(N);
       this->m_Configuration->ReadParameter(newscalesvec, "Scales", 0, N - 1, true);
-      for (unsigned int i = 0; i < N; i++)
+      for (unsigned int i = 0; i < N; ++i)
       {
         newscales[i] = newscalesvec[i];
       }

--- a/Core/ComponentBaseClasses/elxFixedImagePyramidBase.hxx
+++ b/Core/ComponentBaseClasses/elxFixedImagePyramidBase.hxx
@@ -113,9 +113,9 @@ FixedImagePyramidBase<TElastix>::SetFixedSchedule(void)
    * FixedImagePyramid<i>Schedule, for the i-th fixed image pyramid used.
    */
   bool found = true;
-  for (unsigned int i = 0; i < numberOfResolutions; i++)
+  for (unsigned int i = 0; i < numberOfResolutions; ++i)
   {
-    for (unsigned int j = 0; j < FixedImageDimension; j++)
+    for (unsigned int j = 0; j < FixedImageDimension; ++j)
     {
       bool               ijfound = false;
       const unsigned int entrynr = i * FixedImageDimension + j;

--- a/Core/ComponentBaseClasses/elxMetricBase.hxx
+++ b/Core/ComponentBaseClasses/elxMetricBase.hxx
@@ -80,7 +80,7 @@ MetricBase<TElastix>::BeforeEachResolutionBase(void)
 
     /** Read the desired grid spacing of the samples. */
     unsigned int spacing_dim;
-    for (unsigned int dim = 0; dim < FixedImageDimension; dim++)
+    for (unsigned int dim = 0; dim < FixedImageDimension; ++dim)
     {
       spacing_dim = this->m_ExactMetricSampleGridSpacing[dim];
       this->GetConfiguration()->ReadParameter(

--- a/Core/ComponentBaseClasses/elxMovingImagePyramidBase.hxx
+++ b/Core/ComponentBaseClasses/elxMovingImagePyramidBase.hxx
@@ -115,9 +115,9 @@ MovingImagePyramidBase<TElastix>::SetMovingSchedule(void)
    * MovingImagePyramid<i>Schedule, for the i-th moving image pyramid used.
    */
   bool found = true;
-  for (unsigned int i = 0; i < numberOfResolutions; i++)
+  for (unsigned int i = 0; i < numberOfResolutions; ++i)
   {
-    for (unsigned int j = 0; j < MovingImageDimension; j++)
+    for (unsigned int j = 0; j < MovingImageDimension; ++j)
     {
       bool               ijfound = false;
       const unsigned int entrynr = i * MovingImageDimension + j;

--- a/Core/ComponentBaseClasses/elxResamplerBase.hxx
+++ b/Core/ComponentBaseClasses/elxResamplerBase.hxx
@@ -607,7 +607,7 @@ ResamplerBase<TElastix>::ReadFromFile(void)
   SizeType        size;
   DirectionType   direction;
   direction.SetIdentity();
-  for (unsigned int i = 0; i < ImageDimension; i++)
+  for (unsigned int i = 0; i < ImageDimension; ++i)
   {
     /** No default size. Read size from the parameter file. */
     this->m_Configuration->ReadParameter(size[i], "Size", i);
@@ -625,7 +625,7 @@ ResamplerBase<TElastix>::ReadFromFile(void)
     this->m_Configuration->ReadParameter(origin[i], "Origin", i);
 
     /** Read direction cosines. Default identity */
-    for (unsigned int j = 0; j < ImageDimension; j++)
+    for (unsigned int j = 0; j < ImageDimension; ++j)
     {
       this->m_Configuration->ReadParameter(direction(j, i), "Direction", i * ImageDimension + j);
     }
@@ -633,7 +633,7 @@ ResamplerBase<TElastix>::ReadFromFile(void)
 
   /** Check for image size. */
   unsigned int sum = 0;
-  for (unsigned int i = 0; i < ImageDimension; i++)
+  for (unsigned int i = 0; i < ImageDimension; ++i)
   {
     if (size[i] == 0)
     {

--- a/Core/ComponentBaseClasses/elxTransformBase.hxx
+++ b/Core/ComponentBaseClasses/elxTransformBase.hxx
@@ -391,7 +391,7 @@ TransformBase<TElastix>::ReadFromFile(void)
       {
         // NOTE: we could avoid this by directly reading into the transform parameters,
         // e.g. by overloading ReadParameter(), or use swap (?).
-        for (unsigned int i = 0; i < numberOfParameters; i++)
+        for (unsigned int i = 0; i < numberOfParameters; ++i)
         {
           (*(this->m_TransformParametersPointer))[i] = vecPar[i];
         }
@@ -859,7 +859,7 @@ TransformBase<TElastix>::TransformPointsSomePoints(const std::string & filename)
   /** Read the input points, as index or as point. */
   if (!(ippReader->GetPointsAreIndices()))
   {
-    for (unsigned int j = 0; j < nrofpoints; j++)
+    for (unsigned int j = 0; j < nrofpoints; ++j)
     {
       /** Compute index of nearest voxel in fixed image. */
       InputPointType point;
@@ -867,7 +867,7 @@ TransformBase<TElastix>::TransformPointsSomePoints(const std::string & filename)
       inputPointSet->GetPoint(j, &point);
       inputpointvec[j] = point;
       dummyImage->TransformPhysicalPointToContinuousIndex(point, fixedcindex);
-      for (unsigned int i = 0; i < FixedImageDimension; i++)
+      for (unsigned int i = 0; i < FixedImageDimension; ++i)
       {
         inputindexvec[j][i] = static_cast<FixedImageIndexValueType>(itk::Math::Round<double>(fixedcindex[i]));
       }
@@ -875,7 +875,7 @@ TransformBase<TElastix>::TransformPointsSomePoints(const std::string & filename)
   }
   else // so: inputasindex
   {
-    for (unsigned int j = 0; j < nrofpoints; j++)
+    for (unsigned int j = 0; j < nrofpoints; ++j)
     {
       /** The read point from the inutPointSet is actually an index
        * Cast to the proper type.
@@ -883,7 +883,7 @@ TransformBase<TElastix>::TransformPointsSomePoints(const std::string & filename)
       InputPointType point;
       point.Fill(0.0f);
       inputPointSet->GetPoint(j, &point);
-      for (unsigned int i = 0; i < FixedImageDimension; i++)
+      for (unsigned int i = 0; i < FixedImageDimension; ++i)
       {
         inputindexvec[j][i] = static_cast<FixedImageIndexValueType>(itk::Math::Round<double>(point[i]));
       }
@@ -894,14 +894,14 @@ TransformBase<TElastix>::TransformPointsSomePoints(const std::string & filename)
 
   /** Apply the transform. */
   elxout << "  The input points are transformed." << std::endl;
-  for (unsigned int j = 0; j < nrofpoints; j++)
+  for (unsigned int j = 0; j < nrofpoints; ++j)
   {
     /** Call TransformPoint. */
     outputpointvec[j] = this->GetAsITKBaseType()->TransformPoint(inputpointvec[j]);
 
     /** Transform back to index in fixed image domain. */
     dummyImage->TransformPhysicalPointToContinuousIndex(outputpointvec[j], fixedcindex);
-    for (unsigned int i = 0; i < FixedImageDimension; i++)
+    for (unsigned int i = 0; i < FixedImageDimension; ++i)
     {
       outputindexfixedvec[j][i] = static_cast<FixedImageIndexValueType>(itk::Math::Round<double>(fixedcindex[i]));
     }
@@ -910,7 +910,7 @@ TransformBase<TElastix>::TransformPointsSomePoints(const std::string & filename)
     {
       /** Transform back to index in moving image domain. */
       movingImage->TransformPhysicalPointToContinuousIndex(outputpointvec[j], movingcindex);
-      for (unsigned int i = 0; i < MovingImageDimension; i++)
+      for (unsigned int i = 0; i < MovingImageDimension; ++i)
       {
         outputindexmovingvec[j][i] = static_cast<MovingImageIndexValueType>(itk::Math::Round<double>(movingcindex[i]));
       }
@@ -928,39 +928,39 @@ TransformBase<TElastix>::TransformPointsSomePoints(const std::string & filename)
   elxout << "  The transformed points are saved in: " << outputPointsFileName << std::endl;
 
   /** Print the results. */
-  for (unsigned int j = 0; j < nrofpoints; j++)
+  for (unsigned int j = 0; j < nrofpoints; ++j)
   {
     /** The input index. */
     outputPointsFile << "Point\t" << j << "\t; InputIndex = [ ";
-    for (unsigned int i = 0; i < FixedImageDimension; i++)
+    for (unsigned int i = 0; i < FixedImageDimension; ++i)
     {
       outputPointsFile << inputindexvec[j][i] << " ";
     }
 
     /** The input point. */
     outputPointsFile << "]\t; InputPoint = [ ";
-    for (unsigned int i = 0; i < FixedImageDimension; i++)
+    for (unsigned int i = 0; i < FixedImageDimension; ++i)
     {
       outputPointsFile << inputpointvec[j][i] << " ";
     }
 
     /** The output index in fixed image. */
     outputPointsFile << "]\t; OutputIndexFixed = [ ";
-    for (unsigned int i = 0; i < FixedImageDimension; i++)
+    for (unsigned int i = 0; i < FixedImageDimension; ++i)
     {
       outputPointsFile << outputindexfixedvec[j][i] << " ";
     }
 
     /** The output point. */
     outputPointsFile << "]\t; OutputPoint = [ ";
-    for (unsigned int i = 0; i < FixedImageDimension; i++)
+    for (unsigned int i = 0; i < FixedImageDimension; ++i)
     {
       outputPointsFile << outputpointvec[j][i] << " ";
     }
 
     /** The output point minus the input point. */
     outputPointsFile << "]\t; Deformation = [ ";
-    for (unsigned int i = 0; i < MovingImageDimension; i++)
+    for (unsigned int i = 0; i < MovingImageDimension; ++i)
     {
       outputPointsFile << deformationvec[j][i] << " ";
     }
@@ -969,7 +969,7 @@ TransformBase<TElastix>::TransformPointsSomePoints(const std::string & filename)
     {
       /** The output index in moving image. */
       outputPointsFile << "]\t; OutputIndexMoving = [ ";
-      for (unsigned int i = 0; i < MovingImageDimension; i++)
+      for (unsigned int i = 0; i < MovingImageDimension; ++i)
       {
         outputPointsFile << outputindexmovingvec[j][i] << " ";
       }

--- a/Core/Kernel/elxElastixTemplate.hxx
+++ b/Core/Kernel/elxElastixTemplate.hxx
@@ -1055,9 +1055,9 @@ ElastixTemplate<TFixedImage, TMovingImage>::GetOriginalFixedImageDirection(Fixed
     /** Try to read direction cosines from (transform-)parameter file. */
     bool                    retdc = true;
     FixedImageDirectionType directionRead = direction;
-    for (unsigned int i = 0; i < FixedDimension; i++)
+    for (unsigned int i = 0; i < FixedDimension; ++i)
     {
-      for (unsigned int j = 0; j < FixedDimension; j++)
+      for (unsigned int j = 0; j < FixedDimension; ++j)
       {
         retdc &= this->m_Configuration->ReadParameter(directionRead(j, i), "Direction", i * FixedDimension + j, false);
       }
@@ -1072,9 +1072,9 @@ ElastixTemplate<TFixedImage, TMovingImage>::GetOriginalFixedImageDirection(Fixed
   /** Only trust this when the fixed image exists. */
   if (this->m_OriginalFixedImageDirection.size() == FixedDimension * FixedDimension)
   {
-    for (unsigned int i = 0; i < FixedDimension; i++)
+    for (unsigned int i = 0; i < FixedDimension; ++i)
     {
-      for (unsigned int j = 0; j < FixedDimension; j++)
+      for (unsigned int j = 0; j < FixedDimension; ++j)
       {
         direction(j, i) = this->m_OriginalFixedImageDirection[i * FixedDimension + j];
       }
@@ -1098,9 +1098,9 @@ ElastixTemplate<TFixedImage, TMovingImage>::SetOriginalFixedImageDirection(const
 {
   /** flatten to 1d array */
   this->m_OriginalFixedImageDirection.resize(FixedDimension * FixedDimension);
-  for (unsigned int i = 0; i < FixedDimension; i++)
+  for (unsigned int i = 0; i < FixedDimension; ++i)
   {
-    for (unsigned int j = 0; j < FixedDimension; j++)
+    for (unsigned int j = 0; j < FixedDimension; ++j)
     {
       this->m_OriginalFixedImageDirection[i * FixedDimension + j] = arg(j, i);
     }

--- a/Core/Main/elxParameterObject.cxx
+++ b/Core/Main/elxParameterObject.cxx
@@ -119,7 +119,7 @@ ParameterObject::SetParameter(const unsigned int &             index,
 void
 ParameterObject::SetParameter(const ParameterKeyType & key, const ParameterValueType & value)
 {
-  for (unsigned int index = 0; index < this->GetNumberOfParameterMaps(); index++)
+  for (unsigned int index = 0; index < this->GetNumberOfParameterMaps(); ++index)
   {
     this->SetParameter(index, key, value);
   }
@@ -133,7 +133,7 @@ ParameterObject::SetParameter(const ParameterKeyType & key, const ParameterValue
 void
 ParameterObject::SetParameter(const ParameterKeyType & key, const ParameterValueVectorType & value)
 {
-  for (unsigned int index = 0; index < this->GetNumberOfParameterMaps(); index++)
+  for (unsigned int index = 0; index < this->GetNumberOfParameterMaps(); ++index)
   {
     this->SetParameter(index, key, value);
   }
@@ -169,7 +169,7 @@ ParameterObject::RemoveParameter(const unsigned int & index, const ParameterKeyT
 void
 ParameterObject::RemoveParameter(const ParameterKeyType & key)
 {
-  for (unsigned int index = 0; index < this->GetNumberOfParameterMaps(); index++)
+  for (unsigned int index = 0; index < this->GetNumberOfParameterMaps(); ++index)
   {
     this->RemoveParameter(index, key);
   }

--- a/Core/Main/elxTransformixFilter.hxx
+++ b/Core/Main/elxTransformixFilter.hxx
@@ -318,13 +318,13 @@ TransformixFilter<TMovingImage>::GenerateOutputInformation(void)
   typename TMovingImage::PointType     outputOrigin;
   typename TMovingImage::DirectionType outputDirection;
 
-  for (unsigned int i = 0; i < TMovingImage::ImageDimension; i++)
+  for (unsigned int i = 0; i < TMovingImage::ImageDimension; ++i)
   {
     outputSpacing[i] = std::atof(spacingStrings[i].c_str());
     outputSize[i] = std::atoi(sizeStrings[i].c_str());
     outputStartIndex[i] = std::atoi(indexStrings[i].c_str());
     outputOrigin[i] = std::atof(originStrings[i].c_str());
-    for (unsigned int j = 0; j < TMovingImage::ImageDimension; j++)
+    for (unsigned int j = 0; j < TMovingImage::ImageDimension; ++j)
     {
       outputDirection(j, i) = std::atof(directionStrings[i * TMovingImage::ImageDimension + j].c_str());
     }

--- a/Core/Main/itkTransformixFilter.hxx
+++ b/Core/Main/itkTransformixFilter.hxx
@@ -314,13 +314,13 @@ TransformixFilter<TMovingImage>::GenerateOutputInformation()
   typename TMovingImage::PointType     outputOrigin;
   typename TMovingImage::DirectionType outputDirection;
 
-  for (unsigned int i = 0; i < TMovingImage::ImageDimension; i++)
+  for (unsigned int i = 0; i < TMovingImage::ImageDimension; ++i)
   {
     outputSpacing[i] = std::atof(spacingStrings[i].c_str());
     outputSize[i] = std::atoi(sizeStrings[i].c_str());
     outputStartIndex[i] = std::atoi(indexStrings[i].c_str());
     outputOrigin[i] = std::atof(originStrings[i].c_str());
-    for (unsigned int j = 0; j < TMovingImage::ImageDimension; j++)
+    for (unsigned int j = 0; j < TMovingImage::ImageDimension; ++j)
     {
       outputDirection(j, i) = std::atof(directionStrings[i * TMovingImage::ImageDimension + j].c_str());
     }

--- a/Testing/elxInvertTransform.cxx
+++ b/Testing/elxInvertTransform.cxx
@@ -168,14 +168,14 @@ main(int argc, char * argv[])
 
   /** Convert to ParametersType. */
   ParametersType transformParameters(numberOfParameters);
-  for (unsigned int i = 0; i < numberOfParameters; i++)
+  for (unsigned int i = 0; i < numberOfParameters; ++i)
   {
     transformParameters[i] = vecPar[i];
   }
 
   /** Get center of rotation. */
   CenterType centerOfRotation;
-  for (unsigned int i = 0; i < Dimension; i++)
+  for (unsigned int i = 0; i < Dimension; ++i)
   {
     config->ReadParameter(centerOfRotation[i], "CenterOfRotationPoint", i, dummyErrorMessage);
   }
@@ -260,7 +260,7 @@ main(int argc, char * argv[])
 
   /** In this case, write in a normal way to the parameter file. */
   outputTPFile << "(TransformParameters ";
-  for (unsigned int i = 0; i < numberOfParameters - 1; i++)
+  for (unsigned int i = 0; i < numberOfParameters - 1; ++i)
   {
     outputTPFile << transformParametersInv[i] << " ";
   }
@@ -287,7 +287,7 @@ main(int argc, char * argv[])
 
   /** Write image Size. */
   outputTPFile << "(Size ";
-  for (unsigned int i = 0; i < MovDim - 1; i++)
+  for (unsigned int i = 0; i < MovDim - 1; ++i)
   {
     outputTPFile << imageIOBase->GetDimensions(i) << " ";
   }
@@ -295,7 +295,7 @@ main(int argc, char * argv[])
 
   /** Write image Index. */
   outputTPFile << "(Index";
-  for (unsigned int i = 0; i < MovDim; i++)
+  for (unsigned int i = 0; i < MovDim; ++i)
   {
     outputTPFile << " 0";
   }
@@ -308,7 +308,7 @@ main(int argc, char * argv[])
 
   /** Write image Spacing. */
   outputTPFile << "(Spacing ";
-  for (unsigned int i = 0; i < MovDim - 1; i++)
+  for (unsigned int i = 0; i < MovDim - 1; ++i)
   {
     outputTPFile << imageIOBase->GetSpacing(i) << " ";
   }
@@ -316,7 +316,7 @@ main(int argc, char * argv[])
 
   /** Write image Origin. */
   outputTPFile << "(Origin ";
-  for (unsigned int i = 0; i < MovDim - 1; i++)
+  for (unsigned int i = 0; i < MovDim - 1; ++i)
   {
     outputTPFile << imageIOBase->GetOrigin(i) << " ";
   }
@@ -324,9 +324,9 @@ main(int argc, char * argv[])
 
   /** Write direction cosines. */
   outputTPFile << "(Direction";
-  for (unsigned int i = 0; i < MovDim; i++)
+  for (unsigned int i = 0; i < MovDim; ++i)
   {
-    for (unsigned int j = 0; j < MovDim; j++)
+    for (unsigned int j = 0; j < MovDim; ++j)
     {
       outputTPFile << " " << imageIOBase->GetDirection(i)[j];
     }
@@ -371,7 +371,7 @@ main(int argc, char * argv[])
   /** Write to file. */
   outputTPFile << "\n// " << transformType << " specific\n";
   outputTPFile << "(CenterOfRotationPoint";
-  for (unsigned int i = 0; i < Dimension; i++)
+  for (unsigned int i = 0; i < Dimension; ++i)
   {
     outputTPFile << " " << centerOfRotationInv[i];
   }

--- a/Testing/elxTransformParametersCompare.cxx
+++ b/Testing/elxTransformParametersCompare.cxx
@@ -192,7 +192,7 @@ main(int argc, char ** argv)
   if (transformName != "BSplineTransform")
   {
     /** Now compare the two parameter vectors. */
-    for (unsigned int i = 0; i < numberOfParametersTest; i++)
+    for (unsigned int i = 0; i < numberOfParametersTest; ++i)
     {
       baselineNorm += vnl_math::sqr(parametersBaseline[i]);
       diffNorm += vnl_math::sqr(parametersBaseline[i] - parametersTest[i]);
@@ -220,13 +220,13 @@ main(int argc, char ** argv)
     gridOrigin.Fill(0.0);
     DirectionType gridDirection;
     gridDirection.SetIdentity();
-    for (unsigned int i = 0; i < dimension; i++)
+    for (unsigned int i = 0; i < dimension; ++i)
     {
       config->ReadParameter(gridSize[i], "GridSize", i, true, dummyErrorMessage);
       config->ReadParameter(gridIndex[i], "GridIndex", i, true, dummyErrorMessage);
       config->ReadParameter(gridSpacing[i], "GridSpacing", i, true, dummyErrorMessage);
       config->ReadParameter(gridOrigin[i], "GridOrigin", i, true, dummyErrorMessage);
-      for (unsigned int j = 0; j < dimension; j++)
+      for (unsigned int j = 0; j < dimension; ++j)
       {
         config->ReadParameter(gridDirection(j, i), "GridDirection", i * dimension + j, true, dummyErrorMessage);
       }
@@ -272,7 +272,7 @@ main(int argc, char ** argv)
     {
       /** Voxel content. */
       ScalarType diffNormTmp = itk::NumericTraits<ScalarType>::Zero;
-      for (unsigned int i = 0; i < dimension; i++)
+      for (unsigned int i = 0; i < dimension; ++i)
       {
         unsigned int j = index + i * numberParPerDim;
         diffNormTmp += vnl_math::sqr(parametersBaseline[j] - parametersTest[j]);
@@ -294,7 +294,7 @@ main(int argc, char ** argv)
         }
       } // end mask
 
-      for (unsigned int i = 0; i < dimension; i++)
+      for (unsigned int i = 0; i < dimension; ++i)
       {
         unsigned int j = index + i * numberParPerDim;
         baselineNorm += include * vnl_math::sqr(parametersBaseline[j]);

--- a/Testing/itkAccumulateDerivativesParallellizationTest.cxx
+++ b/Testing/itkAccumulateDerivativesParallellizationTest.cxx
@@ -106,7 +106,7 @@ public:
     if (!this->m_UseMultiThreaded) // single threadedly
     {
       derivative = this->m_ThreaderDerivatives[0] * normal_sum;
-      for (ThreadIdType i = 1; i < this->m_NumberOfThreads; i++)
+      for (ThreadIdType i = 1; i < this->m_NumberOfThreads; ++i)
       {
         derivative += this->m_ThreaderDerivatives[i] * normal_sum;
       }

--- a/Testing/itkAdvanceOneStepParallellizationTest.cxx
+++ b/Testing/itkAdvanceOneStepParallellizationTest.cxx
@@ -110,7 +110,7 @@ public:
       InternalScalarType *       newPos = newPosition.data_block();
 
       /** Update the new position. */
-      for (unsigned int j = 0; j < spaceDimension; j++)
+      for (unsigned int j = 0; j < spaceDimension; ++j)
       {
         // newPosition[j] = currentPosition[j] - this->m_LearningRate * this->m_Gradient[j];
         newPos[j] = currentPosition[j] - learningRate * gradient[j];
@@ -129,7 +129,7 @@ public:
       const int nthreads = static_cast<int>(this->m_Threader->GetNumberOfWorkUnits());
       omp_set_num_threads(nthreads);
 #  pragma omp parallel for
-      for (int j = 0; j < static_cast<int>(spaceDimension); j++)
+      for (int j = 0; j < static_cast<int>(spaceDimension); ++j)
       {
         newPos[j] = currentPosition[j] - learningRate * gradient[j];
       }
@@ -201,7 +201,7 @@ public:
     const ParametersType & gradient = this->m_Gradient;
 
     /** Advance one step: mu_{k+1} = mu_k - a_k * gradient_k */
-    for (unsigned int j = jmin; j < jmax; j++)
+    for (unsigned int j = jmin; j < jmax; ++j)
     {
       newPosition[j] = currentPosition[j] - learningRate * gradient[j];
     }
@@ -228,7 +228,7 @@ public:
     InternalScalarType *       newPos = newPosition.data_block();
 
     /** Advance one step: mu_{k+1} = mu_k - a_k * gradient_k */
-    for (unsigned int j = jmin; j < jmax; j++)
+    for (unsigned int j = jmin; j < jmax; ++j)
     {
       newPos[j] = currentPosition[j] - learningRate * gradient[j];
     }

--- a/Testing/itkAdvancedBSplineDeformableTransformTest.cxx
+++ b/Testing/itkAdvancedBSplineDeformableTransformTest.cxx
@@ -346,9 +346,9 @@ main(int argc, char * argv[])
   // JacobianType jacobianDifferenceMatrix = jacobianElastix - jacobianITK;
   // I believe there are future plans to re-enable local support B-splines
   double jacDiff = 0.0;
-  for (unsigned int i = 0; i < nzji.size(); i++)
+  for (unsigned int i = 0; i < nzji.size(); ++i)
   {
-    for (unsigned int j = 0; j < Dimension; j++)
+    for (unsigned int j = 0; j < Dimension; ++j)
     {
       jacDiff += vnl_math::sqr(jacobianElastix[j][i] - jacobianITK[j][nzji[i]]);
     }

--- a/Testing/itkAdvancedLinearInterpolatorTest.cxx
+++ b/Testing/itkAdvancedLinearInterpolatorTest.cxx
@@ -128,9 +128,9 @@ TestInterpolators(void)
   {
     double darray2[12][2] = { { 0.1, 0.2 }, { 3.4, 5.8 }, { 4.0, 6.0 }, { 2.1, 8.0 },  { -0.1, -0.1 }, { 0.0, 0.0 },
                               { 1.3, 1.0 }, { 2.0, 5.7 }, { 9.5, 9.1 }, { 2.0, -0.1 }, { -0.1, 2.0 },  { 12.7, 15.3 } };
-    for (unsigned int i = 0; i < 12; i++)
+    for (unsigned int i = 0; i < 12; ++i)
     {
-      for (unsigned int j = 0; j < Dimension; j++)
+      for (unsigned int j = 0; j < Dimension; ++j)
       {
         darray1[i][j] = darray2[i][j];
       }
@@ -151,9 +151,9 @@ TestInterpolators(void)
     double darray2[12][3] = { { 0.1, 0.2, 0.1 },    { 3.4, 5.8, 4.7 },  { 4.0, 6.0, 5.0 },  { 2.1, 8.0, 3.4 },
                               { -0.1, -0.1, -0.1 }, { 0.0, 0.0, 0.0 },  { 1.3, 1.0, 1.4 },  { 2.0, 5.7, 7.5 },
                               { 9.5, 9.1, 9.3 },    { 2.0, -0.1, 5.3 }, { -0.1, 2.0, 4.0 }, { 12.7, 15.3, 14.1 } };
-    for (unsigned int i = 0; i < count; i++)
+    for (unsigned int i = 0; i < count; ++i)
     {
-      for (unsigned int j = 0; j < Dimension; j++)
+      for (unsigned int j = 0; j < Dimension; ++j)
       {
         darray1[i][j] = darray2[i][j];
       }
@@ -163,7 +163,7 @@ TestInterpolators(void)
   /** Compare results. */
   OutputType          valueLinA, valueBSpline, valueBSpline2;
   CovariantVectorType derivLinA, derivBSpline, derivBSpline2;
-  for (unsigned int i = 0; i < count; i++)
+  for (unsigned int i = 0; i < count; ++i)
   {
     ContinuousIndexType cindex(&darray1[i][0]);
 

--- a/Testing/itkBSplineDerivativeKernelFunctionTest.cxx
+++ b/Testing/itkBSplineDerivativeKernelFunctionTest.cxx
@@ -67,7 +67,7 @@ main(void)
   }
 
   /** For all spline orders. */
-  for (unsigned int so = 0; so < splineOrders.size(); so++)
+  for (unsigned int so = 0; so < splineOrders.size(); ++so)
   {
     std::cerr << "Evaluating spline order " << splineOrders[so] << std::endl;
 
@@ -96,7 +96,7 @@ main(void)
 
     /** Print header. */
     std::cerr << "eval at:";
-    for (unsigned int j = 0; j < u.size(); j++)
+    for (unsigned int j = 0; j < u.size(); ++j)
     {
       std::cerr << " " << u[j];
     }
@@ -105,7 +105,7 @@ main(void)
     /** Time the ITK implementation. */
     std::cerr << "ITK new:";
     clock_t startClock = clock();
-    for (unsigned int j = 0; j < u.size(); j++)
+    for (unsigned int j = 0; j < u.size(); ++j)
     {
       clock_t startClockRegion = clock();
       for (unsigned int i = 0; i < N; ++i)
@@ -121,7 +121,7 @@ main(void)
     /** Time the elx implementation. */
     std::cerr << "elastix:";
     startClock = clock();
-    for (unsigned int j = 0; j < u.size(); j++)
+    for (unsigned int j = 0; j < u.size(); ++j)
     {
       clock_t startClockRegion = clock();
       for (unsigned int i = 0; i < N; ++i)

--- a/Testing/itkBSplineTransformPointPerformanceTest.cxx
+++ b/Testing/itkBSplineTransformPointPerformanceTest.cxx
@@ -87,7 +87,7 @@ public:
     if (!this->m_CoefficientImages[0])
     {
       itkWarningMacro(<< "B-spline coefficients have not been set");
-      for (unsigned int j = 0; j < SpaceDimension; j++)
+      for (unsigned int j = 0; j < SpaceDimension; ++j)
       {
         outputPoint[j] = transformedPoint[j];
       }
@@ -125,7 +125,7 @@ public:
     unsigned long                               counter = 0;
     const PixelType *                           basePointer = this->m_CoefficientImages[0]->GetBufferPointer();
 
-    for (unsigned int j = 0; j < SpaceDimension; j++)
+    for (unsigned int j = 0; j < SpaceDimension; ++j)
     {
       iterator[j] = IteratorType(this->m_CoefficientImages[j], supportRegion);
     }
@@ -137,7 +137,7 @@ public:
       indices[counter] = &(iterator[0].Value()) - basePointer;
 
       // multiply weigth with coefficient to compute displacement
-      for (unsigned int j = 0; j < SpaceDimension; j++)
+      for (unsigned int j = 0; j < SpaceDimension; ++j)
       {
         outputPoint[j] += static_cast<ScalarType>(weights[counter] * iterator[j].Value());
         ++iterator[j];
@@ -147,7 +147,7 @@ public:
     } // end while
 
     // The output point is the start point + displacement.
-    for (unsigned int j = 0; j < SpaceDimension; j++)
+    for (unsigned int j = 0; j < SpaceDimension; ++j)
     {
       outputPoint[j] += transformedPoint[j];
     }

--- a/Testing/itkCommandLineArgumentParser.cxx
+++ b/Testing/itkCommandLineArgumentParser.cxx
@@ -44,7 +44,7 @@ void
 CommandLineArgumentParser::SetCommandLineArguments(int argc, char ** argv)
 {
   this->m_Argv.resize(argc);
-  for (IndexType i = 0; i < static_cast<IndexType>(argc); i++)
+  for (IndexType i = 0; i < static_cast<IndexType>(argc); ++i)
   {
     this->m_Argv[i] = argv[i];
   }
@@ -113,7 +113,7 @@ bool
 CommandLineArgumentParser::ExactlyOneExists(const std::vector<std::string> & keys) const
 {
   unsigned int counter = 0;
-  for (unsigned int i = 0; i < keys.size(); i++)
+  for (unsigned int i = 0; i < keys.size(); ++i)
   {
     if (this->ArgumentExists(keys[i]))
     {
@@ -146,7 +146,7 @@ CommandLineArgumentParser::FindKey(const std::string & key, IndexType & keyIndex
   bool keyFound = false;
   keyIndex = 0;
   nextKeyIndex = this->m_Argv.size();
-  for (IndexType i = 0; i < this->m_Argv.size(); i++)
+  for (IndexType i = 0; i < this->m_Argv.size(); ++i)
   {
     if (!keyFound && this->m_Argv[i] == key)
     {
@@ -287,7 +287,7 @@ CommandLineArgumentParser::CheckForRequiredArguments() const
     if (!this->ExactlyOneExists(exactlyOneOf))
     {
       std::cerr << "ERROR: Exactly one (1) of the arguments in {";
-      for (std::size_t j = 0; j < exactlyOneOf.size() - 1; j++)
+      for (std::size_t j = 0; j < exactlyOneOf.size() - 1; ++j)
       {
         std::cerr << exactlyOneOf[j] << ", ";
       }

--- a/Testing/itkCommandLineArgumentParser.h
+++ b/Testing/itkCommandLineArgumentParser.h
@@ -184,7 +184,7 @@ public:
     newSize = newSize > oldSize ? newSize : oldSize;
     arg.resize(newSize);
     IndexType j = 0;
-    for (IndexType i = keyIndex + 1; i < nextKeyIndex; i++)
+    for (IndexType i = keyIndex + 1; i < nextKeyIndex; ++i)
     {
       /** Cast the string to type T. */
       T    casted;

--- a/Testing/itkGPUBSplineDecompositionImageFilterTest.cxx
+++ b/Testing/itkGPUBSplineDecompositionImageFilterTest.cxx
@@ -90,7 +90,7 @@ main(int argc, char * argv[])
   // Time the filter, run on the CPU
   itk::TimeProbe cputimer;
   cputimer.Start();
-  for (unsigned int i = 0; i < runTimes; i++)
+  for (unsigned int i = 0; i < runTimes; ++i)
   {
     cpuFilter->SetInput(reader->GetOutput());
     try
@@ -159,7 +159,7 @@ main(int argc, char * argv[])
   // Time the filter, run on the GPU
   itk::TimeProbe gputimer;
   gputimer.Start();
-  for (unsigned int i = 0; i < runTimes; i++)
+  for (unsigned int i = 0; i < runTimes; ++i)
   {
     gpuFilter->SetInput(gpuReader->GetOutput());
     try

--- a/Testing/itkGPUCastImageFilterTest.cxx
+++ b/Testing/itkGPUCastImageFilterTest.cxx
@@ -89,7 +89,7 @@ main(int argc, char * argv[])
   // Time the filter, run on the CPU
   itk::TimeProbe cputimer;
   cputimer.Start();
-  for (unsigned int i = 0; i < runTimes; i++)
+  for (unsigned int i = 0; i < runTimes; ++i)
   {
     cpuFilter->SetInput(reader->GetOutput());
     try
@@ -161,7 +161,7 @@ main(int argc, char * argv[])
   // Time the filter, run on the GPU
   itk::TimeProbe gputimer;
   gputimer.Start();
-  for (unsigned int i = 0; i < runTimes; i++)
+  for (unsigned int i = 0; i < runTimes; ++i)
   {
     gpuFilter->SetInput(gpuReader->GetOutput());
     try

--- a/Testing/itkGPUGenericMultiResolutionPyramidImageFilterTest.cxx
+++ b/Testing/itkGPUGenericMultiResolutionPyramidImageFilterTest.cxx
@@ -105,9 +105,9 @@ main(int argc, char * argv[])
   RescaleScheduleType   rescaleSchedule(numberOfLevels, Dimension);
   SmoothingScheduleType smoothingSchedule(numberOfLevels, Dimension);
   double                tmp = 0.0;
-  for (unsigned int i = 0; i < numberOfLevels; i++)
+  for (unsigned int i = 0; i < numberOfLevels; ++i)
   {
-    for (unsigned int j = 0; j < Dimension; j++)
+    for (unsigned int j = 0; j < Dimension; ++j)
     {
       tmp = randomNum->GetUniformVariate(0, 8);
       rescaleSchedule[i][j] = static_cast<unsigned int>(tmp);
@@ -140,7 +140,7 @@ main(int argc, char * argv[])
   // Time the filter, run on the CPU
   itk::TimeProbe cputimer;
   cputimer.Start();
-  for (unsigned int i = 0; i < runTimes; i++)
+  for (unsigned int i = 0; i < runTimes; ++i)
   {
     cpuFilter->SetInput(reader->GetOutput());
 
@@ -160,7 +160,7 @@ main(int argc, char * argv[])
     }
     else
     {
-      for (unsigned int j = 0; j < cpuFilter->GetNumberOfLevels(); j++)
+      for (unsigned int j = 0; j < cpuFilter->GetNumberOfLevels(); ++j)
       {
         cpuFilter->SetCurrentLevel(j);
         try
@@ -264,7 +264,7 @@ main(int argc, char * argv[])
   // Time the filter, run on the GPU
   itk::TimeProbe gputimer;
   gputimer.Start();
-  for (unsigned int i = 0; i < runTimes; i++)
+  for (unsigned int i = 0; i < runTimes; ++i)
   {
     gpuFilter->SetInput(gpuReader->GetOutput());
 
@@ -288,7 +288,7 @@ main(int argc, char * argv[])
     }
     else
     {
-      for (unsigned int j = 0; j < gpuFilter->GetNumberOfLevels(); j++)
+      for (unsigned int j = 0; j < gpuFilter->GetNumberOfLevels(); ++j)
       {
         gpuFilter->SetCurrentLevel(j);
         try

--- a/Testing/itkGPURecursiveGaussianImageFilterTest.cxx
+++ b/Testing/itkGPURecursiveGaussianImageFilterTest.cxx
@@ -101,7 +101,7 @@ main(int argc, char * argv[])
   std::cout << "Testing the Recursive Gaussian filter, CPU vs GPU:\n";
   std::cout << "CPU/GPU sigma direction #threads time speedup RMSE\n";
 
-  for (unsigned int nThreads = 1; nThreads <= maximumNumberOfThreads; nThreads++)
+  for (unsigned int nThreads = 1; nThreads <= maximumNumberOfThreads; ++nThreads)
   {
     // Test CPU
     cputimer.Start();
@@ -190,7 +190,7 @@ main(int argc, char * argv[])
   std::cout << "CPU/GPU sigma direction #threads time speedup RMSE\n";
 
   // Check directions
-  for (direction = 0; direction < ImageDimension; direction++)
+  for (direction = 0; direction < ImageDimension; ++direction)
   {
     cputimer.Start();
     cpuFilter->SetNumberOfWorkUnits(maximumNumberOfThreads);

--- a/Testing/itkGPUResampleImageFilterTest.cxx
+++ b/Testing/itkGPUResampleImageFilterTest.cxx
@@ -96,7 +96,7 @@ PrintTransform(typename TransformType::Pointer & transform)
   if (compositeTransform)
   {
     std::cout << " [";
-    for (std::size_t i = 0; i < compositeTransform->GetNumberOfTransforms(); i++)
+    for (std::size_t i = 0; i < compositeTransform->GetNumberOfTransforms(); ++i)
     {
       std::cout << compositeTransform->GetNthTransform(i)->GetNameOfClass();
       if (i != compositeTransform->GetNumberOfTransforms() - 1)
@@ -125,7 +125,7 @@ ComputeCenterOfTheImage(const typename InputImageType::ConstPointer & image)
 
   typedef itk::ContinuousIndex<double, InputImageType::ImageDimension> ContinuousIndexType;
   ContinuousIndexType                                                  centerAsContInd;
-  for (std::size_t i = 0; i < Dimension; i++)
+  for (std::size_t i = 0; i < Dimension; ++i)
   {
     centerAsContInd[i] = static_cast<double>(index[i]) + static_cast<double>(size[i] - 1) / 2.0;
   }
@@ -190,7 +190,7 @@ DefineAffineParameters(typename AffineTransformType::ParametersType & parameters
       0.0, 0.0, // translation
     };
 
-    for (std::size_t i = 0; i < 6; i++)
+    for (std::size_t i = 0; i < 6; ++i)
     {
       parameters[par++] = matrix[i];
     }
@@ -204,7 +204,7 @@ DefineAffineParameters(typename AffineTransformType::ParametersType & parameters
       -3.02,  1.3,    -0.045 // translation
     };
 
-    for (std::size_t i = 0; i < 12; i++)
+    for (std::size_t i = 0; i < 12; ++i)
     {
       parameters[par++] = matrix[i];
     }
@@ -222,7 +222,7 @@ DefineTranslationParameters(const std::size_t                                   
 
   // Setup parameters
   parameters.SetSize(Dimension);
-  for (std::size_t i = 0; i < Dimension; i++)
+  for (std::size_t i = 0; i < Dimension; ++i)
   {
     parameters[i] = (double)i * (double)transformIndex + (double)transformIndex;
   }
@@ -248,14 +248,14 @@ DefineBSplineParameters(const std::size_t                               transfor
   infile.open(parametersFileName.c_str());
 
   // Skip number of elements to make unique coefficients per each transformIndex
-  for (std::size_t n = 0; n < transformIndex; n++)
+  for (std::size_t n = 0; n < transformIndex; ++n)
   {
     double parValue;
     infile >> parValue;
   }
 
   // Read it
-  for (std::size_t n = 0; n < numberOfNodes * Dimension; n++)
+  for (std::size_t n = 0; n < numberOfNodes * Dimension; ++n)
   {
     double parValue;
     infile >> parValue;
@@ -291,14 +291,14 @@ DefineEulerParameters(const std::size_t transformIndex, typename EulerTransformT
   else if (Dimension == 3)
   {
     // See implementation of Rigid3DTransform::SetParameters()
-    for (std::size_t i = 0; i < 3; i++)
+    for (std::size_t i = 0; i < 3; ++i)
     {
       parameters[par] = angle;
       ++par;
     }
   }
 
-  for (std::size_t i = 0; i < Dimension; i++)
+  for (std::size_t i = 0; i < Dimension; ++i)
   {
     parameters[i + par] = (double)i * (double)transformIndex + (double)transformIndex;
   }
@@ -331,7 +331,7 @@ DefineSimilarityParameters(const std::size_t                                  tr
   else if (Dimension == 3)
   {
     // See implementation of Similarity3DTransform::SetParameters()
-    for (std::size_t i = 0; i < Dimension; i++)
+    for (std::size_t i = 0; i < Dimension; ++i)
     {
       parameters[i] = angle;
     }
@@ -339,7 +339,7 @@ DefineSimilarityParameters(const std::size_t                                  tr
   }
 
   // Translation
-  for (std::size_t i = 0; i < Dimension; i++)
+  for (std::size_t i = 0; i < Dimension; ++i)
   {
     parameters[i + Dimension] = -1.0 * ((double)i * (double)transformIndex + (double)transformIndex);
   }
@@ -445,7 +445,7 @@ SetTransform(const std::size_t                                            transf
 
     typedef typename BSplineTransformType::PhysicalDimensionsType PhysicalDimensionsType;
     PhysicalDimensionsType                                        gridSpacing;
-    for (unsigned int d = 0; d < Dimension; d++)
+    for (unsigned int d = 0; d < Dimension; ++d)
     {
       gridSpacing[d] = inputSpacing[d] * (inputSize[d] - 1.0);
     }
@@ -681,7 +681,7 @@ main(int argc, char * argv[])
   }
 
   // check for supported transforms
-  for (std::size_t i = 0; i < transforms.size(); i++)
+  for (std::size_t i = 0; i < transforms.size(); ++i)
   {
     const std::string transformName = transforms[i];
     if (transformName != "Affine" && transformName != "Translation" && transformName != "BSpline" &&
@@ -697,7 +697,7 @@ main(int argc, char * argv[])
 
   unsigned int runTimes = 1;
   std::string  parametersFileName = "";
-  for (std::size_t i = 0; i < transforms.size(); i++)
+  for (std::size_t i = 0; i < transforms.size(); ++i)
   {
     if (transforms[i] == "BSpline")
     {
@@ -821,7 +821,7 @@ main(int argc, char * argv[])
   std::stringstream              s;
   s << std::setprecision(4) << std::setiosflags(std::ios_base::fixed);
   double tmp1, tmp2;
-  for (std::size_t i = 0; i < Dimension; i++)
+  for (std::size_t i = 0; i < Dimension; ++i)
   {
     tmp1 = randomNum->GetUniformVariate(0.9, 1.1);
     tmp2 = inputSpacing[i] * tmp1;
@@ -835,7 +835,7 @@ main(int argc, char * argv[])
     s >> outputOrigin[i];
     s.clear();
 
-    for (unsigned int j = 0; j < Dimension; j++)
+    for (unsigned int j = 0; j < Dimension; ++j)
     {
       // tmp = randomNum->GetUniformVariate( 0.9 * inputOrigin[ i ], 1.1 *
       // inputOrigin[ i ] );
@@ -882,7 +882,7 @@ main(int argc, char * argv[])
     initialTransform = tmpTransform;
     cpuTransform = tmpTransform;
 
-    for (std::size_t i = 0; i < transforms.size(); i++)
+    for (std::size_t i = 0; i < transforms.size(); ++i)
     {
       if (i == 0)
       {
@@ -943,7 +943,7 @@ main(int argc, char * argv[])
   itk::TimeProbe cputimer;
   cputimer.Start();
 
-  for (std::size_t i = 0; i < runTimes; i++)
+  for (std::size_t i = 0; i < runTimes; ++i)
   {
     cpuFilter->SetInput(cpuReader->GetOutput());
     cpuFilter->SetTransform(cpuTransform);
@@ -1106,7 +1106,7 @@ main(int argc, char * argv[])
   // Time the filter, run on the GPU
   itk::TimeProbe gputimer;
   gputimer.Start();
-  for (std::size_t i = 0; i < runTimes; i++)
+  for (std::size_t i = 0; i < runTimes; ++i)
   {
     try
     {

--- a/Testing/itkGPUShrinkImageFilterTest.cxx
+++ b/Testing/itkGPUShrinkImageFilterTest.cxx
@@ -89,7 +89,7 @@ main(int argc, char * argv[])
   // Time the filter, run on the CPU
   itk::TimeProbe cputimer;
   cputimer.Start();
-  for (unsigned int i = 0; i < runTimes; i++)
+  for (unsigned int i = 0; i < runTimes; ++i)
   {
     cpuFilter->SetInput(reader->GetOutput());
     try
@@ -170,7 +170,7 @@ main(int argc, char * argv[])
   // Time the filter, run on the GPU
   itk::TimeProbe gputimer;
   gputimer.Start();
-  for (unsigned int i = 0; i < runTimes; i++)
+  for (unsigned int i = 0; i < runTimes; ++i)
   {
     gpuFilter->SetInput(gpuReader->GetOutput());
     try

--- a/Testing/itkGPUSmoothingRecursiveGaussianImageFilterTest.cxx
+++ b/Testing/itkGPUSmoothingRecursiveGaussianImageFilterTest.cxx
@@ -86,7 +86,7 @@ main(int argc, char * argv[])
   // Construct the filter
   FilterType::Pointer        filter = FilterType::New();
   FilterType::SigmaArrayType sigmaArray;
-  for (unsigned int i = 0; i < Dimension; i++)
+  for (unsigned int i = 0; i < Dimension; ++i)
   {
     sigmaArray[i] = 3.0;
   }
@@ -98,7 +98,7 @@ main(int argc, char * argv[])
   // Time the filter, run on the CPU
   itk::TimeProbe cputimer;
   cputimer.Start();
-  for (unsigned int i = 0; i < runTimes; i++)
+  for (unsigned int i = 0; i < runTimes; ++i)
   {
     filter->SetInput(reader->GetOutput());
     try
@@ -180,7 +180,7 @@ main(int argc, char * argv[])
   // Time the filter, run on the GPU
   itk::TimeProbe gputimer;
   gputimer.Start();
-  for (unsigned int i = 0; i < runTimes; i++)
+  for (unsigned int i = 0; i < runTimes; ++i)
   {
     gpuFilter->SetInput(gpuReader->GetOutput());
     try

--- a/Testing/itkOpenCLVectorTest.cxx
+++ b/Testing/itkOpenCLVectorTest.cxx
@@ -41,7 +41,7 @@ template <class type>
 bool
 std_first_of(const typename std::vector<type> & v, const std::size_t n, const type value)
 {
-  for (std::size_t i = 0; i < n; i++)
+  for (std::size_t i = 0; i < n; ++i)
   {
     if (v[i] != value)
     {

--- a/Testing/itkTestHelper.h
+++ b/Testing/itkTestHelper.h
@@ -479,7 +479,7 @@ WriteLog(const std::string &                  filename,
   }
 
   fout << filterName << s << dim << s;
-  for (unsigned int i = 0; i < dim; i++)
+  for (unsigned int i = 0; i < dim; ++i)
   {
     fout << imagesize.GetSize()[i];
     if (i < dim - 1)

--- a/Testing/itkThinPlateSplineTransformPerformanceTest.cxx
+++ b/Testing/itkThinPlateSplineTransformPerformanceTest.cxx
@@ -163,7 +163,7 @@ main(int argc, char * argv[])
   std::cerr << "Matrix scalar type: " << typeid(ScalarType).name() << "\n" << std::endl;
 
   // Loop over usedNumberOfLandmarks
-  for (std::size_t i = 0; i < usedNumberOfLandmarks.size(); i++)
+  for (std::size_t i = 0; i < usedNumberOfLandmarks.size(); ++i)
   {
     itk::TimeProbesCollectorBase timeCollector;
 
@@ -174,7 +174,7 @@ main(int argc, char * argv[])
     /** Get subset. */
     PointsContainerPointer usedLandmarkPoints = PointsContainerType::New();
     PointSetType::Pointer  usedLandmarks = PointSetType::New();
-    for (unsigned long j = 0; j < numberOfLandmarks; j++)
+    for (unsigned long j = 0; j < numberOfLandmarks; ++j)
     {
       PointType tmp = (*sourceLandmarks->GetPoints())[j];
       usedLandmarkPoints->push_back(tmp);
@@ -302,14 +302,14 @@ main(int argc, char * argv[])
     jac1.SetSize(Dimension, numberOfLandmarks * Dimension);
     jac1.Fill(0.0);
     PointsIterator sp = usedLandmarks->GetPoints()->Begin();
-    for (unsigned int lnd = 0; lnd < numberOfLandmarks; lnd++)
+    for (unsigned int lnd = 0; lnd < numberOfLandmarks; ++lnd)
     {
       kernelTransform->ComputeGPublic(p - sp->Value(), Gmatrix);
-      for (unsigned int dim = 0; dim < Dimension; dim++)
+      for (unsigned int dim = 0; dim < Dimension; ++dim)
       {
-        for (unsigned int odim = 0; odim < Dimension; odim++)
+        for (unsigned int odim = 0; odim < Dimension; ++odim)
         {
-          for (unsigned int lidx = 0; lidx < numberOfLandmarks * Dimension; lidx++)
+          for (unsigned int lidx = 0; lidx < numberOfLandmarks * Dimension; ++lidx)
           {
             jac1[odim][lidx] += Gmatrix(dim, odim) * lMatrixInverse2[lnd * Dimension + dim][lidx];
           }
@@ -318,11 +318,11 @@ main(int argc, char * argv[])
       ++sp;
     }
 
-    for (unsigned int odim = 0; odim < Dimension; odim++)
+    for (unsigned int odim = 0; odim < Dimension; ++odim)
     {
-      for (unsigned long lidx = 0; lidx < numberOfLandmarks * Dimension; lidx++)
+      for (unsigned long lidx = 0; lidx < numberOfLandmarks * Dimension; ++lidx)
       {
-        for (unsigned int dim = 0; dim < Dimension; dim++)
+        for (unsigned int dim = 0; dim < Dimension; ++dim)
         {
           jac1[odim][lidx] += p[dim] * lMatrixInverse2[(numberOfLandmarks + dim) * Dimension + odim][lidx];
         }

--- a/Testing/itkThinPlateSplineTransformTest.cxx
+++ b/Testing/itkThinPlateSplineTransformTest.cxx
@@ -86,7 +86,7 @@ main(int argc, char * argv[])
   /** Get subset. */
   PointsContainerPointer usedLandmarkPoints = PointsContainerType::New();
   PointSetType::Pointer  usedSourceLandmarks = PointSetType::New();
-  for (unsigned long j = 0; j < usedNumberOfLandmarks; j++)
+  for (unsigned long j = 0; j < usedNumberOfLandmarks; ++j)
   {
     PointType tmp = (*sourceLandmarks->GetPoints())[j];
     usedLandmarkPoints->push_back(tmp);
@@ -108,11 +108,11 @@ main(int argc, char * argv[])
   PointsContainerPointer       newTargetLandmarkPoints = PointsContainerType::New();
   MersenneTwisterType::Pointer mersenneTwister = MersenneTwisterType::New();
   mersenneTwister->Initialize(140377);
-  for (unsigned long j = 0; j < targetLandmarks->GetNumberOfPoints(); j++)
+  for (unsigned long j = 0; j < targetLandmarks->GetNumberOfPoints(); ++j)
   {
     PointType tmp = (*targetLandmarks->GetPoints())[j];
     PointType randomPoint;
-    for (unsigned int dim = 0; dim < Dimension; dim++)
+    for (unsigned int dim = 0; dim < Dimension; ++dim)
     {
       randomPoint[dim] = tmp[dim] + mersenneTwister->GetNormalVariate(1.0, 5.0);
     }


### PR DESCRIPTION
Applied to the root of elastix source tree, at the GNU bash prompt:

    $ find . \( -iname *.cxx -or -iname *.hxx -or -iname *.h \) -exec perl -pi -w -e 's/(\s+for \(.*;.*); (\w+)\+\+\)/$1; ++$2)/g;' {} \;

Follows common C++ guidelines, including:

Google C++ Style Guide: "Use the prefix form (++i) of the increment and decrement operators unless you need postfix semantics."
https://google.github.io/styleguide/cppguide.html#Preincrement_and_Predecrement

Herb Sutter, Andrei Alexandrescu - C++ Coding Standards: 101 Rules, Guidelines, and Best Practices: "Prefer the canonical form of ++ and --. Prefer calling the prefix forms"
https://www.oreilly.com/library/view/c-coding-standards/0321113586/ch29.html

Anticipates "[clang-tidy] Add performance-prefer-preincrement check":
https://reviews.llvm.org/D72553

Corresponding ITK pull requests, which were merged in April 2021:
 - https://github.com/InsightSoftwareConsortium/ITK/pull/2505
 - https://github.com/InsightSoftwareConsortium/ITK/pull/2499
 - https://github.com/InsightSoftwareConsortium/ITK/pull/2493