### PR TITLE
STYLE: Remove elxOverrideGetConstMacro and KernelTransform2::GetAlpha()

### DIFF
--- a/Components/Transforms/SplineKernelTransform/itkElasticBodyReciprocalSplineKernelTransform2.h
+++ b/Components/Transforms/SplineKernelTransform/itkElasticBodyReciprocalSplineKernelTransform2.h
@@ -98,7 +98,7 @@ public:
 
 
   /** Get alpha */
-  elxOverrideGetConstMacro(Alpha, TScalarType);
+  itkGetConstMacro(Alpha, TScalarType);
 
   /** Convenience method */
   void

--- a/Components/Transforms/SplineKernelTransform/itkElasticBodySplineKernelTransform2.h
+++ b/Components/Transforms/SplineKernelTransform/itkElasticBodySplineKernelTransform2.h
@@ -97,7 +97,7 @@ public:
 
 
   /** Get alpha */
-  elxOverrideGetConstMacro(Alpha, TScalarType);
+  itkGetConstMacro(Alpha, TScalarType);
 
   /** Convenience method */
   void

--- a/Components/Transforms/SplineKernelTransform/itkKernelTransform2.h
+++ b/Components/Transforms/SplineKernelTransform/itkKernelTransform2.h
@@ -282,11 +282,6 @@ public:
   virtual void
   SetAlpha(TScalarType itkNotUsed(Alpha))
   {}
-  virtual TScalarType
-  GetAlpha(void) const
-  {
-    return -1.0;
-  }
 
   /** This method makes only sense for the ElasticBody splines.
    * Declare here, so that you can always call it if you don't know

--- a/Core/Install/elxMacro.h
+++ b/Core/Install/elxMacro.h
@@ -253,12 +253,6 @@
   static const char * elxGetClassNameStatic(void) { return _name; }                                                    \
   const char *        elxGetClassName(void) const override { return _name; }
 
-/** Get built-in type.  Creates an override of the virtual member Get"name"()
- * This is the "const" form of the itkGetMacro.  It should be used unless
- * the member can be changed through the "Get" access routine. */
-#define elxOverrideGetConstMacro(name, type)                                                                           \
-  type Get##name() const override { return this->m_##name; }
-
 /** Declares a pair of pure virtual member functions (overloaded for const
  * and non-const) to get a reference to itself, of the specified type.
  */


### PR DESCRIPTION
`elxOverrideGetConstMacro` was only used to override `KernelTransform2::GetAlpha()`, and even this specific use case did not appear very relevant, as `KernelTransform2::GetAlpha()` was never called anywhere in elastix.