### PR TITLE
STYLE: Remove ITK 5.1/5.2 `itk::Experimental` namespace workaround

### DIFF
--- a/Core/Main/GTesting/elxCoreMainGTestUtilities.h
+++ b/Core/Main/GTesting/elxCoreMainGTestUtilities.h
@@ -34,15 +34,6 @@
 #include <gtest/gtest.h>
 
 
-namespace itk
-{
-namespace Experimental
-{
-// Workaround to allow using things that may be either in itk or in itk::Experimental.
-}
-} // namespace itk
-
-
 namespace elastix
 {
 namespace CoreMainGTestUtilities
@@ -100,13 +91,8 @@ FillImageRegion(itk::Image<TPixel, VImageDimension> & image,
                 const itk::Index<VImageDimension> &   regionIndex,
                 const itk::Size<VImageDimension> &    regionSize)
 {
-  // ImageRegionRange is to be moved from namespace itk::Experimental
-  // to namespace itk with ITK version 5.2.
-  using namespace itk;
-  using namespace itk::Experimental;
-
-  const ImageRegionRange<Image<TPixel, VImageDimension>> imageRegionRange{
-    image, ImageRegion<VImageDimension>{ regionIndex, regionSize }
+  const itk::ImageRegionRange<itk::Image<TPixel, VImageDimension>> imageRegionRange{
+    image, itk::ImageRegion<VImageDimension>{ regionIndex, regionSize }
   };
   std::fill(std::begin(imageRegionRange), std::end(imageRegionRange), 1);
 }

--- a/Core/Main/GTesting/itkElastixRegistrationMethodGTest.cxx
+++ b/Core/Main/GTesting/itkElastixRegistrationMethodGTest.cxx
@@ -167,11 +167,6 @@ GTEST_TEST(itkElastixRegistrationMethod, WriteResultImageFalse)
 
 GTEST_TEST(itkElastixRegistrationMethod, InitialTransformParameterFile)
 {
-  // IndexRange is to be moved from namespace itk::Experimental
-  // to namespace itk with ITK version 5.2.
-  using namespace itk;
-  using namespace itk::Experimental;
-
   constexpr auto ImageDimension = 2U;
   using ImageType = itk::Image<float, ImageDimension>;
   using SizeType = itk::Size<ImageDimension>;
@@ -209,7 +204,8 @@ GTEST_TEST(itkElastixRegistrationMethod, InitialTransformParameterFile)
 
   const auto toOffset = [](const IndexType & index) { return index - IndexType(); };
 
-  for (const auto index : ImageRegionIndexRange<ImageDimension>(itk::ImageRegion<ImageDimension>({ 0, -2 }, { 2, 3 })))
+  for (const auto index :
+       itk::ImageRegionIndexRange<ImageDimension>(itk::ImageRegion<ImageDimension>({ 0, -2 }, { 2, 3 })))
   {
     movingImage->FillBuffer(0);
     elx::CoreMainGTestUtilities::FillImageRegion(*movingImage, fixedImageRegionIndex + toOffset(index), regionSize);
@@ -238,11 +234,6 @@ GTEST_TEST(itkElastixRegistrationMethod, InitialTransformParameterFile)
 
 GTEST_TEST(itkElastixRegistrationMethod, InitialTransformParameterFileLinkToTransformFile)
 {
-  // IndexRange is to be moved from namespace itk::Experimental
-  // to namespace itk with ITK version 5.2.
-  using namespace itk;
-  using namespace itk::Experimental;
-
   constexpr auto ImageDimension = 2U;
   using ImageType = itk::Image<float, ImageDimension>;
   using SizeType = itk::Size<ImageDimension>;
@@ -294,7 +285,7 @@ GTEST_TEST(itkElastixRegistrationMethod, InitialTransformParameterFileLinkToTran
     const auto filter2 = createFilter(transformParameterFileName);
 
     for (const auto index :
-         ImageRegionIndexRange<ImageDimension>(itk::ImageRegion<ImageDimension>({ 0, -2 }, { 2, 3 })))
+         itk::ImageRegionIndexRange<ImageDimension>(itk::ImageRegion<ImageDimension>({ 0, -2 }, { 2, 3 })))
     {
       movingImage->FillBuffer(0);
       elx::CoreMainGTestUtilities::FillImageRegion(*movingImage, fixedImageRegionIndex + toOffset(index), regionSize);

--- a/Core/Main/GTesting/itkTransformixFilterGTest.cxx
+++ b/Core/Main/GTesting/itkTransformixFilterGTest.cxx
@@ -160,11 +160,7 @@ template <typename TImage>
 void
 ExpectAlmostEqualPixelValues(const TImage & actualImage, const TImage & expectedImage, const double tolerance)
 {
-  // ImageBufferRange is to be moved from namespace itk::Experimental
-  // to namespace itk with ITK version 5.2.
-  using namespace itk;
-  using namespace itk::Experimental;
-  using ImageBufferRangeType = ImageBufferRange<const TImage>;
+  using ImageBufferRangeType = itk::ImageBufferRange<const TImage>;
 
   const ImageBufferRangeType actualImageBufferRange(actualImage);
   const ImageBufferRangeType expectedImageBufferRange(expectedImage);


### PR DESCRIPTION
With ITK 5.2.0, `ImageRegionRange` and `ImageBufferRange` moved from `itk::Experimental` namespace to the root `itk` namespace.

Follow-up to pull request https://github.com/SuperElastix/elastix/pull/475 commit 6803b26a73aea270cf7b75e0febc4d53ea21053e "COMP: Upgrade ITK from v5.1.1 to v5.2.0"