### PR TITLE
COMP: Upgrade Azure CI from ubuntu-16.04 to ubuntu-18.04

### DIFF
--- a/Testing/CI/Azure/ci.yml
+++ b/Testing/CI/Azure/ci.yml
@@ -46,10 +46,10 @@ jobs:
   - bash: ctest -C Release -VV -j 2 -E "elastix_run_example_COMPARE_IM|elastix_run_3DCT_lung.MI.bspline.ASGD.001_COMPARE_TP"
     displayName: 'CTest Elastix'
     workingDirectory: $(ELASTIX_BINARY_DIR)
-- job: Ubuntu1604
+- job: Ubuntu1804
   timeoutInMinutes: 0
   pool:
-    vmImage: 'ubuntu-16.04'
+    vmImage: 'ubuntu-18.04'
   strategy:
     matrix:
       ITKv5:


### PR DESCRIPTION
Addressed:

> ##[warning]Ubuntu 16.04 LTS environment is deprecated and will be removed on September 20, 2021. Migrate to ubuntu-latest instead. For more details, see https://github.com/actions/virtual-environments/issues/3287.

From https://dev.azure.com/kaspermarstal/Elastix/_build/results?buildId=2229&view=results