### PR TITLE
STYLE: Remove unused AdvancedRigidNDTransform member functions

### DIFF
--- a/Common/Transforms/itkAdvancedRigid2DTransform.h
+++ b/Common/Transforms/itkAdvancedRigid2DTransform.h
@@ -148,75 +148,11 @@ public:
   void
   SetMatrix(const MatrixType & matrix) override;
 
-  /**
-   * Set/Get the rotation matrix. These methods are old and are
-   * retained for backward compatibility. Instead, use SetMatrix()
-   * GetMatrix().
-   */
-  virtual void
-  SetRotationMatrix(const MatrixType & matrix)
-  {
-    this->SetMatrix(matrix);
-  }
-  const MatrixType &
-  GetRotationMatrix() const
-  {
-    return this->GetMatrix();
-  }
-
-  /**
-   * Compose the transformation with a translation
-   *
-   * This method modifies self to include a translation of the
-   * origin.  The translation is precomposed with self if pre is
-   * true, and postcomposed otherwise.
-   */
-  void
-  Translate(const OffsetType & offset, bool pre = false);
-
-  /**
-   * Back transform by an rigid transformation.
-   *
-   * The BackTransform() methods are slated to be removed from ITK.
-   * Instead, please use GetInverse() or CloneInverseTo() to generate
-   * an inverse transform and  then perform the transform using that
-   * inverted transform.
-   */
-  inline InputPointType
-  BackTransform(const OutputPointType & point) const;
-
-  inline InputVectorType
-  BackTransform(const OutputVectorType & vector) const;
-
-  inline InputVnlVectorType
-  BackTransform(const OutputVnlVectorType & vector) const;
-
-  inline InputCovariantVectorType
-  BackTransform(const OutputCovariantVectorType & vector) const;
-
   /** Set/Get the angle of rotation in radians */
   void
   SetAngle(TScalarType angle);
 
   itkGetConstReferenceMacro(Angle, TScalarType);
-
-  /** Set the angle of rotation in degrees. */
-  void
-  SetAngleInDegrees(TScalarType angle);
-
-  /** Set/Get the angle of rotation in radians. These methods
-   * are old and are retained for backward compatibility.
-   * Instead, use SetAngle() and GetAngle(). */
-  void
-  SetRotation(TScalarType angle)
-  {
-    this->SetAngle(angle);
-  }
-  virtual const TScalarType &
-  GetRotation() const
-  {
-    return m_Angle;
-  }
 
   /** Set the transformation from a container of parameters
    * This is typically used by optimizers.
@@ -246,20 +182,6 @@ public:
    * \sa Transform::GetJacobian() */
   void
   GetJacobian(const InputPointType &, JacobianType &, NonZeroJacobianIndicesType &) const override;
-
-  /**
-   * This method creates and returns a new AdvancedRigid2DTransform object
-   * which is the inverse of self.
-   */
-  void
-  CloneInverseTo(Pointer & newinverse) const;
-
-  /**
-   * This method creates and returns a new AdvancedRigid2DTransform object
-   * which has the same parameters.
-   */
-  void
-  CloneTo(Pointer & clone) const;
 
   /** Reset the parameters to create and identity transform. */
   void
@@ -310,49 +232,6 @@ private:
 
   TScalarType m_Angle;
 };
-
-// Back transform a point
-template <class TScalarType>
-inline typename AdvancedRigid2DTransform<TScalarType>::InputPointType
-AdvancedRigid2DTransform<TScalarType>::BackTransform(const OutputPointType & point) const
-{
-  itkWarningMacro(<< "BackTransform(): This method is slated to be removed from ITK.  Instead, please use GetInverse() "
-                     "to generate an inverse transform and then perform the transform using that inverted transform.");
-  return this->GetInverseMatrix() * (point - this->GetOffset());
-}
-
-
-// Back transform a vector
-template <class TScalarType>
-inline typename AdvancedRigid2DTransform<TScalarType>::InputVectorType
-AdvancedRigid2DTransform<TScalarType>::BackTransform(const OutputVectorType & vect) const
-{
-  itkWarningMacro(<< "BackTransform(): This method is slated to be removed from ITK.  Instead, please use GetInverse() "
-                     "to generate an inverse transform and then perform the transform using that inverted transform.");
-  return this->GetInverseMatrix() * vect;
-}
-
-
-// Back transform a vnl_vector
-template <class TScalarType>
-inline typename AdvancedRigid2DTransform<TScalarType>::InputVnlVectorType
-AdvancedRigid2DTransform<TScalarType>::BackTransform(const OutputVnlVectorType & vect) const
-{
-  itkWarningMacro(<< "BackTransform(): This method is slated to be removed from ITK.  Instead, please use GetInverse() "
-                     "to generate an inverse transform and then perform the transform using that inverted transform.");
-  return this->GetInverseMatrix() * vect;
-}
-
-
-// Back Transform a CovariantVector
-template <class TScalarType>
-inline typename AdvancedRigid2DTransform<TScalarType>::InputCovariantVectorType
-AdvancedRigid2DTransform<TScalarType>::BackTransform(const OutputCovariantVectorType & vect) const
-{
-  itkWarningMacro(<< "BackTransform(): This method is slated to be removed from ITK.  Instead, please use GetInverse() "
-                     "to generate an inverse transform and then perform the transform using that inverted transform.");
-  return this->GetMatrix() * vect;
-}
 
 
 } // namespace itk

--- a/Common/Transforms/itkAdvancedRigid2DTransform.hxx
+++ b/Common/Transforms/itkAdvancedRigid2DTransform.hxx
@@ -133,42 +133,6 @@ AdvancedRigid2DTransform<TScalarType>::ComputeMatrixParameters(void)
 }
 
 
-// Compose with a translation
-template <class TScalarType>
-void
-AdvancedRigid2DTransform<TScalarType>::Translate(const OffsetType & offset, bool)
-{
-  OutputVectorType newOffset = this->GetOffset();
-  newOffset += offset;
-  this->SetOffset(newOffset);
-  this->ComputeTranslation();
-}
-
-
-// Create and return an inverse transformation
-template <class TScalarType>
-void
-AdvancedRigid2DTransform<TScalarType>::CloneInverseTo(Pointer & result) const
-{
-  result = New();
-  result->SetCenter(this->GetCenter()); // inverse have the same center
-  result->SetAngle(-this->GetAngle());
-  result->SetTranslation(-(this->GetInverseMatrix() * this->GetTranslation()));
-}
-
-
-// Create and return a clone of the transformation
-template <class TScalarType>
-void
-AdvancedRigid2DTransform<TScalarType>::CloneTo(Pointer & result) const
-{
-  result = New();
-  result->SetCenter(this->GetCenter());
-  result->SetAngle(this->GetAngle());
-  result->SetTranslation(this->GetTranslation());
-}
-
-
 // Reset the transform to an identity transform
 template <class TScalarType>
 void
@@ -190,16 +154,6 @@ AdvancedRigid2DTransform<TScalarType>::SetAngle(TScalarType angle)
   this->ComputeMatrix();
   this->ComputeOffset();
   this->Modified();
-}
-
-
-// Set the angle of rotation
-template <class TScalarType>
-void
-AdvancedRigid2DTransform<TScalarType>::SetAngleInDegrees(TScalarType angle)
-{
-  const TScalarType angleInRadians = angle * std::atan(1.0) / 45.0;
-  this->SetAngle(angleInRadians);
 }
 
 

--- a/Common/Transforms/itkAdvancedRigid3DTransform.h
+++ b/Common/Transforms/itkAdvancedRigid3DTransform.h
@@ -132,22 +132,6 @@ public:
   SetMatrix(const MatrixType & matrix) override;
 
   /**
-   * Set the rotation Matrix of a Rigid3D Transform
-   *
-   * This method sets the 3x3 matrix representing a rotation
-   * in the transform.  The Matrix is expected to be orthogonal
-   * with a certain tolerance.
-   *
-   * \deprecated Use SetMatrix instead
-   *
-   **/
-  virtual void
-  SetRotationMatrix(const MatrixType & matrix)
-  {
-    this->SetMatrix(matrix);
-  }
-
-  /**
    * Utility function to test if a matrix is orthogonal within a specified
    * tolerance
    */

--- a/Common/Transforms/itkAdvancedRigid3DTransform.h
+++ b/Common/Transforms/itkAdvancedRigid3DTransform.h
@@ -132,20 +132,6 @@ public:
   SetMatrix(const MatrixType & matrix) override;
 
   /**
-   * Get rotation Matrix from an AdvancedRigid3DTransform
-   *
-   * This method returns the value of the rotation of the
-   * AdvancedRigid3DTransform.
-   *
-   * \deprecated Use GetMatrix instead
-   **/
-  const MatrixType &
-  GetRotationMatrix()
-  {
-    return this->GetMatrix();
-  }
-
-  /**
    * Set the rotation Matrix of a Rigid3D Transform
    *
    * This method sets the 3x3 matrix representing a rotation
@@ -162,39 +148,6 @@ public:
   }
 
   /**
-   * Compose the transformation with a translation
-   *
-   * This method modifies self to include a translation of the
-   * origin.  The translation is precomposed with self if pre is
-   * true, and postcomposed otherwise.
-   **/
-  void
-  Translate(const OffsetType & offset, bool pre = false);
-
-  /**
-   * Back transform by an affine transformation
-   *
-   * This method finds the point or vector that maps to a given
-   * point or vector under the affine transformation defined by
-   * self.  If no such point exists, an exception is thrown.
-   *
-   * \deprecated Please use GetInverseTransform and then call the forward
-   *   transform using the result.
-   *
-   **/
-  InputPointType
-  BackTransform(const OutputPointType & point) const;
-
-  InputVectorType
-  BackTransform(const OutputVectorType & vector) const;
-
-  InputVnlVectorType
-  BackTransform(const OutputVnlVectorType & vector) const;
-
-  InputCovariantVectorType
-  BackTransform(const OutputCovariantVectorType & vector) const;
-
-  /**
    * Utility function to test if a matrix is orthogonal within a specified
    * tolerance
    */
@@ -203,7 +156,6 @@ public:
 
 protected:
   explicit AdvancedRigid3DTransform(unsigned int paramDim);
-  AdvancedRigid3DTransform(const MatrixType & matrix, const OutputVectorType & offset);
   AdvancedRigid3DTransform();
   ~AdvancedRigid3DTransform() override = default;
 

--- a/Common/Transforms/itkAdvancedRigid3DTransform.hxx
+++ b/Common/Transforms/itkAdvancedRigid3DTransform.hxx
@@ -51,13 +51,6 @@ AdvancedRigid3DTransform<TScalarType>::AdvancedRigid3DTransform(unsigned int par
   : Superclass(paramDim)
 {}
 
-// Constructor with default arguments
-template <class TScalarType>
-AdvancedRigid3DTransform<TScalarType>::AdvancedRigid3DTransform(const MatrixType &       matrix,
-                                                                const OutputVectorType & offset)
-  : Superclass(matrix, offset)
-{}
-
 // Print self
 template <class TScalarType>
 void
@@ -141,64 +134,6 @@ AdvancedRigid3DTransform<TScalarType>::SetParameters(const ParametersType & para
 
   this->Modified();
 }
-
-
-// Compose with a translation
-template <class TScalarType>
-void
-AdvancedRigid3DTransform<TScalarType>::Translate(const OffsetType & offset, bool)
-{
-  OutputVectorType newOffset = this->GetOffset();
-  newOffset += offset;
-  this->SetOffset(newOffset);
-  this->ComputeTranslation();
-}
-
-
-// Back transform a point
-template <class TScalarType>
-auto
-AdvancedRigid3DTransform<TScalarType>::BackTransform(const OutputPointType & point) const -> InputPointType
-{
-  itkWarningMacro(<< "BackTransform(): This method is slated to be removed from ITK.  Instead, please use GetInverse() "
-                     "to generate an inverse transform and then perform the transform using that inverted transform.");
-  return this->GetInverseMatrix() * (point - this->GetOffset());
-}
-
-
-// Back transform a vector
-template <class TScalarType>
-auto
-AdvancedRigid3DTransform<TScalarType>::BackTransform(const OutputVectorType & vect) const -> InputVectorType
-{
-  itkWarningMacro(<< "BackTransform(): This method is slated to be removed from ITK.  Instead, please use GetInverse() "
-                     "to generate an inverse transform and then perform the transform using that inverted transform.");
-  return this->GetInverseMatrix() * vect;
-}
-
-
-// Back transform a vnl_vector
-template <class TScalarType>
-auto
-AdvancedRigid3DTransform<TScalarType>::BackTransform(const OutputVnlVectorType & vect) const -> InputVnlVectorType
-{
-  itkWarningMacro(<< "BackTransform(): This method is slated to be removed from ITK.  Instead, please use GetInverse() "
-                     "to generate an inverse transform and then perform the transform using that inverted transform.");
-  return this->GetInverseMatrix() * vect;
-}
-
-
-// Back Transform a CovariantVector
-template <class TScalarType>
-auto
-AdvancedRigid3DTransform<TScalarType>::BackTransform(const OutputCovariantVectorType & vect) const
-  -> InputCovariantVectorType
-{
-  itkWarningMacro(<< "BackTransform(): This method is slated to be removed from ITK.  Instead, please use GetInverse() "
-                     "to generate an inverse transform and then perform the transform using that inverted transform.");
-  return this->GetMatrix() * vect;
-}
-
 
 } // namespace itk
 

--- a/Common/Transforms/itkAdvancedSimilarity2DTransform.h
+++ b/Common/Transforms/itkAdvancedSimilarity2DTransform.h
@@ -181,20 +181,6 @@ public:
   SetIdentity(void) override;
 
   /**
-   * This method creates and returns a new AdvancedSimilarity2DTransform object
-   * which is the inverse of self.
-   **/
-  void
-  CloneInverseTo(Pointer & newinverse) const;
-
-  /**
-   * This method creates and returns a new AdvancedSimilarity2DTransform object
-   * which has the same parameters.
-   **/
-  void
-  CloneTo(Pointer & clone) const;
-
-  /**
    * Set the rotation Matrix of a Similarity 2D Transform
    *
    * This method sets the 2x2 matrix representing a similarity

--- a/Common/Transforms/itkAdvancedSimilarity2DTransform.hxx
+++ b/Common/Transforms/itkAdvancedSimilarity2DTransform.hxx
@@ -237,32 +237,6 @@ AdvancedSimilarity2DTransform<TScalarType>::PrintSelf(std::ostream & os, Indent 
 }
 
 
-// Create and return an inverse transformation
-template <class TScalarType>
-void
-AdvancedSimilarity2DTransform<TScalarType>::CloneInverseTo(Pointer & result) const
-{
-  result = New();
-  result->SetCenter(this->GetCenter()); // inverse have the same center
-  result->SetScale(1.0 / this->GetScale());
-  result->SetAngle(-this->GetAngle());
-  result->SetTranslation(-(this->GetInverseMatrix() * this->GetTranslation()));
-}
-
-
-// Create and return a clone of the transformation
-template <class TScalarType>
-void
-AdvancedSimilarity2DTransform<TScalarType>::CloneTo(Pointer & result) const
-{
-  result = New();
-  result->SetCenter(this->GetCenter());
-  result->SetScale(this->GetScale());
-  result->SetAngle(this->GetAngle());
-  result->SetTranslation(this->GetTranslation());
-}
-
-
 // Set the similarity matrix
 template <class TScalarType>
 void

--- a/Common/Transforms/itkAdvancedVersorRigid3DTransform.h
+++ b/Common/Transforms/itkAdvancedVersorRigid3DTransform.h
@@ -137,14 +137,6 @@ protected:
   void
   PrintSelf(std::ostream & os, Indent indent) const override;
 
-  /** This method must be made protected here because it is not a safe way of
-   * initializing the Versor */
-  void
-  SetRotationMatrix(const MatrixType & matrix) override
-  {
-    this->Superclass::SetRotationMatrix(matrix);
-  }
-
 private:
   AdvancedVersorRigid3DTransform(const Self &) = delete;
   void

--- a/Common/Transforms/itkAdvancedVersorTransform.h
+++ b/Common/Transforms/itkAdvancedVersorTransform.h
@@ -160,14 +160,6 @@ protected:
   /** Destroy an AdvancedVersorTransform object */
   ~AdvancedVersorTransform() override = default;
 
-  /** This method must be made protected here because it is not a safe way of
-   * initializing the Versor */
-  void
-  SetRotationMatrix(const MatrixType & matrix) override
-  {
-    this->Superclass::SetRotationMatrix(matrix);
-  }
-
   void
   SetVarVersor(const VersorType & newVersor)
   {


### PR DESCRIPTION
Removed member functions from `AdvancedRigid2DTransform` and `AdvancedRigid3DTransform` that appear both unused and untested.