### PR TITLE
STYLE: Replace Dummy classes of transforms by C++11 template aliases

### DIFF
--- a/Common/Transforms/itkEulerTransform.h
+++ b/Common/Transforms/itkEulerTransform.h
@@ -27,7 +27,7 @@ namespace itk
 
 /**
  * \class EulerGroup
- * \brief This class only contains a dummy class.
+ * \brief This class only contains an alias template.
  *
  */
 
@@ -36,17 +36,12 @@ class EulerGroup
 {
 public:
   template <class TScalarType>
-  class Dummy
-  {
-  public:
-    /** Typedef's.*/
-    typedef AdvancedMatrixOffsetTransformBase<TScalarType, Dimension, Dimension> EulerTransform_tmp;
-  };
+  using TransformAlias = AdvancedMatrixOffsetTransformBase<TScalarType, Dimension, Dimension>;
 };
 
 /**
  * \class EulerGroup<2>
- * \brief This class only contains a dummy class for the 2D case.
+ * \brief This class only contains an alias template for the 2D case.
  *
  */
 
@@ -55,17 +50,12 @@ class EulerGroup<2>
 {
 public:
   template <class TScalarType>
-  class Dummy
-  {
-  public:
-    /** Typedef's.*/
-    typedef AdvancedRigid2DTransform<TScalarType> EulerTransform_tmp;
-  };
+  using TransformAlias = AdvancedRigid2DTransform<TScalarType>;
 };
 
 /**
  * \class EulerGroup<3>
- * \brief This class only contains a dummy class for the 3D case.
+ * \brief This class only contains an alias template for the 3D case.
  *
  */
 
@@ -74,44 +64,16 @@ class EulerGroup<3>
 {
 public:
   template <class TScalarType>
-  class Dummy
-  {
-  public:
-    /** Typedef's.*/
-    typedef AdvancedEuler3DTransform<TScalarType> EulerTransform_tmp;
-  };
+  using TransformAlias = AdvancedEuler3DTransform<TScalarType>;
 };
+
 
 /**
- * \class EulerGroupTemplate
- * \brief This class templates the EulerGroup over its dimension.
- *
+ * This alias templates the EulerGroup over its dimension.
  */
-
 template <class TScalarType, unsigned int Dimension>
-class EulerGroupTemplate
-{
-public:
-  typedef EulerGroupTemplate Self;
-  typedef TScalarType        ScalarType;
-  itkStaticConstMacro(SpaceDimension, unsigned int, Dimension);
+using EulerGroupTemplate = typename EulerGroup<Dimension>::template TransformAlias<TScalarType>;
 
-  // This declaration of 'Euler' does not work with the GCC compiler
-  //    typedef EulerGroup<  itkGetStaticConstMacro( SpaceDimension ) >       Euler;
-  // The following trick works though:
-  template <unsigned int D>
-  class EulerGroupWrap
-  {
-  public:
-    typedef EulerGroup<D> Euler;
-  };
-
-  typedef EulerGroupWrap<Dimension>              EulerGroupWrapInstance;
-  typedef typename EulerGroupWrapInstance::Euler Euler;
-
-  typedef typename Euler::template Dummy<ScalarType> EulerDummy;
-  typedef typename EulerDummy::EulerTransform_tmp    EulerTransform_tmp;
-};
 
 /**
  * \class EulerTransform
@@ -123,14 +85,14 @@ public:
  */
 
 template <class TScalarType, unsigned int Dimension>
-class ITK_TEMPLATE_EXPORT EulerTransform : public EulerGroupTemplate<TScalarType, Dimension>::EulerTransform_tmp
+class ITK_TEMPLATE_EXPORT EulerTransform : public EulerGroupTemplate<TScalarType, Dimension>
 {
 public:
   /** Standard ITK-stuff. */
-  typedef EulerTransform                                                          Self;
-  typedef typename EulerGroupTemplate<TScalarType, Dimension>::EulerTransform_tmp Superclass;
-  typedef SmartPointer<Self>                                                      Pointer;
-  typedef SmartPointer<const Self>                                                ConstPointer;
+  typedef EulerTransform                             Self;
+  typedef EulerGroupTemplate<TScalarType, Dimension> Superclass;
+  typedef SmartPointer<Self>                         Pointer;
+  typedef SmartPointer<const Self>                   ConstPointer;
 
   /** Method for creation through the object factory. */
   itkNewMacro(Self);
@@ -197,14 +159,14 @@ private:
 };
 
 template <class TScalarType>
-class EulerTransform<TScalarType, 3> : public EulerGroupTemplate<TScalarType, 3>::EulerTransform_tmp
+class EulerTransform<TScalarType, 3> : public EulerGroupTemplate<TScalarType, 3>
 {
 public:
   /** Standard ITK-stuff. */
-  typedef EulerTransform                                                  Self;
-  typedef typename EulerGroupTemplate<TScalarType, 3>::EulerTransform_tmp Superclass;
-  typedef SmartPointer<Self>                                              Pointer;
-  typedef SmartPointer<const Self>                                        ConstPointer;
+  typedef EulerTransform                     Self;
+  typedef EulerGroupTemplate<TScalarType, 3> Superclass;
+  typedef SmartPointer<Self>                 Pointer;
+  typedef SmartPointer<const Self>           ConstPointer;
 
   /** Method for creation through the object factory. */
   itkNewMacro(Self);

--- a/Components/Transforms/AffineDTITransform/itkAffineDTITransform.h
+++ b/Components/Transforms/AffineDTITransform/itkAffineDTITransform.h
@@ -27,7 +27,7 @@ namespace itk
 
 /**
  * \class AffineDTIGroup
- * \brief This class only contains a dummy class.
+ * \brief This class only contains an alias template.
  *
  */
 
@@ -36,17 +36,12 @@ class AffineDTIGroup
 {
 public:
   template <class TScalarType>
-  class Dummy
-  {
-  public:
-    /** Typedef's.*/
-    typedef AdvancedMatrixOffsetTransformBase<TScalarType, Dimension, Dimension> AffineDTITransform_tmp;
-  };
+  using TransformAlias = AdvancedMatrixOffsetTransformBase<TScalarType, Dimension, Dimension>;
 };
 
 /**
  * \class AffineDTIGroup<2>
- * \brief This class only contains a dummy class for the 2D case.
+ * \brief This class only contains an alias template for the 2D case.
  *
  */
 
@@ -55,17 +50,12 @@ class AffineDTIGroup<2>
 {
 public:
   template <class TScalarType>
-  class Dummy
-  {
-  public:
-    /** Typedef's.*/
-    typedef AffineDTI2DTransform<TScalarType> AffineDTITransform_tmp;
-  };
+  using TransformAlias = AffineDTI2DTransform<TScalarType>;
 };
 
 /**
  * \class AffineDTIGroup<3>
- * \brief This class only contains a dummy class for the 3D case.
+ * \brief This class only contains an alias template for the 3D case.
  *
  */
 
@@ -74,44 +64,16 @@ class AffineDTIGroup<3>
 {
 public:
   template <class TScalarType>
-  class Dummy
-  {
-  public:
-    /** Typedef's.*/
-    typedef AffineDTI3DTransform<TScalarType> AffineDTITransform_tmp;
-  };
+  using TransformAlias = AffineDTI3DTransform<TScalarType>;
 };
+
 
 /**
- * \class AffineDTIGroupTemplate
- * \brief This class templates the AffineDTIGroup over its dimension.
- *
+ * This alias templates the AffineDTIGroup over its dimension.
  */
-
 template <class TScalarType, unsigned int Dimension>
-class AffineDTIGroupTemplate
-{
-public:
-  typedef AffineDTIGroupTemplate Self;
-  typedef TScalarType            ScalarType;
-  itkStaticConstMacro(SpaceDimension, unsigned int, Dimension);
+using AffineDTIGroupTemplate = typename AffineDTIGroup<Dimension>::template TransformAlias<TScalarType>;
 
-  // This declaration of 'AffineDTI' does not work with the GCC compiler
-  //    typedef AffineDTIGroup<  itkGetStaticConstMacro( SpaceDimension ) >       AffineDTI;
-  // The following trick works though:
-  template <unsigned int D>
-  class AffineDTIGroupWrap
-  {
-  public:
-    typedef AffineDTIGroup<D> AffineDTI;
-  };
-
-  typedef AffineDTIGroupWrap<Dimension>                  AffineDTIGroupWrapInstance;
-  typedef typename AffineDTIGroupWrapInstance::AffineDTI AffineDTI;
-
-  typedef typename AffineDTI::template Dummy<ScalarType>  AffineDTIDummy;
-  typedef typename AffineDTIDummy::AffineDTITransform_tmp AffineDTITransform_tmp;
-};
 
 /**
  * \class AffineDTITransform
@@ -123,14 +85,14 @@ public:
  */
 
 template <class TScalarType, unsigned int Dimension>
-class AffineDTITransform : public AffineDTIGroupTemplate<TScalarType, Dimension>::AffineDTITransform_tmp
+class AffineDTITransform : public AffineDTIGroupTemplate<TScalarType, Dimension>
 {
 public:
   /** Standard ITK-stuff. */
-  typedef AffineDTITransform                                                              Self;
-  typedef typename AffineDTIGroupTemplate<TScalarType, Dimension>::AffineDTITransform_tmp Superclass;
-  typedef SmartPointer<Self>                                                              Pointer;
-  typedef SmartPointer<const Self>                                                        ConstPointer;
+  typedef AffineDTITransform                             Self;
+  typedef AffineDTIGroupTemplate<TScalarType, Dimension> Superclass;
+  typedef SmartPointer<Self>                             Pointer;
+  typedef SmartPointer<const Self>                       ConstPointer;
 
   /** Method for creation through the object factory. */
   itkNewMacro(Self);

--- a/Components/Transforms/SimilarityTransform/itkSimilarityTransform.h
+++ b/Components/Transforms/SimilarityTransform/itkSimilarityTransform.h
@@ -28,7 +28,7 @@ namespace itk
 
 /**
  * \class SimilarityGroup
- * \brief This class only contains a dummy class.
+ * \brief This class only contains an alias template.
  *
  */
 
@@ -37,17 +37,12 @@ class SimilarityGroup
 {
 public:
   template <class TScalarType>
-  class Dummy
-  {
-  public:
-    /** Typedef's.*/
-    typedef AdvancedMatrixOffsetTransformBase<TScalarType, Dimension, Dimension> SimilarityTransform_tmp;
-  };
+  using TransformAlias = AdvancedMatrixOffsetTransformBase<TScalarType, Dimension, Dimension>;
 };
 
 /**
  * \class SimilarityGroup<2>
- * \brief This class only contains a dummy class for the 2D case.
+ * \brief This class only contains an alias template for the 2D case.
  *
  */
 
@@ -56,17 +51,12 @@ class SimilarityGroup<2>
 {
 public:
   template <class TScalarType>
-  class Dummy
-  {
-  public:
-    /** Typedef's.*/
-    typedef AdvancedSimilarity2DTransform<TScalarType> SimilarityTransform_tmp;
-  };
+  using TransformAlias = AdvancedSimilarity2DTransform<TScalarType>;
 };
 
 /**
  * \class SimilarityGroup<3>
- * \brief This class only contains a dummy class for the 3D case.
+ * \brief This class only contains an alias template for the 3D case.
  *
  */
 
@@ -75,44 +65,16 @@ class SimilarityGroup<3>
 {
 public:
   template <class TScalarType>
-  class Dummy
-  {
-  public:
-    /** Typedef's.*/
-    typedef AdvancedSimilarity3DTransform<TScalarType> SimilarityTransform_tmp;
-  };
+  using TransformAlias = AdvancedSimilarity3DTransform<TScalarType>;
 };
+
 
 /**
- * \class SimilarityGroupTemplate
- * \brief This class templates the SimilarityGroup over its dimension.
- *
+ * This alias templates the SimilarityGroup over its dimension.
  */
-
 template <class TScalarType, unsigned int Dimension>
-class SimilarityGroupTemplate
-{
-public:
-  typedef SimilarityGroupTemplate Self;
-  typedef TScalarType             ScalarType;
-  itkStaticConstMacro(SpaceDimension, unsigned int, Dimension);
+using SimilarityGroupTemplate = typename SimilarityGroup<Dimension>::template TransformAlias<TScalarType>;
 
-  // This declaration of 'Similarity' does not work with the GCC compiler
-  //    typedef SimilarityGroup<  itkGetStaticConstMacro( SpaceDimension ) >        Similarity;
-  // The following trick works though:
-  template <unsigned int D>
-  class SimilarityGroupWrap
-  {
-  public:
-    typedef SimilarityGroup<D> Similarity;
-  };
-
-  typedef SimilarityGroupWrap<Dimension>                   SimilarityGroupWrapInstance;
-  typedef typename SimilarityGroupWrapInstance::Similarity Similarity;
-
-  typedef typename Similarity::template Dummy<ScalarType>   SimilarityDummy;
-  typedef typename SimilarityDummy::SimilarityTransform_tmp SimilarityTransform_tmp;
-};
 
 /**
  * \class SimilarityTransform
@@ -124,14 +86,14 @@ public:
  */
 
 template <class TScalarType, unsigned int Dimension>
-class SimilarityTransform : public SimilarityGroupTemplate<TScalarType, Dimension>::SimilarityTransform_tmp
+class SimilarityTransform : public SimilarityGroupTemplate<TScalarType, Dimension>
 {
 public:
   /** Standard ITK-stuff. */
-  typedef SimilarityTransform                                                               Self;
-  typedef typename SimilarityGroupTemplate<TScalarType, Dimension>::SimilarityTransform_tmp Superclass;
-  typedef SmartPointer<Self>                                                                Pointer;
-  typedef SmartPointer<const Self>                                                          ConstPointer;
+  typedef SimilarityTransform                             Self;
+  typedef SimilarityGroupTemplate<TScalarType, Dimension> Superclass;
+  typedef SmartPointer<Self>                              Pointer;
+  typedef SmartPointer<const Self>                        ConstPointer;
 
   /** Method for creation through the object factory. */
   itkNewMacro(Self);


### PR DESCRIPTION
Simplified the code that selects the base class (template) of a transform, based on its `ScalarType` and `Dimension`.