### PR TITLE
STYLE: Remove `StackTransform::m_NumberOfSubTransforms` and `virtual`

### DIFF
--- a/Common/Transforms/itkStackTransform.h
+++ b/Common/Transforms/itkStackTransform.h
@@ -170,12 +170,11 @@ public:
 
 
   /** Set/get number of transforms needed. */
-  virtual void
+  void
   SetNumberOfSubTransforms(const unsigned int num)
   {
-    if (this->m_NumberOfSubTransforms != num)
+    if (this->m_SubTransformContainer.size() != num)
     {
-      this->m_NumberOfSubTransforms = num;
       this->m_SubTransformContainer.clear();
       this->m_SubTransformContainer.resize(num);
       this->Modified();
@@ -183,7 +182,12 @@ public:
   }
 
 
-  itkGetConstMacro(NumberOfSubTransforms, unsigned int);
+  auto
+  GetNumberOfSubTransforms() const
+  {
+    return static_cast<unsigned>(m_SubTransformContainer.size());
+  }
+
 
   /** Set/get stack transform parameters. */
   itkSetMacro(StackSpacing, TScalarType);
@@ -192,7 +196,7 @@ public:
   itkGetConstMacro(StackOrigin, TScalarType);
 
   /** Set the initial transform for sub transform i. */
-  virtual void
+  void
   SetSubTransform(unsigned int i, SubTransformType * transform)
   {
     this->m_SubTransformContainer[i] = transform;
@@ -201,23 +205,23 @@ public:
 
 
   /** Set all sub transforms to transform. */
-  virtual void
+  void
   SetAllSubTransforms(SubTransformType * transform)
   {
-    for (unsigned int t = 0; t < this->m_NumberOfSubTransforms; ++t)
+    for (auto & subTransform : m_SubTransformContainer)
     {
       // Copy transform
       SubTransformPointer transformcopy = dynamic_cast<SubTransformType *>(transform->CreateAnother().GetPointer());
       transformcopy->SetFixedParameters(transform->GetFixedParameters());
       transformcopy->SetParameters(transform->GetParameters());
       // Set sub transform
-      this->m_SubTransformContainer[t] = transformcopy;
+      subTransform = transformcopy;
     }
   }
 
 
   /** Get a sub transform. */
-  virtual SubTransformPointer
+  SubTransformPointer
   GetSubTransform(unsigned int i)
   {
     return this->m_SubTransformContainer[i];
@@ -290,8 +294,7 @@ private:
   void
   operator=(const Self &) = delete;
 
-  // Number of transforms and transform container
-  unsigned int              m_NumberOfSubTransforms{ 0 };
+  // Transform container
   SubTransformContainerType m_SubTransformContainer;
 
   // Stack spacing and origin of last dimension

--- a/Common/Transforms/itkStackTransform.hxx
+++ b/Common/Transforms/itkStackTransform.hxx
@@ -51,7 +51,8 @@ StackTransform<TScalarType, NInputDimensions, NOutputDimensions>::SetParameters(
 
   // Set separate subtransform parameters
   const NumberOfParametersType numSubTransformParameters = this->m_SubTransformContainer[0]->GetNumberOfParameters();
-  for (unsigned int t = 0; t < this->m_NumberOfSubTransforms; ++t)
+  const auto                   numberOfSubTransforms = static_cast<unsigned>(m_SubTransformContainer.size());
+  for (unsigned int t = 0; t < numberOfSubTransforms; ++t)
   {
     // NTA, split the parameter by number of subparameters
     const ParametersType subparams(&(param.data_block()[t * numSubTransformParameters]), numSubTransformParameters);
@@ -74,9 +75,9 @@ StackTransform<TScalarType, NInputDimensions, NOutputDimensions>::GetParameters(
 
   // Fill params with parameters of subtransforms
   unsigned int i = 0;
-  for (unsigned int t = 0; t < this->m_NumberOfSubTransforms; ++t)
+  for (const auto & subTransform : m_SubTransformContainer)
   {
-    const ParametersType & subparams = this->m_SubTransformContainer[t]->GetParameters();
+    const ParametersType & subparams = subTransform->GetParameters();
     for (unsigned int p = 0; p < this->m_SubTransformContainer[0]->GetNumberOfParameters(); ++p, ++i)
     {
       this->m_Parameters[i] = subparams[p];
@@ -106,7 +107,7 @@ StackTransform<TScalarType, NInputDimensions, NOutputDimensions>::TransformPoint
   /** Transform point using right subtransform. */
   SubTransformOutputPointType oppr;
   const unsigned int          subt =
-    std::min(this->m_NumberOfSubTransforms - 1,
+    std::min(static_cast<unsigned int>(this->m_SubTransformContainer.size() - 1),
              static_cast<unsigned int>(
                std::max(0, vnl_math::rnd((ipp[ReducedInputSpaceDimension] - m_StackOrigin) / m_StackSpacing))));
   oppr = this->m_SubTransformContainer[subt]->TransformPoint(ippr);
@@ -143,7 +144,7 @@ StackTransform<TScalarType, NInputDimensions, NOutputDimensions>::GetJacobian(co
 
   /** Get Jacobian from right subtransform. */
   const unsigned int subt =
-    std::min(this->m_NumberOfSubTransforms - 1,
+    std::min(static_cast<unsigned int>(this->m_SubTransformContainer.size() - 1),
              static_cast<unsigned int>(
                std::max(0, vnl_math::rnd((ipp[ReducedInputSpaceDimension] - m_StackOrigin) / m_StackSpacing))));
   SubTransformJacobianType subjac;


### PR DESCRIPTION
`m_NumberOfSubTransforms` is always identical to `m_SubTransformContainer.size()`, by definition.

Removed `virtual` from member function declarations of `StackTransform`, as these are not overridden. (Actually, `StackTransform` not being used as base class anyway.) Following C++ Core Guidelines, August 19, 2021, "C.132: Don't make a function virtual without reason", https://isocpp.github.io/CppCoreGuidelines/CppCoreGuidelines#Rh-virtual