### PR TITLE
Support reading Euler and Similarity transforms from ITK (HDF5, TFM) into elastix

### DIFF
--- a/Common/GTesting/elxTransformIOGTest.cxx
+++ b/Common/GTesting/elxTransformIOGTest.cxx
@@ -842,3 +842,27 @@ GTEST_TEST(Transform, TransformedPointSameAsITKEuler3D)
 
   Expect_elx_TransformPoint_yields_same_point_as_ITK<elx::EulerTransformElastix>(*itkTransform);
 }
+
+
+GTEST_TEST(Transform, TransformedPointSameAsITKSimilarity2D)
+{
+  const auto itkTransform = itk::Similarity2DTransform<double>::New();
+  itkTransform->SetScale(0.75);
+  itkTransform->SetTranslation(MakeVector(1.0, 2.0));
+  itkTransform->SetCenter(MakePoint(0.5, 1.5));
+  itkTransform->SetAngle(M_PI_4);
+
+  Expect_elx_TransformPoint_yields_same_point_as_ITK<elx::SimilarityTransformElastix>(*itkTransform);
+}
+
+
+GTEST_TEST(Transform, TransformedPointSameAsITKSimilarity3D)
+{
+  const auto itkTransform = itk::Similarity3DTransform<double>::New();
+  itkTransform->SetScale(0.75);
+  itkTransform->SetTranslation(MakeVector(1.0, 2.0, 3.0));
+  itkTransform->SetCenter(MakePoint(3.0, 2.0, 1.0));
+  itkTransform->SetRotation(itk::Vector<double, 3>(1.0), M_PI_4);
+
+  Expect_elx_TransformPoint_yields_same_point_as_ITK<elx::SimilarityTransformElastix>(*itkTransform);
+}

--- a/Common/GTesting/elxTransformIOGTest.cxx
+++ b/Common/GTesting/elxTransformIOGTest.cxx
@@ -822,11 +822,10 @@ GTEST_TEST(Transform, TransformedPointSameAsITKAffine3D)
 
 GTEST_TEST(Transform, TransformedPointSameAsITKEuler2D)
 {
-  constexpr auto Dimension = 2U;
-
   const auto itkTransform = itk::Euler2DTransform<double>::New();
   itkTransform->SetTranslation(MakeVector(1.0, 2.0));
   itkTransform->SetCenter(MakePoint(0.5, 1.5));
+  itkTransform->SetAngle(M_PI_4);
 
   Expect_elx_TransformPoint_yields_same_point_as_ITK<elx::EulerTransformElastix>(*itkTransform);
 }
@@ -834,11 +833,10 @@ GTEST_TEST(Transform, TransformedPointSameAsITKEuler2D)
 
 GTEST_TEST(Transform, TransformedPointSameAsITKEuler3D)
 {
-  constexpr auto Dimension = 3U;
-
   const auto itkTransform = itk::Euler3DTransform<double>::New();
   itkTransform->SetTranslation(MakeVector(1.0, 2.0, 3.0));
   itkTransform->SetCenter(MakePoint(3.0, 2.0, 1.0));
+  itkTransform->SetRotation(M_PI_2, M_PI_4, M_PI_4 / 2.0);
 
   Expect_elx_TransformPoint_yields_same_point_as_ITK<elx::EulerTransformElastix>(*itkTransform);
 }

--- a/Components/Transforms/EulerTransform/elxEulerTransform.hxx
+++ b/Components/Transforms/EulerTransform/elxEulerTransform.hxx
@@ -64,34 +64,37 @@ template <class TElastix>
 void
 EulerTransformElastix<TElastix>::ReadFromFile(void)
 {
-  /** Variables. */
-  InputPointType centerOfRotationPoint;
-  centerOfRotationPoint.Fill(0.0);
-
-  /** Try first to read the CenterOfRotationPoint from the
-   * transform parameter file, this is the new, and preferred
-   * way, since elastix 3.402.
-   */
-  bool pointRead = this->ReadCenterOfRotationPoint(centerOfRotationPoint);
-
-  if (!pointRead)
+  if (!this->HasITKTransformParameters())
   {
-    xl::xout["error"] << "ERROR: No center of rotation is specified in "
-                      << "the transform parameter file" << std::endl;
-    itkExceptionMacro(<< "Transform parameter file is corrupt.")
-  }
+    /** Variables. */
+    InputPointType centerOfRotationPoint;
+    centerOfRotationPoint.Fill(0.0);
 
-  /** Set the center in this Transform. */
-  this->m_EulerTransform->SetCenter(centerOfRotationPoint);
+    /** Try first to read the CenterOfRotationPoint from the
+     * transform parameter file, this is the new, and preferred
+     * way, since elastix 3.402.
+     */
+    bool pointRead = this->ReadCenterOfRotationPoint(centerOfRotationPoint);
 
-  /** Read the ComputeZYX. */
-  if (SpaceDimension == 3)
-  {
-    std::string computeZYX = "false";
-    this->m_Configuration->ReadParameter(computeZYX, "ComputeZYX", 0);
-    if (computeZYX == "true")
+    if (!pointRead)
     {
-      this->m_EulerTransform->SetComputeZYX(true);
+      xl::xout["error"] << "ERROR: No center of rotation is specified in "
+                        << "the transform parameter file" << std::endl;
+      itkExceptionMacro(<< "Transform parameter file is corrupt.")
+    }
+
+    /** Set the center in this Transform. */
+    this->m_EulerTransform->SetCenter(centerOfRotationPoint);
+
+    /** Read the ComputeZYX. */
+    if (SpaceDimension == 3)
+    {
+      std::string computeZYX = "false";
+      this->m_Configuration->ReadParameter(computeZYX, "ComputeZYX", 0);
+      if (computeZYX == "true")
+      {
+        this->m_EulerTransform->SetComputeZYX(true);
+      }
     }
   }
 

--- a/Components/Transforms/SimilarityTransform/elxSimilarityTransform.hxx
+++ b/Components/Transforms/SimilarityTransform/elxSimilarityTransform.hxx
@@ -63,35 +63,38 @@ template <class TElastix>
 void
 SimilarityTransformElastix<TElastix>::ReadFromFile(void)
 {
-  /** Variables. */
-  InputPointType centerOfRotationPoint;
-  centerOfRotationPoint.Fill(0.0);
-  bool indexRead = false;
-
-  /** Try first to read the CenterOfRotationPoint from the
-   * transform parameter file, this is the new, and preferred
-   * way, since elastix 3.402.
-   */
-  bool pointRead = this->ReadCenterOfRotationPoint(centerOfRotationPoint);
-
-  /** If this did not succeed, probably a transform parameter file
-   * is trying to be read that was generated using an older elastix
-   * version. Try to read it as an index, and convert to point.
-   */
-  if (!pointRead)
+  if (!this->HasITKTransformParameters())
   {
-    indexRead = this->ReadCenterOfRotationIndex(centerOfRotationPoint);
-  }
+    /** Variables. */
+    InputPointType centerOfRotationPoint;
+    centerOfRotationPoint.Fill(0.0);
+    bool indexRead = false;
 
-  if (!pointRead && !indexRead)
-  {
-    xl::xout["error"] << "ERROR: No center of rotation is specified in the "
-                      << "transform parameter file." << std::endl;
-    itkExceptionMacro(<< "Transform parameter file is corrupt.")
-  }
+    /** Try first to read the CenterOfRotationPoint from the
+     * transform parameter file, this is the new, and preferred
+     * way, since elastix 3.402.
+     */
+    bool pointRead = this->ReadCenterOfRotationPoint(centerOfRotationPoint);
 
-  /** Set the center in this Transform. */
-  this->m_SimilarityTransform->SetCenter(centerOfRotationPoint);
+    /** If this did not succeed, probably a transform parameter file
+     * is trying to be read that was generated using an older elastix
+     * version. Try to read it as an index, and convert to point.
+     */
+    if (!pointRead)
+    {
+      indexRead = this->ReadCenterOfRotationIndex(centerOfRotationPoint);
+    }
+
+    if (!pointRead && !indexRead)
+    {
+      xl::xout["error"] << "ERROR: No center of rotation is specified in the "
+                        << "transform parameter file." << std::endl;
+      itkExceptionMacro(<< "Transform parameter file is corrupt.")
+    }
+
+    /** Set the center in this Transform. */
+    this->m_SimilarityTransform->SetCenter(centerOfRotationPoint);
+  }
 
   /** Call the ReadFromFile from the TransformBase.
    * BE AWARE: Only call Superclass2::ReadFromFile() after CenterOfRotation

--- a/Core/ComponentBaseClasses/elxTransformBase.h
+++ b/Core/ComponentBaseClasses/elxTransformBase.h
@@ -271,6 +271,13 @@ protected:
   /** The destructor. */
   ~TransformBase() override = default;
 
+  /** Tells whether this transform is specified by TransformParameters from ITK */
+  bool
+  HasITKTransformParameters(void) const
+  {
+    return this->BaseComponentSE<TElastix>::m_Configuration->HasParameter("ITKTransformParameters");
+  }
+
   /** Estimate a scales vector
    * AutomaticScalesEstimation works like this:
    * \li N=10000 points are sampled on a uniform grid on the fixed image.

--- a/Core/Main/GTesting/itkTransformixFilterGTest.cxx
+++ b/Core/Main/GTesting/itkTransformixFilterGTest.cxx
@@ -27,6 +27,8 @@
 
 // ITK header files:
 #include <itkAffineTransform.h>
+#include <itkEuler2DTransform.h>
+#include <itkEuler3DTransform.h>
 #include <itkImage.h>
 #include <itkImageBufferRange.h>
 #include <itkNumberToString.h>
@@ -376,6 +378,28 @@ GTEST_TEST(itkTransformixFilter, ITKAffineTransform3D)
   itkTransform->SetTranslation(MakeVector(1.0, 2.0, 3.0));
   itkTransform->SetCenter(MakePoint(3.0, 2.0, 1.0));
   itkTransform->Rotate3D(itk::Vector<double, ImageDimension>(1.0), M_PI_4);
+
+  Expect_TransformixFilter_output_equals_ResampleImageFilter_output(
+    *CreateImageFilledWithSequenceOfNaturalNumbers<float>(MakeSize(5, 6, 7)), *itkTransform);
+}
+
+
+GTEST_TEST(itkTransformixFilter, ITKEulerTransform2D)
+{
+  const auto itkTransform = itk::Euler2DTransform<double>::New();
+  itkTransform->SetTranslation(MakeVector(1.0, -2.0));
+  itkTransform->SetCenter(MakePoint(2.5, 3.0));
+
+  Expect_TransformixFilter_output_equals_ResampleImageFilter_output(
+    *CreateImageFilledWithSequenceOfNaturalNumbers<float>(MakeSize(5, 6)), *itkTransform);
+}
+
+
+GTEST_TEST(itkTransformixFilter, ITKEulerTransform3D)
+{
+  const auto itkTransform = itk::Euler3DTransform<double>::New();
+  itkTransform->SetTranslation(MakeVector(1.0, -2.0, 3.0));
+  itkTransform->SetCenter(MakePoint(3.0, 2.0, 1.0));
 
   Expect_TransformixFilter_output_equals_ResampleImageFilter_output(
     *CreateImageFilledWithSequenceOfNaturalNumbers<float>(MakeSize(5, 6, 7)), *itkTransform);

--- a/Core/Main/GTesting/itkTransformixFilterGTest.cxx
+++ b/Core/Main/GTesting/itkTransformixFilterGTest.cxx
@@ -391,6 +391,7 @@ GTEST_TEST(itkTransformixFilter, ITKEulerTransform2D)
   const auto itkTransform = itk::Euler2DTransform<double>::New();
   itkTransform->SetTranslation(MakeVector(1.0, -2.0));
   itkTransform->SetCenter(MakePoint(2.5, 3.0));
+  itkTransform->SetAngle(M_PI_4);
 
   Expect_TransformixFilter_output_equals_ResampleImageFilter_output(
     *CreateImageFilledWithSequenceOfNaturalNumbers<float>(MakeSize(5, 6)), *itkTransform);
@@ -402,6 +403,7 @@ GTEST_TEST(itkTransformixFilter, ITKEulerTransform3D)
   const auto itkTransform = itk::Euler3DTransform<double>::New();
   itkTransform->SetTranslation(MakeVector(1.0, -2.0, 3.0));
   itkTransform->SetCenter(MakePoint(3.0, 2.0, 1.0));
+  itkTransform->SetRotation(M_PI_2, M_PI_4, M_PI_4 / 2.0);
 
   Expect_TransformixFilter_output_equals_ResampleImageFilter_output(
     *CreateImageFilledWithSequenceOfNaturalNumbers<float>(MakeSize(5, 6, 7)), *itkTransform);

--- a/Core/Main/GTesting/itkTransformixFilterGTest.cxx
+++ b/Core/Main/GTesting/itkTransformixFilterGTest.cxx
@@ -33,6 +33,8 @@
 #include <itkImageBufferRange.h>
 #include <itkNumberToString.h>
 #include <itkResampleImageFilter.h>
+#include <itkSimilarity2DTransform.h>
+#include <itkSimilarity3DTransform.h>
 #include <itkTranslationTransform.h>
 
 // GoogleTest header file:
@@ -400,6 +402,32 @@ GTEST_TEST(itkTransformixFilter, ITKEulerTransform3D)
   const auto itkTransform = itk::Euler3DTransform<double>::New();
   itkTransform->SetTranslation(MakeVector(1.0, -2.0, 3.0));
   itkTransform->SetCenter(MakePoint(3.0, 2.0, 1.0));
+
+  Expect_TransformixFilter_output_equals_ResampleImageFilter_output(
+    *CreateImageFilledWithSequenceOfNaturalNumbers<float>(MakeSize(5, 6, 7)), *itkTransform);
+}
+
+
+GTEST_TEST(itkTransformixFilter, ITKSimilarityTransform2D)
+{
+  const auto itkTransform = itk::Similarity2DTransform<double>::New();
+  itkTransform->SetScale(0.75);
+  itkTransform->SetTranslation(MakeVector(1.0, -2.0));
+  itkTransform->SetCenter(MakePoint(2.5, 3.0));
+  itkTransform->SetAngle(M_PI_4);
+
+  Expect_TransformixFilter_output_equals_ResampleImageFilter_output(
+    *CreateImageFilledWithSequenceOfNaturalNumbers<float>(MakeSize(5, 6)), *itkTransform);
+}
+
+
+GTEST_TEST(itkTransformixFilter, ITKSimilarityTransform3D)
+{
+  const auto itkTransform = itk::Similarity3DTransform<double>::New();
+  itkTransform->SetScale(0.75);
+  itkTransform->SetTranslation(MakeVector(1.0, -2.0, 3.0));
+  itkTransform->SetCenter(MakePoint(3.0, 2.0, 1.0));
+  itkTransform->SetRotation(itk::Vector<double, 3>(1.0), M_PI_4);
 
   Expect_TransformixFilter_output_equals_ResampleImageFilter_output(
     *CreateImageFilledWithSequenceOfNaturalNumbers<float>(MakeSize(5, 6, 7)), *itkTransform);


### PR DESCRIPTION
Regarding issue #464 "Support HDF5 or TFM format for all transforms"