### PR TITLE
STYLE: Make protected data GradientDescent, RSGDEach...Optimizer private

### DIFF
--- a/Components/Optimizers/RSGDEachParameterApart/itkRSGDEachParameterApartBaseOptimizer.h
+++ b/Components/Optimizers/RSGDEachParameterApart/itkRSGDEachParameterApartBaseOptimizer.h
@@ -158,7 +158,6 @@ private:
   void
   operator=(const Self &) = delete;
 
-protected:
   DerivativeType m_Gradient;
   DerivativeType m_PreviousGradient;
 

--- a/Components/Optimizers/StandardGradientDescent/itkGradientDescentOptimizer2.h
+++ b/Components/Optimizers/StandardGradientDescent/itkGradientDescentOptimizer2.h
@@ -144,20 +144,20 @@ protected:
   PrintSelf(std::ostream & os, Indent indent) const override;
 
   // made protected so subclass can access
-  double            m_Value{ 0.0 };
   DerivativeType    m_Gradient;
   DerivativeType    m_SearchDirection;
-  double            m_LearningRate{ 1.0 };
   StopConditionType m_StopCondition{ MaximumNumberOfIterations };
-
-  bool          m_Stop{ false };
-  unsigned long m_NumberOfIterations{ 100 };
-  unsigned long m_CurrentIteration{ 0 };
 
 private:
   GradientDescentOptimizer2(const Self &) = delete;
   void
   operator=(const Self &) = delete;
+
+  double        m_Value{ 0.0 };
+  double        m_LearningRate{ 1.0 };
+  bool          m_Stop{ false };
+  unsigned long m_NumberOfIterations{ 100 };
+  unsigned long m_CurrentIteration{ 0 };
 
   bool m_UseOpenMP;
 };


### PR DESCRIPTION
Made `protected` data members of `GradientDescentOptimizer2` and `RSGDEachParameterApartBaseOptimizer` `private` instead.

Note that this cannot be achieved easily for all `protected` data members of all Optimizer classes, without having to deal with various compile errors.

Follows C++ Core Guidelines (June 17, 2021): "C.133: Avoid protected data"
https://github.com/isocpp/CppCoreGuidelines/blob/master/CppCoreGuidelines.md#Rh-protected