### PR TITLE
Remove `itkGetMacro` calls, replace them with `itkGetConstMacro`

### DIFF
--- a/Common/CostFunctions/itkParzenWindowHistogramImageToImageMetric.h
+++ b/Common/CostFunctions/itkParzenWindowHistogramImageToImageMetric.h
@@ -167,7 +167,7 @@ public:
    * should at least be equal to four.
    */
   itkSetClampMacro(NumberOfFixedHistogramBins, unsigned long, 4, NumericTraits<unsigned long>::max());
-  itkGetMacro(NumberOfFixedHistogramBins, unsigned long);
+  itkGetConstMacro(NumberOfFixedHistogramBins, unsigned long);
 
   /** Number of bins to use for the moving image in the histogram.
    * Typical value is 32.  The minimum value is 4 due to the padding
@@ -176,7 +176,7 @@ public:
    * should at least be equal to four.
    */
   itkSetClampMacro(NumberOfMovingHistogramBins, unsigned long, 4, NumericTraits<unsigned long>::max());
-  itkGetMacro(NumberOfMovingHistogramBins, unsigned long);
+  itkGetConstMacro(NumberOfMovingHistogramBins, unsigned long);
 
   /** The B-spline order of the fixed Parzen window; default: 0 */
   itkSetClampMacro(FixedKernelBSplineOrder, unsigned int, 0, 3);

--- a/Common/MevisDicomTiff/itkMevisDicomTiffImageIO.h
+++ b/Common/MevisDicomTiff/itkMevisDicomTiffImageIO.h
@@ -115,9 +115,9 @@ public:
 
   itkNewMacro(Self);
   itkTypeMacro(MevisDicomTiffImageIO, Superclass);
-  itkGetMacro(RescaleSlope, double);
-  itkGetMacro(RescaleIntercept, double);
-  itkGetMacro(GantryTilt, double);
+  itkGetConstMacro(RescaleSlope, double);
+  itkGetConstMacro(RescaleIntercept, double);
+  itkGetConstMacro(GantryTilt, double);
 
   virtual bool
   CanReadFile(const char *);

--- a/Common/Transforms/itkAdvancedBSplineDeformableTransformBase.h
+++ b/Common/Transforms/itkAdvancedBSplineDeformableTransformBase.h
@@ -198,28 +198,24 @@ public:
   virtual void
   SetGridRegion(const RegionType & region) = 0;
 
-  // itkGetMacro( GridRegion, RegionType );
   itkGetConstMacro(GridRegion, RegionType);
 
   /** This method specifies the grid spacing or resolution. */
   virtual void
   SetGridSpacing(const SpacingType & spacing);
 
-  // itkGetMacro( GridSpacing, SpacingType );
   itkGetConstMacro(GridSpacing, SpacingType);
 
   /** This method specifies the grid directions . */
   virtual void
   SetGridDirection(const DirectionType & direction);
 
-  // itkGetMacro( GridDirection, DirectionType );
   itkGetConstMacro(GridDirection, DirectionType);
 
   /** This method specifies the grid origin. */
   virtual void
   SetGridOrigin(const OriginType & origin);
 
-  // itkGetMacro( GridOrigin, OriginType );
   itkGetConstMacro(GridOrigin, OriginType);
 
   /** Parameter index array type. */

--- a/Common/itkMultiOrderBSplineDecompositionImageFilter.h
+++ b/Common/itkMultiOrderBSplineDecompositionImageFilter.h
@@ -125,8 +125,6 @@ public:
   }
 
 
-  // itkGetMacro( SplineOrder, unsigned int * );
-
 #ifdef ITK_USE_CONCEPT_CHECKING
   /** Begin concept checking */
   itkConceptMacro(DimensionCheck, (Concept::SameDimension<ImageDimension, OutputImageDimension>));

--- a/Common/itkMultiResolutionImageRegistrationMethod2.h
+++ b/Common/itkMultiResolutionImageRegistrationMethod2.h
@@ -204,10 +204,10 @@ public:
 
   /** Set/Get the number of multi-resolution levels. */
   itkSetClampMacro(NumberOfLevels, unsigned long, 1, NumericTraits<unsigned long>::max());
-  itkGetMacro(NumberOfLevels, unsigned long);
+  itkGetConstMacro(NumberOfLevels, unsigned long);
 
   /** Get the current resolution level being processed. */
-  itkGetMacro(CurrentLevel, unsigned long);
+  itkGetConstMacro(CurrentLevel, unsigned long);
 
   /** Set/Get the initial transformation parameters. */
   itkSetMacro(InitialTransformParameters, ParametersType);

--- a/Components/Metrics/DistancePreservingRigidityPenalty/itkDistancePreservingRigidityPenaltyTerm.h
+++ b/Components/Metrics/DistancePreservingRigidityPenalty/itkDistancePreservingRigidityPenaltyTerm.h
@@ -196,7 +196,7 @@ public:
   /** Get the Sampled Segmented Image. */
   itkGetModifiableObjectMacro(SampledSegmentedImage, SegmentedImageType);
 
-  itkGetMacro(NumberOfRigidGrids, unsigned int);
+  itkGetConstMacro(NumberOfRigidGrids, unsigned int);
 
 protected:
   /** The constructor. */

--- a/Components/Metrics/RigidityPenalty/itkTransformRigidityPenaltyTerm.h
+++ b/Components/Metrics/RigidityPenalty/itkTransformRigidityPenaltyTerm.h
@@ -206,15 +206,15 @@ public:
 
   /** Set/Get the weight of the linearity condition part. */
   itkSetClampMacro(LinearityConditionWeight, ScalarType, 0.0, NumericTraits<ScalarType>::max());
-  itkGetMacro(LinearityConditionWeight, ScalarType);
+  itkGetConstMacro(LinearityConditionWeight, ScalarType);
 
   /** Set/Get the weight of the orthonormality condition part. */
   itkSetClampMacro(OrthonormalityConditionWeight, ScalarType, 0.0, NumericTraits<ScalarType>::max());
-  itkGetMacro(OrthonormalityConditionWeight, ScalarType);
+  itkGetConstMacro(OrthonormalityConditionWeight, ScalarType);
 
   /** Set/Get the weight of the properness condition part. */
   itkSetClampMacro(PropernessConditionWeight, ScalarType, 0.0, NumericTraits<ScalarType>::max());
-  itkGetMacro(PropernessConditionWeight, ScalarType);
+  itkGetConstMacro(PropernessConditionWeight, ScalarType);
 
   /** Set the usage of the linearity condition part. */
   itkSetMacro(UseLinearityCondition, bool);

--- a/Components/Metrics/StatisticalShapePenalty/itkStatisticalShapePointPenalty.h
+++ b/Components/Metrics/StatisticalShapePenalty/itkStatisticalShapePointPenalty.h
@@ -118,41 +118,41 @@ public:
 
   /** Set/Get the shrinkageIntensity parameter. */
   itkSetClampMacro(ShrinkageIntensity, MeasureType, 0.0, 1.0);
-  itkGetMacro(ShrinkageIntensity, MeasureType);
+  itkGetConstMacro(ShrinkageIntensity, MeasureType);
 
   itkSetMacro(ShrinkageIntensityNeedsUpdate, bool);
   itkBooleanMacro(ShrinkageIntensityNeedsUpdate);
 
   /** Set/Get the BaseVariance parameter. */
   itkSetClampMacro(BaseVariance, MeasureType, -1.0, NumericTraits<MeasureType>::max());
-  itkGetMacro(BaseVariance, MeasureType);
+  itkGetConstMacro(BaseVariance, MeasureType);
 
   itkSetMacro(BaseVarianceNeedsUpdate, bool);
   itkBooleanMacro(BaseVarianceNeedsUpdate);
 
   itkSetClampMacro(CentroidXVariance, MeasureType, -1.0, NumericTraits<MeasureType>::max());
-  itkGetMacro(CentroidXVariance, MeasureType);
+  itkGetConstMacro(CentroidXVariance, MeasureType);
 
   itkSetClampMacro(CentroidYVariance, MeasureType, -1.0, NumericTraits<MeasureType>::max());
-  itkGetMacro(CentroidYVariance, MeasureType);
+  itkGetConstMacro(CentroidYVariance, MeasureType);
 
   itkSetClampMacro(CentroidZVariance, MeasureType, -1.0, NumericTraits<MeasureType>::max());
-  itkGetMacro(CentroidZVariance, MeasureType);
+  itkGetConstMacro(CentroidZVariance, MeasureType);
 
   itkSetClampMacro(SizeVariance, MeasureType, -1.0, NumericTraits<MeasureType>::max());
-  itkGetMacro(SizeVariance, MeasureType);
+  itkGetConstMacro(SizeVariance, MeasureType);
 
   itkSetMacro(VariancesNeedsUpdate, bool);
   itkBooleanMacro(VariancesNeedsUpdate);
 
   itkSetClampMacro(CutOffValue, MeasureType, 0.0, NumericTraits<MeasureType>::max());
-  itkGetMacro(CutOffValue, MeasureType);
+  itkGetConstMacro(CutOffValue, MeasureType);
 
   itkSetClampMacro(CutOffSharpness,
                    MeasureType,
                    NumericTraits<MeasureType>::NonpositiveMin(),
                    NumericTraits<MeasureType>::max());
-  itkGetMacro(CutOffSharpness, MeasureType);
+  itkGetConstMacro(CutOffSharpness, MeasureType);
 
   itkSetMacro(ShapeModelCalculation, int);
   itkGetConstReferenceMacro(ShapeModelCalculation, int);

--- a/Components/Metrics/SumSquaredTissueVolumeDifferenceMetric/itkSumSquaredTissueVolumeDifferenceImageToImageMetric.h
+++ b/Components/Metrics/SumSquaredTissueVolumeDifferenceMetric/itkSumSquaredTissueVolumeDifferenceImageToImageMetric.h
@@ -153,11 +153,11 @@ public:
 
   /** Set/get the air intensity value */
   itkSetMacro(AirValue, RealType);
-  itkGetMacro(AirValue, RealType);
+  itkGetConstMacro(AirValue, RealType);
 
   /** Set/get the tissue intensity value */
   itkSetMacro(TissueValue, RealType);
-  itkGetMacro(TissueValue, RealType);
+  itkGetConstMacro(TissueValue, RealType);
 
 protected:
   SumSquaredTissueVolumeDifferenceImageToImageMetric();

--- a/Components/Optimizers/FiniteDifferenceGradientDescent/itkFiniteDifferenceGradientDescentOptimizer.h
+++ b/Components/Optimizers/FiniteDifferenceGradientDescent/itkFiniteDifferenceGradientDescentOptimizer.h
@@ -109,23 +109,23 @@ public:
 
   /** Set/Get a. */
   itkSetMacro(Param_a, double);
-  itkGetMacro(Param_a, double);
+  itkGetConstMacro(Param_a, double);
 
   /** Set/Get c. */
   itkSetMacro(Param_c, double);
-  itkGetMacro(Param_c, double);
+  itkGetConstMacro(Param_c, double);
 
   /** Set/Get A. */
   itkSetMacro(Param_A, double);
-  itkGetMacro(Param_A, double);
+  itkGetConstMacro(Param_A, double);
 
   /** Set/Get alpha. */
   itkSetMacro(Param_alpha, double);
-  itkGetMacro(Param_alpha, double);
+  itkGetConstMacro(Param_alpha, double);
 
   /** Set/Get gamma. */
   itkSetMacro(Param_gamma, double);
-  itkGetMacro(Param_gamma, double);
+  itkGetConstMacro(Param_gamma, double);
 
   itkGetConstMacro(ComputeCurrentValue, bool);
   itkSetMacro(ComputeCurrentValue, bool);

--- a/Components/Registrations/MultiMetricMultiResolutionRegistration/itkCombinationImageToImageMetric.h
+++ b/Components/Registrations/MultiMetricMultiResolutionRegistration/itkCombinationImageToImageMetric.h
@@ -200,7 +200,7 @@ public:
 
   /** Set and Get the UseRelativeWeights variable. */
   itkSetMacro(UseRelativeWeights, bool);
-  itkGetMacro(UseRelativeWeights, bool);
+  itkGetConstMacro(UseRelativeWeights, bool);
 
   /** Select which metrics are used.
    * This is useful in case you want to compute a certain measure, but not

--- a/Components/Transforms/MultiBSplineTransformWithNormal/itkMultiBSplineDeformableTransformWithNormal.h
+++ b/Components/Transforms/MultiBSplineTransformWithNormal/itkMultiBSplineDeformableTransformWithNormal.h
@@ -244,7 +244,7 @@ public:
   void
   SetLabels(ImageLabelType * labels);
 
-  itkGetMacro(Labels, ImageLabelType *);
+  itkGetConstMacro(Labels, ImageLabelType *);
 
   itkGetConstMacro(NbLabels, unsigned char);
 
@@ -252,7 +252,7 @@ public:
   void
   UpdateLocalBases(void);
 
-  itkGetMacro(LocalBases, ImageBaseType *);
+  itkGetConstMacro(LocalBases, ImageBaseType *);
 
   /** Parameter index array type. */
   typedef Array<unsigned long> ParameterIndexArrayType;

--- a/Components/Transforms/SplineKernelTransform/itkKernelTransform2.h
+++ b/Components/Transforms/SplineKernelTransform/itkKernelTransform2.h
@@ -271,7 +271,7 @@ public:
   }
 
 
-  itkGetMacro(Stiffness, double);
+  itkGetConstMacro(Stiffness, double);
 
   /** This method makes only sense for the ElasticBody splines.
    * Declare here, so that you can always call it if you don't know

--- a/Core/Kernel/elxElastixMain.h
+++ b/Core/Kernel/elxElastixMain.h
@@ -176,10 +176,10 @@ public:
   itkSetMacro(MovingImagePixelType, PixelTypeDescriptionType);
   itkSetMacro(FixedImageDimension, ImageDimensionType);
   itkSetMacro(MovingImageDimension, ImageDimensionType);
-  itkGetMacro(FixedImagePixelType, PixelTypeDescriptionType);
-  itkGetMacro(MovingImagePixelType, PixelTypeDescriptionType);
-  itkGetMacro(FixedImageDimension, ImageDimensionType);
-  itkGetMacro(MovingImageDimension, ImageDimensionType);
+  itkGetConstMacro(FixedImagePixelType, PixelTypeDescriptionType);
+  itkGetConstMacro(MovingImagePixelType, PixelTypeDescriptionType);
+  itkGetConstMacro(FixedImageDimension, ImageDimensionType);
+  itkGetConstMacro(MovingImageDimension, ImageDimensionType);
 
   /** Set/Get functions for the fixed and moving images
    * (if these are not used, elastix tries to read them from disk,

--- a/Core/Main/elxElastixFilter.h
+++ b/Core/Main/elxElastixFilter.h
@@ -154,7 +154,7 @@ public:
 
   /** Set/Get/Remove initial transform parameter filename. */
   itkSetMacro(InitialTransformParameterFileName, std::string);
-  itkGetMacro(InitialTransformParameterFileName, std::string);
+  itkGetConstMacro(InitialTransformParameterFileName, std::string);
   virtual void
   RemoveInitialTransformParameterFileName(void)
   {
@@ -163,7 +163,7 @@ public:
 
   /** Set/Get/Remove fixed point set filename. */
   itkSetMacro(FixedPointSetFileName, std::string);
-  itkGetMacro(FixedPointSetFileName, std::string);
+  itkGetConstMacro(FixedPointSetFileName, std::string);
   void
   RemoveFixedPointSetFileName(void)
   {
@@ -172,7 +172,7 @@ public:
 
   /** Set/Get/Remove moving point set filename. */
   itkSetMacro(MovingPointSetFileName, std::string);
-  itkGetMacro(MovingPointSetFileName, std::string);
+  itkGetConstMacro(MovingPointSetFileName, std::string);
   void
   RemoveMovingPointSetFileName(void)
   {
@@ -181,7 +181,7 @@ public:
 
   /** Set/Get/Remove output directory. */
   itkSetMacro(OutputDirectory, std::string);
-  itkGetMacro(OutputDirectory, std::string);
+  itkGetConstMacro(OutputDirectory, std::string);
   void
   RemoveOutputDirectory()
   {
@@ -214,7 +214,7 @@ public:
   }
 
   itkSetMacro(NumberOfThreads, int);
-  itkGetMacro(NumberOfThreads, int);
+  itkGetConstMacro(NumberOfThreads, int);
 
 protected:
   ElastixFilter(void);

--- a/Core/Main/elxTransformixFilter.h
+++ b/Core/Main/elxTransformixFilter.h
@@ -85,7 +85,7 @@ public:
 
   /** Set/Get/Remove moving point set filename. */
   itkSetMacro(FixedPointSetFileName, std::string);
-  itkGetMacro(FixedPointSetFileName, std::string);
+  itkGetConstMacro(FixedPointSetFileName, std::string);
   virtual void
   RemoveFixedPointSetFileName()
   {

--- a/Core/Main/itkElastixRegistrationMethod.h
+++ b/Core/Main/itkElastixRegistrationMethod.h
@@ -188,7 +188,7 @@ public:
 
   /** Set/Get/Remove initial transform parameter filename. */
   itkSetMacro(InitialTransformParameterFileName, std::string);
-  itkGetMacro(InitialTransformParameterFileName, std::string);
+  itkGetConstMacro(InitialTransformParameterFileName, std::string);
   virtual void
   RemoveInitialTransformParameterFileName()
   {
@@ -197,7 +197,7 @@ public:
 
   /** Set/Get/Remove fixed point set filename. */
   itkSetMacro(FixedPointSetFileName, std::string);
-  itkGetMacro(FixedPointSetFileName, std::string);
+  itkGetConstMacro(FixedPointSetFileName, std::string);
   void
   RemoveFixedPointSetFileName()
   {
@@ -206,7 +206,7 @@ public:
 
   /** Set/Get/Remove moving point set filename. */
   itkSetMacro(MovingPointSetFileName, std::string);
-  itkGetMacro(MovingPointSetFileName, std::string);
+  itkGetConstMacro(MovingPointSetFileName, std::string);
   void
   RemoveMovingPointSetFileName()
   {
@@ -215,7 +215,7 @@ public:
 
   /** Set/Get/Remove output directory. */
   itkSetMacro(OutputDirectory, std::string);
-  itkGetMacro(OutputDirectory, std::string);
+  itkGetConstMacro(OutputDirectory, std::string);
   void
   RemoveOutputDirectory()
   {
@@ -241,7 +241,7 @@ public:
   itkBooleanMacro(LogToFile);
 
   itkSetMacro(NumberOfThreads, int);
-  itkGetMacro(NumberOfThreads, int);
+  itkGetConstMacro(NumberOfThreads, int);
 
 protected:
   ElastixRegistrationMethod();

--- a/Core/Main/itkTransformixFilter.h
+++ b/Core/Main/itkTransformixFilter.h
@@ -113,7 +113,7 @@ public:
 
   /** Set/Get/Remove moving point set filename. */
   itkSetMacro(FixedPointSetFileName, std::string);
-  itkGetMacro(FixedPointSetFileName, std::string);
+  itkGetConstMacro(FixedPointSetFileName, std::string);
   virtual void
   RemoveFixedPointSetFileName()
   {

--- a/Testing/itkCommandLineArgumentParser.h
+++ b/Testing/itkCommandLineArgumentParser.h
@@ -134,7 +134,7 @@ public:
   MarkExactlyOneOfArgumentsAsRequired(const std::vector<std::string> & arguments, const std::string & helpText = "");
 
   itkSetMacro(ProgramHelpText, std::string);
-  itkGetMacro(ProgramHelpText, std::string);
+  itkGetConstMacro(ProgramHelpText, std::string);
 
   /** Get command line argument if arg is a vector type. */
   template <class T>


### PR DESCRIPTION
Removed the commented-out `itkGetMacro` calls, and replaced the remaining calls with `itkGetConstMacro`, to improve const-correctness and consistency.