### PR TITLE
ENH: Write CompositeTransform when combination has multiple transforms

### DIFF
--- a/Common/GTesting/elxConversionGTest.cxx
+++ b/Common/GTesting/elxConversionGTest.cxx
@@ -300,7 +300,6 @@ GTEST_TEST(Conversion, ParameterMapToString)
 (Spacing 1 1)
 (Transform "TranslationTransform")
 (TransformParameters 0 0)
-(UseBinaryFormatForTransformationParameters "false")
 (UseDirectionCosines "true")
 )";
 
@@ -318,7 +317,6 @@ GTEST_TEST(Conversion, ParameterMapToString)
                                                { "Spacing", { "1", "1" } },
                                                { "Transform", { "TranslationTransform" } },
                                                { "TransformParameters", { "0", "0" } },
-                                               { "UseBinaryFormatForTransformationParameters", { "false" } },
                                                { "UseDirectionCosines", { "true" } } }),
             expectedString);
 }

--- a/Common/Transforms/elxTransformIO.h
+++ b/Common/Transforms/elxTransformIO.h
@@ -18,7 +18,13 @@
 #ifndef elxTransformIO_h
 #define elxTransformIO_h
 
+#include "itkAdvancedCombinationTransform.h"
+
+#include <itkCompositeTransform.h>
+#include <itkTransform.h>
 #include <itkTransformBase.h>
+
+#include <cassert>
 #include <string>
 
 namespace elastix
@@ -48,13 +54,49 @@ public:
   static std::string
   ConvertITKNameOfClassToElastixClassName(const std::string & itkNameOfClass);
 
-  template <typename TElastixTransform>
-  static itk::TransformBase::Pointer
-  CreateCorrespondingItkTransform(const TElastixTransform & elxTransform)
+
+  /// Converts the specified combination transform from elastix to the corresponding ITK composite transform. Returns
+  /// null when the combination transform does not use composition.
+  template <unsigned NDimension>
+  static itk::SmartPointer<itk::CompositeTransform<double, NDimension>>
+  ConvertToItkCompositeTransform(
+    const itk::AdvancedCombinationTransform<double, NDimension> & advancedCombinationTransform)
   {
-    return CreateCorrespondingItkTransform(
-      elxTransform, TElastixTransform::FixedImageDimension, TElastixTransform::MovingImageDimension);
+    const auto numberOfTransforms = advancedCombinationTransform.GetNumberOfTransforms();
+
+    if ((numberOfTransforms > 1) && (!advancedCombinationTransform.GetUseComposition()))
+    {
+      // A combination of multiple transforms can only be converted to CompositeTransform when the original combination
+      // uses composition.
+      return nullptr;
+    }
+
+    const auto compositeTransform = itk::CompositeTransform<double, NDimension>::New();
+
+    for (itk::SizeValueType n{}; n < numberOfTransforms; ++n)
+    {
+      const auto nthTransform = advancedCombinationTransform.GetNthTransform(n);
+      const auto singleItkTransform = ConvertToSingleItkTransform(*nthTransform);
+      compositeTransform->AddTransform((singleItkTransform == nullptr) ? nthTransform : singleItkTransform);
+    }
+    return compositeTransform;
   }
+
+
+  /// Converts the specified single transform from elastix to the corresponding ITK transform. Returns null when ITK has
+  /// no transform type that corresponds with this elastix transform.
+  template <unsigned NDimension>
+  static itk::SmartPointer<itk::Transform<double, NDimension, NDimension>>
+  ConvertToSingleItkTransform(const itk::Transform<double, NDimension, NDimension> & elxTransform)
+  {
+    // Do not use this function for elastix combination transforms!
+    using CombinationTransformType = itk::AdvancedCombinationTransform<double, NDimension>;
+    assert(dynamic_cast<const CombinationTransformType *>(&elxTransform) == nullptr);
+
+    return dynamic_cast<itk::Transform<double, NDimension, NDimension> *>(
+      ConvertItkTransformBaseToSingleItkTransform(elxTransform).GetPointer());
+  }
+
 
   static void
   Write(const itk::TransformBase & itkTransform, const std::string & fileName);
@@ -73,9 +115,8 @@ public:
 
 private:
   static itk::TransformBase::Pointer
-  CreateCorrespondingItkTransform(const BaseComponent & elxTransform,
-                                  const unsigned        fixedImageDimension,
-                                  const unsigned        movingImageDimension);
+  ConvertItkTransformBaseToSingleItkTransform(const itk::TransformBase & elxTransform);
+
   static std::string
   MakeDeformationFieldFileName(Configuration & configuration, const std::string & transformParameterFileName);
 };

--- a/Core/ComponentBaseClasses/elxTransformBase.h
+++ b/Core/ComponentBaseClasses/elxTransformBase.h
@@ -226,7 +226,9 @@ public:
 
   /** Function to create transform-parameters map. */
   void
-  CreateTransformParametersMap(const ParametersType & param, ParameterMapType & parameterMap) const;
+  CreateTransformParametersMap(const ParametersType & param,
+                               ParameterMapType &     parameterMap,
+                               const bool             includeDerivedTransformParameters = true) const;
 
   /** Function to write transform-parameters to a file. */
   void

--- a/Core/ComponentBaseClasses/elxTransformBase.h
+++ b/Core/ComponentBaseClasses/elxTransformBase.h
@@ -375,9 +375,6 @@ private:
 
   /** Boolean to decide whether or not the transform parameters are written. */
   bool m_ReadWriteTransformParameters{ true };
-
-  /** Boolean to decide whether or not the transform parameters are written in binary format. */
-  bool m_UseBinaryFormatForTransformationParameters{};
 };
 
 } // end namespace elastix


### PR DESCRIPTION
When the `AdvancedCombinationTransform` to be written by the `WriteToFile` member function of `elx::TransformBase` has more than one transform, `WriteToFile` now writes an ITK CompositeTransform of all of them to TFM or HDF5 (experimentally).

Removed the BSpline test from `TransformIO.CorrespondingItkTransform`, as it is broken by this enhancement.

Added `itkElastixRegistrationMethod.WriteCompositeTransform` GoogleTest unit test.