### PR TITLE
STYLE: Remove `elastix::TransformBase::m_TransformParametersPointer`

### DIFF
--- a/Core/ComponentBaseClasses/elxTransformBase.h
+++ b/Core/ComponentBaseClasses/elxTransformBase.h
@@ -32,8 +32,6 @@
 #include <itkImage.h>
 #include <itkOptimizerParameters.h>
 
-#include <memory> // For unique_ptr.
-
 namespace elastix
 {
 // using namespace itk; //Not here, because a TransformBase class was added to ITK...
@@ -371,9 +369,8 @@ private:
   {}
 
   /** Member variables. */
-  std::unique_ptr<ParametersType> m_TransformParametersPointer{};
-  std::string                     m_TransformParametersFileName;
-  ParametersType                  m_FinalParameters;
+  std::string    m_TransformParametersFileName;
+  ParametersType m_FinalParameters;
 
   /** Boolean to decide whether or not the transform parameters are written. */
   bool m_ReadWriteTransformParameters{ true };


### PR DESCRIPTION
The data member `m_TransformParametersPointer` appears unnecessary. Removing this data member eases the implementation of issue https://github.com/SuperElastix/elastix/issues/464 "Support HDF5 or TFM format for all transforms..."

Discussed with Marius (@mstaring) at the internal elastix sprint.