### PR TITLE
COMP: Use trailing return type instead of `typename` + dependent type

### DIFF
--- a/Common/CostFunctions/itkExponentialLimiterFunction.hxx
+++ b/Common/CostFunctions/itkExponentialLimiterFunction.hxx
@@ -52,8 +52,8 @@ ExponentialLimiterFunction<TInput, NDimension>::Initialize(void)
  */
 
 template <class TInput, unsigned int NDimension>
-typename ExponentialLimiterFunction<TInput, NDimension>::OutputType
-ExponentialLimiterFunction<TInput, NDimension>::Evaluate(const InputType & input) const
+auto
+ExponentialLimiterFunction<TInput, NDimension>::Evaluate(const InputType & input) const -> OutputType
 {
   /** Apply a soft limit if the input is larger than the UpperThreshold */
   const double diffU = static_cast<double>(input - this->m_UpperThreshold);
@@ -79,8 +79,9 @@ ExponentialLimiterFunction<TInput, NDimension>::Evaluate(const InputType & input
  */
 
 template <class TInput, unsigned int NDimension>
-typename ExponentialLimiterFunction<TInput, NDimension>::OutputType
+auto
 ExponentialLimiterFunction<TInput, NDimension>::Evaluate(const InputType & input, DerivativeType & derivative) const
+  -> OutputType
 {
   /** Apply a soft limit if the input is larger than the UpperThreshold */
   const double diffU = static_cast<double>(input - this->m_UpperThreshold);

--- a/Common/CostFunctions/itkHardLimiterFunction.hxx
+++ b/Common/CostFunctions/itkHardLimiterFunction.hxx
@@ -25,8 +25,8 @@ namespace itk
 {
 
 template <class TInput, unsigned int NDimension>
-typename HardLimiterFunction<TInput, NDimension>::OutputType
-HardLimiterFunction<TInput, NDimension>::Evaluate(const InputType & input) const
+auto
+HardLimiterFunction<TInput, NDimension>::Evaluate(const InputType & input) const -> OutputType
 {
   OutputType output = std::min(static_cast<OutputType>(input), this->m_UpperBound);
   return (std::max(output, this->m_LowerBound));
@@ -34,8 +34,9 @@ HardLimiterFunction<TInput, NDimension>::Evaluate(const InputType & input) const
 
 
 template <class TInput, unsigned int NDimension>
-typename HardLimiterFunction<TInput, NDimension>::OutputType
+auto
 HardLimiterFunction<TInput, NDimension>::Evaluate(const InputType & input, DerivativeType & derivative) const
+  -> OutputType
 {
   if (input > this->m_UpperBound)
   {

--- a/Common/CostFunctions/itkMultiInputImageToImageMetricBase.hxx
+++ b/Common/CostFunctions/itkMultiInputImageToImageMetricBase.hxx
@@ -68,8 +68,7 @@
 /** Macro for getting objects. */
 #define itkImplementationGetObjectMacro(_name, _type)                                                                  \
   template <class TFixedImage, class TMovingImage>                                                                     \
-  typename MultiInputImageToImageMetricBase<TFixedImage, TMovingImage>::_type *                                        \
-    MultiInputImageToImageMetricBase<TFixedImage, TMovingImage>::Get##_name(unsigned int pos) const                    \
+  auto MultiInputImageToImageMetricBase<TFixedImage, TMovingImage>::Get##_name(unsigned int pos) const->_type *        \
   {                                                                                                                    \
     if (this->m_##_name##Vector.size() < pos + 1)                                                                      \
     {                                                                                                                  \
@@ -81,8 +80,7 @@
 /** Macro for getting const objects. */
 #define itkImplementationGetConstObjectMacro(_name, _type)                                                             \
   template <class TFixedImage, class TMovingImage>                                                                     \
-  const typename MultiInputImageToImageMetricBase<TFixedImage, TMovingImage>::_type *                                  \
-    MultiInputImageToImageMetricBase<TFixedImage, TMovingImage>::Get##_name(unsigned int pos) const                    \
+  auto MultiInputImageToImageMetricBase<TFixedImage, TMovingImage>::Get##_name(unsigned int pos) const->const _type *  \
   {                                                                                                                    \
     if (this->m_##_name##Vector.size() < pos + 1)                                                                      \
     {                                                                                                                  \
@@ -163,8 +161,9 @@ MultiInputImageToImageMetricBase<TFixedImage, TMovingImage>::SetFixedImageRegion
  */
 
 template <class TFixedImage, class TMovingImage>
-const typename MultiInputImageToImageMetricBase<TFixedImage, TMovingImage>::FixedImageRegionType &
+auto
 MultiInputImageToImageMetricBase<TFixedImage, TMovingImage>::GetFixedImageRegion(unsigned int pos) const
+  -> const FixedImageRegionType &
 {
   if (this->m_FixedImageRegionVector.size() < pos)
   {

--- a/Common/ImageSamplers/itkImageSamplerBase.hxx
+++ b/Common/ImageSamplers/itkImageSamplerBase.hxx
@@ -79,8 +79,8 @@ ImageSamplerBase<TInputImage>::SetMask(const MaskType * _arg, unsigned int pos)
  */
 
 template <class TInputImage>
-const typename ImageSamplerBase<TInputImage>::MaskType *
-ImageSamplerBase<TInputImage>::GetMask(unsigned int pos) const
+auto
+ImageSamplerBase<TInputImage>::GetMask(unsigned int pos) const -> const MaskType *
 {
   if (this->m_MaskVector.size() < pos + 1)
   {
@@ -139,8 +139,8 @@ ImageSamplerBase<TInputImage>::SetInputImageRegion(const InputImageRegionType _a
  */
 
 template <class TInputImage>
-const typename ImageSamplerBase<TInputImage>::InputImageRegionType &
-ImageSamplerBase<TInputImage>::GetInputImageRegion(unsigned int pos) const
+auto
+ImageSamplerBase<TInputImage>::GetInputImageRegion(unsigned int pos) const -> const InputImageRegionType &
 {
   if (this->m_InputImageRegionVector.size() < pos + 1)
   {

--- a/Common/ImageSamplers/itkImageToVectorContainerFilter.hxx
+++ b/Common/ImageSamplers/itkImageToVectorContainerFilter.hxx
@@ -87,8 +87,8 @@ ImageToVectorContainerFilter<TInputImage, TOutputVectorContainer>::SetInput(cons
  */
 
 template <class TInputImage, class TOutputVectorContainer>
-const typename ImageToVectorContainerFilter<TInputImage, TOutputVectorContainer>::InputImageType *
-ImageToVectorContainerFilter<TInputImage, TOutputVectorContainer>::GetInput(void)
+auto
+ImageToVectorContainerFilter<TInputImage, TOutputVectorContainer>::GetInput(void) -> const InputImageType *
 {
   return dynamic_cast<const InputImageType *>(this->ProcessObject::GetInput(0));
 } // end GetInput()
@@ -98,8 +98,8 @@ ImageToVectorContainerFilter<TInputImage, TOutputVectorContainer>::GetInput(void
  */
 
 template <class TInputImage, class TOutputVectorContainer>
-const typename ImageToVectorContainerFilter<TInputImage, TOutputVectorContainer>::InputImageType *
-ImageToVectorContainerFilter<TInputImage, TOutputVectorContainer>::GetInput(unsigned int idx)
+auto
+ImageToVectorContainerFilter<TInputImage, TOutputVectorContainer>::GetInput(unsigned int idx) -> const InputImageType *
 {
   return dynamic_cast<const InputImageType *>(this->ProcessObject::GetInput(idx));
 } // end GetInput()
@@ -109,8 +109,8 @@ ImageToVectorContainerFilter<TInputImage, TOutputVectorContainer>::GetInput(unsi
  */
 
 template <class TInputImage, class TOutputVectorContainer>
-typename ImageToVectorContainerFilter<TInputImage, TOutputVectorContainer>::OutputVectorContainerType *
-ImageToVectorContainerFilter<TInputImage, TOutputVectorContainer>::GetOutput(void)
+auto
+ImageToVectorContainerFilter<TInputImage, TOutputVectorContainer>::GetOutput(void) -> OutputVectorContainerType *
 {
   return dynamic_cast<OutputVectorContainerType *>(this->ProcessObject::GetOutput(0));
 } // end GetOutput()

--- a/Common/ImageSamplers/itkVectorContainerSource.hxx
+++ b/Common/ImageSamplers/itkVectorContainerSource.hxx
@@ -48,8 +48,8 @@ VectorContainerSource<TOutputVectorContainer>::VectorContainerSource()
  */
 
 template <class TOutputVectorContainer>
-typename VectorContainerSource<TOutputVectorContainer>::DataObjectPointer
-VectorContainerSource<TOutputVectorContainer>::MakeOutput(unsigned int itkNotUsed(idx))
+auto
+VectorContainerSource<TOutputVectorContainer>::MakeOutput(unsigned int itkNotUsed(idx)) -> DataObjectPointer
 {
   return static_cast<DataObject *>(TOutputVectorContainer::New().GetPointer());
 } // end MakeOutput()
@@ -60,8 +60,8 @@ VectorContainerSource<TOutputVectorContainer>::MakeOutput(unsigned int itkNotUse
  */
 
 template <class TOutputVectorContainer>
-typename VectorContainerSource<TOutputVectorContainer>::OutputVectorContainerType *
-VectorContainerSource<TOutputVectorContainer>::GetOutput(void)
+auto
+VectorContainerSource<TOutputVectorContainer>::GetOutput(void) -> OutputVectorContainerType *
 {
   if (this->GetNumberOfOutputs() < 1)
   {
@@ -76,8 +76,8 @@ VectorContainerSource<TOutputVectorContainer>::GetOutput(void)
  */
 
 template <class TOutputVectorContainer>
-typename VectorContainerSource<TOutputVectorContainer>::OutputVectorContainerType *
-VectorContainerSource<TOutputVectorContainer>::GetOutput(unsigned int idx)
+auto
+VectorContainerSource<TOutputVectorContainer>::GetOutput(unsigned int idx) -> OutputVectorContainerType *
 {
   return static_cast<OutputVectorContainerType *>(this->ProcessObject::GetOutput(idx));
 } // end GetOutput()

--- a/Common/ImageSamplers/itkVectorDataContainer.hxx
+++ b/Common/ImageSamplers/itkVectorDataContainer.hxx
@@ -54,8 +54,8 @@ namespace itk
  * reference.
  */
 template <typename TElementIdentifier, typename TElement>
-typename VectorDataContainer<TElementIdentifier, TElement>::Element &
-VectorDataContainer<TElementIdentifier, TElement>::ElementAt(ElementIdentifier id)
+auto
+VectorDataContainer<TElementIdentifier, TElement>::ElementAt(ElementIdentifier id) -> Element &
 {
   this->Modified();
   return this->VectorType::operator[](id);
@@ -68,8 +68,8 @@ VectorDataContainer<TElementIdentifier, TElement>::ElementAt(ElementIdentifier i
  *
  */
 template <typename TElementIdentifier, typename TElement>
-const typename VectorDataContainer<TElementIdentifier, TElement>::Element &
-VectorDataContainer<TElementIdentifier, TElement>::ElementAt(ElementIdentifier id) const
+auto
+VectorDataContainer<TElementIdentifier, TElement>::ElementAt(ElementIdentifier id) const -> const Element &
 {
   return this->VectorType::operator[](id);
 }
@@ -83,8 +83,8 @@ VectorDataContainer<TElementIdentifier, TElement>::ElementAt(ElementIdentifier i
  * reference.
  */
 template <typename TElementIdentifier, typename TElement>
-typename VectorDataContainer<TElementIdentifier, TElement>::Element &
-VectorDataContainer<TElementIdentifier, TElement>::CreateElementAt(ElementIdentifier id)
+auto
+VectorDataContainer<TElementIdentifier, TElement>::CreateElementAt(ElementIdentifier id) -> Element &
 {
   if (id >= this->VectorType::size())
   {
@@ -99,8 +99,8 @@ VectorDataContainer<TElementIdentifier, TElement>::CreateElementAt(ElementIdenti
  * It is assumed that the index exists.
  */
 template <typename TElementIdentifier, typename TElement>
-typename VectorDataContainer<TElementIdentifier, TElement>::Element
-VectorDataContainer<TElementIdentifier, TElement>::GetElement(ElementIdentifier id) const
+auto
+VectorDataContainer<TElementIdentifier, TElement>::GetElement(ElementIdentifier id) const -> Element
 {
   return this->VectorType::operator[](id);
 }
@@ -220,8 +220,8 @@ VectorDataContainer<TElementIdentifier, TElement>::DeleteIndex(ElementIdentifier
  * Get a begin const iterator for the vector.
  */
 template <typename TElementIdentifier, typename TElement>
-typename VectorDataContainer<TElementIdentifier, TElement>::ConstIterator
-VectorDataContainer<TElementIdentifier, TElement>::Begin(void) const
+auto
+VectorDataContainer<TElementIdentifier, TElement>::Begin(void) const -> ConstIterator
 {
   return ConstIterator(0, this->VectorType::begin());
 }
@@ -231,8 +231,8 @@ VectorDataContainer<TElementIdentifier, TElement>::Begin(void) const
  * Get an end const iterator for the vector.
  */
 template <typename TElementIdentifier, typename TElement>
-typename VectorDataContainer<TElementIdentifier, TElement>::ConstIterator
-VectorDataContainer<TElementIdentifier, TElement>::End(void) const
+auto
+VectorDataContainer<TElementIdentifier, TElement>::End(void) const -> ConstIterator
 {
   return ConstIterator(this->VectorType::size() - 1, this->VectorType::end());
 }
@@ -242,8 +242,8 @@ VectorDataContainer<TElementIdentifier, TElement>::End(void) const
  * Get a begin iterator for the vector.
  */
 template <typename TElementIdentifier, typename TElement>
-typename VectorDataContainer<TElementIdentifier, TElement>::Iterator
-VectorDataContainer<TElementIdentifier, TElement>::Begin(void)
+auto
+VectorDataContainer<TElementIdentifier, TElement>::Begin(void) -> Iterator
 {
   return Iterator(0, this->VectorType::begin());
 }
@@ -253,8 +253,8 @@ VectorDataContainer<TElementIdentifier, TElement>::Begin(void)
  * Get an end iterator for the vector.
  */
 template <typename TElementIdentifier, typename TElement>
-typename VectorDataContainer<TElementIdentifier, TElement>::Iterator
-VectorDataContainer<TElementIdentifier, TElement>::End(void)
+auto
+VectorDataContainer<TElementIdentifier, TElement>::End(void) -> Iterator
 {
   return Iterator(this->VectorType::size() - 1, this->VectorType::end());
 }

--- a/Common/OpenCL/Filters/itkGPUBSplineBaseTransform.hxx
+++ b/Common/OpenCL/Filters/itkGPUBSplineBaseTransform.hxx
@@ -38,8 +38,8 @@ GPUBSplineBaseTransform<TScalarType, NDimensions>::GPUBSplineBaseTransform()
 
 //------------------------------------------------------------------------------
 template <typename TScalarType, unsigned int NDimensions>
-const typename GPUBSplineBaseTransform<TScalarType, NDimensions>::GPUCoefficientImageArray
-GPUBSplineBaseTransform<TScalarType, NDimensions>::GetGPUCoefficientImages(void) const
+auto
+GPUBSplineBaseTransform<TScalarType, NDimensions>::GetGPUCoefficientImages(void) const -> const GPUCoefficientImageArray
 {
   return this->m_GPUBSplineTransformCoefficientImages;
 }
@@ -47,8 +47,9 @@ GPUBSplineBaseTransform<TScalarType, NDimensions>::GetGPUCoefficientImages(void)
 
 //------------------------------------------------------------------------------
 template <typename TScalarType, unsigned int NDimensions>
-const typename GPUBSplineBaseTransform<TScalarType, NDimensions>::GPUCoefficientImageBaseArray
+auto
 GPUBSplineBaseTransform<TScalarType, NDimensions>::GetGPUCoefficientImagesBases(void) const
+  -> const GPUCoefficientImageBaseArray
 {
   return this->m_GPUBSplineTransformCoefficientImagesBase;
 }

--- a/Common/OpenCL/Filters/itkGPUBSplineInterpolateImageFunction.hxx
+++ b/Common/OpenCL/Filters/itkGPUBSplineInterpolateImageFunction.hxx
@@ -54,8 +54,9 @@ GPUBSplineInterpolateImageFunction<TInputImage, TCoordRep, TCoefficientType>::Se
 
 //------------------------------------------------------------------------------
 template <typename TInputImage, typename TCoordRep, typename TCoefficientType>
-const typename GPUBSplineInterpolateImageFunction<TInputImage, TCoordRep, TCoefficientType>::GPUCoefficientImagePointer
+auto
 GPUBSplineInterpolateImageFunction<TInputImage, TCoordRep, TCoefficientType>::GetGPUCoefficients() const
+  -> const GPUCoefficientImagePointer
 {
   return this->m_GPUCoefficients;
 }
@@ -63,8 +64,9 @@ GPUBSplineInterpolateImageFunction<TInputImage, TCoordRep, TCoefficientType>::Ge
 
 //------------------------------------------------------------------------------
 template <typename TInputImage, typename TCoordRep, typename TCoefficientType>
-const typename GPUBSplineInterpolateImageFunction<TInputImage, TCoordRep, TCoefficientType>::GPUDataManagerPointer
+auto
 GPUBSplineInterpolateImageFunction<TInputImage, TCoordRep, TCoefficientType>::GetGPUCoefficientsImageBase() const
+  -> const GPUDataManagerPointer
 {
   return this->m_GPUCoefficientsImageBase;
 }

--- a/Common/OpenCL/Filters/itkGPUResampleImageFilter.hxx
+++ b/Common/OpenCL/Filters/itkGPUResampleImageFilter.hxx
@@ -941,9 +941,9 @@ GPUResampleImageFilter<TInputImage, TOutputImage, TInterpolatorPrecisionType>::S
  */
 
 template <typename TInputImage, typename TOutputImage, typename TInterpolatorPrecisionType>
-const typename GPUResampleImageFilter<TInputImage, TOutputImage, TInterpolatorPrecisionType>::GPUTransformTypeEnum
+auto
 GPUResampleImageFilter<TInputImage, TOutputImage, TInterpolatorPrecisionType>::GetTransformType(
-  const int & transformIndex) const
+  const int & transformIndex) const -> const GPUTransformTypeEnum
 {
   if (this->m_TransformIsCombo)
   {
@@ -1108,9 +1108,9 @@ GPUResampleImageFilter<TInputImage, TOutputImage, TInterpolatorPrecisionType>::G
  */
 
 template <typename TInputImage, typename TOutputImage, typename TInterpolatorPrecisionType>
-typename GPUResampleImageFilter<TInputImage, TOutputImage, TInterpolatorPrecisionType>::GPUBSplineBaseTransformType *
+auto
 GPUResampleImageFilter<TInputImage, TOutputImage, TInterpolatorPrecisionType>::GetGPUBSplineBaseTransform(
-  const std::size_t transformIndex)
+  const std::size_t transformIndex) -> GPUBSplineBaseTransformType *
 {
   GPUBSplineBaseTransformType * GPUBSplineTransformBase = nullptr;
 

--- a/Common/Transforms/itkAdvancedBSplineDeformableTransform.hxx
+++ b/Common/Transforms/itkAdvancedBSplineDeformableTransform.hxx
@@ -305,9 +305,9 @@ AdvancedBSplineDeformableTransform<TScalarType, NDimensions, VSplineOrder>::Tran
 
 // Transform a point
 template <class TScalarType, unsigned int NDimensions, unsigned int VSplineOrder>
-typename AdvancedBSplineDeformableTransform<TScalarType, NDimensions, VSplineOrder>::OutputPointType
+auto
 AdvancedBSplineDeformableTransform<TScalarType, NDimensions, VSplineOrder>::TransformPoint(
-  const InputPointType & point) const
+  const InputPointType & point) const -> OutputPointType
 {
   /** Allocate memory on the stack: */
   const unsigned long                         numberOfWeights = WeightsFunctionType::NumberOfWeights;
@@ -342,9 +342,9 @@ AdvancedBSplineDeformableTransform<TScalarType, NDimensions, VSplineOrder>::GetN
  */
 
 template <class TScalarType, unsigned int NDimensions, unsigned int VSplineOrder>
-typename AdvancedBSplineDeformableTransform<TScalarType, NDimensions, VSplineOrder>::NumberOfParametersType
+auto
 AdvancedBSplineDeformableTransform<TScalarType, NDimensions, VSplineOrder>::GetNumberOfNonZeroJacobianIndices(
-  void) const
+  void) const -> NumberOfParametersType
 {
   return this->m_WeightsFunction->GetNumberOfWeights() * SpaceDimension;
 } // end GetNumberOfNonZeroJacobianIndices()

--- a/Common/Transforms/itkAdvancedBSplineDeformableTransformBase.hxx
+++ b/Common/Transforms/itkAdvancedBSplineDeformableTransformBase.hxx
@@ -104,8 +104,9 @@ AdvancedBSplineDeformableTransformBase<TScalarType, NDimensions>::~AdvancedBSpli
 
 // Get the number of parameters
 template <class TScalarType, unsigned int NDimensions>
-typename AdvancedBSplineDeformableTransformBase<TScalarType, NDimensions>::NumberOfParametersType
+auto
 AdvancedBSplineDeformableTransformBase<TScalarType, NDimensions>::GetNumberOfParameters(void) const
+  -> NumberOfParametersType
 {
 
   // The number of parameters equal SpaceDimension * number of
@@ -117,8 +118,9 @@ AdvancedBSplineDeformableTransformBase<TScalarType, NDimensions>::GetNumberOfPar
 
 // Get the number of parameters per dimension
 template <class TScalarType, unsigned int NDimensions>
-typename AdvancedBSplineDeformableTransformBase<TScalarType, NDimensions>::NumberOfParametersType
+auto
 AdvancedBSplineDeformableTransformBase<TScalarType, NDimensions>::GetNumberOfParametersPerDimension(void) const
+  -> NumberOfParametersType
 {
   // The number of parameters per dimension equal number of
   // of pixels in the grid region.
@@ -432,8 +434,8 @@ AdvancedBSplineDeformableTransformBase<TScalarType, NDimensions>::SetParametersB
 
 // Get the parameters
 template <class TScalarType, unsigned int NDimensions>
-const typename AdvancedBSplineDeformableTransformBase<TScalarType, NDimensions>::ParametersType &
-AdvancedBSplineDeformableTransformBase<TScalarType, NDimensions>::GetParameters(void) const
+auto
+AdvancedBSplineDeformableTransformBase<TScalarType, NDimensions>::GetParameters(void) const -> const ParametersType &
 {
   /** NOTE: For efficiency, this class does not keep a copy of the parameters -
    * it just keeps pointer to input parameters.
@@ -449,8 +451,9 @@ AdvancedBSplineDeformableTransformBase<TScalarType, NDimensions>::GetParameters(
 
 // Get the parameters
 template <class TScalarType, unsigned int NDimensions>
-const typename AdvancedBSplineDeformableTransformBase<TScalarType, NDimensions>::FixedParametersType &
+auto
 AdvancedBSplineDeformableTransformBase<TScalarType, NDimensions>::GetFixedParameters(void) const
+  -> const FixedParametersType &
 {
   RegionType resRegion = this->GetGridRegion();
 

--- a/Common/Transforms/itkAdvancedCombinationTransform.hxx
+++ b/Common/Transforms/itkAdvancedCombinationTransform.hxx
@@ -47,8 +47,8 @@ AdvancedCombinationTransform<TScalarType, NDimensions>::AdvancedCombinationTrans
  */
 
 template <typename TScalarType, unsigned int NDimensions>
-typename AdvancedCombinationTransform<TScalarType, NDimensions>::NumberOfParametersType
-AdvancedCombinationTransform<TScalarType, NDimensions>::GetNumberOfParameters(void) const
+auto
+AdvancedCombinationTransform<TScalarType, NDimensions>::GetNumberOfParameters(void) const -> NumberOfParametersType
 {
   /** Return the number of parameters that completely define
    * the m_CurrentTransform.
@@ -103,8 +103,9 @@ AdvancedCombinationTransform<TScalarType, NDimensions>::GetNumberOfTransforms(vo
  */
 
 template <typename TScalarType, unsigned int NDimensions>
-const typename AdvancedCombinationTransform<TScalarType, NDimensions>::TransformTypePointer
+auto
 AdvancedCombinationTransform<TScalarType, NDimensions>::GetNthTransform(SizeValueType n) const
+  -> const TransformTypePointer
 {
   const SizeValueType numTransforms = GetNumberOfTransforms();
   if (n > numTransforms - 1)
@@ -150,8 +151,9 @@ AdvancedCombinationTransform<TScalarType, NDimensions>::GetNthTransform(SizeValu
  */
 
 template <typename TScalarType, unsigned int NDimensions>
-typename AdvancedCombinationTransform<TScalarType, NDimensions>::NumberOfParametersType
+auto
 AdvancedCombinationTransform<TScalarType, NDimensions>::GetNumberOfNonZeroJacobianIndices(void) const
+  -> NumberOfParametersType
 {
   /** Return the number of parameters that completely define
    * the m_CurrentTransform.
@@ -189,8 +191,8 @@ AdvancedCombinationTransform<TScalarType, NDimensions>::IsLinear(void) const
  */
 
 template <typename TScalarType, unsigned int NDimensions>
-typename AdvancedCombinationTransform<TScalarType, NDimensions>::TransformCategoryEnum
-AdvancedCombinationTransform<TScalarType, NDimensions>::GetTransformCategory() const
+auto
+AdvancedCombinationTransform<TScalarType, NDimensions>::GetTransformCategory() const -> TransformCategoryEnum
 {
   // Check if all linear
   if (this->IsLinear())
@@ -209,8 +211,8 @@ AdvancedCombinationTransform<TScalarType, NDimensions>::GetTransformCategory() c
  */
 
 template <typename TScalarType, unsigned int NDimensions>
-const typename AdvancedCombinationTransform<TScalarType, NDimensions>::ParametersType &
-AdvancedCombinationTransform<TScalarType, NDimensions>::GetParameters(void) const
+auto
+AdvancedCombinationTransform<TScalarType, NDimensions>::GetParameters(void) const -> const ParametersType &
 {
   /** Return the parameters that completely define the m_CurrentTransform. */
   if (this->m_CurrentTransform.IsNotNull())
@@ -230,8 +232,8 @@ AdvancedCombinationTransform<TScalarType, NDimensions>::GetParameters(void) cons
  */
 
 template <typename TScalarType, unsigned int NDimensions>
-const typename AdvancedCombinationTransform<TScalarType, NDimensions>::FixedParametersType &
-AdvancedCombinationTransform<TScalarType, NDimensions>::GetFixedParameters(void) const
+auto
+AdvancedCombinationTransform<TScalarType, NDimensions>::GetFixedParameters(void) const -> const FixedParametersType &
 {
   /** Return the fixed parameters that define the m_CurrentTransform. */
   if (this->m_CurrentTransform.IsNotNull())
@@ -638,8 +640,9 @@ AdvancedCombinationTransform<TScalarType, NDimensions>::UpdateCombinationMethod(
  */
 
 template <typename TScalarType, unsigned int NDimensions>
-typename AdvancedCombinationTransform<TScalarType, NDimensions>::OutputPointType
+auto
 AdvancedCombinationTransform<TScalarType, NDimensions>::TransformPointUseAddition(const InputPointType & point) const
+  -> OutputPointType
 {
   /** The Initial transform. */
   OutputPointType out0 = this->m_InitialTransform->TransformPoint(point);
@@ -663,8 +666,9 @@ AdvancedCombinationTransform<TScalarType, NDimensions>::TransformPointUseAdditio
  */
 
 template <typename TScalarType, unsigned int NDimensions>
-typename AdvancedCombinationTransform<TScalarType, NDimensions>::OutputPointType
+auto
 AdvancedCombinationTransform<TScalarType, NDimensions>::TransformPointUseComposition(const InputPointType & point) const
+  -> OutputPointType
 {
   return this->m_CurrentTransform->TransformPoint(this->m_InitialTransform->TransformPoint(point));
 
@@ -676,9 +680,9 @@ AdvancedCombinationTransform<TScalarType, NDimensions>::TransformPointUseComposi
  */
 
 template <typename TScalarType, unsigned int NDimensions>
-typename AdvancedCombinationTransform<TScalarType, NDimensions>::OutputPointType
+auto
 AdvancedCombinationTransform<TScalarType, NDimensions>::TransformPointNoInitialTransform(
-  const InputPointType & point) const
+  const InputPointType & point) const -> OutputPointType
 {
   return this->m_CurrentTransform->TransformPoint(point);
 
@@ -690,9 +694,9 @@ AdvancedCombinationTransform<TScalarType, NDimensions>::TransformPointNoInitialT
  */
 
 template <typename TScalarType, unsigned int NDimensions>
-typename AdvancedCombinationTransform<TScalarType, NDimensions>::OutputPointType
+auto
 AdvancedCombinationTransform<TScalarType, NDimensions>::TransformPointNoCurrentTransform(
-  const InputPointType & point) const
+  const InputPointType & point) const -> OutputPointType
 {
   /** Throw an exception. */
   itkExceptionMacro(<< NoCurrentTransformSet);
@@ -1411,8 +1415,9 @@ AdvancedCombinationTransform<TScalarType, NDimensions>::GetJacobianOfSpatialHess
  */
 
 template <typename TScalarType, unsigned int NDimensions>
-typename AdvancedCombinationTransform<TScalarType, NDimensions>::OutputPointType
+auto
 AdvancedCombinationTransform<TScalarType, NDimensions>::TransformPoint(const InputPointType & point) const
+  -> OutputPointType
 {
   /** Call the selected TransformPoint. */
   return ((*this).*m_SelectedTransformPointFunction)(point);

--- a/Common/Transforms/itkAdvancedEuler3DTransform.hxx
+++ b/Common/Transforms/itkAdvancedEuler3DTransform.hxx
@@ -121,8 +121,8 @@ AdvancedEuler3DTransform<TScalarType>::SetParameters(const ParametersType & para
 
 // Get Parameters
 template <class TScalarType>
-const typename AdvancedEuler3DTransform<TScalarType>::ParametersType &
-AdvancedEuler3DTransform<TScalarType>::GetParameters(void) const
+auto
+AdvancedEuler3DTransform<TScalarType>::GetParameters(void) const -> const ParametersType &
 {
   this->m_Parameters[0] = m_AngleX;
   this->m_Parameters[1] = m_AngleY;

--- a/Common/Transforms/itkAdvancedImageMomentsCalculator.hxx
+++ b/Common/Transforms/itkAdvancedImageMomentsCalculator.hxx
@@ -444,8 +444,8 @@ AdvancedImageMomentsCalculator<TImage>::DoPostProcessing()
 //---------------------------------------------------------------------
 // Get sum of intensities
 template <typename TImage>
-typename AdvancedImageMomentsCalculator<TImage>::ScalarType
-AdvancedImageMomentsCalculator<TImage>::GetTotalMass() const
+auto
+AdvancedImageMomentsCalculator<TImage>::GetTotalMass() const -> ScalarType
 {
   if (!m_Valid)
   {
@@ -457,8 +457,8 @@ AdvancedImageMomentsCalculator<TImage>::GetTotalMass() const
 //--------------------------------------------------------------------
 // Get first moments about origin, in index coordinates
 template <typename TImage>
-typename AdvancedImageMomentsCalculator<TImage>::VectorType
-AdvancedImageMomentsCalculator<TImage>::GetFirstMoments() const
+auto
+AdvancedImageMomentsCalculator<TImage>::GetFirstMoments() const -> VectorType
 {
   if (!m_Valid)
   {
@@ -470,8 +470,8 @@ AdvancedImageMomentsCalculator<TImage>::GetFirstMoments() const
 //--------------------------------------------------------------------
 // Get second moments about origin, in index coordinates
 template <typename TImage>
-typename AdvancedImageMomentsCalculator<TImage>::MatrixType
-AdvancedImageMomentsCalculator<TImage>::GetSecondMoments() const
+auto
+AdvancedImageMomentsCalculator<TImage>::GetSecondMoments() const -> MatrixType
 {
   if (!m_Valid)
   {
@@ -483,8 +483,8 @@ AdvancedImageMomentsCalculator<TImage>::GetSecondMoments() const
 //--------------------------------------------------------------------
 // Get center of gravity, in physical coordinates
 template <typename TImage>
-typename AdvancedImageMomentsCalculator<TImage>::VectorType
-AdvancedImageMomentsCalculator<TImage>::GetCenterOfGravity() const
+auto
+AdvancedImageMomentsCalculator<TImage>::GetCenterOfGravity() const -> VectorType
 {
   if (!m_Valid)
   {
@@ -496,8 +496,8 @@ AdvancedImageMomentsCalculator<TImage>::GetCenterOfGravity() const
 //--------------------------------------------------------------------
 // Get second central moments, in physical coordinates
 template <typename TImage>
-typename AdvancedImageMomentsCalculator<TImage>::MatrixType
-AdvancedImageMomentsCalculator<TImage>::GetCentralMoments() const
+auto
+AdvancedImageMomentsCalculator<TImage>::GetCentralMoments() const -> MatrixType
 {
   if (!m_Valid)
   {
@@ -509,8 +509,8 @@ AdvancedImageMomentsCalculator<TImage>::GetCentralMoments() const
 //--------------------------------------------------------------------
 // Get principal moments, in physical coordinates
 template <typename TImage>
-typename AdvancedImageMomentsCalculator<TImage>::VectorType
-AdvancedImageMomentsCalculator<TImage>::GetPrincipalMoments() const
+auto
+AdvancedImageMomentsCalculator<TImage>::GetPrincipalMoments() const -> VectorType
 {
   if (!m_Valid)
   {
@@ -523,8 +523,8 @@ AdvancedImageMomentsCalculator<TImage>::GetPrincipalMoments() const
 //--------------------------------------------------------------------
 // Get principal axes, in physical coordinates
 template <typename TImage>
-typename AdvancedImageMomentsCalculator<TImage>::MatrixType
-AdvancedImageMomentsCalculator<TImage>::GetPrincipalAxes() const
+auto
+AdvancedImageMomentsCalculator<TImage>::GetPrincipalAxes() const -> MatrixType
 {
   if (!m_Valid)
   {
@@ -536,8 +536,8 @@ AdvancedImageMomentsCalculator<TImage>::GetPrincipalAxes() const
 //--------------------------------------------------------------------
 // Get principal axes to physical axes transform
 template <typename TImage>
-typename AdvancedImageMomentsCalculator<TImage>::AffineTransformPointer
-AdvancedImageMomentsCalculator<TImage>::GetPrincipalAxesToPhysicalAxesTransform(void) const
+auto
+AdvancedImageMomentsCalculator<TImage>::GetPrincipalAxesToPhysicalAxesTransform(void) const -> AffineTransformPointer
 {
   typename AffineTransformType::MatrixType matrix;
   typename AffineTransformType::OffsetType offset;
@@ -562,8 +562,8 @@ AdvancedImageMomentsCalculator<TImage>::GetPrincipalAxesToPhysicalAxesTransform(
 // Get physical axes to principal axes transform
 
 template <typename TImage>
-typename AdvancedImageMomentsCalculator<TImage>::AffineTransformPointer
-AdvancedImageMomentsCalculator<TImage>::GetPhysicalAxesToPrincipalAxesTransform(void) const
+auto
+AdvancedImageMomentsCalculator<TImage>::GetPhysicalAxesToPrincipalAxesTransform(void) const -> AffineTransformPointer
 {
   typename AffineTransformType::MatrixType matrix;
   typename AffineTransformType::OffsetType offset;

--- a/Common/Transforms/itkAdvancedMatrixOffsetTransformBase.hxx
+++ b/Common/Transforms/itkAdvancedMatrixOffsetTransformBase.hxx
@@ -244,9 +244,9 @@ AdvancedMatrixOffsetTransformBase<TScalarType, NInputDimensions, NOutputDimensio
 
 // Transform a point
 template <class TScalarType, unsigned int NInputDimensions, unsigned int NOutputDimensions>
-typename AdvancedMatrixOffsetTransformBase<TScalarType, NInputDimensions, NOutputDimensions>::OutputPointType
+auto
 AdvancedMatrixOffsetTransformBase<TScalarType, NInputDimensions, NOutputDimensions>::TransformPoint(
-  const InputPointType & point) const
+  const InputPointType & point) const -> OutputPointType
 {
   return m_Matrix * point + m_Offset;
 }
@@ -254,9 +254,9 @@ AdvancedMatrixOffsetTransformBase<TScalarType, NInputDimensions, NOutputDimensio
 
 // Transform a vector
 template <class TScalarType, unsigned int NInputDimensions, unsigned int NOutputDimensions>
-typename AdvancedMatrixOffsetTransformBase<TScalarType, NInputDimensions, NOutputDimensions>::OutputVectorType
+auto
 AdvancedMatrixOffsetTransformBase<TScalarType, NInputDimensions, NOutputDimensions>::TransformVector(
-  const InputVectorType & vect) const
+  const InputVectorType & vect) const -> OutputVectorType
 {
   return m_Matrix * vect;
 }
@@ -264,9 +264,9 @@ AdvancedMatrixOffsetTransformBase<TScalarType, NInputDimensions, NOutputDimensio
 
 // Transform a vnl_vector_fixed
 template <class TScalarType, unsigned int NInputDimensions, unsigned int NOutputDimensions>
-typename AdvancedMatrixOffsetTransformBase<TScalarType, NInputDimensions, NOutputDimensions>::OutputVnlVectorType
+auto
 AdvancedMatrixOffsetTransformBase<TScalarType, NInputDimensions, NOutputDimensions>::TransformVector(
-  const InputVnlVectorType & vect) const
+  const InputVnlVectorType & vect) const -> OutputVnlVectorType
 {
   return m_Matrix * vect;
 }
@@ -274,9 +274,9 @@ AdvancedMatrixOffsetTransformBase<TScalarType, NInputDimensions, NOutputDimensio
 
 // Transform a CovariantVector
 template <class TScalarType, unsigned int NInputDimensions, unsigned int NOutputDimensions>
-typename AdvancedMatrixOffsetTransformBase<TScalarType, NInputDimensions, NOutputDimensions>::OutputCovariantVectorType
+auto
 AdvancedMatrixOffsetTransformBase<TScalarType, NInputDimensions, NOutputDimensions>::TransformCovariantVector(
-  const InputCovariantVectorType & vec) const
+  const InputCovariantVectorType & vec) const -> OutputCovariantVectorType
 {
   OutputCovariantVectorType result; // Converted vector
 
@@ -294,8 +294,9 @@ AdvancedMatrixOffsetTransformBase<TScalarType, NInputDimensions, NOutputDimensio
 
 // Recompute the inverse matrix (internal)
 template <class TScalarType, unsigned int NInputDimensions, unsigned int NOutputDimensions>
-const typename AdvancedMatrixOffsetTransformBase<TScalarType, NInputDimensions, NOutputDimensions>::InverseMatrixType &
+auto
 AdvancedMatrixOffsetTransformBase<TScalarType, NInputDimensions, NOutputDimensions>::GetInverseMatrix(void) const
+  -> const InverseMatrixType &
 {
   // If the transform has been modified we recompute the inverse
   if (m_InverseMatrixMTime != m_MatrixMTime)
@@ -373,8 +374,9 @@ const typename AdvancedMatrixOffsetTransformBase<TScalarType, NInputDimensions, 
 
 // Get parameters
 template <class TScalarType, unsigned int NInputDimensions, unsigned int NOutputDimensions>
-const typename AdvancedMatrixOffsetTransformBase<TScalarType, NInputDimensions, NOutputDimensions>::ParametersType &
+auto
 AdvancedMatrixOffsetTransformBase<TScalarType, NInputDimensions, NOutputDimensions>::GetParameters(void) const
+  -> const ParametersType &
 {
   // Transfer the linear part
   unsigned int par = 0;

--- a/Common/Transforms/itkAdvancedRigid2DTransform.hxx
+++ b/Common/Transforms/itkAdvancedRigid2DTransform.hxx
@@ -258,8 +258,8 @@ AdvancedRigid2DTransform<TScalarType>::SetParameters(const ParametersType & para
 
 // Get Parameters
 template <class TScalarType>
-const typename AdvancedRigid2DTransform<TScalarType>::ParametersType &
-AdvancedRigid2DTransform<TScalarType>::GetParameters(void) const
+auto
+AdvancedRigid2DTransform<TScalarType>::GetParameters(void) const -> const ParametersType &
 {
   itkDebugMacro(<< "Getting parameters ");
 

--- a/Common/Transforms/itkAdvancedRigid3DTransform.hxx
+++ b/Common/Transforms/itkAdvancedRigid3DTransform.hxx
@@ -161,8 +161,8 @@ AdvancedRigid3DTransform<TScalarType>::Translate(const OffsetType & offset, bool
 
 // Back transform a point
 template <class TScalarType>
-typename AdvancedRigid3DTransform<TScalarType>::InputPointType
-AdvancedRigid3DTransform<TScalarType>::BackTransform(const OutputPointType & point) const
+auto
+AdvancedRigid3DTransform<TScalarType>::BackTransform(const OutputPointType & point) const -> InputPointType
 {
   itkWarningMacro(<< "BackTransform(): This method is slated to be removed from ITK.  Instead, please use GetInverse() "
                      "to generate an inverse transform and then perform the transform using that inverted transform.");
@@ -172,8 +172,8 @@ AdvancedRigid3DTransform<TScalarType>::BackTransform(const OutputPointType & poi
 
 // Back transform a vector
 template <class TScalarType>
-typename AdvancedRigid3DTransform<TScalarType>::InputVectorType
-AdvancedRigid3DTransform<TScalarType>::BackTransform(const OutputVectorType & vect) const
+auto
+AdvancedRigid3DTransform<TScalarType>::BackTransform(const OutputVectorType & vect) const -> InputVectorType
 {
   itkWarningMacro(<< "BackTransform(): This method is slated to be removed from ITK.  Instead, please use GetInverse() "
                      "to generate an inverse transform and then perform the transform using that inverted transform.");
@@ -183,8 +183,8 @@ AdvancedRigid3DTransform<TScalarType>::BackTransform(const OutputVectorType & ve
 
 // Back transform a vnl_vector
 template <class TScalarType>
-typename AdvancedRigid3DTransform<TScalarType>::InputVnlVectorType
-AdvancedRigid3DTransform<TScalarType>::BackTransform(const OutputVnlVectorType & vect) const
+auto
+AdvancedRigid3DTransform<TScalarType>::BackTransform(const OutputVnlVectorType & vect) const -> InputVnlVectorType
 {
   itkWarningMacro(<< "BackTransform(): This method is slated to be removed from ITK.  Instead, please use GetInverse() "
                      "to generate an inverse transform and then perform the transform using that inverted transform.");
@@ -194,8 +194,9 @@ AdvancedRigid3DTransform<TScalarType>::BackTransform(const OutputVnlVectorType &
 
 // Back Transform a CovariantVector
 template <class TScalarType>
-typename AdvancedRigid3DTransform<TScalarType>::InputCovariantVectorType
+auto
 AdvancedRigid3DTransform<TScalarType>::BackTransform(const OutputCovariantVectorType & vect) const
+  -> InputCovariantVectorType
 {
   itkWarningMacro(<< "BackTransform(): This method is slated to be removed from ITK.  Instead, please use GetInverse() "
                      "to generate an inverse transform and then perform the transform using that inverted transform.");

--- a/Common/Transforms/itkAdvancedSimilarity2DTransform.hxx
+++ b/Common/Transforms/itkAdvancedSimilarity2DTransform.hxx
@@ -95,8 +95,8 @@ AdvancedSimilarity2DTransform<TScalarType>::SetParameters(const ParametersType &
 
 // Get Parameters
 template <class TScalarType>
-const typename AdvancedSimilarity2DTransform<TScalarType>::ParametersType &
-AdvancedSimilarity2DTransform<TScalarType>::GetParameters(void) const
+auto
+AdvancedSimilarity2DTransform<TScalarType>::GetParameters(void) const -> const ParametersType &
 {
   itkDebugMacro(<< "Getting parameters ");
 

--- a/Common/Transforms/itkAdvancedSimilarity3DTransform.hxx
+++ b/Common/Transforms/itkAdvancedSimilarity3DTransform.hxx
@@ -187,8 +187,8 @@ AdvancedSimilarity3DTransform<TScalarType>::SetParameters(const ParametersType &
 //
 
 template <class TScalarType>
-const typename AdvancedSimilarity3DTransform<TScalarType>::ParametersType &
-AdvancedSimilarity3DTransform<TScalarType>::GetParameters(void) const
+auto
+AdvancedSimilarity3DTransform<TScalarType>::GetParameters(void) const -> const ParametersType &
 {
   itkDebugMacro(<< "Getting parameters ");
 

--- a/Common/Transforms/itkAdvancedTransform.hxx
+++ b/Common/Transforms/itkAdvancedTransform.hxx
@@ -111,8 +111,9 @@ AdvancedTransform<TScalarType, NInputDimensions, NOutputDimensions>::EvaluateJac
  */
 
 template <class TScalarType, unsigned int NInputDimensions, unsigned int NOutputDimensions>
-typename AdvancedTransform<TScalarType, NInputDimensions, NOutputDimensions>::NumberOfParametersType
+auto
 AdvancedTransform<TScalarType, NInputDimensions, NOutputDimensions>::GetNumberOfNonZeroJacobianIndices(void) const
+  -> NumberOfParametersType
 {
   return this->GetNumberOfParameters();
 

--- a/Common/Transforms/itkAdvancedTranslationTransform.hxx
+++ b/Common/Transforms/itkAdvancedTranslationTransform.hxx
@@ -108,8 +108,8 @@ AdvancedTranslationTransform<TScalarType, NDimensions>::SetParameters(const Para
 
 // Get the parameters
 template <class TScalarType, unsigned int NDimensions>
-const typename AdvancedTranslationTransform<TScalarType, NDimensions>::ParametersType &
-AdvancedTranslationTransform<TScalarType, NDimensions>::GetParameters(void) const
+auto
+AdvancedTranslationTransform<TScalarType, NDimensions>::GetParameters(void) const -> const ParametersType &
 {
   for (unsigned int i = 0; i < SpaceDimension; ++i)
   {
@@ -156,8 +156,9 @@ AdvancedTranslationTransform<TScalarType, NDimensions>::Translate(const OutputVe
 
 // Transform a point
 template <class TScalarType, unsigned int NDimensions>
-typename AdvancedTranslationTransform<TScalarType, NDimensions>::OutputPointType
+auto
 AdvancedTranslationTransform<TScalarType, NDimensions>::TransformPoint(const InputPointType & point) const
+  -> OutputPointType
 {
   return point + m_Offset;
 }
@@ -165,8 +166,9 @@ AdvancedTranslationTransform<TScalarType, NDimensions>::TransformPoint(const Inp
 
 // Transform a vector
 template <class TScalarType, unsigned int NDimensions>
-typename AdvancedTranslationTransform<TScalarType, NDimensions>::OutputVectorType
+auto
 AdvancedTranslationTransform<TScalarType, NDimensions>::TransformVector(const InputVectorType & vect) const
+  -> OutputVectorType
 {
   return vect;
 }
@@ -174,8 +176,9 @@ AdvancedTranslationTransform<TScalarType, NDimensions>::TransformVector(const In
 
 // Transform a vnl_vector_fixed
 template <class TScalarType, unsigned int NDimensions>
-typename AdvancedTranslationTransform<TScalarType, NDimensions>::OutputVnlVectorType
+auto
 AdvancedTranslationTransform<TScalarType, NDimensions>::TransformVector(const InputVnlVectorType & vect) const
+  -> OutputVnlVectorType
 {
   return vect;
 }
@@ -183,9 +186,9 @@ AdvancedTranslationTransform<TScalarType, NDimensions>::TransformVector(const In
 
 // Transform a CovariantVector
 template <class TScalarType, unsigned int NDimensions>
-typename AdvancedTranslationTransform<TScalarType, NDimensions>::OutputCovariantVectorType
+auto
 AdvancedTranslationTransform<TScalarType, NDimensions>::TransformCovariantVector(
-  const InputCovariantVectorType & vect) const
+  const InputCovariantVectorType & vect) const -> OutputCovariantVectorType
 {
   return vect;
 }

--- a/Common/Transforms/itkAdvancedVersorRigid3DTransform.hxx
+++ b/Common/Transforms/itkAdvancedVersorRigid3DTransform.hxx
@@ -120,8 +120,8 @@ AdvancedVersorRigid3DTransform<TScalarType>::SetParameters(const ParametersType 
 //
 
 template <class TScalarType>
-const typename AdvancedVersorRigid3DTransform<TScalarType>::ParametersType &
-AdvancedVersorRigid3DTransform<TScalarType>::GetParameters(void) const
+auto
+AdvancedVersorRigid3DTransform<TScalarType>::GetParameters(void) const -> const ParametersType &
 {
   itkDebugMacro(<< "Getting parameters ");
 

--- a/Common/Transforms/itkAdvancedVersorTransform.hxx
+++ b/Common/Transforms/itkAdvancedVersorTransform.hxx
@@ -98,8 +98,8 @@ AdvancedVersorTransform<TScalarType>::SetParameters(const ParametersType & param
 
 /** Set Parameters */
 template <class TScalarType>
-const typename AdvancedVersorTransform<TScalarType>::ParametersType &
-AdvancedVersorTransform<TScalarType>::GetParameters(void) const
+auto
+AdvancedVersorTransform<TScalarType>::GetParameters(void) const -> const ParametersType &
 {
   this->m_Parameters[0] = this->m_Versor.GetRight()[0];
   this->m_Parameters[1] = this->m_Versor.GetRight()[1];

--- a/Common/Transforms/itkBSplineInterpolationWeightFunctionBase.hxx
+++ b/Common/Transforms/itkBSplineInterpolationWeightFunctionBase.hxx
@@ -145,9 +145,9 @@ BSplineInterpolationWeightFunctionBase<TCoordRep, VSpaceDimension, VSplineOrder>
  */
 
 template <class TCoordRep, unsigned int VSpaceDimension, unsigned int VSplineOrder>
-typename BSplineInterpolationWeightFunctionBase<TCoordRep, VSpaceDimension, VSplineOrder>::WeightsType
+auto
 BSplineInterpolationWeightFunctionBase<TCoordRep, VSpaceDimension, VSplineOrder>::Evaluate(
-  const ContinuousIndexType & cindex) const
+  const ContinuousIndexType & cindex) const -> WeightsType
 {
   /** Construct arguments for the Evaluate function that really does the work. */
   WeightsType weights(this->m_NumberOfWeights);

--- a/Common/Transforms/itkRecursiveBSplineTransform.hxx
+++ b/Common/Transforms/itkRecursiveBSplineTransform.hxx
@@ -46,8 +46,9 @@ RecursiveBSplineTransform<TScalar, NDimensions, VSplineOrder>::RecursiveBSplineT
  */
 
 template <typename TScalar, unsigned int NDimensions, unsigned int VSplineOrder>
-typename RecursiveBSplineTransform<TScalar, NDimensions, VSplineOrder>::OutputPointType
+auto
 RecursiveBSplineTransform<TScalar, NDimensions, VSplineOrder>::TransformPoint(const InputPointType & point) const
+  -> OutputPointType
 {
   /** Define some constants. */
   const unsigned int numberOfWeights = RecursiveBSplineWeightFunctionType::NumberOfWeights;

--- a/Common/Transforms/itkStackTransform.hxx
+++ b/Common/Transforms/itkStackTransform.hxx
@@ -67,8 +67,8 @@ StackTransform<TScalarType, NInputDimensions, NOutputDimensions>::SetParameters(
  */
 
 template <class TScalarType, unsigned int NInputDimensions, unsigned int NOutputDimensions>
-const typename StackTransform<TScalarType, NInputDimensions, NOutputDimensions>::ParametersType &
-StackTransform<TScalarType, NInputDimensions, NOutputDimensions>::GetParameters(void) const
+auto
+StackTransform<TScalarType, NInputDimensions, NOutputDimensions>::GetParameters(void) const -> const ParametersType &
 {
   this->m_Parameters.SetSize(this->GetNumberOfParameters());
 
@@ -92,8 +92,9 @@ StackTransform<TScalarType, NInputDimensions, NOutputDimensions>::GetParameters(
  */
 
 template <class TScalarType, unsigned int NInputDimensions, unsigned int NOutputDimensions>
-typename StackTransform<TScalarType, NInputDimensions, NOutputDimensions>::OutputPointType
+auto
 StackTransform<TScalarType, NInputDimensions, NOutputDimensions>::TransformPoint(const InputPointType & ipp) const
+  -> OutputPointType
 {
   /** Reduce dimension of input point. */
   SubTransformInputPointType ippr;
@@ -173,8 +174,9 @@ StackTransform<TScalarType, NInputDimensions, NOutputDimensions>::GetJacobian(co
  */
 
 template <class TScalarType, unsigned int NInputDimensions, unsigned int NOutputDimensions>
-typename StackTransform<TScalarType, NInputDimensions, NOutputDimensions>::NumberOfParametersType
+auto
 StackTransform<TScalarType, NInputDimensions, NOutputDimensions>::GetNumberOfNonZeroJacobianIndices(void) const
+  -> NumberOfParametersType
 {
   return this->m_SubTransformContainer[0]->GetNumberOfNonZeroJacobianIndices();
 

--- a/Common/Transforms/itkTransformToDeterminantOfSpatialJacobianSource.hxx
+++ b/Common/Transforms/itkTransformToDeterminantOfSpatialJacobianSource.hxx
@@ -108,8 +108,9 @@ TransformToDeterminantOfSpatialJacobianSource<TOutputImage, TTransformPrecisionT
  * Get the output image size.
  */
 template <class TOutputImage, class TTransformPrecisionType>
-const typename TransformToDeterminantOfSpatialJacobianSource<TOutputImage, TTransformPrecisionType>::SizeType &
+auto
 TransformToDeterminantOfSpatialJacobianSource<TOutputImage, TTransformPrecisionType>::GetOutputSize()
+  -> const SizeType &
 {
   return this->m_OutputRegion.GetSize();
 }
@@ -130,8 +131,9 @@ TransformToDeterminantOfSpatialJacobianSource<TOutputImage, TTransformPrecisionT
  * Get the output image index.
  */
 template <class TOutputImage, class TTransformPrecisionType>
-const typename TransformToDeterminantOfSpatialJacobianSource<TOutputImage, TTransformPrecisionType>::IndexType &
+auto
 TransformToDeterminantOfSpatialJacobianSource<TOutputImage, TTransformPrecisionType>::GetOutputIndex()
+  -> const IndexType &
 {
   return this->m_OutputRegion.GetIndex();
 }

--- a/Common/Transforms/itkTransformToSpatialJacobianSource.hxx
+++ b/Common/Transforms/itkTransformToSpatialJacobianSource.hxx
@@ -101,8 +101,8 @@ TransformToSpatialJacobianSource<TOutputImage, TTransformPrecisionType>::SetOutp
  * Get the output image size.
  */
 template <class TOutputImage, class TTransformPrecisionType>
-const typename TransformToSpatialJacobianSource<TOutputImage, TTransformPrecisionType>::SizeType &
-TransformToSpatialJacobianSource<TOutputImage, TTransformPrecisionType>::GetOutputSize()
+auto
+TransformToSpatialJacobianSource<TOutputImage, TTransformPrecisionType>::GetOutputSize() -> const SizeType &
 {
   return this->m_OutputRegion.GetSize();
 }
@@ -122,8 +122,8 @@ TransformToSpatialJacobianSource<TOutputImage, TTransformPrecisionType>::SetOutp
  * Get the output image index.
  */
 template <class TOutputImage, class TTransformPrecisionType>
-const typename TransformToSpatialJacobianSource<TOutputImage, TTransformPrecisionType>::IndexType &
-TransformToSpatialJacobianSource<TOutputImage, TTransformPrecisionType>::GetOutputIndex()
+auto
+TransformToSpatialJacobianSource<TOutputImage, TTransformPrecisionType>::GetOutputIndex() -> const IndexType &
 {
   return this->m_OutputRegion.GetIndex();
 }

--- a/Common/itkAdvancedRayCastInterpolateImageFunction.hxx
+++ b/Common/itkAdvancedRayCastInterpolateImageFunction.hxx
@@ -1516,8 +1516,8 @@ AdvancedRayCastInterpolateImageFunction<TInputImage, TCoordRep>::PrintSelf(std::
    ----------------------------------------------------------------------- */
 
 template <class TInputImage, class TCoordRep>
-typename AdvancedRayCastInterpolateImageFunction<TInputImage, TCoordRep>::OutputType
-AdvancedRayCastInterpolateImageFunction<TInputImage, TCoordRep>::Evaluate(const PointType & point) const
+auto
+AdvancedRayCastInterpolateImageFunction<TInputImage, TCoordRep>::Evaluate(const PointType & point) const -> OutputType
 {
   double integral = 0;
 
@@ -1538,9 +1538,9 @@ AdvancedRayCastInterpolateImageFunction<TInputImage, TCoordRep>::Evaluate(const 
 
 
 template <class TInputImage, class TCoordRep>
-typename AdvancedRayCastInterpolateImageFunction<TInputImage, TCoordRep>::OutputType
+auto
 AdvancedRayCastInterpolateImageFunction<TInputImage, TCoordRep>::EvaluateAtContinuousIndex(
-  const ContinuousIndexType & index) const
+  const ContinuousIndexType & index) const -> OutputType
 {
   OutputPointType point;
   this->m_Image->TransformContinuousIndexToPhysicalPoint(index, point);

--- a/Common/itkMultiResolutionImageRegistrationMethod2.hxx
+++ b/Common/itkMultiResolutionImageRegistrationMethod2.hxx
@@ -453,8 +453,8 @@ MultiResolutionImageRegistrationMethod2<TFixedImage, TMovingImage>::GetMTime(voi
  *  Get Output
  */
 template <typename TFixedImage, typename TMovingImage>
-const typename MultiResolutionImageRegistrationMethod2<TFixedImage, TMovingImage>::TransformOutputType *
-MultiResolutionImageRegistrationMethod2<TFixedImage, TMovingImage>::GetOutput() const
+auto
+MultiResolutionImageRegistrationMethod2<TFixedImage, TMovingImage>::GetOutput() const -> const TransformOutputType *
 {
   return static_cast<const TransformOutputType *>(this->ProcessObject::GetOutput(0));
 }

--- a/Common/itkNDImageBase.h
+++ b/Common/itkNDImageBase.h
@@ -263,8 +263,8 @@ namespace itk
 {
 
 template <class TPixel>
-typename NDImageBase<TPixel>::Pointer
-NDImageBase<TPixel>::NewNDImage(unsigned int dim)
+auto
+NDImageBase<TPixel>::NewNDImage(unsigned int dim) -> Pointer
 {
   switch (dim)
   {

--- a/Common/itkNDImageTemplate.hxx
+++ b/Common/itkNDImageTemplate.hxx
@@ -115,15 +115,15 @@ NDImageTemplate<TPixel, VDimension>::GetBufferPointer() const
 
 
 template <class TPixel, unsigned int VDimension>
-typename NDImageTemplate<TPixel, VDimension>::PixelContainer *
-NDImageTemplate<TPixel, VDimension>::GetPixelContainer()
+auto
+NDImageTemplate<TPixel, VDimension>::GetPixelContainer() -> PixelContainer *
 {
   return this->m_Image->GetPixelContainer();
 }
 
 template <class TPixel, unsigned int VDimension>
-const typename NDImageTemplate<TPixel, VDimension>::PixelContainer *
-NDImageTemplate<TPixel, VDimension>::GetPixelContainer() const
+auto
+NDImageTemplate<TPixel, VDimension>::GetPixelContainer() const -> const PixelContainer *
 {
   return this->m_Image->GetPixelContainer();
 }
@@ -137,16 +137,16 @@ NDImageTemplate<TPixel, VDimension>::SetPixelContainer(PixelContainer * containe
 
 
 template <class TPixel, unsigned int VDimension>
-typename NDImageTemplate<TPixel, VDimension>::AccessorType
-NDImageTemplate<TPixel, VDimension>::GetPixelAccessor(void)
+auto
+NDImageTemplate<TPixel, VDimension>::GetPixelAccessor(void) -> AccessorType
 {
   return this->m_Image->GetPixelAccessor();
 }
 
 
 template <class TPixel, unsigned int VDimension>
-const typename NDImageTemplate<TPixel, VDimension>::AccessorType
-NDImageTemplate<TPixel, VDimension>::GetPixelAccessor(void) const
+auto
+NDImageTemplate<TPixel, VDimension>::GetPixelAccessor(void) const -> const AccessorType
 {
   return this->m_Image->GetPixelAccessor();
 }
@@ -169,16 +169,16 @@ NDImageTemplate<TPixel, VDimension>::SetOrigin(const PointType & origin)
 
 
 template <class TPixel, unsigned int VDimension>
-typename NDImageTemplate<TPixel, VDimension>::SpacingType
-NDImageTemplate<TPixel, VDimension>::GetSpacing(void)
+auto
+NDImageTemplate<TPixel, VDimension>::GetSpacing(void) -> SpacingType
 {
   return ConvertToDynamicArray<SpacingTypeD, SpacingType>::DO(this->m_Image->GetSpacing());
 }
 
 
 template <class TPixel, unsigned int VDimension>
-typename NDImageTemplate<TPixel, VDimension>::PointType
-NDImageTemplate<TPixel, VDimension>::GetOrigin(void)
+auto
+NDImageTemplate<TPixel, VDimension>::GetOrigin(void) -> PointType
 {
   return ConvertToDynamicArray<PointTypeD, PointType>::DO(this->m_Image->GetOrigin());
 }
@@ -193,23 +193,23 @@ NDImageTemplate<TPixel, VDimension>::CopyInformation(const DataObject * data)
 
 
 template <class TPixel, unsigned int VDimension>
-const typename NDImageTemplate<TPixel, VDimension>::OffsetValueType *
-NDImageTemplate<TPixel, VDimension>::GetOffsetTable() const
+auto
+NDImageTemplate<TPixel, VDimension>::GetOffsetTable() const -> const OffsetValueType *
 {
   return this->m_Image->GetOffsetTable();
 }
 
 template <class TPixel, unsigned int VDimension>
-typename NDImageTemplate<TPixel, VDimension>::OffsetValueType
-NDImageTemplate<TPixel, VDimension>::ComputeOffset(const IndexType & ind) const
+auto
+NDImageTemplate<TPixel, VDimension>::ComputeOffset(const IndexType & ind) const -> OffsetValueType
 {
   return this->m_Image->ComputeOffset(ConvertToStaticArray<IndexType, IndexTypeD>::DO(ind));
 }
 
 
 template <class TPixel, unsigned int VDimension>
-typename NDImageTemplate<TPixel, VDimension>::IndexType
-NDImageTemplate<TPixel, VDimension>::ComputeIndex(OffsetValueType offset) const
+auto
+NDImageTemplate<TPixel, VDimension>::ComputeIndex(OffsetValueType offset) const -> IndexType
 {
   return ConvertToDynamicArray<IndexTypeD, IndexType>::DO(this->m_Image->ComputeIndex(offset));
 }

--- a/Common/itkRecursiveBSplineInterpolationWeightFunction.hxx
+++ b/Common/itkRecursiveBSplineInterpolationWeightFunction.hxx
@@ -74,9 +74,9 @@ RecursiveBSplineInterpolationWeightFunction<TCoordRep, VSpaceDimension, VSplineO
  */
 
 template <typename TCoordRep, unsigned int VSpaceDimension, unsigned int VSplineOrder>
-typename RecursiveBSplineInterpolationWeightFunction<TCoordRep, VSpaceDimension, VSplineOrder>::WeightsType
+auto
 RecursiveBSplineInterpolationWeightFunction<TCoordRep, VSpaceDimension, VSplineOrder>::Evaluate(
-  const ContinuousIndexType & index) const
+  const ContinuousIndexType & index) const -> WeightsType
 {
   WeightsType weights(this->m_NumberOfWeights);
   IndexType   startIndex;

--- a/Common/itkReducedDimensionBSplineInterpolateImageFunction.hxx
+++ b/Common/itkReducedDimensionBSplineInterpolateImageFunction.hxx
@@ -139,9 +139,9 @@ ReducedDimensionBSplineInterpolateImageFunction<TImageType, TCoordRep, TCoeffici
 
 
 template <class TImageType, class TCoordRep, class TCoefficientType>
-typename ReducedDimensionBSplineInterpolateImageFunction<TImageType, TCoordRep, TCoefficientType>::OutputType
+auto
 ReducedDimensionBSplineInterpolateImageFunction<TImageType, TCoordRep, TCoefficientType>::EvaluateAtContinuousIndex(
-  const ContinuousIndexType & x) const
+  const ContinuousIndexType & x) const -> OutputType
 {
   /** Allocate memory on the stack: */
   const unsigned int maxSplineOrder = 5;
@@ -188,9 +188,9 @@ ReducedDimensionBSplineInterpolateImageFunction<TImageType, TCoordRep, TCoeffici
 
 
 template <class TImageType, class TCoordRep, class TCoefficientType>
-typename ReducedDimensionBSplineInterpolateImageFunction<TImageType, TCoordRep, TCoefficientType>::CovariantVectorType
+auto
 ReducedDimensionBSplineInterpolateImageFunction<TImageType, TCoordRep, TCoefficientType>::
-  EvaluateDerivativeAtContinuousIndex(const ContinuousIndexType & x) const
+  EvaluateDerivativeAtContinuousIndex(const ContinuousIndexType & x) const -> CovariantVectorType
 {
   /** Allocate memory on the stack: */
   const unsigned int maxSplineOrder = 5;

--- a/Components/Metrics/AdvancedKappaStatistic/itkAdvancedKappaStatisticImageToImageMetric.hxx
+++ b/Components/Metrics/AdvancedKappaStatistic/itkAdvancedKappaStatisticImageToImageMetric.hxx
@@ -125,9 +125,9 @@ AdvancedKappaStatisticImageToImageMetric<TFixedImage, TMovingImage>::PrintSelf(s
  */
 
 template <class TFixedImage, class TMovingImage>
-typename AdvancedKappaStatisticImageToImageMetric<TFixedImage, TMovingImage>::MeasureType
+auto
 AdvancedKappaStatisticImageToImageMetric<TFixedImage, TMovingImage>::GetValue(
-  const TransformParametersType & parameters) const
+  const TransformParametersType & parameters) const -> MeasureType
 {
   itkDebugMacro("GetValue( " << parameters << " ) ");
 

--- a/Components/Metrics/AdvancedMattesMutualInformation/itkParzenWindowMutualInformationImageToImageMetric.hxx
+++ b/Components/Metrics/AdvancedMattesMutualInformation/itkParzenWindowMutualInformationImageToImageMetric.hxx
@@ -74,9 +74,9 @@ ParzenWindowMutualInformationImageToImageMetric<TFixedImage, TMovingImage>::Init
  */
 
 template <class TFixedImage, class TMovingImage>
-typename ParzenWindowMutualInformationImageToImageMetric<TFixedImage, TMovingImage>::MeasureType
+auto
 ParzenWindowMutualInformationImageToImageMetric<TFixedImage, TMovingImage>::GetValue(
-  const ParametersType & parameters) const
+  const ParametersType & parameters) const -> MeasureType
 {
   /** Construct the JointPDF and Alpha. */
   this->ComputePDFs(parameters);

--- a/Components/Metrics/AdvancedMeanSquares/itkAdvancedMeanSquaresImageToImageMetric.hxx
+++ b/Components/Metrics/AdvancedMeanSquares/itkAdvancedMeanSquaresImageToImageMetric.hxx
@@ -178,9 +178,9 @@ AdvancedMeanSquaresImageToImageMetric<TFixedImage, TMovingImage>::PrintSelf(std:
  */
 
 template <class TFixedImage, class TMovingImage>
-typename AdvancedMeanSquaresImageToImageMetric<TFixedImage, TMovingImage>::MeasureType
+auto
 AdvancedMeanSquaresImageToImageMetric<TFixedImage, TMovingImage>::GetValueSingleThreaded(
-  const TransformParametersType & parameters) const
+  const TransformParametersType & parameters) const -> MeasureType
 {
   /** Initialize some variables. */
   this->m_NumberOfPixelsCounted = 0;
@@ -271,9 +271,9 @@ AdvancedMeanSquaresImageToImageMetric<TFixedImage, TMovingImage>::GetValueSingle
  */
 
 template <class TFixedImage, class TMovingImage>
-typename AdvancedMeanSquaresImageToImageMetric<TFixedImage, TMovingImage>::MeasureType
+auto
 AdvancedMeanSquaresImageToImageMetric<TFixedImage, TMovingImage>::GetValue(
-  const TransformParametersType & parameters) const
+  const TransformParametersType & parameters) const -> MeasureType
 {
   /** Option for now to still use the single threaded code. */
   if (!this->m_UseMultiThread)

--- a/Components/Metrics/AdvancedNormalizedCorrelation/itkAdvancedNormalizedCorrelationImageToImageMetric.hxx
+++ b/Components/Metrics/AdvancedNormalizedCorrelation/itkAdvancedNormalizedCorrelationImageToImageMetric.hxx
@@ -181,9 +181,9 @@ AdvancedNormalizedCorrelationImageToImageMetric<TFixedImage, TMovingImage>::Upda
  */
 
 template <class TFixedImage, class TMovingImage>
-typename AdvancedNormalizedCorrelationImageToImageMetric<TFixedImage, TMovingImage>::MeasureType
+auto
 AdvancedNormalizedCorrelationImageToImageMetric<TFixedImage, TMovingImage>::GetValue(
-  const TransformParametersType & parameters) const
+  const TransformParametersType & parameters) const -> MeasureType
 {
   itkDebugMacro("GetValue( " << parameters << " ) ");
 

--- a/Components/Metrics/BendingEnergyPenalty/itkTransformBendingEnergyPenaltyTerm.hxx
+++ b/Components/Metrics/BendingEnergyPenalty/itkTransformBendingEnergyPenaltyTerm.hxx
@@ -49,8 +49,9 @@ TransformBendingEnergyPenaltyTerm<TFixedImage, TScalarType>::TransformBendingEne
  */
 
 template <class TFixedImage, class TScalarType>
-typename TransformBendingEnergyPenaltyTerm<TFixedImage, TScalarType>::MeasureType
+auto
 TransformBendingEnergyPenaltyTerm<TFixedImage, TScalarType>::GetValue(const ParametersType & parameters) const
+  -> MeasureType
 {
   /** Initialize some variables. */
   this->m_NumberOfPixelsCounted = 0;

--- a/Components/Metrics/CorrespondingPointsEuclideanDistanceMetric/itkCorrespondingPointsEuclideanDistancePointMetric.hxx
+++ b/Components/Metrics/CorrespondingPointsEuclideanDistanceMetric/itkCorrespondingPointsEuclideanDistancePointMetric.hxx
@@ -37,9 +37,9 @@ CorrespondingPointsEuclideanDistancePointMetric<TFixedPointSet,
  */
 
 template <class TFixedPointSet, class TMovingPointSet>
-typename CorrespondingPointsEuclideanDistancePointMetric<TFixedPointSet, TMovingPointSet>::MeasureType
+auto
 CorrespondingPointsEuclideanDistancePointMetric<TFixedPointSet, TMovingPointSet>::GetValue(
-  const TransformParametersType & parameters) const
+  const TransformParametersType & parameters) const -> MeasureType
 {
   /** Sanity checks. */
   FixedPointSetConstPointer fixedPointSet = this->GetFixedPointSet();

--- a/Components/Metrics/DisplacementMagnitudePenalty/itkDisplacementMagnitudePenaltyTerm.hxx
+++ b/Components/Metrics/DisplacementMagnitudePenalty/itkDisplacementMagnitudePenaltyTerm.hxx
@@ -61,8 +61,9 @@ DisplacementMagnitudePenaltyTerm< TFixedImage, TScalarType >
  */
 
 template <class TFixedImage, class TScalarType>
-typename DisplacementMagnitudePenaltyTerm<TFixedImage, TScalarType>::MeasureType
+auto
 DisplacementMagnitudePenaltyTerm<TFixedImage, TScalarType>::GetValue(const ParametersType & parameters) const
+  -> MeasureType
 {
   /** Initialize some variables. */
   this->m_NumberOfPixelsCounted = 0;

--- a/Components/Metrics/DistancePreservingRigidityPenalty/itkDistancePreservingRigidityPenaltyTerm.hxx
+++ b/Components/Metrics/DistancePreservingRigidityPenalty/itkDistancePreservingRigidityPenaltyTerm.hxx
@@ -161,8 +161,9 @@ DistancePreservingRigidityPenaltyTerm<TFixedImage, TScalarType>::Initialize(void
  */
 
 template <class TFixedImage, class TScalarType>
-typename DistancePreservingRigidityPenaltyTerm<TFixedImage, TScalarType>::MeasureType
+auto
 DistancePreservingRigidityPenaltyTerm<TFixedImage, TScalarType>::GetValue(const ParametersType & parameters) const
+  -> MeasureType
 {
   /** Set output values to zero. */
   this->m_RigidityPenaltyTermValue = NumericTraits<MeasureType>::Zero;

--- a/Components/Metrics/GradientDifference/itkGradientDifferenceImageToImageMetric2.hxx
+++ b/Components/Metrics/GradientDifference/itkGradientDifferenceImageToImageMetric2.hxx
@@ -336,10 +336,10 @@ GradientDifferenceImageToImageMetric<TFixedImage, TMovingImage>::ComputeVariance
  */
 
 template <class TFixedImage, class TMovingImage>
-typename GradientDifferenceImageToImageMetric<TFixedImage, TMovingImage>::MeasureType
+auto
 GradientDifferenceImageToImageMetric<TFixedImage, TMovingImage>::ComputeMeasure(
   const TransformParametersType & parameters,
-  const double *                  subtractionFactor) const
+  const double *                  subtractionFactor) const -> MeasureType
 {
   /** Call non-thread-safe stuff, such as:
    *   this->SetTransformParameters( parameters );
@@ -444,9 +444,9 @@ GradientDifferenceImageToImageMetric<TFixedImage, TMovingImage>::ComputeMeasure(
  */
 
 template <class TFixedImage, class TMovingImage>
-typename GradientDifferenceImageToImageMetric<TFixedImage, TMovingImage>::MeasureType
+auto
 GradientDifferenceImageToImageMetric<TFixedImage, TMovingImage>::GetValue(
-  const TransformParametersType & parameters) const
+  const TransformParametersType & parameters) const -> MeasureType
 {
   unsigned int iFilter;
   unsigned int iDimension;

--- a/Components/Metrics/KNNGraphAlphaMutualInformation/KNN/itkBinaryANNTreeSearchBase.hxx
+++ b/Components/Metrics/KNNGraphAlphaMutualInformation/KNN/itkBinaryANNTreeSearchBase.hxx
@@ -83,9 +83,9 @@ BinaryANNTreeSearchBase<TBinaryTree>::SetBinaryTree(BinaryTreeType * tree)
  *
 
 template < class TBinaryTree >
-  const typename BinaryANNTreeSearchBase<TBinaryTree>::BinaryTreeType *
+  auto
   BinaryANNTreeSearchBase<TBinaryTree>
-  ::GetBinaryTree( void ) const
+  ::GetBinaryTree( void ) const -> const BinaryTreeType *
 {
   return this->m_BinaryTree.GetPointer();
 } // end GetBinaryTree

--- a/Components/Metrics/KNNGraphAlphaMutualInformation/KNN/itkBinaryTreeBase.hxx
+++ b/Components/Metrics/KNNGraphAlphaMutualInformation/KNN/itkBinaryTreeBase.hxx
@@ -39,8 +39,8 @@ BinaryTreeBase<TListSample>::BinaryTreeBase()
  */
 
 template <class TListSample>
-typename BinaryTreeBase<TListSample>::TotalAbsoluteFrequencyType
-BinaryTreeBase<TListSample>::GetNumberOfDataPoints(void) const
+auto
+BinaryTreeBase<TListSample>::GetNumberOfDataPoints(void) const -> TotalAbsoluteFrequencyType
 {
   if (this->m_Sample)
   {
@@ -56,8 +56,8 @@ BinaryTreeBase<TListSample>::GetNumberOfDataPoints(void) const
  */
 
 template <class TListSample>
-typename BinaryTreeBase<TListSample>::TotalAbsoluteFrequencyType
-BinaryTreeBase<TListSample>::GetActualNumberOfDataPoints(void) const
+auto
+BinaryTreeBase<TListSample>::GetActualNumberOfDataPoints(void) const -> TotalAbsoluteFrequencyType
 {
   if (this->m_Sample)
   {
@@ -73,8 +73,8 @@ BinaryTreeBase<TListSample>::GetActualNumberOfDataPoints(void) const
  */
 
 template <class TListSample>
-typename BinaryTreeBase<TListSample>::MeasurementVectorSizeType
-BinaryTreeBase<TListSample>::GetDataDimension(void) const
+auto
+BinaryTreeBase<TListSample>::GetDataDimension(void) const -> MeasurementVectorSizeType
 {
   if (this->m_Sample)
   {

--- a/Components/Metrics/KNNGraphAlphaMutualInformation/KNN/itkBinaryTreeSearchBase.hxx
+++ b/Components/Metrics/KNNGraphAlphaMutualInformation/KNN/itkBinaryTreeSearchBase.hxx
@@ -67,8 +67,8 @@ BinaryTreeSearchBase<TBinaryTree>::SetBinaryTree(BinaryTreeType * tree)
  */
 
 template <class TBinaryTree>
-const typename BinaryTreeSearchBase<TBinaryTree>::BinaryTreeType *
-BinaryTreeSearchBase<TBinaryTree>::GetBinaryTree(void) const
+auto
+BinaryTreeSearchBase<TBinaryTree>::GetBinaryTree(void) const -> const BinaryTreeType *
 {
   return this->m_BinaryTree.GetPointer();
 } // end GetBinaryTree

--- a/Components/Metrics/KNNGraphAlphaMutualInformation/KNN/itkListSampleCArray.hxx
+++ b/Components/Metrics/KNNGraphAlphaMutualInformation/KNN/itkListSampleCArray.hxx
@@ -73,8 +73,9 @@ ListSampleCArray<TMeasurementVector, TInternalValue>::GetMeasurementVector(Insta
  */
 
 template <class TMeasurementVector, class TInternalValue>
-const typename ListSampleCArray<TMeasurementVector, TInternalValue>::MeasurementVectorType &
+auto
 ListSampleCArray<TMeasurementVector, TInternalValue>::GetMeasurementVector(InstanceIdentifier id) const
+  -> const MeasurementVectorType &
 {
   if (id < this->m_InternalContainerSize)
   {
@@ -236,8 +237,8 @@ ListSampleCArray<TMeasurementVector, TInternalValue>::DeallocateInternalContaine
  */
 
 template <class TMeasurementVector, class TInternalValue>
-typename ListSampleCArray<TMeasurementVector, TInternalValue>::AbsoluteFrequencyType
-ListSampleCArray<TMeasurementVector, TInternalValue>::GetFrequency(InstanceIdentifier id) const
+auto
+ListSampleCArray<TMeasurementVector, TInternalValue>::GetFrequency(InstanceIdentifier id) const -> AbsoluteFrequencyType
 {
   if (id < this->m_InternalContainerSize)
   {

--- a/Components/Metrics/KNNGraphAlphaMutualInformation/itkKNNGraphAlphaMutualInformationImageToImageMetric.hxx
+++ b/Components/Metrics/KNNGraphAlphaMutualInformation/itkKNNGraphAlphaMutualInformationImageToImageMetric.hxx
@@ -284,9 +284,9 @@ KNNGraphAlphaMutualInformationImageToImageMetric<TFixedImage, TMovingImage>::Ini
  */
 
 template <class TFixedImage, class TMovingImage>
-typename KNNGraphAlphaMutualInformationImageToImageMetric<TFixedImage, TMovingImage>::MeasureType
+auto
 KNNGraphAlphaMutualInformationImageToImageMetric<TFixedImage, TMovingImage>::GetValue(
-  const TransformParametersType & parameters) const
+  const TransformParametersType & parameters) const -> MeasureType
 {
   /** Initialize some variables. */
   MeasureType measure = NumericTraits<MeasureType>::Zero;

--- a/Components/Metrics/MissingStructurePenalty/itkMissingStructurePenalty.hxx
+++ b/Components/Metrics/MissingStructurePenalty/itkMissingStructurePenalty.hxx
@@ -97,8 +97,9 @@ MissingVolumeMeshPenalty<TFixedPointSet, TMovingPointSet>::Initialize(void)
  */
 
 template <class TFixedPointSet, class TMovingPointSet>
-typename MissingVolumeMeshPenalty<TFixedPointSet, TMovingPointSet>::MeasureType
+auto
 MissingVolumeMeshPenalty<TFixedPointSet, TMovingPointSet>::GetValue(const TransformParametersType & parameters) const
+  -> MeasureType
 {
   /** Sanity checks. */
   FixedMeshContainerConstPointer fixedMeshContainer = this->GetFixedMeshContainer();

--- a/Components/Metrics/NormalizedGradientCorrelation/itkNormalizedGradientCorrelationImageToImageMetric.hxx
+++ b/Components/Metrics/NormalizedGradientCorrelation/itkNormalizedGradientCorrelationImageToImageMetric.hxx
@@ -288,9 +288,9 @@ NormalizedGradientCorrelationImageToImageMetric<TFixedImage, TMovingImage>::Comp
  */
 
 template <class TFixedImage, class TMovingImage>
-typename NormalizedGradientCorrelationImageToImageMetric<TFixedImage, TMovingImage>::MeasureType
+auto
 NormalizedGradientCorrelationImageToImageMetric<TFixedImage, TMovingImage>::ComputeMeasure(
-  const TransformParametersType & parameters) const
+  const TransformParametersType & parameters) const -> MeasureType
 {
   this->SetTransformParameters(parameters);
   this->m_TransformMovingImageFilter->Modified();
@@ -387,9 +387,9 @@ NormalizedGradientCorrelationImageToImageMetric<TFixedImage, TMovingImage>::Comp
  */
 
 template <class TFixedImage, class TMovingImage>
-typename NormalizedGradientCorrelationImageToImageMetric<TFixedImage, TMovingImage>::MeasureType
+auto
 NormalizedGradientCorrelationImageToImageMetric<TFixedImage, TMovingImage>::GetValue(
-  const TransformParametersType & parameters) const
+  const TransformParametersType & parameters) const -> MeasureType
 {
   /** Call non-thread-safe stuff, such as:
    *   this->SetTransformParameters( parameters );

--- a/Components/Metrics/NormalizedMutualInformation/itkParzenWindowNormalizedMutualInformationImageToImageMetric.hxx
+++ b/Components/Metrics/NormalizedMutualInformation/itkParzenWindowNormalizedMutualInformationImageToImageMetric.hxx
@@ -86,9 +86,9 @@ ParzenWindowNormalizedMutualInformationImageToImageMetric<TFixedImage, TMovingIm
  */
 
 template <class TFixedImage, class TMovingImage>
-typename ParzenWindowNormalizedMutualInformationImageToImageMetric<TFixedImage, TMovingImage>::MeasureType
+auto
 ParzenWindowNormalizedMutualInformationImageToImageMetric<TFixedImage, TMovingImage>::
-  ComputeNormalizedMutualInformation(MeasureType & jointEntropy) const
+  ComputeNormalizedMutualInformation(MeasureType & jointEntropy) const -> MeasureType
 {
   /** Typedef iterators */
   typedef ImageLinearConstIteratorWithIndex<JointPDFType> JointPDFConstIteratorType;
@@ -138,9 +138,9 @@ ParzenWindowNormalizedMutualInformationImageToImageMetric<TFixedImage, TMovingIm
  */
 
 template <class TFixedImage, class TMovingImage>
-typename ParzenWindowNormalizedMutualInformationImageToImageMetric<TFixedImage, TMovingImage>::MeasureType
+auto
 ParzenWindowNormalizedMutualInformationImageToImageMetric<TFixedImage, TMovingImage>::GetValue(
-  const ParametersType & parameters) const
+  const ParametersType & parameters) const -> MeasureType
 {
   /** Construct the JointPDF and Alpha */
   this->ComputePDFs(parameters);

--- a/Components/Metrics/PCAMetric/itkPCAMetric.hxx
+++ b/Components/Metrics/PCAMetric/itkPCAMetric.hxx
@@ -161,8 +161,8 @@ PCAMetric<TFixedImage, TMovingImage>::EvaluateTransformJacobianInnerProduct(
  */
 
 template <class TFixedImage, class TMovingImage>
-typename PCAMetric<TFixedImage, TMovingImage>::MeasureType
-PCAMetric<TFixedImage, TMovingImage>::GetValue(const TransformParametersType & parameters) const
+auto
+PCAMetric<TFixedImage, TMovingImage>::GetValue(const TransformParametersType & parameters) const -> MeasureType
 {
   itkDebugMacro("GetValue( " << parameters << " ) ");
   bool UseGetValueAndDerivative = false;

--- a/Components/Metrics/PCAMetric/itkPCAMetric_F_multithreaded.hxx
+++ b/Components/Metrics/PCAMetric/itkPCAMetric_F_multithreaded.hxx
@@ -175,8 +175,8 @@ PCAMetric<TFixedImage, TMovingImage>::EvaluateTransformJacobianInnerProduct(
  */
 
 template <class TFixedImage, class TMovingImage>
-typename PCAMetric<TFixedImage, TMovingImage>::MeasureType
-PCAMetric<TFixedImage, TMovingImage>::GetValue(const TransformParametersType & parameters) const
+auto
+PCAMetric<TFixedImage, TMovingImage>::GetValue(const TransformParametersType & parameters) const -> MeasureType
 {
   itkDebugMacro("GetValue( " << parameters << " ) ");
 

--- a/Components/Metrics/PCAMetric2/itkPCAMetric2.hxx
+++ b/Components/Metrics/PCAMetric2/itkPCAMetric2.hxx
@@ -144,8 +144,8 @@ PCAMetric2<TFixedImage, TMovingImage>::EvaluateTransformJacobianInnerProduct(
  */
 
 template <class TFixedImage, class TMovingImage>
-typename PCAMetric2<TFixedImage, TMovingImage>::MeasureType
-PCAMetric2<TFixedImage, TMovingImage>::GetValue(const TransformParametersType & parameters) const
+auto
+PCAMetric2<TFixedImage, TMovingImage>::GetValue(const TransformParametersType & parameters) const -> MeasureType
 {
   itkDebugMacro("GetValue( " << parameters << " ) ");
   bool UseGetValueAndDerivative = false;

--- a/Components/Metrics/PatternIntensity/itkPatternIntensityImageToImageMetric.hxx
+++ b/Components/Metrics/PatternIntensity/itkPatternIntensityImageToImageMetric.hxx
@@ -126,8 +126,8 @@ PatternIntensityImageToImageMetric<TFixedImage, TMovingImage>::PrintSelf(std::os
  */
 
 template <class TFixedImage, class TMovingImage>
-typename PatternIntensityImageToImageMetric<TFixedImage, TMovingImage>::MeasureType
-PatternIntensityImageToImageMetric<TFixedImage, TMovingImage>::ComputePIFixed() const
+auto
+PatternIntensityImageToImageMetric<TFixedImage, TMovingImage>::ComputePIFixed() const -> MeasureType
 {
   MeasureType measure = NumericTraits<MeasureType>::Zero;
   MeasureType diff = NumericTraits<MeasureType>::Zero;
@@ -219,9 +219,9 @@ PatternIntensityImageToImageMetric<TFixedImage, TMovingImage>::ComputePIFixed() 
  */
 
 template <class TFixedImage, class TMovingImage>
-typename PatternIntensityImageToImageMetric<TFixedImage, TMovingImage>::MeasureType
+auto
 PatternIntensityImageToImageMetric<TFixedImage, TMovingImage>::ComputePIDiff(const TransformParametersType & parameters,
-                                                                             float scalingfactor) const
+                                                                             float scalingfactor) const -> MeasureType
 {
   /** Call non-thread-safe stuff, such as:
    *   this->SetTransformParameters( parameters );
@@ -330,9 +330,9 @@ PatternIntensityImageToImageMetric<TFixedImage, TMovingImage>::ComputePIDiff(con
  */
 
 template <class TFixedImage, class TMovingImage>
-typename PatternIntensityImageToImageMetric<TFixedImage, TMovingImage>::MeasureType
+auto
 PatternIntensityImageToImageMetric<TFixedImage, TMovingImage>::GetValue(
-  const TransformParametersType & parameters) const
+  const TransformParametersType & parameters) const -> MeasureType
 {
   /** Call non-thread-safe stuff, such as:
    *   this->SetTransformParameters( parameters );

--- a/Components/Metrics/PolydataDummyPenalty/itkPolydataDummyPenalty.hxx
+++ b/Components/Metrics/PolydataDummyPenalty/itkPolydataDummyPenalty.hxx
@@ -113,8 +113,8 @@ MeshPenalty<TFixedPointSet, TMovingPointSet>::Initialize(void)
  */
 
 template <class TFixedPointSet, class TMovingPointSet>
-typename MeshPenalty<TFixedPointSet, TMovingPointSet>::MeasureType
-MeshPenalty<TFixedPointSet, TMovingPointSet>::GetValue(const TransformParametersType & parameters) const
+auto
+MeshPenalty<TFixedPointSet, TMovingPointSet>::GetValue(const TransformParametersType & parameters) const -> MeasureType
 {
   /** Sanity checks. */
   FixedMeshContainerConstPointer fixedMeshContainer = this->GetFixedMeshContainer();

--- a/Components/Metrics/RigidityPenalty/itkTransformRigidityPenaltyTerm.hxx
+++ b/Components/Metrics/RigidityPenalty/itkTransformRigidityPenaltyTerm.hxx
@@ -460,8 +460,8 @@ TransformRigidityPenaltyTerm<TFixedImage, TScalarType>::FillRigidityCoefficientI
  */
 
 template <class TFixedImage, class TScalarType>
-typename TransformRigidityPenaltyTerm<TFixedImage, TScalarType>::MeasureType
-TransformRigidityPenaltyTerm<TFixedImage, TScalarType>::GetValue(const ParametersType & parameters) const
+auto
+TransformRigidityPenaltyTerm<TFixedImage, TScalarType>::GetValue(const ParametersType & parameters) const -> MeasureType
 {
   /** Fill the rigidity image based on the current transform parameters. */
   this->FillRigidityCoefficientImage(parameters);
@@ -2162,10 +2162,10 @@ TransformRigidityPenaltyTerm<TFixedImage, TScalarType>::Create1DOperator(
  */
 
 template <class TFixedImage, class TScalarType>
-typename TransformRigidityPenaltyTerm<TFixedImage, TScalarType>::CoefficientImagePointer
+auto
 TransformRigidityPenaltyTerm<TFixedImage, TScalarType>::FilterSeparable(
   const CoefficientImageType *          image,
-  const std::vector<NeighborhoodType> & Operators) const
+  const std::vector<NeighborhoodType> & Operators) const -> CoefficientImagePointer
 {
   /** Create filters, supply them with boundary conditions and operators. */
   std::vector<typename NOIFType::Pointer> filters(ImageDimension);

--- a/Components/Metrics/StatisticalShapePenalty/itkStatisticalShapePointPenalty.hxx
+++ b/Components/Metrics/StatisticalShapePenalty/itkStatisticalShapePointPenalty.hxx
@@ -342,9 +342,9 @@ StatisticalShapePointPenalty<TFixedPointSet, TMovingPointSet>::Initialize(void)
  */
 
 template <class TFixedPointSet, class TMovingPointSet>
-typename StatisticalShapePointPenalty<TFixedPointSet, TMovingPointSet>::MeasureType
+auto
 StatisticalShapePointPenalty<TFixedPointSet, TMovingPointSet>::GetValue(
-  const TransformParametersType & parameters) const
+  const TransformParametersType & parameters) const -> MeasureType
 {
   /** Sanity checks. */
   FixedPointSetConstPointer fixedPointSet = this->GetFixedPointSet();

--- a/Components/Metrics/SumOfPairwiseCorrelationsMetric/itkSumOfPairwiseCorrelationCoefficientsMetric.hxx
+++ b/Components/Metrics/SumOfPairwiseCorrelationsMetric/itkSumOfPairwiseCorrelationCoefficientsMetric.hxx
@@ -138,9 +138,9 @@ SumOfPairwiseCorrelationCoefficientsMetric<TFixedImage, TMovingImage>::EvaluateT
  */
 
 template <class TFixedImage, class TMovingImage>
-typename SumOfPairwiseCorrelationCoefficientsMetric<TFixedImage, TMovingImage>::MeasureType
+auto
 SumOfPairwiseCorrelationCoefficientsMetric<TFixedImage, TMovingImage>::GetValue(
-  const TransformParametersType & parameters) const
+  const TransformParametersType & parameters) const -> MeasureType
 {
   itkDebugMacro("GetValue( " << parameters << " ) ");
 

--- a/Components/Metrics/SumSquaredTissueVolumeDifferenceMetric/itkSumSquaredTissueVolumeDifferenceImageToImageMetric.hxx
+++ b/Components/Metrics/SumSquaredTissueVolumeDifferenceMetric/itkSumSquaredTissueVolumeDifferenceImageToImageMetric.hxx
@@ -66,9 +66,9 @@ SumSquaredTissueVolumeDifferenceImageToImageMetric<TFixedImage, TMovingImage>::P
  */
 
 template <class TFixedImage, class TMovingImage>
-typename SumSquaredTissueVolumeDifferenceImageToImageMetric<TFixedImage, TMovingImage>::MeasureType
+auto
 SumSquaredTissueVolumeDifferenceImageToImageMetric<TFixedImage, TMovingImage>::GetValueSingleThreaded(
-  const TransformParametersType & parameters) const
+  const TransformParametersType & parameters) const -> MeasureType
 {
   itkDebugMacro("GetValue( " << parameters << " ) ");
 
@@ -160,9 +160,9 @@ SumSquaredTissueVolumeDifferenceImageToImageMetric<TFixedImage, TMovingImage>::G
  */
 
 template <class TFixedImage, class TMovingImage>
-typename SumSquaredTissueVolumeDifferenceImageToImageMetric<TFixedImage, TMovingImage>::MeasureType
+auto
 SumSquaredTissueVolumeDifferenceImageToImageMetric<TFixedImage, TMovingImage>::GetValue(
-  const TransformParametersType & parameters) const
+  const TransformParametersType & parameters) const -> MeasureType
 {
 
   /** Option for now to still use the single threaded code. */

--- a/Components/Metrics/VarianceOverLastDimension/itkVarianceOverLastDimensionImageMetric.hxx
+++ b/Components/Metrics/VarianceOverLastDimension/itkVarianceOverLastDimensionImageMetric.hxx
@@ -189,9 +189,9 @@ VarianceOverLastDimensionImageMetric<TFixedImage, TMovingImage>::EvaluateTransfo
  */
 
 template <class TFixedImage, class TMovingImage>
-typename VarianceOverLastDimensionImageMetric<TFixedImage, TMovingImage>::MeasureType
+auto
 VarianceOverLastDimensionImageMetric<TFixedImage, TMovingImage>::GetValue(
-  const TransformParametersType & parameters) const
+  const TransformParametersType & parameters) const -> MeasureType
 {
   itkDebugMacro("GetValue( " << parameters << " ) ");
 

--- a/Components/Registrations/MultiMetricMultiResolutionRegistration/itkCombinationImageToImageMetric.hxx
+++ b/Components/Registrations/MultiMetricMultiResolutionRegistration/itkCombinationImageToImageMetric.hxx
@@ -84,8 +84,7 @@
 /** for getting const object, implement one method */
 #define itkImplementationGetConstObjectMacro1(_name, _type)                                                            \
   template <class TFixedImage, class TMovingImage>                                                                     \
-  const typename CombinationImageToImageMetric<TFixedImage, TMovingImage>::_type *                                     \
-    CombinationImageToImageMetric<TFixedImage, TMovingImage>::Get##_name(unsigned int pos) const                       \
+  auto CombinationImageToImageMetric<TFixedImage, TMovingImage>::Get##_name(unsigned int pos) const->const _type *     \
   {                                                                                                                    \
     const ImageMetricType * testPtr1 = dynamic_cast<const ImageMetricType *>(this->GetMetric(pos));                    \
     if (testPtr1)                                                                                                      \
@@ -100,8 +99,7 @@
 
 #define itkImplementationGetConstObjectMacro2(_name, _type)                                                            \
   template <class TFixedImage, class TMovingImage>                                                                     \
-  const typename CombinationImageToImageMetric<TFixedImage, TMovingImage>::_type *                                     \
-    CombinationImageToImageMetric<TFixedImage, TMovingImage>::Get##_name(unsigned int pos) const                       \
+  auto CombinationImageToImageMetric<TFixedImage, TMovingImage>::Get##_name(unsigned int pos) const->const _type *     \
   {                                                                                                                    \
     const ImageMetricType *    testPtr1 = dynamic_cast<const ImageMetricType *>(this->GetMetric(pos));                 \
     const PointSetMetricType * testPtr2 = dynamic_cast<const PointSetMetricType *>(this->GetMetric(pos));              \
@@ -223,8 +221,9 @@ CombinationImageToImageMetric<TFixedImage, TMovingImage>::SetFixedImageRegion(co
  */
 
 template <class TFixedImage, class TMovingImage>
-const typename CombinationImageToImageMetric<TFixedImage, TMovingImage>::FixedImageRegionType &
+auto
 CombinationImageToImageMetric<TFixedImage, TMovingImage>::GetFixedImageRegion(unsigned int pos) const
+  -> const FixedImageRegionType &
 {
   const ImageMetricType * testPtr = dynamic_cast<const ImageMetricType *>(this->GetMetric(pos));
   if (testPtr)
@@ -292,8 +291,9 @@ CombinationImageToImageMetric<TFixedImage, TMovingImage>::SetMetric(SingleValued
  */
 
 template <class TFixedImage, class TMovingImage>
-typename CombinationImageToImageMetric<TFixedImage, TMovingImage>::SingleValuedCostFunctionType *
+auto
 CombinationImageToImageMetric<TFixedImage, TMovingImage>::GetMetric(unsigned int pos) const
+  -> SingleValuedCostFunctionType *
 {
   if (pos >= this->GetNumberOfMetrics())
   {
@@ -458,8 +458,8 @@ CombinationImageToImageMetric<TFixedImage, TMovingImage>::GetUseMetric(unsigned 
  */
 
 template <class TFixedImage, class TMovingImage>
-typename CombinationImageToImageMetric<TFixedImage, TMovingImage>::MeasureType
-CombinationImageToImageMetric<TFixedImage, TMovingImage>::GetMetricValue(unsigned int pos) const
+auto
+CombinationImageToImageMetric<TFixedImage, TMovingImage>::GetMetricValue(unsigned int pos) const -> MeasureType
 {
   if (pos >= this->GetNumberOfMetrics())
   {
@@ -478,8 +478,9 @@ CombinationImageToImageMetric<TFixedImage, TMovingImage>::GetMetricValue(unsigne
  */
 
 template <class TFixedImage, class TMovingImage>
-const typename CombinationImageToImageMetric<TFixedImage, TMovingImage>::DerivativeType &
+auto
 CombinationImageToImageMetric<TFixedImage, TMovingImage>::GetMetricDerivative(unsigned int pos) const
+  -> const DerivativeType &
 {
   if (pos >= this->GetNumberOfMetrics())
   {
@@ -658,8 +659,9 @@ CombinationImageToImageMetric<TFixedImage, TMovingImage>::GetFinalMetricWeight(u
  */
 
 template <class TFixedImage, class TMovingImage>
-typename CombinationImageToImageMetric<TFixedImage, TMovingImage>::MeasureType
+auto
 CombinationImageToImageMetric<TFixedImage, TMovingImage>::GetValue(const ParametersType & parameters) const
+  -> MeasureType
 {
   /** Initialise. */
   MeasureType measure = NumericTraits<MeasureType>::Zero;

--- a/Components/Registrations/MultiMetricMultiResolutionRegistration/itkMultiMetricMultiResolutionImageRegistrationMethod.hxx
+++ b/Components/Registrations/MultiMetricMultiResolutionRegistration/itkMultiMetricMultiResolutionImageRegistrationMethod.hxx
@@ -47,8 +47,8 @@
 /** Macro that implements the get methods. */
 #define itkImplementationGetMacro(_name, _type1, _type2)                                                               \
   template <typename TFixedImage, typename TMovingImage>                                                               \
-  _type1 typename MultiMetricMultiResolutionImageRegistrationMethod<TFixedImage, TMovingImage>::_type2                 \
-    MultiMetricMultiResolutionImageRegistrationMethod<TFixedImage, TMovingImage>::Get##_name(unsigned int pos) const   \
+  auto MultiMetricMultiResolutionImageRegistrationMethod<TFixedImage, TMovingImage>::Get##_name(unsigned int pos)      \
+    const->_type1 _type2                                                                                               \
   {                                                                                                                    \
     if (pos >= this->GetNumberOf##_name##s())                                                                          \
     {                                                                                                                  \
@@ -98,9 +98,9 @@ MultiMetricMultiResolutionImageRegistrationMethod<TFixedImage,
  */
 
 template <typename TFixedImage, typename TMovingImage>
-const typename MultiMetricMultiResolutionImageRegistrationMethod<TFixedImage, TMovingImage>::FixedImageRegionType &
+auto
 MultiMetricMultiResolutionImageRegistrationMethod<TFixedImage, TMovingImage>::GetFixedImageRegion(
-  unsigned int pos) const
+  unsigned int pos) const -> const FixedImageRegionType &
 {
   if (pos >= this->GetNumberOfFixedImageRegions())
   {

--- a/Components/Registrations/MultiResolutionRegistrationWithFeatures/itkMultiInputMultiResolutionImageRegistrationMethodBase.hxx
+++ b/Components/Registrations/MultiResolutionRegistrationWithFeatures/itkMultiInputMultiResolutionImageRegistrationMethodBase.hxx
@@ -83,8 +83,9 @@ MultiInputMultiResolutionImageRegistrationMethodBase<TFixedImage, TMovingImage>:
  */
 
 template <typename TFixedImage, typename TMovingImage>
-const typename MultiInputMultiResolutionImageRegistrationMethodBase<TFixedImage, TMovingImage>::FixedImageType *
+auto
 MultiInputMultiResolutionImageRegistrationMethodBase<TFixedImage, TMovingImage>::GetFixedImage(unsigned int pos) const
+  -> const FixedImageType *
 {
   if (pos >= this->GetNumberOfFixedImages())
   {
@@ -102,8 +103,9 @@ MultiInputMultiResolutionImageRegistrationMethodBase<TFixedImage, TMovingImage>:
  */
 
 template <typename TFixedImage, typename TMovingImage>
-const typename MultiInputMultiResolutionImageRegistrationMethodBase<TFixedImage, TMovingImage>::MovingImageType *
+auto
 MultiInputMultiResolutionImageRegistrationMethodBase<TFixedImage, TMovingImage>::GetMovingImage(unsigned int pos) const
+  -> const MovingImageType *
 {
   if (pos >= this->GetNumberOfMovingImages())
   {
@@ -121,8 +123,9 @@ MultiInputMultiResolutionImageRegistrationMethodBase<TFixedImage, TMovingImage>:
  */
 
 template <typename TFixedImage, typename TMovingImage>
-typename MultiInputMultiResolutionImageRegistrationMethodBase<TFixedImage, TMovingImage>::InterpolatorType *
+auto
 MultiInputMultiResolutionImageRegistrationMethodBase<TFixedImage, TMovingImage>::GetInterpolator(unsigned int pos) const
+  -> InterpolatorType *
 {
   if (pos >= this->GetNumberOfInterpolators())
   {
@@ -140,9 +143,9 @@ MultiInputMultiResolutionImageRegistrationMethodBase<TFixedImage, TMovingImage>:
  */
 
 template <typename TFixedImage, typename TMovingImage>
-typename MultiInputMultiResolutionImageRegistrationMethodBase<TFixedImage, TMovingImage>::FixedImageInterpolatorType *
+auto
 MultiInputMultiResolutionImageRegistrationMethodBase<TFixedImage, TMovingImage>::GetFixedImageInterpolator(
-  unsigned int pos) const
+  unsigned int pos) const -> FixedImageInterpolatorType *
 {
   if (pos >= this->GetNumberOfFixedImageInterpolators())
   {
@@ -160,9 +163,9 @@ MultiInputMultiResolutionImageRegistrationMethodBase<TFixedImage, TMovingImage>:
  */
 
 template <typename TFixedImage, typename TMovingImage>
-typename MultiInputMultiResolutionImageRegistrationMethodBase<TFixedImage, TMovingImage>::FixedImagePyramidType *
+auto
 MultiInputMultiResolutionImageRegistrationMethodBase<TFixedImage, TMovingImage>::GetFixedImagePyramid(
-  unsigned int pos) const
+  unsigned int pos) const -> FixedImagePyramidType *
 {
   if (pos >= this->GetNumberOfFixedImagePyramids())
   {
@@ -180,9 +183,9 @@ MultiInputMultiResolutionImageRegistrationMethodBase<TFixedImage, TMovingImage>:
  */
 
 template <typename TFixedImage, typename TMovingImage>
-typename MultiInputMultiResolutionImageRegistrationMethodBase<TFixedImage, TMovingImage>::MovingImagePyramidType *
+auto
 MultiInputMultiResolutionImageRegistrationMethodBase<TFixedImage, TMovingImage>::GetMovingImagePyramid(
-  unsigned int pos) const
+  unsigned int pos) const -> MovingImagePyramidType *
 {
   if (pos >= this->GetNumberOfMovingImagePyramids())
   {
@@ -200,9 +203,9 @@ MultiInputMultiResolutionImageRegistrationMethodBase<TFixedImage, TMovingImage>:
  */
 
 template <typename TFixedImage, typename TMovingImage>
-const typename MultiInputMultiResolutionImageRegistrationMethodBase<TFixedImage, TMovingImage>::FixedImageRegionType &
+auto
 MultiInputMultiResolutionImageRegistrationMethodBase<TFixedImage, TMovingImage>::GetFixedImageRegion(
-  unsigned int pos) const
+  unsigned int pos) const -> const FixedImageRegionType &
 {
   if (pos >= this->GetNumberOfFixedImageRegions())
   {

--- a/Components/Transforms/AffineDTITransform/itkAffineDTI2DTransform.hxx
+++ b/Components/Transforms/AffineDTITransform/itkAffineDTI2DTransform.hxx
@@ -110,8 +110,8 @@ AffineDTI2DTransform<TScalarType>::SetParameters(const ParametersType & paramete
 
 // Get Parameters
 template <class TScalarType>
-const typename AffineDTI2DTransform<TScalarType>::ParametersType &
-AffineDTI2DTransform<TScalarType>::GetParameters(void) const
+auto
+AffineDTI2DTransform<TScalarType>::GetParameters(void) const -> const ParametersType &
 {
   this->m_Parameters[0] = this->m_Angle[0];
   this->m_Parameters[1] = this->m_Shear[0];

--- a/Components/Transforms/AffineDTITransform/itkAffineDTI3DTransform.hxx
+++ b/Components/Transforms/AffineDTITransform/itkAffineDTI3DTransform.hxx
@@ -132,8 +132,8 @@ AffineDTI3DTransform<TScalarType>::SetParameters(const ParametersType & paramete
 
 // Get Parameters
 template <class TScalarType>
-const typename AffineDTI3DTransform<TScalarType>::ParametersType &
-AffineDTI3DTransform<TScalarType>::GetParameters(void) const
+auto
+AffineDTI3DTransform<TScalarType>::GetParameters(void) const -> const ParametersType &
 {
   this->m_Parameters[0] = this->m_Angle[0];
   this->m_Parameters[1] = this->m_Angle[1];

--- a/Components/Transforms/AffineLogTransform/itkAffineLogTransform.hxx
+++ b/Components/Transforms/AffineLogTransform/itkAffineLogTransform.hxx
@@ -110,8 +110,8 @@ AffineLogTransform<TScalarType, Dimension>::SetParameters(const ParametersType &
 
 // Get Parameters
 template <class TScalarType, unsigned int Dimension>
-const typename AffineLogTransform<TScalarType, Dimension>::ParametersType &
-AffineLogTransform<TScalarType, Dimension>::GetParameters(void) const
+auto
+AffineLogTransform<TScalarType, Dimension>::GetParameters(void) const -> const ParametersType &
 {
   unsigned int k = 0; // Dummy loop index
 

--- a/Components/Transforms/DeformationFieldTransform/itkDeformationFieldInterpolatingTransform.hxx
+++ b/Components/Transforms/DeformationFieldTransform/itkDeformationFieldInterpolatingTransform.hxx
@@ -46,9 +46,9 @@ DeformationFieldInterpolatingTransform<TScalarType, NDimensions, TComponentType>
 
 // Transform a point
 template <class TScalarType, unsigned int NDimensions, class TComponentType>
-typename DeformationFieldInterpolatingTransform<TScalarType, NDimensions, TComponentType>::OutputPointType
+auto
 DeformationFieldInterpolatingTransform<TScalarType, NDimensions, TComponentType>::TransformPoint(
-  const InputPointType & point) const
+  const InputPointType & point) const -> OutputPointType
 {
   InputContinuousIndexType cindex;
   this->m_DeformationFieldInterpolator->ConvertPointToContinuousIndex(point, cindex);

--- a/Components/Transforms/MultiBSplineTransformWithNormal/itkMultiBSplineDeformableTransformWithNormal.hxx
+++ b/Components/Transforms/MultiBSplineTransformWithNormal/itkMultiBSplineDeformableTransformWithNormal.hxx
@@ -62,8 +62,9 @@ MultiBSplineDeformableTransformWithNormal<TScalarType, NDimensions, VSplineOrder
 
 // Get the number of parameters
 template <class TScalarType, unsigned int NDimensions, unsigned int VSplineOrder>
-typename MultiBSplineDeformableTransformWithNormal<TScalarType, NDimensions, VSplineOrder>::NumberOfParametersType
+auto
 MultiBSplineDeformableTransformWithNormal<TScalarType, NDimensions, VSplineOrder>::GetNumberOfParameters(void) const
+  -> NumberOfParametersType
 {
   if (m_NbLabels > 0)
   {
@@ -79,9 +80,9 @@ MultiBSplineDeformableTransformWithNormal<TScalarType, NDimensions, VSplineOrder
 // Get the number of parameters per dimension
 // FIXME :  Do we need to declare this function ?
 template <class TScalarType, unsigned int NDimensions, unsigned int VSplineOrder>
-typename MultiBSplineDeformableTransformWithNormal<TScalarType, NDimensions, VSplineOrder>::NumberOfParametersType
+auto
 MultiBSplineDeformableTransformWithNormal<TScalarType, NDimensions, VSplineOrder>::GetNumberOfParametersPerDimension(
-  void) const
+  void) const -> NumberOfParametersType
 {
   // FIXME : Depends on which dimension we are speaking here. should check it
   if (m_NbLabels > 0)
@@ -114,8 +115,7 @@ MultiBSplineDeformableTransformWithNormal<TScalarType, NDimensions, VSplineOrder
 
 #define GET_FIRST_LABEL(FUNC, TYPE)                                                                                    \
   template <class TScalarType, unsigned int NDimensions, unsigned int VSplineOrder>                                    \
-  typename MultiBSplineDeformableTransformWithNormal<TScalarType, NDimensions, VSplineOrder>::TYPE                     \
-    MultiBSplineDeformableTransformWithNormal<TScalarType, NDimensions, VSplineOrder>::Get##FUNC() const               \
+  auto MultiBSplineDeformableTransformWithNormal<TScalarType, NDimensions, VSplineOrder>::Get##FUNC() const->TYPE      \
   {                                                                                                                    \
     return m_Trans[0]->Get##FUNC();                                                                                    \
   }
@@ -585,8 +585,9 @@ MultiBSplineDeformableTransformWithNormal<TScalarType, NDimensions, VSplineOrder
 
 // Get the parameters
 template <class TScalarType, unsigned int NDimensions, unsigned int VSplineOrder>
-const typename MultiBSplineDeformableTransformWithNormal<TScalarType, NDimensions, VSplineOrder>::ParametersType &
+auto
 MultiBSplineDeformableTransformWithNormal<TScalarType, NDimensions, VSplineOrder>::GetParameters(void) const
+  -> const ParametersType &
 {
   /** NOTE: For efficiency, this class does not keep a copy of the parameters -
    * it just keeps pointer to input parameters.
@@ -602,8 +603,9 @@ MultiBSplineDeformableTransformWithNormal<TScalarType, NDimensions, VSplineOrder
 
 // Get the parameters
 template <class TScalarType, unsigned int NDimensions, unsigned int VSplineOrder>
-const typename MultiBSplineDeformableTransformWithNormal<TScalarType, NDimensions, VSplineOrder>::ParametersType &
+auto
 MultiBSplineDeformableTransformWithNormal<TScalarType, NDimensions, VSplineOrder>::GetFixedParameters(void) const
+  -> const ParametersType &
 {
   return (m_Trans[0]->GetFixedParameters());
 }
@@ -649,9 +651,9 @@ MultiBSplineDeformableTransformWithNormal<TScalarType, NDimensions, VSplineOrder
 
 
 template <class TScalarType, unsigned int NDimensions, unsigned int VSplineOrder>
-typename MultiBSplineDeformableTransformWithNormal<TScalarType, NDimensions, VSplineOrder>::OutputPointType
+auto
 MultiBSplineDeformableTransformWithNormal<TScalarType, NDimensions, VSplineOrder>::TransformPoint(
-  const InputPointType & point) const
+  const InputPointType & point) const -> OutputPointType
 {
   int lidx = 0;
   this->PointToLabel(point, lidx);
@@ -666,9 +668,9 @@ MultiBSplineDeformableTransformWithNormal<TScalarType, NDimensions, VSplineOrder
 
 
 // template<class TScalarType, unsigned int NDimensions, unsigned int VSplineOrder>
-// const typename MultiBSplineDeformableTransformWithNormal<TScalarType, NDimensions, VSplineOrder>::JacobianType&
+// auto
 // MultiBSplineDeformableTransformWithNormal<TScalarType, NDimensions, VSplineOrder>
-//::GetJacobian( const InputPointType & point ) const
+//::GetJacobian( const InputPointType & point ) const -> const JacobianType&
 //{
 //  this->m_Jacobian.set_size(SpaceDimension, this->GetNumberOfParameters());
 //  this->m_Jacobian.Fill(0.0);

--- a/Components/Transforms/SplineKernelTransform/itkKernelTransform2.hxx
+++ b/Components/Transforms/SplineKernelTransform/itkKernelTransform2.hxx
@@ -520,8 +520,8 @@ KernelTransform2<TScalarType, NDimensions>::ReorganizeW(void)
  */
 
 template <class TScalarType, unsigned int NDimensions>
-typename KernelTransform2<TScalarType, NDimensions>::OutputPointType
-KernelTransform2<TScalarType, NDimensions>::TransformPoint(const InputPointType & thisPoint) const
+auto
+KernelTransform2<TScalarType, NDimensions>::TransformPoint(const InputPointType & thisPoint) const -> OutputPointType
 {
   OutputPointType opp;
   opp.Fill(NumericTraits<typename OutputPointType::ValueType>::ZeroValue());
@@ -689,8 +689,8 @@ KernelTransform2<TScalarType, NDimensions>::UpdateParameters(void)
  */
 
 template <class TScalarType, unsigned int NDimensions>
-const typename KernelTransform2<TScalarType, NDimensions>::ParametersType &
-KernelTransform2<TScalarType, NDimensions>::GetParameters(void) const
+auto
+KernelTransform2<TScalarType, NDimensions>::GetParameters(void) const -> const ParametersType &
 {
   return this->m_Parameters;
 } // end GetParameters()
@@ -700,8 +700,8 @@ KernelTransform2<TScalarType, NDimensions>::GetParameters(void) const
  */
 
 template <class TScalarType, unsigned int NDimensions>
-const typename KernelTransform2<TScalarType, NDimensions>::ParametersType &
-KernelTransform2<TScalarType, NDimensions>::GetFixedParameters(void) const
+auto
+KernelTransform2<TScalarType, NDimensions>::GetFixedParameters(void) const -> const ParametersType &
 {
   this->m_FixedParameters = ParametersType(this->m_SourceLandmarks->GetNumberOfPoints() * NDimensions);
   PointsIterator itr = this->m_SourceLandmarks->GetPoints()->Begin();

--- a/Components/Transforms/WeightedCombinationTransform/itkWeightedCombinationTransform.hxx
+++ b/Components/Transforms/WeightedCombinationTransform/itkWeightedCombinationTransform.hxx
@@ -82,9 +82,9 @@ WeightedCombinationTransform<TScalarType, NInputDimensions, NOutputDimensions>::
  */
 
 template <class TScalarType, unsigned int NInputDimensions, unsigned int NOutputDimensions>
-typename WeightedCombinationTransform<TScalarType, NInputDimensions, NOutputDimensions>::OutputPointType
+auto
 WeightedCombinationTransform<TScalarType, NInputDimensions, NOutputDimensions>::TransformPoint(
-  const InputPointType & ipp) const
+  const InputPointType & ipp) const -> OutputPointType
 {
   OutputPointType opp;
   opp.Fill(0.0);

--- a/Core/ComponentBaseClasses/elxMetricBase.hxx
+++ b/Core/ComponentBaseClasses/elxMetricBase.hxx
@@ -231,8 +231,8 @@ MetricBase<TElastix>::SelectNewSamples(void)
  */
 
 template <class TElastix>
-typename MetricBase<TElastix>::MeasureType
-MetricBase<TElastix>::GetExactValue(const ParametersType & parameters)
+auto
+MetricBase<TElastix>::GetExactValue(const ParametersType & parameters) -> MeasureType
 {
   /** Get the current image sampler. */
   typename ImageSamplerBaseType::Pointer currentSampler = this->GetAdvancedMetricImageSampler();
@@ -337,8 +337,8 @@ MetricBase<TElastix>::SetAdvancedMetricImageSampler(ImageSamplerBaseType * sampl
  */
 
 template <class TElastix>
-typename MetricBase<TElastix>::ImageSamplerBaseType *
-MetricBase<TElastix>::GetAdvancedMetricImageSampler(void) const
+auto
+MetricBase<TElastix>::GetAdvancedMetricImageSampler(void) const -> ImageSamplerBaseType *
 {
   /** Cast this to AdvancedMetricType. */
   const AdvancedMetricType * thisAsMetricWithSampler = dynamic_cast<const AdvancedMetricType *>(this);

--- a/Core/ComponentBaseClasses/elxRegistrationBase.hxx
+++ b/Core/ComponentBaseClasses/elxRegistrationBase.hxx
@@ -95,11 +95,11 @@ RegistrationBase<TElastix>::ReadMaskParameters(UseMaskErosionArrayType & useMask
  */
 
 template <class TElastix>
-typename RegistrationBase<TElastix>::FixedMaskSpatialObjectPointer
+auto
 RegistrationBase<TElastix>::GenerateFixedMaskSpatialObject(const FixedMaskImageType *    maskImage,
                                                            bool                          useMaskErosion,
                                                            const FixedImagePyramidType * pyramid,
-                                                           unsigned int                  level) const
+                                                           unsigned int level) const -> FixedMaskSpatialObjectPointer
 {
   FixedMaskSpatialObjectPointer fixedMaskSpatialObject; // default-constructed (null)
   if (!maskImage)
@@ -157,11 +157,11 @@ RegistrationBase<TElastix>::GenerateFixedMaskSpatialObject(const FixedMaskImageT
  */
 
 template <class TElastix>
-typename RegistrationBase<TElastix>::MovingMaskSpatialObjectPointer
+auto
 RegistrationBase<TElastix>::GenerateMovingMaskSpatialObject(const MovingMaskImageType *    maskImage,
                                                             bool                           useMaskErosion,
                                                             const MovingImagePyramidType * pyramid,
-                                                            unsigned int                   level) const
+                                                            unsigned int level) const -> MovingMaskSpatialObjectPointer
 {
   MovingMaskSpatialObjectPointer movingMaskSpatialObject; // default-constructed (null)
   if (!maskImage)

--- a/Core/ComponentBaseClasses/elxTransformBase.hxx
+++ b/Core/ComponentBaseClasses/elxTransformBase.hxx
@@ -256,8 +256,8 @@ TransformBase<TElastix>::BeforeRegistrationBase(void)
  */
 
 template <class TElastix>
-const typename TransformBase<TElastix>::InitialTransformType *
-TransformBase<TElastix>::GetInitialTransform(void) const
+auto
+TransformBase<TElastix>::GetInitialTransform(void) const -> const InitialTransformType *
 {
   return this->GetAsITKBaseType()->GetInitialTransform();
 
@@ -1075,8 +1075,8 @@ TransformBase<TElastix>::TransformPointsAllPoints(void) const
  */
 
 template <class TElastix>
-typename TransformBase<TElastix>::DeformationFieldImageType::Pointer
-TransformBase<TElastix>::GenerateDeformationFieldImage(void) const
+auto
+TransformBase<TElastix>::GenerateDeformationFieldImage(void) const -> typename DeformationFieldImageType::Pointer
 {
   /** Typedef's. */
   typedef typename FixedImageType::DirectionType FixedImageDirectionType;

--- a/Core/Kernel/elxElastixTemplate.hxx
+++ b/Core/Kernel/elxElastixTemplate.hxx
@@ -43,8 +43,8 @@ namespace elastix
  */
 
 template <class TFixedImage, class TMovingImage>
-typename ElastixTemplate<TFixedImage, TMovingImage>::FixedImageType *
-ElastixTemplate<TFixedImage, TMovingImage>::GetFixedImage(unsigned int idx) const
+auto
+ElastixTemplate<TFixedImage, TMovingImage>::GetFixedImage(unsigned int idx) const -> FixedImageType *
 {
   if (idx < this->GetNumberOfFixedImages())
   {
@@ -60,8 +60,8 @@ ElastixTemplate<TFixedImage, TMovingImage>::GetFixedImage(unsigned int idx) cons
  */
 
 template <class TFixedImage, class TMovingImage>
-typename ElastixTemplate<TFixedImage, TMovingImage>::MovingImageType *
-ElastixTemplate<TFixedImage, TMovingImage>::GetMovingImage(unsigned int idx) const
+auto
+ElastixTemplate<TFixedImage, TMovingImage>::GetMovingImage(unsigned int idx) const -> MovingImageType *
 {
   if (idx < this->GetNumberOfMovingImages())
   {
@@ -77,8 +77,8 @@ ElastixTemplate<TFixedImage, TMovingImage>::GetMovingImage(unsigned int idx) con
  */
 
 template <class TFixedImage, class TMovingImage>
-typename ElastixTemplate<TFixedImage, TMovingImage>::FixedMaskType *
-ElastixTemplate<TFixedImage, TMovingImage>::GetFixedMask(unsigned int idx) const
+auto
+ElastixTemplate<TFixedImage, TMovingImage>::GetFixedMask(unsigned int idx) const -> FixedMaskType *
 {
   if (idx < this->GetNumberOfFixedMasks())
   {
@@ -94,8 +94,8 @@ ElastixTemplate<TFixedImage, TMovingImage>::GetFixedMask(unsigned int idx) const
  */
 
 template <class TFixedImage, class TMovingImage>
-typename ElastixTemplate<TFixedImage, TMovingImage>::MovingMaskType *
-ElastixTemplate<TFixedImage, TMovingImage>::GetMovingMask(unsigned int idx) const
+auto
+ElastixTemplate<TFixedImage, TMovingImage>::GetMovingMask(unsigned int idx) const -> MovingMaskType *
 {
   if (idx < this->GetNumberOfMovingMasks())
   {

--- a/Core/Main/elxElastixFilter.hxx
+++ b/Core/Main/elxElastixFilter.hxx
@@ -315,8 +315,8 @@ ElastixFilter<TFixedImage, TMovingImage>::SetParameterObject(ParameterObjectType
  */
 
 template <typename TFixedImage, typename TMovingImage>
-typename ElastixFilter<TFixedImage, TMovingImage>::ParameterObjectType *
-ElastixFilter<TFixedImage, TMovingImage>::GetParameterObject(void)
+auto
+ElastixFilter<TFixedImage, TMovingImage>::GetParameterObject(void) -> ParameterObjectType *
 {
   return itkDynamicCastInDebugMode<ParameterObjectType *>(itk::ProcessObject::GetInput("ParameterObject"));
 }
@@ -326,8 +326,8 @@ ElastixFilter<TFixedImage, TMovingImage>::GetParameterObject(void)
  */
 
 template <typename TFixedImage, typename TMovingImage>
-const typename ElastixFilter<TFixedImage, TMovingImage>::ParameterObjectType *
-ElastixFilter<TFixedImage, TMovingImage>::GetParameterObject(void) const
+auto
+ElastixFilter<TFixedImage, TMovingImage>::GetParameterObject(void) const -> const ParameterObjectType *
 {
   return itkDynamicCastInDebugMode<const ParameterObjectType *>(itk::ProcessObject::GetInput("ParameterObject"));
 }
@@ -337,8 +337,8 @@ ElastixFilter<TFixedImage, TMovingImage>::GetParameterObject(void) const
  */
 
 template <typename TFixedImage, typename TMovingImage>
-typename ElastixFilter<TFixedImage, TMovingImage>::ParameterObjectType *
-ElastixFilter<TFixedImage, TMovingImage>::GetTransformParameterObject(void)
+auto
+ElastixFilter<TFixedImage, TMovingImage>::GetTransformParameterObject(void) -> ParameterObjectType *
 {
   if (this->HasOutput("TransformParameterObject"))
   {
@@ -354,8 +354,8 @@ ElastixFilter<TFixedImage, TMovingImage>::GetTransformParameterObject(void)
  */
 
 template <typename TFixedImage, typename TMovingImage>
-const typename ElastixFilter<TFixedImage, TMovingImage>::ParameterObjectType *
-ElastixFilter<TFixedImage, TMovingImage>::GetTransformParameterObject(void) const
+auto
+ElastixFilter<TFixedImage, TMovingImage>::GetTransformParameterObject(void) const -> const ParameterObjectType *
 {
   if (this->HasOutput("TransformParameterObject"))
   {
@@ -404,8 +404,8 @@ ElastixFilter<TFixedImage, TMovingImage>::AddFixedImage(TFixedImage * fixedImage
  */
 
 template <typename TFixedImage, typename TMovingImage>
-typename ElastixFilter<TFixedImage, TMovingImage>::FixedImageConstPointer
-ElastixFilter<TFixedImage, TMovingImage>::GetFixedImage(void) const
+auto
+ElastixFilter<TFixedImage, TMovingImage>::GetFixedImage(void) const -> FixedImageConstPointer
 {
   if (this->GetNumberOfInputsOfType("FixedImage") > 1)
   {
@@ -421,8 +421,8 @@ ElastixFilter<TFixedImage, TMovingImage>::GetFixedImage(void) const
  */
 
 template <typename TFixedImage, typename TMovingImage>
-typename ElastixFilter<TFixedImage, TMovingImage>::FixedImageConstPointer
-ElastixFilter<TFixedImage, TMovingImage>::GetFixedImage(const unsigned int index) const
+auto
+ElastixFilter<TFixedImage, TMovingImage>::GetFixedImage(const unsigned int index) const -> FixedImageConstPointer
 {
   unsigned int  n = 0;
   NameArrayType inputNames = this->GetInputNames();
@@ -493,8 +493,8 @@ ElastixFilter<TFixedImage, TMovingImage>::AddMovingImage(TMovingImage * movingIm
  */
 
 template <typename TFixedImage, typename TMovingImage>
-typename ElastixFilter<TFixedImage, TMovingImage>::MovingImageConstPointer
-ElastixFilter<TFixedImage, TMovingImage>::GetMovingImage(void) const
+auto
+ElastixFilter<TFixedImage, TMovingImage>::GetMovingImage(void) const -> MovingImageConstPointer
 {
   if (this->GetNumberOfInputsOfType("MovingImage") > 1)
   {
@@ -510,8 +510,8 @@ ElastixFilter<TFixedImage, TMovingImage>::GetMovingImage(void) const
  */
 
 template <typename TFixedImage, typename TMovingImage>
-typename ElastixFilter<TFixedImage, TMovingImage>::MovingImageConstPointer
-ElastixFilter<TFixedImage, TMovingImage>::GetMovingImage(const unsigned int index) const
+auto
+ElastixFilter<TFixedImage, TMovingImage>::GetMovingImage(const unsigned int index) const -> MovingImageConstPointer
 {
   unsigned int  n = 0;
   NameArrayType inputNames = this->GetInputNames();
@@ -575,8 +575,8 @@ ElastixFilter<TFixedImage, TMovingImage>::AddFixedMask(FixedMaskType * fixedMask
  */
 
 template <typename TFixedImage, typename TMovingImage>
-typename ElastixFilter<TFixedImage, TMovingImage>::FixedMaskConstPointer
-ElastixFilter<TFixedImage, TMovingImage>::GetFixedMask(void) const
+auto
+ElastixFilter<TFixedImage, TMovingImage>::GetFixedMask(void) const -> FixedMaskConstPointer
 {
   return itkDynamicCastInDebugMode<const FixedMaskType *>(this->GetInput("FixedMask"));
 }
@@ -587,8 +587,8 @@ ElastixFilter<TFixedImage, TMovingImage>::GetFixedMask(void) const
  */
 
 template <typename TFixedImage, typename TMovingImage>
-typename ElastixFilter<TFixedImage, TMovingImage>::FixedMaskConstPointer
-ElastixFilter<TFixedImage, TMovingImage>::GetFixedMask(const unsigned int index) const
+auto
+ElastixFilter<TFixedImage, TMovingImage>::GetFixedMask(const unsigned int index) const -> FixedMaskConstPointer
 {
   unsigned int  n = 0;
   NameArrayType inputNames = this->GetInputNames();
@@ -664,8 +664,8 @@ ElastixFilter<TFixedImage, TMovingImage>::AddMovingMask(MovingMaskType * movingM
  */
 
 template <typename TFixedImage, typename TMovingImage>
-typename ElastixFilter<TFixedImage, TMovingImage>::MovingMaskConstPointer
-ElastixFilter<TFixedImage, TMovingImage>::GetMovingMask(void) const
+auto
+ElastixFilter<TFixedImage, TMovingImage>::GetMovingMask(void) const -> MovingMaskConstPointer
 {
 
   return itkDynamicCastInDebugMode<const MovingMaskType *>(this->GetInput("MovingMask"));
@@ -677,8 +677,8 @@ ElastixFilter<TFixedImage, TMovingImage>::GetMovingMask(void) const
  */
 
 template <typename TFixedImage, typename TMovingImage>
-typename ElastixFilter<TFixedImage, TMovingImage>::MovingMaskConstPointer
-ElastixFilter<TFixedImage, TMovingImage>::GetMovingMask(const unsigned int index) const
+auto
+ElastixFilter<TFixedImage, TMovingImage>::GetMovingMask(const unsigned int index) const -> MovingMaskConstPointer
 {
   unsigned int  n = 0;
   NameArrayType inputNames = this->GetInputNames();

--- a/Core/Main/elxTransformixFilter.hxx
+++ b/Core/Main/elxTransformixFilter.hxx
@@ -232,8 +232,8 @@ TransformixFilter<TMovingImage>::GenerateData(void)
  */
 
 template <typename TMovingImage>
-typename TransformixFilter<TMovingImage>::DataObjectPointer
-TransformixFilter<TMovingImage>::MakeOutput(const DataObjectIdentifierType & key)
+auto
+TransformixFilter<TMovingImage>::MakeOutput(const DataObjectIdentifierType & key) -> DataObjectPointer
 {
   if (key == "ResultImage")
   {
@@ -369,8 +369,8 @@ TransformixFilter<TMovingImage>::SetMovingImage(TMovingImage * inputImage)
  */
 
 template <typename TMovingImage>
-typename TransformixFilter<TMovingImage>::InputImageConstPointer
-TransformixFilter<TMovingImage>::GetMovingImage(void)
+auto
+TransformixFilter<TMovingImage>::GetMovingImage(void) -> InputImageConstPointer
 {
   return itkDynamicCastInDebugMode<TMovingImage *>(this->GetInput("InputImage"));
 } // end GetMovingImage()
@@ -405,8 +405,8 @@ TransformixFilter<TMovingImage>::SetTransformParameterObject(ParameterObjectPoin
  */
 
 template <typename TMovingImage>
-typename TransformixFilter<TMovingImage>::ParameterObjectType *
-TransformixFilter<TMovingImage>::GetTransformParameterObject(void)
+auto
+TransformixFilter<TMovingImage>::GetTransformParameterObject(void) -> ParameterObjectType *
 {
   return dynamic_cast<ParameterObjectType *>(this->GetInput("TransformParameterObject"));
 } // end GetTransformParameterObject()
@@ -417,8 +417,8 @@ TransformixFilter<TMovingImage>::GetTransformParameterObject(void)
  */
 
 template <typename TMovingImage>
-const typename TransformixFilter<TMovingImage>::ParameterObjectType *
-TransformixFilter<TMovingImage>::GetTransformParameterObject(void) const
+auto
+TransformixFilter<TMovingImage>::GetTransformParameterObject(void) const -> const ParameterObjectType *
 {
   return dynamic_cast<const ParameterObjectType *>(this->GetInput("TransformParameterObject"));
 } // end GetTransformParameterObject()
@@ -428,8 +428,8 @@ TransformixFilter<TMovingImage>::GetTransformParameterObject(void) const
  *  ********************* GetOutputDeformationField *********************
  */
 template <typename TMovingImage>
-typename TransformixFilter<TMovingImage>::OutputDeformationFieldType *
-TransformixFilter<TMovingImage>::GetOutputDeformationField()
+auto
+TransformixFilter<TMovingImage>::GetOutputDeformationField() -> OutputDeformationFieldType *
 {
 
   return itkDynamicCastInDebugMode<OutputDeformationFieldType *>(
@@ -440,8 +440,8 @@ TransformixFilter<TMovingImage>::GetOutputDeformationField()
  *  ********************* GetOutputDeformationField *********************
  */
 template <typename TMovingImage>
-const typename TransformixFilter<TMovingImage>::OutputDeformationFieldType *
-TransformixFilter<TMovingImage>::GetOutputDeformationField() const
+auto
+TransformixFilter<TMovingImage>::GetOutputDeformationField() const -> const OutputDeformationFieldType *
 {
 
   return itkDynamicCastInDebugMode<const OutputDeformationFieldType *>(

--- a/Core/Main/itkElastixRegistrationMethod.hxx
+++ b/Core/Main/itkElastixRegistrationMethod.hxx
@@ -324,48 +324,48 @@ ElastixRegistrationMethod<TFixedImage, TMovingImage>::SetParameterObject(Paramet
 
 
 template <typename TFixedImage, typename TMovingImage>
-typename ElastixRegistrationMethod<TFixedImage, TMovingImage>::ParameterObjectType *
-ElastixRegistrationMethod<TFixedImage, TMovingImage>::GetParameterObject()
+auto
+ElastixRegistrationMethod<TFixedImage, TMovingImage>::GetParameterObject() -> ParameterObjectType *
 {
   return itkDynamicCastInDebugMode<ParameterObjectType *>(this->ProcessObject::GetInput("ParameterObject"));
 }
 
 
 template <typename TFixedImage, typename TMovingImage>
-const typename ElastixRegistrationMethod<TFixedImage, TMovingImage>::ParameterObjectType *
-ElastixRegistrationMethod<TFixedImage, TMovingImage>::GetParameterObject() const
+auto
+ElastixRegistrationMethod<TFixedImage, TMovingImage>::GetParameterObject() const -> const ParameterObjectType *
 {
   return itkDynamicCastInDebugMode<const ParameterObjectType *>(this->ProcessObject::GetInput("ParameterObject"));
 }
 
 
 template <typename TFixedImage, typename TMovingImage>
-typename ElastixRegistrationMethod<TFixedImage, TMovingImage>::ParameterObjectType *
-ElastixRegistrationMethod<TFixedImage, TMovingImage>::GetTransformParameterObject()
+auto
+ElastixRegistrationMethod<TFixedImage, TMovingImage>::GetTransformParameterObject() -> ParameterObjectType *
 {
   return static_cast<ParameterObjectType *>(this->ProcessObject::GetOutput(1));
 }
 
 
 template <typename TFixedImage, typename TMovingImage>
-const typename ElastixRegistrationMethod<TFixedImage, TMovingImage>::ParameterObjectType *
-ElastixRegistrationMethod<TFixedImage, TMovingImage>::GetTransformParameterObject() const
+auto
+ElastixRegistrationMethod<TFixedImage, TMovingImage>::GetTransformParameterObject() const -> const ParameterObjectType *
 {
   return static_cast<const ParameterObjectType *>(this->ProcessObject::GetOutput(1));
 }
 
 
 template <typename TFixedImage, typename TMovingImage>
-typename ElastixRegistrationMethod<TFixedImage, TMovingImage>::ResultImageType *
-ElastixRegistrationMethod<TFixedImage, TMovingImage>::GetOutput()
+auto
+ElastixRegistrationMethod<TFixedImage, TMovingImage>::GetOutput() -> ResultImageType *
 {
   return static_cast<ResultImageType *>(this->ProcessObject::GetOutput(0));
 }
 
 
 template <typename TFixedImage, typename TMovingImage>
-const typename ElastixRegistrationMethod<TFixedImage, TMovingImage>::ResultImageType *
-ElastixRegistrationMethod<TFixedImage, TMovingImage>::GetOutput() const
+auto
+ElastixRegistrationMethod<TFixedImage, TMovingImage>::GetOutput() const -> const ResultImageType *
 {
   return static_cast<const ResultImageType *>(this->ProcessObject::GetOutput(0));
 }
@@ -425,8 +425,8 @@ ElastixRegistrationMethod<TFixedImage, TMovingImage>::AddFixedImage(TFixedImage 
 
 
 template <typename TFixedImage, typename TMovingImage>
-const typename ElastixRegistrationMethod<TFixedImage, TMovingImage>::FixedImageType *
-ElastixRegistrationMethod<TFixedImage, TMovingImage>::GetFixedImage() const
+auto
+ElastixRegistrationMethod<TFixedImage, TMovingImage>::GetFixedImage() const -> const FixedImageType *
 {
   if (this->GetNumberOfInputsOfType("FixedImage") > 1)
   {
@@ -438,8 +438,9 @@ ElastixRegistrationMethod<TFixedImage, TMovingImage>::GetFixedImage() const
 
 
 template <typename TFixedImage, typename TMovingImage>
-const typename ElastixRegistrationMethod<TFixedImage, TMovingImage>::FixedImageType *
+auto
 ElastixRegistrationMethod<TFixedImage, TMovingImage>::GetFixedImage(const unsigned int index) const
+  -> const FixedImageType *
 {
   unsigned int  n = 0;
   NameArrayType inputNames = this->GetInputNames();
@@ -494,8 +495,8 @@ ElastixRegistrationMethod<TFixedImage, TMovingImage>::AddMovingImage(TMovingImag
 
 
 template <typename TFixedImage, typename TMovingImage>
-const typename ElastixRegistrationMethod<TFixedImage, TMovingImage>::MovingImageType *
-ElastixRegistrationMethod<TFixedImage, TMovingImage>::GetMovingImage() const
+auto
+ElastixRegistrationMethod<TFixedImage, TMovingImage>::GetMovingImage() const -> const MovingImageType *
 {
   if (this->GetNumberOfInputsOfType("MovingImage") > 1)
   {
@@ -507,8 +508,9 @@ ElastixRegistrationMethod<TFixedImage, TMovingImage>::GetMovingImage() const
 
 
 template <typename TFixedImage, typename TMovingImage>
-const typename ElastixRegistrationMethod<TFixedImage, TMovingImage>::MovingImageType *
+auto
 ElastixRegistrationMethod<TFixedImage, TMovingImage>::GetMovingImage(const unsigned int index) const
+  -> const MovingImageType *
 {
   unsigned int  n = 0;
   NameArrayType inputNames = this->GetInputNames();
@@ -556,16 +558,17 @@ ElastixRegistrationMethod<TFixedImage, TMovingImage>::AddFixedMask(FixedMaskType
 
 
 template <typename TFixedImage, typename TMovingImage>
-const typename ElastixRegistrationMethod<TFixedImage, TMovingImage>::FixedMaskType *
-ElastixRegistrationMethod<TFixedImage, TMovingImage>::GetFixedMask() const
+auto
+ElastixRegistrationMethod<TFixedImage, TMovingImage>::GetFixedMask() const -> const FixedMaskType *
 {
   return itkDynamicCastInDebugMode<const FixedMaskType *>(this->ProcessObject::GetInput("FixedMask"));
 }
 
 
 template <typename TFixedImage, typename TMovingImage>
-const typename ElastixRegistrationMethod<TFixedImage, TMovingImage>::FixedMaskType *
+auto
 ElastixRegistrationMethod<TFixedImage, TMovingImage>::GetFixedMask(const unsigned int index) const
+  -> const FixedMaskType *
 {
   unsigned int  n = 0;
   NameArrayType inputNames = this->GetInputNames();
@@ -621,16 +624,17 @@ ElastixRegistrationMethod<TFixedImage, TMovingImage>::AddMovingMask(MovingMaskTy
 
 
 template <typename TFixedImage, typename TMovingImage>
-const typename ElastixRegistrationMethod<TFixedImage, TMovingImage>::MovingMaskType *
-ElastixRegistrationMethod<TFixedImage, TMovingImage>::GetMovingMask() const
+auto
+ElastixRegistrationMethod<TFixedImage, TMovingImage>::GetMovingMask() const -> const MovingMaskType *
 {
   return itkDynamicCastInDebugMode<const MovingMaskType *>(this->ProcessObject::GetInput("MovingMask"));
 }
 
 
 template <typename TFixedImage, typename TMovingImage>
-const typename ElastixRegistrationMethod<TFixedImage, TMovingImage>::MovingMaskType *
+auto
 ElastixRegistrationMethod<TFixedImage, TMovingImage>::GetMovingMask(const unsigned int index) const
+  -> const MovingMaskType *
 {
   unsigned int  n = 0;
   NameArrayType inputNames = this->GetInputNames();
@@ -677,8 +681,8 @@ ElastixRegistrationMethod<TFixedImage, TMovingImage>::SetInput(FixedImageType * 
 
 
 template <typename TFixedImage, typename TMovingImage>
-const typename ElastixRegistrationMethod<TFixedImage, TMovingImage>::FixedImageType *
-ElastixRegistrationMethod<TFixedImage, TMovingImage>::GetInput() const
+auto
+ElastixRegistrationMethod<TFixedImage, TMovingImage>::GetInput() const -> const FixedImageType *
 {
   return this->GetFixedImage();
 }

--- a/Core/Main/itkTransformixFilter.hxx
+++ b/Core/Main/itkTransformixFilter.hxx
@@ -234,8 +234,8 @@ TransformixFilter<TMovingImage>::GenerateData()
 
 
 template <typename TMovingImage>
-typename TransformixFilter<TMovingImage>::DataObjectPointer
-TransformixFilter<TMovingImage>::MakeOutput(const DataObjectIdentifierType & key)
+auto
+TransformixFilter<TMovingImage>::MakeOutput(const DataObjectIdentifierType & key) -> DataObjectPointer
 {
   if (key == "ResultDeformationField")
   {
@@ -355,8 +355,8 @@ TransformixFilter<TMovingImage>::SetMovingImage(TMovingImage * inputImage)
 
 
 template <typename TMovingImage>
-const typename TransformixFilter<TMovingImage>::InputImageType *
-TransformixFilter<TMovingImage>::GetMovingImage() const
+auto
+TransformixFilter<TMovingImage>::GetMovingImage() const -> const InputImageType *
 {
   return itkDynamicCastInDebugMode<const TMovingImage *>(this->ProcessObject::GetInput("MovingImage"));
 }
@@ -378,8 +378,8 @@ TransformixFilter<TMovingImage>::SetInput(InputImageType * inputImage)
 
 
 template <typename TMovingImage>
-const typename TransformixFilter<TMovingImage>::InputImageType *
-TransformixFilter<TMovingImage>::GetInput() const
+auto
+TransformixFilter<TMovingImage>::GetInput() const -> const InputImageType *
 {
   return itkDynamicCastInDebugMode<const TMovingImage *>(this->ProcessObject::GetInput("MovingImage"));
 }
@@ -426,16 +426,16 @@ TransformixFilter<TMovingImage>::SetTransformParameterObject(ParameterObjectType
 
 
 template <typename TMovingImage>
-typename TransformixFilter<TMovingImage>::ParameterObjectType *
-TransformixFilter<TMovingImage>::GetTransformParameterObject(void)
+auto
+TransformixFilter<TMovingImage>::GetTransformParameterObject(void) -> ParameterObjectType *
 {
   return itkDynamicCastInDebugMode<ParameterObjectType *>(this->ProcessObject::GetInput("TransformParameterObject"));
 }
 
 
 template <typename TMovingImage>
-const typename TransformixFilter<TMovingImage>::ParameterObjectType *
-TransformixFilter<TMovingImage>::GetTransformParameterObject() const
+auto
+TransformixFilter<TMovingImage>::GetTransformParameterObject() const -> const ParameterObjectType *
 {
   return itkDynamicCastInDebugMode<const ParameterObjectType *>(
     this->ProcessObject::GetInput("TransformParameterObject"));
@@ -443,8 +443,8 @@ TransformixFilter<TMovingImage>::GetTransformParameterObject() const
 
 
 template <typename TMovingImage>
-typename TransformixFilter<TMovingImage>::OutputDeformationFieldType *
-TransformixFilter<TMovingImage>::GetOutputDeformationField()
+auto
+TransformixFilter<TMovingImage>::GetOutputDeformationField() -> OutputDeformationFieldType *
 {
   return itkDynamicCastInDebugMode<OutputDeformationFieldType *>(
     this->itk::ProcessObject::GetOutput("ResultDeformationField"));
@@ -452,8 +452,8 @@ TransformixFilter<TMovingImage>::GetOutputDeformationField()
 
 
 template <typename TMovingImage>
-const typename TransformixFilter<TMovingImage>::OutputDeformationFieldType *
-TransformixFilter<TMovingImage>::GetOutputDeformationField() const
+auto
+TransformixFilter<TMovingImage>::GetOutputDeformationField() const -> const OutputDeformationFieldType *
 {
   return itkDynamicCastInDebugMode<const OutputDeformationFieldType *>(
     this->itk::ProcessObject::GetOutput("ResultDeformationField"));
@@ -461,16 +461,16 @@ TransformixFilter<TMovingImage>::GetOutputDeformationField() const
 
 
 template <typename TMovingImage>
-typename TransformixFilter<TMovingImage>::OutputImageType *
-TransformixFilter<TMovingImage>::GetOutput()
+auto
+TransformixFilter<TMovingImage>::GetOutput() -> OutputImageType *
 {
   return static_cast<OutputImageType *>(this->ProcessObject::GetOutput(0));
 }
 
 
 template <typename TMovingImage>
-const typename TransformixFilter<TMovingImage>::OutputImageType *
-TransformixFilter<TMovingImage>::GetOutput() const
+auto
+TransformixFilter<TMovingImage>::GetOutput() const -> const OutputImageType *
 {
   return static_cast<const OutputImageType *>(this->ProcessObject::GetOutput(0));
 }


### PR DESCRIPTION
Modernized template member function definitions by using trailing return types, specifically for return types that are themselves specified in terms of a member type, dependent on the specific class template.

By Notepad++ v8.1.4, Find in Files:

    Find what: ^typename (\w+<.+>::)(.+)\r\n\1(.+)\r\n{\r\n
    Replace with: auto\r\n$1$3 -> $2\r\n{\r\n
    Filter: itk*.hxx
    [v] Match case
    (*) Regular expression

Following ITK commit https://github.com/InsightSoftwareConsortium/ITK/commit/c54ad6715a68570f9db14f002c239ec7ea06383d

Anticipating ITK SoftwareGuide pull request https://github.com/InsightSoftwareConsortium/ITKSoftwareGuide/pull/162 "ENH: Add "Trailing Return Types" section"

Manually fixed `elx::TransformBase::GenerateDeformationFieldImage(void)` by adding a `typename` keyword.