### PR TITLE
Support MaximumNumberOfIterations = 0, allowing to just do an AutomaticTransformInitialization

### DIFF
--- a/Components/Optimizers/AdaptiveStochasticLBFGS/elxAdaptiveStochasticLBFGS.hxx
+++ b/Components/Optimizers/AdaptiveStochasticLBFGS/elxAdaptiveStochasticLBFGS.hxx
@@ -660,6 +660,15 @@ AdaptiveStochasticLBFGS<TElastix>::ResumeOptimization(void)
   /** Loop over the iterations. */
   while (!this->m_Stop)
   {
+    // Check m_CurrentIteration right at the start of the loop, ensuring that
+    // no step at all is performed when when m_NumberOfIterations is zero.
+    if (m_CurrentIteration >= m_NumberOfIterations)
+    {
+      this->m_StopCondition = MaximumNumberOfIterations;
+      this->StopOptimization();
+      break;
+    }
+
     /** Every iteration we update the mean position over a block of L iterations
      * with the previous position.
      */
@@ -811,12 +820,6 @@ AdaptiveStochasticLBFGS<TElastix>::ResumeOptimization(void)
 
     this->m_CurrentIteration++;
 
-    if (m_CurrentIteration >= m_NumberOfIterations)
-    {
-      this->m_StopCondition = MaximumNumberOfIterations;
-      this->StopOptimization();
-      break;
-    }
   } // end while iterations
 
 } // end ResumeOptimization()

--- a/Components/Optimizers/AdaptiveStochasticVarianceReducedGradient/elxAdaptiveStochasticVarianceReducedGradient.hxx
+++ b/Components/Optimizers/AdaptiveStochasticVarianceReducedGradient/elxAdaptiveStochasticVarianceReducedGradient.hxx
@@ -523,6 +523,15 @@ AdaptiveStochasticVarianceReducedGradient<TElastix>::ResumeOptimization(void)
   SizeValueType nrofsamplesCheck;
   while (!this->m_Stop)
   {
+    // Check m_CurrentIteration right at the start of the loop, ensuring that
+    // no step at all is performed when when m_NumberOfIterations is zero.
+    if (this->m_CurrentIteration >= this->m_NumberOfIterations)
+    {
+      this->m_StopCondition = MaximumNumberOfIterations;
+      this->StopOptimization();
+      break;
+    }
+
     /** The following code relies on the fact that all
      * components have been set up and that the initial
      * position has been set, so must be called in this
@@ -665,12 +674,6 @@ AdaptiveStochasticVarianceReducedGradient<TElastix>::ResumeOptimization(void)
     /** Reset the current time to initial time. */
     this->ResetCurrentTimeToInitialTime();
 
-    if (this->m_CurrentIteration >= this->m_NumberOfIterations)
-    {
-      this->m_StopCondition = MaximumNumberOfIterations;
-      this->StopOptimization();
-      break;
-    }
   } // end while
 
   timeCollector.Report(std::cout);

--- a/Components/Optimizers/AdaptiveStochasticVarianceReducedGradient/itkStochasticVarianceReducedGradientDescentOptimizer.cxx
+++ b/Components/Optimizers/AdaptiveStochasticVarianceReducedGradient/itkStochasticVarianceReducedGradientDescentOptimizer.cxx
@@ -115,6 +115,15 @@ StochasticVarianceReducedGradientDescentOptimizer::ResumeOptimization(void)
 
   while (!this->m_Stop)
   {
+    // Check m_CurrentIteration right at the start of the loop, ensuring that
+    // no step at all is performed when when m_NumberOfIterations is zero.
+    if (m_CurrentIteration >= m_NumberOfIterations)
+    {
+      this->m_StopCondition = MaximumNumberOfIterations;
+      this->StopOptimization();
+      break;
+    }
+
     try
     {
       this->GetScaledValueAndDerivative(this->GetScaledCurrentPosition(), m_Value, this->m_Gradient);
@@ -139,13 +148,6 @@ StochasticVarianceReducedGradientDescentOptimizer::ResumeOptimization(void)
     }
 
     this->m_CurrentIteration++;
-
-    if (m_CurrentIteration >= m_NumberOfIterations)
-    {
-      this->m_StopCondition = MaximumNumberOfIterations;
-      this->StopOptimization();
-      break;
-    }
 
   } // end while
 

--- a/Components/Optimizers/FiniteDifferenceGradientDescent/itkFiniteDifferenceGradientDescentOptimizer.cxx
+++ b/Components/Optimizers/FiniteDifferenceGradientDescent/itkFiniteDifferenceGradientDescentOptimizer.cxx
@@ -106,6 +106,15 @@ FiniteDifferenceGradientDescentOptimizer::ResumeOptimization(void)
   InvokeEvent(StartEvent());
   while (!this->m_Stop)
   {
+    // Check m_CurrentIteration right at the start of the loop, ensuring that
+    // no step at all is performed when when m_NumberOfIterations is zero.
+    if (this->m_CurrentIteration >= this->m_NumberOfIterations)
+    {
+      this->m_StopCondition = MaximumNumberOfIterations;
+      StopOptimization();
+      break;
+    }
+
     /** Get the Number of parameters.*/
     spaceDimension = this->GetScaledCostFunction()->GetNumberOfParameters();
 
@@ -179,13 +188,6 @@ FiniteDifferenceGradientDescentOptimizer::ResumeOptimization(void)
     this->AdvanceOneStep();
 
     this->m_CurrentIteration++;
-
-    if (this->m_CurrentIteration >= this->m_NumberOfIterations)
-    {
-      this->m_StopCondition = MaximumNumberOfIterations;
-      StopOptimization();
-      break;
-    }
 
   } // while !m_stop
 

--- a/Components/Optimizers/PreconditionedGradientDescent/itkPreconditionedGradientDescentOptimizer.cxx
+++ b/Components/Optimizers/PreconditionedGradientDescent/itkPreconditionedGradientDescentOptimizer.cxx
@@ -158,6 +158,15 @@ PreconditionedGradientDescentOptimizer::ResumeOptimization(void)
 
   while (!this->m_Stop)
   {
+    // Check m_CurrentIteration right at the start of the loop, ensuring that
+    // no step at all is performed when when m_NumberOfIterations is zero.
+    if (this->m_CurrentIteration >= this->m_NumberOfIterations)
+    {
+      this->m_StopCondition = MaximumNumberOfIterations;
+      this->StopOptimization();
+      break;
+    }
+
     try
     {
       this->GetScaledValueAndDerivative(this->GetScaledCurrentPosition(), this->m_Value, this->m_Gradient);
@@ -182,13 +191,6 @@ PreconditionedGradientDescentOptimizer::ResumeOptimization(void)
     }
 
     this->m_CurrentIteration++;
-
-    if (this->m_CurrentIteration >= this->m_NumberOfIterations)
-    {
-      this->m_StopCondition = MaximumNumberOfIterations;
-      this->StopOptimization();
-      break;
-    }
 
   } // end while
 

--- a/Components/Optimizers/StandardGradientDescent/itkGradientDescentOptimizer2.cxx
+++ b/Components/Optimizers/StandardGradientDescent/itkGradientDescentOptimizer2.cxx
@@ -108,6 +108,15 @@ GradientDescentOptimizer2 ::ResumeOptimization(void)
 
   while (!this->m_Stop)
   {
+    // Check m_CurrentIteration right at the start of the loop, ensuring that
+    // no step at all is performed when when m_NumberOfIterations is zero.
+    if (m_CurrentIteration >= m_NumberOfIterations)
+    {
+      this->m_StopCondition = MaximumNumberOfIterations;
+      this->StopOptimization();
+      break;
+    }
+
     try
     {
       this->GetScaledValueAndDerivative(this->GetScaledCurrentPosition(), m_Value, m_Gradient);
@@ -132,13 +141,6 @@ GradientDescentOptimizer2 ::ResumeOptimization(void)
     }
 
     this->m_CurrentIteration++;
-
-    if (m_CurrentIteration >= m_NumberOfIterations)
-    {
-      this->m_StopCondition = MaximumNumberOfIterations;
-      this->StopOptimization();
-      break;
-    }
 
   } // end while
 

--- a/Components/Optimizers/StandardStochasticGradientDescent/itkStochasticGradientDescentOptimizer.cxx
+++ b/Components/Optimizers/StandardStochasticGradientDescent/itkStochasticGradientDescentOptimizer.cxx
@@ -114,6 +114,14 @@ StochasticGradientDescentOptimizer::ResumeOptimization(void)
 
   while (!this->m_Stop)
   {
+    if (m_CurrentIteration >= m_NumberOfIterations)
+    {
+      // Check m_CurrentIteration right at the start of the loop, ensuring that
+      // no step at all is performed when when m_NumberOfIterations is zero.
+      this->m_StopCondition = MaximumNumberOfIterations;
+      this->StopOptimization();
+      break;
+    }
 
     try
     {
@@ -139,13 +147,6 @@ StochasticGradientDescentOptimizer::ResumeOptimization(void)
     }
 
     this->m_CurrentIteration++;
-
-    if (m_CurrentIteration >= m_NumberOfIterations)
-    {
-      this->m_StopCondition = MaximumNumberOfIterations;
-      this->StopOptimization();
-      break;
-    }
 
   } // end while
 


### PR DESCRIPTION
Until now, optimizers appear to do a single iteration step, even when the elastix parameter "MaximumNumberOfIterations" has the value "0". It appears that those optimizers did the check `if (m_CurrentIteration >= m_NumberOfIterations) break;` when it was too late already to avoid the first iteration. 

Supporting MaximumNumberOfIterations = 0 (by doing no optimizer iteration at all) allows inspecting the result of just doing an AutomaticTransformInitialization. As hereby tested.