### PR TITLE
STYLE: Declare functions with explicitly-defaulted definitions `default`

### DIFF
--- a/Common/Transforms/itkAdvancedBSplineDeformableTransform.h
+++ b/Common/Transforms/itkAdvancedBSplineDeformableTransform.h
@@ -300,7 +300,7 @@ protected:
   PrintSelf(std::ostream & os, Indent indent) const override;
 
   AdvancedBSplineDeformableTransform();
-  ~AdvancedBSplineDeformableTransform() override;
+  ~AdvancedBSplineDeformableTransform() override = default;
 
   /** Allow subclasses to access and manipulate the weights function. */
   // Why??

--- a/Common/Transforms/itkAdvancedBSplineDeformableTransform.hxx
+++ b/Common/Transforms/itkAdvancedBSplineDeformableTransform.hxx
@@ -141,11 +141,6 @@ AdvancedBSplineDeformableTransform<TScalarType, NDimensions, VSplineOrder>::Adva
 } // end Constructor
 
 
-// Destructor
-template <class TScalarType, unsigned int NDimensions, unsigned int VSplineOrder>
-AdvancedBSplineDeformableTransform<TScalarType, NDimensions, VSplineOrder>::~AdvancedBSplineDeformableTransform() =
-  default;
-
 // Set the grid region
 template <class TScalarType, unsigned int NDimensions, unsigned int VSplineOrder>
 void

--- a/Common/Transforms/itkAdvancedBSplineDeformableTransformBase.h
+++ b/Common/Transforms/itkAdvancedBSplineDeformableTransformBase.h
@@ -300,7 +300,7 @@ protected:
   PrintSelf(std::ostream & os, Indent indent) const override;
 
   AdvancedBSplineDeformableTransformBase();
-  ~AdvancedBSplineDeformableTransformBase() override;
+  ~AdvancedBSplineDeformableTransformBase() override = default;
 
   /** Wrap flat array into images of coefficients. */
   void

--- a/Common/Transforms/itkAdvancedBSplineDeformableTransformBase.hxx
+++ b/Common/Transforms/itkAdvancedBSplineDeformableTransformBase.hxx
@@ -98,10 +98,6 @@ AdvancedBSplineDeformableTransformBase<TScalarType, NDimensions>::AdvancedBSplin
 }
 
 
-// Destructor
-template <class TScalarType, unsigned int NDimensions>
-AdvancedBSplineDeformableTransformBase<TScalarType, NDimensions>::~AdvancedBSplineDeformableTransformBase() = default;
-
 // Get the number of parameters
 template <class TScalarType, unsigned int NDimensions>
 auto

--- a/Common/Transforms/itkAdvancedRigid2DTransform.h
+++ b/Common/Transforms/itkAdvancedRigid2DTransform.h
@@ -270,7 +270,7 @@ protected:
   explicit AdvancedRigid2DTransform(unsigned int parametersDimension);
   AdvancedRigid2DTransform(unsigned int outputSpaceDimension, unsigned int parametersDimension);
 
-  ~AdvancedRigid2DTransform() override;
+  ~AdvancedRigid2DTransform() override = default;
 
   /**
    * Print contents of an AdvancedRigid2DTransform

--- a/Common/Transforms/itkAdvancedRigid2DTransform.hxx
+++ b/Common/Transforms/itkAdvancedRigid2DTransform.hxx
@@ -71,10 +71,6 @@ AdvancedRigid2DTransform<TScalarType>::AdvancedRigid2DTransform(unsigned int spa
 }
 
 
-// Destructor
-template <class TScalarType>
-AdvancedRigid2DTransform<TScalarType>::~AdvancedRigid2DTransform() = default;
-
 // Print self
 template <class TScalarType>
 void

--- a/Common/Transforms/itkAdvancedRigid3DTransform.h
+++ b/Common/Transforms/itkAdvancedRigid3DTransform.h
@@ -205,7 +205,7 @@ protected:
   explicit AdvancedRigid3DTransform(unsigned int paramDim);
   AdvancedRigid3DTransform(const MatrixType & matrix, const OutputVectorType & offset);
   AdvancedRigid3DTransform();
-  ~AdvancedRigid3DTransform() override;
+  ~AdvancedRigid3DTransform() override = default;
 
   /**
    * Print contents of an AdvancedRigid3DTransform

--- a/Common/Transforms/itkAdvancedRigid3DTransform.hxx
+++ b/Common/Transforms/itkAdvancedRigid3DTransform.hxx
@@ -58,10 +58,6 @@ AdvancedRigid3DTransform<TScalarType>::AdvancedRigid3DTransform(const MatrixType
   : Superclass(matrix, offset)
 {}
 
-// Destructor
-template <class TScalarType>
-AdvancedRigid3DTransform<TScalarType>::~AdvancedRigid3DTransform() = default;
-
 // Print self
 template <class TScalarType>
 void

--- a/Common/Transforms/itkCyclicBSplineDeformableTransform.h
+++ b/Common/Transforms/itkCyclicBSplineDeformableTransform.h
@@ -126,7 +126,7 @@ public:
 
 protected:
   CyclicBSplineDeformableTransform();
-  ~CyclicBSplineDeformableTransform() override;
+  ~CyclicBSplineDeformableTransform() override = default;
 
   void
   ComputeNonZeroJacobianIndices(NonZeroJacobianIndicesType & nonZeroJacobianIndices,

--- a/Common/Transforms/itkCyclicBSplineDeformableTransform.hxx
+++ b/Common/Transforms/itkCyclicBSplineDeformableTransform.hxx
@@ -31,10 +31,6 @@ CyclicBSplineDeformableTransform<TScalarType, NDimensions, VSplineOrder>::Cyclic
   : Superclass()
 {}
 
-/** Destructor. */
-template <class TScalarType, unsigned int NDimensions, unsigned int VSplineOrder>
-CyclicBSplineDeformableTransform<TScalarType, NDimensions, VSplineOrder>::~CyclicBSplineDeformableTransform() = default;
-
 /** Set the grid region. */
 template <class TScalarType, unsigned int NDimensions, unsigned int VSplineOrder>
 void

--- a/Common/itkAdvancedLinearInterpolateImageFunction.h
+++ b/Common/itkAdvancedLinearInterpolateImageFunction.h
@@ -117,7 +117,7 @@ public:
 
 
 protected:
-  AdvancedLinearInterpolateImageFunction();
+  AdvancedLinearInterpolateImageFunction() = default;
   ~AdvancedLinearInterpolateImageFunction() override = default;
 
 private:

--- a/Common/itkAdvancedLinearInterpolateImageFunction.hxx
+++ b/Common/itkAdvancedLinearInterpolateImageFunction.hxx
@@ -26,13 +26,6 @@ namespace itk
 {
 
 /**
- * ***************** Constructor ***********************
- */
-
-template <class TInputImage, class TCoordRep>
-AdvancedLinearInterpolateImageFunction<TInputImage, TCoordRep>::AdvancedLinearInterpolateImageFunction() = default;
-
-/**
  * ***************** EvaluateDerivativeAtContinuousIndex ***********************
  */
 

--- a/Common/itkMultiResolutionGaussianSmoothingPyramidImageFilter.h
+++ b/Common/itkMultiResolutionGaussianSmoothingPyramidImageFilter.h
@@ -186,7 +186,7 @@ public:
   GenerateInputRequestedRegion() override;
 
 protected:
-  MultiResolutionGaussianSmoothingPyramidImageFilter();
+  MultiResolutionGaussianSmoothingPyramidImageFilter() = default;
   ~MultiResolutionGaussianSmoothingPyramidImageFilter() override = default;
   void
   PrintSelf(std::ostream & os, Indent indent) const override;

--- a/Common/itkMultiResolutionGaussianSmoothingPyramidImageFilter.hxx
+++ b/Common/itkMultiResolutionGaussianSmoothingPyramidImageFilter.hxx
@@ -48,14 +48,6 @@ namespace itk
 {
 
 /*
- * Constructor
- */
-template <class TInputImage, class TOutputImage>
-MultiResolutionGaussianSmoothingPyramidImageFilter<TInputImage,
-                                                   TOutputImage>::MultiResolutionGaussianSmoothingPyramidImageFilter() =
-  default;
-
-/*
  * Set the multi-resolution schedule
  */
 template <class TInputImage, class TOutputImage>

--- a/Components/Metrics/KNNGraphAlphaMutualInformation/KNN/itkANNFixedRadiusTreeSearch.h
+++ b/Components/Metrics/KNNGraphAlphaMutualInformation/KNN/itkANNFixedRadiusTreeSearch.h
@@ -81,7 +81,7 @@ public:
 
 protected:
   ANNFixedRadiusTreeSearch();
-  ~ANNFixedRadiusTreeSearch() override;
+  ~ANNFixedRadiusTreeSearch() override = default;
 
   /** Member variables. */
   double m_ErrorBound;

--- a/Components/Metrics/KNNGraphAlphaMutualInformation/KNN/itkANNFixedRadiusTreeSearch.hxx
+++ b/Components/Metrics/KNNGraphAlphaMutualInformation/KNN/itkANNFixedRadiusTreeSearch.hxx
@@ -36,13 +36,6 @@ ANNFixedRadiusTreeSearch<TBinaryTree>::ANNFixedRadiusTreeSearch()
 
 
 /**
- * ************************ Destructor *************************
- */
-
-template <class TBinaryTree>
-ANNFixedRadiusTreeSearch<TBinaryTree>::~ANNFixedRadiusTreeSearch() = default; // end Destructor
-
-/**
  * ************************ Search *************************
  */
 

--- a/Components/Metrics/KNNGraphAlphaMutualInformation/KNN/itkANNPriorityTreeSearch.h
+++ b/Components/Metrics/KNNGraphAlphaMutualInformation/KNN/itkANNPriorityTreeSearch.h
@@ -80,7 +80,7 @@ public:
 
 protected:
   ANNPriorityTreeSearch();
-  ~ANNPriorityTreeSearch() override;
+  ~ANNPriorityTreeSearch() override = default;
 
   /** Member variables. */
   double          m_ErrorBound;

--- a/Components/Metrics/KNNGraphAlphaMutualInformation/KNN/itkANNPriorityTreeSearch.hxx
+++ b/Components/Metrics/KNNGraphAlphaMutualInformation/KNN/itkANNPriorityTreeSearch.hxx
@@ -36,13 +36,6 @@ ANNPriorityTreeSearch<TBinaryTree>::ANNPriorityTreeSearch()
 
 
 /**
- * ************************ Destructor *************************
- */
-
-template <class TBinaryTree>
-ANNPriorityTreeSearch<TBinaryTree>::~ANNPriorityTreeSearch() = default; // end Destructor
-
-/**
  * ************************ SetBinaryTree *************************
  *
  */

--- a/Components/Metrics/KNNGraphAlphaMutualInformation/KNN/itkANNStandardTreeSearch.h
+++ b/Components/Metrics/KNNGraphAlphaMutualInformation/KNN/itkANNStandardTreeSearch.h
@@ -73,7 +73,7 @@ public:
 
 protected:
   ANNStandardTreeSearch();
-  ~ANNStandardTreeSearch() override;
+  ~ANNStandardTreeSearch() override = default;
 
   /** Member variables. */
   double m_ErrorBound;

--- a/Components/Metrics/KNNGraphAlphaMutualInformation/KNN/itkANNStandardTreeSearch.hxx
+++ b/Components/Metrics/KNNGraphAlphaMutualInformation/KNN/itkANNStandardTreeSearch.hxx
@@ -35,13 +35,6 @@ ANNStandardTreeSearch<TBinaryTree>::ANNStandardTreeSearch()
 
 
 /**
- * ************************ Destructor *************************
- */
-
-template <class TBinaryTree>
-ANNStandardTreeSearch<TBinaryTree>::~ANNStandardTreeSearch() = default; // end Destructor
-
-/**
  * ************************ Search *************************
  */
 

--- a/Components/Metrics/KNNGraphAlphaMutualInformation/KNN/itkBinaryANNTreeBase.h
+++ b/Components/Metrics/KNNGraphAlphaMutualInformation/KNN/itkBinaryANNTreeBase.h
@@ -61,7 +61,7 @@ public:
 
 protected:
   /** Constructor. */
-  BinaryANNTreeBase();
+  BinaryANNTreeBase() = default;
 
   /** Destructor. */
   ~BinaryANNTreeBase() override = default;

--- a/Components/Metrics/KNNGraphAlphaMutualInformation/KNN/itkBinaryANNTreeBase.hxx
+++ b/Components/Metrics/KNNGraphAlphaMutualInformation/KNN/itkBinaryANNTreeBase.hxx
@@ -20,16 +20,4 @@
 
 #include "itkBinaryANNTreeBase.h"
 
-namespace itk
-{
-
-/**
- * ************************ Constructor *************************
- */
-
-template <class TListSample>
-BinaryANNTreeBase<TListSample>::BinaryANNTreeBase() = default; // end Constructor
-
-} // end namespace itk
-
 #endif // end #ifndef itkBinaryANNTreeBase_hxx

--- a/Components/Metrics/KNNGraphAlphaMutualInformation/KNN/itkBinaryANNTreeSearchBase.h
+++ b/Components/Metrics/KNNGraphAlphaMutualInformation/KNN/itkBinaryANNTreeSearchBase.h
@@ -73,7 +73,7 @@ public:
 
 protected:
   BinaryANNTreeSearchBase();
-  ~BinaryANNTreeSearchBase() override;
+  ~BinaryANNTreeSearchBase() override = default;
 
   /** Member variables. */
   typename BinaryANNTreeType::Pointer m_BinaryTreeAsITKANNType;

--- a/Components/Metrics/KNNGraphAlphaMutualInformation/KNN/itkBinaryANNTreeSearchBase.hxx
+++ b/Components/Metrics/KNNGraphAlphaMutualInformation/KNN/itkBinaryANNTreeSearchBase.hxx
@@ -35,13 +35,6 @@ BinaryANNTreeSearchBase<TBinaryTree>::BinaryANNTreeSearchBase()
 
 
 /**
- * ************************ Destructor *************************
- */
-
-template <class TBinaryTree>
-BinaryANNTreeSearchBase<TBinaryTree>::~BinaryANNTreeSearchBase() = default; // end Destructor
-
-/**
  * ************************ SetBinaryTree *************************
  */
 

--- a/Components/Metrics/KNNGraphAlphaMutualInformation/KNN/itkBinaryTreeSearchBase.h
+++ b/Components/Metrics/KNNGraphAlphaMutualInformation/KNN/itkBinaryTreeSearchBase.h
@@ -73,7 +73,7 @@ public:
 
 protected:
   BinaryTreeSearchBase();
-  ~BinaryTreeSearchBase() override;
+  ~BinaryTreeSearchBase() override = default;
 
   /** Member variables. */
   BinaryTreePointer m_BinaryTree;

--- a/Components/Metrics/KNNGraphAlphaMutualInformation/KNN/itkBinaryTreeSearchBase.hxx
+++ b/Components/Metrics/KNNGraphAlphaMutualInformation/KNN/itkBinaryTreeSearchBase.hxx
@@ -36,13 +36,6 @@ BinaryTreeSearchBase<TBinaryTree>::BinaryTreeSearchBase()
 
 
 /**
- * ************************ Destructor *************************
- */
-
-template <class TBinaryTree>
-BinaryTreeSearchBase<TBinaryTree>::~BinaryTreeSearchBase() = default; // end Destructor
-
-/**
  * ************************ SetBinaryTree *************************
  */
 

--- a/Components/Metrics/MissingStructurePenalty/itkMissingStructurePenalty.h
+++ b/Components/Metrics/MissingStructurePenalty/itkMissingStructurePenalty.h
@@ -156,7 +156,7 @@ public:
 
 protected:
   MissingVolumeMeshPenalty();
-  ~MissingVolumeMeshPenalty() override;
+  ~MissingVolumeMeshPenalty() override = default;
 
   /** PrintSelf. */
   // void PrintSelf(std::ostream& os, Indent indent) const;

--- a/Components/Metrics/MissingStructurePenalty/itkMissingStructurePenalty.hxx
+++ b/Components/Metrics/MissingStructurePenalty/itkMissingStructurePenalty.hxx
@@ -36,14 +36,6 @@ MissingVolumeMeshPenalty<TFixedPointSet, TMovingPointSet>::MissingVolumeMeshPena
 
 
 /**
- * ******************* Destructor *******************
- */
-
-template <class TFixedPointSet, class TMovingPointSet>
-MissingVolumeMeshPenalty<TFixedPointSet, TMovingPointSet>::~MissingVolumeMeshPenalty() = default; // end Destructor
-
-
-/**
  * *********************** Initialize *****************************
  */
 

--- a/Components/Metrics/PolydataDummyPenalty/itkPolydataDummyPenalty.h
+++ b/Components/Metrics/PolydataDummyPenalty/itkPolydataDummyPenalty.h
@@ -173,7 +173,7 @@ public:
 
 protected:
   MeshPenalty();
-  ~MeshPenalty() override;
+  ~MeshPenalty() override = default;
 
   /** PrintSelf. */
   void

--- a/Components/Metrics/PolydataDummyPenalty/itkPolydataDummyPenalty.hxx
+++ b/Components/Metrics/PolydataDummyPenalty/itkPolydataDummyPenalty.hxx
@@ -35,13 +35,6 @@ MeshPenalty<TFixedPointSet, TMovingPointSet>::MeshPenalty()
 
 
 /**
- * ******************* Destructor *******************
- */
-
-template <class TFixedPointSet, class TMovingPointSet>
-MeshPenalty<TFixedPointSet, TMovingPointSet>::~MeshPenalty() = default; // end Destructor
-
-/**
  * *********************** Initialize *****************************
  */
 

--- a/Components/Registrations/MultiResolutionRegistrationWithFeatures/itkMultiInputMultiResolutionImageRegistrationMethodBase.h
+++ b/Components/Registrations/MultiResolutionRegistrationWithFeatures/itkMultiInputMultiResolutionImageRegistrationMethodBase.h
@@ -262,7 +262,7 @@ public:
 
 protected:
   /** Constructor. */
-  MultiInputMultiResolutionImageRegistrationMethodBase();
+  MultiInputMultiResolutionImageRegistrationMethodBase() = default;
 
   /** Destructor. */
   ~MultiInputMultiResolutionImageRegistrationMethodBase() override = default;

--- a/Components/Registrations/MultiResolutionRegistrationWithFeatures/itkMultiInputMultiResolutionImageRegistrationMethodBase.hxx
+++ b/Components/Registrations/MultiResolutionRegistrationWithFeatures/itkMultiInputMultiResolutionImageRegistrationMethodBase.hxx
@@ -71,12 +71,6 @@ itkImplementationSetMacro(MovingImagePyramid, MovingImagePyramidType *);
 itkImplementationSetMacro(Interpolator, InterpolatorType *);
 itkImplementationSetMacro2(FixedImageInterpolator, FixedImageInterpolatorType *);
 
-/**
- * ****************** Constructor ******************
- */
-template <typename TFixedImage, typename TMovingImage>
-MultiInputMultiResolutionImageRegistrationMethodBase<TFixedImage, TMovingImage>::
-  MultiInputMultiResolutionImageRegistrationMethodBase() = default; // end Constructor()
 
 /**
  * **************** GetFixedImage **********************************

--- a/Components/Transforms/AdvancedBSplineTransform/elxAdvancedBSplineTransform.h
+++ b/Components/Transforms/AdvancedBSplineTransform/elxAdvancedBSplineTransform.h
@@ -269,7 +269,7 @@ public:
 
 protected:
   /** The constructor. */
-  AdvancedBSplineTransform();
+  AdvancedBSplineTransform() = default;
 
   /** The destructor. */
   ~AdvancedBSplineTransform() override = default;

--- a/Components/Transforms/AdvancedBSplineTransform/elxAdvancedBSplineTransform.hxx
+++ b/Components/Transforms/AdvancedBSplineTransform/elxAdvancedBSplineTransform.hxx
@@ -28,14 +28,6 @@ namespace elastix
 {
 
 /**
- * ********************* Constructor ****************************
- */
-
-template <class TElastix>
-AdvancedBSplineTransform<TElastix>::AdvancedBSplineTransform() = default; // end Constructor()
-
-
-/**
  * ************ InitializeBSplineTransform ***************
  */
 

--- a/Components/Transforms/AffineLogStackTransform/elxAffineLogStackTransform.h
+++ b/Components/Transforms/AffineLogStackTransform/elxAffineLogStackTransform.h
@@ -163,7 +163,7 @@ public:
 
 protected:
   /** The constructor. */
-  AffineLogStackTransform();
+  AffineLogStackTransform() = default;
 
   /** The destructor. */
   ~AffineLogStackTransform() override = default;

--- a/Components/Transforms/AffineLogStackTransform/elxAffineLogStackTransform.hxx
+++ b/Components/Transforms/AffineLogStackTransform/elxAffineLogStackTransform.hxx
@@ -27,13 +27,6 @@ namespace elastix
 {
 
 /**
- * ********************* Constructor ****************************
- */
-template <class TElastix>
-AffineLogStackTransform<TElastix>::AffineLogStackTransform() = default; // end Constructor
-
-
-/**
  * ********************* InitializeAffineTransform ****************************
  */
 template <class TElastix>

--- a/Components/Transforms/BSplineStackTransform/elxBSplineStackTransform.h
+++ b/Components/Transforms/BSplineStackTransform/elxBSplineStackTransform.h
@@ -280,7 +280,7 @@ public:
 
 protected:
   /** The constructor. */
-  BSplineStackTransform();
+  BSplineStackTransform() = default;
 
   /** The destructor. */
   ~BSplineStackTransform() override = default;

--- a/Components/Transforms/BSplineStackTransform/elxBSplineStackTransform.hxx
+++ b/Components/Transforms/BSplineStackTransform/elxBSplineStackTransform.hxx
@@ -27,14 +27,6 @@ namespace elastix
 {
 
 /**
- * ********************* Constructor ****************************
- */
-
-template <class TElastix>
-BSplineStackTransform<TElastix>::BSplineStackTransform() = default; // end Constructor()
-
-
-/**
  * ************ InitializeBSplineTransform ***************
  */
 template <class TElastix>

--- a/Components/Transforms/DeformationFieldTransform/itkDeformationFieldInterpolatingTransform.h
+++ b/Components/Transforms/DeformationFieldTransform/itkDeformationFieldInterpolatingTransform.h
@@ -242,7 +242,7 @@ public:
 
 protected:
   DeformationFieldInterpolatingTransform();
-  ~DeformationFieldInterpolatingTransform() override;
+  ~DeformationFieldInterpolatingTransform() override = default;
 
   /** Typedef which is used internally */
   typedef typename DeformationFieldInterpolatorType::ContinuousIndexType InputContinuousIndexType;

--- a/Components/Transforms/DeformationFieldTransform/itkDeformationFieldInterpolatingTransform.hxx
+++ b/Components/Transforms/DeformationFieldTransform/itkDeformationFieldInterpolatingTransform.hxx
@@ -39,11 +39,6 @@ DeformationFieldInterpolatingTransform<TScalarType, NDimensions, TComponentType>
 } // end Constructor
 
 
-// Destructor
-template <class TScalarType, unsigned int NDimensions, class TComponentType>
-DeformationFieldInterpolatingTransform<TScalarType, NDimensions, TComponentType>::
-  ~DeformationFieldInterpolatingTransform() = default; // end Destructor
-
 // Transform a point
 template <class TScalarType, unsigned int NDimensions, class TComponentType>
 auto

--- a/Components/Transforms/EulerStackTransform/elxEulerStackTransform.h
+++ b/Components/Transforms/EulerStackTransform/elxEulerStackTransform.h
@@ -210,7 +210,7 @@ public:
 
 protected:
   /** The constructor. */
-  EulerStackTransform();
+  EulerStackTransform() = default;
 
   /** The destructor. */
   ~EulerStackTransform() override = default;

--- a/Components/Transforms/EulerStackTransform/elxEulerStackTransform.hxx
+++ b/Components/Transforms/EulerStackTransform/elxEulerStackTransform.hxx
@@ -24,13 +24,6 @@ namespace elastix
 {
 
 /**
- * ********************* Constructor ****************************
- */
-template <class TElastix>
-EulerStackTransform<TElastix>::EulerStackTransform() = default; // end Constructor
-
-
-/**
  * ********************* InitializeAffineTransform ****************************
  */
 template <class TElastix>

--- a/Components/Transforms/MultiBSplineTransformWithNormal/elxMultiBSplineTransformWithNormal.h
+++ b/Components/Transforms/MultiBSplineTransformWithNormal/elxMultiBSplineTransformWithNormal.h
@@ -245,7 +245,7 @@ public:
 
 protected:
   /** The constructor. */
-  MultiBSplineTransformWithNormal();
+  MultiBSplineTransformWithNormal() = default;
 
   /** The destructor. */
   ~MultiBSplineTransformWithNormal() override = default;

--- a/Components/Transforms/MultiBSplineTransformWithNormal/elxMultiBSplineTransformWithNormal.hxx
+++ b/Components/Transforms/MultiBSplineTransformWithNormal/elxMultiBSplineTransformWithNormal.hxx
@@ -31,13 +31,6 @@ namespace elastix
 {
 
 /**
- * ********************* Constructor ****************************
- */
-
-template <class TElastix>
-MultiBSplineTransformWithNormal<TElastix>::MultiBSplineTransformWithNormal() = default; // end Constructor()
-
-/**
  * ************ InitializeBSplineTransform ***************
  */
 

--- a/Components/Transforms/MultiBSplineTransformWithNormal/itkMultiBSplineDeformableTransformWithNormal.h
+++ b/Components/Transforms/MultiBSplineTransformWithNormal/itkMultiBSplineDeformableTransformWithNormal.h
@@ -423,7 +423,7 @@ protected:
   PrintSelf(std::ostream & os, Indent indent) const override;
 
   MultiBSplineDeformableTransformWithNormal();
-  ~MultiBSplineDeformableTransformWithNormal() override;
+  ~MultiBSplineDeformableTransformWithNormal() override = default;
 
   /** Wrap flat array into images of coefficients. */
   // void WrapAsImages( void );

--- a/Components/Transforms/MultiBSplineTransformWithNormal/itkMultiBSplineDeformableTransformWithNormal.hxx
+++ b/Components/Transforms/MultiBSplineTransformWithNormal/itkMultiBSplineDeformableTransformWithNormal.hxx
@@ -55,11 +55,6 @@ MultiBSplineDeformableTransformWithNormal<TScalarType, NDimensions, VSplineOrder
 }
 
 
-// Destructor
-template <class TScalarType, unsigned int NDimensions, unsigned int VSplineOrder>
-MultiBSplineDeformableTransformWithNormal<TScalarType, NDimensions, VSplineOrder>::
-  ~MultiBSplineDeformableTransformWithNormal() = default;
-
 // Get the number of parameters
 template <class TScalarType, unsigned int NDimensions, unsigned int VSplineOrder>
 auto

--- a/Components/Transforms/RecursiveBSplineTransform/elxRecursiveBSplineTransform.h
+++ b/Components/Transforms/RecursiveBSplineTransform/elxRecursiveBSplineTransform.h
@@ -266,7 +266,7 @@ public:
 
 protected:
   /** The constructor. */
-  RecursiveBSplineTransform();
+  RecursiveBSplineTransform() = default;
 
   /** The destructor. */
   ~RecursiveBSplineTransform() override = default;

--- a/Components/Transforms/RecursiveBSplineTransform/elxRecursiveBSplineTransform.hxx
+++ b/Components/Transforms/RecursiveBSplineTransform/elxRecursiveBSplineTransform.hxx
@@ -27,14 +27,6 @@ namespace elastix
 {
 
 /**
- * ********************* Constructor ****************************
- */
-
-template <class TElastix>
-RecursiveBSplineTransform<TElastix>::RecursiveBSplineTransform() = default; // end Constructor()
-
-
-/**
  * ************ InitializeBSplineTransform ***************
  */
 


### PR DESCRIPTION
Removed function definitions that are explicitly-defaulted from hxx files, and declare them `= default` in the corresponding h files.

Hoping to slightly speed-up compilations, and ease further maintenance.