### PR TITLE
STYLE: Use angle brackets (`<`, `>`) for `#include`'s of VNL headers

### DIFF
--- a/Common/CostFunctions/itkAdvancedImageToImageMetric.h
+++ b/Common/CostFunctions/itkAdvancedImageToImageMetric.h
@@ -28,7 +28,7 @@
 #include "itkLimiterFunctionBase.h"
 #include "itkFixedArray.h"
 #include "itkAdvancedTransform.h"
-#include "vnl/vnl_sparse_matrix.h"
+#include <vnl/vnl_sparse_matrix.h>
 
 #include "itkImageMaskSpatialObject.h"
 

--- a/Common/CostFunctions/itkExponentialLimiterFunction.hxx
+++ b/Common/CostFunctions/itkExponentialLimiterFunction.hxx
@@ -19,7 +19,7 @@
 #define itkExponentialLimiterFunction_hxx
 
 #include "itkExponentialLimiterFunction.h"
-#include "vnl/vnl_math.h"
+#include <vnl/vnl_math.h>
 
 namespace itk
 {

--- a/Common/CostFunctions/itkHardLimiterFunction.hxx
+++ b/Common/CostFunctions/itkHardLimiterFunction.hxx
@@ -19,7 +19,7 @@
 #define itkHardLimiterFunction_hxx
 
 #include "itkHardLimiterFunction.h"
-#include "vnl/vnl_math.h"
+#include <vnl/vnl_math.h>
 
 namespace itk
 {

--- a/Common/CostFunctions/itkParzenWindowHistogramImageToImageMetric.hxx
+++ b/Common/CostFunctions/itkParzenWindowHistogramImageToImageMetric.hxx
@@ -24,7 +24,7 @@
 #include "itkBSplineDerivativeKernelFunction2.h"
 #include "itkImageLinearIteratorWithIndex.h"
 #include "itkImageScanlineIterator.h"
-#include "vnl/vnl_math.h"
+#include <vnl/vnl_math.h>
 
 namespace itk
 {

--- a/Common/CostFunctions/itkScaledSingleValuedCostFunction.cxx
+++ b/Common/CostFunctions/itkScaledSingleValuedCostFunction.cxx
@@ -17,7 +17,7 @@
  *=========================================================================*/
 
 #include "itkScaledSingleValuedCostFunction.h"
-#include "vnl/vnl_math.h"
+#include <vnl/vnl_math.h>
 
 namespace itk
 {

--- a/Common/ImageSamplers/itkImageRandomCoordinateSampler.hxx
+++ b/Common/ImageSamplers/itkImageRandomCoordinateSampler.hxx
@@ -19,7 +19,7 @@
 #define itkImageRandomCoordinateSampler_hxx
 
 #include "itkImageRandomCoordinateSampler.h"
-#include "vnl/vnl_math.h"
+#include <vnl/vnl_math.h>
 
 namespace itk
 {

--- a/Common/ImageSamplers/itkMultiInputImageRandomCoordinateSampler.hxx
+++ b/Common/ImageSamplers/itkMultiInputImageRandomCoordinateSampler.hxx
@@ -19,7 +19,7 @@
 #define itkMultiInputImageRandomCoordinateSampler_hxx
 
 #include "itkMultiInputImageRandomCoordinateSampler.h"
-#include "vnl/vnl_inverse.h"
+#include <vnl/vnl_inverse.h>
 #include "itkConfigure.h"
 
 namespace itk

--- a/Common/Transforms/itkAdvancedBSplineDeformableTransform.hxx
+++ b/Common/Transforms/itkAdvancedBSplineDeformableTransform.hxx
@@ -40,7 +40,7 @@
 #include "itkContinuousIndex.h"
 #include "itkImageScanlineConstIterator.h"
 #include "itkIdentityTransform.h"
-#include "vnl/vnl_math.h"
+#include <vnl/vnl_math.h>
 #include <vector>
 #include <algorithm> // std::copy
 

--- a/Common/Transforms/itkAdvancedBSplineDeformableTransformBase.hxx
+++ b/Common/Transforms/itkAdvancedBSplineDeformableTransformBase.hxx
@@ -21,7 +21,7 @@
 #include "itkAdvancedBSplineDeformableTransformBase.h"
 #include "itkContinuousIndex.h"
 #include "itkIdentityTransform.h"
-#include "vnl/vnl_math.h"
+#include <vnl/vnl_math.h>
 
 namespace itk
 {

--- a/Common/Transforms/itkAdvancedIdentityTransform.h
+++ b/Common/Transforms/itkAdvancedIdentityTransform.h
@@ -38,7 +38,7 @@
 #include "itkPoint.h"
 #include "itkVector.h"
 #include "itkCovariantVector.h"
-#include "vnl/vnl_vector_fixed.h"
+#include <vnl/vnl_vector_fixed.h>
 #include "itkArray.h"
 #include "itkArray2D.h"
 #include "itkAdvancedTransform.h"

--- a/Common/Transforms/itkAdvancedImageMomentsCalculator.h
+++ b/Common/Transforms/itkAdvancedImageMomentsCalculator.h
@@ -26,9 +26,9 @@
 #include "itkImageGridSampler.h"
 #include "itkImageFullSampler.h"
 
-#include "vnl/vnl_vector_fixed.h"
-#include "vnl/vnl_matrix_fixed.h"
-#include "vnl/vnl_diag_matrix.h"
+#include <vnl/vnl_vector_fixed.h>
+#include <vnl/vnl_matrix_fixed.h>
+#include <vnl/vnl_diag_matrix.h>
 
 #include "itkPlatformMultiThreader.h"
 

--- a/Common/Transforms/itkAdvancedImageMomentsCalculator.hxx
+++ b/Common/Transforms/itkAdvancedImageMomentsCalculator.hxx
@@ -20,8 +20,8 @@
 
 #include "itkAdvancedImageMomentsCalculator.h"
 
-#include "vnl/algo/vnl_real_eigensystem.h"
-#include "vnl/algo/vnl_symmetric_eigensystem.h"
+#include <vnl/algo/vnl_real_eigensystem.h>
+#include <vnl/algo/vnl_symmetric_eigensystem.h>
 #include "itkImageRegionConstIteratorWithIndex.h"
 
 namespace itk

--- a/Common/Transforms/itkAdvancedMatrixOffsetTransformBase.hxx
+++ b/Common/Transforms/itkAdvancedMatrixOffsetTransformBase.hxx
@@ -37,7 +37,7 @@
 
 #include "itkNumericTraits.h"
 #include "itkAdvancedMatrixOffsetTransformBase.h"
-#include "vnl/algo/vnl_matrix_inverse.h"
+#include <vnl/algo/vnl_matrix_inverse.h>
 
 namespace itk
 {

--- a/Common/Transforms/itkAdvancedRigid2DTransform.hxx
+++ b/Common/Transforms/itkAdvancedRigid2DTransform.hxx
@@ -35,7 +35,7 @@
 #define itkAdvancedRigid2DTransform_hxx
 
 #include "itkAdvancedRigid2DTransform.h"
-#include "vnl/algo/vnl_svd_fixed.h"
+#include <vnl/algo/vnl_svd_fixed.h>
 
 namespace itk
 {

--- a/Common/Transforms/itkAdvancedSimilarity2DTransform.hxx
+++ b/Common/Transforms/itkAdvancedSimilarity2DTransform.hxx
@@ -35,7 +35,7 @@
 #define _itkAdvancedSimilarity2DTransform_hxx
 
 #include "itkAdvancedSimilarity2DTransform.h"
-#include "vnl/vnl_math.h"
+#include <vnl/vnl_math.h>
 
 namespace itk
 {

--- a/Common/Transforms/itkAdvancedSimilarity3DTransform.hxx
+++ b/Common/Transforms/itkAdvancedSimilarity3DTransform.hxx
@@ -35,8 +35,8 @@
 #define _itkAdvancedSimilarity3DTransform_hxx
 
 #include "itkAdvancedSimilarity3DTransform.h"
-#include "vnl/vnl_math.h"
-#include "vnl/vnl_det.h"
+#include <vnl/vnl_math.h>
+#include <vnl/vnl_det.h>
 
 namespace itk
 {

--- a/Common/Transforms/itkAdvancedVersorTransform.h
+++ b/Common/Transforms/itkAdvancedVersorTransform.h
@@ -36,7 +36,7 @@
 
 #include <iostream>
 #include "itkAdvancedRigid3DTransform.h"
-#include "vnl/vnl_quaternion.h"
+#include <vnl/vnl_quaternion.h>
 #include "itkVersor.h"
 
 namespace itk

--- a/Common/Transforms/itkBSplineDerivativeKernelFunction2.h
+++ b/Common/Transforms/itkBSplineDerivativeKernelFunction2.h
@@ -35,7 +35,7 @@
 #define itkBSplineDerivativeKernelFunction2_h
 
 #include "itkKernelFunctionBase2.h"
-#include "vnl/vnl_math.h"
+#include <vnl/vnl_math.h>
 
 namespace itk
 {

--- a/Common/Transforms/itkBSplineInterpolationSecondOrderDerivativeWeightFunction.h
+++ b/Common/Transforms/itkBSplineInterpolationSecondOrderDerivativeWeightFunction.h
@@ -19,7 +19,7 @@
 #define itkBSplineInterpolationSecondOrderDerivativeWeightFunction_h
 
 #include "itkBSplineInterpolationWeightFunctionBase.h"
-#include "vnl/vnl_vector_fixed.h"
+#include <vnl/vnl_vector_fixed.h>
 
 namespace itk
 {

--- a/Common/Transforms/itkBSplineInterpolationSecondOrderDerivativeWeightFunction.hxx
+++ b/Common/Transforms/itkBSplineInterpolationSecondOrderDerivativeWeightFunction.hxx
@@ -21,7 +21,7 @@
 #include "itkBSplineInterpolationSecondOrderDerivativeWeightFunction.h"
 #include "itkImage.h"
 #include "itkImageRegionConstIteratorWithIndex.h"
-#include "vnl/vnl_vector.h"
+#include <vnl/vnl_vector.h>
 
 namespace itk
 {

--- a/Common/Transforms/itkBSplineKernelFunction2.h
+++ b/Common/Transforms/itkBSplineKernelFunction2.h
@@ -35,7 +35,7 @@
 #define itkBSplineKernelFunction2_h
 
 #include "itkKernelFunctionBase2.h"
-#include "vnl/vnl_math.h"
+#include <vnl/vnl_math.h>
 
 namespace itk
 {

--- a/Common/Transforms/itkBSplineSecondOrderDerivativeKernelFunction2.h
+++ b/Common/Transforms/itkBSplineSecondOrderDerivativeKernelFunction2.h
@@ -19,7 +19,7 @@
 #define itkBSplineSecondOrderDerivativeKernelFunction2_h
 
 #include "itkKernelFunctionBase.h"
-#include "vnl/vnl_math.h"
+#include <vnl/vnl_math.h>
 #include <cmath> // For abs.
 
 namespace itk

--- a/Common/Transforms/itkGridScheduleComputer.hxx
+++ b/Common/Transforms/itkGridScheduleComputer.hxx
@@ -22,7 +22,7 @@
 
 #include "itkImageRegionExclusionConstIteratorWithIndex.h"
 #include "itkConfigure.h"
-#include "vnl/vnl_inverse.h"
+#include <vnl/vnl_inverse.h>
 #include "itkBoundingBox.h"
 
 namespace itk

--- a/Common/Transforms/itkTransformToDeterminantOfSpatialJacobianSource.hxx
+++ b/Common/Transforms/itkTransformToDeterminantOfSpatialJacobianSource.hxx
@@ -39,7 +39,7 @@
 #include "itkAdvancedIdentityTransform.h"
 #include "itkProgressReporter.h"
 #include "itkImageRegionIteratorWithIndex.h"
-#include "vnl/vnl_det.h"
+#include <vnl/vnl_det.h>
 
 namespace itk
 {

--- a/Common/Transforms/itkTransformToSpatialJacobianSource.hxx
+++ b/Common/Transforms/itkTransformToSpatialJacobianSource.hxx
@@ -23,7 +23,7 @@
 #include "itkAdvancedIdentityTransform.h"
 #include "itkProgressReporter.h"
 #include "itkImageRegionIteratorWithIndex.h"
-#include "vnl/vnl_copy.h"
+#include <vnl/vnl_copy.h>
 
 namespace itk
 {

--- a/Common/itkAdvancedLinearInterpolateImageFunction.hxx
+++ b/Common/itkAdvancedLinearInterpolateImageFunction.hxx
@@ -20,7 +20,7 @@
 
 #include "itkAdvancedLinearInterpolateImageFunction.h"
 
-#include "vnl/vnl_math.h"
+#include <vnl/vnl_math.h>
 
 namespace itk
 {

--- a/Common/itkAdvancedRayCastInterpolateImageFunction.hxx
+++ b/Common/itkAdvancedRayCastInterpolateImageFunction.hxx
@@ -36,7 +36,7 @@ PURPOSE.  See the above copyright notices for more information.
 
 #include "itkAdvancedRayCastInterpolateImageFunction.h"
 
-#include "vnl/vnl_math.h"
+#include <vnl/vnl_math.h>
 
 // Put the helper class in an anonymous namespace so that it is not
 // exposed to the user

--- a/Common/itkComputeDisplacementDistribution.hxx
+++ b/Common/itkComputeDisplacementDistribution.hxx
@@ -21,9 +21,9 @@
 #include "itkComputeDisplacementDistribution.h"
 
 #include <string>
-#include "vnl/vnl_math.h"
-#include "vnl/vnl_fastops.h"
-#include "vnl/vnl_diag_matrix.h"
+#include <vnl/vnl_math.h>
+#include <vnl/vnl_fastops.h>
+#include <vnl/vnl_diag_matrix.h>
 
 #include "itkImageScanlineIterator.h"
 #include "itkImageSliceIteratorWithIndex.h"

--- a/Common/itkComputeJacobianTerms.hxx
+++ b/Common/itkComputeJacobianTerms.hxx
@@ -20,10 +20,10 @@
 
 #include "itkComputeJacobianTerms.h"
 
-#include "vnl/vnl_math.h"
-#include "vnl/vnl_fastops.h"
-#include "vnl/vnl_diag_matrix.h"
-#include "vnl/vnl_sparse_matrix.h"
+#include <vnl/vnl_math.h>
+#include <vnl/vnl_fastops.h>
+#include <vnl/vnl_diag_matrix.h>
+#include <vnl/vnl_sparse_matrix.h>
 
 namespace itk
 {

--- a/Common/itkComputePreconditionerUsingDisplacementDistribution.hxx
+++ b/Common/itkComputePreconditionerUsingDisplacementDistribution.hxx
@@ -20,7 +20,7 @@
 
 #include "itkComputePreconditionerUsingDisplacementDistribution.h"
 
-#include "vnl/vnl_math.h"
+#include <vnl/vnl_math.h>
 
 #include "itkImageScanlineIterator.h"
 #include "itkImageSliceIteratorWithIndex.h"

--- a/Common/itkImageFileCastWriter.hxx
+++ b/Common/itkImageFileCastWriter.hxx
@@ -23,7 +23,7 @@
 #include "itkObjectFactoryBase.h"
 #include "itkImageIOFactory.h"
 #include "itkCommand.h"
-#include "vnl/vnl_vector.h"
+#include <vnl/vnl_vector.h>
 #include "itkVectorImage.h"
 #include "itkDefaultConvertPixelTraits.h"
 #include "itkMetaImageIO.h"

--- a/Common/itkMultiOrderBSplineDecompositionImageFilter.h
+++ b/Common/itkMultiOrderBSplineDecompositionImageFilter.h
@@ -40,7 +40,7 @@
 #include <vector>
 
 #include "itkImageLinearIteratorWithIndex.h"
-#include "vnl/vnl_matrix.h"
+#include <vnl/vnl_matrix.h>
 
 #include "itkImageToImageFilter.h"
 

--- a/Common/itkMultiResolutionGaussianSmoothingPyramidImageFilter.hxx
+++ b/Common/itkMultiResolutionGaussianSmoothingPyramidImageFilter.hxx
@@ -42,7 +42,7 @@
 #include "itkRecursiveGaussianImageFilter.h"
 #include "itkMacro.h"
 
-#include "vnl/vnl_math.h"
+#include <vnl/vnl_math.h>
 
 namespace itk
 {

--- a/Common/itkMultiResolutionImageRegistrationMethod2.hxx
+++ b/Common/itkMultiResolutionImageRegistrationMethod2.hxx
@@ -42,7 +42,7 @@
 #include "itkMultiResolutionImageRegistrationMethod2.h"
 #include "itkRecursiveMultiResolutionPyramidImageFilter.h"
 #include "itkContinuousIndex.h"
-#include "vnl/vnl_math.h"
+#include <vnl/vnl_math.h>
 
 namespace itk
 {

--- a/Common/itkMultiResolutionShrinkPyramidImageFilter.hxx
+++ b/Common/itkMultiResolutionShrinkPyramidImageFilter.hxx
@@ -21,7 +21,7 @@
 #include "itkMultiResolutionShrinkPyramidImageFilter.h"
 
 #include "itkShrinkImageFilter.h"
-#include "vnl/vnl_math.h"
+#include <vnl/vnl_math.h>
 
 namespace itk
 {

--- a/Common/itkReducedDimensionBSplineInterpolateImageFunction.h
+++ b/Common/itkReducedDimensionBSplineInterpolateImageFunction.h
@@ -42,7 +42,7 @@
 
 #include "itkImageLinearIteratorWithIndex.h"
 #include "itkInterpolateImageFunction.h"
-#include "vnl/vnl_matrix.h"
+#include <vnl/vnl_matrix.h>
 
 #include "itkMultiOrderBSplineDecompositionImageFilter.h"
 #include "itkConceptChecking.h"

--- a/Common/itkReducedDimensionBSplineInterpolateImageFunction.hxx
+++ b/Common/itkReducedDimensionBSplineInterpolateImageFunction.hxx
@@ -46,7 +46,7 @@
 #include "itkVector.h"
 
 #include "itkMatrix.h"
-#include "vnl/vnl_matrix_ref.h"
+#include <vnl/vnl_matrix_ref.h>
 
 namespace itk
 {

--- a/Components/Metrics/AdvancedMattesMutualInformation/elxAdvancedMattesMutualInformationMetric.hxx
+++ b/Components/Metrics/AdvancedMattesMutualInformation/elxAdvancedMattesMutualInformationMetric.hxx
@@ -23,7 +23,7 @@
 #include "itkHardLimiterFunction.h"
 #include "itkExponentialLimiterFunction.h"
 #include <string>
-#include "vnl/vnl_math.h"
+#include <vnl/vnl_math.h>
 #include "itkTimeProbe.h"
 
 namespace elastix

--- a/Components/Metrics/AdvancedMattesMutualInformation/itkParzenWindowMutualInformationImageToImageMetric.hxx
+++ b/Components/Metrics/AdvancedMattesMutualInformation/itkParzenWindowMutualInformationImageToImageMetric.hxx
@@ -22,10 +22,10 @@
 
 #include "itkImageLinearConstIteratorWithIndex.h"
 #include "itkImageScanlineConstIterator.h"
-#include "vnl/vnl_math.h"
+#include <vnl/vnl_math.h>
 #include "itkMatrix.h"
-#include "vnl/vnl_inverse.h"
-#include "vnl/vnl_det.h"
+#include <vnl/vnl_inverse.h>
+#include <vnl/vnl_det.h>
 
 #ifdef ELASTIX_USE_OPENMP
 #  include <omp.h>

--- a/Components/Metrics/AdvancedMeanSquares/itkAdvancedMeanSquaresImageToImageMetric.hxx
+++ b/Components/Metrics/AdvancedMeanSquares/itkAdvancedMeanSquaresImageToImageMetric.hxx
@@ -19,7 +19,7 @@
 #define _itkAdvancedMeanSquaresImageToImageMetric_hxx
 
 #include "itkAdvancedMeanSquaresImageToImageMetric.h"
-#include "vnl/algo/vnl_matrix_update.h"
+#include <vnl/algo/vnl_matrix_update.h>
 #include "itkMersenneTwisterRandomVariateGenerator.h"
 #include "itkComputeImageExtremaFilter.h"
 

--- a/Components/Metrics/NormalizedMutualInformation/itkParzenWindowNormalizedMutualInformationImageToImageMetric.hxx
+++ b/Components/Metrics/NormalizedMutualInformation/itkParzenWindowNormalizedMutualInformationImageToImageMetric.hxx
@@ -22,7 +22,7 @@
 #include "itkParzenWindowNormalizedMutualInformationImageToImageMetric.h"
 
 #include "itkImageLinearConstIteratorWithIndex.h"
-#include "vnl/vnl_math.h"
+#include <vnl/vnl_math.h>
 
 namespace itk
 {

--- a/Components/Metrics/PCAMetric/itkPCAMetric.hxx
+++ b/Components/Metrics/PCAMetric/itkPCAMetric.hxx
@@ -21,11 +21,11 @@
 #include "itkPCAMetric.h"
 
 #include "itkMersenneTwisterRandomVariateGenerator.h"
-#include "vnl/algo/vnl_matrix_update.h"
+#include <vnl/algo/vnl_matrix_update.h>
 #include "itkImage.h"
-#include "vnl/algo/vnl_svd.h"
-#include "vnl/vnl_trace.h"
-#include "vnl/algo/vnl_symmetric_eigensystem.h"
+#include <vnl/algo/vnl_svd.h>
+#include <vnl/vnl_trace.h>
+#include <vnl/algo/vnl_symmetric_eigensystem.h>
 #include <numeric>
 #include <fstream>
 

--- a/Components/Metrics/PCAMetric/itkPCAMetric_F_multithreaded.hxx
+++ b/Components/Metrics/PCAMetric/itkPCAMetric_F_multithreaded.hxx
@@ -21,11 +21,11 @@
 #include "itkPCAMetric_F_multithreaded.h"
 
 #include "itkMersenneTwisterRandomVariateGenerator.h"
-#include "vnl/algo/vnl_matrix_update.h"
+#include <vnl/algo/vnl_matrix_update.h>
 #include "itkImage.h"
-#include "vnl/algo/vnl_svd.h"
-#include "vnl/vnl_trace.h"
-#include "vnl/algo/vnl_symmetric_eigensystem.h"
+#include <vnl/algo/vnl_svd.h>
+#include <vnl/vnl_trace.h>
+#include <vnl/algo/vnl_symmetric_eigensystem.h>
 #include <numeric>
 #include <fstream>
 

--- a/Components/Metrics/PCAMetric2/itkPCAMetric2.hxx
+++ b/Components/Metrics/PCAMetric2/itkPCAMetric2.hxx
@@ -21,11 +21,11 @@
 #include "itkPCAMetric2.h"
 
 #include "itkMersenneTwisterRandomVariateGenerator.h"
-#include "vnl/algo/vnl_matrix_update.h"
+#include <vnl/algo/vnl_matrix_update.h>
 #include "itkImage.h"
-#include "vnl/algo/vnl_svd.h"
-#include "vnl/vnl_trace.h"
-#include "vnl/algo/vnl_symmetric_eigensystem.h"
+#include <vnl/algo/vnl_svd.h>
+#include <vnl/vnl_trace.h>
+#include <vnl/algo/vnl_symmetric_eigensystem.h>
 #include <numeric>
 #include <fstream>
 

--- a/Components/Metrics/SumOfPairwiseCorrelationsMetric/itkSumOfPairwiseCorrelationCoefficientsMetric.hxx
+++ b/Components/Metrics/SumOfPairwiseCorrelationsMetric/itkSumOfPairwiseCorrelationCoefficientsMetric.hxx
@@ -21,7 +21,7 @@
 #include "itkSumOfPairwiseCorrelationCoefficientsMetric.h"
 
 #include "itkMersenneTwisterRandomVariateGenerator.h"
-#include "vnl/algo/vnl_matrix_update.h"
+#include <vnl/algo/vnl_matrix_update.h>
 #include "itkImage.h"
 #include <numeric>
 

--- a/Components/Metrics/SumSquaredTissueVolumeDifferenceMetric/itkSumSquaredTissueVolumeDifferenceImageToImageMetric.hxx
+++ b/Components/Metrics/SumSquaredTissueVolumeDifferenceMetric/itkSumSquaredTissueVolumeDifferenceImageToImageMetric.hxx
@@ -19,7 +19,7 @@
 #define _itkSumSquaredTissueVolumeDifferenceImageToImageMetric_txx
 
 #include "itkSumSquaredTissueVolumeDifferenceImageToImageMetric.h"
-#include "vnl/algo/vnl_matrix_update.h"
+#include <vnl/algo/vnl_matrix_update.h>
 
 #ifdef ELASTIX_USE_OPENMP
 #  include <omp.h>

--- a/Components/Metrics/VarianceOverLastDimension/itkVarianceOverLastDimensionImageMetric.hxx
+++ b/Components/Metrics/VarianceOverLastDimension/itkVarianceOverLastDimensionImageMetric.hxx
@@ -20,7 +20,7 @@
 
 #include "itkVarianceOverLastDimensionImageMetric.h"
 #include "itkMersenneTwisterRandomVariateGenerator.h"
-#include "vnl/algo/vnl_matrix_update.h"
+#include <vnl/algo/vnl_matrix_update.h>
 #include <numeric>
 
 namespace itk

--- a/Components/Optimizers/AdaGrad/itkAdaptiveStepsizeOptimizer.cxx
+++ b/Components/Optimizers/AdaGrad/itkAdaptiveStepsizeOptimizer.cxx
@@ -18,7 +18,7 @@
 
 #include "itkAdaptiveStepsizeOptimizer.h"
 
-#include "vnl/vnl_math.h"
+#include <vnl/vnl_math.h>
 #include "itkSigmoidImageFilter.h"
 
 namespace itk

--- a/Components/Optimizers/AdaptiveStochasticGradientDescent/itkAdaptiveStochasticGradientDescentOptimizer.cxx
+++ b/Components/Optimizers/AdaptiveStochasticGradientDescent/itkAdaptiveStochasticGradientDescentOptimizer.cxx
@@ -18,7 +18,7 @@
 
 #include "itkAdaptiveStochasticGradientDescentOptimizer.h"
 
-#include "vnl/vnl_math.h"
+#include <vnl/vnl_math.h>
 #include "itkSigmoidImageFilter.h"
 
 namespace itk

--- a/Components/Optimizers/AdaptiveStochasticLBFGS/itkAdaptiveStochasticLBFGSOptimizer.cxx
+++ b/Components/Optimizers/AdaptiveStochasticLBFGS/itkAdaptiveStochasticLBFGSOptimizer.cxx
@@ -18,7 +18,7 @@
 
 #include "itkAdaptiveStochasticLBFGSOptimizer.h"
 
-#include "vnl/vnl_math.h"
+#include <vnl/vnl_math.h>
 #include "itkSigmoidImageFilter.h"
 
 namespace itk

--- a/Components/Optimizers/AdaptiveStochasticVarianceReducedGradient/itkAdaptiveStochasticVarianceReducedGradientOptimizer.cxx
+++ b/Components/Optimizers/AdaptiveStochasticVarianceReducedGradient/itkAdaptiveStochasticVarianceReducedGradientOptimizer.cxx
@@ -18,7 +18,7 @@
 
 #include "itkAdaptiveStochasticVarianceReducedGradientOptimizer.h"
 
-#include "vnl/vnl_math.h"
+#include <vnl/vnl_math.h>
 #include "itkSigmoidImageFilter.h"
 
 namespace itk

--- a/Components/Optimizers/AdaptiveStochasticVarianceReducedGradient/itkStandardStochasticVarianceReducedGradientDescentOptimizer.cxx
+++ b/Components/Optimizers/AdaptiveStochasticVarianceReducedGradient/itkStandardStochasticVarianceReducedGradientDescentOptimizer.cxx
@@ -18,7 +18,7 @@
 
 #include "itkStandardStochasticVarianceReducedGradientDescentOptimizer.h"
 
-#include "vnl/vnl_math.h"
+#include <vnl/vnl_math.h>
 
 namespace itk
 {

--- a/Components/Optimizers/CMAEvolutionStrategy/elxCMAEvolutionStrategy.hxx
+++ b/Components/Optimizers/CMAEvolutionStrategy/elxCMAEvolutionStrategy.hxx
@@ -22,7 +22,7 @@
 #include "elxCMAEvolutionStrategy.h"
 #include <iomanip>
 #include <string>
-#include "vnl/vnl_math.h"
+#include <vnl/vnl_math.h>
 
 namespace elastix
 {

--- a/Components/Optimizers/CMAEvolutionStrategy/itkCMAEvolutionStrategyOptimizer.cxx
+++ b/Components/Optimizers/CMAEvolutionStrategy/itkCMAEvolutionStrategyOptimizer.cxx
@@ -18,7 +18,7 @@
 
 #include "itkCMAEvolutionStrategyOptimizer.h"
 #include "itkSymmetricEigenAnalysis.h"
-#include "vnl/vnl_math.h"
+#include <vnl/vnl_math.h>
 #include <algorithm>
 #include <cmath>
 #include "itkCommand.h"

--- a/Components/Optimizers/CMAEvolutionStrategy/itkCMAEvolutionStrategyOptimizer.h
+++ b/Components/Optimizers/CMAEvolutionStrategy/itkCMAEvolutionStrategyOptimizer.h
@@ -27,7 +27,7 @@
 #include "itkArray.h"
 #include "itkArray2D.h"
 #include "itkMersenneTwisterRandomVariateGenerator.h"
-#include "vnl/vnl_diag_matrix.h"
+#include <vnl/vnl_diag_matrix.h>
 
 namespace itk
 {

--- a/Components/Optimizers/ConjugateGradient/elxConjugateGradient.hxx
+++ b/Components/Optimizers/ConjugateGradient/elxConjugateGradient.hxx
@@ -22,7 +22,7 @@
 #include "elxConjugateGradient.h"
 #include <iomanip>
 #include <string>
-#include "vnl/vnl_math.h"
+#include <vnl/vnl_math.h>
 
 namespace elastix
 {

--- a/Components/Optimizers/ConjugateGradient/itkGenericConjugateGradientOptimizer.cxx
+++ b/Components/Optimizers/ConjugateGradient/itkGenericConjugateGradientOptimizer.cxx
@@ -17,7 +17,7 @@
  *=========================================================================*/
 
 #include "itkGenericConjugateGradientOptimizer.h"
-#include "vnl/vnl_math.h"
+#include <vnl/vnl_math.h>
 
 namespace itk
 {

--- a/Components/Optimizers/ConjugateGradientFRPR/elxConjugateGradientFRPR.hxx
+++ b/Components/Optimizers/ConjugateGradientFRPR/elxConjugateGradientFRPR.hxx
@@ -23,7 +23,7 @@
 #include <cmath>
 #include <iomanip>
 #include <string>
-#include "vnl/vnl_math.h"
+#include <vnl/vnl_math.h>
 
 namespace elastix
 {

--- a/Components/Optimizers/FiniteDifferenceGradientDescent/itkFiniteDifferenceGradientDescentOptimizer.cxx
+++ b/Components/Optimizers/FiniteDifferenceGradientDescent/itkFiniteDifferenceGradientDescentOptimizer.cxx
@@ -22,7 +22,7 @@
 #include "itkMacro.h"
 
 #include "math.h"
-#include "vnl/vnl_math.h"
+#include <vnl/vnl_math.h>
 
 namespace itk
 {

--- a/Components/Optimizers/FullSearch/elxFullSearchOptimizer.hxx
+++ b/Components/Optimizers/FullSearch/elxFullSearchOptimizer.hxx
@@ -22,7 +22,7 @@
 #include <iomanip>
 #include <sstream>
 #include <string>
-#include "vnl/vnl_math.h"
+#include <vnl/vnl_math.h>
 
 namespace elastix
 {

--- a/Components/Optimizers/Powell/elxPowell.hxx
+++ b/Components/Optimizers/Powell/elxPowell.hxx
@@ -22,7 +22,7 @@
 #include "elxPowell.h"
 #include <iomanip>
 #include <string>
-#include "vnl/vnl_math.h"
+#include <vnl/vnl_math.h>
 
 namespace elastix
 {

--- a/Components/Optimizers/PreconditionedGradientDescent/itkAdaptiveStochasticPreconditionedGradientDescentOptimizer.h
+++ b/Components/Optimizers/PreconditionedGradientDescent/itkAdaptiveStochasticPreconditionedGradientDescentOptimizer.h
@@ -20,7 +20,7 @@
 
 #include "itkStochasticPreconditionedGradientDescentOptimizer.h"
 
-#include "vnl/vnl_math.h"
+#include <vnl/vnl_math.h>
 #include "itkSigmoidImageFilter.h"
 
 namespace itk

--- a/Components/Optimizers/PreconditionedGradientDescent/itkPreconditionedGradientDescentOptimizer.cxx
+++ b/Components/Optimizers/PreconditionedGradientDescent/itkPreconditionedGradientDescentOptimizer.cxx
@@ -21,8 +21,8 @@
 #include "itkCommand.h"
 #include "itkEventObject.h"
 #include "itkMacro.h"
-#include "vnl/vnl_vector.h"
-#include "vnl/algo/vnl_sparse_symmetric_eigensystem.h"
+#include <vnl/vnl_vector.h>
+#include <vnl/algo/vnl_sparse_symmetric_eigensystem.h>
 #include <algorithm> // For max.
 
 namespace itk

--- a/Components/Optimizers/PreconditionedGradientDescent/itkPreconditionedGradientDescentOptimizer.h
+++ b/Components/Optimizers/PreconditionedGradientDescent/itkPreconditionedGradientDescentOptimizer.h
@@ -20,7 +20,7 @@
 
 #include "itkScaledSingleValuedNonLinearOptimizer.h"
 #include "itkArray2D.h"
-#include "vnl/vnl_sparse_matrix.h"
+#include <vnl/vnl_sparse_matrix.h>
 #include "cholmod.h"
 
 namespace itk

--- a/Components/Optimizers/PreconditionedGradientDescent/itkStochasticPreconditionedGradientDescentOptimizer.cxx
+++ b/Components/Optimizers/PreconditionedGradientDescent/itkStochasticPreconditionedGradientDescentOptimizer.cxx
@@ -17,7 +17,7 @@
  *=========================================================================*/
 
 #include "itkStochasticPreconditionedGradientDescentOptimizer.h"
-#include "vnl/vnl_math.h"
+#include <vnl/vnl_math.h>
 
 namespace itk
 {

--- a/Components/Optimizers/PreconditionedStochasticGradientDescent/itkPreconditionedASGDOptimizer.cxx
+++ b/Components/Optimizers/PreconditionedStochasticGradientDescent/itkPreconditionedASGDOptimizer.cxx
@@ -18,7 +18,7 @@
 
 #include "itkPreconditionedASGDOptimizer.h"
 
-#include "vnl/vnl_math.h"
+#include <vnl/vnl_math.h>
 #include "itkSigmoidImageFilter.h"
 
 namespace itk

--- a/Components/Optimizers/QuasiNewtonLBFGS/elxQuasiNewtonLBFGS.hxx
+++ b/Components/Optimizers/QuasiNewtonLBFGS/elxQuasiNewtonLBFGS.hxx
@@ -22,7 +22,7 @@
 #include "elxQuasiNewtonLBFGS.h"
 #include <iomanip>
 #include <string>
-#include "vnl/vnl_math.h"
+#include <vnl/vnl_math.h>
 
 namespace elastix
 {

--- a/Components/Optimizers/QuasiNewtonLBFGS/itkQuasiNewtonLBFGSOptimizer.cxx
+++ b/Components/Optimizers/QuasiNewtonLBFGS/itkQuasiNewtonLBFGSOptimizer.cxx
@@ -18,7 +18,7 @@
 
 #include "itkQuasiNewtonLBFGSOptimizer.h"
 #include "itkArray.h"
-#include "vnl/vnl_math.h"
+#include <vnl/vnl_math.h>
 
 namespace itk
 {

--- a/Components/Optimizers/RSGDEachParameterApart/elxRSGDEachParameterApart.hxx
+++ b/Components/Optimizers/RSGDEachParameterApart/elxRSGDEachParameterApart.hxx
@@ -22,7 +22,7 @@
 #include "elxRSGDEachParameterApart.h"
 #include <iomanip>
 #include <string>
-#include "vnl/vnl_math.h"
+#include <vnl/vnl_math.h>
 
 namespace elastix
 {

--- a/Components/Optimizers/RSGDEachParameterApart/itkRSGDEachParameterApartBaseOptimizer.cxx
+++ b/Components/Optimizers/RSGDEachParameterApart/itkRSGDEachParameterApartBaseOptimizer.cxx
@@ -19,7 +19,7 @@
 #include "itkRSGDEachParameterApartBaseOptimizer.h"
 #include "itkCommand.h"
 #include "itkEventObject.h"
-#include "vnl/vnl_math.h"
+#include <vnl/vnl_math.h>
 
 namespace itk
 {

--- a/Components/Optimizers/RegularStepGradientDescent/elxRegularStepGradientDescent.hxx
+++ b/Components/Optimizers/RegularStepGradientDescent/elxRegularStepGradientDescent.hxx
@@ -22,7 +22,7 @@
 #include "elxRegularStepGradientDescent.h"
 #include <iomanip>
 #include <string>
-#include "vnl/vnl_math.h"
+#include <vnl/vnl_math.h>
 
 namespace elastix
 {

--- a/Components/Optimizers/Simplex/elxSimplex.hxx
+++ b/Components/Optimizers/Simplex/elxSimplex.hxx
@@ -22,7 +22,7 @@
 #include "elxSimplex.h"
 #include <iomanip>
 #include <string>
-#include "vnl/vnl_math.h"
+#include <vnl/vnl_math.h>
 
 namespace elastix
 {

--- a/Components/Optimizers/SimultaneousPerturbation/elxSimultaneousPerturbation.hxx
+++ b/Components/Optimizers/SimultaneousPerturbation/elxSimultaneousPerturbation.hxx
@@ -22,7 +22,7 @@
 #include "elxSimultaneousPerturbation.h"
 #include <iomanip>
 #include <string>
-#include "vnl/vnl_math.h"
+#include <vnl/vnl_math.h>
 
 namespace elastix
 {

--- a/Components/Optimizers/StandardGradientDescent/itkStandardGradientDescentOptimizer.cxx
+++ b/Components/Optimizers/StandardGradientDescent/itkStandardGradientDescentOptimizer.cxx
@@ -17,7 +17,7 @@
  *=========================================================================*/
 
 #include "itkStandardGradientDescentOptimizer.h"
-#include "vnl/vnl_math.h"
+#include <vnl/vnl_math.h>
 
 namespace itk
 {

--- a/Components/Optimizers/StandardStochasticGradientDescent/itkStandardStochasticGradientDescentOptimizer.cxx
+++ b/Components/Optimizers/StandardStochasticGradientDescent/itkStandardStochasticGradientDescentOptimizer.cxx
@@ -18,7 +18,7 @@
 
 #include "itkStandardStochasticGradientDescentOptimizer.h"
 
-#include "vnl/vnl_math.h"
+#include <vnl/vnl_math.h>
 
 namespace itk
 {

--- a/Components/Registrations/MultiMetricMultiResolutionRegistration/itkMultiMetricMultiResolutionImageRegistrationMethod.hxx
+++ b/Components/Registrations/MultiMetricMultiResolutionRegistration/itkMultiMetricMultiResolutionImageRegistrationMethod.hxx
@@ -21,7 +21,7 @@
 #include "itkMultiMetricMultiResolutionImageRegistrationMethod.h"
 
 #include "itkContinuousIndex.h"
-#include "vnl/vnl_math.h"
+#include <vnl/vnl_math.h>
 
 /** Macro that implements the set methods. */
 #define itkImplementationSetMacro(_name, _type)                                                                        \

--- a/Components/Registrations/MultiResolutionRegistration/elxMultiResolutionRegistration.hxx
+++ b/Components/Registrations/MultiResolutionRegistration/elxMultiResolutionRegistration.hxx
@@ -19,7 +19,7 @@
 #define elxMultiResolutionRegistration_hxx
 
 #include "elxMultiResolutionRegistration.h"
-#include "vnl/vnl_math.h"
+#include <vnl/vnl_math.h>
 #include "itkTimeProbe.h"
 
 namespace elastix

--- a/Components/Registrations/MultiResolutionRegistrationWithFeatures/itkMultiInputMultiResolutionImageRegistrationMethodBase.hxx
+++ b/Components/Registrations/MultiResolutionRegistrationWithFeatures/itkMultiInputMultiResolutionImageRegistrationMethodBase.hxx
@@ -21,7 +21,7 @@
 #include "itkMultiInputMultiResolutionImageRegistrationMethodBase.h"
 
 #include "itkContinuousIndex.h"
-#include "vnl/vnl_math.h"
+#include <vnl/vnl_math.h>
 
 /** macro that implements the Set methods */
 #define itkImplementationSetMacro(_name, _type)                                                                        \

--- a/Components/Registrations/MultiResolutionRegistrationWithFeatures/itkMultiResolutionImageRegistrationMethodWithFeatures.hxx
+++ b/Components/Registrations/MultiResolutionRegistrationWithFeatures/itkMultiResolutionImageRegistrationMethodWithFeatures.hxx
@@ -21,7 +21,7 @@
 #include "itkMultiResolutionImageRegistrationMethodWithFeatures.h"
 
 #include "itkContinuousIndex.h"
-#include "vnl/vnl_math.h"
+#include <vnl/vnl_math.h>
 
 namespace itk
 {

--- a/Components/Transforms/AdvancedBSplineTransform/elxAdvancedBSplineTransform.hxx
+++ b/Components/Transforms/AdvancedBSplineTransform/elxAdvancedBSplineTransform.hxx
@@ -21,7 +21,7 @@
 #include "elxAdvancedBSplineTransform.h"
 
 #include "itkImageRegionExclusionConstIteratorWithIndex.h"
-#include "vnl/vnl_math.h"
+#include <vnl/vnl_math.h>
 
 
 namespace elastix

--- a/Components/Transforms/AffineLogStackTransform/elxAffineLogStackTransform.hxx
+++ b/Components/Transforms/AffineLogStackTransform/elxAffineLogStackTransform.hxx
@@ -21,7 +21,7 @@
 #include "elxAffineLogStackTransform.h"
 
 #include "itkImageRegionExclusionConstIteratorWithIndex.h"
-#include "vnl/vnl_math.h"
+#include <vnl/vnl_math.h>
 
 namespace elastix
 {

--- a/Components/Transforms/AffineLogTransform/itkAffineLogTransform.hxx
+++ b/Components/Transforms/AffineLogTransform/itkAffineLogTransform.hxx
@@ -18,7 +18,7 @@
 #ifndef itkAffineLogTransform_hxx
 #define itkAffineLogTransform_hxx
 
-#include "vnl/vnl_matrix_exp.h"
+#include <vnl/vnl_matrix_exp.h>
 #include "itkMath.h"
 #include "itkAffineLogTransform.h"
 

--- a/Components/Transforms/BSplineStackTransform/elxBSplineStackTransform.hxx
+++ b/Components/Transforms/BSplineStackTransform/elxBSplineStackTransform.hxx
@@ -21,7 +21,7 @@
 #include "elxBSplineStackTransform.h"
 
 #include "itkImageRegionExclusionConstIteratorWithIndex.h"
-#include "vnl/vnl_math.h"
+#include <vnl/vnl_math.h>
 
 namespace elastix
 {

--- a/Components/Transforms/MultiBSplineTransformWithNormal/elxMultiBSplineTransformWithNormal.hxx
+++ b/Components/Transforms/MultiBSplineTransformWithNormal/elxMultiBSplineTransformWithNormal.hxx
@@ -25,7 +25,7 @@
 #include "itkResampleImageFilter.h"
 #include "itkNearestNeighborInterpolateImageFunction.h"
 #include "itksys/System.h"
-#include "vnl/vnl_math.h"
+#include <vnl/vnl_math.h>
 
 namespace elastix
 {

--- a/Components/Transforms/RecursiveBSplineTransform/elxRecursiveBSplineTransform.hxx
+++ b/Components/Transforms/RecursiveBSplineTransform/elxRecursiveBSplineTransform.hxx
@@ -21,7 +21,7 @@
 #include "elxRecursiveBSplineTransform.h"
 
 #include "itkImageRegionExclusionConstIteratorWithIndex.h"
-#include "vnl/vnl_math.h"
+#include <vnl/vnl_math.h>
 
 namespace elastix
 {

--- a/Components/Transforms/SplineKernelTransform/elxSplineKernelTransform.hxx
+++ b/Components/Transforms/SplineKernelTransform/elxSplineKernelTransform.hxx
@@ -20,7 +20,7 @@
 
 #include "elxSplineKernelTransform.h"
 #include "itkTransformixInputPointFileReader.h"
-#include "vnl/vnl_math.h"
+#include <vnl/vnl_math.h>
 #include "itkTimeProbe.h"
 
 namespace elastix

--- a/Components/Transforms/SplineKernelTransform/itkKernelTransform2.h
+++ b/Components/Transforms/SplineKernelTransform/itkKernelTransform2.h
@@ -41,13 +41,13 @@ PURPOSE.  See the above copyright notices for more information.
 #include "itkPointSet.h"
 #include <deque>
 #include <math.h>
-#include "vnl/vnl_matrix_fixed.h"
-#include "vnl/vnl_matrix.h"
-#include "vnl/vnl_vector.h"
-#include "vnl/vnl_vector_fixed.h"
-#include "vnl/vnl_sample.h"
-#include "vnl/algo/vnl_svd.h"
-#include "vnl/algo/vnl_qr.h"
+#include <vnl/vnl_matrix_fixed.h>
+#include <vnl/vnl_matrix.h>
+#include <vnl/vnl_vector.h>
+#include <vnl/vnl_vector_fixed.h>
+#include <vnl/vnl_sample.h>
+#include <vnl/algo/vnl_svd.h>
+#include <vnl/algo/vnl_qr.h>
 
 namespace itk
 {

--- a/Components/Transforms/TranslationStackTransform/elxTranslationStackTransform.hxx
+++ b/Components/Transforms/TranslationStackTransform/elxTranslationStackTransform.hxx
@@ -21,7 +21,7 @@
 #include "elxTranslationStackTransform.h"
 
 #include "itkImageRegionExclusionConstIteratorWithIndex.h"
-#include "vnl/vnl_math.h"
+#include <vnl/vnl_math.h>
 
 namespace elastix
 {

--- a/Testing/itkThinPlateSplineTransformPerformanceTest.cxx
+++ b/Testing/itkThinPlateSplineTransformPerformanceTest.cxx
@@ -25,12 +25,12 @@
 #include <fstream>
 #include <iomanip>
 
-#include "vnl/algo/vnl_qr.h"
-//#include "vnl/algo/vnl_sparse_lu.h"
-//#include "vnl/algo/vnl_cholesky.h"
-#include "vnl/vnl_matlab_filewrite.h"
-#include "vnl/vnl_matrix_fixed.h"
-#include "vnl/vnl_sparse_matrix.h"
+#include <vnl/algo/vnl_qr.h>
+//#include <vnl/algo/vnl_sparse_lu.h>
+//#include <vnl/algo/vnl_cholesky.h>
+#include <vnl/vnl_matlab_filewrite.h>
+#include <vnl/vnl_matrix_fixed.h>
+#include <vnl/vnl_sparse_matrix.h>
 
 //-------------------------------------------------------------------------------------
 // Helper class to be able to access protected functions and variables.


### PR DESCRIPTION
It is common practice to use angle brackets, rather than double-quotes, for `#include` directives that include headers of external libraries. Doing so may slightly improve the compilation speed, as well as the performance of the Visual Studio IDE, when opening the elastix project.

By Notepad++ v8.1.9.2, Find in Files:

    Find what: include "vnl/(.+)"
    Replace with: include <vnl/$1>
    Filter: *.hxx;*.h;*.cxx
    [v] Match case
    (*) Regular expression