### PR TITLE
STYLE: Mark constructors `explicit`, to avoid unintended conversions

### DIFF
--- a/Common/ImageSamplers/itkVectorDataContainer.h
+++ b/Common/ImageSamplers/itkVectorDataContainer.h
@@ -100,7 +100,7 @@ protected:
     : DataObject()
     , VectorType()
   {}
-  VectorDataContainer(size_type n)
+  explicit VectorDataContainer(size_type n)
     : DataObject()
     , VectorType(n)
   {}

--- a/Common/Transforms/itkAdvancedEuler3DTransform.h
+++ b/Common/Transforms/itkAdvancedEuler3DTransform.h
@@ -141,7 +141,7 @@ public:
 protected:
   AdvancedEuler3DTransform();
   AdvancedEuler3DTransform(const MatrixType & matrix, const OutputPointType & offset);
-  AdvancedEuler3DTransform(unsigned int paramsSpaceDims);
+  explicit AdvancedEuler3DTransform(unsigned int paramsSpaceDims);
 
   ~AdvancedEuler3DTransform() override = default;
 

--- a/Common/Transforms/itkAdvancedMatrixOffsetTransformBase.h
+++ b/Common/Transforms/itkAdvancedMatrixOffsetTransformBase.h
@@ -453,7 +453,7 @@ protected:
    * transformation in the appropriate number of dimensions.
    */
   AdvancedMatrixOffsetTransformBase(const MatrixType & matrix, const OutputVectorType & offset);
-  AdvancedMatrixOffsetTransformBase(unsigned int paramDims);
+  explicit AdvancedMatrixOffsetTransformBase(unsigned int paramDims);
   AdvancedMatrixOffsetTransformBase();
 
   /** Called by constructors: */

--- a/Common/Transforms/itkAdvancedRigid2DTransform.h
+++ b/Common/Transforms/itkAdvancedRigid2DTransform.h
@@ -267,7 +267,7 @@ public:
 
 protected:
   AdvancedRigid2DTransform();
-  AdvancedRigid2DTransform(unsigned int parametersDimension);
+  explicit AdvancedRigid2DTransform(unsigned int parametersDimension);
   AdvancedRigid2DTransform(unsigned int outputSpaceDimension, unsigned int parametersDimension);
 
   ~AdvancedRigid2DTransform() override;

--- a/Common/Transforms/itkAdvancedRigid3DTransform.h
+++ b/Common/Transforms/itkAdvancedRigid3DTransform.h
@@ -202,7 +202,7 @@ public:
   MatrixIsOrthogonal(const MatrixType & matrix, double tol = 1e-10);
 
 protected:
-  AdvancedRigid3DTransform(unsigned int paramDim);
+  explicit AdvancedRigid3DTransform(unsigned int paramDim);
   AdvancedRigid3DTransform(const MatrixType & matrix, const OutputVectorType & offset);
   AdvancedRigid3DTransform();
   ~AdvancedRigid3DTransform() override;

--- a/Common/Transforms/itkAdvancedTransform.h
+++ b/Common/Transforms/itkAdvancedTransform.h
@@ -292,7 +292,7 @@ public:
 
 protected:
   AdvancedTransform();
-  AdvancedTransform(NumberOfParametersType numberOfParameters);
+  explicit AdvancedTransform(NumberOfParametersType numberOfParameters);
   ~AdvancedTransform() override = default;
 
   bool m_HasNonZeroSpatialHessian;


### PR DESCRIPTION
Did run LLVM 12.0.1 Clang-Tidy option `google-explicit-constructor`:

> Checks that constructors callable with a single argument and conversion operators are marked explicit to avoid the risk of unintentional implicit conversions.

https://clang.llvm.org/extra/clang-tidy/checks/google-explicit-constructor.html

Note that the `ConstIterator(const Iterator &)` constructor of `VectorDataContainer::ConstIterator` does intentionally support implicit conversion, so this constructor is not marked `explicit`.