### PR TITLE
STYLE: Call the `empty()` member function of `std` containers

### DIFF
--- a/Common/OpenCL/Filters/itkGPUBSplineBaseTransform.hxx
+++ b/Common/OpenCL/Filters/itkGPUBSplineBaseTransform.hxx
@@ -71,7 +71,7 @@ template <typename TScalarType, unsigned int NDimensions>
 bool
 GPUBSplineBaseTransform<TScalarType, NDimensions>::GetSourceCode(std::string & source) const
 {
-  if (this->m_Sources.size() == 0)
+  if (this->m_Sources.empty())
   {
     return false;
   }

--- a/Common/OpenCL/Filters/itkGPUBSplineInterpolateImageFunction.hxx
+++ b/Common/OpenCL/Filters/itkGPUBSplineInterpolateImageFunction.hxx
@@ -75,7 +75,7 @@ template <typename TInputImage, typename TCoordRep, typename TCoefficientType>
 bool
 GPUBSplineInterpolateImageFunction<TInputImage, TCoordRep, TCoefficientType>::GetSourceCode(std::string & source) const
 {
-  if (this->m_Sources.size() == 0)
+  if (this->m_Sources.empty())
   {
     return false;
   }

--- a/Common/OpenCL/Filters/itkGPUIdentityTransform.hxx
+++ b/Common/OpenCL/Filters/itkGPUIdentityTransform.hxx
@@ -38,7 +38,7 @@ template <typename TScalarType, unsigned int NDimensions, typename TParentTransf
 bool
 GPUIdentityTransform<TScalarType, NDimensions, TParentTransform>::GetSourceCode(std::string & source) const
 {
-  if (this->m_Sources.size() == 0)
+  if (this->m_Sources.empty())
   {
     return false;
   }

--- a/Common/OpenCL/Filters/itkGPULinearInterpolateImageFunction.hxx
+++ b/Common/OpenCL/Filters/itkGPULinearInterpolateImageFunction.hxx
@@ -42,7 +42,7 @@ template <typename TInputImage, typename TCoordRep>
 bool
 GPULinearInterpolateImageFunction<TInputImage, TCoordRep>::GetSourceCode(std::string & source) const
 {
-  if (this->m_Sources.size() == 0)
+  if (this->m_Sources.empty())
   {
     return false;
   }

--- a/Common/OpenCL/Filters/itkGPUMatrixOffsetTransformBase.hxx
+++ b/Common/OpenCL/Filters/itkGPUMatrixOffsetTransformBase.hxx
@@ -274,7 +274,7 @@ bool
 GPUMatrixOffsetTransformBase<TScalarType, NInputDimensions, NOutputDimensions>::GetSourceCode(
   std::string & source) const
 {
-  if (this->m_Sources.size() == 0)
+  if (this->m_Sources.empty())
   {
     return false;
   }

--- a/Common/OpenCL/Filters/itkGPUNearestNeighborInterpolateImageFunction.hxx
+++ b/Common/OpenCL/Filters/itkGPUNearestNeighborInterpolateImageFunction.hxx
@@ -42,7 +42,7 @@ template <typename TInputImage, typename TCoordRep>
 bool
 GPUNearestNeighborInterpolateImageFunction<TInputImage, TCoordRep>::GetSourceCode(std::string & source) const
 {
-  if (this->m_Sources.size() == 0)
+  if (this->m_Sources.empty())
   {
     return false;
   }

--- a/Common/OpenCL/Filters/itkGPUResampleImageFilter.hxx
+++ b/Common/OpenCL/Filters/itkGPUResampleImageFilter.hxx
@@ -1000,7 +1000,7 @@ bool
 GPUResampleImageFilter<TInputImage, TOutputImage, TInterpolatorPrecisionType>::HasTransform(
   const GPUTransformTypeEnum type) const
 {
-  if (this->m_FilterLoopGPUKernelHandle.size() == 0)
+  if (this->m_FilterLoopGPUKernelHandle.empty())
   {
     return false;
   }
@@ -1024,7 +1024,7 @@ int
 GPUResampleImageFilter<TInputImage, TOutputImage, TInterpolatorPrecisionType>::GetTransformHandle(
   const GPUTransformTypeEnum type) const
 {
-  if (this->m_FilterLoopGPUKernelHandle.size() == 0)
+  if (this->m_FilterLoopGPUKernelHandle.empty())
   {
     return -1;
   }

--- a/Common/OpenCL/Filters/itkGPUTranslationTransformBase.hxx
+++ b/Common/OpenCL/Filters/itkGPUTranslationTransformBase.hxx
@@ -181,7 +181,7 @@ template <typename TScalarType, unsigned int NDimensions>
 bool
 GPUTranslationTransformBase<TScalarType, NDimensions>::GetSourceCode(std::string & source) const
 {
-  if (this->m_Sources.size() == 0)
+  if (this->m_Sources.empty())
   {
     return false;
   }

--- a/Common/OpenCL/ITKimprovements/itkOpenCLContext.cxx
+++ b/Common/OpenCL/ITKimprovements/itkOpenCLContext.cxx
@@ -1135,7 +1135,7 @@ OpenCLContext::CreateProgramFromSourceCode(const std::string & sourceCode,
   // kernel code must exist in a text file separate from the code of the host.
   // Also the full path to the file has to be provided.
   const std::string fileName = GetOpenCLDebugFileName(oclSource);
-  if (prefixSourceCode != "")
+  if (!prefixSourceCode.empty())
   {
     std::ofstream debugfile(fileName.c_str());
     if (debugfile.is_open() == false)
@@ -1215,11 +1215,11 @@ OpenCLContext::CreateProgramFromSourceFile(const std::string & filename,
   // To work with the Intel SDK for OpenCL* - Debugger plug-in, the OpenCL*
   // kernel code must exist in a text file separate from the code of the host.
   // Also the full path to the file has to be provided.
-  if (prefixSourceCode != "")
+  if (!prefixSourceCode.empty())
   {
     fileName = GetOpenCLDebugFileName(oclSource);
   }
-  if (prefixSourceCode != "")
+  if (!prefixSourceCode.empty())
   {
     std::ofstream debugfile(fileName.c_str());
     if (debugfile.is_open() == false)

--- a/Common/OpenCL/ITKimprovements/itkOpenCLProgram.cxx
+++ b/Common/OpenCL/ITKimprovements/itkOpenCLProgram.cxx
@@ -68,7 +68,7 @@ GetOpenCLMathAndOptimizationOptions(std::string & options)
 
 #ifndef OPENCL_OPTIMIZATION_OPT_DISABLE
 #  ifdef OPENCL_OPTIMIZATION_MAD_ENABLE
-  if (options.size() != 0)
+  if (!options.empty())
   {
     options.append(" ");
   }
@@ -262,7 +262,7 @@ OpenCLProgram::Build(const std::list<OpenCLDevice> & devices, const std::string 
   oclOptions = !extraBuildOptions.empty() ? oclOptions + " " + extraBuildOptions : oclOptions;
 
 #if (defined(_WIN32) && defined(_DEBUG)) || !defined(NDEBUG)
-  if (GetFileName().size() > 0)
+  if (!GetFileName().empty())
   {
     const std::string message = "clBuildProgram from file '" + GetFileName() + "'";
     this->GetContext()->OpenCLDebug(message);
@@ -296,7 +296,7 @@ OpenCLProgram::Build(const std::list<OpenCLDevice> & devices, const std::string 
     error = clBuildProgram(this->m_Id, devs.size(), &devs[0], oclOptions.empty() ? 0 : &oclOptions[0], 0, 0);
   }
 #else
-  if (devs.size() == 0)
+  if (devs.empty())
   {
     error = clBuildProgram(this->m_Id, 0, 0, oclOptions.empty() ? 0 : &oclOptions[0], 0, 0);
   }

--- a/Common/Transforms/itkStackTransform.h
+++ b/Common/Transforms/itkStackTransform.h
@@ -162,7 +162,7 @@ public:
   NumberOfParametersType
   GetNumberOfParameters(void) const override
   {
-    if (this->m_SubTransformContainer.size() == 0)
+    if (this->m_SubTransformContainer.empty())
     {
       return 0;
     }

--- a/Common/itkGenericMultiResolutionPyramidImageFilter.hxx
+++ b/Common/itkGenericMultiResolutionPyramidImageFilter.hxx
@@ -912,7 +912,7 @@ GenericMultiResolutionPyramidImageFilter<TInputImage, TOutputImage, TPrecisionTy
      << std::endl;
   os << indent << "SmoothingScheduleDefined: " << (this->m_SmoothingScheduleDefined ? "true" : "false") << std::endl;
   os << indent << "Smoothing Schedule: ";
-  if (this->m_SmoothingSchedule.size() == 0)
+  if (this->m_SmoothingSchedule.empty())
   {
     os << "Not set" << std::endl;
   }

--- a/Common/itkMeshFileReaderBase.hxx
+++ b/Common/itkMeshFileReaderBase.hxx
@@ -50,7 +50,7 @@ MeshFileReaderBase<TOutputMesh>::GenerateOutputInformation(void)
   itkDebugMacro(<< "Reading file for GenerateOutputInformation(): " << this->m_FileName);
 
   /** Check to see if we can read the file given the name or prefix */
-  if (this->m_FileName == "")
+  if (this->m_FileName.empty())
   {
     throw MeshFileReaderException(__FILE__, __LINE__, "FileName must be specified", ITK_LOCATION);
   }

--- a/Components/Metrics/RigidityPenalty/elxTransformRigidityPenaltyTerm.hxx
+++ b/Components/Metrics/RigidityPenalty/elxTransformRigidityPenaltyTerm.hxx
@@ -46,7 +46,7 @@ TransformRigidityPenalty<TElastix>::BeforeRegistration(void)
   typedef typename ChangeInfoFilterType::Pointer               ChangeInfoFilterPointer;
   typedef typename RigidityImageType::DirectionType            DirectionType;
 
-  if (fixedRigidityImageName != "")
+  if (!fixedRigidityImageName.empty())
   {
     /** Use the FixedRigidityImage. */
     this->SetUseFixedRigidityImage(true);
@@ -93,7 +93,7 @@ TransformRigidityPenalty<TElastix>::BeforeRegistration(void)
     movingRigidityImageName, "MovingRigidityImageName", this->GetComponentLabel(), 0, -1, false);
 
   typename RigidityImageReaderType::Pointer movingRigidityReader;
-  if (movingRigidityImageName != "")
+  if (!movingRigidityImageName.empty())
   {
     /** Use the movingRigidityImage. */
     this->SetUseMovingRigidityImage(true);
@@ -135,7 +135,7 @@ TransformRigidityPenalty<TElastix>::BeforeRegistration(void)
   }
 
   /** Important check: at least one rigidity image must be given. */
-  if (fixedRigidityImageName == "" && movingRigidityImageName == "")
+  if (fixedRigidityImageName.empty() && movingRigidityImageName.empty())
   {
     xl::xout["warning"] << "WARNING: FixedRigidityImageName and "
                         << "MovingRigidityImage are both not supplied.\n"

--- a/Components/Registrations/MultiMetricMultiResolutionRegistration/elxMultiMetricMultiResolutionRegistration.hxx
+++ b/Components/Registrations/MultiMetricMultiResolutionRegistration/elxMultiMetricMultiResolutionRegistration.hxx
@@ -104,7 +104,7 @@ MultiMetricMultiResolutionRegistration<TElastix>::BeforeRegistration(void)
 
   /** Temporary? Use the multi-threaded version or not. */
   std::string tmp = this->m_Configuration->GetCommandLineArgument("-mtcombo");
-  if (tmp == "true" || tmp == "")
+  if (tmp == "true" || tmp.empty())
   {
     this->GetCombinationMetric()->SetUseMultiThread(true);
   }

--- a/Components/Transforms/BSplineDeformableTransformWithDiffusion/elxBSplineTransformWithDiffusion.hxx
+++ b/Components/Transforms/BSplineDeformableTransformWithDiffusion/elxBSplineTransformWithDiffusion.hxx
@@ -179,7 +179,7 @@ BSplineTransformWithDiffusion<TElastix>::BeforeRegistration(void)
   if (this->m_UseMovingSegmentation)
   {
     this->m_Configuration->ReadParameter(this->m_MovingSegmentationFileName, "MovingSegmentationFileName", 0);
-    if (m_MovingSegmentationFileName == "")
+    if (m_MovingSegmentationFileName.empty())
     {
       xl::xout["error"] << "ERROR: No MovingSegmentation filename specified." << std::endl;
       /** Create and throw an exception. */
@@ -203,7 +203,7 @@ BSplineTransformWithDiffusion<TElastix>::BeforeRegistration(void)
   if (this->m_UseFixedSegmentation)
   {
     this->m_Configuration->ReadParameter(this->m_FixedSegmentationFileName, "FixedSegmentationFileName", 0);
-    if (m_FixedSegmentationFileName == "")
+    if (m_FixedSegmentationFileName.empty())
     {
       xl::xout["error"] << "ERROR: No FixedSegmentation filename specified." << std::endl;
       /** Create and throw an exception. */
@@ -843,7 +843,7 @@ BSplineTransformWithDiffusion<TElastix>::ReadFromFile(void)
   this->m_Configuration->ReadParameter(fileName, "DeformationFieldFileName", 0);
 
   /** Error checking ... */
-  if (fileName == "")
+  if (fileName.empty())
   {
     xl::xout["error"] << "ERROR: DeformationFieldFileName not specified." << std::endl
                       << "Unable to read and set the transform parameters." << std::endl;

--- a/Components/Transforms/DeformationFieldTransform/elxDeformationFieldTransform.hxx
+++ b/Components/Transforms/DeformationFieldTransform/elxDeformationFieldTransform.hxx
@@ -75,7 +75,7 @@ DeformationFieldTransform<TElastix>::ReadFromFile(void)
   /** Read deformationFieldImage-name from parameter-file. */
   std::string fileName = "";
   this->m_Configuration->ReadParameter(fileName, "DeformationFieldFileName", 0);
-  if (fileName == "")
+  if (fileName.empty())
   {
     xl::xout["error"]
       << "ERROR: the entry (DeformationFieldFileName \"...\") is missing in the transform parameter file!" << std::endl;

--- a/Components/Transforms/MultiBSplineTransformWithNormal/elxMultiBSplineTransformWithNormal.hxx
+++ b/Components/Transforms/MultiBSplineTransformWithNormal/elxMultiBSplineTransformWithNormal.hxx
@@ -91,7 +91,7 @@ MultiBSplineTransformWithNormal<TElastix>::BeforeAll(void)
     this->m_SplineOrder, "BSplineTransformSplineOrder", this->GetComponentLabel(), 0, 0, true);
 
   this->m_LabelsPath = this->m_Configuration->GetCommandLineArgument("-labels");
-  if (this->m_LabelsPath != "")
+  if (!this->m_LabelsPath.empty())
   {
     typename itk::ImageFileReader<ImageLabelType>::Pointer reader = itk::ImageFileReader<ImageLabelType>::New();
     reader->SetFileName(this->m_LabelsPath);
@@ -599,7 +599,7 @@ MultiBSplineTransformWithNormal<TElastix>::ReadFromFile(void)
   /** Read the labels map */
   this->GetConfiguration()->ReadParameter(
     this->m_LabelsPath, "MultiBSplineTransformWithNormalLabels", this->GetComponentLabel(), 0, 0);
-  if (this->m_LabelsPath != "")
+  if (!this->m_LabelsPath.empty())
   {
     typename itk::ImageFileReader<ImageLabelType>::Pointer reader = itk::ImageFileReader<ImageLabelType>::New();
     reader->SetFileName(this->m_LabelsPath);

--- a/Core/ComponentBaseClasses/elxMetricBase.hxx
+++ b/Core/ComponentBaseClasses/elxMetricBase.hxx
@@ -161,7 +161,7 @@ MetricBase<TElastix>::BeforeEachResolutionBase(void)
     if (useMultiThreading)
     {
       std::string tmp = this->m_Configuration->GetCommandLineArgument("-threads");
-      if (tmp != "")
+      if (!tmp.empty())
       {
         const unsigned int nrOfThreads = atoi(tmp.c_str());
         thisAsAdvanced->SetNumberOfWorkUnits(nrOfThreads);

--- a/Core/ComponentBaseClasses/elxTransformBase.hxx
+++ b/Core/ComponentBaseClasses/elxTransformBase.hxx
@@ -157,7 +157,7 @@ TransformBase<TElastix>::BeforeAllTransformix(void)
 
   /** Check for appearance of "-ipp". */
   check = this->m_Configuration->GetCommandLineArgument("-ipp");
-  if (check != "")
+  if (!check.empty())
   {
     elxout << "-ipp      " << check << std::endl;
     // Deprecated since elastix 4.3
@@ -166,7 +166,7 @@ TransformBase<TElastix>::BeforeAllTransformix(void)
 
   /** Check for appearance of "-def". */
   check = this->m_Configuration->GetCommandLineArgument("-def");
-  if (check == "")
+  if (check.empty())
   {
     elxout << "-def      unspecified, so no input points transformed" << std::endl;
   }
@@ -177,7 +177,7 @@ TransformBase<TElastix>::BeforeAllTransformix(void)
 
   /** Check for appearance of "-jac". */
   check = this->m_Configuration->GetCommandLineArgument("-jac");
-  if (check == "")
+  if (check.empty())
   {
     elxout << "-jac      unspecified, so no det(dT/dx) computed" << std::endl;
   }
@@ -188,7 +188,7 @@ TransformBase<TElastix>::BeforeAllTransformix(void)
 
   /** Check for appearance of "-jacmat". */
   check = this->m_Configuration->GetCommandLineArgument("-jacmat");
-  if (check == "")
+  if (check.empty())
   {
     elxout << "-jacmat   unspecified, so no dT/dx computed" << std::endl;
   }
@@ -712,18 +712,18 @@ TransformBase<TElastix>::TransformPoints(void) const
   std::string       def = this->GetConfiguration()->GetCommandLineArgument("-def");
 
   /** For backwards compatibility def = ipp. */
-  if (def != "" && ipp != "")
+  if (!def.empty() && !ipp.empty())
   {
     itkExceptionMacro(<< "ERROR: Can not use both \"-def\" and \"-ipp\"!\n"
                       << "  \"-ipp\" is deprecated, use only \"-def\".\n");
   }
-  else if (def == "" && ipp != "")
+  else if (def.empty() && !ipp.empty())
   {
     def = ipp;
   }
 
   /** If there is an input point-file? */
-  if (def != "" && def != "all")
+  if (!def.empty() && def != "all")
   {
     if (itksys::SystemTools::StringEndsWith(def.c_str(), ".vtk") ||
         itksys::SystemTools::StringEndsWith(def.c_str(), ".VTK"))
@@ -1199,7 +1199,7 @@ TransformBase<TElastix>::ComputeDeterminantOfSpatialJacobian(void) const
    * then and only then we continue.
    */
   std::string jac = this->GetConfiguration()->GetCommandLineArgument("-jac");
-  if (jac == "")
+  if (jac.empty())
   {
     elxout << "  The command-line option \"-jac\" is not used, "
            << "so no det(dT/dx) computed." << std::endl;

--- a/Core/Configuration/elxConfiguration.cxx
+++ b/Core/Configuration/elxConfiguration.cxx
@@ -172,17 +172,17 @@ Configuration::Initialize(const CommandLineArgumentMapType & _arg)
   std::string p = this->GetCommandLineArgument("-p");
   std::string tp = this->GetCommandLineArgument("-tp");
 
-  if (p != "" && tp == "")
+  if (!p.empty() && tp.empty())
   {
     /** elastix called Initialize(). */
     this->SetParameterFileName(p.c_str());
   }
-  else if (p == "" && tp != "")
+  else if (p.empty() && !tp.empty())
   {
     /** transformix called Initialize(). */
     this->SetParameterFileName(tp.c_str());
   }
-  else if (p == "" && tp == "")
+  else if (p.empty() && tp.empty())
   {
     xl::xout["error"] << "ERROR: No (Transform-)Parameter file has been entered" << std::endl;
     xl::xout["error"] << "for elastix: command line option \"-p\"" << std::endl;

--- a/Core/Configuration/elxConfiguration.h
+++ b/Core/Configuration/elxConfiguration.h
@@ -159,7 +159,7 @@ public:
     std::string errorMessage = "";
     bool        found = this->m_ParameterMapInterface->ReadParameter(
       parameterValue, parameterName, entry_nr, printThisErrorMessage, errorMessage);
-    if (errorMessage != "")
+    if (!errorMessage.empty())
     {
       xl::xout["error"] << errorMessage;
     }
@@ -175,7 +175,7 @@ public:
   {
     std::string errorMessage = "";
     bool found = this->m_ParameterMapInterface->ReadParameter(parameterValue, parameterName, entry_nr, errorMessage);
-    if (errorMessage != "")
+    if (!errorMessage.empty())
     {
       xl::xout["error"] << errorMessage;
     }
@@ -197,7 +197,7 @@ public:
     std::string errorMessage = "";
     bool        found = this->m_ParameterMapInterface->ReadParameter(
       parameterValue, parameterName, prefix, entry_nr, default_entry_nr, printThisErrorMessage, errorMessage);
-    if (errorMessage != "")
+    if (!errorMessage.empty())
     {
       xl::xout["error"] << errorMessage;
     }
@@ -218,7 +218,7 @@ public:
     std::string errorMessage = "";
     bool        found = this->m_ParameterMapInterface->ReadParameter(
       parameterValue, parameterName, prefix, entry_nr, default_entry_nr, errorMessage);
-    if (errorMessage != "")
+    if (!errorMessage.empty())
     {
       xl::xout["error"] << errorMessage;
     }
@@ -268,7 +268,7 @@ public:
     std::string errorMessage = "";
     bool        found = this->m_ParameterMapInterface->ReadParameter(
       parameterValues, parameterName, entry_nr_start, entry_nr_end, printThisErrorMessage, errorMessage);
-    if (errorMessage != "")
+    if (!errorMessage.empty())
     {
       xl::xout["error"] << errorMessage;
     }

--- a/Core/Kernel/elxElastixBase.cxx
+++ b/Core/Kernel/elxElastixBase.cxx
@@ -51,14 +51,14 @@ GenerateFileNameContainer(const Configuration & configuration,
   argusedss << optionkey << 0;
   std::string argused = argusedss.str();
   std::string check = configuration.GetCommandLineArgument(argused.c_str());
-  if (check == "")
+  if (check.empty())
   {
     /** Try optionkey. */
     std::ostringstream argusedss2("");
     argusedss2 << optionkey;
     argused = argusedss2.str();
     check = configuration.GetCommandLineArgument(argused.c_str());
-    if (check == "")
+    if (check.empty())
     {
       /** Both failed; return an error message, if desired. */
       if (printerrors)
@@ -73,7 +73,7 @@ GenerateFileNameContainer(const Configuration & configuration,
   }
 
   /** Optionkey or optionkey0 is found. */
-  if (check != "")
+  if (!check.empty())
   {
     /** Print info, if desired. */
     if (printinfo)
@@ -96,7 +96,7 @@ GenerateFileNameContainer(const Configuration & configuration,
       argusedss2 << optionkey << i;
       argused = argusedss2.str();
       check = configuration.GetCommandLineArgument(argused.c_str());
-      if (check == "")
+      if (check.empty())
       {
         readsuccess = false;
       }
@@ -264,7 +264,7 @@ ElastixBase::BeforeAllBase(void)
    * Here we do it again. MS: WHY?
    */
   check = this->GetConfiguration()->GetCommandLineArgument("-out");
-  if (check == "")
+  if (check.empty())
   {
     xl::xout["error"] << "ERROR: No CommandLine option \"-out\" given!" << std::endl;
     returndummy |= 1;
@@ -302,7 +302,7 @@ ElastixBase::BeforeAllBase(void)
     std::ostringstream tempPname("");
     tempPname << "-p(" << i << ")";
     check = this->GetConfiguration()->GetCommandLineArgument(tempPname.str().c_str());
-    if (check == "")
+    if (check.empty())
     {
       loop = false;
     }
@@ -316,7 +316,7 @@ ElastixBase::BeforeAllBase(void)
   /** Check for appearance of "-priority", if this is a Windows station. */
 #ifdef _WIN32
   check = this->GetConfiguration()->GetCommandLineArgument("-priority");
-  if (check == "")
+  if (check.empty())
   {
     elxout << "-priority unspecified, so NORMAL process priority" << std::endl;
   }
@@ -328,7 +328,7 @@ ElastixBase::BeforeAllBase(void)
 
   /** Check for appearance of -threads, which specifies the maximum number of threads. */
   check = this->GetConfiguration()->GetCommandLineArgument("-threads");
-  if (check == "")
+  if (check.empty())
   {
     elxout << "-threads  unspecified, so all available threads are used" << std::endl;
   }
@@ -397,7 +397,7 @@ ElastixBase::BeforeAllTransformixBase(void)
   }
   /** Check for appearance of "-out". */
   std::string check = this->GetConfiguration()->GetCommandLineArgument("-out");
-  if (check == "")
+  if (check.empty())
   {
     xl::xout["error"] << "ERROR: No CommandLine option \"-out\" given!" << std::endl;
     returndummy |= 1;
@@ -414,7 +414,7 @@ ElastixBase::BeforeAllTransformixBase(void)
 
   /** Check for appearance of -threads, which specifies the maximum number of threads. */
   check = this->GetConfiguration()->GetCommandLineArgument("-threads");
-  if (check == "")
+  if (check.empty())
   {
     elxout << "-threads  unspecified, so all available threads are used" << std::endl;
   }

--- a/Core/Kernel/elxElastixMain.cxx
+++ b/Core/Kernel/elxElastixMain.cxx
@@ -507,13 +507,13 @@ ElastixMain::InitDBIndex(void)
       {
         /** Get the fixed image file name. */
         std::string fixedImageFileName = this->m_Configuration->GetCommandLineArgument("-f");
-        if (fixedImageFileName == "")
+        if (fixedImageFileName.empty())
         {
           fixedImageFileName = this->m_Configuration->GetCommandLineArgument("-f0");
         }
 
         /** Sanity check. */
-        if (fixedImageFileName == "")
+        if (fixedImageFileName.empty())
         {
           xl::xout["error"] << "ERROR: could not read fixed image." << std::endl;
           xl::xout["error"] << "  both -f and -f0 are unspecified" << std::endl;
@@ -584,13 +584,13 @@ ElastixMain::InitDBIndex(void)
       {
         /** Get the moving image file name. */
         std::string movingImageFileName = this->m_Configuration->GetCommandLineArgument("-m");
-        if (movingImageFileName == "")
+        if (movingImageFileName.empty())
         {
           movingImageFileName = this->m_Configuration->GetCommandLineArgument("-m0");
         }
 
         /** Sanity check. */
-        if (movingImageFileName == "")
+        if (movingImageFileName.empty())
         {
           xl::xout["error"] << "ERROR: could not read moving image." << std::endl;
           xl::xout["error"] << "  both -m and -m0 are unspecified" << std::endl;
@@ -792,7 +792,7 @@ ElastixMain::CreateComponents(const std::string &              key,
    * flag is true, and not component was given by the user,
    * then elastix quits.
    */
-  if (!found && (defaultComponentName == ""))
+  if (!found && (defaultComponentName.empty()))
   {
     if (mandatoryComponent)
     {
@@ -886,7 +886,7 @@ ElastixMain::SetProcessPriority(void) const
     SetPriorityClass(GetCurrentProcess(), IDLE_PRIORITY_CLASS);
 #endif
   }
-  else if (processPriority != "")
+  else if (!processPriority.empty())
   {
     xl::xout["warning"]
       << "Unsupported -priority value. Specify one of <high, abovenormal, normal, belownormal, idle, ''>." << std::endl;
@@ -906,7 +906,7 @@ ElastixMain::SetMaximumNumberOfThreads(void) const
   std::string maximumNumberOfThreadsString = this->m_Configuration->GetCommandLineArgument("-threads");
 
   /** If supplied, set the maximum number of threads. */
-  if (maximumNumberOfThreadsString != "")
+  if (!maximumNumberOfThreadsString.empty())
   {
     const int maximumNumberOfThreads = atoi(maximumNumberOfThreadsString.c_str());
     itk::MultiThreaderBase::SetGlobalMaximumNumberOfThreads(maximumNumberOfThreads);
@@ -954,7 +954,7 @@ ElastixMain::GetTransformParametersMap(void) const
 void
 ElastixMain::GetImageInformationFromFile(const std::string & filename, ImageDimensionType & imageDimension) const
 {
-  if (filename != "")
+  if (!filename.empty())
   {
     /** Dummy image type. */
     const unsigned int                                 DummyDimension = 3;

--- a/Core/Main/elxElastixFilter.hxx
+++ b/Core/Main/elxElastixFilter.hxx
@@ -126,7 +126,7 @@ ElastixFilter<TFixedImage, TMovingImage>::GenerateData(void)
     itkDynamicCastInDebugMode<ParameterObject *>(this->GetInput("ParameterObject"));
   ParameterMapVectorType parameterMapVector = parameterObject->GetParameterMap();
 
-  if (parameterMapVector.size() == 0)
+  if (parameterMapVector.empty())
   {
     itkExceptionMacro("Empty parameter map in parameter object.");
   }

--- a/Core/Main/elxParameterObject.cxx
+++ b/Core/Main/elxParameterObject.cxx
@@ -197,7 +197,7 @@ ParameterObject::ReadParameterFile(const ParameterFileNameType & parameterFileNa
 void
 ParameterObject::ReadParameterFile(const ParameterFileNameVectorType & parameterFileNameVector)
 {
-  if (parameterFileNameVector.size() == 0)
+  if (parameterFileNameVector.empty())
   {
     itkExceptionMacro("Parameter filename container is empty.");
   }
@@ -320,7 +320,7 @@ ParameterObject::WriteParameterFile(const ParameterMapType &      parameterMap,
 void
 ParameterObject::WriteParameterFile(const ParameterFileNameType & parameterFileName)
 {
-  if (this->m_ParameterMap.size() == 0)
+  if (this->m_ParameterMap.empty())
   {
     itkExceptionMacro("Error writing parameter map to disk: The parameter object is empty.");
   }

--- a/Core/Main/itkElastixRegistrationMethod.hxx
+++ b/Core/Main/itkElastixRegistrationMethod.hxx
@@ -145,7 +145,7 @@ ElastixRegistrationMethod<TFixedImage, TMovingImage>::GenerateData()
     itkDynamicCastInDebugMode<elastix::ParameterObject *>(this->ProcessObject::GetInput("ParameterObject"));
   ParameterMapVectorType parameterMapVector = parameterObject->GetParameterMap();
 
-  if (parameterMapVector.size() == 0)
+  if (parameterMapVector.empty())
   {
     itkExceptionMacro("Empty parameter map in parameter object.");
   }

--- a/Core/Main/itkTransformixFilter.hxx
+++ b/Core/Main/itkTransformixFilter.hxx
@@ -178,7 +178,7 @@ TransformixFilter<TMovingImage>::GenerateData()
   ParameterMapVectorType transformParameterMapVector = transformParameterObject->GetParameterMap();
 
   // Assert user did not set empty parameter map
-  if (transformParameterMapVector.size() == 0)
+  if (transformParameterMapVector.empty())
   {
     itkExceptionMacro("Empty parameter map in parameter object.");
   }

--- a/Testing/elxTransformParametersCompare.cxx
+++ b/Testing/elxTransformParametersCompare.cxx
@@ -246,7 +246,7 @@ main(int argc, char ** argv)
     /** Read the mask image, if given. */
     MaskImageType::Pointer maskImage;
     MaskIteratorType       itM;
-    if (maskFileName != "")
+    if (!maskFileName.empty())
     {
       MaskReaderType::Pointer maskReader = MaskReaderType::New();
       maskReader->SetFileName(maskFileName);
@@ -282,7 +282,7 @@ main(int argc, char ** argv)
 
       /** Compare. */
       include = 1.0;
-      if (maskFileName != "")
+      if (!maskFileName.empty())
       {
         indexInCoefficientImage = it.GetIndex();
         coefImage->TransformIndexToPhysicalPoint(indexInCoefficientImage, physicalPoint);
@@ -304,7 +304,7 @@ main(int argc, char ** argv)
       /** Update iterators. */
       ++it;
       ++index;
-      if (maskFileName != "")
+      if (!maskFileName.empty())
       {
         ++itM;
       }
@@ -315,7 +315,7 @@ main(int argc, char ** argv)
 
     /** Create name for difference image. */
     std::string diffImageFileName = itksys::SystemTools::GetFilenamePath(testFileName);
-    if (diffImageFileName != "")
+    if (!diffImageFileName.empty())
     {
       diffImageFileName += "/";
     }


### PR DESCRIPTION
Ran Clang-Tidy (LLVM 11.1.0) `readability-container-size-empty`, as motivated at https://clang.llvm.org/extra/clang-tidy/checks/readability-container-size-empty.html :

"The emptiness of a container should be checked using the empty() method instead of the size() method. It is not guaranteed that size() is a constant-time function, and it is generally more efficient and also shows clearer intent to use empty(). Furthermore some containers may implement the empty() method but not implement the size() method. Using empty() whenever possible makes it easier to switch to another container in the future."

Got extra motivated by having my very first microsoft/STL commit on this topic: https://github.com/microsoft/STL/commit/b95ba0ef2f018530587977d0c730cf0881dfc51a "Avoid calling size() in empty() member functions" (merged from pull request https://github.com/microsoft/STL/pull/1836)

Follows ITK pull request https://github.com/InsightSoftwareConsortium/ITK/pull/414 commit https://github.com/InsightSoftwareConsortium/ITK/commit/c82a5f23d694f82057ff26262dff30c4835d3b5b "PERF: readability container size empty", Hans Johnson, January 2019.