### PR TITLE
STYLE: Clean up #include's elxElastixTemplate, itkTransl...Initializer.h

### DIFF
--- a/Components/Transforms/TranslationTransform/itkTranslationTransformInitializer.h
+++ b/Components/Transforms/TranslationTransform/itkTranslationTransformInitializer.h
@@ -19,9 +19,9 @@
 #ifndef itkTranslationTransformInitializer_h
 #define itkTranslationTransformInitializer_h
 
-#include "itkObject.h"
-#include "itkObjectFactory.h"
-#include "itkImageMomentsCalculator.h"
+// ITK header files:
+#include <itkImageMomentsCalculator.h>
+#include <itkObject.h>
 
 #include <iostream>
 

--- a/Core/ComponentBaseClasses/elxResampleInterpolatorBase.hxx
+++ b/Core/ComponentBaseClasses/elxResampleInterpolatorBase.hxx
@@ -20,6 +20,7 @@
 #define elxResampleInterpolatorBase_hxx
 
 #include "elxResampleInterpolatorBase.h"
+#include "elxConversion.h"
 
 namespace elastix
 {

--- a/Core/Kernel/elxElastixTemplate.h
+++ b/Core/Kernel/elxElastixTemplate.h
@@ -19,24 +19,21 @@
 #define elxElastixTemplate_h
 
 #include "elxElastixBase.h"
-#include "itkObject.h"
-
-#include "itkObjectFactory.h"
-#include "itkCommand.h"
-#include "itkImage.h"
-#include "itkImageFileReader.h"
-#include "itkImageToImageMetric.h"
-
-#include "elxRegistrationBase.h"
 #include "elxFixedImagePyramidBase.h"
-#include "elxMovingImagePyramidBase.h"
-#include "elxInterpolatorBase.h"
 #include "elxImageSamplerBase.h"
+#include "elxInterpolatorBase.h"
 #include "elxMetricBase.h"
+#include "elxMovingImagePyramidBase.h"
 #include "elxOptimizerBase.h"
-#include "elxResamplerBase.h"
+#include "elxRegistrationBase.h"
 #include "elxResampleInterpolatorBase.h"
+#include "elxResamplerBase.h"
 #include "elxTransformBase.h"
+
+// ITK header files:
+#include <itkCommand.h>
+#include <itkImage.h>
+#include <itkObject.h>
 
 #include <sstream>
 


### PR DESCRIPTION
- Removed unused #include's
- Sorted #include's alphabetically
- Used angle brackets (`<`, `>`) for ITK header files

Added a missing #include to elxResampleInterpolatorBase.hxx