### PR TITLE
BUG: `AdvancedSimilarity3DTransform::SetScale` should recompute m_Offset

### DIFF
--- a/Common/Transforms/itkAdvancedSimilarity3DTransform.hxx
+++ b/Common/Transforms/itkAdvancedSimilarity3DTransform.hxx
@@ -72,6 +72,7 @@ AdvancedSimilarity3DTransform<TScalarType>::SetScale(ScaleType scale)
 {
   m_Scale = scale;
   this->ComputeMatrix();
+  this->ComputeOffset();
 }
 
 


### PR DESCRIPTION
Following ITK issue https://github.com/InsightSoftwareConsortium/ITK/issues/2629 and pull request https://github.com/InsightSoftwareConsortium/ITK/pull/2627