### PR TITLE
COMP: Upgrade ITK from v5.1.1 to v5.2.0

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -29,7 +29,7 @@ if(ELASTIX_USE_OPENCL)
 endif()
 
 # Find ITK.
-find_package( ITK 5.1.1 REQUIRED COMPONENTS
+find_package( ITK 5.2.0 REQUIRED COMPONENTS
     ITKCommon
     ITKDisplacementField
     ITKDistanceMap

--- a/Testing/CI/Azure/ci.yml
+++ b/Testing/CI/Azure/ci.yml
@@ -1,5 +1,5 @@
 variables:
-  ITKv5_VERSION: v5.1.1
+  ITKv5_VERSION: v5.2.0
   ITK_GIT_URL: https://github.com/InsightSoftwareConsortium/ITK
   ITK_SOURCE_DIR: $(Agent.BuildDirectory)/ITK-source
   ITK_BINARY_DIR: $(Agent.BuildDirectory)/ITK-build


### PR DESCRIPTION
Upgraded to ITK version 5.2.0, which was released on May 28, 2021.

ITK 5.2.0 fixed a critical issue, with commit  https://github.com/InsightSoftwareConsortium/ITK/commit/7cebc26dfae73d90dbf4702aa1ccc544e9b70a37 "COMP: Fix OpenJPEG build error with Visual Studio 16.9", by James Butler (@jamesobutler) and @spacelg

Following pull request https://github.com/SuperElastix/SimpleElastix/pull/425 and https://github.com/SuperElastix/SimpleElastix/pull/428 by David Young (@yoda-vid)

Obviously, ITK 5.2.0 has many other improvements: https://github.com/InsightSoftwareConsortium/ITK/releases/tag/v5.2.0