### PR TITLE
STYLE: Use the new ITK 5.2 `OptimizerParameters` constructors

### DIFF
--- a/Common/GTesting/elxConversionGTest.cxx
+++ b/Common/GTesting/elxConversionGTest.cxx
@@ -265,9 +265,7 @@ GTEST_TEST(Conversion, ToOptimizerParameters)
 
   for (const double value : { -1.0, 0.0, 1.0, DBL_MIN, DBL_MAX })
   {
-    OptimizerParametersType expectedOptimizerParameters(1U);
-    expectedOptimizerParameters[0] = value;
-    EXPECT_EQ(Conversion::ToOptimizerParameters(StdVectorType{ value }), expectedOptimizerParameters);
+    EXPECT_EQ(Conversion::ToOptimizerParameters(StdVectorType{ value }), OptimizerParametersType(1U, value));
   }
 
   StdVectorType stdVector(10U);

--- a/Common/GTesting/elxTransformIOGTest.cxx
+++ b/Common/GTesting/elxTransformIOGTest.cxx
@@ -275,9 +275,9 @@ struct WithDimension
       elxTransform->SetElastix(elastixObject);
       elxTransform->BeforeAll();
 
-      ParameterMapType                       parameterMap;
-      const itk::OptimizerParameters<double> optimizerParameters(itk::Array<double>(vnl_vector<double>(2U, testValue)));
-      elxTransform->CreateTransformParametersMap(optimizerParameters, parameterMap);
+      ParameterMapType parameterMap;
+
+      elxTransform->CreateTransformParametersMap(itk::OptimizerParameters<double>(2U, testValue), parameterMap);
 
       for (const auto key : { "TransformParameters", "Origin", "Spacing" })
       {

--- a/Common/Transforms/itkStackTransform.hxx
+++ b/Common/Transforms/itkStackTransform.hxx
@@ -56,13 +56,8 @@ StackTransform<TScalarType, NInputDimensions, NOutputDimensions>::SetParameters(
   const NumberOfParametersType numSubTransformParameters = this->m_SubTransformContainer[0]->GetNumberOfParameters();
   for (unsigned int t = 0; t < this->m_NumberOfSubTransforms; ++t)
   {
-    // MS, \todo: the new itk::TransformParameters only have constructors taking 1 argument
-    // ParametersType subparams ( ParametersArrayType( &( param.data_block()[ t * numSubTransformParameters ] ),
-    // numSubTransformParameters, false ) ); ParametersType subparams ( &( param.data_block()[ t *
-    // numSubTransformParameters ] ), numSubTransformParameters, false );
     // NTA, split the parameter by number of subparameters
-    const Array<double> subarray(&(param.data_block()[t * numSubTransformParameters]), numSubTransformParameters);
-    ParametersType      subparams(subarray);
+    const ParametersType subparams(&(param.data_block()[t * numSubTransformParameters]), numSubTransformParameters);
     this->m_SubTransformContainer[t]->SetParametersByValue(subparams);
   }
 

--- a/Common/itkComputePreconditionerUsingDisplacementDistribution.hxx
+++ b/Common/itkComputePreconditionerUsingDisplacementDistribution.hxx
@@ -199,9 +199,8 @@ ComputePreconditionerUsingDisplacementDistribution<TFixedImage, TTransform>::Com
 #endif
 
   /** Loop over all voxels in the sample container. */
-  ParametersType binCount(P);
-  binCount.Fill(0.0);
-  unsigned int samplenr = 0; // needed for global value only
+  ParametersType binCount(P, 0.0);
+  unsigned int   samplenr = 0; // needed for global value only
 
   for (iter = begin; iter != end; ++iter)
   {
@@ -631,8 +630,7 @@ ComputePreconditionerUsingDisplacementDistribution<TFixedImage, TTransform>::Com
   JacobianType               jacjjacj(outdim, outdim);
   const double               sqrt2 = std::sqrt(static_cast<double>(2.0));
   NonZeroJacobianIndicesType jacind(sizejacind);
-  ParametersType             binCount(P);
-  binCount.Fill(0.0);
+  ParametersType             binCount(P, 0.0);
 
   /** Loop over all voxels in the sample container. */
   for (iter = begin; iter != end; ++iter)

--- a/Components/Optimizers/CMAEvolutionStrategy/itkCMAEvolutionStrategyOptimizer.cxx
+++ b/Components/Optimizers/CMAEvolutionStrategy/itkCMAEvolutionStrategyOptimizer.cxx
@@ -404,8 +404,7 @@ CMAEvolutionStrategyOptimizer::InitializeProgressVariables(void)
   this->m_Heaviside = 0.0;
 
   /** m_SearchDirs */
-  ParametersType zeroParam(N);
-  zeroParam.Fill(0.0);
+  const ParametersType zeroParam(N, 0.0);
   this->m_SearchDirs.clear();
   this->m_SearchDirs.resize(lambda, zeroParam);
 

--- a/Core/Install/elxConversion.cxx
+++ b/Core/Install/elxConversion.cxx
@@ -91,7 +91,7 @@ Conversion::SecondsToDHMS(const double totalSeconds, const unsigned int precisio
 itk::OptimizerParameters<double>
 Conversion::ToOptimizerParameters(const std::vector<double> & stdVector)
 {
-  return itk::OptimizerParameters<double>(itk::Array<double>(stdVector.data(), stdVector.size()));
+  return itk::OptimizerParameters<double>(stdVector.data(), stdVector.size());
 };
 
 

--- a/Testing/elxInvertTransform.cxx
+++ b/Testing/elxInvertTransform.cxx
@@ -167,11 +167,7 @@ main(int argc, char * argv[])
   config->ReadParameter(vecPar, "TransformParameters", 0, numberOfParameters - 1, true, dummyErrorMessage);
 
   /** Convert to ParametersType. */
-  ParametersType transformParameters(numberOfParameters);
-  for (unsigned int i = 0; i < numberOfParameters; ++i)
-  {
-    transformParameters[i] = vecPar[i];
-  }
+  const ParametersType transformParameters(vecPar.data(), numberOfParameters);
 
   /** Get center of rotation. */
   CenterType centerOfRotation;


### PR DESCRIPTION
Simplified the code by using these two `explicit` constructors, which are added with ITK 5.2:

    OptimizerParameters(SizeValueType dimension, const ValueType & value);

    OptimizerParameters(const ValueType * inputData, SizeValueType dimension);

Follow-up to pull request https://github.com/SuperElastix/elastix/pull/475 commit 6803b26a73aea270cf7b75e0febc4d53ea21053e "COMP: Upgrade ITK from v5.1.1 to v5.2.0"