### PR TITLE
STYLE: Convert constructor member initializers to default member init

### DIFF
--- a/Common/Transforms/itkStackTransform.h
+++ b/Common/Transforms/itkStackTransform.h
@@ -295,11 +295,12 @@ private:
   operator=(const Self &) = delete;
 
   // Number of transforms and transform container
-  unsigned int              m_NumberOfSubTransforms;
+  unsigned int              m_NumberOfSubTransforms{ 0 };
   SubTransformContainerType m_SubTransformContainer;
 
   // Stack spacing and origin of last dimension
-  TScalarType m_StackSpacing, m_StackOrigin;
+  TScalarType m_StackSpacing{ 1.0 };
+  TScalarType m_StackOrigin{ 0.0 };
 };
 
 } // end namespace itk

--- a/Common/Transforms/itkStackTransform.hxx
+++ b/Common/Transforms/itkStackTransform.hxx
@@ -30,9 +30,6 @@ namespace itk
 template <class TScalarType, unsigned int NInputDimensions, unsigned int NOutputDimensions>
 StackTransform<TScalarType, NInputDimensions, NOutputDimensions>::StackTransform()
   : Superclass(OutputSpaceDimension)
-  , m_NumberOfSubTransforms(0)
-  , m_StackSpacing(1.0)
-  , m_StackOrigin(0.0)
 {} // end Constructor
 
 

--- a/Components/Metrics/PCAMetric/itkPCAMetric_F_multithreaded.h
+++ b/Components/Metrics/PCAMetric/itkPCAMetric_F_multithreaded.h
@@ -228,16 +228,16 @@ private:
   unsigned int m_LastDimIndex;
 
   /** Bool to determine if we want to subtract the mean derivate from the derivative elements. */
-  bool m_SubtractMean;
+  bool m_SubtractMean{ false };
 
   /** GridSize of B-spline transform. */
   FixedImageSizeType m_GridSize;
 
   /** Bool to indicate if the transform used is a stacktransform. Set by elx files. */
-  bool m_TransformIsStackTransform;
+  bool m_TransformIsStackTransform{ false };
 
   /** Integer to indicate how many eigenvalues you want to use in the metric */
-  unsigned int m_NumEigenValues;
+  unsigned int m_NumEigenValues{ 6 };
 
   /** Matrices, needed for derivative calculation */
   mutable std::vector<unsigned int> m_PixelStartIndex;

--- a/Components/Metrics/PCAMetric/itkPCAMetric_F_multithreaded.hxx
+++ b/Components/Metrics/PCAMetric/itkPCAMetric_F_multithreaded.hxx
@@ -41,9 +41,6 @@ namespace itk
 
 template <class TFixedImage, class TMovingImage>
 PCAMetric<TFixedImage, TMovingImage>::PCAMetric()
-  : m_SubtractMean(false)
-  , m_TransformIsStackTransform(false)
-  , m_NumEigenValues(6)
 {
   this->SetUseImageSampler(true);
   this->SetUseFixedImageLimiter(false);

--- a/Components/Metrics/PCAMetric2/itkPCAMetric2.h
+++ b/Components/Metrics/PCAMetric2/itkPCAMetric2.h
@@ -165,13 +165,13 @@ private:
   unsigned int m_ReducedDimensionIndex;
 
   /** Bool to determine if we want to subtract the mean derivate from the derivative elements. */
-  bool m_SubtractMean;
+  bool m_SubtractMean{ false };
 
   /** GridSize of B-spline transform. */
   FixedImageSizeType m_GridSize;
 
   /** Bool to indicate if the transform used is a stacktransform. Set by elx files. */
-  bool m_TransformIsStackTransform;
+  bool m_TransformIsStackTransform{ false };
 };
 
 } // end namespace itk

--- a/Components/Metrics/PCAMetric2/itkPCAMetric2.hxx
+++ b/Components/Metrics/PCAMetric2/itkPCAMetric2.hxx
@@ -37,8 +37,6 @@ namespace itk
 
 template <class TFixedImage, class TMovingImage>
 PCAMetric2<TFixedImage, TMovingImage>::PCAMetric2()
-  : m_SubtractMean(false)
-  , m_TransformIsStackTransform(false)
 {
   this->SetUseImageSampler(true);
   this->SetUseFixedImageLimiter(false);

--- a/Components/Metrics/SumOfPairwiseCorrelationsMetric/itkSumOfPairwiseCorrelationCoefficientsMetric.h
+++ b/Components/Metrics/SumOfPairwiseCorrelationsMetric/itkSumOfPairwiseCorrelationCoefficientsMetric.h
@@ -165,13 +165,13 @@ private:
   unsigned int m_ReducedDimensionIndex;
 
   /** Bool to determine if we want to subtract the mean derivate from the derivative elements. */
-  bool m_SubtractMean;
+  bool m_SubtractMean{ true };
 
   /** GridSize of B-spline transform. */
   FixedImageSizeType m_GridSize;
 
   /** Bool to indicate if the transform used is a stacktransform. Set by elx files. */
-  bool m_TransformIsStackTransform;
+  bool m_TransformIsStackTransform{ true };
 };
 
 } // end namespace itk

--- a/Components/Metrics/SumOfPairwiseCorrelationsMetric/itkSumOfPairwiseCorrelationCoefficientsMetric.hxx
+++ b/Components/Metrics/SumOfPairwiseCorrelationsMetric/itkSumOfPairwiseCorrelationCoefficientsMetric.hxx
@@ -33,8 +33,6 @@ namespace itk
 
 template <class TFixedImage, class TMovingImage>
 SumOfPairwiseCorrelationCoefficientsMetric<TFixedImage, TMovingImage>::SumOfPairwiseCorrelationCoefficientsMetric()
-  : m_SubtractMean(true)
-  , m_TransformIsStackTransform(true)
 {
   this->SetUseImageSampler(true);
   this->SetUseFixedImageLimiter(false);

--- a/Components/Metrics/VarianceOverLastDimension/itkVarianceOverLastDimensionImageMetric.h
+++ b/Components/Metrics/VarianceOverLastDimension/itkVarianceOverLastDimensionImageMetric.h
@@ -187,13 +187,13 @@ private:
   SampleRandom(const int n, const int m, std::vector<int> & numbers) const;
 
   /** Variables to control random sampling in last dimension. */
-  bool         m_SampleLastDimensionRandomly;
-  unsigned int m_NumSamplesLastDimension;
+  bool         m_SampleLastDimensionRandomly{ false };
+  unsigned int m_NumSamplesLastDimension{ 10 };
   unsigned int m_NumAdditionalSamplesFixed;
   unsigned int m_ReducedDimensionIndex;
 
   /** Bool to determine if we want to subtract the mean derivate from the derivative elements. */
-  bool m_SubtractMean;
+  bool m_SubtractMean{ false };
 
   /** Initial variance in last dimension, used as normalization factor. */
   float m_InitialVariance;
@@ -202,7 +202,7 @@ private:
   FixedImageSizeType m_GridSize;
 
   /** Bool to indicate if the transform used is a stacktransform. Set by elx files. */
-  bool m_TransformIsStackTransform;
+  bool m_TransformIsStackTransform{ false };
 };
 
 } // end namespace itk

--- a/Components/Metrics/VarianceOverLastDimension/itkVarianceOverLastDimensionImageMetric.hxx
+++ b/Components/Metrics/VarianceOverLastDimension/itkVarianceOverLastDimensionImageMetric.hxx
@@ -32,10 +32,6 @@ namespace itk
 
 template <class TFixedImage, class TMovingImage>
 VarianceOverLastDimensionImageMetric<TFixedImage, TMovingImage>::VarianceOverLastDimensionImageMetric()
-  : m_SampleLastDimensionRandomly(false)
-  , m_NumSamplesLastDimension(10)
-  , m_SubtractMean(false)
-  , m_TransformIsStackTransform(false)
 {
   this->SetUseImageSampler(true);
   this->SetUseFixedImageLimiter(false);


### PR DESCRIPTION
Converted default-constructor member-initializers into C++11 in-class default-member-initializers, using Clang-Tidy option `modernize-use-default-member-init`:

https://clang.llvm.org/extra/clang-tidy/checks/modernize-use-default-member-init.html

Manually did the TScalarType data members of `StackTransform`.