### PR TITLE
STYLE: Use `auto` for declaration of variables initialized by `New()`

### DIFF
--- a/Common/ImageSamplers/itkImageRandomCoordinateSampler.hxx
+++ b/Common/ImageSamplers/itkImageRandomCoordinateSampler.hxx
@@ -32,7 +32,7 @@ template <class TInputImage>
 ImageRandomCoordinateSampler<TInputImage>::ImageRandomCoordinateSampler()
 {
   /** Set default interpolator. */
-  typename DefaultInterpolatorType::Pointer bsplineInterpolator = DefaultInterpolatorType::New();
+  auto bsplineInterpolator = DefaultInterpolatorType::New();
   bsplineInterpolator->SetSplineOrder(3);
   this->m_Interpolator = bsplineInterpolator;
 

--- a/Common/ImageSamplers/itkImageSamplerBase.hxx
+++ b/Common/ImageSamplers/itkImageSamplerBase.hxx
@@ -338,9 +338,9 @@ ImageSamplerBase<TInputImage>::CropInputImageRegion(void)
     typedef typename MaskType::BoundingBoxType        BoundingBoxType;
     typedef typename BoundingBoxType::PointsContainer PointsContainerType;
     typename BoundingBoxType::ConstPointer            bb = this->m_Mask->GetMyBoundingBoxInWorldSpace();
-    typename BoundingBoxType::Pointer                 bbIndex = BoundingBoxType::New();
+    auto                                              bbIndex = BoundingBoxType::New();
     const PointsContainerType *                       cornersWorld = bb->GetPoints();
-    typename PointsContainerType::Pointer             cornersIndex = PointsContainerType::New();
+    auto                                              cornersIndex = PointsContainerType::New();
     cornersIndex->Reserve(cornersWorld->Size());
     typename PointsContainerType::const_iterator                                itCW = cornersWorld->begin();
     typename PointsContainerType::iterator                                      itCI = cornersIndex->begin();

--- a/Common/ImageSamplers/itkMultiInputImageRandomCoordinateSampler.hxx
+++ b/Common/ImageSamplers/itkMultiInputImageRandomCoordinateSampler.hxx
@@ -33,7 +33,7 @@ template <class TInputImage>
 MultiInputImageRandomCoordinateSampler<TInputImage>::MultiInputImageRandomCoordinateSampler()
 {
   /** Set the default interpolator. */
-  typename DefaultInterpolatorType::Pointer bsplineInterpolator = DefaultInterpolatorType::New();
+  auto bsplineInterpolator = DefaultInterpolatorType::New();
   bsplineInterpolator->SetSplineOrder(3);
   this->m_Interpolator = bsplineInterpolator;
 

--- a/Common/MevisDicomTiff/itkMevisDicomTiffImageIOFactory.h
+++ b/Common/MevisDicomTiff/itkMevisDicomTiffImageIOFactory.h
@@ -54,7 +54,7 @@ public:
   static void
   RegisterOneFactory(void)
   {
-    MevisDicomTiffImageIOFactory::Pointer metaFactory = MevisDicomTiffImageIOFactory::New();
+    auto metaFactory = MevisDicomTiffImageIOFactory::New();
     ObjectFactoryBase::RegisterFactory(metaFactory);
   }
 

--- a/Common/OpenCL/Factories/itkGPUAdvancedBSplineDeformableTransformFactory.hxx
+++ b/Common/OpenCL/Factories/itkGPUAdvancedBSplineDeformableTransformFactory.hxx
@@ -27,7 +27,7 @@ void
 GPUAdvancedBSplineDeformableTransformFactory2<NDimensions>::RegisterOneFactory()
 {
   typedef GPUAdvancedBSplineDeformableTransformFactory2<NDimensions> GPUTransformFactoryType;
-  typename GPUTransformFactoryType::Pointer                          factory = GPUTransformFactoryType::New();
+  auto                                                               factory = GPUTransformFactoryType::New();
   ObjectFactoryBase::RegisterFactory(factory);
 }
 

--- a/Common/OpenCL/Factories/itkGPUAdvancedCombinationTransformFactory.hxx
+++ b/Common/OpenCL/Factories/itkGPUAdvancedCombinationTransformFactory.hxx
@@ -27,7 +27,7 @@ void
 GPUAdvancedCombinationTransformFactory2<NDimensions>::RegisterOneFactory()
 {
   typedef GPUAdvancedCombinationTransformFactory2<NDimensions> GPUTransformFactoryType;
-  typename GPUTransformFactoryType::Pointer                    factory = GPUTransformFactoryType::New();
+  auto                                                         factory = GPUTransformFactoryType::New();
   ObjectFactoryBase::RegisterFactory(factory);
 }
 

--- a/Common/OpenCL/Factories/itkGPUAdvancedEuler2DTransformFactory.hxx
+++ b/Common/OpenCL/Factories/itkGPUAdvancedEuler2DTransformFactory.hxx
@@ -27,7 +27,7 @@ void
 GPUAdvancedEuler2DTransformFactory2<NDimensions>::RegisterOneFactory()
 {
   typedef GPUAdvancedEuler2DTransformFactory2<NDimensions> GPUTransformFactoryType;
-  typename GPUTransformFactoryType::Pointer                factory = GPUTransformFactoryType::New();
+  auto                                                     factory = GPUTransformFactoryType::New();
   ObjectFactoryBase::RegisterFactory(factory);
 }
 

--- a/Common/OpenCL/Factories/itkGPUAdvancedEuler3DTransformFactory.hxx
+++ b/Common/OpenCL/Factories/itkGPUAdvancedEuler3DTransformFactory.hxx
@@ -27,7 +27,7 @@ void
 GPUAdvancedEuler3DTransformFactory2<NDimensions>::RegisterOneFactory()
 {
   typedef GPUAdvancedEuler3DTransformFactory2<NDimensions> GPUTransformFactoryType;
-  typename GPUTransformFactoryType::Pointer                factory = GPUTransformFactoryType::New();
+  auto                                                     factory = GPUTransformFactoryType::New();
   ObjectFactoryBase::RegisterFactory(factory);
 }
 

--- a/Common/OpenCL/Factories/itkGPUAdvancedMatrixOffsetTransformBaseFactory.hxx
+++ b/Common/OpenCL/Factories/itkGPUAdvancedMatrixOffsetTransformBaseFactory.hxx
@@ -27,7 +27,7 @@ void
 GPUAdvancedMatrixOffsetTransformBaseFactory2<NDimensions>::RegisterOneFactory()
 {
   typedef GPUAdvancedMatrixOffsetTransformBaseFactory2<NDimensions> GPUTransformFactoryType;
-  typename GPUTransformFactoryType::Pointer                         factory = GPUTransformFactoryType::New();
+  auto                                                              factory = GPUTransformFactoryType::New();
   ObjectFactoryBase::RegisterFactory(factory);
 }
 

--- a/Common/OpenCL/Factories/itkGPUAdvancedSimilarity2DTransformFactory.hxx
+++ b/Common/OpenCL/Factories/itkGPUAdvancedSimilarity2DTransformFactory.hxx
@@ -27,7 +27,7 @@ void
 GPUAdvancedSimilarity2DTransformFactory2<NDimensions>::RegisterOneFactory()
 {
   typedef GPUAdvancedSimilarity2DTransformFactory2<NDimensions> GPUTransformFactoryType;
-  typename GPUTransformFactoryType::Pointer                     factory = GPUTransformFactoryType::New();
+  auto                                                          factory = GPUTransformFactoryType::New();
   ObjectFactoryBase::RegisterFactory(factory);
 }
 

--- a/Common/OpenCL/Factories/itkGPUAdvancedSimilarity3DTransformFactory.hxx
+++ b/Common/OpenCL/Factories/itkGPUAdvancedSimilarity3DTransformFactory.hxx
@@ -27,7 +27,7 @@ void
 GPUAdvancedSimilarity3DTransformFactory2<NDimensions>::RegisterOneFactory()
 {
   typedef GPUAdvancedSimilarity3DTransformFactory2<NDimensions> GPUTransformFactoryType;
-  typename GPUTransformFactoryType::Pointer                     factory = GPUTransformFactoryType::New();
+  auto                                                          factory = GPUTransformFactoryType::New();
   ObjectFactoryBase::RegisterFactory(factory);
 }
 

--- a/Common/OpenCL/Factories/itkGPUAdvancedTranslationTransformFactory.hxx
+++ b/Common/OpenCL/Factories/itkGPUAdvancedTranslationTransformFactory.hxx
@@ -27,7 +27,7 @@ void
 GPUAdvancedTranslationTransformFactory2<NDimensions>::RegisterOneFactory()
 {
   typedef GPUAdvancedTranslationTransformFactory2<NDimensions> GPUTransformFactoryType;
-  typename GPUTransformFactoryType::Pointer                    factory = GPUTransformFactoryType::New();
+  auto                                                         factory = GPUTransformFactoryType::New();
   ObjectFactoryBase::RegisterFactory(factory);
 }
 

--- a/Common/OpenCL/Factories/itkGPUAffineTransformFactory.hxx
+++ b/Common/OpenCL/Factories/itkGPUAffineTransformFactory.hxx
@@ -27,7 +27,7 @@ void
 GPUAffineTransformFactory2<NDimensions>::RegisterOneFactory()
 {
   typedef GPUAffineTransformFactory2<NDimensions> GPUTransformFactoryType;
-  typename GPUTransformFactoryType::Pointer       factory = GPUTransformFactoryType::New();
+  auto                                            factory = GPUTransformFactoryType::New();
   ObjectFactoryBase::RegisterFactory(factory);
 }
 

--- a/Common/OpenCL/Factories/itkGPUBSplineDecompositionImageFilterFactory.hxx
+++ b/Common/OpenCL/Factories/itkGPUBSplineDecompositionImageFilterFactory.hxx
@@ -27,7 +27,7 @@ void
 GPUBSplineDecompositionImageFilterFactory2<TTypeListIn, TTypeListOut, NDimensions>::RegisterOneFactory()
 {
   typedef GPUBSplineDecompositionImageFilterFactory2<TTypeListIn, TTypeListOut, NDimensions> GPUFilterFactoryType;
-  typename GPUFilterFactoryType::Pointer factory = GPUFilterFactoryType::New();
+  auto factory = GPUFilterFactoryType::New();
   ObjectFactoryBase::RegisterFactory(factory);
 }
 

--- a/Common/OpenCL/Factories/itkGPUBSplineInterpolateImageFunctionFactory.hxx
+++ b/Common/OpenCL/Factories/itkGPUBSplineInterpolateImageFunctionFactory.hxx
@@ -27,7 +27,7 @@ void
 GPUBSplineInterpolateImageFunctionFactory2<TTypeList, NDimensions>::RegisterOneFactory()
 {
   typedef GPUBSplineInterpolateImageFunctionFactory2<TTypeList, NDimensions> GPUInterpolateFactoryType;
-  typename GPUInterpolateFactoryType::Pointer                                factory = GPUInterpolateFactoryType::New();
+  auto                                                                       factory = GPUInterpolateFactoryType::New();
   ObjectFactoryBase::RegisterFactory(factory);
 }
 

--- a/Common/OpenCL/Factories/itkGPUBSplineTransformFactory.hxx
+++ b/Common/OpenCL/Factories/itkGPUBSplineTransformFactory.hxx
@@ -27,7 +27,7 @@ void
 GPUBSplineTransformFactory2<NDimensions>::RegisterOneFactory()
 {
   typedef GPUBSplineTransformFactory2<NDimensions> GPUTransformFactoryType;
-  typename GPUTransformFactoryType::Pointer        factory = GPUTransformFactoryType::New();
+  auto                                             factory = GPUTransformFactoryType::New();
   ObjectFactoryBase::RegisterFactory(factory);
 }
 

--- a/Common/OpenCL/Factories/itkGPUCastImageFilterFactory.hxx
+++ b/Common/OpenCL/Factories/itkGPUCastImageFilterFactory.hxx
@@ -27,7 +27,7 @@ void
 GPUCastImageFilterFactory2<TTypeListIn, TTypeListOut, NDimensions>::RegisterOneFactory()
 {
   typedef GPUCastImageFilterFactory2<TTypeListIn, TTypeListOut, NDimensions> GPUFilterFactoryType;
-  typename GPUFilterFactoryType::Pointer                                     factory = GPUFilterFactoryType::New();
+  auto                                                                       factory = GPUFilterFactoryType::New();
   ObjectFactoryBase::RegisterFactory(factory);
 }
 

--- a/Common/OpenCL/Factories/itkGPUCompositeTransformFactory.hxx
+++ b/Common/OpenCL/Factories/itkGPUCompositeTransformFactory.hxx
@@ -27,7 +27,7 @@ void
 GPUCompositeTransformFactory2<NDimensions>::RegisterOneFactory()
 {
   typedef GPUCompositeTransformFactory2<NDimensions> GPUTransformFactoryType;
-  typename GPUTransformFactoryType::Pointer          factory = GPUTransformFactoryType::New();
+  auto                                               factory = GPUTransformFactoryType::New();
   ObjectFactoryBase::RegisterFactory(factory);
 }
 

--- a/Common/OpenCL/Factories/itkGPUEuler2DTransformFactory.hxx
+++ b/Common/OpenCL/Factories/itkGPUEuler2DTransformFactory.hxx
@@ -27,7 +27,7 @@ void
 GPUEuler2DTransformFactory2<NDimensions>::RegisterOneFactory()
 {
   typedef GPUEuler2DTransformFactory2<NDimensions> GPUTransformFactoryType;
-  typename GPUTransformFactoryType::Pointer        factory = GPUTransformFactoryType::New();
+  auto                                             factory = GPUTransformFactoryType::New();
   ObjectFactoryBase::RegisterFactory(factory);
 }
 

--- a/Common/OpenCL/Factories/itkGPUEuler3DTransformFactory.hxx
+++ b/Common/OpenCL/Factories/itkGPUEuler3DTransformFactory.hxx
@@ -27,7 +27,7 @@ void
 GPUEuler3DTransformFactory2<NDimensions>::RegisterOneFactory()
 {
   typedef GPUEuler3DTransformFactory2<NDimensions> GPUTransformFactoryType;
-  typename GPUTransformFactoryType::Pointer        factory = GPUTransformFactoryType::New();
+  auto                                             factory = GPUTransformFactoryType::New();
   ObjectFactoryBase::RegisterFactory(factory);
 }
 

--- a/Common/OpenCL/Factories/itkGPUIdentityTransformFactory.hxx
+++ b/Common/OpenCL/Factories/itkGPUIdentityTransformFactory.hxx
@@ -27,7 +27,7 @@ void
 GPUIdentityTransformFactory2<NDimensions>::RegisterOneFactory()
 {
   typedef GPUIdentityTransformFactory2<NDimensions> GPUTransformFactoryType;
-  typename GPUTransformFactoryType::Pointer         factory = GPUTransformFactoryType::New();
+  auto                                              factory = GPUTransformFactoryType::New();
   ObjectFactoryBase::RegisterFactory(factory);
 }
 

--- a/Common/OpenCL/Factories/itkGPUImageFactory.hxx
+++ b/Common/OpenCL/Factories/itkGPUImageFactory.hxx
@@ -27,7 +27,7 @@ void
 GPUImageFactory2<TTypeList, NDimensions>::RegisterOneFactory()
 {
   typedef GPUImageFactory2<TTypeList, NDimensions> GPUImageFactoryType;
-  typename GPUImageFactoryType::Pointer            factory = GPUImageFactoryType::New();
+  auto                                             factory = GPUImageFactoryType::New();
   ObjectFactoryBase::RegisterFactory(factory);
 }
 

--- a/Common/OpenCL/Factories/itkGPULinearInterpolateImageFunctionFactory.hxx
+++ b/Common/OpenCL/Factories/itkGPULinearInterpolateImageFunctionFactory.hxx
@@ -27,7 +27,7 @@ void
 GPULinearInterpolateImageFunctionFactory2<TTypeList, NDimensions>::RegisterOneFactory()
 {
   typedef GPULinearInterpolateImageFunctionFactory2<TTypeList, NDimensions> GPUInterpolateFactoryType;
-  typename GPUInterpolateFactoryType::Pointer                               factory = GPUInterpolateFactoryType::New();
+  auto                                                                      factory = GPUInterpolateFactoryType::New();
   ObjectFactoryBase::RegisterFactory(factory);
 }
 

--- a/Common/OpenCL/Factories/itkGPUNearestNeighborInterpolateImageFunctionFactory.hxx
+++ b/Common/OpenCL/Factories/itkGPUNearestNeighborInterpolateImageFunctionFactory.hxx
@@ -27,7 +27,7 @@ void
 GPUNearestNeighborInterpolateImageFunctionFactory2<TTypeList, NDimensions>::RegisterOneFactory()
 {
   typedef GPUNearestNeighborInterpolateImageFunctionFactory2<TTypeList, NDimensions> GPUInterpolateFactoryType;
-  typename GPUInterpolateFactoryType::Pointer factory = GPUInterpolateFactoryType::New();
+  auto factory = GPUInterpolateFactoryType::New();
   ObjectFactoryBase::RegisterFactory(factory);
 }
 

--- a/Common/OpenCL/Factories/itkGPURecursiveGaussianImageFilterFactory.hxx
+++ b/Common/OpenCL/Factories/itkGPURecursiveGaussianImageFilterFactory.hxx
@@ -27,7 +27,7 @@ void
 GPURecursiveGaussianImageFilterFactory2<TTypeListIn, TTypeListOut, NDimensions>::RegisterOneFactory()
 {
   typedef GPURecursiveGaussianImageFilterFactory2<TTypeListIn, TTypeListOut, NDimensions> GPUFilterFactoryType;
-  typename GPUFilterFactoryType::Pointer factory = GPUFilterFactoryType::New();
+  auto factory = GPUFilterFactoryType::New();
   ObjectFactoryBase::RegisterFactory(factory);
 }
 

--- a/Common/OpenCL/Factories/itkGPUResampleImageFilterFactory.hxx
+++ b/Common/OpenCL/Factories/itkGPUResampleImageFilterFactory.hxx
@@ -27,7 +27,7 @@ void
 GPUResampleImageFilterFactory2<TTypeListIn, TTypeListOut, NDimensions>::RegisterOneFactory()
 {
   typedef GPUResampleImageFilterFactory2<TTypeListIn, TTypeListOut, NDimensions> GPUFilterFactoryType;
-  typename GPUFilterFactoryType::Pointer                                         factory = GPUFilterFactoryType::New();
+  auto                                                                           factory = GPUFilterFactoryType::New();
   ObjectFactoryBase::RegisterFactory(factory);
 }
 

--- a/Common/OpenCL/Factories/itkGPUShrinkImageFilterFactory.hxx
+++ b/Common/OpenCL/Factories/itkGPUShrinkImageFilterFactory.hxx
@@ -27,7 +27,7 @@ void
 GPUShrinkImageFilterFactory2<TTypeListIn, TTypeListOut, NDimensions>::RegisterOneFactory()
 {
   typedef GPUShrinkImageFilterFactory2<TTypeListIn, TTypeListOut, NDimensions> GPUFilterFactoryType;
-  typename GPUFilterFactoryType::Pointer                                       factory = GPUFilterFactoryType::New();
+  auto                                                                         factory = GPUFilterFactoryType::New();
   ObjectFactoryBase::RegisterFactory(factory);
 }
 

--- a/Common/OpenCL/Factories/itkGPUSimilarity2DTransformFactory.hxx
+++ b/Common/OpenCL/Factories/itkGPUSimilarity2DTransformFactory.hxx
@@ -27,7 +27,7 @@ void
 GPUSimilarity2DTransformFactory2<NDimensions>::RegisterOneFactory()
 {
   typedef GPUSimilarity2DTransformFactory2<NDimensions> GPUTransformFactoryType;
-  typename GPUTransformFactoryType::Pointer             factory = GPUTransformFactoryType::New();
+  auto                                                  factory = GPUTransformFactoryType::New();
   ObjectFactoryBase::RegisterFactory(factory);
 }
 

--- a/Common/OpenCL/Factories/itkGPUSimilarity3DTransformFactory.hxx
+++ b/Common/OpenCL/Factories/itkGPUSimilarity3DTransformFactory.hxx
@@ -27,7 +27,7 @@ void
 GPUSimilarity3DTransformFactory2<NDimensions>::RegisterOneFactory()
 {
   typedef GPUSimilarity3DTransformFactory2<NDimensions> GPUTransformFactoryType;
-  typename GPUTransformFactoryType::Pointer             factory = GPUTransformFactoryType::New();
+  auto                                                  factory = GPUTransformFactoryType::New();
   ObjectFactoryBase::RegisterFactory(factory);
 }
 

--- a/Common/OpenCL/Factories/itkGPUTranslationTransformFactory.hxx
+++ b/Common/OpenCL/Factories/itkGPUTranslationTransformFactory.hxx
@@ -27,7 +27,7 @@ void
 GPUTranslationTransformFactory2<NDimensions>::RegisterOneFactory()
 {
   typedef GPUTranslationTransformFactory2<NDimensions> GPUTransformFactoryType;
-  typename GPUTransformFactoryType::Pointer            factory = GPUTransformFactoryType::New();
+  auto                                                 factory = GPUTransformFactoryType::New();
   ObjectFactoryBase::RegisterFactory(factory);
 }
 

--- a/Common/OpenCL/Filters/itkGPUAdvancedCombinationTransformCopier.h
+++ b/Common/OpenCL/Filters/itkGPUAdvancedCombinationTransformCopier.h
@@ -41,7 +41,7 @@ namespace itk
  *  typedef typelist::MakeTypeList< short, float >::Type OCLImageTypes;
  *  typedef itk::AdvancedCombinationTransform< float, 3 > TransformType;
  *  typedef itk::GPUAdvancedCombinationTransformCopier< OCLImageTypes, OCLImageDims, TransformType, float > CopierType;
- *  CopierType::Pointer copier = CopierType::New();
+ *  auto copier = CopierType::New();
  *  copier->SetInputTransform(CPUTransform);
  *  copier->Update();
  *  TransformType::Pointer GPUTransform = copier->GetModifiableOutput();

--- a/Common/OpenCL/Filters/itkGPUBSplineDecompositionImageFilter.hxx
+++ b/Common/OpenCL/Filters/itkGPUBSplineDecompositionImageFilter.hxx
@@ -127,7 +127,7 @@ GPUBSplineDecompositionImageFilter<TInputImage, TOutputImage>::GPUGenerateData(v
   // Cast here, see the same call in this->CopyImageToImage() of
   // BSplineDecompositionImageFilter::DataToCoefficientsND()
   typedef GPUCastImageFilter<GPUInputImage, GPUOutputImage> CasterType;
-  typename CasterType::Pointer                              caster = CasterType::New();
+  auto                                                      caster = CasterType::New();
   caster->SetInput(inPtr);
   caster->GraftOutput(otPtr);
   caster->Update();

--- a/Common/OpenCL/Filters/itkGPUCompositeTransformCopier.h
+++ b/Common/OpenCL/Filters/itkGPUCompositeTransformCopier.h
@@ -42,7 +42,7 @@ namespace itk
  *  typedef typelist::MakeTypeList< short, float >::Type OCLImageTypes;
  *  typedef itk::CompositeTransform< float, 3 > TransformType;
  *  typedef itk::GPUCompositeTransformCopier< OCLImageTypes, OCLImageDims, TransformType, float > CopierType;
- *  CopierType::Pointer copier = CopierType::New();
+ *  auto copier = CopierType::New();
  *  copier->SetInputTransform(CPUTransform);
  *  copier->Update();
  *  TransformType::Pointer GPUTransform = copier->GetModifiableOutput();

--- a/Common/OpenCL/Filters/itkGPUInterpolatorCopier.h
+++ b/Common/OpenCL/Filters/itkGPUInterpolatorCopier.h
@@ -43,7 +43,7 @@ namespace itk
  *  typedef typelist::MakeTypeList< short, float >::Type OCLImageTypes;
  *  typedef itk::InterpolateImageFunction< ImageType, float > InterpolatorType;
  *  typedef itk::GPUInterpolatorCopier< OCLImageTypes, OCLImageDims, InterpolatorType, float > CopierType;
- *  CopierType::Pointer copier = CopierType::New();
+ *  auto copier = CopierType::New();
  *  copier->SetInputInterpolator(CPUInterpolator);
  *  copier->Update();
  *  TransformType::Pointer GPUInterpolator = copier->GetModifiableOutput();

--- a/Common/OpenCL/Filters/itkGPUInterpolatorCopier.hxx
+++ b/Common/OpenCL/Filters/itkGPUInterpolatorCopier.hxx
@@ -135,8 +135,8 @@ GPUInterpolatorCopier<TTypeList, NDimensions, TInterpolator, TOutputCoordRep>::U
 
         // Create GPU BSpline interpolator in explicit mode
         typedef GPUBSplineInterpolateImageFunction<GPUInputImageType, GPUCoordRepType, GPUCoordRepType>
-                                                     GPUBSplineInterpolatorType;
-        typename GPUBSplineInterpolatorType::Pointer bsplineInterpolator = GPUBSplineInterpolatorType::New();
+             GPUBSplineInterpolatorType;
+        auto bsplineInterpolator = GPUBSplineInterpolatorType::New();
         bsplineInterpolator->SetSplineOrder(bspline->GetSplineOrder());
 
         // UnRegister image factory
@@ -148,8 +148,8 @@ GPUInterpolatorCopier<TTypeList, NDimensions, TInterpolator, TOutputCoordRep>::U
       {
         // Create GPU BSpline interpolator in implicit mode
         typedef BSplineInterpolateImageFunction<CPUInputImageType, GPUCoordRepType, GPUCoordRepType>
-                                                     GPUBSplineInterpolatorType;
-        typename GPUBSplineInterpolatorType::Pointer bsplineInterpolator = GPUBSplineInterpolatorType::New();
+             GPUBSplineInterpolatorType;
+        auto bsplineInterpolator = GPUBSplineInterpolatorType::New();
         bsplineInterpolator->SetSplineOrder(bspline->GetSplineOrder());
         this->m_Output = bsplineInterpolator;
       }

--- a/Common/OpenCL/Filters/itkGPUResampleImageFilter.hxx
+++ b/Common/OpenCL/Filters/itkGPUResampleImageFilter.hxx
@@ -434,7 +434,7 @@ GPUResampleImageFilter<TInputImage, TOutputImage, TInterpolatorPrecisionType>::G
   }
 
   typedef ImageRegionSplitterSlowDimension RegionSplitterType;
-  RegionSplitterType::Pointer              splitter = RegionSplitterType::New();
+  auto                                     splitter = RegionSplitterType::New();
   const unsigned int numberOfChunks = splitter->GetNumberOfSplits(outputLargestRegion, requestedNumberOfSplits);
 
   // Get the maximum chunk size

--- a/Common/OpenCL/Filters/itkGPUTransformCopier.h
+++ b/Common/OpenCL/Filters/itkGPUTransformCopier.h
@@ -40,7 +40,7 @@ namespace itk
  *
  *  typedef typelist::MakeTypeList< short, float >::Type OCLImageTypes;
  *  typedef itk::GPUTransformCopier< OCLImageTypes, OCLImageDims, TransformType, float > CopierType;
- *  CopierType::Pointer copier = CopierType::New();
+ *  auto copier = CopierType::New();
  *  copier->SetInputTransform(CPUTransform);
  *  copier->Update();
  *  TransformType::Pointer GPUTransform = copier->GetModifiableOutput();

--- a/Common/Transforms/itkAdvancedBSplineDeformableTransform.h
+++ b/Common/Transforms/itkAdvancedBSplineDeformableTransform.h
@@ -84,7 +84,7 @@ class ITK_TEMPLATE_EXPORT MultiBSplineDeformableTransformWithNormal;
  * The following illustrates the typical usage of this class:
  * \verbatim
  * typedef AdvancedBSplineDeformableTransform<double,2,3> TransformType;
- * TransformType::Pointer transform = TransformType::New();
+ * auto transform = TransformType::New();
  *
  * transform->SetGridRegion( region );
  * transform->SetGridSpacing( spacing );

--- a/Common/Transforms/itkAdvancedImageMomentsCalculator.hxx
+++ b/Common/Transforms/itkAdvancedImageMomentsCalculator.hxx
@@ -114,7 +114,7 @@ AdvancedImageMomentsCalculator<TImage>::ComputeSingleThreaded()
 {
   if (this->m_CenterOfGravityUsesLowerThreshold)
   {
-    typename BinaryThresholdImageFilterType::Pointer thresholdFilter = BinaryThresholdImageFilterType::New();
+    auto thresholdFilter = BinaryThresholdImageFilterType::New();
     thresholdFilter->SetInput(this->m_Image);
     thresholdFilter->SetLowerThreshold(this->m_LowerThresholdForCenterGravity);
     thresholdFilter->SetInsideValue(1);
@@ -223,7 +223,7 @@ AdvancedImageMomentsCalculator<TImage>::BeforeThreadedCompute()
 
   if (this->m_CenterOfGravityUsesLowerThreshold)
   {
-    typename BinaryThresholdImageFilterType::Pointer thresholdFilter = BinaryThresholdImageFilterType::New();
+    auto thresholdFilter = BinaryThresholdImageFilterType::New();
     thresholdFilter->SetInput(this->m_Image);
     thresholdFilter->SetLowerThreshold(this->m_LowerThresholdForCenterGravity);
     thresholdFilter->SetInsideValue(1);

--- a/Common/Transforms/itkBSplineInterpolationWeightFunctionBase.hxx
+++ b/Common/Transforms/itkBSplineInterpolationWeightFunctionBase.hxx
@@ -72,7 +72,7 @@ BSplineInterpolationWeightFunctionBase<TCoordRep, VSpaceDimension, VSplineOrder>
 {
   /** Create a temporary image. */
   typedef Image<char, SpaceDimension> CharImageType;
-  typename CharImageType::Pointer     tempImage = CharImageType::New();
+  auto                                tempImage = CharImageType::New();
   tempImage->SetRegions(this->m_SupportSize);
   tempImage->Allocate();
 

--- a/Common/Transforms/itkGridScheduleComputer.hxx
+++ b/Common/Transforms/itkGridScheduleComputer.hxx
@@ -219,7 +219,7 @@ GridScheduleComputer<TTransformScalarType, VImageDimension>::ApplyInitialTransfo
 
   /** Create a temporary image. As small as possible, for memory savings. */
   typedef Image<unsigned char, Dimension> ImageType; // bool??
-  typename ImageType::Pointer             image = ImageType::New();
+  auto                                    image = ImageType::New();
   image->SetOrigin(this->m_ImageOrigin);
   image->SetSpacing(this->m_ImageSpacing);
   image->SetDirection(this->m_ImageDirection);

--- a/Common/Transforms/itkUpsampleBSplineParametersFilter.hxx
+++ b/Common/Transforms/itkUpsampleBSplineParametersFilter.hxx
@@ -102,9 +102,9 @@ UpsampleBSplineParametersFilter<TArray, TImage>::UpsampleParameters(const ArrayT
      *
      * This code is derived from the itk-example DeformableRegistration6.cxx.
      */
-    typename UpsampleFilterType::Pointer              upsampler = UpsampleFilterType::New();
-    typename CoefficientUpsampleFunctionType::Pointer coeffUpsampleFunction = CoefficientUpsampleFunctionType::New();
-    typename DecompositionFilterType::Pointer         decompositionFilter = DecompositionFilterType::New();
+    auto upsampler = UpsampleFilterType::New();
+    auto coeffUpsampleFunction = CoefficientUpsampleFunctionType::New();
+    auto decompositionFilter = DecompositionFilterType::New();
 
     /** Setup the upsampler. */
     upsampler->SetInterpolator(coeffUpsampleFunction);

--- a/Common/itkComputePreconditionerUsingDisplacementDistribution.hxx
+++ b/Common/itkComputePreconditionerUsingDisplacementDistribution.hxx
@@ -147,9 +147,9 @@ ComputePreconditionerUsingDisplacementDistribution<TFixedImage, TTransform>::Com
   // MS: why is all this needed?
   // MS: ok, to have 1's in the middle and 0 in outer rim
 #if METHOD_BSPLINE == 1
-  typename FixedImageType::Pointer compactImage = FixedImageType::New();
-  FixedImageRegionType             supportRegion;
-  FixedImageRegionType             compactRegion;
+  auto                 compactImage = FixedImageType::New();
+  FixedImageRegionType supportRegion;
+  FixedImageRegionType compactRegion;
 
   typename FixedImageRegionType::SizeType size;
   unsigned int                            supportRegionSize = sizejacind / outdim;
@@ -752,14 +752,14 @@ ComputePreconditionerUsingDisplacementDistribution<TFixedImage, TTransform>::Pre
   GridOriginType    gridOrigin = testPtr_bspline->GetGridOrigin();
   GridDirectionType gridDirection = testPtr_bspline->GetGridDirection();
 
-  typename CoefficientImageType::Pointer coefImage = CoefficientImageType::New();
+  auto coefImage = CoefficientImageType::New();
   coefImage->SetRegions(gridRegion);
   coefImage->SetSpacing(gridSpacing);
   coefImage->SetOrigin(gridOrigin);
   coefImage->SetDirection(gridDirection);
   coefImage->Allocate();
 
-  //   typename MaskImageType::Pointer mask = MaskImageType::New();
+  //   auto mask = MaskImageType::New();
   //   mask->CopyInformation( coefImage );
   //   mask->Allocate();
   //   mask->FillBuffer( 0 );
@@ -802,19 +802,19 @@ ComputePreconditionerUsingDisplacementDistribution<TFixedImage, TTransform>::Pre
 
     // tmp write
     //     typedef ImageFileWriter<CoefficientImageType> WriterType;
-    //     typename WriterType::Pointer writer1 = WriterType::New();
+    //     auto writer1 = WriterType::New();
     //     writer1->SetFileName( "P_0.mha" );
     //     writer1->SetInput( coefImage );
     //     writer1->Update();
 
     // first time smooth
-    typename SmoothingFilterType::Pointer smoother = SmoothingFilterType::New();
+    auto smoother = SmoothingFilterType::New();
     //     smoother->SetInput(coefImage);
     //     smoother->SetSigma(0.5);
     //     smoother->Update();
     //
     //     // tmp write
-    //     typename WriterType::Pointer writer3 = WriterType::New();
+    //     auto writer3 = WriterType::New();
     //     writer3->SetFileName("P_coefImageSmooth.mha");
     //     //writer2->SetInput( padder->GetOutput() );
     //     writer3->SetInput(smoother->GetOutput());
@@ -952,7 +952,7 @@ ComputePreconditionerUsingDisplacementDistribution<TFixedImage, TTransform>::Pre
 #endif
 
     // tmp write
-    //     typename WriterType::Pointer writer2 = WriterType::New();
+    //     auto writer2 = WriterType::New();
     //     writer2->SetFileName("P_1.mha");
     //     writer2->SetInput( coefImage );
     //     writer2->Update();
@@ -960,7 +960,7 @@ ComputePreconditionerUsingDisplacementDistribution<TFixedImage, TTransform>::Pre
 #ifdef UseOldMethod
     GridSizeType size_tmp;
     // First remove the outer border with -1 information
-    typename CropImageFilterType::Pointer cropper = CropImageFilterType::New();
+    auto cropper = CropImageFilterType::New();
     cropper->SetInput(coefImage);
     size_tmp.Fill(1);
     cropper->SetUpperBoundaryCropSize(size_tmp);
@@ -968,7 +968,7 @@ ComputePreconditionerUsingDisplacementDistribution<TFixedImage, TTransform>::Pre
     cropper->SetLowerBoundaryCropSize(size_tmp);
 
     // Then add the border using zero flux Neumann
-    typename PadImageFilterType::Pointer padder = PadImageFilterType::New();
+    auto padder = PadImageFilterType::New();
     padder->SetInput(cropper->GetOutput());
     size_tmp.Fill(1);
     padder->SetPadUpperBound(size_tmp);
@@ -977,7 +977,7 @@ ComputePreconditionerUsingDisplacementDistribution<TFixedImage, TTransform>::Pre
 #endif
 
     // smooth?
-    // typename SmoothingFilterType::Pointer smoother = SmoothingFilterType::New();
+    // auto smoother = SmoothingFilterType::New();
 #ifdef UseOldMethod
     smoother->SetInput(padder->GetOutput());
 #else
@@ -986,7 +986,7 @@ ComputePreconditionerUsingDisplacementDistribution<TFixedImage, TTransform>::Pre
     smoother->SetSigma(0.5);
 
     // tmp write
-    // typename WriterType::Pointer writer2 = WriterType::New();
+    // auto writer2 = WriterType::New();
     // writer2->SetFileName( "P_3.mha" );
 #ifdef UseOldMethod
     // writer2->SetInput( padder->GetOutput() );

--- a/Common/itkErodeMaskImageFilter.hxx
+++ b/Common/itkErodeMaskImageFilter.hxx
@@ -79,13 +79,13 @@ ErodeMaskImageFilter<TImage>::GenerateData(void)
 
   /** Threshold the data first. Every voxel with intensity >= 1 is used.
   // Not needed since IsInside of a mask checks for != 0.
-  typename ThresholdFilterType::Pointer threshold = ThresholdFilterType::New();
+  auto threshold = ThresholdFilterType::New();
   threshold->ThresholdAbove(  itk::NumericTraits<InputPixelType>::OneValue() );
   threshold->SetOutsideValue( itk::NumericTraits<InputPixelType>::OneValue() );
   threshold->SetInput( this->GetInput() ); */
 
   /** Create and run the erosion filter. */
-  typename ErodeFilterType::Pointer erosion = ErodeFilterType::New();
+  auto erosion = ErodeFilterType::New();
   erosion->SetUseImageSpacing(false);
   erosion->SetScale(radiusarray);
   // erosion->SetInput( threshold->GetOutput() );

--- a/Common/itkGenericMultiResolutionPyramidImageFilter.hxx
+++ b/Common/itkGenericMultiResolutionPyramidImageFilter.hxx
@@ -486,7 +486,7 @@ GenericMultiResolutionPyramidImageFilter<TInputImage, TOutputImage, TPrecisionTy
       if (this->GetUseShrinkImageFilter())
       {
         // Define and setup shrinker
-        typename ShrinkerSameType::Pointer shrinker = ShrinkerSameType::New();
+        auto shrinker = ShrinkerSameType::New();
         shrinker->SetShrinkFactors(shrinkFactors);
 
         // Assign
@@ -495,16 +495,16 @@ GenericMultiResolutionPyramidImageFilter<TInputImage, TOutputImage, TPrecisionTy
       else
       {
         // Define and setup resampler
-        typename ResamplerSameType::Pointer resampler = ResamplerSameType::New();
+        auto resampler = ResamplerSameType::New();
         resampler->SetOutputParametersFromImage(outputPtr);
         resampler->SetDefaultPixelValue(0);
 
         // Define and set interpolator
-        typename InterpolatorForSameType::Pointer interpolator = InterpolatorForSameType::New();
+        auto interpolator = InterpolatorForSameType::New();
         resampler->SetInterpolator(interpolator);
 
         // Define and set transform
-        typename TransformType::Pointer transform = TransformType::New();
+        auto transform = TransformType::New();
         resampler->SetTransform(transform);
 
         // Assign
@@ -542,7 +542,7 @@ GenericMultiResolutionPyramidImageFilter<TInputImage, TOutputImage, TPrecisionTy
     if (this->GetUseShrinkImageFilter())
     {
       // Define and setup shrinker
-      typename ShrinkerDifferentType::Pointer shrinker = ShrinkerDifferentType::New();
+      auto shrinker = ShrinkerDifferentType::New();
       shrinker->SetShrinkFactors(shrinkFactors);
 
       // Assign
@@ -551,16 +551,16 @@ GenericMultiResolutionPyramidImageFilter<TInputImage, TOutputImage, TPrecisionTy
     else
     {
       // Define and setup resampler
-      typename ResamplerDifferentType::Pointer resampler = ResamplerDifferentType::New();
+      auto resampler = ResamplerDifferentType::New();
       resampler->SetOutputParametersFromImage(outputPtr);
       resampler->SetDefaultPixelValue(0);
 
       // Define and set interpolator
-      typename InterpolatorForDifferentType::Pointer interpolator = InterpolatorForDifferentType::New();
+      auto interpolator = InterpolatorForDifferentType::New();
       resampler->SetInterpolator(interpolator);
 
       // Define and set transform
-      typename TransformType::Pointer transform = TransformType::New();
+      auto transform = TransformType::New();
       resampler->SetTransform(transform);
 
       // Assign

--- a/Common/itkImageFileCastWriter.h
+++ b/Common/itkImageFileCastWriter.h
@@ -97,9 +97,9 @@ private:
     this->GetModifiableImageIO()->SetPixelTypeInfo(static_cast<const OutputComponentType *>(nullptr));
 
     /** cast the input image */
-    typename CasterType::Pointer caster = CasterType::New();
+    auto caster = CasterType::New();
     this->m_Caster = caster;
-    typename ScalarInputImageType::Pointer localInputImage = ScalarInputImageType::New();
+    auto localInputImage = ScalarInputImageType::New();
 
     localInputImage->Graft(static_cast<const ScalarInputImageType *>(inputImage));
 

--- a/Common/itkImageFileCastWriter.hxx
+++ b/Common/itkImageFileCastWriter.hxx
@@ -46,7 +46,7 @@ std::string
 ImageFileCastWriter<TInputImage>::GetDefaultOutputComponentType(void) const
 {
   /** Make a dummy imageIO object, which has some handy functions */
-  MetaImageIO::Pointer dummyImageIO = MetaImageIO::New();
+  auto dummyImageIO = MetaImageIO::New();
 
   /** Set the pixeltype. */
   typedef typename InputImageType::InternalPixelType ScalarType;

--- a/Common/itkMultiResolutionGaussianSmoothingPyramidImageFilter.hxx
+++ b/Common/itkMultiResolutionGaussianSmoothingPyramidImageFilter.hxx
@@ -100,8 +100,8 @@ MultiResolutionGaussianSmoothingPyramidImageFilter<TInputImage, TOutputImage>::G
   /** Create smoother pointer array, this array contains pointers
    * to the filters for the different dimensions.
    */
-  typename CasterType::Pointer caster = CasterType::New();
-  SmootherArrayType            smootherArray;
+  auto              caster = CasterType::New();
+  SmootherArrayType smootherArray;
   for (unsigned int i = 0; i < ImageDimension; ++i)
   {
     smootherArray[i] = SmootherType::New();

--- a/Common/itkMultiResolutionShrinkPyramidImageFilter.hxx
+++ b/Common/itkMultiResolutionShrinkPyramidImageFilter.hxx
@@ -35,7 +35,7 @@ MultiResolutionShrinkPyramidImageFilter<TInputImage, TOutputImage>::GenerateData
 {
   /** Create the shrinking filter. */
   typedef ShrinkImageFilter<TInputImage, TOutputImage> ShrinkerType;
-  typename ShrinkerType::Pointer                       shrinker = ShrinkerType::New();
+  auto                                                 shrinker = ShrinkerType::New();
   shrinker->SetInput(this->GetInput());
 
   /** Loop over all resolution levels. */

--- a/Components/FixedImagePyramids/OpenCLFixedGenericPyramid/elxOpenCLFixedGenericPyramid.hxx
+++ b/Components/FixedImagePyramids/OpenCLFixedGenericPyramid/elxOpenCLFixedGenericPyramid.hxx
@@ -232,13 +232,13 @@ OpenCLFixedGenericPyramid<TElastix>::RegisterFactories(void)
   typedef itk::GPULinearInterpolateImageFunctionFactory2<OpenCLImageTypes, OpenCLImageDimentions> LinearFactoryType;
 
   // Create factories
-  typename ImageFactoryType::Pointer             imageFactory = ImageFactoryType::New();
-  typename RecursiveGaussianFactoryType::Pointer recursiveFactory = RecursiveGaussianFactoryType::New();
-  typename CastFactoryType::Pointer              castFactory = CastFactoryType::New();
-  typename ShrinkFactoryType::Pointer            shrinkFactory = ShrinkFactoryType::New();
-  typename ResampleFactoryType::Pointer          resampleFactory = ResampleFactoryType::New();
-  typename IdentityFactoryType::Pointer          identityFactory = IdentityFactoryType::New();
-  typename LinearFactoryType::Pointer            linearFactory = LinearFactoryType::New();
+  auto imageFactory = ImageFactoryType::New();
+  auto recursiveFactory = RecursiveGaussianFactoryType::New();
+  auto castFactory = CastFactoryType::New();
+  auto shrinkFactory = ShrinkFactoryType::New();
+  auto resampleFactory = ResampleFactoryType::New();
+  auto identityFactory = IdentityFactoryType::New();
+  auto linearFactory = LinearFactoryType::New();
 
   // Register factories
   itk::ObjectFactoryBase::RegisterFactory(imageFactory);

--- a/Components/ImageSamplers/MultInputRandomCoordinate/elxMultiInputRandomCoordinateSampler.hxx
+++ b/Components/ImageSamplers/MultInputRandomCoordinate/elxMultiInputRandomCoordinateSampler.hxx
@@ -41,8 +41,8 @@ MultiInputRandomCoordinateSampler<TElastix>::BeforeEachResolution(void)
   this->SetNumberOfSamples(numberOfSpatialSamples);
 
   /** Set up the fixed image interpolator and set the SplineOrder, default value = 1. */
-  typename DefaultInterpolatorType::Pointer fixedImageInterpolator = DefaultInterpolatorType::New();
-  unsigned int                              splineOrder = 1;
+  auto         fixedImageInterpolator = DefaultInterpolatorType::New();
+  unsigned int splineOrder = 1;
   this->GetConfiguration()->ReadParameter(
     splineOrder, "FixedImageBSplineInterpolationOrder", this->GetComponentLabel(), level, 0);
   fixedImageInterpolator->SetSplineOrder(splineOrder);

--- a/Components/ImageSamplers/RandomCoordinate/elxRandomCoordinateSampler.hxx
+++ b/Components/ImageSamplers/RandomCoordinate/elxRandomCoordinateSampler.hxx
@@ -47,12 +47,12 @@ RandomCoordinateSampler<TElastix>::BeforeEachResolution(void)
   if (splineOrder == 1)
   {
     typedef itk::LinearInterpolateImageFunction<InputImageType, CoordRepType> LinearInterpolatorType;
-    typename LinearInterpolatorType::Pointer fixedImageLinearInterpolator = LinearInterpolatorType::New();
+    auto fixedImageLinearInterpolator = LinearInterpolatorType::New();
     this->SetInterpolator(fixedImageLinearInterpolator);
   }
   else
   {
-    typename DefaultInterpolatorType::Pointer fixedImageBSplineInterpolator = DefaultInterpolatorType::New();
+    auto fixedImageBSplineInterpolator = DefaultInterpolatorType::New();
     fixedImageBSplineInterpolator->SetSplineOrder(splineOrder);
     this->SetInterpolator(fixedImageBSplineInterpolator);
   }

--- a/Components/Metrics/AdvancedKappaStatistic/itkAdvancedKappaStatisticImageToImageMetric.hxx
+++ b/Components/Metrics/AdvancedKappaStatistic/itkAdvancedKappaStatisticImageToImageMetric.hxx
@@ -831,7 +831,7 @@ AdvancedKappaStatisticImageToImageMetric<TFixedImage, TMovingImage>::ComputeGrad
   typedef itk::ImageRegionConstIteratorWithIndex<MovingImageType> MovingIteratorType;
 
   /** Create a temporary moving gradient image. */
-  typename GradientImageType::Pointer tempGradientImage = GradientImageType::New();
+  auto tempGradientImage = GradientImageType::New();
   tempGradientImage->SetRegions(this->m_MovingImage->GetBufferedRegion().GetSize());
   tempGradientImage->Allocate();
 

--- a/Components/Metrics/AdvancedMeanSquares/itkAdvancedMeanSquaresImageToImageMetric.hxx
+++ b/Components/Metrics/AdvancedMeanSquares/itkAdvancedMeanSquaresImageToImageMetric.hxx
@@ -873,13 +873,13 @@ AdvancedMeanSquaresImageToImageMetric<TFixedImage, TMovingImage>::GetSelfHessian
   // H.Fill(0.0); // done by set_size if sparse matrix
 
   /** Smooth fixed image */
-  typename SmootherType::Pointer smoother = SmootherType::New();
+  auto smoother = SmootherType::New();
   smoother->SetInput(this->GetFixedImage());
   smoother->SetSigma(this->GetSelfHessianSmoothingSigma());
   smoother->Update();
 
   /** Set up interpolator for fixed image */
-  typename FixedImageInterpolatorType::Pointer fixedInterpolator = FixedImageInterpolatorType::New();
+  auto fixedInterpolator = FixedImageInterpolatorType::New();
   if (this->m_BSplineInterpolator.IsNotNull())
   {
     fixedInterpolator->SetSplineOrder(this->m_BSplineInterpolator->GetSplineOrder());
@@ -893,7 +893,7 @@ AdvancedMeanSquaresImageToImageMetric<TFixedImage, TMovingImage>::GetSelfHessian
   /** Set up random coordinate sampler
    * Actually we could do without a sampler, but it's easy like this.
    */
-  typename SelfHessianSamplerType::Pointer sampler = SelfHessianSamplerType::New();
+  auto sampler = SelfHessianSamplerType::New();
   // typename DummyFixedImageInterpolatorType::Pointer dummyInterpolator =
   //  DummyFixedImageInterpolatorType::New();
   sampler->SetInputImageRegion(this->GetImageSampler()->GetInputImageRegion());

--- a/Components/Metrics/BendingEnergyPenalty/itkTransformBendingEnergyPenaltyTerm.hxx
+++ b/Components/Metrics/BendingEnergyPenalty/itkTransformBendingEnergyPenaltyTerm.hxx
@@ -685,7 +685,7 @@ TransformBendingEnergyPenaltyTerm<TFixedImage, TScalarType>::GetSelfHessian(cons
   }
 
   /** Set up grid sampler */
-  typename SelfHessianSamplerType::Pointer sampler = SelfHessianSamplerType::New();
+  auto sampler = SelfHessianSamplerType::New();
   sampler->SetInputImageRegion(this->GetImageSampler()->GetInputImageRegion());
   sampler->SetMask(this->GetImageSampler()->GetMask());
   sampler->SetInput(this->GetFixedImage());

--- a/Components/Metrics/CorrespondingPointsEuclideanDistanceMetric/elxCorrespondingPointsEuclideanDistanceMetric.hxx
+++ b/Components/Metrics/CorrespondingPointsEuclideanDistanceMetric/elxCorrespondingPointsEuclideanDistanceMetric.hxx
@@ -153,7 +153,7 @@ CorrespondingPointsEuclideanDistanceMetric<TElastix>::ReadLandmarks(const std::s
   elxout << "Loading landmarks for " << this->GetComponentLabel() << ":" << this->elxGetClassName() << "." << std::endl;
 
   /** Read the landmarks. */
-  typename PointSetReaderType::Pointer reader = PointSetReaderType::New();
+  auto reader = PointSetReaderType::New();
   reader->SetFileName(landmarkFileName.c_str());
   elxout << "  Reading landmark file: " << landmarkFileName << std::endl;
   try

--- a/Components/Metrics/DistancePreservingRigidityPenalty/elxDistancePreservingRigidityPenaltyTerm.hxx
+++ b/Components/Metrics/DistancePreservingRigidityPenalty/elxDistancePreservingRigidityPenaltyTerm.hxx
@@ -48,7 +48,7 @@ DistancePreservingRigidityPenalty<TElastix>::BeforeRegistration(void)
   typedef typename SegmentedImageType::SizeType::SizeValueType  SizeValueType;
 
   /** Create the reader and set the filename. */
-  typename SegmentedImageReaderType::Pointer segmentedImageReader = SegmentedImageReaderType::New();
+  auto segmentedImageReader = SegmentedImageReaderType::New();
   segmentedImageReader->SetFileName(segmentedImageName);
   segmentedImageReader->Update();
 
@@ -102,14 +102,14 @@ DistancePreservingRigidityPenalty<TElastix>::BeforeRegistration(void)
 
   /** Create resampler, identity transform and linear interpolator. */
   typedef itk::ResampleImageFilter<SegmentedImageType, SegmentedImageType> ResampleFilterType;
-  typename ResampleFilterType::Pointer                                     resampler = ResampleFilterType::New();
+  auto                                                                     resampler = ResampleFilterType::New();
 
   typedef itk::IdentityTransform<double, Superclass1::ImageDimension> IdentityTransformType;
-  typename IdentityTransformType::Pointer                             identityTransform = IdentityTransformType::New();
+  auto                                                                identityTransform = IdentityTransformType::New();
   identityTransform->SetIdentity();
 
   typedef itk::LinearInterpolateImageFunction<SegmentedImageType, double> LinearInterpolatorType;
-  typename LinearInterpolatorType::Pointer linearInterpolator = LinearInterpolatorType::New();
+  auto linearInterpolator = LinearInterpolatorType::New();
 
   /** Configure the resampler and run it. */
   resampler->SetInterpolator(linearInterpolator);

--- a/Components/Metrics/DistancePreservingRigidityPenalty/itkDistancePreservingRigidityPenaltyTerm.hxx
+++ b/Components/Metrics/DistancePreservingRigidityPenalty/itkDistancePreservingRigidityPenaltyTerm.hxx
@@ -131,7 +131,7 @@ DistancePreservingRigidityPenaltyTerm<TFixedImage, TScalarType>::Initialize(void
 
   // typedef itk::LinearInterpolateImageFunction< SegmentedImageType, double > SegmentedImageInterpolatorType;
   typedef itk::NearestNeighborInterpolateImageFunction<SegmentedImageType, double> SegmentedImageInterpolatorType;
-  typename SegmentedImageInterpolatorType::Pointer segmentedImageInterpolator = SegmentedImageInterpolatorType::New();
+  auto segmentedImageInterpolator = SegmentedImageInterpolatorType::New();
 
   segmentedImageInterpolator->SetInputImage(this->m_SampledSegmentedImage);
 
@@ -196,7 +196,7 @@ DistancePreservingRigidityPenaltyTerm<TFixedImage, TScalarType>::GetValue(const 
 
   // interpolation of segmented image
   typedef itk::NearestNeighborInterpolateImageFunction<SegmentedImageType, double> SegmentedImageInterpolatorType;
-  typename SegmentedImageInterpolatorType::Pointer segmentedImageInterpolator = SegmentedImageInterpolatorType::New();
+  auto segmentedImageInterpolator = SegmentedImageInterpolatorType::New();
 
   segmentedImageInterpolator->SetInputImage(this->m_SampledSegmentedImage);
 
@@ -324,7 +324,7 @@ DistancePreservingRigidityPenaltyTerm<TFixedImage, TScalarType>::GetValueAndDeri
   typename PenaltyGridImageType::PointType penaltyGridPoint, neighborPenaltyGridPoint, xn, xf;
 
   typedef itk::BSplineKernelFunction<3> BSplineKernelFunctionType;
-  BSplineKernelFunctionType::Pointer    bSplineKernel = BSplineKernelFunctionType::New();
+  auto                                  bSplineKernel = BSplineKernelFunctionType::New();
 
   typedef itk::BSplineInterpolationWeightFunction<double, ImageDimension, 3> WeightsFunctionType;
   typedef typename WeightsFunctionType::ContinuousIndexType                  ContinuousIndexType;
@@ -361,7 +361,7 @@ DistancePreservingRigidityPenaltyTerm<TFixedImage, TScalarType>::GetValueAndDeri
 
   // interpolation of segmented image
   typedef itk::NearestNeighborInterpolateImageFunction<SegmentedImageType, double> SegmentedImageInterpolatorType;
-  typename SegmentedImageInterpolatorType::Pointer segmentedImageInterpolator = SegmentedImageInterpolatorType::New();
+  auto segmentedImageInterpolator = SegmentedImageInterpolatorType::New();
 
   segmentedImageInterpolator->SetInputImage(this->m_SampledSegmentedImage);
 

--- a/Components/Metrics/KNNGraphAlphaMutualInformation/itkKNNGraphAlphaMutualInformationImageToImageMetric.hxx
+++ b/Components/Metrics/KNNGraphAlphaMutualInformation/itkKNNGraphAlphaMutualInformationImageToImageMetric.hxx
@@ -73,9 +73,9 @@ KNNGraphAlphaMutualInformationImageToImageMetric<TFixedImage, TMovingImage>::Set
   std::string  splittingRuleMoving,
   std::string  splittingRuleJoint)
 {
-  typename ANNkDTreeType::Pointer tmpPtrF = ANNkDTreeType::New();
-  typename ANNkDTreeType::Pointer tmpPtrM = ANNkDTreeType::New();
-  typename ANNkDTreeType::Pointer tmpPtrJ = ANNkDTreeType::New();
+  auto tmpPtrF = ANNkDTreeType::New();
+  auto tmpPtrM = ANNkDTreeType::New();
+  auto tmpPtrJ = ANNkDTreeType::New();
 
   tmpPtrF->SetBucketSize(bucketSize);
   tmpPtrM->SetBucketSize(bucketSize);
@@ -123,9 +123,9 @@ KNNGraphAlphaMutualInformationImageToImageMetric<TFixedImage, TMovingImage>::Set
   std::string  shrinkingRuleMoving,
   std::string  shrinkingRuleJoint)
 {
-  typename ANNbdTreeType::Pointer tmpPtrF = ANNbdTreeType::New();
-  typename ANNbdTreeType::Pointer tmpPtrM = ANNbdTreeType::New();
-  typename ANNbdTreeType::Pointer tmpPtrJ = ANNbdTreeType::New();
+  auto tmpPtrF = ANNbdTreeType::New();
+  auto tmpPtrM = ANNbdTreeType::New();
+  auto tmpPtrJ = ANNbdTreeType::New();
 
   tmpPtrF->SetBucketSize(bucketSize);
   tmpPtrM->SetBucketSize(bucketSize);
@@ -171,9 +171,9 @@ KNNGraphAlphaMutualInformationImageToImageMetric<TFixedImage, TMovingImage>::Set
   unsigned int kNearestNeighbors,
   double       errorBound)
 {
-  typename ANNStandardTreeSearchType::Pointer tmpPtrF = ANNStandardTreeSearchType::New();
-  typename ANNStandardTreeSearchType::Pointer tmpPtrM = ANNStandardTreeSearchType::New();
-  typename ANNStandardTreeSearchType::Pointer tmpPtrJ = ANNStandardTreeSearchType::New();
+  auto tmpPtrF = ANNStandardTreeSearchType::New();
+  auto tmpPtrM = ANNStandardTreeSearchType::New();
+  auto tmpPtrJ = ANNStandardTreeSearchType::New();
 
   tmpPtrF->SetKNearestNeighbors(kNearestNeighbors);
   tmpPtrM->SetKNearestNeighbors(kNearestNeighbors);
@@ -201,9 +201,9 @@ KNNGraphAlphaMutualInformationImageToImageMetric<TFixedImage, TMovingImage>::Set
   double       errorBound,
   double       squaredRadius)
 {
-  typename ANNFixedRadiusTreeSearchType::Pointer tmpPtrF = ANNFixedRadiusTreeSearchType::New();
-  typename ANNFixedRadiusTreeSearchType::Pointer tmpPtrM = ANNFixedRadiusTreeSearchType::New();
-  typename ANNFixedRadiusTreeSearchType::Pointer tmpPtrJ = ANNFixedRadiusTreeSearchType::New();
+  auto tmpPtrF = ANNFixedRadiusTreeSearchType::New();
+  auto tmpPtrM = ANNFixedRadiusTreeSearchType::New();
+  auto tmpPtrJ = ANNFixedRadiusTreeSearchType::New();
 
   tmpPtrF->SetKNearestNeighbors(kNearestNeighbors);
   tmpPtrM->SetKNearestNeighbors(kNearestNeighbors);
@@ -234,9 +234,9 @@ KNNGraphAlphaMutualInformationImageToImageMetric<TFixedImage, TMovingImage>::Set
   unsigned int kNearestNeighbors,
   double       errorBound)
 {
-  typename ANNPriorityTreeSearchType::Pointer tmpPtrF = ANNPriorityTreeSearchType::New();
-  typename ANNPriorityTreeSearchType::Pointer tmpPtrM = ANNPriorityTreeSearchType::New();
-  typename ANNPriorityTreeSearchType::Pointer tmpPtrJ = ANNPriorityTreeSearchType::New();
+  auto tmpPtrF = ANNPriorityTreeSearchType::New();
+  auto tmpPtrM = ANNPriorityTreeSearchType::New();
+  auto tmpPtrJ = ANNPriorityTreeSearchType::New();
 
   tmpPtrF->SetKNearestNeighbors(kNearestNeighbors);
   tmpPtrM->SetKNearestNeighbors(kNearestNeighbors);

--- a/Components/Metrics/MissingStructurePenalty/elxMissingStructurePenalty.hxx
+++ b/Components/Metrics/MissingStructurePenalty/elxMissingStructurePenalty.hxx
@@ -159,7 +159,7 @@ MissingStructurePenalty<TElastix>::BeforeRegistration(void)
 
   this->SetFixedMeshContainer(meshPointerContainer);
 
-  typename PointSetType::Pointer dummyPointSet = PointSetType::New();
+  auto dummyPointSet = PointSetType::New();
   this->SetFixedPointSet(dummyPointSet);  // TODO solve dirty hack
   this->SetMovingPointSet(dummyPointSet); // TODO solve dirty hack
   // itkCombinationImageToImageMetric.hxx checks if metric base class is ImageMetricType or PointSetMetricType.
@@ -282,7 +282,7 @@ MissingStructurePenalty<TElastix>::ReadMesh(const std::string & meshFileName, ty
   typedef itk::MeshFileReader<MeshType> MeshReaderType;
 
   /** Read the input mesh. */
-  typename MeshReaderType::Pointer meshReader = MeshReaderType::New();
+  auto meshReader = MeshReaderType::New();
   meshReader->SetFileName(meshFileName.c_str());
   elxout << "  Reading input mesh file: " << meshFileName << std::endl;
   try
@@ -316,7 +316,7 @@ MissingStructurePenalty<TElastix>::WriteResultMesh(const char * filename, MeshId
   typedef itk::MeshFileWriter<MeshType> MeshWriterType;
 
   /** Create writer. */
-  typename MeshWriterType::Pointer meshWriter = MeshWriterType::New();
+  auto meshWriter = MeshWriterType::New();
 
   /** Setup the pipeline. */
 
@@ -422,7 +422,7 @@ the sequence of points to form a 2d connected polydata contour.
   typedef itk::Vector<float, FixedImageDimension>                               DeformationVectorType;
 
   /** Construct an ipp-file reader. */
-  typename IPPReaderType::Pointer ippReader = IPPReaderType::New();
+  auto ippReader = IPPReaderType::New();
   ippReader->SetFileName(filename.c_str());
 
   /** Read the input points. */
@@ -473,7 +473,7 @@ the sequence of points to form a 2d connected polydata contour.
   region.SetIndex(this->m_Elastix->GetElxResamplerBase()->GetAsITKBaseType()->GetOutputStartIndex());
   region.SetSize(this->m_Elastix->GetElxResamplerBase()->GetAsITKBaseType()->GetSize());
 
-  typename FixedImageType::Pointer dummyImage = FixedImageType::New();
+  auto dummyImage = FixedImageType::New();
   dummyImage->SetRegions(region);
   dummyImage->SetOrigin(origin);
   dummyImage->SetSpacing(spacing);

--- a/Components/Metrics/MissingStructurePenalty/itkMissingStructurePenalty.hxx
+++ b/Components/Metrics/MissingStructurePenalty/itkMissingStructurePenalty.hxx
@@ -65,10 +65,10 @@ MissingVolumeMeshPenalty<TFixedPointSet, TMovingPointSet>::Initialize(void)
     MeshPointsContainerConstPointer fixedPoints = fixedMesh->GetPoints();
     const unsigned int              numberOfPoints = fixedPoints->Size();
 
-    typename MeshPointsContainerType::Pointer mappedPoints = MeshPointsContainerType::New();
+    auto mappedPoints = MeshPointsContainerType::New();
     mappedPoints->Reserve(numberOfPoints);
 
-    typename FixedMeshType::Pointer mappedMesh = FixedMeshType::New();
+    auto mappedMesh = FixedMeshType::New();
     mappedMesh->SetPoints(mappedPoints);
 
     // mappedMesh was constructed with a Cellscontainer and CellDatacontainer of size 0.

--- a/Components/Metrics/PCAMetric/itkPCAMetric_F_multithreaded.hxx
+++ b/Components/Metrics/PCAMetric/itkPCAMetric_F_multithreaded.hxx
@@ -935,7 +935,7 @@ PCAMetric<TFixedImage, TMovingImage>::LaunchGetSamplesThreaderCallback(void) con
 {
   /** Setup local threader. */
   // \todo: is a global threader better performance-wise? check
-  typename ThreaderType::Pointer local_threader = ThreaderType::New();
+  auto local_threader = ThreaderType::New();
   local_threader->SetNumberOfWorkUnits(Self::GetNumberOfWorkUnits());
   local_threader->SetSingleMethod(this->GetSamplesThreaderCallback,
                                   const_cast<void *>(static_cast<const void *>(&this->m_PCAMetricThreaderParameters)));
@@ -1138,7 +1138,7 @@ PCAMetric<TFixedImage, TMovingImage>::LaunchComputeDerivativeThreaderCallback(vo
 {
   /** Setup local threader. */
   // \todo: is a global threader better performance-wise? check
-  typename ThreaderType::Pointer local_threader = ThreaderType::New();
+  auto local_threader = ThreaderType::New();
   local_threader->SetNumberOfWorkUnits(Self::GetNumberOfWorkUnits());
   local_threader->SetSingleMethod(this->ComputeDerivativeThreaderCallback,
                                   const_cast<void *>(static_cast<const void *>(&this->m_PCAMetricThreaderParameters)));

--- a/Components/Metrics/PolydataDummyPenalty/elxPolydataDummyPenalty.hxx
+++ b/Components/Metrics/PolydataDummyPenalty/elxPolydataDummyPenalty.hxx
@@ -146,7 +146,7 @@ PolydataDummyPenalty<TElastix>::BeforeRegistration(void)
 
   this->SetFixedMeshContainer(meshPointerContainer);
 
-  typename PointSetType::Pointer dummyPointSet = PointSetType::New();
+  auto dummyPointSet = PointSetType::New();
   this->SetFixedPointSet(dummyPointSet);  // FB: TODO solve hack
   this->SetMovingPointSet(dummyPointSet); // FB: TODO solve hack
   // itkCombinationImageToImageMetric.hxx checks if metric base class is ImageMetricType or PointSetMetricType.
@@ -270,7 +270,7 @@ PolydataDummyPenalty<TElastix>::ReadMesh(const std::string & meshFileName, typen
   typedef itk::MeshFileReader<MeshType> MeshReaderType;
 
   /** Read the input mesh. */
-  typename MeshReaderType::Pointer meshReader = MeshReaderType::New();
+  auto meshReader = MeshReaderType::New();
   meshReader->SetFileName(meshFileName.c_str());
 
   elxout << "  Reading input mesh file: " << meshFileName << std::endl;
@@ -305,7 +305,7 @@ PolydataDummyPenalty<TElastix>::WriteResultMesh(const char * filename, MeshIdTyp
   /** Typedef's for writing the output mesh. */
   typedef itk::MeshFileWriter<MeshType> MeshWriterType;
   /** Create writer. */
-  typename MeshWriterType::Pointer meshWriter = MeshWriterType::New();
+  auto meshWriter = MeshWriterType::New();
 
   /** Set the points of the latest transformation. */
   const MappedMeshContainerPointer mappedMeshContainer = this->GetModifiableMappedMeshContainer();
@@ -402,7 +402,7 @@ PolydataDummyPenalty<TElastix>::ReadTransformixPoints(const std::string &       
   typedef itk::Vector<float, FixedImageDimension>                               DeformationVectorType;
 
   /** Construct an ipp-file reader. */
-  typename IPPReaderType::Pointer ippReader = IPPReaderType::New();
+  auto ippReader = IPPReaderType::New();
   ippReader->SetFileName(filename.c_str());
 
   /** Read the input points. */
@@ -451,7 +451,7 @@ PolydataDummyPenalty<TElastix>::ReadTransformixPoints(const std::string &       
   region.SetIndex(this->m_Elastix->GetElxResamplerBase()->GetAsITKBaseType()->GetOutputStartIndex());
   region.SetSize(this->m_Elastix->GetElxResamplerBase()->GetAsITKBaseType()->GetSize());
 
-  typename FixedImageType::Pointer dummyImage = FixedImageType::New();
+  auto dummyImage = FixedImageType::New();
   dummyImage->SetRegions(region);
   dummyImage->SetOrigin(origin);
   dummyImage->SetSpacing(spacing);

--- a/Components/Metrics/PolydataDummyPenalty/itkPolydataDummyPenalty.hxx
+++ b/Components/Metrics/PolydataDummyPenalty/itkPolydataDummyPenalty.hxx
@@ -77,13 +77,13 @@ MeshPenalty<TFixedPointSet, TMovingPointSet>::Initialize(void)
     //  itkExceptionMacro( << "numberOfPoints does not match numberOfNormals" );
     //}
 
-    typename MeshPointsContainerType::Pointer mappedPoints = MeshPointsContainerType::New();
+    auto mappedPoints = MeshPointsContainerType::New();
     mappedPoints->Reserve(numberOfPoints);
 
-    // MeshPointDataContainerType::Pointer mappedPointNormals = MeshPointDataContainerType::New();
+    // auto mappedPointNormals = MeshPointDataContainerType::New();
     // mappedPointNormals->Reserve(numberOfNormals);
 
-    typename FixedMeshType::Pointer mappedMesh = FixedMeshType::New();
+    auto mappedMesh = FixedMeshType::New();
     mappedMesh->SetPoints(mappedPoints);
 
     mappedMesh->SetPointData(nullptr);

--- a/Components/Metrics/StatisticalShapePenalty/elxStatisticalShapePenalty.hxx
+++ b/Components/Metrics/StatisticalShapePenalty/elxStatisticalShapePenalty.hxx
@@ -284,7 +284,7 @@ StatisticalShapePenalty<TElastix>::ReadLandmarks(const std::string &            
   elxout << "Loading landmarks for " << this->GetComponentLabel() << ":" << this->elxGetClassName() << "." << std::endl;
 
   /** Read the landmarks. */
-  typename PointSetReaderType::Pointer reader = PointSetReaderType::New();
+  auto reader = PointSetReaderType::New();
   reader->SetFileName(landmarkFileName.c_str());
   elxout << "  Reading landmark file: " << landmarkFileName << std::endl;
   try
@@ -361,7 +361,7 @@ StatisticalShapePenalty<TElastix>::ReadShape(const std::string &                
   typedef VTKPolyDataReader<MeshType>                                  MeshReaderType;
 
   /** Read the input points. */
-  typename MeshReaderType::Pointer meshReader = MeshReaderType::New();
+  auto meshReader = MeshReaderType::New();
   meshReader->SetFileName(ShapeFileName.c_str());
   elxout << "  Reading input point file: " << ShapeFileName << std::endl;
   try

--- a/Components/MovingImagePyramids/OpenCLMovingGenericPyramid/elxOpenCLMovingGenericPyramid.hxx
+++ b/Components/MovingImagePyramids/OpenCLMovingGenericPyramid/elxOpenCLMovingGenericPyramid.hxx
@@ -232,13 +232,13 @@ OpenCLMovingGenericPyramid<TElastix>::RegisterFactories(void)
   typedef itk::GPULinearInterpolateImageFunctionFactory2<OpenCLImageTypes, OpenCLImageDimentions> LinearFactoryType;
 
   // Create factories
-  typename ImageFactoryType::Pointer             imageFactory = ImageFactoryType::New();
-  typename RecursiveGaussianFactoryType::Pointer recursiveFactory = RecursiveGaussianFactoryType::New();
-  typename CastFactoryType::Pointer              castFactory = CastFactoryType::New();
-  typename ShrinkFactoryType::Pointer            shrinkFactory = ShrinkFactoryType::New();
-  typename ResampleFactoryType::Pointer          resampleFactory = ResampleFactoryType::New();
-  typename IdentityFactoryType::Pointer          identityFactory = IdentityFactoryType::New();
-  typename LinearFactoryType::Pointer            linearFactory = LinearFactoryType::New();
+  auto imageFactory = ImageFactoryType::New();
+  auto recursiveFactory = RecursiveGaussianFactoryType::New();
+  auto castFactory = CastFactoryType::New();
+  auto shrinkFactory = ShrinkFactoryType::New();
+  auto resampleFactory = ResampleFactoryType::New();
+  auto identityFactory = IdentityFactoryType::New();
+  auto linearFactory = LinearFactoryType::New();
 
   // Register factories
   itk::ObjectFactoryBase::RegisterFactory(imageFactory);

--- a/Components/Optimizers/AdaptiveStochasticGradientDescent/elxAdaptiveStochasticGradientDescent.hxx
+++ b/Components/Optimizers/AdaptiveStochasticGradientDescent/elxAdaptiveStochasticGradientDescent.hxx
@@ -528,7 +528,7 @@ AdaptiveStochasticGradientDescent<TElastix>::AutomaticParameterEstimationOrigina
   }
 
   /** Construct computeJacobianTerms to initialize the parameter estimation. */
-  typename ComputeJacobianTermsType::Pointer computeJacobianTerms = ComputeJacobianTermsType::New();
+  auto computeJacobianTerms = ComputeJacobianTermsType::New();
   computeJacobianTerms->SetFixedImage(testPtr->GetFixedImage());
   computeJacobianTerms->SetFixedImageRegion(testPtr->GetFixedImageRegion());
   computeJacobianTerms->SetFixedImageMask(testPtr->GetFixedImageMask());

--- a/Components/Optimizers/AdaptiveStochasticLBFGS/elxAdaptiveStochasticLBFGS.hxx
+++ b/Components/Optimizers/AdaptiveStochasticLBFGS/elxAdaptiveStochasticLBFGS.hxx
@@ -934,7 +934,7 @@ AdaptiveStochasticLBFGS<TElastix>::AutomaticParameterEstimationOriginal(void)
   }
 
   /** Construct computeJacobianTerms to initialize the parameter estimation. */
-  typename ComputeJacobianTermsType::Pointer computeJacobianTerms = ComputeJacobianTermsType::New();
+  auto computeJacobianTerms = ComputeJacobianTermsType::New();
   computeJacobianTerms->SetFixedImage(testPtr->GetFixedImage());
   computeJacobianTerms->SetFixedImageRegion(testPtr->GetFixedImageRegion());
   computeJacobianTerms->SetFixedImageMask(testPtr->GetFixedImageMask());

--- a/Components/Optimizers/AdaptiveStochasticVarianceReducedGradient/elxAdaptiveStochasticVarianceReducedGradient.hxx
+++ b/Components/Optimizers/AdaptiveStochasticVarianceReducedGradient/elxAdaptiveStochasticVarianceReducedGradient.hxx
@@ -791,7 +791,7 @@ AdaptiveStochasticVarianceReducedGradient<TElastix>::AutomaticParameterEstimatio
   }
 
   /** Construct computeJacobianTerms to initialize the parameter estimation. */
-  typename ComputeJacobianTermsType::Pointer computeJacobianTerms = ComputeJacobianTermsType::New();
+  auto computeJacobianTerms = ComputeJacobianTermsType::New();
   computeJacobianTerms->SetFixedImage(testPtr->GetFixedImage());
   computeJacobianTerms->SetFixedImageRegion(testPtr->GetFixedImageRegion());
   computeJacobianTerms->SetFixedImageMask(testPtr->GetFixedImageMask());

--- a/Components/Optimizers/AdaptiveStochasticVarianceReducedGradient/itkStochasticVarianceReducedGradientDescentOptimizer.cxx
+++ b/Components/Optimizers/AdaptiveStochasticVarianceReducedGradient/itkStochasticVarianceReducedGradientDescentOptimizer.cxx
@@ -286,7 +286,7 @@ StochasticVarianceReducedGradientDescentOptimizer::AdvanceOneStep(void)
     temp->t_Optimizer = this;
 
     /** Call multi-threaded AdvanceOneStep(). */
-    ThreaderType::Pointer local_threader = ThreaderType::New();
+    auto local_threader = ThreaderType::New();
     local_threader->SetNumberOfWorkUnits(this->m_Threader->GetNumberOfWorkUnits());
     local_threader->SetSingleMethod(AdvanceOneStepThreaderCallback, temp);
     local_threader->SingleMethodExecute();

--- a/Components/Optimizers/StandardStochasticGradientDescent/itkStochasticGradientDescentOptimizer.cxx
+++ b/Components/Optimizers/StandardStochasticGradientDescent/itkStochasticGradientDescentOptimizer.cxx
@@ -285,7 +285,7 @@ StochasticGradientDescentOptimizer::AdvanceOneStep(void)
     temp.t_Optimizer = this;
 
     /** Call multi-threaded AdvanceOneStep(). */
-    ThreaderType::Pointer local_threader = ThreaderType::New();
+    auto local_threader = ThreaderType::New();
     local_threader->SetNumberOfWorkUnits(this->m_Threader->GetNumberOfWorkUnits());
     local_threader->SetSingleMethod(AdvanceOneStepThreaderCallback, &temp);
     local_threader->SingleMethodExecute();

--- a/Components/Transforms/AdvancedAffineTransform/itkCenteredTransformInitializer2.hxx
+++ b/Components/Transforms/AdvancedAffineTransform/itkCenteredTransformInitializer2.hxx
@@ -195,7 +195,7 @@ CenteredTransformInitializer2<TTransform, TFixedImage, TMovingImage>::Initialize
     FixedRegionType                             fixedRegion = this->m_FixedImage->GetLargestPossibleRegion();
     if (this->m_FixedImageMask)
     {
-      typename FixedMaskSpatialObjectType::Pointer fixedMaskAsSpatialObject = FixedMaskSpatialObjectType::New();
+      auto fixedMaskAsSpatialObject = FixedMaskSpatialObjectType::New();
       fixedMaskAsSpatialObject->SetImage(this->m_FixedImageMask);
       fixedRegion = fixedMaskAsSpatialObject->ComputeMyBoundingBoxInIndexSpace();
     }
@@ -205,7 +205,7 @@ CenteredTransformInitializer2<TTransform, TFixedImage, TMovingImage>::Initialize
     MovingRegionType                             movingRegion = this->m_MovingImage->GetLargestPossibleRegion();
     if (this->m_MovingImageMask)
     {
-      typename MovingMaskSpatialObjectType::Pointer movingMaskAsSpatialObject = MovingMaskSpatialObjectType::New();
+      auto movingMaskAsSpatialObject = MovingMaskSpatialObjectType::New();
       movingMaskAsSpatialObject->SetImage(this->m_MovingImageMask);
       movingRegion = movingMaskAsSpatialObject->ComputeMyBoundingBoxInIndexSpace();
     }
@@ -302,7 +302,7 @@ CenteredTransformInitializer2<TTransform, TFixedImage, TMovingImage>::Initialize
     FixedRegionType                             fixedRegion = this->m_FixedImage->GetLargestPossibleRegion();
     if (this->m_FixedImageMask)
     {
-      typename FixedMaskSpatialObjectType::Pointer fixedMaskAsSpatialObject = FixedMaskSpatialObjectType::New();
+      auto fixedMaskAsSpatialObject = FixedMaskSpatialObjectType::New();
       fixedMaskAsSpatialObject->SetImage(this->m_FixedImageMask);
       fixedRegion = fixedMaskAsSpatialObject->ComputeMyBoundingBoxInIndexSpace();
     }
@@ -321,7 +321,7 @@ CenteredTransformInitializer2<TTransform, TFixedImage, TMovingImage>::Initialize
     MovingRegionType                             movingRegion = this->m_MovingImage->GetLargestPossibleRegion();
     if (this->m_MovingImageMask)
     {
-      typename MovingMaskSpatialObjectType::Pointer movingMaskAsSpatialObject = MovingMaskSpatialObjectType::New();
+      auto movingMaskAsSpatialObject = MovingMaskSpatialObjectType::New();
       movingMaskAsSpatialObject->SetImage(this->m_MovingImageMask);
       movingRegion = movingMaskAsSpatialObject->ComputeMyBoundingBoxInIndexSpace();
     }

--- a/Components/Transforms/BSplineDeformableTransformWithDiffusion/elxBSplineTransformWithDiffusion.hxx
+++ b/Components/Transforms/BSplineDeformableTransformWithDiffusion/elxBSplineTransformWithDiffusion.hxx
@@ -770,10 +770,10 @@ BSplineTransformWithDiffusion<TElastix>::IncreaseScale(void)
      * DeformableRegistration6.cxx .
      */
 
-    typename UpsampleFilterType::Pointer              upsampler = UpsampleFilterType::New();
-    typename IdentityTransformType::Pointer           identity = IdentityTransformType::New();
-    typename CoefficientUpsampleFunctionType::Pointer coeffUpsampleFunction = CoefficientUpsampleFunctionType::New();
-    typename DecompositionFilterType::Pointer         decompositionFilter = DecompositionFilterType::New();
+    auto upsampler = UpsampleFilterType::New();
+    auto identity = IdentityTransformType::New();
+    auto coeffUpsampleFunction = CoefficientUpsampleFunctionType::New();
+    auto decompositionFilter = DecompositionFilterType::New();
 
     upsampler->SetInterpolator(coeffUpsampleFunction);
     upsampler->SetTransform(identity);
@@ -850,7 +850,7 @@ BSplineTransformWithDiffusion<TElastix>::ReadFromFile(void)
   }
 
   /** Read in the deformationField image. */
-  typename VectorReaderType::Pointer vectorReader = VectorReaderType::New();
+  auto vectorReader = VectorReaderType::New();
   vectorReader->SetFileName(fileName.c_str());
 
   /** Do the reading. */
@@ -980,7 +980,7 @@ void
 BSplineTransformWithDiffusion<TElastix>::WriteDerivedTransformDataToFile(void) const
 {
   /** Write the deformation field image. */
-  typename DeformationFieldWriterType::Pointer writer = DeformationFieldWriterType::New();
+  auto writer = DeformationFieldWriterType::New();
   writer->SetFileName(TransformIO::MakeDeformationFieldFileName(*this));
   writer->SetInput(this->m_DiffusedField);
 
@@ -1054,7 +1054,7 @@ BSplineTransformWithDiffusion<TElastix>::DiffuseDeformationField(void)
   /** First, create a dummyImage with the right region info, so
    * that the TransformIndexToPhysicalPoint-functions will be right.
    */
-  typename DummyImageType::Pointer dummyImage = DummyImageType::New();
+  auto dummyImage = DummyImageType::New();
   dummyImage->SetRegions(this->m_DeformationRegion);
   dummyImage->SetOrigin(this->m_DeformationOrigin);
   dummyImage->SetSpacing(this->m_DeformationSpacing);
@@ -1279,7 +1279,7 @@ BSplineTransformWithDiffusion<TElastix>::DiffuseDeformationField(void)
 
     /** Write the deformationFieldImage. */
     makeFileName1 << begin.str() << "deformationField" << end.str();
-    typename DeformationFieldWriterType::Pointer deformationFieldWriter = DeformationFieldWriterType::New();
+    auto deformationFieldWriter = DeformationFieldWriterType::New();
     deformationFieldWriter->SetFileName(makeFileName1.str().c_str());
     deformationFieldWriter->SetInput(this->m_DeformationField);
 
@@ -1302,7 +1302,7 @@ BSplineTransformWithDiffusion<TElastix>::DiffuseDeformationField(void)
     /** Write the GrayValueImage. */
     std::ostringstream makeFileName2("");
     makeFileName2 << begin.str() << "GrayValueImage" << end.str();
-    typename GrayValueImageWriterType::Pointer grayValueImageWriter = GrayValueImageWriterType::New();
+    auto grayValueImageWriter = GrayValueImageWriterType::New();
     grayValueImageWriter->SetFileName(makeFileName2.str().c_str());
     if (this->m_AlsoFixed || this->m_UseFixedSegmentation)
     {
@@ -1332,7 +1332,7 @@ BSplineTransformWithDiffusion<TElastix>::DiffuseDeformationField(void)
     /** Write the diffusedFieldImage. */
     std::ostringstream makeFileName3("");
     makeFileName3 << begin.str() << "diffusedField" << end.str();
-    typename DeformationFieldWriterType::Pointer diffusedFieldWriter = DeformationFieldWriterType::New();
+    auto diffusedFieldWriter = DeformationFieldWriterType::New();
     diffusedFieldWriter->SetFileName(makeFileName3.str().c_str());
     diffusedFieldWriter->SetInput(this->m_DiffusedField);
 

--- a/Components/Transforms/BSplineDeformableTransformWithDiffusion/itkDeformationFieldRegulizer.hxx
+++ b/Components/Transforms/BSplineDeformableTransformWithDiffusion/itkDeformationFieldRegulizer.hxx
@@ -50,7 +50,7 @@ DeformationFieldRegulizer<TAnyITKTransform>::InitializeDeformationFields(void)
   this->m_IntermediaryDeformationFieldTransform = IntermediaryDFTransformType::New();
 
   /** Initialize this->m_IntermediaryDeformationField. */
-  typename VectorImageType::Pointer intermediaryDeformationField = VectorImageType::New();
+  auto intermediaryDeformationField = VectorImageType::New();
   intermediaryDeformationField->SetRegions(this->m_DeformationFieldRegion);
   intermediaryDeformationField->SetSpacing(this->m_DeformationFieldSpacing);
   intermediaryDeformationField->SetOrigin(this->m_DeformationFieldOrigin);

--- a/Components/Transforms/BSplineDeformableTransformWithDiffusion/itkDeformationVectorFieldTransform.hxx
+++ b/Components/Transforms/BSplineDeformableTransformWithDiffusion/itkDeformationVectorFieldTransform.hxx
@@ -134,7 +134,7 @@ DeformationVectorFieldTransform<TScalarType, NDimensions>::GetCoefficientVectorI
   const CoefficientImagePointer * coefImage = this->GetCoefficientImages();
 
   /** Combine the coefficient images to a vector image. */
-  typename ScalarImageCombineType::Pointer combiner = ScalarImageCombineType::New();
+  auto combiner = ScalarImageCombineType::New();
   for (unsigned int i = 0; i < SpaceDimension; ++i)
   {
     combiner->SetInput(i, coefImage[i]);

--- a/Components/Transforms/BSplineDeformableTransformWithDiffusion/itkVectorMeanDiffusionImageFilter.hxx
+++ b/Components/Transforms/BSplineDeformableTransformWithDiffusion/itkVectorMeanDiffusionImageFilter.hxx
@@ -133,7 +133,7 @@ VectorMeanDiffusionImageFilter<TInputImage, TGrayValueImage>::GenerateData(void)
   /** Allocate output. */
   typename InputImageType::ConstPointer input(this->GetInput());
   typename InputImageType::Pointer      output(this->GetOutput());
-  typename InputImageType::Pointer      outputtmp = InputImageType::New();
+  auto                                  outputtmp = InputImageType::New();
   output->SetRegions(input->GetLargestPossibleRegion());
 
   try

--- a/Components/Transforms/DeformationFieldTransform/elxDeformationFieldTransform.hxx
+++ b/Components/Transforms/DeformationFieldTransform/elxDeformationFieldTransform.hxx
@@ -69,7 +69,7 @@ DeformationFieldTransform<TElastix>::ReadFromFile(void)
 
   /** Setup VectorImageReader. */
   typedef itk::ImageFileReader<DeformationFieldType> VectorReaderType;
-  typename VectorReaderType::Pointer                 vectorReader = VectorReaderType::New();
+  auto                                               vectorReader = VectorReaderType::New();
 
   /** Read deformationFieldImage-name from parameter-file. */
   std::string fileName = "";
@@ -160,14 +160,14 @@ DeformationFieldTransform<TElastix>::WriteDerivedTransformDataToFile(void) const
     this->m_DeformationFieldInterpolatingTransform->GetDeformationFieldInterpolator()->GetNameOfClass();
 
   /** Possibly change the direction cosines to there original value */
-  typename ChangeInfoFilterType::Pointer infoChanger = ChangeInfoFilterType::New();
+  auto infoChanger = ChangeInfoFilterType::New();
   infoChanger->SetOutputDirection(this->m_OriginalDeformationFieldDirection);
   infoChanger->SetChangeDirection(!this->GetElastix()->GetUseDirectionCosines());
   infoChanger->SetInput(this->m_DeformationFieldInterpolatingTransform->GetDeformationField());
 
   /** Write the deformation field image. */
   typedef itk::ImageFileWriter<DeformationFieldType> VectorWriterType;
-  typename VectorWriterType::Pointer                 writer = VectorWriterType::New();
+  auto                                               writer = VectorWriterType::New();
   writer->SetFileName(TransformIO::MakeDeformationFieldFileName(*this));
   writer->SetInput(infoChanger->GetOutput());
 

--- a/Components/Transforms/MultiBSplineTransformWithNormal/itkMultiBSplineDeformableTransformWithNormal.hxx
+++ b/Components/Transforms/MultiBSplineTransformWithNormal/itkMultiBSplineDeformableTransformWithNormal.hxx
@@ -151,8 +151,8 @@ MultiBSplineDeformableTransformWithNormal<TScalarType, NDimensions, VSplineOrder
   {
     // Save current settings
     this->m_Labels = labels;
-    ParametersType                   para = this->GetFixedParameters();
-    typename StatisticsType::Pointer stat = StatisticsType::New();
+    ParametersType para = this->GetFixedParameters();
+    auto           stat = StatisticsType::New();
     stat->SetInput(this->m_Labels);
     stat->Update();
     this->m_NbLabels = stat->GetMaximum() + 1;
@@ -385,7 +385,7 @@ MultiBSplineDeformableTransformWithNormal<TScalarType, NDimensions, VSplineOrder
     upperExtend[i] = std::ceil((transEnd[i] - labelEnd[i])) / labelSpac[i];
   }
 
-  typename PadFilterType::Pointer padFilter = PadFilterType::New();
+  auto padFilter = PadFilterType::New();
   padFilter->SetInput(this->m_Labels);
   padFilter->SetPadLowerBound(lowerExtend);
   padFilter->SetPadUpperBound(upperExtend);
@@ -393,30 +393,30 @@ MultiBSplineDeformableTransformWithNormal<TScalarType, NDimensions, VSplineOrder
 
   for (int l = 0; l < this->m_NbLabels; ++l)
   {
-    typename LabelExtractorType::Pointer labelExtractor = LabelExtractorType::New();
+    auto labelExtractor = LabelExtractorType::New();
     labelExtractor->SetInput(padFilter->GetOutput());
     labelExtractor->SetLowerThreshold(l);
     labelExtractor->SetUpperThreshold(l);
     labelExtractor->SetInsideValue(1);
     labelExtractor->SetOutsideValue(0);
 
-    typename DistFilterType::Pointer distFilter = DistFilterType::New();
+    auto distFilter = DistFilterType::New();
     distFilter->SetInsideValue(1);
     distFilter->SetOutsideValue(0);
     distFilter->SetInput(labelExtractor->GetOutput());
 
-    typename SmoothFilterType::Pointer smoothFilter = SmoothFilterType::New();
+    auto smoothFilter = SmoothFilterType::New();
     smoothFilter->SetInput(distFilter->GetOutput());
     smoothFilter->SetSigma(4.);
 
-    typename GradFilterType::Pointer gradFilter = GradFilterType::New();
+    auto gradFilter = GradFilterType::New();
     gradFilter->SetInput(smoothFilter->GetOutput());
 
     const auto castFilter = itk::CastImageFilter<typename GradFilterType::OutputImageType, ImageVectorType>::New();
 
     castFilter->SetInput(gradFilter->GetOutput());
 
-    typename MaskVectorImageType::Pointer maskFilter = MaskVectorImageType::New();
+    auto maskFilter = MaskVectorImageType::New();
     maskFilter->SetInput(castFilter->GetOutput());
     maskFilter->SetMaskImage(labelExtractor->GetOutput());
     maskFilter->SetOutsideValue(itk::NumericTraits<VectorType>::ZeroValue());
@@ -428,7 +428,7 @@ MultiBSplineDeformableTransformWithNormal<TScalarType, NDimensions, VSplineOrder
     }
     else
     {
-      typename AddVectorImageType::Pointer addFilter = AddVectorImageType::New();
+      auto addFilter = AddVectorImageType::New();
       addFilter->SetInput1(this->m_LabelsNormals);
       addFilter->SetInput2(maskFilter->GetOutput());
       addFilter->Update();

--- a/Components/Transforms/SimilarityTransform/elxSimilarityTransform.hxx
+++ b/Components/Transforms/SimilarityTransform/elxSimilarityTransform.hxx
@@ -412,9 +412,9 @@ SimilarityTransformElastix<TElastix>::ReadCenterOfRotationIndex(InputPointType &
   /** Make a temporary image with the right region info,
    * so that the TransformIndexToPhysicalPoint-functions will be right.
    */
-  typedef FixedImageType           DummyImageType;
-  typename DummyImageType::Pointer dummyImage = DummyImageType::New();
-  RegionType                       region;
+  typedef FixedImageType DummyImageType;
+  auto                   dummyImage = DummyImageType::New();
+  RegionType             region;
   region.SetIndex(index);
   region.SetSize(size);
   dummyImage->SetRegions(region);

--- a/Components/Transforms/SplineKernelTransform/elxSplineKernelTransform.hxx
+++ b/Components/Transforms/SplineKernelTransform/elxSplineKernelTransform.hxx
@@ -291,7 +291,7 @@ SplineKernelTransform<TElastix>::ReadLandmarkFile(const std::string & filename,
   typedef itk::TransformixInputPointFileReader<PointSetType> LandmarkReaderType;
 
   /** Construct a landmark file reader and read the points. */
-  typename LandmarkReaderType::Pointer landmarkReader = LandmarkReaderType::New();
+  auto landmarkReader = LandmarkReaderType::New();
   landmarkReader->SetFileName(filename.c_str());
   try
   {

--- a/Components/Transforms/SplineKernelTransform/itkKernelTransform2.hxx
+++ b/Components/Transforms/SplineKernelTransform/itkKernelTransform2.hxx
@@ -577,8 +577,8 @@ void
 KernelTransform2<TScalarType, NDimensions>::SetParameters(const ParametersType & parameters)
 {
   this->m_Parameters = parameters;
-  typename PointsContainer::Pointer landmarks = PointsContainer::New();
-  const unsigned int                numberOfLandmarks = parameters.Size() / NDimensions;
+  auto               landmarks = PointsContainer::New();
+  const unsigned int numberOfLandmarks = parameters.Size() / NDimensions;
   landmarks->Reserve(numberOfLandmarks);
 
   PointsIterator itr = landmarks->Begin();
@@ -622,8 +622,8 @@ template <class TScalarType, unsigned int NDimensions>
 void
 KernelTransform2<TScalarType, NDimensions>::SetFixedParameters(const ParametersType & parameters)
 {
-  typename PointsContainer::Pointer landmarks = PointsContainer::New();
-  const unsigned int                numberOfLandmarks = parameters.Size() / NDimensions;
+  auto               landmarks = PointsContainer::New();
+  const unsigned int numberOfLandmarks = parameters.Size() / NDimensions;
   landmarks->Reserve(numberOfLandmarks);
 
   PointsIterator itr = landmarks->Begin();

--- a/Components/Transforms/TranslationTransform/itkTranslationTransformInitializer.hxx
+++ b/Components/Transforms/TranslationTransform/itkTranslationTransformInitializer.hxx
@@ -127,7 +127,7 @@ TranslationTransformInitializer<TTransform, TFixedImage, TMovingImage>::Initiali
     FixedRegionType                             fixedRegion = this->m_FixedImage->GetLargestPossibleRegion();
     if (this->m_FixedMask)
     {
-      typename FixedMaskSpatialObjectType::Pointer fixedMaskAsSpatialObject = FixedMaskSpatialObjectType::New();
+      auto fixedMaskAsSpatialObject = FixedMaskSpatialObjectType::New();
       fixedMaskAsSpatialObject->SetImage(this->m_FixedMask);
       fixedRegion = fixedMaskAsSpatialObject->ComputeMyBoundingBoxInIndexSpace();
     }
@@ -146,7 +146,7 @@ TranslationTransformInitializer<TTransform, TFixedImage, TMovingImage>::Initiali
     MovingRegionType                             movingRegion = this->m_MovingImage->GetLargestPossibleRegion();
     if (this->m_MovingMask)
     {
-      typename MovingMaskSpatialObjectType::Pointer movingMaskAsSpatialObject = MovingMaskSpatialObjectType::New();
+      auto movingMaskAsSpatialObject = MovingMaskSpatialObjectType::New();
       movingMaskAsSpatialObject->SetImage(this->m_MovingMask);
       movingRegion = movingMaskAsSpatialObject->ComputeMyBoundingBoxInIndexSpace();
     }

--- a/Core/ComponentBaseClasses/elxFixedImagePyramidBase.hxx
+++ b/Core/ComponentBaseClasses/elxFixedImagePyramidBase.hxx
@@ -168,7 +168,7 @@ FixedImagePyramidBase<TElastix>::WritePyramidImage(const std::string &  filename
 
   /** Create writer. */
   typedef itk::ImageFileCastWriter<OutputImageType> WriterType;
-  typename WriterType::Pointer                      writer = WriterType::New();
+  auto                                              writer = WriterType::New();
 
   /** Setup the pipeline. */
   writer->SetInput(this->GetAsITKBaseType()->GetOutput(level));

--- a/Core/ComponentBaseClasses/elxMovingImagePyramidBase.hxx
+++ b/Core/ComponentBaseClasses/elxMovingImagePyramidBase.hxx
@@ -171,7 +171,7 @@ MovingImagePyramidBase<TElastix>::WritePyramidImage(const std::string &  filenam
 
   /** Create writer. */
   typedef itk::ImageFileCastWriter<OutputImageType> WriterType;
-  typename WriterType::Pointer                      writer = WriterType::New();
+  auto                                              writer = WriterType::New();
 
   /** Setup the pipeline. */
   writer->SetInput(this->GetAsITKBaseType()->GetOutput(level));

--- a/Core/ComponentBaseClasses/elxResamplerBase.hxx
+++ b/Core/ComponentBaseClasses/elxResamplerBase.hxx
@@ -380,9 +380,9 @@ ResamplerBase<TElastix>::WriteResultImage(OutputImageType * image, const char * 
    * in the tp-file, or by the fixed image. This is only necessary when
    * the UseDirectionCosines flag was set to false.
    */
-  typename ChangeInfoFilterType::Pointer infoChanger = ChangeInfoFilterType::New();
-  DirectionType                          originalDirection;
-  bool                                   retdc = this->GetElastix()->GetOriginalFixedImageDirection(originalDirection);
+  auto          infoChanger = ChangeInfoFilterType::New();
+  DirectionType originalDirection;
+  bool          retdc = this->GetElastix()->GetOriginalFixedImageDirection(originalDirection);
   infoChanger->SetOutputDirection(originalDirection);
   infoChanger->SetChangeDirection(retdc & !this->GetElastix()->GetUseDirectionCosines());
   infoChanger->SetInput(image);
@@ -476,9 +476,9 @@ ResamplerBase<TElastix>::CreateItkResultImage(void)
    * in the tp-file, or by the fixed image. This is only necessary when
    * the UseDirectionCosines flag was set to false.
    */
-  typename ChangeInfoFilterType::Pointer infoChanger = ChangeInfoFilterType::New();
-  DirectionType                          originalDirection;
-  bool                                   retdc = this->GetElastix()->GetOriginalFixedImageDirection(originalDirection);
+  auto          infoChanger = ChangeInfoFilterType::New();
+  DirectionType originalDirection;
+  bool          retdc = this->GetElastix()->GetOriginalFixedImageDirection(originalDirection);
   infoChanger->SetOutputDirection(originalDirection);
   infoChanger->SetChangeDirection(retdc & !this->GetElastix()->GetUseDirectionCosines());
   infoChanger->SetInput(this->GetAsITKBaseType()->GetOutput());
@@ -500,21 +500,21 @@ ResamplerBase<TElastix>::CreateItkResultImage(void)
   /** cast the image to the correct output image Type */
   if (resultImagePixelType == "char")
   {
-    typename CastFilterChar::Pointer castFilter = CastFilterChar::New();
+    auto castFilter = CastFilterChar::New();
     castFilter->SetInput(infoChanger->GetOutput());
     castFilter->Update();
     resultImage = castFilter->GetOutput();
   }
   if (resultImagePixelType == "unsigned char")
   {
-    typename CastFilterUChar::Pointer castFilter = CastFilterUChar::New();
+    auto castFilter = CastFilterUChar::New();
     castFilter->SetInput(infoChanger->GetOutput());
     castFilter->Update();
     resultImage = castFilter->GetOutput();
   }
   else if (resultImagePixelType == "short")
   {
-    typename CastFilterShort::Pointer castFilter = CastFilterShort::New();
+    auto castFilter = CastFilterShort::New();
     castFilter->SetInput(infoChanger->GetOutput());
     castFilter->Update();
     resultImage = castFilter->GetOutput();
@@ -522,49 +522,49 @@ ResamplerBase<TElastix>::CreateItkResultImage(void)
   else if (resultImagePixelType == "ushort" ||
            resultImagePixelType == "unsigned short") // <-- ushort for backwards compatibility
   {
-    typename CastFilterUShort::Pointer castFilter = CastFilterUShort::New();
+    auto castFilter = CastFilterUShort::New();
     castFilter->SetInput(infoChanger->GetOutput());
     castFilter->Update();
     resultImage = castFilter->GetOutput();
   }
   else if (resultImagePixelType == "int")
   {
-    typename CastFilterInt::Pointer castFilter = CastFilterInt::New();
+    auto castFilter = CastFilterInt::New();
     castFilter->SetInput(infoChanger->GetOutput());
     castFilter->Update();
     resultImage = castFilter->GetOutput();
   }
   else if (resultImagePixelType == "unsigned int")
   {
-    typename CastFilterUInt::Pointer castFilter = CastFilterUInt::New();
+    auto castFilter = CastFilterUInt::New();
     castFilter->SetInput(infoChanger->GetOutput());
     castFilter->Update();
     resultImage = castFilter->GetOutput();
   }
   else if (resultImagePixelType == "long")
   {
-    typename CastFilterLong::Pointer castFilter = CastFilterLong::New();
+    auto castFilter = CastFilterLong::New();
     castFilter->SetInput(infoChanger->GetOutput());
     castFilter->Update();
     resultImage = castFilter->GetOutput();
   }
   else if (resultImagePixelType == "unsigned long")
   {
-    typename CastFilterULong::Pointer castFilter = CastFilterULong::New();
+    auto castFilter = CastFilterULong::New();
     castFilter->SetInput(infoChanger->GetOutput());
     castFilter->Update();
     resultImage = castFilter->GetOutput();
   }
   else if (resultImagePixelType == "float")
   {
-    typename CastFilterFloat::Pointer castFilter = CastFilterFloat::New();
+    auto castFilter = CastFilterFloat::New();
     castFilter->SetInput(infoChanger->GetOutput());
     castFilter->Update();
     resultImage = castFilter->GetOutput();
   }
   else if (resultImagePixelType == "double")
   {
-    typename CastFilterDouble::Pointer castFilter = CastFilterDouble::New();
+    auto castFilter = CastFilterDouble::New();
     castFilter->SetInput(infoChanger->GetOutput());
     castFilter->Update();
     resultImage = castFilter->GetOutput();

--- a/Core/Kernel/elxElastixMain.cxx
+++ b/Core/Kernel/elxElastixMain.cxx
@@ -962,7 +962,7 @@ ElastixMain::GetImageInformationFromFile(const std::string & filename, ImageDime
 
     /** Create a testReader. */
     typedef itk::ImageFileReader<DummyImageType> ReaderType;
-    ReaderType::Pointer                          testReader = ReaderType::New();
+    auto                                         testReader = ReaderType::New();
     testReader->SetFileName(filename);
 
     /** Generate all information. */

--- a/Core/Main/elxElastixFilter.hxx
+++ b/Core/Main/elxElastixFilter.hxx
@@ -292,7 +292,7 @@ ElastixFilter<TFixedImage, TMovingImage>::GenerateData(void)
   }
 
   // Save parameter map
-  ParameterObject::Pointer transformParameterObject = ParameterObject::New();
+  auto transformParameterObject = ParameterObject::New();
   transformParameterObject->SetParameterMap(transformParameterMapVector);
   this->SetOutput("TransformParameterObject", transformParameterObject);
 }

--- a/Core/elxProgressCommand.h
+++ b/Core/elxProgressCommand.h
@@ -38,7 +38,7 @@ namespace elastix
  * as follows:
  *
  * \code
- *   ProgressCommandType::Pointer command = ProgressCommandType::New();
+ *   auto command = ProgressCommandType::New();
  *   command->ConnectObserver( filterpointer );
  *   command->SetStartString( "  Progress: " );
  *   command->SetEndString( "%" );
@@ -56,7 +56,7 @@ namespace elastix
  * that the progress message should be printed with. For example
  *
  * \code
- *   ProgressCommandType::Pointer command = ProgressCommandType::New();
+ *   auto command = ProgressCommandType::New();
  *   command->SetUpdateFrequency( maxnrofvoxels, 100 );
  *   command->SetStartString( "  Progress: " );
  *   command->SetEndString( "%" );
@@ -71,7 +71,7 @@ namespace elastix
  * \li The last possibility is to directly use the PrintProgress function:
  *
  * \code
- *   ProgressCommandType::Pointer command = ProgressCommandType::New();
+ *   auto command = ProgressCommandType::New();
  *   command->SetStartString( "  Progress: " );
  *   command->SetEndString( "%" );
  *   elxout << "Reading, casting, writing..."

--- a/Testing/elxImageCompare.cxx
+++ b/Testing/elxImageCompare.cxx
@@ -94,7 +94,7 @@ main(int argc, char ** argv)
   typedef itk::ImageFileReader<ImageType>            ReaderType;
 
   // Read the baseline file
-  ReaderType::Pointer baselineReader = ReaderType::New();
+  auto baselineReader = ReaderType::New();
   baselineReader->SetFileName(baselineImageFileName);
   try
   {
@@ -107,7 +107,7 @@ main(int argc, char ** argv)
   }
 
   // Read the file to test
-  ReaderType::Pointer testReader = ReaderType::New();
+  auto testReader = ReaderType::New();
   testReader->SetFileName(testImageFileName);
   try
   {
@@ -135,7 +135,7 @@ main(int argc, char ** argv)
 
   // Now compare the two images
   typedef itk::Testing::ComparisonImageFilter<ImageType, ImageType> ComparisonFilterType;
-  ComparisonFilterType::Pointer                                     comparisonFilter = ComparisonFilterType::New();
+  auto                                                              comparisonFilter = ComparisonFilterType::New();
   comparisonFilter->SetTestInput(testReader->GetOutput());
   comparisonFilter->SetValidInput(baselineReader->GetOutput());
   comparisonFilter->SetDifferenceThreshold(diffThreshold);
@@ -165,7 +165,7 @@ main(int argc, char ** argv)
     diffImageFileName += itksys::SystemTools::GetFilenameLastExtension(testImageFileName);
 
     typedef itk::ImageFileWriter<ImageType> WriterType;
-    WriterType::Pointer                     writer = WriterType::New();
+    auto                                    writer = WriterType::New();
     writer->SetFileName(diffImageFileName);
     writer->SetInput(comparisonFilter->GetOutput());
     try

--- a/Testing/elxInvertTransform.cxx
+++ b/Testing/elxInvertTransform.cxx
@@ -99,8 +99,8 @@ main(int argc, char * argv[])
   /** Interface to the original transform parameters file. */
   typedef itk::ParameterFileParser   ParserType;
   typedef itk::ParameterMapInterface InterfaceType;
-  ParserType::Pointer                parser = ParserType::New();
-  InterfaceType::Pointer             config = InterfaceType::New();
+  auto                               parser = ParserType::New();
+  auto                               config = InterfaceType::New();
   parser->SetParameterFileName(inputTransformParametersName);
   parser->ReadParameterFile();
   config->SetParameterMap(parser->GetParameterMap());
@@ -137,7 +137,7 @@ main(int argc, char * argv[])
   /** Create a testReader. */
   typedef itk::Image<short, Dimension>         DummyImageType;
   typedef itk::ImageFileReader<DummyImageType> ReaderType;
-  ReaderType::Pointer                          testReader = ReaderType::New();
+  auto                                         testReader = ReaderType::New();
   testReader->SetFileName(movingImageFileName);
 
   /** Generate all information. */
@@ -187,11 +187,11 @@ main(int argc, char * argv[])
   {
     if (transformType == "EulerTransform")
     {
-      RigidTransformType::Pointer rigidTransform = RigidTransformType::New();
+      auto rigidTransform = RigidTransformType::New();
       rigidTransform->SetCenter(centerOfRotation);
       rigidTransform->SetParametersByValue(transformParameters);
 
-      RigidTransformType::Pointer inverseRigidTransform = RigidTransformType::New();
+      auto inverseRigidTransform = RigidTransformType::New();
       rigidTransform->GetInverse(inverseRigidTransform);
 
       transformParametersInv = inverseRigidTransform->GetParameters();
@@ -199,11 +199,11 @@ main(int argc, char * argv[])
     }
     else if (transformType == "AffineTransform")
     {
-      AffineTransformType::Pointer affineTransform = AffineTransformType::New();
+      auto affineTransform = AffineTransformType::New();
       affineTransform->SetCenter(centerOfRotation);
       affineTransform->SetParametersByValue(transformParameters);
 
-      AffineTransformType::Pointer inverseAffineTransform = AffineTransformType::New();
+      auto inverseAffineTransform = AffineTransformType::New();
       affineTransform->GetInverse(inverseAffineTransform);
 
       transformParametersInv = inverseAffineTransform->GetParameters();

--- a/Testing/elxTransformParametersCompare.cxx
+++ b/Testing/elxTransformParametersCompare.cxx
@@ -124,8 +124,8 @@ main(int argc, char ** argv)
   typedef double ScalarType;
   std::string    dummyErrorMessage = "";
 
-  ParserType::Pointer    parameterFileParser = ParserType::New();
-  InterfaceType::Pointer config = InterfaceType::New();
+  auto parameterFileParser = ParserType::New();
+  auto config = InterfaceType::New();
 
   /** Read test parameters. */
   parameterFileParser->SetParameterFileName(testFileName.c_str());
@@ -233,8 +233,8 @@ main(int argc, char ** argv)
     }
 
     /** Create the coefficient image. */
-    CoefficientImageType::Pointer coefImage = CoefficientImageType::New();
-    RegionType                    region;
+    auto       coefImage = CoefficientImageType::New();
+    RegionType region;
     region.SetSize(gridSize);
     region.SetIndex(gridIndex);
     coefImage->SetRegions(region);
@@ -248,7 +248,7 @@ main(int argc, char ** argv)
     MaskIteratorType       itM;
     if (!maskFileName.empty())
     {
-      MaskReaderType::Pointer maskReader = MaskReaderType::New();
+      auto maskReader = MaskReaderType::New();
       maskReader->SetFileName(maskFileName);
       maskReader->Update();
       maskImage = maskReader->GetOutput();
@@ -325,7 +325,7 @@ main(int argc, char ** argv)
     /** Write the difference image. */
     if (diffNormNormalized > 1e-10)
     {
-      WriterType::Pointer writer = WriterType::New();
+      auto writer = WriterType::New();
       writer->SetFileName(diffImageFileName);
       writer->SetInput(coefImage);
       try

--- a/Testing/itkAccumulateDerivativesParallellizationTest.cxx
+++ b/Testing/itkAccumulateDerivativesParallellizationTest.cxx
@@ -193,7 +193,7 @@ main(void)
   typedef MetricTEMP                  MetricClass;
   typedef MetricClass::DerivativeType DerivativeType;
 
-  MetricClass::Pointer metric = MetricClass::New();
+  auto metric = MetricClass::New();
 
   // test parameters
   std::vector<unsigned int> arraySizes;

--- a/Testing/itkAdvanceOneStepParallellizationTest.cxx
+++ b/Testing/itkAdvanceOneStepParallellizationTest.cxx
@@ -251,7 +251,7 @@ main(void)
   typedef OptimizerTEMP                  OptimizerClass;
   typedef OptimizerClass::ParametersType ParametersType;
 
-  OptimizerClass::Pointer optimizer = OptimizerClass::New();
+  auto optimizer = OptimizerClass::New();
 
   // test parameters
   std::vector<unsigned int> arraySizes;

--- a/Testing/itkAdvancedBSplineDeformableTransformTest.cxx
+++ b/Testing/itkAdvancedBSplineDeformableTransformTest.cxx
@@ -83,8 +83,8 @@ main(int argc, char * argv[])
   typedef InputImageType::DirectionType                       DirectionType;
 
   /** Create the transform. */
-  TransformType::Pointer    transform = TransformType::New();
-  ITKTransformType::Pointer transformITK = ITKTransformType::New();
+  auto transform = TransformType::New();
+  auto transformITK = ITKTransformType::New();
 
   /** Setup the B-spline transform:
    * (GridSize 44 43 35)

--- a/Testing/itkAdvancedLinearInterpolatorTest.cxx
+++ b/Testing/itkAdvancedLinearInterpolatorTest.cxx
@@ -89,7 +89,7 @@ TestInterpolators(void)
     direction[2][0] = 1.0;
   }
 
-  typename InputImageType::Pointer image = InputImageType::New();
+  auto image = InputImageType::New();
   image->SetRegions(region);
   image->SetOrigin(origin);
   image->SetSpacing(spacing);
@@ -107,15 +107,15 @@ TestInterpolators(void)
   }
 
   /** Write the image. */
-  // WriterType::Pointer writer = WriterType::New();
+  // auto writer = WriterType::New();
   // writer->SetInput( image );
   // writer->SetFileName( "image.mhd" );
   // writer->Update();
 
   /** Create and setup interpolators. */
-  typename LinearInterpolatorType::Pointer         linear = LinearInterpolatorType::New();
-  typename AdvancedLinearInterpolatorType::Pointer linearA = AdvancedLinearInterpolatorType::New();
-  typename BSplineInterpolatorType::Pointer        bspline = BSplineInterpolatorType::New();
+  auto linear = LinearInterpolatorType::New();
+  auto linearA = AdvancedLinearInterpolatorType::New();
+  auto bspline = BSplineInterpolatorType::New();
   linear->SetInputImage(image);
   linearA->SetInputImage(image);
   bspline->SetSplineOrder(1); // prior to SetInputImage()

--- a/Testing/itkAdvancedRecursiveBSplineTransformTest.cxx
+++ b/Testing/itkAdvancedRecursiveBSplineTransformTest.cxx
@@ -86,9 +86,9 @@ main(int argc, char * argv[])
   typedef itk::Statistics::MersenneTwisterRandomVariateGenerator MersenneTwisterType;
 
   /** Create the transforms. */
-  ITKTransformType::Pointer       transformITK = ITKTransformType::New();
-  TransformType::Pointer          transform = TransformType::New();
-  RecursiveTransformType::Pointer recursiveTransform = RecursiveTransformType::New();
+  auto transformITK = ITKTransformType::New();
+  auto transform = TransformType::New();
+  auto recursiveTransform = RecursiveTransformType::New();
 
   /** Setup the B-spline transform:
    * (GridSize 44 43 35)
@@ -246,7 +246,7 @@ main(int argc, char * argv[])
   indices2.SetSize(dummyNum);
 
   // Generate a list of random points
-  MersenneTwisterType::Pointer mersenneTwister = MersenneTwisterType::New();
+  auto mersenneTwister = MersenneTwisterType::New();
   mersenneTwister->Initialize(140377);
   std::vector<InputPointType>  pointList(N);
   std::vector<OutputPointType> transformedPointList1(N);

--- a/Testing/itkBSplineInterpolationDerivativeWeightFunctionTest.cxx
+++ b/Testing/itkBSplineInterpolationDerivativeWeightFunctionTest.cxx
@@ -52,7 +52,7 @@ main(void)
   std::cerr << "TESTING:\n" << std::endl;
 
   /** Construct several weight functions. */
-  DerivativeWeightFunctionType::Pointer foWeightFunction = DerivativeWeightFunctionType::New();
+  auto foWeightFunction = DerivativeWeightFunctionType::New();
 
   /** Create and fill a continuous index.
    * NOTE: don't change this, since the hard-coded ground truth depends on this.

--- a/Testing/itkBSplineInterpolationSODerivativeWeightFunctionTest.cxx
+++ b/Testing/itkBSplineInterpolationSODerivativeWeightFunctionTest.cxx
@@ -55,7 +55,7 @@ main(void)
   std::cerr << "\nTESTING: derivatives (0,1)\n" << std::endl;
 
   /** Construct several weight functions. */
-  SODerivativeWeightFunctionType::Pointer soWeightFunction = SODerivativeWeightFunctionType::New();
+  auto soWeightFunction = SODerivativeWeightFunctionType::New();
 
   /** Create and fill a continuous index.
    * NOTE: don't change this, since the hard-coded ground truth depends on this.

--- a/Testing/itkBSplineInterpolationWeightFunctionTest.cxx
+++ b/Testing/itkBSplineInterpolationWeightFunctionTest.cxx
@@ -58,8 +58,8 @@ main(void)
   std::cerr << "2D TESTING:\n" << std::endl;
 
   /** Construct several weight functions. */
-  WeightFunctionType2D::Pointer  weightFunction2D = WeightFunctionType2D::New();
-  WeightFunction2Type2D::Pointer weight2Function2D = WeightFunction2Type2D::New();
+  auto weightFunction2D = WeightFunctionType2D::New();
+  auto weight2Function2D = WeightFunction2Type2D::New();
 
   /** Create and fill a continuous index. */
   ContinuousIndexType2D cindex;
@@ -145,8 +145,8 @@ main(void)
   std::cerr << "\n3D TESTING:\n" << std::endl;
 
   /** Construct several weight functions. */
-  WeightFunctionType3D::Pointer  weightFunction3D = WeightFunctionType3D::New();
-  WeightFunction2Type3D::Pointer weight2Function3D = WeightFunction2Type3D::New();
+  auto weightFunction3D = WeightFunctionType3D::New();
+  auto weight2Function3D = WeightFunction2Type3D::New();
 
   /** Create and fill a continuous index. */
   ContinuousIndexType3D cindex3D;

--- a/Testing/itkBSplineJacobianGradientPerformanceTest.cxx
+++ b/Testing/itkBSplineJacobianGradientPerformanceTest.cxx
@@ -77,8 +77,8 @@ main(int argc, char * argv[])
   typedef InputImageType::DirectionType                       DirectionType;
 
   /** Create the transform. */
-  TransformType::Pointer          transform = TransformType::New();
-  RecursiveTransformType::Pointer recursiveTransform = RecursiveTransformType::New();
+  auto transform = TransformType::New();
+  auto recursiveTransform = RecursiveTransformType::New();
 
   /** Setup the B-spline transform:
    * (GridSize 44 43 35)

--- a/Testing/itkBSplineSODerivativeKernelFunctionTest.cxx
+++ b/Testing/itkBSplineSODerivativeKernelFunctionTest.cxx
@@ -44,9 +44,9 @@ main(void)
   typedef itk::BSplineSecondOrderDerivativeKernelFunction2<SplineOrder> BSplineSODerivativeKernelType2;
 
   /** Create the kernel. */
-  BSplineSODerivativeKernelType::Pointer dkernel = BSplineSODerivativeKernelType::New();
-  const unsigned int                     size_u = 15;
-  std::vector<double>                    u(size_u);
+  auto                dkernel = BSplineSODerivativeKernelType::New();
+  const unsigned int  size_u = 15;
+  std::vector<double> u(size_u);
   u[0] = -2.5;
   u[1] = -2.0;
   u[2] = -1.9;
@@ -72,7 +72,7 @@ main(void)
   std::cerr << "The elapsed time for ITK implementation is: " << clockDiff << std::endl;
 
   /** Create the kernel. */
-  BSplineSODerivativeKernelType2::Pointer dkernel2 = BSplineSODerivativeKernelType2::New();
+  auto dkernel2 = BSplineSODerivativeKernelType2::New();
 
   /** Time the implementation. */
   startClock = clock();

--- a/Testing/itkBSplineTransformPointPerformanceTest.cxx
+++ b/Testing/itkBSplineTransformPointPerformanceTest.cxx
@@ -204,7 +204,7 @@ main(int argc, char * argv[])
   typedef InputImageType::DirectionType                       DirectionType;
 
   /** Create the transform. */
-  TransformType::Pointer transform = TransformType::New();
+  auto transform = TransformType::New();
 
   /** Setup the B-spline transform:
    * (GridSize 44 43 35)

--- a/Testing/itkGPUBSplineDecompositionImageFilterTest.cxx
+++ b/Testing/itkGPUBSplineDecompositionImageFilterTest.cxx
@@ -76,12 +76,12 @@ main(int argc, char * argv[])
   typedef itk::ImageFileWriter<ImageType>                            WriterType;
 
   // Reader
-  ReaderType::Pointer reader = ReaderType::New();
+  auto reader = ReaderType::New();
   reader->SetFileName(inputFileName);
   reader->Update();
 
   // Construct the filter
-  FilterType::Pointer cpuFilter = FilterType::New();
+  auto cpuFilter = FilterType::New();
   cpuFilter->SetSplineOrder(splineOrder);
 
   std::cout << "Testing the BSplineDecompositionImageFilter, CPU vs GPU:\n";
@@ -111,7 +111,7 @@ main(int argc, char * argv[])
             << std::endl;
 
   /** Write the CPU result. */
-  WriterType::Pointer writer = WriterType::New();
+  auto writer = WriterType::New();
   writer->SetInput(cpuFilter->GetOutput());
   writer->SetFileName(outputFileNameCPU.c_str());
   try
@@ -153,7 +153,7 @@ main(int argc, char * argv[])
   // reads a GPUImage instead of a normal image.
   // Otherwise, you will get an exception when running the GPU filter:
   // "ERROR: The GPU InputImage is NULL. Filter unable to perform."
-  ReaderType::Pointer gpuReader = ReaderType::New();
+  auto gpuReader = ReaderType::New();
   gpuReader->SetFileName(inputFileName);
 
   // Time the filter, run on the GPU
@@ -180,7 +180,7 @@ main(int argc, char * argv[])
             << cputimer.GetMean() / gputimer.GetMean();
 
   /** Write the GPU result. */
-  WriterType::Pointer gpuWriter = WriterType::New();
+  auto gpuWriter = WriterType::New();
   gpuWriter->SetInput(gpuFilter->GetOutput());
   gpuWriter->SetFileName(outputFileNameGPU.c_str());
   try

--- a/Testing/itkGPUCastImageFilterTest.cxx
+++ b/Testing/itkGPUCastImageFilterTest.cxx
@@ -76,12 +76,12 @@ main(int argc, char * argv[])
   typedef itk::ImageFileWriter<OutputImageType>                 WriterType;
 
   // Reader
-  ReaderType::Pointer reader = ReaderType::New();
+  auto reader = ReaderType::New();
   reader->SetFileName(inputFileName);
   reader->Update();
 
   // Construct the filter
-  FilterType::Pointer cpuFilter = FilterType::New();
+  auto cpuFilter = FilterType::New();
 
   std::cout << "Testing the CastImageFilter, CPU vs GPU:\n";
   std::cout << "CPU/GPU splineOrder #threads time speedup RMSE\n";
@@ -114,7 +114,7 @@ main(int argc, char * argv[])
   std::cout << "CPU " << cpuFilter->GetNumberOfWorkUnits() << " " << cputimer.GetMean() / runTimes << std::endl;
 
   /** Write the CPU result. */
-  WriterType::Pointer writer = WriterType::New();
+  auto writer = WriterType::New();
   writer->SetInput(cpuFilter->GetOutput());
   writer->SetFileName(outputFileNameCPU.c_str());
   try
@@ -155,7 +155,7 @@ main(int argc, char * argv[])
   // reads a GPUImage instead of a normal image.
   // Otherwise, you will get an exception when running the GPU filter:
   // "ERROR: The GPU InputImage is NULL. Filter unable to perform."
-  ReaderType::Pointer gpuReader = ReaderType::New();
+  auto gpuReader = ReaderType::New();
   gpuReader->SetFileName(inputFileName);
 
   // Time the filter, run on the GPU
@@ -185,7 +185,7 @@ main(int argc, char * argv[])
   std::cout << "GPU x " << gputimer.GetMean() / runTimes << " " << cputimer.GetMean() / gputimer.GetMean();
 
   /** Write the GPU result. */
-  WriterType::Pointer gpuWriter = WriterType::New();
+  auto gpuWriter = WriterType::New();
   gpuWriter->SetInput(gpuFilter->GetOutput());
   gpuWriter->SetFileName(outputFileNameGPU.c_str());
   try

--- a/Testing/itkGPUGenericMultiResolutionPyramidImageFilterTest.cxx
+++ b/Testing/itkGPUGenericMultiResolutionPyramidImageFilterTest.cxx
@@ -89,12 +89,12 @@ main(int argc, char * argv[])
   typedef itk::ImageFileWriter<OutputImageType>                                          WriterType;
 
   // Reader
-  ReaderType::Pointer reader = ReaderType::New();
+  auto reader = ReaderType::New();
   reader->SetFileName(inputFileName);
   reader->Update();
 
   // Construct the filter
-  FilterType::Pointer cpuFilter = FilterType::New();
+  auto cpuFilter = FilterType::New();
 
   typedef FilterType::RescaleScheduleType   RescaleScheduleType;
   typedef FilterType::SmoothingScheduleType SmoothingScheduleType;
@@ -186,7 +186,7 @@ main(int argc, char * argv[])
   std::cout << "CPU " << cpuFilter->GetNumberOfWorkUnits() << " " << cputimer.GetMean() / runTimes << std::endl;
 
   /** Write the CPU result. */
-  WriterType::Pointer writer = WriterType::New();
+  auto writer = WriterType::New();
   writer->SetInput(cpuFilter->GetOutput(numberOfLevels - 1));
   writer->SetFileName(outputFileNameCPU.c_str());
   try
@@ -251,7 +251,7 @@ main(int argc, char * argv[])
   // reads a GPUImage instead of a normal image.
   // Otherwise, you will get an exception when running the GPU filter:
   // "ERROR: The GPU InputImage is NULL. Filter unable to perform."
-  ReaderType::Pointer gpuReader = ReaderType::New();
+  auto gpuReader = ReaderType::New();
   gpuReader->SetFileName(inputFileName);
 
   // \todo: If the following line is uncommented something goes wrong with
@@ -314,7 +314,7 @@ main(int argc, char * argv[])
   std::cout << "GPU x " << gputimer.GetMean() / runTimes << " " << cputimer.GetMean() / gputimer.GetMean();
 
   /** Write the GPU result. */
-  WriterType::Pointer gpuWriter = WriterType::New();
+  auto gpuWriter = WriterType::New();
   gpuWriter->SetInput(gpuFilter->GetOutput(numberOfLevels - 1));
   gpuWriter->SetFileName(outputFileNameGPU.c_str());
   try

--- a/Testing/itkGPURecursiveGaussianImageFilterTest.cxx
+++ b/Testing/itkGPURecursiveGaussianImageFilterTest.cxx
@@ -78,7 +78,7 @@ main(int argc, char * argv[])
   std::cout << std::showpoint << std::setprecision(4);
 
   // Reader
-  ReaderType::Pointer reader = ReaderType::New();
+  auto reader = ReaderType::New();
   reader->SetFileName(inputFileName);
   try
   {
@@ -94,7 +94,7 @@ main(int argc, char * argv[])
   itk::TimeProbe cputimer;
   itk::TimeProbe gputimer;
 
-  CPUFilterType::Pointer cpuFilter = CPUFilterType::New();
+  auto cpuFilter = CPUFilterType::New();
 
   // Test 1~n threads for CPU
   // Speed CPU vs GPU
@@ -116,7 +116,7 @@ main(int argc, char * argv[])
   }
 
   /** Write the CPU result. */
-  WriterType::Pointer writer = WriterType::New();
+  auto writer = WriterType::New();
   writer->SetInput(cpuFilter->GetOutput());
   writer->SetFileName(outputFileNameCPU.c_str());
   try
@@ -158,7 +158,7 @@ main(int argc, char * argv[])
             << cputimer.GetMean() / gputimer.GetMean();
 
   /** Write the GPU result. */
-  WriterType::Pointer gpuWriter = WriterType::New();
+  auto gpuWriter = WriterType::New();
   gpuWriter->SetInput(gpuFilter->GetOutput());
   gpuWriter->SetFileName(outputFileNameGPU.c_str());
   try

--- a/Testing/itkGPUResampleImageFilterTest.cxx
+++ b/Testing/itkGPUResampleImageFilterTest.cxx
@@ -155,17 +155,17 @@ DefineInterpolator(typename InterpolatorType::Pointer & interpolator,
 
   if (interpolatorName == "NearestNeighbor")
   {
-    typename NearestNeighborInterpolatorType::Pointer tmpInterpolator = NearestNeighborInterpolatorType::New();
+    auto tmpInterpolator = NearestNeighborInterpolatorType::New();
     interpolator = tmpInterpolator;
   }
   else if (interpolatorName == "Linear")
   {
-    typename LinearInterpolatorType::Pointer tmpInterpolator = LinearInterpolatorType::New();
+    auto tmpInterpolator = LinearInterpolatorType::New();
     interpolator = tmpInterpolator;
   }
   else if (interpolatorName == "BSpline")
   {
-    typename BSplineInterpolatorType::Pointer tmpInterpolator = BSplineInterpolatorType::New();
+    auto tmpInterpolator = BSplineInterpolatorType::New();
     tmpInterpolator->SetSplineOrder(splineOrderInterpolator);
     interpolator = tmpInterpolator;
   }
@@ -383,7 +383,7 @@ SetTransform(const std::size_t                                            transf
     if (advancedTransform.IsNull())
     {
       // Create Affine transform
-      typename AffineTransformType::Pointer affineTransform = AffineTransformType::New();
+      auto affineTransform = AffineTransformType::New();
 
       // Define and set affine parameters
       typename AffineTransformType::ParametersType parameters;
@@ -395,7 +395,7 @@ SetTransform(const std::size_t                                            transf
     else
     {
       // Create Advanced Affine transform
-      typename AdvancedAffineTransformType::Pointer affineTransform = AdvancedAffineTransformType::New();
+      auto affineTransform = AdvancedAffineTransformType::New();
       advancedTransform->SetCurrentTransform(affineTransform);
 
       // Define and set advanced affine parameters
@@ -409,7 +409,7 @@ SetTransform(const std::size_t                                            transf
     if (advancedTransform.IsNull())
     {
       // Create Translation transform
-      typename TranslationTransformType::Pointer translationTransform = TranslationTransformType::New();
+      auto translationTransform = TranslationTransformType::New();
 
       // Define and set translation parameters
       typename TranslationTransformType::ParametersType parameters;
@@ -421,7 +421,7 @@ SetTransform(const std::size_t                                            transf
     else
     {
       // Create Advanced Translation transform
-      typename AdvancedTranslationTransformType::Pointer translationTransform = AdvancedTranslationTransformType::New();
+      auto translationTransform = AdvancedTranslationTransformType::New();
       advancedTransform->SetCurrentTransform(translationTransform);
 
       // Define and set advanced translation parameters
@@ -453,7 +453,7 @@ SetTransform(const std::size_t                                            transf
     if (advancedTransform.IsNull())
     {
       // Create BSpline transform
-      typename BSplineTransformType::Pointer bsplineTransform = BSplineTransformType::New();
+      auto bsplineTransform = BSplineTransformType::New();
 
       // Set grid properties
       bsplineTransform->SetTransformDomainOrigin(inputOrigin);
@@ -478,7 +478,7 @@ SetTransform(const std::size_t                                            transf
     else
     {
       // Create Advanced BSpline transform
-      typename AdvancedBSplineTransformType::Pointer bsplineTransform = AdvancedBSplineTransformType::New();
+      auto bsplineTransform = AdvancedBSplineTransformType::New();
       advancedTransform->SetCurrentTransform(bsplineTransform);
 
       // Set grid properties
@@ -509,7 +509,7 @@ SetTransform(const std::size_t                                            transf
     if (advancedTransform.IsNull())
     {
       // Create Euler transform
-      typename EulerTransformType::Pointer eulerTransform = EulerTransformType::New();
+      auto eulerTransform = EulerTransformType::New();
 
       // Set center
       eulerTransform->SetCenter(center);
@@ -524,7 +524,7 @@ SetTransform(const std::size_t                                            transf
     else
     {
       // Create Advanced Euler transform
-      typename AdvancedEulerTransformType::Pointer eulerTransform = AdvancedEulerTransformType::New();
+      auto eulerTransform = AdvancedEulerTransformType::New();
       advancedTransform->SetCurrentTransform(eulerTransform);
 
       // Set center
@@ -544,7 +544,7 @@ SetTransform(const std::size_t                                            transf
     if (advancedTransform.IsNull())
     {
       // Create Similarity transform
-      typename SimilarityTransformType::Pointer similarityTransform = SimilarityTransformType::New();
+      auto similarityTransform = SimilarityTransformType::New();
 
       // Set center
       similarityTransform->SetCenter(center);
@@ -559,7 +559,7 @@ SetTransform(const std::size_t                                            transf
     else
     {
       // Create Advanced Similarity transform
-      typename AdvancedSimilarityTransformType::Pointer similarityTransform = AdvancedSimilarityTransformType::New();
+      auto similarityTransform = AdvancedSimilarityTransformType::New();
       advancedTransform->SetCurrentTransform(similarityTransform);
 
       // Set center
@@ -878,7 +878,7 @@ main(int argc, char * argv[])
   {
     AdvancedTransformType::Pointer            currentTransform;
     AdvancedCombinationTransformType::Pointer initialTransform;
-    AdvancedCombinationTransformType::Pointer tmpTransform = AdvancedCombinationTransformType::New();
+    auto                                      tmpTransform = AdvancedCombinationTransformType::New();
     initialTransform = tmpTransform;
     cpuTransform = tmpTransform;
 
@@ -906,7 +906,7 @@ main(int argc, char * argv[])
       }
       else
       {
-        AdvancedCombinationTransformType::Pointer initialNext = AdvancedCombinationTransformType::New();
+        auto initialNext = AdvancedCombinationTransformType::New();
 
         SetTransform<
           // ITK Transforms
@@ -971,7 +971,7 @@ main(int argc, char * argv[])
             << cpuFilter->GetNumberOfWorkUnits() << " " << cputimer.GetMean() / runTimes << std::endl;
 
   /** Write the CPU result. */
-  WriterType::Pointer cpuWriter = WriterType::New();
+  auto cpuWriter = WriterType::New();
   cpuWriter->SetInput(cpuFilter->GetOutput());
   cpuWriter->SetFileName(outputFileNames[0].c_str());
   try
@@ -1062,7 +1062,7 @@ main(int argc, char * argv[])
   {
     if (!useComboTransform)
     {
-      TransformCopierType::Pointer copier = TransformCopierType::New();
+      auto copier = TransformCopierType::New();
       copier->SetInputTransform(cpuTransform);
       copier->SetExplicitMode(false);
       copier->Update();
@@ -1075,7 +1075,7 @@ main(int argc, char * argv[])
         dynamic_cast<const AdvancedCombinationTransformType *>(cpuTransform.GetPointer());
       if (CPUAdvancedCombinationTransform)
       {
-        AdvancedTransformCopierType::Pointer copier = AdvancedTransformCopierType::New();
+        auto copier = AdvancedTransformCopierType::New();
         copier->SetInputTransform(CPUAdvancedCombinationTransform);
         copier->SetExplicitMode(false);
         copier->Update();
@@ -1097,7 +1097,7 @@ main(int argc, char * argv[])
   }
 
   // Create GPU copy for interpolator here
-  InterpolateCopierType::Pointer interpolateCopier = InterpolateCopierType::New();
+  auto interpolateCopier = InterpolateCopierType::New();
   interpolateCopier->SetInputInterpolator(cpuInterpolator);
   interpolateCopier->SetExplicitMode(false);
   interpolateCopier->Update();
@@ -1143,7 +1143,7 @@ main(int argc, char * argv[])
             << gputimer.GetMean() / runTimes << " " << cputimer.GetMean() / gputimer.GetMean();
 
   /** Write the GPU result. */
-  WriterType::Pointer gpuWriter = WriterType::New();
+  auto gpuWriter = WriterType::New();
   gpuWriter->SetInput(gpuFilter->GetOutput());
   gpuWriter->SetFileName(outputFileNames[1].c_str());
   try

--- a/Testing/itkGPUShrinkImageFilterTest.cxx
+++ b/Testing/itkGPUShrinkImageFilterTest.cxx
@@ -75,12 +75,12 @@ main(int argc, char * argv[])
   typedef itk::ImageFileWriter<ImageType>              WriterType;
 
   // Reader
-  ReaderType::Pointer reader = ReaderType::New();
+  auto reader = ReaderType::New();
   reader->SetFileName(inputFileName);
   reader->Update();
 
   // Construct the filter
-  FilterType::Pointer cpuFilter = FilterType::New();
+  auto cpuFilter = FilterType::New();
   cpuFilter->SetShrinkFactors(shrinkFactor);
 
   std::cout << "Testing the ShrinkImageFilter, CPU vs GPU:\n";
@@ -115,7 +115,7 @@ main(int argc, char * argv[])
             << cputimer.GetMean() / runTimes << std::endl;
 
   /** Write the CPU result. */
-  WriterType::Pointer writer = WriterType::New();
+  auto writer = WriterType::New();
   writer->SetInput(cpuFilter->GetOutput());
   writer->SetFileName(outputFileNameCPU.c_str());
   try
@@ -157,7 +157,7 @@ main(int argc, char * argv[])
   // reads a GPUImage instead of a normal image.
   // Otherwise, you will get an exception when running the GPU filter:
   // "ERROR: The GPU InputImage is NULL. Filter unable to perform."
-  ReaderType::Pointer gpuReader = ReaderType::New();
+  auto gpuReader = ReaderType::New();
   gpuReader->SetFileName(inputFileName);
 
   // \todo: If the following line is uncommented something goes wrong with
@@ -195,7 +195,7 @@ main(int argc, char * argv[])
             << cputimer.GetMean() / gputimer.GetMean();
 
   /** Write the GPU result. */
-  WriterType::Pointer gpuWriter = WriterType::New();
+  auto gpuWriter = WriterType::New();
   gpuWriter->SetInput(gpuFilter->GetOutput());
   gpuWriter->SetFileName(outputFileNameGPU.c_str());
   try

--- a/Testing/itkGPUSmoothingRecursiveGaussianImageFilterTest.cxx
+++ b/Testing/itkGPUSmoothingRecursiveGaussianImageFilterTest.cxx
@@ -79,12 +79,12 @@ main(int argc, char * argv[])
   typedef itk::ImageFileWriter<OutputImageType>                                       WriterType;
 
   // Reader
-  ReaderType::Pointer reader = ReaderType::New();
+  auto reader = ReaderType::New();
   reader->SetFileName(inputFileName);
   reader->Update();
 
   // Construct the filter
-  FilterType::Pointer        filter = FilterType::New();
+  auto                       filter = FilterType::New();
   FilterType::SigmaArrayType sigmaArray;
   for (unsigned int i = 0; i < Dimension; ++i)
   {
@@ -118,7 +118,7 @@ main(int argc, char * argv[])
   std::cout << "CPU " << sigmaArray[0] << " " << filter->GetNumberOfWorkUnits() << " " << cputimer.GetMean() / runTimes;
 
   /** Write the CPU result. */
-  WriterType::Pointer writer = WriterType::New();
+  auto writer = WriterType::New();
   writer->SetInput(filter->GetOutput());
   writer->SetFileName(outputFileNameCPU.c_str());
   try
@@ -167,7 +167,7 @@ main(int argc, char * argv[])
   // reads a GPUImage instead of a normal image.
   // Otherwise, you will get an exception when running the GPU filter:
   // "ERROR: The GPU InputImage is NULL. Filter unable to perform."
-  ReaderType::Pointer gpuReader = ReaderType::New();
+  auto gpuReader = ReaderType::New();
   gpuReader->SetFileName(inputFileName);
 
   // \todo: If the following line is uncommented something goes wrong with
@@ -201,7 +201,7 @@ main(int argc, char * argv[])
             << cputimer.GetMean() / gputimer.GetMean();
 
   /** Write the GPU result. */
-  WriterType::Pointer gpuWriter = WriterType::New();
+  auto gpuWriter = WriterType::New();
   gpuWriter->SetInput(gpuFilter->GetOutput());
   gpuWriter->SetFileName(outputFileNameGPU.c_str());
   try

--- a/Testing/itkMevisDicomTiffImageIOTest.cxx
+++ b/Testing/itkMevisDicomTiffImageIOTest.cxx
@@ -53,13 +53,13 @@ testMevis(void)
   typedef typename ImageType::DirectionType                         DirectionType;
   typedef itk::ImageRegionIterator<ImageType>                       IteratorType;
 
-  typename WriterType::Pointer writer = WriterType::New();
-  typename ReaderType::Pointer reader = ReaderType::New();
-  typename ImageType::Pointer  inputImage = ImageType::New();
-  SizeType                     size;
-  SpacingType                  spacing;
-  OriginType                   origin;
-  DirectionType                direction;
+  auto          writer = WriterType::New();
+  auto          reader = ReaderType::New();
+  auto          inputImage = ImageType::New();
+  SizeType      size;
+  SpacingType   spacing;
+  OriginType    origin;
+  DirectionType direction;
 
   direction.Fill(0.0);
   for (unsigned int i = 0; i < Dimension; ++i)
@@ -200,7 +200,7 @@ testMevis(void)
     return 1;
   }
 
-  typename ComparisonFilterType::Pointer comparisonFilter = ComparisonFilterType::New();
+  auto comparisonFilter = ComparisonFilterType::New();
   comparisonFilter->SetTestInput(outputImage);
   comparisonFilter->SetValidInput(inputImage);
   comparisonFilter->Update();

--- a/Testing/itkOpenCLKernelToImageBridgeTest.cxx
+++ b/Testing/itkOpenCLKernelToImageBridgeTest.cxx
@@ -45,7 +45,7 @@ main(void)
 
     // Create ITK Image
     typedef itk::Image<float, 2> ImageType;
-    ImageType::Pointer           image = ImageType::New();
+    auto                         image = ImageType::New();
 
     ImageType::SizeType size;
     size[0] = 64;

--- a/Testing/itkTestHelper.h
+++ b/Testing/itkTestHelper.h
@@ -124,7 +124,7 @@ CreateOpenCLLogger(const std::string & prefixFileName)
 void
 SetupForDebugging()
 {
-  TestOutputWindow::Pointer tow = TestOutputWindow::New();
+  auto tow = TestOutputWindow::New();
   OutputWindow::SetInstance(tow);
 
 #if (defined(_WIN32) && defined(_DEBUG)) || !defined(NDEBUG)

--- a/Testing/itkThinPlateSplineTransformPerformanceTest.cxx
+++ b/Testing/itkThinPlateSplineTransformPerformanceTest.cxx
@@ -122,14 +122,14 @@ main(int argc, char * argv[])
   typedef PointSetType::PointType       PointType;
   typedef TransformType::LMatrixType    LMatrixType;
 
-  PointSetType::Pointer dummyLandmarks = PointSetType::New();
+  auto dummyLandmarks = PointSetType::New();
 
   /** Create the kernel transform. */
-  TransformType::Pointer kernelTransform = TransformType::New();
+  auto kernelTransform = TransformType::New();
   kernelTransform->SetStiffness(0.0); // interpolating
 
   /** Read landmarks. */
-  IPPReaderType::Pointer ippReader = IPPReaderType::New();
+  auto ippReader = IPPReaderType::New();
   ippReader->SetFileName(argv[1]);
   try
   {
@@ -173,7 +173,7 @@ main(int argc, char * argv[])
 
     /** Get subset. */
     PointsContainerPointer usedLandmarkPoints = PointsContainerType::New();
-    PointSetType::Pointer  usedLandmarks = PointSetType::New();
+    auto                   usedLandmarks = PointSetType::New();
     for (unsigned long j = 0; j < numberOfLandmarks; ++j)
     {
       PointType tmp = (*sourceLandmarks->GetPoints())[j];

--- a/Testing/itkThinPlateSplineTransformTest.cxx
+++ b/Testing/itkThinPlateSplineTransformTest.cxx
@@ -59,10 +59,10 @@ main(int argc, char * argv[])
   typedef itk::Statistics::MersenneTwisterRandomVariateGenerator MersenneTwisterType;
 
   /** Create the kernel transform. */
-  TransformType::Pointer kernelTransform = TransformType::New();
+  auto kernelTransform = TransformType::New();
 
   /** Read landmarks. */
-  IPPReaderType::Pointer landmarkReader = IPPReaderType::New();
+  auto landmarkReader = IPPReaderType::New();
   landmarkReader->SetFileName(argv[1]);
   try
   {
@@ -85,7 +85,7 @@ main(int argc, char * argv[])
 
   /** Get subset. */
   PointsContainerPointer usedLandmarkPoints = PointsContainerType::New();
-  PointSetType::Pointer  usedSourceLandmarks = PointSetType::New();
+  auto                   usedSourceLandmarks = PointSetType::New();
   for (unsigned long j = 0; j < usedNumberOfLandmarks; ++j)
   {
     PointType tmp = (*sourceLandmarks->GetPoints())[j];
@@ -104,9 +104,9 @@ main(int argc, char * argv[])
   kernelTransform->SetIdentity();                  // target landmarks = source landmarks
 
   /** Create new target landmarks by adding a random vector to it. */
-  PointSetType::ConstPointer   targetLandmarks = kernelTransform->GetTargetLandmarks();
-  PointsContainerPointer       newTargetLandmarkPoints = PointsContainerType::New();
-  MersenneTwisterType::Pointer mersenneTwister = MersenneTwisterType::New();
+  PointSetType::ConstPointer targetLandmarks = kernelTransform->GetTargetLandmarks();
+  PointsContainerPointer     newTargetLandmarkPoints = PointsContainerType::New();
+  auto                       mersenneTwister = MersenneTwisterType::New();
   mersenneTwister->Initialize(140377);
   for (unsigned long j = 0; j < targetLandmarks->GetNumberOfPoints(); ++j)
   {
@@ -118,7 +118,7 @@ main(int argc, char * argv[])
     }
     newTargetLandmarkPoints->push_back(randomPoint);
   }
-  PointSetType::Pointer newTargetLandmarks = PointSetType::New();
+  auto newTargetLandmarks = PointSetType::New();
   newTargetLandmarks->SetPoints(newTargetLandmarkPoints);
 
   /** Test 2: Time setting the target landmarks. */


### PR DESCRIPTION
Replaced initializations of the form `T::Pointer var = T::New()` (sometimes starting with `typename`) with `auto var = T::New()`, to reduce code redundancy.

In accordance with C++ Core Guidelines, August 19, 2021: "ES.11: Use `auto` to avoid redundant repetition of type names" https://isocpp.github.io/CppCoreGuidelines/CppCoreGuidelines#Res-auto

Using Notepad++ v8.1.4, Find in Files (Regular expression):

    Find what:  typename (\w+)::Pointer[ ]+(\w+) = \1::New\(\);
    Replace with:  auto $2 = $1::New\(\);
    Filters: itk*.hxx;itk*.h;itk*.cxx

And then again without `typename`:

    Find what:  (\w+)::Pointer[ ]+(\w+) = \1::New\(\);

Corresponds with ITK pull request https://github.com/InsightSoftwareConsortium/ITK/pull/2826/