### PR TITLE
Fix Doxygen 1.9.1 warnings on unsupported tags, IMAGE_PATH, and unresolved link requests

### DIFF
--- a/Components/Metrics/AdvancedMattesMutualInformation/itkParzenWindowMutualInformationImageToImageMetric.h
+++ b/Components/Metrics/AdvancedMattesMutualInformation/itkParzenWindowMutualInformationImageToImageMetric.h
@@ -187,7 +187,7 @@ protected:
    *
    * Implements a version that only loops once over the samples, but uses
    * a large block of memory to explicitly store the joint histogram derivative.
-   * It's size is #FixedHistogramBins * #MovingHistogramBins * #parameters * float.
+   * It's size is \#FixedHistogramBins * \#MovingHistogramBins * \#parameters * float.
    */
   void
   GetValueAndAnalyticDerivative(const ParametersType & parameters,

--- a/Core/Install/elxMacro.h
+++ b/Core/Install/elxMacro.h
@@ -84,7 +84,7 @@
  * not less.
  *
  * Details: a function "int _classname##InstallComponent( _cdb )" is defined.
- * In this function a template is defined, _classname##_install<VIndex>.
+ * In this function a template is defined, _classname\#\#_install<VIndex>.
  * It contains the ElastixTypedef<VIndex>, and recursive function DO(cdb).
  * DO installs the component for all defined ElastixTypedefs (so for all
  * supported image types).

--- a/Core/Kernel/elxElastixTemplate.h
+++ b/Core/Kernel/elxElastixTemplate.h
@@ -51,7 +51,7 @@
  * The second retrieves the metric component from the MetricContainer
  * and casts it to a MetricBaseType*;
  *
- * This macro is #undef'ed at the end of this header file.
+ * This macro is \#undef'ed at the end of this header file.
  */
 
 #define elxGetBaseMacro(_name, _elxbasetype)                                                                           \

--- a/Core/Main/elastixlib.h
+++ b/Core/Main/elastixlib.h
@@ -81,7 +81,7 @@ public:
    *     1 = error
    *    -2 = output folder does not exist
    *    \todo generate file elastix_errors.h containing error codedefines
-   *      (e.g. #define ELASTIX_NO_ERROR 0)
+   *      (e.g. \#define ELASTIX_NO_ERROR 0)
    */
   int
   RegisterImages(ImagePointer             fixedImage,

--- a/dox/doxygen/doxyfile.in
+++ b/dox/doxygen/doxyfile.in
@@ -960,7 +960,7 @@ EXAMPLE_RECURSIVE      = NO
 # that contain images that are to be included in the documentation (see the
 # \image command).
 
-IMAGE_PATH             = "@ELASTIX_DOXYGEN_DIR@/images"
+IMAGE_PATH             = ""
 
 # The INPUT_FILTER tag can be used to specify a program that doxygen should
 # invoke to filter for each input file. Doxygen will invoke the filter program

--- a/dox/doxygen/doxyfile.in
+++ b/dox/doxygen/doxyfile.in
@@ -265,12 +265,6 @@ ALIASES                = "parameter=\xrefitem parameter \"Parameters\" \"Paramet
                          "transformparameter=\xrefitem transformparameter \"Transform Parameters\" \"%Transform Parameters\"" \
                          "commandlinearg=\xrefitem commandlinearg \"Command line arguments\" \"Command line arguments\""
 
-# This tag can be used to specify a number of word-keyword mappings (TCL only).
-# A mapping has the form "name=value". For example adding "class=itcl::class"
-# will allow you to use the command class in the itcl::class meaning.
-
-TCL_SUBST              =
-
 # Set the OPTIMIZE_OUTPUT_FOR_C tag to YES if your project consists of C sources
 # only. Doxygen will then generate output that is more tailored for C. For
 # instance, some of the names that are used will be different. The list of all

--- a/dox/doxygen/doxyfile.in
+++ b/dox/doxygen/doxyfile.in
@@ -1150,13 +1150,6 @@ CLANG_DATABASE_PATH    =
 
 ALPHABETICAL_INDEX     = YES
 
-# The COLS_IN_ALPHA_INDEX tag can be used to specify the number of columns in
-# which the alphabetical index list will be split.
-# Minimum value: 1, maximum value: 20, default value: 5.
-# This tag requires that the tag ALPHABETICAL_INDEX is set to YES.
-
-COLS_IN_ALPHA_INDEX    = 2
-
 # In case all classes in a project start with a common prefix, all classes will
 # be put under the same header in the alphabetical index. The IGNORE_PREFIX tag
 # can be used to specify a prefix (or a list of prefixes) that should be ignored


### PR DESCRIPTION
Fixed various warnings from Doxygen 1.9.1.

Triggered by issue #233 "Some missing figures in documentation", reported by Ibraheem Al-Dhamari (@idhamari)
Related to issue #479 "Document how to generate Doxygen documentation"