### PR TITLE
STYLE: Replace `std::string::compare` calls by simple `==` expressions

### DIFF
--- a/Core/ComponentBaseClasses/elxResamplerBase.hxx
+++ b/Core/ComponentBaseClasses/elxResamplerBase.hxx
@@ -498,71 +498,71 @@ ResamplerBase<TElastix>::CreateItkResultImage(void)
   typedef itk::CastImageFilter<InputImageType, itk::Image<double, InputImageType::ImageDimension>> CastFilterDouble;
 
   /** cast the image to the correct output image Type */
-  if (resultImagePixelType.compare("char") == 0)
+  if (resultImagePixelType == "char")
   {
     typename CastFilterChar::Pointer castFilter = CastFilterChar::New();
     castFilter->SetInput(infoChanger->GetOutput());
     castFilter->Update();
     resultImage = castFilter->GetOutput();
   }
-  if (resultImagePixelType.compare("unsigned char") == 0)
+  if (resultImagePixelType == "unsigned char")
   {
     typename CastFilterUChar::Pointer castFilter = CastFilterUChar::New();
     castFilter->SetInput(infoChanger->GetOutput());
     castFilter->Update();
     resultImage = castFilter->GetOutput();
   }
-  else if (resultImagePixelType.compare("short") == 0)
+  else if (resultImagePixelType == "short")
   {
     typename CastFilterShort::Pointer castFilter = CastFilterShort::New();
     castFilter->SetInput(infoChanger->GetOutput());
     castFilter->Update();
     resultImage = castFilter->GetOutput();
   }
-  else if (resultImagePixelType.compare("ushort") == 0 ||
-           resultImagePixelType.compare("unsigned short") == 0) // <-- ushort for backwards compatibility
+  else if (resultImagePixelType == "ushort" ||
+           resultImagePixelType == "unsigned short") // <-- ushort for backwards compatibility
   {
     typename CastFilterUShort::Pointer castFilter = CastFilterUShort::New();
     castFilter->SetInput(infoChanger->GetOutput());
     castFilter->Update();
     resultImage = castFilter->GetOutput();
   }
-  else if (resultImagePixelType.compare("int") == 0)
+  else if (resultImagePixelType == "int")
   {
     typename CastFilterInt::Pointer castFilter = CastFilterInt::New();
     castFilter->SetInput(infoChanger->GetOutput());
     castFilter->Update();
     resultImage = castFilter->GetOutput();
   }
-  else if (resultImagePixelType.compare("unsigned int") == 0)
+  else if (resultImagePixelType == "unsigned int")
   {
     typename CastFilterUInt::Pointer castFilter = CastFilterUInt::New();
     castFilter->SetInput(infoChanger->GetOutput());
     castFilter->Update();
     resultImage = castFilter->GetOutput();
   }
-  else if (resultImagePixelType.compare("long") == 0)
+  else if (resultImagePixelType == "long")
   {
     typename CastFilterLong::Pointer castFilter = CastFilterLong::New();
     castFilter->SetInput(infoChanger->GetOutput());
     castFilter->Update();
     resultImage = castFilter->GetOutput();
   }
-  else if (resultImagePixelType.compare("unsigned long") == 0)
+  else if (resultImagePixelType == "unsigned long")
   {
     typename CastFilterULong::Pointer castFilter = CastFilterULong::New();
     castFilter->SetInput(infoChanger->GetOutput());
     castFilter->Update();
     resultImage = castFilter->GetOutput();
   }
-  else if (resultImagePixelType.compare("float") == 0)
+  else if (resultImagePixelType == "float")
   {
     typename CastFilterFloat::Pointer castFilter = CastFilterFloat::New();
     castFilter->SetInput(infoChanger->GetOutput());
     castFilter->Update();
     resultImage = castFilter->GetOutput();
   }
-  else if (resultImagePixelType.compare("double") == 0)
+  else if (resultImagePixelType == "double")
   {
     typename CastFilterDouble::Pointer castFilter = CastFilterDouble::New();
     castFilter->SetInput(infoChanger->GetOutput());


### PR DESCRIPTION
Ran Clang-Tidy-Fix (LLVM 11.1.0) `readability-string-compare`:

https://clang.llvm.org/extra/clang-tidy/checks/readability-string-compare.html

Which says:

"A common mistake is to use the string’s compare method instead of using the equality or inequality operators. The compare method is intended for sorting functions and thus returns a negative number, a positive number or zero depending on the lexicographical relationship between the strings compared. If an equality or inequality check can suffice, that is recommended. This is recommended to avoid the risk of incorrect interpretation of the return value and to simplify the code."

Fixes Clang warnings like:

> elxResamplerBase.hxx(501): warning: do not use 'compare' to test equality of strings; use the string equality operator instead [readability-string-compare]