### PR TITLE
COMP: Upgrade Azure CI from macOS-10.14 to macOS-10.15

### DIFF
--- a/Testing/CI/Azure/ci.yml
+++ b/Testing/CI/Azure/ci.yml
@@ -114,7 +114,7 @@ jobs:
 - job: macOS
   timeoutInMinutes: 0
   pool:
-    vmImage: 'macOS-10.14'
+    vmImage: 'macOS-10.15'
   strategy:
     matrix:
       ITKv5:


### PR DESCRIPTION
Addressed:

> ##[warning]The macOS-10.14 environment is deprecated and will be removed on December 10, 2021. For more details see https://devblogs.microsoft.com/devops/hosted-pipelines-image-deprecation/

From https://dev.azure.com/kaspermarstal/Elastix/_build/results?buildId=2778&view=results