### PR TITLE
STYLE: C++11 in-class default-member-initializers for Optimizers

### DIFF
--- a/Components/Optimizers/AdaGrad/itkAdaptiveStepsizeOptimizer.cxx
+++ b/Components/Optimizers/AdaGrad/itkAdaptiveStepsizeOptimizer.cxx
@@ -28,14 +28,7 @@ namespace itk
  * ************************* Constructor ************************
  */
 
-AdaptiveStepsizeOptimizer::AdaptiveStepsizeOptimizer()
-{
-  this->m_UseAdaptiveStepSizes = true;
-  this->m_SigmoidMax = 1.0;
-  this->m_SigmoidMin = -0.8;
-  this->m_SigmoidScale = 1e-8;
-
-} // end Constructor
+AdaptiveStepsizeOptimizer::AdaptiveStepsizeOptimizer() = default;
 
 
 /**

--- a/Components/Optimizers/AdaGrad/itkAdaptiveStepsizeOptimizer.h
+++ b/Components/Optimizers/AdaGrad/itkAdaptiveStepsizeOptimizer.h
@@ -140,10 +140,10 @@ private:
   operator=(const Self &) = delete;
 
   /** Settings */
-  bool   m_UseAdaptiveStepSizes;
-  double m_SigmoidMax;
-  double m_SigmoidMin;
-  double m_SigmoidScale;
+  bool   m_UseAdaptiveStepSizes{ true };
+  double m_SigmoidMax{ 1.0 };
+  double m_SigmoidMin{ -0.8 };
+  double m_SigmoidScale{ 1e-8 };
 };
 
 } // end namespace itk

--- a/Components/Optimizers/AdaptiveStochasticGradientDescent/itkAdaptiveStochasticGradientDescentOptimizer.cxx
+++ b/Components/Optimizers/AdaptiveStochasticGradientDescent/itkAdaptiveStochasticGradientDescentOptimizer.cxx
@@ -28,14 +28,7 @@ namespace itk
  * ************************* Constructor ************************
  */
 
-AdaptiveStochasticGradientDescentOptimizer::AdaptiveStochasticGradientDescentOptimizer()
-{
-  this->m_UseAdaptiveStepSizes = true;
-  this->m_SigmoidMax = 1.0;
-  this->m_SigmoidMin = -0.8;
-  this->m_SigmoidScale = 1e-8;
-
-} // end Constructor
+AdaptiveStochasticGradientDescentOptimizer::AdaptiveStochasticGradientDescentOptimizer() = default;
 
 
 /**

--- a/Components/Optimizers/AdaptiveStochasticGradientDescent/itkAdaptiveStochasticGradientDescentOptimizer.h
+++ b/Components/Optimizers/AdaptiveStochasticGradientDescent/itkAdaptiveStochasticGradientDescentOptimizer.h
@@ -137,10 +137,10 @@ private:
   operator=(const Self &) = delete;
 
   /** Settings */
-  bool   m_UseAdaptiveStepSizes;
-  double m_SigmoidMax;
-  double m_SigmoidMin;
-  double m_SigmoidScale;
+  bool   m_UseAdaptiveStepSizes{ true };
+  double m_SigmoidMax{ 1.0 };
+  double m_SigmoidMin{ -0.8 };
+  double m_SigmoidScale{ 1e-8 };
 };
 
 } // end namespace itk

--- a/Components/Optimizers/AdaptiveStochasticLBFGS/itkAdaptiveStochasticLBFGSOptimizer.cxx
+++ b/Components/Optimizers/AdaptiveStochasticLBFGS/itkAdaptiveStochasticLBFGSOptimizer.cxx
@@ -28,15 +28,7 @@ namespace itk
  * ************************* Constructor ************************
  */
 
-AdaptiveStochasticLBFGSOptimizer::AdaptiveStochasticLBFGSOptimizer()
-{
-  this->m_UseAdaptiveStepSizes = true;
-  this->m_SigmoidMax = 1.0;
-  this->m_SigmoidMin = -0.8;
-  this->m_SigmoidScale = 1e-8;
-  this->m_SearchLengthScale = 10;
-
-} // end Constructor
+AdaptiveStochasticLBFGSOptimizer::AdaptiveStochasticLBFGSOptimizer() = default;
 
 
 /**

--- a/Components/Optimizers/AdaptiveStochasticLBFGS/itkAdaptiveStochasticLBFGSOptimizer.h
+++ b/Components/Optimizers/AdaptiveStochasticLBFGS/itkAdaptiveStochasticLBFGSOptimizer.h
@@ -134,8 +134,8 @@ protected:
   // DerivativeType m_PrePreviousGradient;
   unsigned long m_UpdateFrequenceL;
   bool          m_UseSearchDirForAdaptiveStepSize;
-  bool          m_UseAdaptiveStepSizes;
-  double        m_SearchLengthScale;
+  bool          m_UseAdaptiveStepSizes{ true };
+  double        m_SearchLengthScale{ 10 };
   std::string   m_StepSizeStrategy;
 
 private:
@@ -145,9 +145,9 @@ private:
 
   /** Settings */
 
-  double m_SigmoidMax;
-  double m_SigmoidMin;
-  double m_SigmoidScale;
+  double m_SigmoidMax{ 1.0 };
+  double m_SigmoidMin{ -0.8 };
+  double m_SigmoidScale{ 1e-8 };
 
 }; // end class AdaptiveStochasticLBFGSOptimizer
 

--- a/Components/Optimizers/AdaptiveStochasticVarianceReducedGradient/itkAdaptiveStochasticVarianceReducedGradientOptimizer.cxx
+++ b/Components/Optimizers/AdaptiveStochasticVarianceReducedGradient/itkAdaptiveStochasticVarianceReducedGradientOptimizer.cxx
@@ -28,14 +28,7 @@ namespace itk
  * ************************* Constructor ************************
  */
 
-AdaptiveStochasticVarianceReducedGradientOptimizer::AdaptiveStochasticVarianceReducedGradientOptimizer()
-{
-  this->m_UseAdaptiveStepSizes = true;
-  this->m_SigmoidMax = 1.0;
-  this->m_SigmoidMin = -0.8;
-  this->m_SigmoidScale = 1e-8;
-
-} // end Constructor
+AdaptiveStochasticVarianceReducedGradientOptimizer::AdaptiveStochasticVarianceReducedGradientOptimizer() = default;
 
 
 /**

--- a/Components/Optimizers/AdaptiveStochasticVarianceReducedGradient/itkAdaptiveStochasticVarianceReducedGradientOptimizer.h
+++ b/Components/Optimizers/AdaptiveStochasticVarianceReducedGradient/itkAdaptiveStochasticVarianceReducedGradientOptimizer.h
@@ -135,10 +135,10 @@ private:
   operator=(const Self &) = delete;
 
   /** Settings */
-  bool   m_UseAdaptiveStepSizes;
-  double m_SigmoidMax;
-  double m_SigmoidMin;
-  double m_SigmoidScale;
+  bool   m_UseAdaptiveStepSizes{ true };
+  double m_SigmoidMax{ 1.0 };
+  double m_SigmoidMin{ -0.8 };
+  double m_SigmoidScale{ 1e-8 };
 
 }; // end class AdaptiveStochasticVarianceReducedGradientOptimizer
 

--- a/Components/Optimizers/AdaptiveStochasticVarianceReducedGradient/itkStandardStochasticVarianceReducedGradientDescentOptimizer.cxx
+++ b/Components/Optimizers/AdaptiveStochasticVarianceReducedGradient/itkStandardStochasticVarianceReducedGradientDescentOptimizer.cxx
@@ -27,16 +27,7 @@ namespace itk
  * ************************* Constructor ************************
  */
 
-StandardStochasticVarianceReducedGradientOptimizer::StandardStochasticVarianceReducedGradientOptimizer()
-{
-  this->m_Param_a = 1.0;
-  this->m_Param_A = 1.0;
-  this->m_Param_alpha = 0.602;
-
-  this->m_CurrentTime = 0.0;
-  this->m_InitialTime = 0.0;
-
-} // end Constructor
+StandardStochasticVarianceReducedGradientOptimizer::StandardStochasticVarianceReducedGradientOptimizer() = default;
 
 
 /**

--- a/Components/Optimizers/AdaptiveStochasticVarianceReducedGradient/itkStandardStochasticVarianceReducedGradientDescentOptimizer.h
+++ b/Components/Optimizers/AdaptiveStochasticVarianceReducedGradient/itkStandardStochasticVarianceReducedGradientDescentOptimizer.h
@@ -146,7 +146,7 @@ protected:
   UpdateCurrentTime(void);
 
   /** The current time, which serves as input for Compute_a */
-  double m_CurrentTime;
+  double m_CurrentTime{ 0.0 };
 
   /** Constant step size or others, different value of k. */
   bool m_UseConstantStep;
@@ -157,13 +157,13 @@ private:
   operator=(const Self &) = delete;
 
   /**Parameters, as described by Spall.*/
-  double m_Param_a;
+  double m_Param_a{ 1.0 };
   double m_Param_beta;
-  double m_Param_A;
-  double m_Param_alpha;
+  double m_Param_A{ 1.0 };
+  double m_Param_alpha{ 0.602 };
 
   /** Settings */
-  double m_InitialTime;
+  double m_InitialTime{ 0.0 };
 
 }; // end class StandardStochasticVarianceReducedGradientOptimizer
 

--- a/Components/Optimizers/AdaptiveStochasticVarianceReducedGradient/itkStochasticVarianceReducedGradientDescentOptimizer.cxx
+++ b/Components/Optimizers/AdaptiveStochasticVarianceReducedGradient/itkStochasticVarianceReducedGradientDescentOptimizer.cxx
@@ -42,18 +42,6 @@ StochasticVarianceReducedGradientDescentOptimizer::StochasticVarianceReducedGrad
 {
   itkDebugMacro("Constructor");
 
-  this->m_LearningRate = 1.0;
-  this->m_NumberOfIterations = 100;
-  this->m_CurrentIteration = 0;
-  this->m_LBFGSMemory = 0;
-  this->m_Value = 0.0;
-  this->m_StopCondition = MaximumNumberOfIterations;
-
-  this->m_Threader = ThreaderType::New();
-  this->m_UseMultiThread = false;
-  this->m_UseOpenMP = false;
-  this->m_UseEigen = false;
-
 } // end Constructor
 
 

--- a/Components/Optimizers/AdaptiveStochasticVarianceReducedGradient/itkStochasticVarianceReducedGradientDescentOptimizer.h
+++ b/Components/Optimizers/AdaptiveStochasticVarianceReducedGradient/itkStochasticVarianceReducedGradientDescentOptimizer.h
@@ -179,25 +179,25 @@ protected:
   typedef ThreaderType::WorkUnitInfo ThreadInfoType;
 
   // made protected so subclass can access
-  double         m_Value;
+  double         m_Value{ 0.0 };
   DerivativeType m_Gradient;
   ParametersType m_SearchDir;
   ParametersType m_PreviousSearchDir;
   // ParametersType                m_PrePreviousSearchDir;
   ParametersType    m_MeanSearchDir;
-  double            m_LearningRate;
-  StopConditionType m_StopCondition;
+  double            m_LearningRate{ 1.0 };
+  StopConditionType m_StopCondition{ MaximumNumberOfIterations };
   DerivativeType    m_PreviousGradient;
   // DerivativeType                m_PrePreviousGradient;
   ParametersType        m_PreviousPosition;
-  ThreaderType::Pointer m_Threader;
+  ThreaderType::Pointer m_Threader{ ThreaderType::New() };
 
-  bool          m_Stop;
-  unsigned long m_NumberOfIterations;
+  bool          m_Stop{ false };
+  unsigned long m_NumberOfIterations{ 100 };
   unsigned long m_NumberOfInnerIterations;
-  unsigned long m_CurrentIteration;
+  unsigned long m_CurrentIteration{ 0 };
   unsigned long m_CurrentInnerIteration;
-  unsigned long m_LBFGSMemory;
+  unsigned long m_LBFGSMemory{ 0 };
 
 private:
   StochasticVarianceReducedGradientDescentOptimizer(const Self &) = delete;
@@ -205,15 +205,15 @@ private:
   operator=(const Self &) = delete;
 
   // multi-threaded AdvanceOneStep:
-  bool m_UseMultiThread;
+  bool m_UseMultiThread{ false };
   struct MultiThreaderParameterType
   {
     ParametersType * t_NewPosition;
     Self *           t_Optimizer;
   };
 
-  bool m_UseOpenMP;
-  bool m_UseEigen;
+  bool m_UseOpenMP{ false };
+  bool m_UseEigen{ false };
 
   /** The callback function. */
   static ITK_THREAD_RETURN_FUNCTION_CALL_CONVENTION

--- a/Components/Optimizers/CMAEvolutionStrategy/itkCMAEvolutionStrategyOptimizer.cxx
+++ b/Components/Optimizers/CMAEvolutionStrategy/itkCMAEvolutionStrategyOptimizer.cxx
@@ -36,44 +36,6 @@ CMAEvolutionStrategyOptimizer::CMAEvolutionStrategyOptimizer()
 {
   itkDebugMacro("Constructor");
 
-  this->m_RandomGenerator = RandomGeneratorType::GetInstance();
-
-  this->m_CurrentValue = NumericTraits<MeasureType>::Zero;
-  this->m_CurrentIteration = 0;
-  this->m_StopCondition = Unknown;
-  this->m_Stop = false;
-
-  this->m_UseCovarianceMatrixAdaptation = true;
-  this->m_PopulationSize = 0;
-  this->m_NumberOfParents = 0;
-  this->m_UpdateBDPeriod = 1;
-
-  this->m_EffectiveMu = 0.0;
-  this->m_ConjugateEvolutionPathConstant = 0.0;
-  this->m_SigmaDampingConstant = 0.0;
-  this->m_CovarianceMatrixAdaptationConstant = 0.0;
-  this->m_EvolutionPathConstant = 0.0;
-  this->m_CovarianceMatrixAdaptationWeight = 0.0;
-  this->m_ExpectationNormNormalDistribution = 0.0;
-  this->m_HistoryLength = 0;
-  this->m_CurrentMaximumD = 1.0;
-  this->m_CurrentMinimumD = 1.0;
-
-  this->m_CurrentSigma = 0.0;
-  this->m_Heaviside = false;
-
-  this->m_MaximumNumberOfIterations = 100;
-  this->m_UseDecayingSigma = false;
-  this->m_InitialSigma = 1.0;
-  this->m_SigmaDecayA = 50;
-  this->m_SigmaDecayAlpha = 0.602;
-  this->m_RecombinationWeightsPreset = "superlinear";
-  this->m_MaximumDeviation = NumericTraits<double>::max();
-  this->m_MinimumDeviation = 0.0;
-  this->m_PositionToleranceMin = 1e-12;
-  this->m_PositionToleranceMax = 1e8;
-  this->m_ValueTolerance = 1e-12;
-
 } // end constructor
 
 
@@ -185,7 +147,6 @@ CMAEvolutionStrategyOptimizer::ResumeOptimization()
 {
   itkDebugMacro("ResumeOptimization");
 
-  this->m_Stop = false;
   this->m_StopCondition = Unknown;
 
   this->InvokeEvent(StartEvent());

--- a/Components/Optimizers/CMAEvolutionStrategy/itkCMAEvolutionStrategyOptimizer.h
+++ b/Components/Optimizers/CMAEvolutionStrategy/itkCMAEvolutionStrategyOptimizer.h
@@ -235,58 +235,58 @@ protected:
   typedef itk::Statistics::MersenneTwisterRandomVariateGenerator RandomGeneratorType;
 
   /** The random number generator used to generate the offspring. */
-  RandomGeneratorType::Pointer m_RandomGenerator;
+  RandomGeneratorType::Pointer m_RandomGenerator{ RandomGeneratorType::GetInstance() };
 
   /** The value of the cost function at the current position */
-  MeasureType m_CurrentValue;
+  MeasureType m_CurrentValue{ 0.0 };
 
   /** The current iteration number */
-  unsigned long m_CurrentIteration;
+  unsigned long m_CurrentIteration{ 0 };
 
   /** The stop condition */
-  StopConditionType m_StopCondition;
+  StopConditionType m_StopCondition{ Unknown };
 
   /** Boolean that indicates whether the optimizer should stop */
-  bool m_Stop;
+  bool m_Stop{ false };
 
   /** Settings that may be changed by the optimizer: */
-  bool         m_UseCovarianceMatrixAdaptation;
-  unsigned int m_PopulationSize;
-  unsigned int m_NumberOfParents;
-  unsigned int m_UpdateBDPeriod;
+  bool         m_UseCovarianceMatrixAdaptation{ true };
+  unsigned int m_PopulationSize{ 0 };
+  unsigned int m_NumberOfParents{ 0 };
+  unsigned int m_UpdateBDPeriod{ 1 };
 
   /** Some other constants, without set/get methods
    * These settings have default values. */
 
   /** \f$\mu_{eff}\f$ */
-  double m_EffectiveMu;
+  double m_EffectiveMu{ 0.0 };
   /** \f$c_{\sigma}\f$ */
-  double m_ConjugateEvolutionPathConstant;
+  double m_ConjugateEvolutionPathConstant{ 0.0 };
   /** \f$d_{\sigma}\f$ */
-  double m_SigmaDampingConstant;
+  double m_SigmaDampingConstant{ 0.0 };
   /** \f$c_{cov}\f$ */
-  double m_CovarianceMatrixAdaptationConstant;
+  double m_CovarianceMatrixAdaptationConstant{ 0.0 };
   /** \f$c_c\f$ */
-  double m_EvolutionPathConstant;
+  double m_EvolutionPathConstant{ 0.0 };
   /** \f$\mu_{cov} = \mu_{eff}\f$ */
-  double m_CovarianceMatrixAdaptationWeight;
+  double m_CovarianceMatrixAdaptationWeight{ 0.0 };
   /** \f$chiN  = E( \|N(0,I)\|\f$ */
-  double m_ExpectationNormNormalDistribution;
+  double m_ExpectationNormNormalDistribution{ 0.0 };
   /** array of \f$w_i\f$ */
   RecombinationWeightsType m_RecombinationWeights;
   /** Length of the MeasureHistory deque */
-  unsigned long m_HistoryLength;
+  unsigned long m_HistoryLength{ 0 };
 
   /** The current value of Sigma */
-  double m_CurrentSigma;
+  double m_CurrentSigma{ 0.0 };
 
   /** The current minimum square root eigen value: */
-  double m_CurrentMinimumD;
+  double m_CurrentMinimumD{ 1.0 };
   /** The current maximum square root eigen value: */
-  double m_CurrentMaximumD;
+  double m_CurrentMaximumD{ 1.0 };
 
   /** \f$h_{\sigma}\f$ */
-  bool m_Heaviside;
+  bool m_Heaviside{ false };
 
   /** \f$d_i = x_i - m\f$ */
   ParameterContainerType m_SearchDirs;
@@ -427,17 +427,17 @@ private:
   operator=(const Self &) = delete;
 
   /** Settings that are only inspected/changed by the associated get/set member functions. */
-  unsigned long m_MaximumNumberOfIterations;
-  bool          m_UseDecayingSigma;
-  double        m_InitialSigma;
-  double        m_SigmaDecayA;
-  double        m_SigmaDecayAlpha;
-  std::string   m_RecombinationWeightsPreset;
-  double        m_MaximumDeviation;
-  double        m_MinimumDeviation;
-  double        m_PositionToleranceMax;
-  double        m_PositionToleranceMin;
-  double        m_ValueTolerance;
+  unsigned long m_MaximumNumberOfIterations{ 100 };
+  bool          m_UseDecayingSigma{ false };
+  double        m_InitialSigma{ 1.0 };
+  double        m_SigmaDecayA{ 50 };
+  double        m_SigmaDecayAlpha{ 0.602 };
+  std::string   m_RecombinationWeightsPreset{ "superlinear" };
+  double        m_MaximumDeviation{ std::numeric_limits<double>::max() };
+  double        m_MinimumDeviation{ 0.0 };
+  double        m_PositionToleranceMax{ 1e8 };
+  double        m_PositionToleranceMin{ 1e-12 };
+  double        m_ValueTolerance{ 1e-12 };
 };
 
 } // end namespace itk

--- a/Components/Optimizers/ConjugateGradient/itkGenericConjugateGradientOptimizer.cxx
+++ b/Components/Optimizers/ConjugateGradient/itkGenericConjugateGradientOptimizer.cxx
@@ -30,20 +30,6 @@ GenericConjugateGradientOptimizer::GenericConjugateGradientOptimizer()
 {
   itkDebugMacro("Constructor");
 
-  this->m_CurrentValue = NumericTraits<MeasureType>::Zero;
-  this->m_CurrentIteration = 0;
-  this->m_StopCondition = Unknown;
-  this->m_Stop = false;
-  this->m_CurrentStepLength = 0.0;
-  this->m_InLineSearch = false;
-  this->m_MaximumNumberOfIterations = 100;
-  this->m_ValueTolerance = 1e-5;
-  this->m_GradientMagnitudeTolerance = 1e-5;
-  this->m_MaxNrOfItWithoutImprovement = 10;
-  this->m_UseDefaultMaxNrOfItWithoutImprovement = true;
-  this->m_LineSearchOptimizer = nullptr;
-  this->m_PreviousGradientAndSearchDirValid = false;
-
   this->AddBetaDefinition("SteepestDescent", &Self::ComputeBetaSD);
   this->AddBetaDefinition("FletcherReeves", &Self::ComputeBetaFR);
   this->AddBetaDefinition("PolakRibiere", &Self::ComputeBetaPR);
@@ -109,7 +95,6 @@ GenericConjugateGradientOptimizer::ResumeOptimization()
 {
   itkDebugMacro("ResumeOptimization");
 
-  this->m_Stop = false;
   this->m_StopCondition = Unknown;
   this->m_PreviousGradientAndSearchDirValid = false;
   const double TINY_NUMBER = 1e-20;

--- a/Components/Optimizers/ConjugateGradient/itkGenericConjugateGradientOptimizer.h
+++ b/Components/Optimizers/ConjugateGradient/itkGenericConjugateGradientOptimizer.h
@@ -143,25 +143,25 @@ protected:
   PrintSelf(std::ostream & os, Indent indent) const override;
 
   DerivativeType    m_CurrentGradient;
-  MeasureType       m_CurrentValue;
-  unsigned long     m_CurrentIteration;
-  StopConditionType m_StopCondition;
-  bool              m_Stop;
-  double            m_CurrentStepLength;
+  MeasureType       m_CurrentValue{ 0.0 };
+  unsigned long     m_CurrentIteration{ 0 };
+  StopConditionType m_StopCondition{ Unknown };
+  bool              m_Stop{ false };
+  double            m_CurrentStepLength{ 0.0 };
 
   /** Flag that is true as long as the method
    * SetMaxNrOfItWithoutImprovement is never called */
-  bool m_UseDefaultMaxNrOfItWithoutImprovement;
+  bool m_UseDefaultMaxNrOfItWithoutImprovement{ true };
 
   /** Is true when the LineSearchOptimizer has been started. */
-  bool m_InLineSearch;
+  bool m_InLineSearch{ false };
   itkSetMacro(InLineSearch, bool);
 
   /** Flag that says if the previous gradient and search direction are known.
    * Typically 'true' at the start of optimization, or when a stopped optimisation
    * is resumed (in the latter case the previous gradient and search direction
    * may of course still be valid, but to be safe it is assumed that they are not). */
-  bool m_PreviousGradientAndSearchDirValid;
+  bool m_PreviousGradientAndSearchDirValid{ false };
 
   /** The name of the BetaDefinition */
   BetaDefinitionType m_BetaDefinition;
@@ -256,12 +256,12 @@ private:
   void
   operator=(const Self &) = delete;
 
-  unsigned long m_MaximumNumberOfIterations;
-  double        m_ValueTolerance;
-  double        m_GradientMagnitudeTolerance;
-  unsigned long m_MaxNrOfItWithoutImprovement;
+  unsigned long m_MaximumNumberOfIterations{ 100 };
+  double        m_ValueTolerance{ 1e-5 };
+  double        m_GradientMagnitudeTolerance{ 1e-5 };
+  unsigned long m_MaxNrOfItWithoutImprovement{ 10 };
 
-  LineSearchOptimizerPointer m_LineSearchOptimizer;
+  LineSearchOptimizerPointer m_LineSearchOptimizer{ nullptr };
 };
 
 } // end namespace itk

--- a/Components/Optimizers/FiniteDifferenceGradientDescent/itkFiniteDifferenceGradientDescentOptimizer.cxx
+++ b/Components/Optimizers/FiniteDifferenceGradientDescent/itkFiniteDifferenceGradientDescentOptimizer.cxx
@@ -35,21 +35,6 @@ FiniteDifferenceGradientDescentOptimizer::FiniteDifferenceGradientDescentOptimiz
 {
   itkDebugMacro("Constructor");
 
-  this->m_Stop = false;
-  this->m_NumberOfIterations = 100;
-  this->m_CurrentIteration = 0;
-  this->m_Value = 0.0;
-  this->m_StopCondition = MaximumNumberOfIterations;
-
-  this->m_GradientMagnitude = 0.0;
-  this->m_LearningRate = 0.0;
-  this->m_ComputeCurrentValue = false;
-  this->m_Param_a = 1.0;
-  this->m_Param_c = 1.0;
-  this->m_Param_A = 1.0;
-  this->m_Param_alpha = 0.602;
-  this->m_Param_gamma = 0.101;
-
 } // end Constructor
 
 

--- a/Components/Optimizers/FiniteDifferenceGradientDescent/itkFiniteDifferenceGradientDescentOptimizer.h
+++ b/Components/Optimizers/FiniteDifferenceGradientDescent/itkFiniteDifferenceGradientDescentOptimizer.h
@@ -145,15 +145,15 @@ protected:
 
   // made protected so subclass can access
   DerivativeType m_Gradient;
-  double         m_LearningRate;
-  double         m_GradientMagnitude;
+  double         m_LearningRate{ 0.0 };
+  double         m_GradientMagnitude{ 0.0 };
 
   /** Boolean that says if the current value of
    * the metric has to be computed. This is not
    * necessary for optimisation; just nice for
    * progress information.
    */
-  bool m_ComputeCurrentValue;
+  bool m_ComputeCurrentValue{ false };
 
   // Functions to compute the parameters at iteration k.
   virtual double
@@ -168,18 +168,18 @@ private:
   operator=(const Self &) = delete;
 
   /** Private member variables.*/
-  bool              m_Stop;
-  double            m_Value;
-  StopConditionType m_StopCondition;
-  unsigned long     m_NumberOfIterations;
-  unsigned long     m_CurrentIteration;
+  bool              m_Stop{ false };
+  double            m_Value{ 0.0 };
+  StopConditionType m_StopCondition{ MaximumNumberOfIterations };
+  unsigned long     m_NumberOfIterations{ 100 };
+  unsigned long     m_CurrentIteration{ 0 };
 
   /**Parameters, as described by Spall.*/
-  double m_Param_a;
-  double m_Param_c;
-  double m_Param_A;
-  double m_Param_alpha;
-  double m_Param_gamma;
+  double m_Param_a{ 1.0 };
+  double m_Param_c{ 1.0 };
+  double m_Param_A{ 1.0 };
+  double m_Param_alpha{ 0.602 };
+  double m_Param_gamma{ 0.101 };
 };
 
 } // end namespace itk

--- a/Components/Optimizers/FullSearch/itkFullSearchOptimizer.cxx
+++ b/Components/Optimizers/FullSearch/itkFullSearchOptimizer.cxx
@@ -32,16 +32,6 @@ FullSearchOptimizer::FullSearchOptimizer()
 {
   itkDebugMacro("Constructor");
 
-  m_CurrentIteration = 0;
-  m_Maximize = false;
-  m_Value = 0.0;
-  m_BestValue = 0.0;
-  m_StopCondition = FullRangeSearched;
-  m_Stop = false;
-  m_NumberOfSearchSpaceDimensions = 0;
-  m_SearchSpace = nullptr;
-  m_LastSearchSpaceChanges = 0;
-
 } // end constructor
 
 

--- a/Components/Optimizers/FullSearch/itkFullSearchOptimizer.h
+++ b/Components/Optimizers/FullSearch/itkFullSearchOptimizer.h
@@ -220,21 +220,21 @@ protected:
 
   // void PrintSelf(std::ostream& os, Indent indent) const;
 
-  bool              m_Maximize;
-  bool              m_Stop;
-  double            m_Value;
-  double            m_BestValue;
-  StopConditionType m_StopCondition;
+  bool              m_Maximize{ false };
+  bool              m_Stop{ false };
+  double            m_Value{ 0.0 };
+  double            m_BestValue{ 0.0 };
+  StopConditionType m_StopCondition{ FullRangeSearched };
 
-  SearchSpacePointer   m_SearchSpace;
+  SearchSpacePointer   m_SearchSpace{ nullptr };
   SearchSpacePointType m_CurrentPointInSearchSpace;
   SearchSpaceIndexType m_CurrentIndexInSearchSpace;
   SearchSpacePointType m_BestPointInSearchSpace;
   SearchSpaceIndexType m_BestIndexInSearchSpace;
   SearchSpaceSizeType  m_SearchSpaceSize;
-  unsigned int         m_NumberOfSearchSpaceDimensions;
+  unsigned int         m_NumberOfSearchSpaceDimensions{ 0 };
 
-  unsigned long m_LastSearchSpaceChanges;
+  unsigned long m_LastSearchSpaceChanges{ 0 };
   virtual void
   ProcessSearchSpaceChanges(void);
 
@@ -243,7 +243,7 @@ private:
   void
   operator=(const Self &) = delete;
 
-  unsigned long m_CurrentIteration;
+  unsigned long m_CurrentIteration{ 0 };
 };
 
 } // end namespace itk

--- a/Components/Optimizers/PreconditionedGradientDescent/itkAdaptiveStochasticPreconditionedGradientDescentOptimizer.cxx
+++ b/Components/Optimizers/PreconditionedGradientDescent/itkAdaptiveStochasticPreconditionedGradientDescentOptimizer.cxx
@@ -26,13 +26,8 @@ namespace itk
  * ************************* Constructor ************************
  */
 
-AdaptiveStochasticPreconditionedGradientDescentOptimizer::AdaptiveStochasticPreconditionedGradientDescentOptimizer()
-{
-  this->m_UseAdaptiveStepSizes = true;
-  this->m_SigmoidMax = 1.0;
-  this->m_SigmoidMin = -0.8;
-  this->m_SigmoidScale = 1e-8;
-} // end Constructor
+AdaptiveStochasticPreconditionedGradientDescentOptimizer::AdaptiveStochasticPreconditionedGradientDescentOptimizer() =
+  default;
 
 
 /**

--- a/Components/Optimizers/PreconditionedGradientDescent/itkAdaptiveStochasticPreconditionedGradientDescentOptimizer.h
+++ b/Components/Optimizers/PreconditionedGradientDescent/itkAdaptiveStochasticPreconditionedGradientDescentOptimizer.h
@@ -149,10 +149,10 @@ private:
   operator=(const Self &) = delete;
 
   /** Settings */
-  bool   m_UseAdaptiveStepSizes;
-  double m_SigmoidMax;
-  double m_SigmoidMin;
-  double m_SigmoidScale;
+  bool   m_UseAdaptiveStepSizes{ true };
+  double m_SigmoidMax{ 1.0 };
+  double m_SigmoidMin{ -0.8 };
+  double m_SigmoidScale{ 1e-8 };
 
 }; // end class AdaptiveStochasticPreconditionedGradientDescentOptimizer
 

--- a/Components/Optimizers/PreconditionedGradientDescent/itkPreconditionedGradientDescentOptimizer.cxx
+++ b/Components/Optimizers/PreconditionedGradientDescent/itkPreconditionedGradientDescentOptimizer.cxx
@@ -47,17 +47,6 @@ PreconditionedGradientDescentOptimizer::PreconditionedGradientDescentOptimizer()
 {
   itkDebugMacro("Constructor");
 
-  this->m_LearningRate = 1.0;
-  this->m_NumberOfIterations = 100;
-  this->m_CurrentIteration = 0;
-  this->m_Value = 0.0;
-  this->m_StopCondition = MaximumNumberOfIterations;
-  this->m_DiagonalWeight = 1e-6;
-  this->m_MinimumGradientElementMagnitude = 1e-10;
-  this->m_LargestEigenValue = 1.0;
-  this->m_Sparsity = 1.0;
-  this->m_ConditionNumber = 1.0;
-
   /** Prepare cholmod */
   this->m_CholmodCommon = new cholmod_common;
   if (this->m_CholmodCommon)
@@ -75,9 +64,6 @@ PreconditionedGradientDescentOptimizer::PreconditionedGradientDescentOptimizer()
      */
     this->m_CholmodCommon->final_ll = 1;
   }
-
-  this->m_CholmodFactor = 0;
-  this->m_CholmodGradient = 0;
 
 } // end Constructor
 

--- a/Components/Optimizers/PreconditionedGradientDescent/itkPreconditionedGradientDescentOptimizer.h
+++ b/Components/Optimizers/PreconditionedGradientDescent/itkPreconditionedGradientDescentOptimizer.h
@@ -201,16 +201,16 @@ protected:
 
   // made protected so subclass can access
   DerivativeType    m_Gradient;
-  double            m_LearningRate;
-  StopConditionType m_StopCondition;
+  double            m_LearningRate{ 1.0 };
+  StopConditionType m_StopCondition{ MaximumNumberOfIterations };
   DerivativeType    m_SearchDirection;
-  double            m_LargestEigenValue;
-  double            m_ConditionNumber;
-  double            m_Sparsity;
+  double            m_LargestEigenValue{ 1.0 };
+  double            m_ConditionNumber{ 1.0 };
+  double            m_Sparsity{ 1.0 };
 
   cholmod_common * m_CholmodCommon;
-  cholmod_factor * m_CholmodFactor;
-  cholmod_sparse * m_CholmodGradient;
+  cholmod_factor * m_CholmodFactor{ nullptr };
+  cholmod_sparse * m_CholmodGradient{ nullptr };
 
   /** Solve Hx = g, using the Cholesky decomposition of the preconditioner.
    * Matlab notation: x = L'\(L\g) = Pg = searchDirection
@@ -224,14 +224,14 @@ private:
   void
   operator=(const Self &) = delete;
 
-  bool   m_Stop;
-  double m_Value;
+  bool   m_Stop{ false };
+  double m_Value{ 0.0 };
 
-  unsigned long m_NumberOfIterations;
-  unsigned long m_CurrentIteration;
+  unsigned long m_NumberOfIterations{ 100 };
+  unsigned long m_CurrentIteration{ 0 };
 
-  double m_DiagonalWeight;
-  double m_MinimumGradientElementMagnitude;
+  double m_DiagonalWeight{ 1e-6 };
+  double m_MinimumGradientElementMagnitude{ 1e-10 };
 };
 
 } // end namespace itk

--- a/Components/Optimizers/PreconditionedGradientDescent/itkStochasticPreconditionedGradientDescentOptimizer.cxx
+++ b/Components/Optimizers/PreconditionedGradientDescent/itkStochasticPreconditionedGradientDescentOptimizer.cxx
@@ -25,16 +25,7 @@ namespace itk
  * ************************* Constructor ************************
  */
 
-StochasticPreconditionedGradientDescentOptimizer::StochasticPreconditionedGradientDescentOptimizer()
-{
-  this->m_Param_a = 1.0;
-  this->m_Param_A = 1.0;
-  this->m_Param_alpha = 0.602;
-
-  this->m_CurrentTime = 0.0;
-  this->m_InitialTime = 0.0;
-
-} // end Constructor
+StochasticPreconditionedGradientDescentOptimizer::StochasticPreconditionedGradientDescentOptimizer() = default;
 
 
 /**

--- a/Components/Optimizers/PreconditionedGradientDescent/itkStochasticPreconditionedGradientDescentOptimizer.h
+++ b/Components/Optimizers/PreconditionedGradientDescent/itkStochasticPreconditionedGradientDescentOptimizer.h
@@ -136,7 +136,7 @@ protected:
   UpdateCurrentTime(void);
 
   /** The current time, which serves as input for Compute_a */
-  double m_CurrentTime;
+  double m_CurrentTime{ 0.0 };
 
 private:
   StochasticPreconditionedGradientDescentOptimizer(const Self &) = delete;
@@ -144,12 +144,12 @@ private:
   operator=(const Self &) = delete;
 
   /**Parameters, as described by Spall. */
-  double m_Param_a;
-  double m_Param_A;
-  double m_Param_alpha;
+  double m_Param_a{ 1.0 };
+  double m_Param_A{ 1.0 };
+  double m_Param_alpha{ 0.602 };
 
   /** Settings */
-  double m_InitialTime;
+  double m_InitialTime{ 0.0 };
 
 }; // end class StochasticPreconditionedGradientDescentOptimizer
 

--- a/Components/Optimizers/PreconditionedStochasticGradientDescent/itkPreconditionedASGDOptimizer.cxx
+++ b/Components/Optimizers/PreconditionedStochasticGradientDescent/itkPreconditionedASGDOptimizer.cxx
@@ -28,14 +28,7 @@ namespace itk
  * ************************* Constructor ************************
  */
 
-PreconditionedASGDOptimizer::PreconditionedASGDOptimizer()
-{
-  this->m_UseAdaptiveStepSizes = true;
-  this->m_SigmoidMax = 1.0;
-  this->m_SigmoidMin = -0.8;
-  this->m_SigmoidScale = 1e-8;
-
-} // end Constructor
+PreconditionedASGDOptimizer::PreconditionedASGDOptimizer() = default;
 
 
 /**

--- a/Components/Optimizers/PreconditionedStochasticGradientDescent/itkPreconditionedASGDOptimizer.h
+++ b/Components/Optimizers/PreconditionedStochasticGradientDescent/itkPreconditionedASGDOptimizer.h
@@ -139,10 +139,10 @@ private:
   operator=(const Self &) = delete;
 
   /** Settings */
-  bool   m_UseAdaptiveStepSizes;
-  double m_SigmoidMax;
-  double m_SigmoidMin;
-  double m_SigmoidScale;
+  bool   m_UseAdaptiveStepSizes{ true };
+  double m_SigmoidMax{ 1.0 };
+  double m_SigmoidMin{ -0.8 };
+  double m_SigmoidScale{ 1e-8 };
 };
 
 } // end namespace itk

--- a/Components/Optimizers/QuasiNewtonLBFGS/itkQuasiNewtonLBFGSOptimizer.cxx
+++ b/Components/Optimizers/QuasiNewtonLBFGS/itkQuasiNewtonLBFGSOptimizer.cxx
@@ -31,21 +31,6 @@ QuasiNewtonLBFGSOptimizer::QuasiNewtonLBFGSOptimizer()
 {
   itkDebugMacro("Constructor");
 
-  this->m_CurrentValue = NumericTraits<MeasureType>::Zero;
-  this->m_CurrentIteration = 0;
-  this->m_StopCondition = Unknown;
-  this->m_Stop = false;
-  this->m_CurrentStepLength = 0.0;
-  this->m_InLineSearch = false;
-  this->m_Point = 0;
-  this->m_PreviousPoint = 0;
-  this->m_Bound = 0;
-
-  this->m_MaximumNumberOfIterations = 100;
-  this->m_GradientMagnitudeTolerance = 1e-5;
-  this->m_LineSearchOptimizer = nullptr;
-  this->m_Memory = 5;
-
 } // end constructor
 
 

--- a/Components/Optimizers/QuasiNewtonLBFGS/itkQuasiNewtonLBFGSOptimizer.h
+++ b/Components/Optimizers/QuasiNewtonLBFGS/itkQuasiNewtonLBFGSOptimizer.h
@@ -141,22 +141,22 @@ protected:
   {}
 
   DerivativeType    m_CurrentGradient;
-  MeasureType       m_CurrentValue;
-  unsigned long     m_CurrentIteration;
-  StopConditionType m_StopCondition;
-  bool              m_Stop;
-  double            m_CurrentStepLength;
+  MeasureType       m_CurrentValue{ 0.0 };
+  unsigned long     m_CurrentIteration{ 0 };
+  StopConditionType m_StopCondition{ Unknown };
+  bool              m_Stop{ false };
+  double            m_CurrentStepLength{ 0.0 };
 
   /** Is true when the LineSearchOptimizer has been started. */
-  bool m_InLineSearch;
+  bool m_InLineSearch{ false };
 
   RhoType m_Rho;
   SType   m_S;
   YType   m_Y;
 
-  unsigned int m_Point;
-  unsigned int m_PreviousPoint;
-  unsigned int m_Bound;
+  unsigned int m_Point{ 0 };
+  unsigned int m_PreviousPoint{ 0 };
+  unsigned int m_Bound{ 0 };
 
   itkSetMacro(InLineSearch, bool);
 
@@ -200,10 +200,10 @@ private:
   void
   operator=(const Self &) = delete;
 
-  unsigned long              m_MaximumNumberOfIterations;
-  double                     m_GradientMagnitudeTolerance;
-  LineSearchOptimizerPointer m_LineSearchOptimizer;
-  unsigned int               m_Memory;
+  unsigned long              m_MaximumNumberOfIterations{ 100 };
+  double                     m_GradientMagnitudeTolerance{ 1e-5 };
+  LineSearchOptimizerPointer m_LineSearchOptimizer{ nullptr };
+  unsigned int               m_Memory{ 5 };
 };
 
 } // end namespace itk

--- a/Components/Optimizers/RSGDEachParameterApart/itkRSGDEachParameterApartBaseOptimizer.cxx
+++ b/Components/Optimizers/RSGDEachParameterApart/itkRSGDEachParameterApartBaseOptimizer.cxx
@@ -29,27 +29,7 @@ namespace itk
  */
 RSGDEachParameterApartBaseOptimizer ::RSGDEachParameterApartBaseOptimizer()
 {
-
   itkDebugMacro("Constructor");
-
-  m_Stop = false;
-  m_MaximumStepLength = 1.0;
-  m_MinimumStepLength = 1e-3;
-  m_GradientMagnitudeTolerance = 1e-4;
-  m_NumberOfIterations = 100;
-  m_CurrentIteration = 0;
-  m_Value = 0;
-  m_Maximize = false;
-  m_CostFunction = nullptr;
-
-  m_CurrentStepLengths.Fill(0.0f);
-  m_CurrentStepLength = 0;
-
-  m_StopCondition = MaximumNumberOfIterations;
-  m_Gradient.Fill(0.0f);
-  m_PreviousGradient.Fill(0.0f);
-
-  m_GradientMagnitude = 0.0;
 }
 
 

--- a/Components/Optimizers/RSGDEachParameterApart/itkRSGDEachParameterApartBaseOptimizer.h
+++ b/Components/Optimizers/RSGDEachParameterApart/itkRSGDEachParameterApartBaseOptimizer.h
@@ -162,23 +162,23 @@ protected:
   DerivativeType m_Gradient;
   DerivativeType m_PreviousGradient;
 
-  bool        m_Stop;
-  bool        m_Maximize;
-  MeasureType m_Value;
-  double      m_GradientMagnitudeTolerance;
-  double      m_MaximumStepLength;
-  double      m_MinimumStepLength;
+  bool        m_Stop{ false };
+  bool        m_Maximize{ false };
+  MeasureType m_Value{ 0.0 };
+  double      m_GradientMagnitudeTolerance{ 1e-4 };
+  double      m_MaximumStepLength{ 1.0 };
+  double      m_MinimumStepLength{ 1e-3 };
 
   /** All current step lengths */
   DerivativeType m_CurrentStepLengths;
   /** The average current step length */
-  double m_CurrentStepLength;
+  double m_CurrentStepLength{ 0 };
 
-  StopConditionType m_StopCondition;
-  unsigned long     m_NumberOfIterations;
-  unsigned long     m_CurrentIteration;
+  StopConditionType m_StopCondition{ MaximumNumberOfIterations };
+  unsigned long     m_NumberOfIterations{ 100 };
+  unsigned long     m_CurrentIteration{ 0 };
 
-  double m_GradientMagnitude;
+  double m_GradientMagnitude{ 0.0 };
 };
 
 } // end namespace itk

--- a/Components/Optimizers/StandardGradientDescent/itkGradientDescentOptimizer2.cxx
+++ b/Components/Optimizers/StandardGradientDescent/itkGradientDescentOptimizer2.cxx
@@ -35,20 +35,13 @@ namespace itk
  */
 
 GradientDescentOptimizer2 ::GradientDescentOptimizer2()
+  : m_UseOpenMP{
+#ifdef ELASTIX_USE_OPENMP
+    true
+#endif
+  }
 {
   itkDebugMacro("Constructor");
-
-  this->m_Stop = false;
-  this->m_LearningRate = 1.0;
-  this->m_NumberOfIterations = 100;
-  this->m_CurrentIteration = 0;
-  this->m_Value = 0.0;
-  this->m_StopCondition = MaximumNumberOfIterations;
-
-  this->m_UseOpenMP = false;
-#ifdef ELASTIX_USE_OPENMP
-  this->m_UseOpenMP = true;
-#endif
 
 } // end Constructor
 

--- a/Components/Optimizers/StandardGradientDescent/itkGradientDescentOptimizer2.h
+++ b/Components/Optimizers/StandardGradientDescent/itkGradientDescentOptimizer2.h
@@ -144,15 +144,15 @@ protected:
   PrintSelf(std::ostream & os, Indent indent) const override;
 
   // made protected so subclass can access
-  double            m_Value;
+  double            m_Value{ 0.0 };
   DerivativeType    m_Gradient;
   DerivativeType    m_SearchDirection;
-  double            m_LearningRate;
-  StopConditionType m_StopCondition;
+  double            m_LearningRate{ 1.0 };
+  StopConditionType m_StopCondition{ MaximumNumberOfIterations };
 
-  bool          m_Stop;
-  unsigned long m_NumberOfIterations;
-  unsigned long m_CurrentIteration;
+  bool          m_Stop{ false };
+  unsigned long m_NumberOfIterations{ 100 };
+  unsigned long m_CurrentIteration{ 0 };
 
 private:
   GradientDescentOptimizer2(const Self &) = delete;

--- a/Components/Optimizers/StandardGradientDescent/itkStandardGradientDescentOptimizer.cxx
+++ b/Components/Optimizers/StandardGradientDescent/itkStandardGradientDescentOptimizer.cxx
@@ -26,17 +26,7 @@ namespace itk
  * ************************* Constructor ************************
  */
 
-StandardGradientDescentOptimizer::StandardGradientDescentOptimizer()
-{
-  this->m_Param_a = 1.0;
-  this->m_Param_A = 1.0;
-  this->m_Param_alpha = 0.602;
-
-  this->m_CurrentTime = 0.0;
-  this->m_InitialTime = 0.0;
-  this->m_UseConstantStep = false;
-
-} // end Constructor
+StandardGradientDescentOptimizer::StandardGradientDescentOptimizer() = default;
 
 
 /**

--- a/Components/Optimizers/StandardGradientDescent/itkStandardGradientDescentOptimizer.h
+++ b/Components/Optimizers/StandardGradientDescent/itkStandardGradientDescentOptimizer.h
@@ -147,10 +147,10 @@ protected:
   UpdateCurrentTime(void);
 
   /** The current time, which serves as input for Compute_a */
-  double m_CurrentTime;
+  double m_CurrentTime{ 0.0 };
 
   /** Constant step size or others, different value of k. */
-  bool m_UseConstantStep;
+  bool m_UseConstantStep{ false };
 
 private:
   StandardGradientDescentOptimizer(const Self &) = delete;
@@ -158,12 +158,12 @@ private:
   operator=(const Self &) = delete;
 
   /**Parameters, as described by Spall.*/
-  double m_Param_a;
-  double m_Param_A;
-  double m_Param_alpha;
+  double m_Param_a{ 1.0 };
+  double m_Param_A{ 1.0 };
+  double m_Param_alpha{ 0.602 };
 
   /** Settings */
-  double m_InitialTime;
+  double m_InitialTime{ 0.0 };
 };
 
 } // end namespace itk

--- a/Components/Optimizers/StandardStochasticGradientDescent/itkStandardStochasticGradientDescentOptimizer.cxx
+++ b/Components/Optimizers/StandardStochasticGradientDescent/itkStandardStochasticGradientDescentOptimizer.cxx
@@ -27,16 +27,7 @@ namespace itk
  * ************************* Constructor ************************
  */
 
-StandardStochasticGradientOptimizer::StandardStochasticGradientOptimizer()
-{
-  this->m_Param_a = 1.0;
-  this->m_Param_A = 1.0;
-  this->m_Param_alpha = 0.602;
-
-  this->m_CurrentTime = 0.0;
-  this->m_InitialTime = 0.0;
-
-} // end Constructor
+StandardStochasticGradientOptimizer::StandardStochasticGradientOptimizer() = default;
 
 
 /**

--- a/Components/Optimizers/StandardStochasticGradientDescent/itkStandardStochasticGradientDescentOptimizer.h
+++ b/Components/Optimizers/StandardStochasticGradientDescent/itkStandardStochasticGradientDescentOptimizer.h
@@ -152,7 +152,7 @@ protected:
   UpdateCurrentTime(void);
 
   /** The current time, which serves as input for Compute_a */
-  double m_CurrentTime;
+  double m_CurrentTime{ 0.0 };
 
   /** Constant step size or others, different value of k. */
   bool m_UseConstantStep;
@@ -163,13 +163,13 @@ private:
   operator=(const Self &) = delete;
 
   /**Parameters, as described by Spall.*/
-  double m_Param_a;
+  double m_Param_a{ 1.0 };
   double m_Param_beta;
-  double m_Param_A;
-  double m_Param_alpha;
+  double m_Param_A{ 1.0 };
+  double m_Param_alpha{ 0.602 };
 
   /** Settings */
-  double m_InitialTime;
+  double m_InitialTime{ 0.0 };
 
 }; // end class StandardStochasticGradientOptimizer
 

--- a/Components/Optimizers/StandardStochasticGradientDescent/itkStochasticGradientDescentOptimizer.cxx
+++ b/Components/Optimizers/StandardStochasticGradientDescent/itkStochasticGradientDescentOptimizer.cxx
@@ -41,18 +41,6 @@ StochasticGradientDescentOptimizer::StochasticGradientDescentOptimizer()
 {
   itkDebugMacro("Constructor");
 
-  this->m_LearningRate = 1.0;
-  this->m_NumberOfIterations = 100;
-  this->m_CurrentIteration = 0;
-  this->m_LBFGSMemory = 0;
-  this->m_Value = 0.0;
-  this->m_StopCondition = MaximumNumberOfIterations;
-
-  this->m_Threader = ThreaderType::New();
-  this->m_UseMultiThread = false;
-  this->m_UseOpenMP = false;
-  this->m_UseEigen = false;
-
 } // end Constructor
 
 

--- a/Components/Optimizers/StandardStochasticGradientDescent/itkStochasticGradientDescentOptimizer.h
+++ b/Components/Optimizers/StandardStochasticGradientDescent/itkStochasticGradientDescentOptimizer.h
@@ -180,25 +180,25 @@ protected:
   typedef ThreaderType::WorkUnitInfo ThreadInfoType;
 
   // made protected so subclass can access
-  double                m_Value;
+  double                m_Value{ 0.0 };
   DerivativeType        m_Gradient;
   ParametersType        m_SearchDir;
   ParametersType        m_PreviousSearchDir;
   ParametersType        m_PrePreviousSearchDir;
   ParametersType        m_MeanSearchDir;
-  double                m_LearningRate;
-  StopConditionType     m_StopCondition;
+  double                m_LearningRate{ 1.0 };
+  StopConditionType     m_StopCondition{ MaximumNumberOfIterations };
   DerivativeType        m_PreviousGradient;
   DerivativeType        m_PrePreviousGradient;
   ParametersType        m_PreviousPosition;
-  ThreaderType::Pointer m_Threader;
+  ThreaderType::Pointer m_Threader{ ThreaderType::New() };
 
-  bool          m_Stop;
-  unsigned long m_NumberOfIterations;
+  bool          m_Stop{ false };
+  unsigned long m_NumberOfIterations{ 100 };
   unsigned long m_NumberOfInnerIterations;
-  unsigned long m_CurrentIteration;
+  unsigned long m_CurrentIteration{ 0 };
   unsigned long m_CurrentInnerIteration;
-  unsigned long m_LBFGSMemory;
+  unsigned long m_LBFGSMemory{ 0 };
 
 private:
   StochasticGradientDescentOptimizer(const Self &) = delete;
@@ -206,15 +206,15 @@ private:
   operator=(const Self &) = delete;
 
   // multi-threaded AdvanceOneStep:
-  bool m_UseMultiThread;
+  bool m_UseMultiThread{ false };
   struct MultiThreaderParameterType
   {
     ParametersType * t_NewPosition;
     Self *           t_Optimizer;
   };
 
-  bool m_UseOpenMP;
-  bool m_UseEigen;
+  bool m_UseOpenMP{ false };
+  bool m_UseEigen{ false };
 
   /** The callback function. */
   static ITK_THREAD_RETURN_FUNCTION_CALL_CONVENTION


### PR DESCRIPTION
Follows C++ Core Guidelines (June 17, 2021) C.49: "Prefer initialization to assignment in constructors"
https://github.com/isocpp/CppCoreGuidelines/blob/master/CppCoreGuidelines.md#c49-prefer-initialization-to-assignment-in-constructors which says:

> An initialization explicitly states that initialization, rather than assignment, is done and can be more elegant and efficient. Prevents "use before set" errors.

Note: Clang-Tidy of LLVM 13 (still under development) appears to have an option to do such a refactoring automatically: https://clang.llvm.org/extra/clang-tidy/checks/cppcoreguidelines-prefer-member-initializer.html which says:

> Finds member initializations in the constructor body which can be converted into member initializers of the constructor instead. This not only improves the readability of the code but also positively affects its performance.