### PR TITLE
STYLE: Replace m_TransformParametersPointer by ParametersType member var

### DIFF
--- a/Core/ComponentBaseClasses/elxTransformBase.h
+++ b/Core/ComponentBaseClasses/elxTransformBase.h
@@ -32,8 +32,6 @@
 #include <itkImage.h>
 #include <itkOptimizerParameters.h>
 
-#include <memory> // For unique_ptr.
-
 namespace elastix
 {
 // using namespace itk; //Not here, because a TransformBase class was added to ITK...
@@ -371,9 +369,9 @@ private:
   {}
 
   /** Member variables. */
-  std::unique_ptr<ParametersType> m_TransformParametersPointer{};
-  std::string                     m_TransformParametersFileName;
-  ParametersType                  m_FinalParameters;
+  std::string    m_TransformParametersFileName;
+  ParametersType m_TransformParameters;
+  ParametersType m_FinalParameters;
 
   /** Boolean to decide whether or not the transform parameters are written. */
   bool m_ReadWriteTransformParameters{ true };


### PR DESCRIPTION
Simplified `elastix::TransformBase<TElastix>::ReadFromFile(void)` by using `ParametersType` instead of `std::unique_ptr<ParametersType>`.