### PR TITLE
STYLE: Use in-class default-member-initialization for current transforms

### DIFF
--- a/Components/Transforms/AdvancedAffineTransform/elxAdvancedAffineTransform.h
+++ b/Components/Transforms/AdvancedAffineTransform/elxAdvancedAffineTransform.h
@@ -226,7 +226,7 @@ private:
   void
   operator=(const Self &) = delete;
 
-  AffineTransformPointer m_AffineTransform;
+  const AffineTransformPointer m_AffineTransform{ AffineTransformType::New() };
 };
 
 } // end namespace elastix

--- a/Components/Transforms/AdvancedAffineTransform/elxAdvancedAffineTransform.hxx
+++ b/Components/Transforms/AdvancedAffineTransform/elxAdvancedAffineTransform.hxx
@@ -37,7 +37,6 @@ namespace elastix
 template <class TElastix>
 AdvancedAffineTransformElastix<TElastix>::AdvancedAffineTransformElastix()
 {
-  this->m_AffineTransform = AffineTransformType::New();
   this->SetCurrentTransform(this->m_AffineTransform);
 
 } // end Constructor

--- a/Components/Transforms/AffineDTITransform/elxAffineDTITransform.h
+++ b/Components/Transforms/AffineDTITransform/elxAffineDTITransform.h
@@ -227,7 +227,7 @@ private:
   void
   operator=(const Self &) = delete;
 
-  AffineDTITransformPointer m_AffineDTITransform;
+  const AffineDTITransformPointer m_AffineDTITransform{ AffineDTITransformType::New() };
 };
 
 } // end namespace elastix

--- a/Components/Transforms/AffineDTITransform/elxAffineDTITransform.hxx
+++ b/Components/Transforms/AffineDTITransform/elxAffineDTITransform.hxx
@@ -31,7 +31,6 @@ namespace elastix
 template <class TElastix>
 AffineDTITransformElastix<TElastix>::AffineDTITransformElastix()
 {
-  this->m_AffineDTITransform = AffineDTITransformType::New();
   this->SetCurrentTransform(this->m_AffineDTITransform);
 
 } // end Constructor

--- a/Components/Transforms/AffineLogTransform/elxAffineLogTransform.h
+++ b/Components/Transforms/AffineLogTransform/elxAffineLogTransform.h
@@ -191,7 +191,7 @@ private:
   void
   operator=(const Self &) = delete;
 
-  AffineLogTransformPointer m_AffineLogTransform;
+  const AffineLogTransformPointer m_AffineLogTransform{ AffineLogTransformType::New() };
 };
 
 } // end namespace elastix

--- a/Components/Transforms/AffineLogTransform/elxAffineLogTransform.hxx
+++ b/Components/Transforms/AffineLogTransform/elxAffineLogTransform.hxx
@@ -32,7 +32,6 @@ template <class TElastix>
 AffineLogTransformElastix<TElastix>::AffineLogTransformElastix()
 {
   elxout << "Constructor" << std::endl;
-  this->m_AffineLogTransform = AffineLogTransformType::New();
   this->SetCurrentTransform(this->m_AffineLogTransform);
 
 } // end Constructor

--- a/Components/Transforms/DeformationFieldTransform/elxDeformationFieldTransform.h
+++ b/Components/Transforms/DeformationFieldTransform/elxDeformationFieldTransform.h
@@ -156,7 +156,9 @@ private:
 
   /** The transform that is set as current transform in the
    * CcombinationTransform */
-  DeformationFieldInterpolatingTransformPointer m_DeformationFieldInterpolatingTransform;
+  const DeformationFieldInterpolatingTransformPointer m_DeformationFieldInterpolatingTransform{
+    DeformationFieldInterpolatingTransformType::New()
+  };
 
   /** Original direction cosines; stored to facilitate UseDirectionCosines option. */
   DirectionType m_OriginalDeformationFieldDirection;

--- a/Components/Transforms/DeformationFieldTransform/elxDeformationFieldTransform.hxx
+++ b/Components/Transforms/DeformationFieldTransform/elxDeformationFieldTransform.hxx
@@ -39,7 +39,6 @@ template <class TElastix>
 DeformationFieldTransform<TElastix>::DeformationFieldTransform()
 {
   /** Initialize. */
-  this->m_DeformationFieldInterpolatingTransform = DeformationFieldInterpolatingTransformType::New();
   this->SetCurrentTransform(this->m_DeformationFieldInterpolatingTransform);
 
   /** Make sure that the TransformBase::WriteToFile() does

--- a/Components/Transforms/EulerTransform/elxEulerTransform.h
+++ b/Components/Transforms/EulerTransform/elxEulerTransform.h
@@ -230,7 +230,7 @@ private:
   void
   operator=(const Self &) = delete;
 
-  EulerTransformPointer m_EulerTransform;
+  const EulerTransformPointer m_EulerTransform{ EulerTransformType::New() };
 };
 
 } // end namespace elastix

--- a/Components/Transforms/EulerTransform/elxEulerTransform.hxx
+++ b/Components/Transforms/EulerTransform/elxEulerTransform.hxx
@@ -33,7 +33,6 @@ namespace elastix
 template <class TElastix>
 EulerTransformElastix<TElastix>::EulerTransformElastix()
 {
-  this->m_EulerTransform = EulerTransformType::New();
   this->SetCurrentTransform(this->m_EulerTransform);
 
 } // end Constructor

--- a/Components/Transforms/SimilarityTransform/elxSimilarityTransform.h
+++ b/Components/Transforms/SimilarityTransform/elxSimilarityTransform.h
@@ -240,7 +240,7 @@ private:
   void
   operator=(const Self &) = delete;
 
-  SimilarityTransformPointer m_SimilarityTransform;
+  const SimilarityTransformPointer m_SimilarityTransform{ SimilarityTransformType::New() };
 };
 
 } // end namespace elastix

--- a/Components/Transforms/SimilarityTransform/elxSimilarityTransform.hxx
+++ b/Components/Transforms/SimilarityTransform/elxSimilarityTransform.hxx
@@ -32,7 +32,6 @@ namespace elastix
 template <class TElastix>
 SimilarityTransformElastix<TElastix>::SimilarityTransformElastix()
 {
-  this->m_SimilarityTransform = SimilarityTransformType::New();
   this->SetCurrentTransform(this->m_SimilarityTransform);
 
 } // end Constructor()

--- a/Components/Transforms/TranslationTransform/elxTranslationTransform.h
+++ b/Components/Transforms/TranslationTransform/elxTranslationTransform.h
@@ -141,7 +141,7 @@ protected:
   /** The destructor. */
   ~TranslationTransformElastix() override = default;
 
-  TranslationTransformPointer m_TranslationTransform;
+  const TranslationTransformPointer m_TranslationTransform{ TranslationTransformType::New() };
 
 private:
   elxOverrideGetSelfMacro;

--- a/Components/Transforms/TranslationTransform/elxTranslationTransform.hxx
+++ b/Components/Transforms/TranslationTransform/elxTranslationTransform.hxx
@@ -30,7 +30,6 @@ namespace elastix
 template <class TElastix>
 TranslationTransformElastix<TElastix>::TranslationTransformElastix()
 {
-  this->m_TranslationTransform = TranslationTransformType::New();
   this->SetCurrentTransform(this->m_TranslationTransform);
 } // end Constructor
 

--- a/Components/Transforms/WeightedCombinationTransform/elxWeightedCombinationTransform.h
+++ b/Components/Transforms/WeightedCombinationTransform/elxWeightedCombinationTransform.h
@@ -204,8 +204,8 @@ protected:
   /** The destructor. */
   ~WeightedCombinationTransformElastix() override = default;
 
-  WeightedCombinationTransformPointer m_WeightedCombinationTransform;
-  std::vector<std::string>            m_SubTransformFileNames;
+  const WeightedCombinationTransformPointer m_WeightedCombinationTransform{ WeightedCombinationTransformType::New() };
+  std::vector<std::string>                  m_SubTransformFileNames;
 
 private:
   elxOverrideGetSelfMacro;

--- a/Components/Transforms/WeightedCombinationTransform/elxWeightedCombinationTransform.hxx
+++ b/Components/Transforms/WeightedCombinationTransform/elxWeightedCombinationTransform.hxx
@@ -31,7 +31,6 @@ namespace elastix
 template <class TElastix>
 WeightedCombinationTransformElastix<TElastix>::WeightedCombinationTransformElastix()
 {
-  this->m_WeightedCombinationTransform = WeightedCombinationTransformType::New();
   this->SetCurrentTransform(this->m_WeightedCombinationTransform);
 } // end Constructor
 


### PR DESCRIPTION
Replace `TransformType::New()` assignments in the body of constructors by C++11 in-class default-member-initialization, for the "current transform" data member of eight elastix transforms.