### PR TITLE
BUG: Do not wrap any GoogleTest `ASSERT` into a lambda

### DIFF
--- a/Core/Main/GTesting/ElastixLibGTest.cxx
+++ b/Core/Main/GTesting/ElastixLibGTest.cxx
@@ -60,8 +60,7 @@ template <unsigned VDimension>
 std::array<double, VDimension>
 ConvertStringsToArrayOfDouble(const std::vector<std::string> & strings)
 {
-  // Wrap ASSERT_EQ in a lambda, because it returns void!
-  [&strings] { ASSERT_EQ(strings.size(), VDimension); }();
+  ELX_GTEST_EXPECT_FALSE_AND_THROW_EXCEPTION_IF(strings.size() != VDimension);
 
   std::array<double, VDimension> result;
 
@@ -72,7 +71,7 @@ ConvertStringsToArrayOfDouble(const std::vector<std::string> & strings)
     result[i] = std::stod(str, &index);
 
     // Test that all characters have been processed, by std::stod.
-    [&str, index] { ASSERT_EQ(str.size(), index); }();
+    EXPECT_EQ(index, str.size());
   }
 
   return result;

--- a/Core/Main/GTesting/elxCoreMainGTestUtilities.h
+++ b/Core/Main/GTesting/elxCoreMainGTestUtilities.h
@@ -57,6 +57,15 @@ public:
 };
 
 
+/// Expect the specified condition to be false, and throw an exception if it is true.
+#define ELX_GTEST_EXPECT_FALSE_AND_THROW_EXCEPTION_IF(condition)                                                       \
+  if (condition)                                                                                                       \
+  {                                                                                                                    \
+    EXPECT_FALSE(true) << "Expected to be false: " #condition;                                                         \
+    throw ::elastix::CoreMainGTestUtilities::Exception("Exception thrown because " #condition);                        \
+  }                                                                                                                    \
+  static_assert(true, "Expect a semi-colon ';' at the end of a macro call")
+
 /// Dereferences the specified pointer. Throws an `Exception` instead, when the pointer is null.
 template <typename T>
 T &
@@ -105,7 +114,7 @@ std::map<std::string, std::vector<std::string>> inline CreateParameterMap(
 
   for (const auto & pair : initializerList)
   {
-    [&pair, &result] { ASSERT_TRUE(result.insert({ pair.first, { pair.second } }).second); }();
+    EXPECT_TRUE(result.insert({ pair.first, { pair.second } }).second);
   }
   return result;
 }
@@ -119,7 +128,7 @@ CreateParameterMap(std::initializer_list<std::pair<std::string, std::string>> in
 
   for (const auto & key : { "FixedImageDimension", "MovingImageDimension" })
   {
-    [&key, &result] { ASSERT_TRUE(result.insert({ key, { std::to_string(VImageDimension) } }).second); }();
+    EXPECT_TRUE(result.insert({ key, { std::to_string(VImageDimension) } }).second);
   }
   return result;
 }

--- a/Core/Main/GTesting/itkElastixRegistrationMethodGTest.cxx
+++ b/Core/Main/GTesting/itkElastixRegistrationMethodGTest.cxx
@@ -280,7 +280,7 @@ GTEST_TEST(itkElastixRegistrationMethod, InitialTransformParameterFileLinkToTran
 
   const auto createFilter = [fixedImage](const std::string & initialTransformParameterFileName) {
     const auto filter = RegistrationMethodType::New();
-    [filter] { ASSERT_NE(filter, nullptr); }();
+    ELX_GTEST_EXPECT_FALSE_AND_THROW_EXCEPTION_IF(filter == nullptr);
     filter->SetFixedImage(fixedImage);
     filter->SetInitialTransformParameterFileName(elx::CoreMainGTestUtilities::GetDataDirectoryPath() +
                                                  "/Translation(1,-2)/" + initialTransformParameterFileName);


### PR DESCRIPTION
Wrapping GoogleTest `ASSERT`s into lambda's appeared to be a clever workaround to avoid compile errors, like

> error C2440: 'return': cannot convert from 'void' to 'std::array<double,2>'

From elastix\Core\Main\GTesting\ElastixLibGTest.cxx as follows:

    template <unsigned VDimension>
    std::array<double, VDimension>
    ConvertStringsToArrayOfDouble(const std::vector<std::string> & strings)
    {
      ASSERT_EQ(strings.size(), VDimension);  // compile error!!!
      ...

Wrapped in a lambda as:

    [&strings] { ASSERT_EQ(strings.size(), VDimension); }();

However, the wrapped versions don't break the program flow anymore, as "expected" from an assert failure.

Fixed by using GoogleTest `EXCEPT` macro's instead, and the introduced `ELX_GTEST_EXPECT_FALSE_AND_THROW_EXCEPTION_IF(condition)`