### PR TITLE
ENH: Add `ELASTIX_USE_GTEST` and `USE_ALL_COMPONENTS` to GitHub Actions

### DIFF
--- a/.github/workflows/ElastixGitHubActions.yml
+++ b/.github/workflows/ElastixGitHubActions.yml
@@ -122,6 +122,8 @@ jobs:
         endif()
         set(dashboard_cache "
         ITK_DIR:PATH=\${CTEST_DASHBOARD_ROOT}/ITK-build
+        ELASTIX_USE_GTEST:BOOL=ON
+        USE_ALL_COMPONENTS:BOOL=ON
         BUILD_TESTING:BOOL=ON
         ")
         string(TIMESTAMP build_date "%Y-%m-%d")


### PR DESCRIPTION
Added `USE_ALL_COMPONENTS` to include components that are OFF by default:

    Optimizers\AdaGrad
    Optimizers\AdaptiveStochasticLBFGS
    Optimizers\AdaptiveStochasticVarianceReducedGradient
    Transforms\BSplineDeformableTransformWithDiffusion

(The component Optimizers\PreconditionedGradientDescent is still excluded, because of its SuiteSparse dependency.) See also pull request #291 "ENH: Enable almost all components by default"

Added `ELASTIX_USE_GTEST`, to include GoogleTest based unit tests.