### PR TITLE
ENH: Add `MakeVector` and `MakePoint` to GTestUtilities

### DIFF
--- a/Common/GTesting/elxGTestUtilities.h
+++ b/Common/GTesting/elxGTestUtilities.h
@@ -18,7 +18,9 @@
 #ifndef elxGTestUtilities_h
 #define elxGTestUtilities_h
 
+#include <itkPoint.h>
 #include <itkSmartPointer.h>
+#include <itkVector.h>
 
 // GoogleTest header file:
 #include <gtest/gtest.h>
@@ -79,6 +81,25 @@ CreateDefaultElastixObject()
 
   return elastixObject;
 }
+
+
+template <typename T, typename... TVariadic>
+auto
+MakeVector(const T firstValue, TVariadic... remainingValues) -> itk::Vector<T, 1 + sizeof...(remainingValues)>
+{
+  const T data[] = { firstValue, remainingValues... };
+  return data;
+}
+
+
+template <typename T, typename... TVariadic>
+auto
+MakePoint(const T firstValue, TVariadic... remainingValues) -> itk::Point<T, 1 + sizeof...(remainingValues)>
+{
+  const T data[] = { firstValue, remainingValues... };
+  return data;
+}
+
 
 } // namespace GTestUtilities
 } // namespace elastix

--- a/Common/GTesting/elxTransformIOGTest.cxx
+++ b/Common/GTesting/elxTransformIOGTest.cxx
@@ -61,6 +61,9 @@
 using ParameterValuesType = itk::ParameterFileParser::ParameterValuesType;
 using ParameterMapType = itk::ParameterFileParser::ParameterMapType;
 
+using elx::GTestUtilities::MakePoint;
+using elx::GTestUtilities::MakeVector;
+
 namespace
 {
 
@@ -772,7 +775,7 @@ GTEST_TEST(Transform, TransformedPointSameAsITKTranslation2D)
   constexpr auto Dimension = 2U;
 
   const auto itkTransform = itk::TranslationTransform<double, Dimension>::New();
-  itkTransform->SetOffset(std::array<double, Dimension>{ 1.0, 2.0 }.data());
+  itkTransform->SetOffset(MakeVector(1.0, 2.0));
 
   Expect_elx_TransformPoint_yields_same_point_as_ITK<elx::TranslationTransformElastix>(*itkTransform);
 }
@@ -783,7 +786,7 @@ GTEST_TEST(Transform, TransformedPointSameAsITKTranslation3D)
   constexpr auto Dimension = 3U;
 
   const auto itkTransform = itk::TranslationTransform<double, Dimension>::New();
-  itkTransform->SetOffset(std::array<double, Dimension>{ 1.0, 2.0, 3.0 }.data());
+  itkTransform->SetOffset(MakeVector(1.0, 2.0, 3.0));
 
   Expect_elx_TransformPoint_yields_same_point_as_ITK<elx::TranslationTransformElastix>(*itkTransform);
 }
@@ -794,9 +797,9 @@ GTEST_TEST(Transform, TransformedPointSameAsITKAffine2D)
   constexpr auto Dimension = 2U;
 
   const auto itkTransform = itk::AffineTransform<double, Dimension>::New();
-  itkTransform->SetTranslation(std::array<double, Dimension>{ 1.0, 2.0 }.data());
-  itkTransform->Scale(std::array<double, Dimension>{ 1.5, 1.75 }.data());
-  itkTransform->SetCenter(itk::Point<double, Dimension>(std::array<double, Dimension>{ 0.5, 1.5 }));
+  itkTransform->SetTranslation(MakeVector(1.0, 2.0));
+  itkTransform->Scale(MakeVector(1.5, 1.75));
+  itkTransform->SetCenter(MakePoint(0.5, 1.5));
   itkTransform->Rotate2D(M_PI_4);
 
   Expect_elx_TransformPoint_yields_same_point_as_ITK<elx::AdvancedAffineTransformElastix>(*itkTransform);
@@ -808,9 +811,9 @@ GTEST_TEST(Transform, TransformedPointSameAsITKAffine3D)
   constexpr auto Dimension = 3U;
 
   const auto itkTransform = itk::AffineTransform<double, Dimension>::New();
-  itkTransform->SetTranslation(std::array<double, Dimension>{ 1.0, 2.0, 3.0 }.data());
-  itkTransform->SetCenter(itk::Point<double, Dimension>(std::array<double, Dimension>{ 3.0, 2.0, 1.0 }));
-  itkTransform->Scale(std::array<double, Dimension>{ 1.25, 1.5, 1.75 }.data());
+  itkTransform->SetTranslation(MakeVector(1.0, 2.0, 3.0));
+  itkTransform->SetCenter(MakePoint(3.0, 2.0, 1.0));
+  itkTransform->Scale(MakeVector(1.25, 1.5, 1.75));
   itkTransform->Rotate3D(itk::Vector<double, Dimension>(1.0), M_PI_4);
 
   Expect_elx_TransformPoint_yields_same_point_as_ITK<elx::AdvancedAffineTransformElastix>(*itkTransform);
@@ -822,8 +825,8 @@ GTEST_TEST(Transform, TransformedPointSameAsITKEuler2D)
   constexpr auto Dimension = 2U;
 
   const auto itkTransform = itk::Euler2DTransform<double>::New();
-  itkTransform->SetTranslation(std::array<double, Dimension>{ 1.0, 2.0 }.data());
-  itkTransform->SetCenter(itk::Point<double, Dimension>(std::array<double, Dimension>{ 0.5, 1.5 }));
+  itkTransform->SetTranslation(MakeVector(1.0, 2.0));
+  itkTransform->SetCenter(MakePoint(0.5, 1.5));
 
   Expect_elx_TransformPoint_yields_same_point_as_ITK<elx::EulerTransformElastix>(*itkTransform);
 }
@@ -834,8 +837,8 @@ GTEST_TEST(Transform, TransformedPointSameAsITKEuler3D)
   constexpr auto Dimension = 3U;
 
   const auto itkTransform = itk::Euler3DTransform<double>::New();
-  itkTransform->SetTranslation(std::array<double, Dimension>{ 1.0, 2.0, 3.0 }.data());
-  itkTransform->SetCenter(itk::Point<double, Dimension>(std::array<double, Dimension>{ 3.0, 2.0, 1.0 }));
+  itkTransform->SetTranslation(MakeVector(1.0, 2.0, 3.0));
+  itkTransform->SetCenter(MakePoint(3.0, 2.0, 1.0));
 
   Expect_elx_TransformPoint_yields_same_point_as_ITK<elx::EulerTransformElastix>(*itkTransform);
 }

--- a/Core/Main/GTesting/itkTransformixFilterGTest.cxx
+++ b/Core/Main/GTesting/itkTransformixFilterGTest.cxx
@@ -23,6 +23,7 @@
 #include <itkParameterFileParser.h>
 
 #include "elxCoreMainGTestUtilities.h"
+#include "GTesting/elxGTestUtilities.h"
 
 // ITK header files:
 #include <itkAffineTransform.h>
@@ -48,6 +49,8 @@ template <typename TPixel, unsigned VImageDimension>
 using ResampleImageFilterType =
   itk::ResampleImageFilter<itk::Image<TPixel, VImageDimension>, itk::Image<TPixel, VImageDimension>>;
 
+using elx::GTestUtilities::MakePoint;
+using elx::GTestUtilities::MakeVector;
 using elx::CoreMainGTestUtilities::Deref;
 
 namespace
@@ -331,7 +334,7 @@ GTEST_TEST(itkTransformixFilter, ITKTranslationTransform2D)
   constexpr auto ImageDimension = 2U;
 
   const auto itkTransform = itk::TranslationTransform<double, ImageDimension>::New();
-  itkTransform->SetOffset(itk::Vector<double, ImageDimension>(std::array<double, ImageDimension>{ 1.0, -2.0 }.data()));
+  itkTransform->SetOffset(MakeVector(1.0, -2.0));
 
   Expect_TransformixFilter_output_equals_ResampleImageFilter_output(
     *CreateImageFilledWithSequenceOfNaturalNumbers<float, ImageDimension>({ 5, 6 }), *itkTransform);
@@ -343,8 +346,7 @@ GTEST_TEST(itkTransformixFilter, ITKTranslationTransform3D)
   constexpr auto ImageDimension = 3U;
 
   const auto itkTransform = itk::TranslationTransform<double, ImageDimension>::New();
-  itkTransform->SetOffset(
-    itk::Vector<double, ImageDimension>(std::array<double, ImageDimension>{ 1.0, -2.0, 3.0 }.data()));
+  itkTransform->SetOffset(MakeVector(1.0, -2.0, 3.0));
 
   Expect_TransformixFilter_output_equals_ResampleImageFilter_output(
     *CreateImageFilledWithSequenceOfNaturalNumbers<float, ImageDimension>({ 5, 6, 7 }), *itkTransform);
@@ -356,9 +358,8 @@ GTEST_TEST(itkTransformixFilter, ITKAffineTransform2D)
   constexpr auto ImageDimension = 2U;
 
   const auto itkTransform = itk::AffineTransform<double, ImageDimension>::New();
-  itkTransform->SetTranslation(
-    itk::Vector<double, ImageDimension>(std::array<double, ImageDimension>{ 1.0, -2.0 }.data()));
-  itkTransform->SetCenter(itk::Point<double, ImageDimension>(std::array<double, ImageDimension>{ 2.5, 3.0 }));
+  itkTransform->SetTranslation(MakeVector(1.0, -2.0));
+  itkTransform->SetCenter(MakePoint(2.5, 3.0));
   itkTransform->Rotate2D(M_PI_4);
 
   Expect_TransformixFilter_output_equals_ResampleImageFilter_output(
@@ -371,9 +372,8 @@ GTEST_TEST(itkTransformixFilter, ITKAffineTransform3D)
   constexpr auto ImageDimension = 3U;
 
   const auto itkTransform = itk::AffineTransform<double, ImageDimension>::New();
-  itkTransform->SetTranslation(
-    itk::Vector<double, ImageDimension>(std::array<double, ImageDimension>{ 1.0, 2.0, 3.0 }.data()));
-  itkTransform->SetCenter(itk::Point<double, ImageDimension>(std::array<double, ImageDimension>{ 3.0, 2.0, 1.0 }));
+  itkTransform->SetTranslation(MakeVector(1.0, 2.0, 3.0));
+  itkTransform->SetCenter(MakePoint(3.0, 2.0, 1.0));
   itkTransform->Rotate3D(itk::Vector<double, ImageDimension>(1.0), M_PI_4);
 
   Expect_TransformixFilter_output_equals_ResampleImageFilter_output(


### PR DESCRIPTION
Simplifies creation of an `itk::Point` or an `itk::Vector` "on the fly".