### PR TITLE
STYLE: Make StackTransform Parameters empty by default

### DIFF
--- a/Common/Transforms/itkStackTransform.hxx
+++ b/Common/Transforms/itkStackTransform.hxx
@@ -29,7 +29,7 @@ namespace itk
 
 template <class TScalarType, unsigned int NInputDimensions, unsigned int NOutputDimensions>
 StackTransform<TScalarType, NInputDimensions, NOutputDimensions>::StackTransform()
-  : Superclass(OutputSpaceDimension)
+  : Superclass(0)
 {} // end Constructor
 
 


### PR DESCRIPTION
Instead of using `OutputSpaceDimension` as initial "guess" for the number of parameters to be allocated, just make it zero, in the `StackTransform` default-constructor.

Eventually, the number of parameters of a stack transform is defined as the number of subtransforms _times_ the number of parameters of a single subtransform.

The original initial number (`OutputSpaceDimension`) just caused unnecessary memory reallocations.