### PR TITLE
STYLE: Remove `StackTransform` template argument defaults for dimensions

### DIFF
--- a/Common/Transforms/itkStackTransform.h
+++ b/Common/Transforms/itkStackTransform.h
@@ -34,7 +34,7 @@ namespace itk
  * \ingroup Transforms
  *
  */
-template <class TScalarType, unsigned int NInputDimensions = 3, unsigned int NOutputDimensions = 3>
+template <class TScalarType, unsigned int NInputDimensions, unsigned int NOutputDimensions>
 class ITK_TEMPLATE_EXPORT StackTransform : public AdvancedTransform<TScalarType, NInputDimensions, NOutputDimensions>
 {
 public:


### PR DESCRIPTION
These defaults appear counter-intuitive. For example, it does not seem logical to have `NOutputDimensions = 3` by default, for `StackTransform<double, 2>`.