### PR TITLE
ENH: Add `ParameterMapInterface::StringCast` overload to convert to bool

### DIFF
--- a/Common/GTesting/itkParameterMapInterfaceTest.cxx
+++ b/Common/GTesting/itkParameterMapInterfaceTest.cxx
@@ -31,6 +31,7 @@ using itk::ParameterMapInterface;
 GTEST_TEST(ParameterMapInterface, RetrieveValuesReturnsNullWhenParameterMapIsEmpty)
 {
   const auto parameterMapInterface = ParameterMapInterface::New();
+  EXPECT_EQ(parameterMapInterface->RetrieveValues<bool>("parameterName"), nullptr);
   EXPECT_EQ(parameterMapInterface->RetrieveValues<double>("parameterName"), nullptr);
 }
 
@@ -40,6 +41,7 @@ GTEST_TEST(ParameterMapInterface, RetrieveValuesReturnsNullWhenParameterNameIsMi
   const auto parameterMapInterface = ParameterMapInterface::New();
   parameterMapInterface->SetParameterMap({ { "ParameterName", { "0", "1" } } });
 
+  EXPECT_EQ(parameterMapInterface->RetrieveValues<bool>("MissingParameterName"), nullptr);
   EXPECT_EQ(parameterMapInterface->RetrieveValues<double>("MissingParameterName"), nullptr);
 }
 
@@ -68,6 +70,14 @@ GTEST_TEST(ParameterMapInterface, RetrieveValuesSupportsSingleValue)
     const auto retrievedValues = parameterMapInterface->RetrieveValues<double>(parameterName);
     ASSERT_NE(retrievedValues, nullptr);
     EXPECT_EQ(*retrievedValues, std::vector<double>{ testValue });
+  }
+  for (const bool testValue : { false, true })
+  {
+    parameterMapInterface->SetParameterMap({ { parameterName, { testValue ? "true" : "false" } } });
+
+    const auto retrievedValues = parameterMapInterface->RetrieveValues<bool>(parameterName);
+    ASSERT_NE(retrievedValues, nullptr);
+    EXPECT_EQ(*retrievedValues, std::vector<bool>{ testValue });
   }
 }
 
@@ -99,7 +109,8 @@ GTEST_TEST(ParameterMapInterface, RetrieveValuesThrowsExceptionWhenConversionFai
   const auto        parameterMapInterface = ParameterMapInterface::New();
   const std::string parameterName("Key");
 
-  parameterMapInterface->SetParameterMap({ { parameterName, { "not-a-valid-floating-point-value" } } });
+  parameterMapInterface->SetParameterMap({ { parameterName, { "not-a-valid-bool-or-double-value" } } });
+  EXPECT_THROW(parameterMapInterface->RetrieveValues<bool>(parameterName), itk::ExceptionObject);
   EXPECT_THROW(parameterMapInterface->RetrieveValues<double>(parameterName), itk::ExceptionObject);
 
   // A typical input error where floating point value 1.25 might have been intended:

--- a/Common/ParameterFileParser/itkParameterMapInterface.cxx
+++ b/Common/ParameterFileParser/itkParameterMapInterface.cxx
@@ -131,15 +131,8 @@ ParameterMapInterface::ReadParameter(bool &              parameterValue,
 
   /** Translate the read-in string to boolean. */
   parameterValue = false;
-  if (parameterValueString == "true")
-  {
-    parameterValue = true;
-  }
-  else if (parameterValueString == "false")
-  {
-    parameterValue = false;
-  }
-  else
+
+  if (!StringCast(parameterValueString, parameterValue))
   {
     /** Trying to read a string other than "true" or "false" as a boolean. */
     std::stringstream ss;
@@ -272,6 +265,23 @@ bool
 ParameterMapInterface::StringCast(const std::string & parameterValue, unsigned char & casted)
 {
   return StringCastToCharType(parameterValue, casted);
+}
+
+
+bool
+ParameterMapInterface::StringCast(const std::string & parameterValue, bool & casted)
+{
+  if (parameterValue == "false")
+  {
+    casted = false;
+    return true;
+  }
+  if (parameterValue == "true")
+  {
+    casted = true;
+    return true;
+  }
+  return false;
 }
 
 

--- a/Common/ParameterFileParser/itkParameterMapInterface.h
+++ b/Common/ParameterFileParser/itkParameterMapInterface.h
@@ -437,9 +437,8 @@ private:
   static bool
   StringCast(const std::string & parameterValue, T & casted)
   {
-    // StringCast is only called by the templated ReadParameter<T>, while there
-    // is a non-templated ReadParameter overload for `bool` parameter values.
-    static_assert(!std::is_same<T, bool>::value, "StringCast does not support bool!");
+    // Conversion to bool is supported by another StringCast overload.
+    static_assert(!std::is_same<T, bool>::value, "This StringCast<T> overload does not support bool!");
 
     // 8-bits (signed/unsigned) char types are supported by other StringCast
     // overloads.
@@ -495,6 +494,10 @@ private:
 
   static bool
   StringCast(const std::string & parameterValue, unsigned char & casted);
+
+  /** Overload to cast a string to a bool. Returns true when casting was successful and false otherwise. */
+  static bool
+  StringCast(const std::string & parameterValue, bool & casted);
 };
 
 } // end of namespace itk


### PR DESCRIPTION
Allows calling something like `configuration.RetrieveValuesOfParameter<bool>("parameter")`.

Extended `ParameterMapInterface` GoogleTest to test `RetrieveValues<bool>`.

Adjusted the `bool` specific overload of `ReadParameter` to internally use `StringCast`.