### PR TITLE
PERF: Make AdvancedNormalizedCorrelationImageToImageMetric faster

### DIFF
--- a/Common/CostFunctions/itkAdvancedImageToImageMetric.h
+++ b/Common/CostFunctions/itkAdvancedImageToImageMetric.h
@@ -507,7 +507,21 @@ protected:
   virtual bool
   EvaluateMovingImageValueAndDerivative(const MovingImagePointType & mappedPoint,
                                         RealType &                   movingImageValue,
-                                        MovingImageDerivativeType *  gradient) const;
+                                        MovingImageDerivativeType *  gradient) const
+  {
+    return EvaluateMovingImageValueAndDerivativeWithOptionalThreadId(mappedPoint, movingImageValue, gradient);
+  }
+
+  /* A faster version of `EvaluateMovingImageValueAndDerivative`: Non-virtual, using multithreading, and doing less
+   * dynamic memory allocation/decallocation operations, internally. */
+  bool
+  FastEvaluateMovingImageValueAndDerivative(const MovingImagePointType & mappedPoint,
+                                            RealType &                   movingImageValue,
+                                            MovingImageDerivativeType *  gradient,
+                                            const ThreadIdType           threadId) const
+  {
+    return EvaluateMovingImageValueAndDerivativeWithOptionalThreadId(mappedPoint, movingImageValue, gradient, threadId);
+  }
 
   /** Computes the inner product of transform Jacobian with moving image gradient.
    * The results are stored in imageJacobian, which is supposed
@@ -570,6 +584,13 @@ private:
   AdvancedImageToImageMetric(const Self &) = delete;
   void
   operator=(const Self &) = delete;
+
+  template <typename... TOptionalThreadId>
+  bool
+  EvaluateMovingImageValueAndDerivativeWithOptionalThreadId(const MovingImagePointType & mappedPoint,
+                                                            RealType &                   movingImageValue,
+                                                            MovingImageDerivativeType *  gradient,
+                                                            const TOptionalThreadId... optionalThreadId) const;
 
   /** Private member variables. */
   bool   m_UseImageSampler{ false };

--- a/Components/Metrics/AdvancedNormalizedCorrelation/itkAdvancedNormalizedCorrelationImageToImageMetric.hxx
+++ b/Components/Metrics/AdvancedNormalizedCorrelation/itkAdvancedNormalizedCorrelationImageToImageMetric.hxx
@@ -590,7 +590,8 @@ AdvancedNormalizedCorrelationImageToImageMetric<TFixedImage, TMovingImage>::Thre
      */
     if (sampleOk)
     {
-      sampleOk = this->EvaluateMovingImageValueAndDerivative(mappedPoint, movingImageValue, &movingImageDerivative);
+      sampleOk = this->FastEvaluateMovingImageValueAndDerivative(
+        mappedPoint, movingImageValue, &movingImageDerivative, threadId);
     }
 
     if (sampleOk)


### PR DESCRIPTION
Added a new member function to `AdvancedImageToImageMetric`, `FastEvaluateMovingImageValueAndDerivative`, which calls the multi-threaded overload of ITK's `itk::BSplineInterpolateImageFunction::EvaluateValueAndDerivativeAtContinuousIndex`, indirectly. (It does so via `EvaluateMovingImageValueAndDerivativeWithOptionalThreadId`, another new member function.)

Made `AdvancedNormalizedCorrelationImageToImageMetric::ThreadedGetValueAndDerivative` faster, by calling this new `FastEvaluateMovingImageValueAndDerivative`.

A large performance improvement was observed for GoogleTest unit test `itkElastixRegistrationMethod.EulerDiscRotation2D` (which uses the "AdvancedNormalizedCorrelation" metric), from ~1.5 second before this commit down to ~0.9 second after this commit, using Visual Studio 2019, Release configuration. (For a Debug configuration even from ~15 seconds before, down to ~4 seconds after this commit.)