### PR TITLE
PERF: Avoid creation of multiple IOFactoryRegisterManager instances

### DIFF
--- a/Common/Transforms/elxTransformIO.cxx
+++ b/Common/Transforms/elxTransformIO.cxx
@@ -15,6 +15,11 @@
  *  limitations under the License.
  *
  *=========================================================================*/
+
+// Avoid creation of instances of `itk::ImageIOFactoryRegisterManager`, `itk::MeshIOFactoryRegisterManager`, and
+// `itk::TransformIOFactoryRegisterManager` at this point.
+#undef ITK_IO_FACTORY_REGISTER_MANAGER
+
 #include "elxTransformIO.h"
 
 #include "elxBaseComponent.h"

--- a/Core/Install/elxComponentLoader.cxx
+++ b/Core/Install/elxComponentLoader.cxx
@@ -21,8 +21,15 @@
 #include "elxInstallFunctions.h"
 #include "elxMacro.h"
 #include "elxInstallAllComponents.h"
+
+// ITKFactoryRegistration headers:
+#include <itkImageIOFactoryRegisterManager.h>
+#include <itkMeshIOFactoryRegisterManager.h>
+#include <itkTransformIOFactoryRegisterManager.h>
+
 #include <iostream>
 #include <string>
+#include <tuple>
 
 namespace elastix
 {
@@ -126,6 +133,13 @@ ComponentLoader::InstallSupportedImageTypes(void)
 int
 ComponentLoader::LoadComponents(void)
 {
+  // Retrieve those IOFactoryRegisterManager instances, just to ensure that they are really constructed.
+  const volatile auto ioFactoryRegisterManagerInstances =
+    std::make_tuple(itk::ImageIOFactoryRegisterManagerInstance,
+                    itk::MeshIOFactoryRegisterManagerInstance,
+                    itk::TransformIOFactoryRegisterManagerInstance);
+  (void)ioFactoryRegisterManagerInstances;
+
   int installReturnCode = 0;
 
   /** Generate the mapping between indices and image types */

--- a/Core/Install/elxMacro.h
+++ b/Core/Install/elxMacro.h
@@ -18,6 +18,10 @@
 #ifndef elxMacro_h
 #define elxMacro_h
 
+// Avoid creation of multiple instances of `itk::ImageIOFactoryRegisterManager`, `itk::MeshIOFactoryRegisterManager`,
+// and `itk::TransformIOFactoryRegisterManager`.
+#undef ITK_IO_FACTORY_REGISTER_MANAGER
+
 /** This include is only used to get rid of a MSVS compiler warning
  * when using std::copy. The warning is like:
  *   'conversion' conversion from 'type1' to 'type2', possible loss of data


### PR DESCRIPTION
Before this commit, 86 `itk::ImageIOFactoryRegisterManager` instances and 83 `itk::MeshIOFactoryRegisterManager` instances were constructed automatically, when starting a default-configured elastix executable!