### PR TITLE
COMP: Add `override` specifiers to OpenCL components, using Clang-Tidy

### DIFF
--- a/Common/OpenCL/Factories/itkGPUCastImageFilterFactory.h
+++ b/Common/OpenCL/Factories/itkGPUCastImageFilterFactory.h
@@ -44,7 +44,7 @@ public:
 
   /** Return a descriptive string describing the factory. */
   const char *
-  GetDescription() const
+  GetDescription() const override
   {
     return "A Factory for GPUCastImageFilter";
   }
@@ -102,19 +102,19 @@ public:
 
 protected:
   GPUCastImageFilterFactory2();
-  virtual ~GPUCastImageFilterFactory2() = default;
+  ~GPUCastImageFilterFactory2() override = default;
 
   /** Register methods for 1D. */
-  virtual void
-  Register1D();
+  void
+  Register1D() override;
 
   /** Register methods for 2D. */
-  virtual void
-  Register2D();
+  void
+  Register2D() override;
 
   /** Register methods for 3D. */
-  virtual void
-  Register3D();
+  void
+  Register3D() override;
 
 private:
   GPUCastImageFilterFactory2(const Self &) = delete;

--- a/Common/OpenCL/Factories/itkGPUIdentityTransformFactory.h
+++ b/Common/OpenCL/Factories/itkGPUIdentityTransformFactory.h
@@ -44,7 +44,7 @@ public:
 
   /** Return a descriptive string describing the factory. */
   const char *
-  GetDescription() const
+  GetDescription() const override
   {
     return "A Factory for GPUIdentityTransform";
   }
@@ -74,22 +74,22 @@ public:
 
 protected:
   GPUIdentityTransformFactory2();
-  virtual ~GPUIdentityTransformFactory2() = default;
+  ~GPUIdentityTransformFactory2() override = default;
 
   /** Typedef for real type list. */
   typedef typelist::MakeTypeList<float, double>::Type RealTypeList;
 
   /** Register methods for 1D. */
-  virtual void
-  Register1D();
+  void
+  Register1D() override;
 
   /** Register methods for 2D. */
-  virtual void
-  Register2D();
+  void
+  Register2D() override;
 
   /** Register methods for 3D. */
-  virtual void
-  Register3D();
+  void
+  Register3D() override;
 
 private:
   GPUIdentityTransformFactory2(const Self &) = delete;

--- a/Common/OpenCL/Factories/itkGPUImageFactory.h
+++ b/Common/OpenCL/Factories/itkGPUImageFactory.h
@@ -44,7 +44,7 @@ public:
 
   /** Return a descriptive string describing the factory. */
   const char *
-  GetDescription() const
+  GetDescription() const override
   {
     return "A Factory for GPUImage";
   }
@@ -74,19 +74,19 @@ public:
 
 protected:
   GPUImageFactory2();
-  virtual ~GPUImageFactory2() = default;
+  ~GPUImageFactory2() override = default;
 
   /** Register methods for 1D. */
-  virtual void
-  Register1D();
+  void
+  Register1D() override;
 
   /** Register methods for 2D. */
-  virtual void
-  Register2D();
+  void
+  Register2D() override;
 
   /** Register methods for 3D. */
-  virtual void
-  Register3D();
+  void
+  Register3D() override;
 
 private:
   GPUImageFactory2(const Self &) = delete;

--- a/Common/OpenCL/Factories/itkGPULinearInterpolateImageFunctionFactory.h
+++ b/Common/OpenCL/Factories/itkGPULinearInterpolateImageFunctionFactory.h
@@ -44,7 +44,7 @@ public:
 
   /** Return a descriptive string describing the factory. */
   const char *
-  GetDescription() const
+  GetDescription() const override
   {
     return "A Factory for GPULinearInterpolateImageFunction";
   }
@@ -102,19 +102,19 @@ public:
 
 protected:
   GPULinearInterpolateImageFunctionFactory2();
-  virtual ~GPULinearInterpolateImageFunctionFactory2() = default;
+  ~GPULinearInterpolateImageFunctionFactory2() override = default;
 
   /** Register methods for 1D. */
-  virtual void
-  Register1D();
+  void
+  Register1D() override;
 
   /** Register methods for 2D. */
-  virtual void
-  Register2D();
+  void
+  Register2D() override;
 
   /** Register methods for 3D. */
-  virtual void
-  Register3D();
+  void
+  Register3D() override;
 
 private:
   GPULinearInterpolateImageFunctionFactory2(const Self &) = delete;

--- a/Common/OpenCL/Factories/itkGPURecursiveGaussianImageFilterFactory.h
+++ b/Common/OpenCL/Factories/itkGPURecursiveGaussianImageFilterFactory.h
@@ -44,7 +44,7 @@ public:
 
   /** Return a descriptive string describing the factory. */
   const char *
-  GetDescription() const
+  GetDescription() const override
   {
     return "A Factory for GPURecursiveGaussianImageFilter";
   }
@@ -106,19 +106,19 @@ public:
 
 protected:
   GPURecursiveGaussianImageFilterFactory2();
-  virtual ~GPURecursiveGaussianImageFilterFactory2() = default;
+  ~GPURecursiveGaussianImageFilterFactory2() override = default;
 
   /** Register methods for 1D. */
-  virtual void
-  Register1D();
+  void
+  Register1D() override;
 
   /** Register methods for 2D. */
-  virtual void
-  Register2D();
+  void
+  Register2D() override;
 
   /** Register methods for 3D. */
-  virtual void
-  Register3D();
+  void
+  Register3D() override;
 
 private:
   GPURecursiveGaussianImageFilterFactory2(const Self &) = delete;

--- a/Common/OpenCL/Factories/itkGPUResampleImageFilterFactory.h
+++ b/Common/OpenCL/Factories/itkGPUResampleImageFilterFactory.h
@@ -44,7 +44,7 @@ public:
 
   /** Return a descriptive string describing the factory. */
   const char *
-  GetDescription() const
+  GetDescription() const override
   {
     return "A Factory for GPUResampleImageFilter";
   }
@@ -140,19 +140,19 @@ public:
 
 protected:
   GPUResampleImageFilterFactory2();
-  virtual ~GPUResampleImageFilterFactory2() = default;
+  ~GPUResampleImageFilterFactory2() override = default;
 
   /** Register methods for 1D. */
-  virtual void
-  Register1D();
+  void
+  Register1D() override;
 
   /** Register methods for 2D. */
-  virtual void
-  Register2D();
+  void
+  Register2D() override;
 
   /** Register methods for 3D. */
-  virtual void
-  Register3D();
+  void
+  Register3D() override;
 
 private:
   GPUResampleImageFilterFactory2(const Self &) = delete;

--- a/Common/OpenCL/Factories/itkGPUShrinkImageFilterFactory.h
+++ b/Common/OpenCL/Factories/itkGPUShrinkImageFilterFactory.h
@@ -44,7 +44,7 @@ public:
 
   /** Return a descriptive string describing the factory. */
   const char *
-  GetDescription() const
+  GetDescription() const override
   {
     return "A Factory for GPUShrinkImageFilter";
   }
@@ -102,19 +102,19 @@ public:
 
 protected:
   GPUShrinkImageFilterFactory2();
-  virtual ~GPUShrinkImageFilterFactory2() = default;
+  ~GPUShrinkImageFilterFactory2() override = default;
 
   /** Register methods for 1D. */
-  virtual void
-  Register1D();
+  void
+  Register1D() override;
 
   /** Register methods for 2D. */
-  virtual void
-  Register2D();
+  void
+  Register2D() override;
 
   /** Register methods for 3D. */
-  virtual void
-  Register3D();
+  void
+  Register3D() override;
 
 private:
   GPUShrinkImageFilterFactory2(const Self &) = delete;

--- a/Common/OpenCL/Filters/itkGPUAdvancedBSplineDeformableTransform.h
+++ b/Common/OpenCL/Filters/itkGPUAdvancedBSplineDeformableTransform.h
@@ -63,15 +63,15 @@ public:
 
   /** This method sets the parameters of the transform. */
   void
-  SetParameters(const ParametersType & parameters);
+  SetParameters(const ParametersType & parameters) override;
 
   /** Set the array of coefficient images. */
   void
-  SetCoefficientImages(ImagePointer images[]);
+  SetCoefficientImages(ImagePointer images[]) override;
 
 protected:
   GPUAdvancedBSplineDeformableTransform();
-  virtual ~GPUAdvancedBSplineDeformableTransform() = default;
+  ~GPUAdvancedBSplineDeformableTransform() override = default;
 
   void
   PrintSelf(std::ostream & os, Indent indent) const override;

--- a/Common/OpenCL/Filters/itkGPUAdvancedCombinationTransform.h
+++ b/Common/OpenCL/Filters/itkGPUAdvancedCombinationTransform.h
@@ -61,22 +61,22 @@ public:
   typedef typename GPUSuperclass::TransformTypeConstPointer TransformTypeConstPointer;
 
   /** Get number of transforms in composite transform. */
-  virtual SizeValueType
-  GetNumberOfTransforms(void) const
+  SizeValueType
+  GetNumberOfTransforms(void) const override
   {
     return CPUSuperclass::GetNumberOfTransforms();
   }
 
   /** Get the Nth transform. */
-  virtual const TransformTypePointer
-  GetNthTransform(SizeValueType n) const
+  const TransformTypePointer
+  GetNthTransform(SizeValueType n) const override
   {
     return CPUSuperclass::GetNthTransform(n);
   }
 
 protected:
   GPUAdvancedCombinationTransform() = default;
-  virtual ~GPUAdvancedCombinationTransform() = default;
+  ~GPUAdvancedCombinationTransform() override = default;
   void
   PrintSelf(std::ostream & s, Indent indent) const override
   {

--- a/Common/OpenCL/Filters/itkGPUAdvancedEuler2DTransform.h
+++ b/Common/OpenCL/Filters/itkGPUAdvancedEuler2DTransform.h
@@ -59,29 +59,29 @@ public:
   typedef typename GPUSuperclass::CPUOutputVectorType  CPUOutputVectorType;
 
   /** Get CPU matrix of an MatrixOffsetTransformBase. */
-  virtual const CPUMatrixType &
-  GetCPUMatrix(void) const
+  const CPUMatrixType &
+  GetCPUMatrix(void) const override
   {
     return this->GetMatrix();
   }
 
   /** Get CPU inverse matrix of an MatrixOffsetTransformBase. */
-  virtual const CPUInverseMatrixType &
-  GetCPUInverseMatrix(void) const
+  const CPUInverseMatrixType &
+  GetCPUInverseMatrix(void) const override
   {
     return this->GetInverseMatrix();
   }
 
   /** Get CPU offset of an MatrixOffsetTransformBase. */
-  virtual const CPUOutputVectorType &
-  GetCPUOffset(void) const
+  const CPUOutputVectorType &
+  GetCPUOffset(void) const override
   {
     return this->GetOffset();
   }
 
 protected:
   GPUAdvancedEuler2DTransform() = default;
-  virtual ~GPUAdvancedEuler2DTransform() = default;
+  ~GPUAdvancedEuler2DTransform() override = default;
 
 private:
   GPUAdvancedEuler2DTransform(const Self & other) = delete;

--- a/Common/OpenCL/Filters/itkGPUAdvancedEuler3DTransform.h
+++ b/Common/OpenCL/Filters/itkGPUAdvancedEuler3DTransform.h
@@ -59,29 +59,29 @@ public:
   typedef typename GPUSuperclass::CPUOutputVectorType  CPUOutputVectorType;
 
   /** Get CPU matrix of an MatrixOffsetTransformBase. */
-  virtual const CPUMatrixType &
-  GetCPUMatrix(void) const
+  const CPUMatrixType &
+  GetCPUMatrix(void) const override
   {
     return this->GetMatrix();
   }
 
   /** Get CPU inverse matrix of an MatrixOffsetTransformBase. */
-  virtual const CPUInverseMatrixType &
-  GetCPUInverseMatrix(void) const
+  const CPUInverseMatrixType &
+  GetCPUInverseMatrix(void) const override
   {
     return this->GetInverseMatrix();
   }
 
   /** Get CPU offset of an MatrixOffsetTransformBase. */
-  virtual const CPUOutputVectorType &
-  GetCPUOffset(void) const
+  const CPUOutputVectorType &
+  GetCPUOffset(void) const override
   {
     return this->GetOffset();
   }
 
 protected:
   GPUAdvancedEuler3DTransform() = default;
-  virtual ~GPUAdvancedEuler3DTransform() = default;
+  ~GPUAdvancedEuler3DTransform() override = default;
 
 private:
   GPUAdvancedEuler3DTransform(const Self & other) = delete;

--- a/Common/OpenCL/Filters/itkGPUAdvancedMatrixOffsetTransformBase.h
+++ b/Common/OpenCL/Filters/itkGPUAdvancedMatrixOffsetTransformBase.h
@@ -61,29 +61,29 @@ public:
   typedef typename GPUSuperclass::CPUOutputVectorType  CPUOutputVectorType;
 
   /** Get CPU matrix of an MatrixOffsetTransformBase. */
-  virtual const CPUMatrixType &
-  GetCPUMatrix(void) const
+  const CPUMatrixType &
+  GetCPUMatrix(void) const override
   {
     return this->GetMatrix();
   }
 
   /** Get CPU inverse matrix of an MatrixOffsetTransformBase. */
-  virtual const CPUInverseMatrixType &
-  GetCPUInverseMatrix(void) const
+  const CPUInverseMatrixType &
+  GetCPUInverseMatrix(void) const override
   {
     return this->GetInverseMatrix();
   }
 
   /** Get CPU offset of an MatrixOffsetTransformBase. */
-  virtual const CPUOutputVectorType &
-  GetCPUOffset(void) const
+  const CPUOutputVectorType &
+  GetCPUOffset(void) const override
   {
     return this->GetOffset();
   }
 
 protected:
   GPUAdvancedMatrixOffsetTransformBase() = default;
-  virtual ~GPUAdvancedMatrixOffsetTransformBase() = default;
+  ~GPUAdvancedMatrixOffsetTransformBase() override = default;
 
 private:
   GPUAdvancedMatrixOffsetTransformBase(const Self & other) = delete;

--- a/Common/OpenCL/Filters/itkGPUAdvancedSimilarity2DTransform.h
+++ b/Common/OpenCL/Filters/itkGPUAdvancedSimilarity2DTransform.h
@@ -59,29 +59,29 @@ public:
   typedef typename GPUSuperclass::CPUOutputVectorType  CPUOutputVectorType;
 
   /** Get CPU matrix of an MatrixOffsetTransformBase. */
-  virtual const CPUMatrixType &
-  GetCPUMatrix(void) const
+  const CPUMatrixType &
+  GetCPUMatrix(void) const override
   {
     return this->GetMatrix();
   }
 
   /** Get CPU inverse matrix of an MatrixOffsetTransformBase. */
-  virtual const CPUInverseMatrixType &
-  GetCPUInverseMatrix(void) const
+  const CPUInverseMatrixType &
+  GetCPUInverseMatrix(void) const override
   {
     return this->GetInverseMatrix();
   }
 
   /** Get CPU offset of an MatrixOffsetTransformBase. */
-  virtual const CPUOutputVectorType &
-  GetCPUOffset(void) const
+  const CPUOutputVectorType &
+  GetCPUOffset(void) const override
   {
     return this->GetOffset();
   }
 
 protected:
   GPUAdvancedSimilarity2DTransform() = default;
-  virtual ~GPUAdvancedSimilarity2DTransform() = default;
+  ~GPUAdvancedSimilarity2DTransform() override = default;
 
 private:
   GPUAdvancedSimilarity2DTransform(const Self & other) = delete;

--- a/Common/OpenCL/Filters/itkGPUAdvancedSimilarity3DTransform.h
+++ b/Common/OpenCL/Filters/itkGPUAdvancedSimilarity3DTransform.h
@@ -59,29 +59,29 @@ public:
   typedef typename GPUSuperclass::CPUOutputVectorType  CPUOutputVectorType;
 
   /** Get CPU matrix of an MatrixOffsetTransformBase. */
-  virtual const CPUMatrixType &
-  GetCPUMatrix(void) const
+  const CPUMatrixType &
+  GetCPUMatrix(void) const override
   {
     return this->GetMatrix();
   }
 
   /** Get CPU inverse matrix of an MatrixOffsetTransformBase. */
-  virtual const CPUInverseMatrixType &
-  GetCPUInverseMatrix(void) const
+  const CPUInverseMatrixType &
+  GetCPUInverseMatrix(void) const override
   {
     return this->GetInverseMatrix();
   }
 
   /** Get CPU offset of an MatrixOffsetTransformBase. */
-  virtual const CPUOutputVectorType &
-  GetCPUOffset(void) const
+  const CPUOutputVectorType &
+  GetCPUOffset(void) const override
   {
     return this->GetOffset();
   }
 
 protected:
   GPUAdvancedSimilarity3DTransform() = default;
-  virtual ~GPUAdvancedSimilarity3DTransform() = default;
+  ~GPUAdvancedSimilarity3DTransform() override = default;
 
 private:
   GPUAdvancedSimilarity3DTransform(const Self & other) = delete;

--- a/Common/OpenCL/Filters/itkGPUAdvancedTranslationTransform.h
+++ b/Common/OpenCL/Filters/itkGPUAdvancedTranslationTransform.h
@@ -59,15 +59,15 @@ public:
   typedef typename GPUSuperclass::CPUOutputVectorType CPUOutputVectorType;
 
   /** This method returns the CPU value of the offset of the TranslationTransform. */
-  virtual const CPUOutputVectorType &
-  GetCPUOffset(void) const
+  const CPUOutputVectorType &
+  GetCPUOffset(void) const override
   {
     return this->GetOffset();
   }
 
 protected:
   GPUAdvancedTranslationTransform() = default;
-  virtual ~GPUAdvancedTranslationTransform() = default;
+  ~GPUAdvancedTranslationTransform() override = default;
 
 private:
   GPUAdvancedTranslationTransform(const Self & other) = delete;

--- a/Common/OpenCL/Filters/itkGPUBSplineInterpolateImageFunction.h
+++ b/Common/OpenCL/Filters/itkGPUBSplineInterpolateImageFunction.h
@@ -76,8 +76,8 @@ public:
   typedef typename GPUDataManager::Pointer                GPUDataManagerPointer;
 
   /** Set the input image. This must be set by the user. */
-  virtual void
-  SetInputImage(const TInputImage * inputData);
+  void
+  SetInputImage(const TInputImage * inputData) override;
 
   /** Get the GPU coefficient image. */
   const GPUCoefficientImagePointer
@@ -89,7 +89,7 @@ public:
 
 protected:
   GPUBSplineInterpolateImageFunction();
-  ~GPUBSplineInterpolateImageFunction() = default;
+  ~GPUBSplineInterpolateImageFunction() override = default;
   void
   PrintSelf(std::ostream & os, Indent indent) const override;
 

--- a/Common/OpenCL/Filters/itkGPUCastImageFilter.h
+++ b/Common/OpenCL/Filters/itkGPUCastImageFilter.h
@@ -100,12 +100,12 @@ public:
 
 protected:
   GPUCastImageFilter();
-  virtual ~GPUCastImageFilter() = default;
+  ~GPUCastImageFilter() override = default;
 
   /** Unlike CPU version, GPU version of binary threshold filter is not
   multi-threaded */
-  virtual void
-  GPUGenerateData(void);
+  void
+  GPUGenerateData(void) override;
 
 private:
   GPUCastImageFilter(const Self &) = delete;

--- a/Common/OpenCL/Filters/itkGPULinearInterpolateImageFunction.h
+++ b/Common/OpenCL/Filters/itkGPULinearInterpolateImageFunction.h
@@ -60,7 +60,7 @@ public:
 
 protected:
   GPULinearInterpolateImageFunction();
-  ~GPULinearInterpolateImageFunction() = default;
+  ~GPULinearInterpolateImageFunction() override = default;
   void
   PrintSelf(std::ostream & os, Indent indent) const override;
 

--- a/Common/OpenCL/Filters/itkGPUNearestNeighborInterpolateImageFunction.h
+++ b/Common/OpenCL/Filters/itkGPUNearestNeighborInterpolateImageFunction.h
@@ -62,7 +62,7 @@ public:
 
 protected:
   GPUNearestNeighborInterpolateImageFunction();
-  ~GPUNearestNeighborInterpolateImageFunction() = default;
+  ~GPUNearestNeighborInterpolateImageFunction() override = default;
   void
   PrintSelf(std::ostream & os, Indent indent) const override;
 

--- a/Common/OpenCL/Filters/itkGPURecursiveGaussianImageFilter.h
+++ b/Common/OpenCL/Filters/itkGPURecursiveGaussianImageFilter.h
@@ -74,13 +74,13 @@ public:
 
 protected:
   GPURecursiveGaussianImageFilter();
-  ~GPURecursiveGaussianImageFilter() = default;
+  ~GPURecursiveGaussianImageFilter() override = default;
 
   void
   PrintSelf(std::ostream & os, Indent indent) const override;
 
-  virtual void
-  GPUGenerateData();
+  void
+  GPUGenerateData() override;
 
 private:
   GPURecursiveGaussianImageFilter(const Self &) = delete;

--- a/Common/OpenCL/Filters/itkGPUResampleImageFilter.h
+++ b/Common/OpenCL/Filters/itkGPUResampleImageFilter.h
@@ -100,16 +100,16 @@ public:
   typedef GPUBSplineBaseTransform<InterpolatorPrecisionType, InputImageDimension> GPUBSplineBaseTransformType;
 
   /** Set the interpolator. */
-  virtual void
-  SetInterpolator(InterpolatorType * _arg);
+  void
+  SetInterpolator(InterpolatorType * _arg) override;
 
   /** Set the extrapolator. Not yet supported. */
-  virtual void
-  SetExtrapolator(ExtrapolatorType * _arg);
+  void
+  SetExtrapolator(ExtrapolatorType * _arg) override;
 
   /** Set the transform. */
-  virtual void
-  SetTransform(const TransformType * _arg);
+  void
+  SetTransform(const TransformType * _arg) override;
 
   /** Set/Get the requested number of splits on OpenCL device.
    * Only works for 3D images. For 1D, 2D are always equal 1. */
@@ -118,12 +118,12 @@ public:
 
 protected:
   GPUResampleImageFilter();
-  ~GPUResampleImageFilter() = default;
+  ~GPUResampleImageFilter() override = default;
   void
   PrintSelf(std::ostream & os, Indent indent) const override;
 
-  virtual void
-  GPUGenerateData(void);
+  void
+  GPUGenerateData(void) override;
 
   // Supported GPU transform types
   typedef enum

--- a/Common/OpenCL/Filters/itkGPUShrinkImageFilter.h
+++ b/Common/OpenCL/Filters/itkGPUShrinkImageFilter.h
@@ -80,12 +80,12 @@ public:
 
 protected:
   GPUShrinkImageFilter();
-  ~GPUShrinkImageFilter() = default;
+  ~GPUShrinkImageFilter() override = default;
   void
   PrintSelf(std::ostream & os, Indent indent) const override;
 
-  virtual void
-  GPUGenerateData();
+  void
+  GPUGenerateData() override;
 
 private:
   GPUShrinkImageFilter(const Self &) = delete;

--- a/Common/OpenCL/ITKimprovements/itkGPUImage.h
+++ b/Common/OpenCL/ITKimprovements/itkGPUImage.h
@@ -101,8 +101,8 @@ public:
   void
   AllocateGPU(void);
 
-  virtual void
-  Initialize(void);
+  void
+  Initialize(void) override;
 
   void
   FillBuffer(const TPixel & value);
@@ -133,10 +133,10 @@ public:
 
   /** Get CPU buffer pointer */
   TPixel *
-  GetBufferPointer(void);
+  GetBufferPointer(void) override;
 
   const TPixel *
-  GetBufferPointer(void) const;
+  GetBufferPointer(void) const override;
 
   /** Return the Pixel Accessor object */
   AccessorType
@@ -219,7 +219,7 @@ public:
    * CPU's time stamp will be increased after that.
    */
   void
-  DataHasBeenGenerated(void)
+  DataHasBeenGenerated(void) override
   {
     Superclass::DataHasBeenGenerated();
 
@@ -231,15 +231,15 @@ public:
 
 
   /** Graft the data and information from one GPUImage to another. */
-  virtual void
-  Graft(const DataObject * data);
+  void
+  Graft(const DataObject * data) override;
 
   void
   GraftITKImage(const DataObject * data);
 
   /** Whenever the image has been modified, set the GPU Buffer to dirty */
-  virtual void
-  Modified(void) const;
+  void
+  Modified(void) const override;
 
   /** Get matrices intended to help with the conversion of Index coordinates
    *  to PhysicalPoint coordinates */
@@ -248,10 +248,10 @@ public:
 
 protected:
   GPUImage();
-  virtual ~GPUImage() = default;
+  ~GPUImage() override = default;
 
-  virtual void
-  PrintSelf(std::ostream & os, Indent indent) const;
+  void
+  PrintSelf(std::ostream & os, Indent indent) const override;
 
 private:
   GPUImage(const Self &) = delete;

--- a/Common/OpenCL/ITKimprovements/itkGPUImageToImageFilter.h
+++ b/Common/OpenCL/ITKimprovements/itkGPUImageToImageFilter.h
@@ -99,24 +99,24 @@ public:
   itkGetConstMacro(GPUEnabled, bool);
   itkBooleanMacro(GPUEnabled);
 
-  virtual void
-  GraftOutput(DataObject * graft);
+  void
+  GraftOutput(DataObject * graft) override;
 
-  virtual void
-  GraftOutput(const DataObjectIdentifierType & key, DataObject * graft);
+  void
+  GraftOutput(const DataObjectIdentifierType & key, DataObject * graft) override;
 
-  virtual void
-  SetNumberOfWorkUnits(ThreadIdType _arg);
+  void
+  SetNumberOfWorkUnits(ThreadIdType _arg) override;
 
 protected:
   GPUImageToImageFilter();
-  ~GPUImageToImageFilter() = default;
+  ~GPUImageToImageFilter() override = default;
 
-  virtual void
-  PrintSelf(std::ostream & os, Indent indent) const;
+  void
+  PrintSelf(std::ostream & os, Indent indent) const override;
 
-  virtual void
-  GenerateData();
+  void
+  GenerateData() override;
 
   virtual void
   GPUGenerateData()

--- a/Common/OpenCL/ITKimprovements/itkGPUInPlaceImageFilter.h
+++ b/Common/OpenCL/ITKimprovements/itkGPUInPlaceImageFilter.h
@@ -92,10 +92,10 @@ public:
 
 protected:
   GPUInPlaceImageFilter() = default;
-  ~GPUInPlaceImageFilter() = default;
+  ~GPUInPlaceImageFilter() override = default;
 
-  virtual void
-  PrintSelf(std::ostream & os, Indent indent) const;
+  void
+  PrintSelf(std::ostream & os, Indent indent) const override;
 
   /** The GenerateData method normally allocates the buffers for all
    * of the outputs of a filter. Since InPlaceImageFilter's can use an
@@ -109,8 +109,8 @@ protected:
    * an InPlaceFilter is not threaded (i.e. it provides an
    * implementation of GenerateData()), then this method (or
    * equivalent) must be called in GenerateData(). */
-  virtual void
-  AllocateOutputs();
+  void
+  AllocateOutputs() override;
 
   /** InPlaceImageFilter may transfer ownership of the input bulk data
    * to the output object.  Once the output object owns the bulk data
@@ -121,8 +121,8 @@ protected:
    * releases the input that it has overwritten.
    *
    * \sa ProcessObject::ReleaseInputs() */
-  virtual void
-  ReleaseInputs();
+  void
+  ReleaseInputs() override;
 
 private:
   GPUInPlaceImageFilter(const Self &) = delete;

--- a/Common/OpenCL/ITKimprovements/itkGPUUnaryFunctorImageFilter.h
+++ b/Common/OpenCL/ITKimprovements/itkGPUUnaryFunctorImageFilter.h
@@ -123,13 +123,13 @@ public:
 protected:
   GPUUnaryFunctorImageFilter() = default;
 
-  virtual ~GPUUnaryFunctorImageFilter() = default;
+  ~GPUUnaryFunctorImageFilter() override = default;
 
-  virtual void
-  GenerateOutputInformation();
+  void
+  GenerateOutputInformation() override;
 
-  virtual void
-  GPUGenerateData();
+  void
+  GPUGenerateData() override;
 
   /** GPU kernel handle is defined here instead of in the child class
    * because GPUGenerateData() in this base class is used. */

--- a/Common/Transforms/itkAdvancedSimilarity3DTransform.h
+++ b/Common/Transforms/itkAdvancedSimilarity3DTransform.h
@@ -146,7 +146,7 @@ protected:
   AdvancedSimilarity3DTransform(unsigned int outputSpaceDim, unsigned int paramDim);
   AdvancedSimilarity3DTransform(const MatrixType & matrix, const OutputVectorType & offset);
   AdvancedSimilarity3DTransform();
-  ~AdvancedSimilarity3DTransform() = default;
+  ~AdvancedSimilarity3DTransform() override = default;
 
   void
   PrintSelf(std::ostream & os, Indent indent) const override;

--- a/Common/Transforms/itkAdvancedVersorRigid3DTransform.h
+++ b/Common/Transforms/itkAdvancedVersorRigid3DTransform.h
@@ -132,7 +132,7 @@ protected:
   AdvancedVersorRigid3DTransform(unsigned int outputSpaceDim, unsigned int paramDim);
   AdvancedVersorRigid3DTransform(const MatrixType & matrix, const OutputVectorType & offset);
   AdvancedVersorRigid3DTransform();
-  ~AdvancedVersorRigid3DTransform() = default;
+  ~AdvancedVersorRigid3DTransform() override = default;
 
   void
   PrintSelf(std::ostream & os, Indent indent) const override;

--- a/Common/Transforms/itkAdvancedVersorTransform.h
+++ b/Common/Transforms/itkAdvancedVersorTransform.h
@@ -158,7 +158,7 @@ protected:
   AdvancedVersorTransform();
 
   /** Destroy an AdvancedVersorTransform object */
-  ~AdvancedVersorTransform() = default;
+  ~AdvancedVersorTransform() override = default;
 
   /** This method must be made protected here because it is not a safe way of
    * initializing the Versor */

--- a/Components/FixedImagePyramids/OpenCLFixedGenericPyramid/elxOpenCLFixedGenericPyramid.h
+++ b/Components/FixedImagePyramids/OpenCLFixedGenericPyramid/elxOpenCLFixedGenericPyramid.h
@@ -89,8 +89,8 @@ public:
   typedef typename GPUPyramidType::Pointer                                                            GPUPyramidPointer;
 
   /** Do some things before registration. */
-  virtual void
-  BeforeRegistration(void);
+  void
+  BeforeRegistration(void) override;
 
   /** Function to read parameters from a file. */
   virtual void
@@ -102,13 +102,13 @@ protected:
   BeforeGenerateData(void);
 
   /** Executes GPU pyramid. */
-  virtual void
-  GenerateData(void);
+  void
+  GenerateData(void) override;
 
   /** The constructor. */
   OpenCLFixedGenericPyramid();
   /** The destructor. */
-  virtual ~OpenCLFixedGenericPyramid() = default;
+  ~OpenCLFixedGenericPyramid() override = default;
 
 private:
   elxOverrideGetSelfMacro;

--- a/Components/MovingImagePyramids/OpenCLMovingGenericPyramid/elxOpenCLMovingGenericPyramid.h
+++ b/Components/MovingImagePyramids/OpenCLMovingGenericPyramid/elxOpenCLMovingGenericPyramid.h
@@ -89,8 +89,8 @@ public:
   typedef typename GPUPyramidType::Pointer                                                            GPUPyramidPointer;
 
   /** Do some things before registration. */
-  virtual void
-  BeforeRegistration(void);
+  void
+  BeforeRegistration(void) override;
 
   /** Function to read parameters from a file. */
   virtual void
@@ -102,13 +102,13 @@ protected:
   BeforeGenerateData(void);
 
   /** Executes GPU pyramid. */
-  virtual void
-  GenerateData(void);
+  void
+  GenerateData(void) override;
 
   /** The constructor. */
   OpenCLMovingGenericPyramid();
   /** The destructor. */
-  virtual ~OpenCLMovingGenericPyramid() = default;
+  ~OpenCLMovingGenericPyramid() override = default;
 
 private:
   elxOverrideGetSelfMacro;

--- a/Components/Resamplers/OpenCLResampler/elxOpenCLResampler.h
+++ b/Components/Resamplers/OpenCLResampler/elxOpenCLResampler.h
@@ -101,34 +101,34 @@ public:
   typedef typename Superclass2::ParameterMapType ParameterMapType;
 
   /** Set the transform. */
-  virtual void
-  SetTransform(const TransformType * _arg);
+  void
+  SetTransform(const TransformType * _arg) override;
 
   /** Set the interpolator. */
-  virtual void
-  SetInterpolator(InterpolatorType * _arg);
+  void
+  SetInterpolator(InterpolatorType * _arg) override;
 
   /** Do some things before registration. */
-  virtual void
-  BeforeRegistration(void);
+  void
+  BeforeRegistration(void) override;
 
   /** Function to read parameters from a file. */
-  virtual void
-  ReadFromFile(void);
+  void
+  ReadFromFile(void) override;
 
 protected:
   /** The constructor. */
   OpenCLResampler();
   /** The destructor. */
-  virtual ~OpenCLResampler() = default;
+  ~OpenCLResampler() override = default;
 
   /** This method performs all configuration for GPU resampler. */
   void
   BeforeGenerateData(void);
 
   /** Executes GPU resampler. */
-  virtual void
-  GenerateData(void);
+  void
+  GenerateData(void) override;
 
   /** Transform copier */
   typedef typename ResamplerBase<TElastix>::CoordRepType InterpolatorPrecisionType;

--- a/Components/Transforms/AffineDTITransform/itkAffineDTI3DTransform.h
+++ b/Components/Transforms/AffineDTITransform/itkAffineDTI3DTransform.h
@@ -149,7 +149,7 @@ protected:
   AffineDTI3DTransform(const MatrixType & matrix, const OutputPointType & offset);
   AffineDTI3DTransform(unsigned int outputSpaceDims, unsigned int paramsSpaceDims);
 
-  ~AffineDTI3DTransform() = default;
+  ~AffineDTI3DTransform() override = default;
 
   void
   PrintSelf(std::ostream & os, Indent indent) const override;


### PR DESCRIPTION
Added `override` specifiers to the OpenCL specific part of elastix, by running Clang-Tidy-Fix (LLVM 11.1.0) `modernize-use-override`:

https://clang.llvm.org/extra/clang-tidy/checks/modernize-use-override.html

Fixes Clang warnings like:

> Common\OpenCL\Factories\itkGPUCastImageFilterFactory.h(47): warning: 'GetDescription' overrides a member function but is not marked 'override' [clang-diagnostic-inconsistent-missing-override]

Follow-up to commit bb6bf2f3a2c03eb7130997f4bf287cf3b00b0159 "COMP: Added override by Clang Tidy-Fix modernize-use-override".

Regarding issue https://github.com/SuperElastix/elastix/issues/110 ("-Winconsistent-missing-override on MacOS") by Harmen Stoppels (@haampie).