### PR TITLE
COMP: Do `#include <double-conversion.h>`, and add its include path

### DIFF
--- a/Common/ParameterFileParser/CMakeLists.txt
+++ b/Common/ParameterFileParser/CMakeLists.txt
@@ -14,6 +14,12 @@ install( TARGETS param
   LIBRARY DESTINATION ${ELASTIX_LIBRARY_DIR}
   RUNTIME DESTINATION ${ELASTIX_RUNTIME_DIR} )
 
+# Support #include <double-conversion.h>, which is either in the root of the
+# ITK install directory (its "install prefix"), or at the following location
+# of the ITK source tree (which is the parent directory of "{ITK_CMAKE_DIR}"):
+target_include_directories( param PRIVATE
+  ${ITK_CMAKE_DIR}/../Modules/ThirdParty/DoubleConversion/src/double-conversion )
+
 target_link_libraries( param ${ITK_LIBRARIES} )
 
 # Group in IDE's like Visual Studio

--- a/Common/ParameterFileParser/itkParameterMapInterface.cxx
+++ b/Common/ParameterFileParser/itkParameterMapInterface.cxx
@@ -18,7 +18,7 @@
 
 #include "itkParameterMapInterface.h"
 
-#include <double-conversion/double-conversion.h>
+#include <double-conversion.h>
 
 // Standard C++ header files:
 #include <cmath> // For fpclassify and FP_SUBNORMAL.


### PR DESCRIPTION
Aims to fix a SimpleElastix compilation error, encountered by Viktor (@ViktorvdValk).