### PR TITLE
STYLE: Remove unnecessary `std::string::c_str()` calls, using Clang-Tidy

### DIFF
--- a/Common/OpenCL/Filters/itkGPUResampleImageFilter.hxx
+++ b/Common/OpenCL/Filters/itkGPUResampleImageFilter.hxx
@@ -190,7 +190,7 @@ GPUResampleImageFilter<TInputImage, TOutputImage, TInterpolatorPrecisionType>::S
 
   // Build and create kernel
   const OpenCLProgram program =
-    this->m_PostKernelManager->BuildProgramFromSourceCode(resamplePostSource.str(), defines.c_str());
+    this->m_PostKernelManager->BuildProgramFromSourceCode(resamplePostSource.str(), defines);
   if (program.IsNull())
   {
     itkExceptionMacro(<< "Kernel has not been loaded from string:\n"

--- a/Components/Metrics/DistancePreservingRigidityPenalty/elxDistancePreservingRigidityPenaltyTerm.hxx
+++ b/Components/Metrics/DistancePreservingRigidityPenalty/elxDistancePreservingRigidityPenaltyTerm.hxx
@@ -49,7 +49,7 @@ DistancePreservingRigidityPenalty<TElastix>::BeforeRegistration(void)
 
   /** Create the reader and set the filename. */
   typename SegmentedImageReaderType::Pointer segmentedImageReader = SegmentedImageReaderType::New();
-  segmentedImageReader->SetFileName(segmentedImageName.c_str());
+  segmentedImageReader->SetFileName(segmentedImageName);
   segmentedImageReader->Update();
 
   /** Possibly overrule the direction cosines. */

--- a/Components/Metrics/RigidityPenalty/elxTransformRigidityPenaltyTerm.hxx
+++ b/Components/Metrics/RigidityPenalty/elxTransformRigidityPenaltyTerm.hxx
@@ -53,7 +53,7 @@ TransformRigidityPenalty<TElastix>::BeforeRegistration(void)
 
     /** Create the reader and set the filename. */
     fixedRigidityReader = RigidityImageReaderType::New();
-    fixedRigidityReader->SetFileName(fixedRigidityImageName.c_str());
+    fixedRigidityReader->SetFileName(fixedRigidityImageName);
 
     /** Possibly overrule the direction cosines. */
     ChangeInfoFilterPointer infoChanger = ChangeInfoFilterType::New();
@@ -100,7 +100,7 @@ TransformRigidityPenalty<TElastix>::BeforeRegistration(void)
 
     /** Create the reader and set the filename. */
     movingRigidityReader = RigidityImageReaderType::New();
-    movingRigidityReader->SetFileName(movingRigidityImageName.c_str());
+    movingRigidityReader->SetFileName(movingRigidityImageName);
 
     /** Possibly overrule the direction cosines. */
     ChangeInfoFilterPointer infoChanger = ChangeInfoFilterType::New();

--- a/Components/Optimizers/FullSearch/elxFullSearchOptimizer.hxx
+++ b/Components/Optimizers/FullSearch/elxFullSearchOptimizer.hxx
@@ -94,32 +94,32 @@ FullSearch<TElastix>::BeforeEachResolution(void)
 
     if (realGood && found)
     {
-      found = this->GetConfiguration()->ReadParameter(name, fullFieldName.c_str(), entry_nr, false);
-      realGood = this->CheckSearchSpaceRangeDefinition(fullFieldName.c_str(), found, entry_nr);
+      found = this->GetConfiguration()->ReadParameter(name, fullFieldName, entry_nr, false);
+      realGood = this->CheckSearchSpaceRangeDefinition(fullFieldName, found, entry_nr);
       entry_nr++;
     }
     if (realGood && found)
     {
-      found = this->GetConfiguration()->ReadParameter(param_nr, fullFieldName.c_str(), entry_nr, false);
-      realGood = this->CheckSearchSpaceRangeDefinition(fullFieldName.c_str(), found, entry_nr);
+      found = this->GetConfiguration()->ReadParameter(param_nr, fullFieldName, entry_nr, false);
+      realGood = this->CheckSearchSpaceRangeDefinition(fullFieldName, found, entry_nr);
       entry_nr++;
     }
     if (realGood && found)
     {
-      found = this->GetConfiguration()->ReadParameter(minimum, fullFieldName.c_str(), entry_nr, false);
-      realGood = this->CheckSearchSpaceRangeDefinition(fullFieldName.c_str(), found, entry_nr);
+      found = this->GetConfiguration()->ReadParameter(minimum, fullFieldName, entry_nr, false);
+      realGood = this->CheckSearchSpaceRangeDefinition(fullFieldName, found, entry_nr);
       entry_nr++;
     }
     if (realGood && found)
     {
-      found = this->GetConfiguration()->ReadParameter(maximum, fullFieldName.c_str(), entry_nr, false);
-      realGood = this->CheckSearchSpaceRangeDefinition(fullFieldName.c_str(), found, entry_nr);
+      found = this->GetConfiguration()->ReadParameter(maximum, fullFieldName, entry_nr, false);
+      realGood = this->CheckSearchSpaceRangeDefinition(fullFieldName, found, entry_nr);
       entry_nr++;
     }
     if (realGood && found)
     {
-      found = this->GetConfiguration()->ReadParameter(stepsize, fullFieldName.c_str(), entry_nr, false);
-      realGood = this->CheckSearchSpaceRangeDefinition(fullFieldName.c_str(), found, entry_nr);
+      found = this->GetConfiguration()->ReadParameter(stepsize, fullFieldName, entry_nr, false);
+      realGood = this->CheckSearchSpaceRangeDefinition(fullFieldName, found, entry_nr);
       entry_nr++;
     }
 

--- a/Components/Transforms/DeformationFieldTransform/elxDeformationFieldTransform.hxx
+++ b/Components/Transforms/DeformationFieldTransform/elxDeformationFieldTransform.hxx
@@ -91,7 +91,7 @@ DeformationFieldTransform<TElastix>::ReadFromFile(void)
   infoChanger->SetInput(vectorReader->GetOutput());
 
   /** Read deformationFieldImage from file. */
-  vectorReader->SetFileName(fileName.c_str());
+  vectorReader->SetFileName(fileName);
   try
   {
     infoChanger->Update();

--- a/Core/ComponentBaseClasses/elxRegistrationBase.hxx
+++ b/Core/ComponentBaseClasses/elxRegistrationBase.hxx
@@ -55,7 +55,7 @@ RegistrationBase<TElastix>::ReadMaskParameters(UseMaskErosionArrayType & useMask
     /** Default values for all masks. Look for ErodeMask, or Erode<Fixed,Moving>Mask. */
     bool erosionOrNot = true;
     this->GetConfiguration()->ReadParameter(erosionOrNot, "ErodeMask", "", level, 0, false);
-    this->GetConfiguration()->ReadParameter(erosionOrNot, whichErodeMaskOption.c_str(), "", level, 0);
+    this->GetConfiguration()->ReadParameter(erosionOrNot, whichErodeMaskOption, "", level, 0);
     if (erosionOrNot)
     {
       /** fill with 'true's. */
@@ -71,7 +71,7 @@ RegistrationBase<TElastix>::ReadMaskParameters(UseMaskErosionArrayType & useMask
       std::ostringstream makestring;
       makestring << whichErodeMaskOption << i; // key for parameter file
       bool erosionOrNot_i = erosionOrNot;      // default value
-      this->GetConfiguration()->ReadParameter(erosionOrNot_i, makestring.str().c_str(), "", level, 0, false);
+      this->GetConfiguration()->ReadParameter(erosionOrNot_i, makestring.str(), "", level, 0, false);
       if (erosionOrNot_i)
       {
         useMaskErosionArray[i] = true;

--- a/Core/ComponentBaseClasses/elxTransformBase.hxx
+++ b/Core/ComponentBaseClasses/elxTransformBase.hxx
@@ -445,7 +445,7 @@ TransformBase<TElastix>::ReadFromFile(void)
        * is not the same as this transform parameter file. Otherwise,
        * we will have an infinite loop.
        */
-      std::string fullFileName1 = itksys::SystemTools::CollapseFullPath(fileName.c_str());
+      std::string fullFileName1 = itksys::SystemTools::CollapseFullPath(fileName);
       std::string fullFileName2 = itksys::SystemTools::CollapseFullPath(this->m_Configuration->GetParameterFileName());
       if (fullFileName1 == fullFileName2)
       {

--- a/Core/Kernel/elxElastixBase.cxx
+++ b/Core/Kernel/elxElastixBase.cxx
@@ -51,14 +51,14 @@ GenerateFileNameContainer(const Configuration & configuration,
   std::ostringstream argusedss("");
   argusedss << optionkey << 0;
   std::string argused = argusedss.str();
-  std::string check = configuration.GetCommandLineArgument(argused.c_str());
+  std::string check = configuration.GetCommandLineArgument(argused);
   if (check.empty())
   {
     /** Try optionkey. */
     std::ostringstream argusedss2("");
     argusedss2 << optionkey;
     argused = argusedss2.str();
-    check = configuration.GetCommandLineArgument(argused.c_str());
+    check = configuration.GetCommandLineArgument(argused);
     if (check.empty())
     {
       /** Both failed; return an error message, if desired. */
@@ -96,7 +96,7 @@ GenerateFileNameContainer(const Configuration & configuration,
       std::ostringstream argusedss2("");
       argusedss2 << optionkey << i;
       argused = argusedss2.str();
-      check = configuration.GetCommandLineArgument(argused.c_str());
+      check = configuration.GetCommandLineArgument(argused);
       if (check.empty())
       {
         readsuccess = false;
@@ -280,7 +280,7 @@ ElastixBase::BeforeAllBase(void)
       folder.append("/");
       folder = Conversion::ToNativePathNameSeparators(folder);
 
-      this->GetConfiguration()->SetCommandLineArgument("-out", folder.c_str());
+      this->GetConfiguration()->SetCommandLineArgument("-out", folder);
     }
     elxout << "-out      " << check << std::endl;
   }
@@ -292,7 +292,7 @@ ElastixBase::BeforeAllBase(void)
   {
     std::ostringstream tempPname("");
     tempPname << "-p(" << i << ")";
-    check = this->GetConfiguration()->GetCommandLineArgument(tempPname.str().c_str());
+    check = this->GetConfiguration()->GetCommandLineArgument(tempPname.str());
     if (check.empty())
     {
       loop = false;

--- a/Core/Kernel/elxElastixMain.cxx
+++ b/Core/Kernel/elxElastixMain.cxx
@@ -964,7 +964,7 @@ ElastixMain::GetImageInformationFromFile(const std::string & filename, ImageDime
     /** Create a testReader. */
     typedef itk::ImageFileReader<DummyImageType> ReaderType;
     ReaderType::Pointer                          testReader = ReaderType::New();
-    testReader->SetFileName(filename.c_str());
+    testReader->SetFileName(filename);
 
     /** Generate all information. */
     testReader->UpdateOutputInformation();

--- a/Core/Main/transformix.cxx
+++ b/Core/Main/transformix.cxx
@@ -141,7 +141,7 @@ main(int argc, char ** argv)
   if (outFolderPresent)
   {
     /** Check if the output directory exists. */
-    bool outFolderExists = itksys::SystemTools::FileIsDirectory(outFolder.c_str());
+    bool outFolderExists = itksys::SystemTools::FileIsDirectory(outFolder);
     if (!outFolderExists)
     {
       std::cerr << "ERROR: the output directory \"" << outFolder << "\" does not exist." << std::endl;

--- a/Core/Main/transformixlib.cxx
+++ b/Core/Main/transformixlib.cxx
@@ -154,7 +154,7 @@ TRANSFORMIX::TransformImage(ImagePointer                    inputImage,
   if (performLogging)
   {
     /** Check if the output directory exists. */
-    bool outFolderExists = itksys::SystemTools::FileIsDirectory(outFolder.c_str());
+    bool outFolderExists = itksys::SystemTools::FileIsDirectory(outFolder);
     if (!outFolderExists)
     {
       if (performCout)

--- a/Testing/elxComputeOverlap.cxx
+++ b/Testing/elxComputeOverlap.cxx
@@ -100,9 +100,9 @@ main(int argc, char ** argv)
 
   /** Create readers and an AND filter. */
   ImageReaderPointer reader1 = ImageReaderType::New();
-  reader1->SetFileName(inputFileNames[0].c_str());
+  reader1->SetFileName(inputFileNames[0]);
   ImageReaderPointer reader2 = ImageReaderType::New();
-  reader2->SetFileName(inputFileNames[1].c_str());
+  reader2->SetFileName(inputFileNames[1]);
   AndFilterPointer ANDFilter = AndFilterType::New();
   ANDFilter->SetInput1(reader2->GetOutput());
   ANDFilter->SetInput2(reader1->GetOutput());

--- a/Testing/elxInvertTransform.cxx
+++ b/Testing/elxInvertTransform.cxx
@@ -138,7 +138,7 @@ main(int argc, char * argv[])
   typedef itk::Image<short, Dimension>         DummyImageType;
   typedef itk::ImageFileReader<DummyImageType> ReaderType;
   ReaderType::Pointer                          testReader = ReaderType::New();
-  testReader->SetFileName(movingImageFileName.c_str());
+  testReader->SetFileName(movingImageFileName);
 
   /** Generate all information. */
   try


### PR DESCRIPTION
Ran Clang-Tidy-Fix (LLVM 11.1.0) `readability-redundant-string-cstr`:

https://clang.llvm.org/extra/clang-tidy/checks/readability-redundant-string-cstr.html