### PR TITLE
ENH: Add `elastix::DefaultConstructibleSubclass<TObject>`

### DIFF
--- a/Common/CMakeLists.txt
+++ b/Common/CMakeLists.txt
@@ -16,6 +16,7 @@ endif()
 # Define lists of files in the subdirectories.
 
 set( CommonFiles
+  elxDefaultConstructibleSubclass.h
   itkAdvancedLinearInterpolateImageFunction.h
   itkAdvancedLinearInterpolateImageFunction.hxx
   itkAdvancedRayCastInterpolateImageFunction.h

--- a/Common/GTesting/CMakeLists.txt
+++ b/Common/GTesting/CMakeLists.txt
@@ -1,5 +1,6 @@
 add_executable(CommonGTest
   elxConversionGTest.cxx
+  elxDefaultConstructibleSubclassGTest.cxx
   elxElastixMainGTest.cxx
   elxGTestUtilities.h
   elxResampleInterpolatorGTest.cxx

--- a/Common/GTesting/elxDefaultConstructibleSubclassGTest.cxx
+++ b/Common/GTesting/elxDefaultConstructibleSubclassGTest.cxx
@@ -1,0 +1,80 @@
+/*=========================================================================
+ *
+ *  Copyright UMC Utrecht and contributors
+ *
+ *  Licensed under the Apache License, Version 2.0 (the "License");
+ *  you may not use this file except in compliance with the License.
+ *  You may obtain a copy of the License at
+ *
+ *        http://www.apache.org/licenses/LICENSE-2.0.txt
+ *
+ *  Unless required by applicable law or agreed to in writing, software
+ *  distributed under the License is distributed on an "AS IS" BASIS,
+ *  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *  See the License for the specific language governing permissions and
+ *  limitations under the License.
+ *
+ *=========================================================================*/
+
+// First include the header file to be tested:
+#include "elxDefaultConstructibleSubclass.h"
+#include <itkImage.h>
+#include <gtest/gtest.h>
+#include <type_traits> // For is_base_of and is_default_constructible.
+
+// The class template to be tested:
+using elastix::DefaultConstructibleSubclass;
+
+// Example type, to be used as template argument of DefaultConstructibleSubclass.
+using ImageType = itk::Image<int>;
+
+namespace
+{
+// A minimal test class, to be used as template argument of DefaultConstructibleSubclass.
+class TestObject : public itk::LightObject
+{
+public:
+  ITK_DISALLOW_COPY_AND_MOVE(TestObject);
+  using Self = TestObject;
+  using Superclass = itk::LightObject;
+  using Pointer = itk::SmartPointer<Self>;
+  itkNewMacro(Self);
+
+protected:
+  TestObject() = default;
+  ~TestObject() = default;
+
+private:
+  int m_data{};
+
+  friend bool
+  operator==(const Self & lhs, const Self & rhs)
+  {
+    return lhs.m_data == rhs.m_data;
+  }
+
+  friend bool
+  operator!=(const Self & lhs, const Self & rhs)
+  {
+    return !(lhs == rhs);
+  }
+};
+} // namespace
+
+
+static_assert(std::is_base_of<TestObject, DefaultConstructibleSubclass<TestObject>>{} &&
+                std::is_base_of<ImageType, DefaultConstructibleSubclass<ImageType>>{},
+              "DefaultConstructibleSubclass<T> must be a subclass of T! ");
+
+static_assert(std::is_default_constructible<DefaultConstructibleSubclass<TestObject>>{} &&
+                std::is_default_constructible<DefaultConstructibleSubclass<ImageType>>{},
+              "DefaultConstructibleSubclass<T> must be default-constructible! ");
+
+GTEST_TEST(DefaultConstructibleSubclass, Check)
+{
+  const DefaultConstructibleSubclass<ImageType>  defaultConstructedImage{};
+  const DefaultConstructibleSubclass<TestObject> defaultConstructedTestObject{};
+
+  EXPECT_EQ(defaultConstructedTestObject, *TestObject::New());
+  EXPECT_EQ(defaultConstructedImage, *ImageType::New());
+}

--- a/Common/elxDefaultConstructibleSubclass.h
+++ b/Common/elxDefaultConstructibleSubclass.h
@@ -1,0 +1,45 @@
+/*=========================================================================
+ *
+ *  Copyright UMC Utrecht and contributors
+ *
+ *  Licensed under the Apache License, Version 2.0 (the "License");
+ *  you may not use this file except in compliance with the License.
+ *  You may obtain a copy of the License at
+ *
+ *        http://www.apache.org/licenses/LICENSE-2.0.txt
+ *
+ *  Unless required by applicable law or agreed to in writing, software
+ *  distributed under the License is distributed on an "AS IS" BASIS,
+ *  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *  See the License for the specific language governing permissions and
+ *  limitations under the License.
+ *
+ *=========================================================================*/
+#ifndef elxDefaultConstructibleSubclass_h
+#define elxDefaultConstructibleSubclass_h
+
+#include <itkLightObject.h>
+
+namespace elastix
+{
+/// Allows default-constructing an `itk::LightObject` derived object without calling `New()`.
+/// May improve the runtime performance, by avoiding heap allocation and pointer indirection.
+template <typename TObject>
+class DefaultConstructibleSubclass : public TObject
+{
+public:
+  ITK_DISALLOW_COPY_AND_MOVE(DefaultConstructibleSubclass);
+
+  /// Public default-constructor. Just calls the (typically protected) default-constructor of `TObject`.
+  DefaultConstructibleSubclass() = default;
+
+  /// Public destructor. Just calls the (typically protected) destructor of `TObject`.
+  ~DefaultConstructibleSubclass() override
+  {
+    // Suppress warning "Trying to delete object with non-zero reference count."
+    this->itk::LightObject::m_ReferenceCount = 0;
+  }
+};
+} // namespace elastix
+
+#endif


### PR DESCRIPTION
Allows default-constructing an `itk::LightObject` derived object without calling `New()`. May improve the runtime performance, by avoiding heap allocation and pointer indirection.

Included GoogleTest.