### PR TITLE
ENH: Add `AdvancedBSplineDeformableTransformBase::Create(splineOrder)`

### DIFF
--- a/Common/Transforms/itkAdvancedBSplineDeformableTransformBase.h
+++ b/Common/Transforms/itkAdvancedBSplineDeformableTransformBase.h
@@ -81,6 +81,29 @@ public:
   using typename Superclass::MovingImageGradientType;
   using typename Superclass::MovingImageGradientValueType;
 
+  /* Creates a `BSplineDeformableTransform` of the specified derived type and spline order. */
+  template <template <class, unsigned, unsigned> class TBSplineDeformableTransform>
+  static Pointer
+  Create(const unsigned splineOrder)
+  {
+    switch (splineOrder)
+    {
+      case 1:
+      {
+        return TBSplineDeformableTransform<TScalarType, NDimensions, 1>::New();
+      }
+      case 2:
+      {
+        return TBSplineDeformableTransform<TScalarType, NDimensions, 2>::New();
+      }
+      case 3:
+      {
+        return TBSplineDeformableTransform<TScalarType, NDimensions, 3>::New();
+      }
+    }
+    itkGenericExceptionMacro(<< "ERROR: The provided spline order (" << splineOrder << ") is not supported.");
+  }
+
   /** This method sets the parameters of the transform.
    * For a B-spline deformation transform, the parameters are the BSpline
    * coefficients on a sparse grid.

--- a/Components/Transforms/AdvancedBSplineTransform/elxAdvancedBSplineTransform.h
+++ b/Components/Transforms/AdvancedBSplineTransform/elxAdvancedBSplineTransform.h
@@ -144,26 +144,6 @@ public:
                                                      BSplineTransformBaseType;
   typedef typename BSplineTransformBaseType::Pointer BSplineTransformBasePointer;
 
-  /** Typedef for supported BSplineTransform types. */
-  typedef itk::
-    AdvancedBSplineDeformableTransform<typename elx::TransformBase<TElastix>::CoordRepType, Self::SpaceDimension, 1>
-      BSplineTransformLinearType;
-  typedef itk::
-    AdvancedBSplineDeformableTransform<typename elx::TransformBase<TElastix>::CoordRepType, Self::SpaceDimension, 2>
-      BSplineTransformQuadraticType;
-  typedef itk::
-    AdvancedBSplineDeformableTransform<typename elx::TransformBase<TElastix>::CoordRepType, Self::SpaceDimension, 3>
-      BSplineTransformCubicType;
-  typedef itk::
-    CyclicBSplineDeformableTransform<typename elx::TransformBase<TElastix>::CoordRepType, Self::SpaceDimension, 1>
-      CyclicBSplineTransformLinearType;
-  typedef itk::
-    CyclicBSplineDeformableTransform<typename elx::TransformBase<TElastix>::CoordRepType, Self::SpaceDimension, 2>
-      CyclicBSplineTransformQuadraticType;
-  typedef itk::
-    CyclicBSplineDeformableTransform<typename elx::TransformBase<TElastix>::CoordRepType, Self::SpaceDimension, 3>
-      CyclicBSplineTransformCubicType;
-
   /** Typedefs inherited from the superclass. */
   using typename Superclass1::ScalarType;
   using typename Superclass1::ParametersType;

--- a/Components/Transforms/AdvancedBSplineTransform/elxAdvancedBSplineTransform.hxx
+++ b/Components/Transforms/AdvancedBSplineTransform/elxAdvancedBSplineTransform.hxx
@@ -40,47 +40,15 @@ AdvancedBSplineTransform<TElastix>::InitializeBSplineTransform(void)
   {
     this->m_GridScheduleComputer = CyclicGridScheduleComputerType::New();
     this->m_GridScheduleComputer->SetBSplineOrder(this->m_SplineOrder);
-
-    if (this->m_SplineOrder == 1)
-    {
-      this->m_BSplineTransform = CyclicBSplineTransformLinearType::New();
-    }
-    else if (this->m_SplineOrder == 2)
-    {
-      this->m_BSplineTransform = CyclicBSplineTransformQuadraticType::New();
-    }
-    else if (this->m_SplineOrder == 3)
-    {
-      this->m_BSplineTransform = CyclicBSplineTransformCubicType::New();
-    }
-    else
-    {
-      itkExceptionMacro(<< "ERROR: The provided spline order is not supported.");
-      return 1;
-    }
+    m_BSplineTransform =
+      BSplineTransformBaseType::template Create<itk::CyclicBSplineDeformableTransform>(m_SplineOrder);
   }
   else
   {
     this->m_GridScheduleComputer = GridScheduleComputerType::New();
     this->m_GridScheduleComputer->SetBSplineOrder(this->m_SplineOrder);
-
-    if (this->m_SplineOrder == 1)
-    {
-      this->m_BSplineTransform = BSplineTransformLinearType::New();
-    }
-    else if (this->m_SplineOrder == 2)
-    {
-      this->m_BSplineTransform = BSplineTransformQuadraticType::New();
-    }
-    else if (this->m_SplineOrder == 3)
-    {
-      this->m_BSplineTransform = BSplineTransformCubicType::New();
-    }
-    else
-    {
-      itkExceptionMacro(<< "ERROR: The provided spline order is not supported.");
-      return 1;
-    }
+    m_BSplineTransform =
+      BSplineTransformBaseType::template Create<itk::AdvancedBSplineDeformableTransform>(m_SplineOrder);
   }
 
   this->SetCurrentTransform(this->m_BSplineTransform);

--- a/Components/Transforms/BSplineStackTransform/elxBSplineStackTransform.h
+++ b/Components/Transforms/BSplineStackTransform/elxBSplineStackTransform.h
@@ -154,20 +154,6 @@ public:
                                                                      ReducedDimensionBSplineTransformBaseType;
   typedef typename ReducedDimensionBSplineTransformBaseType::Pointer ReducedDimensionBSplineTransformBasePointer;
 
-  /** Typedef for supported BSplineTransform types. */
-  typedef itk::AdvancedBSplineDeformableTransform<typename elx::TransformBase<TElastix>::CoordRepType,
-                                                  Self::ReducedSpaceDimension,
-                                                  1>
-    BSplineTransformLinearType;
-  typedef itk::AdvancedBSplineDeformableTransform<typename elx::TransformBase<TElastix>::CoordRepType,
-                                                  Self::ReducedSpaceDimension,
-                                                  2>
-    BSplineTransformQuadraticType;
-  typedef itk::AdvancedBSplineDeformableTransform<typename elx::TransformBase<TElastix>::CoordRepType,
-                                                  Self::ReducedSpaceDimension,
-                                                  3>
-    BSplineTransformCubicType;
-
   /** Typedefs inherited from the superclass. */
   using typename Superclass1::ParametersType;
   using typename Superclass2::ParameterMapType;

--- a/Components/Transforms/BSplineStackTransform/elxBSplineStackTransform.hxx
+++ b/Components/Transforms/BSplineStackTransform/elxBSplineStackTransform.hxx
@@ -36,23 +36,8 @@ BSplineStackTransform<TElastix>::InitializeBSplineTransform()
   /** Initialize the right BSplineTransform and GridScheduleComputer. */
   this->m_GridScheduleComputer = GridScheduleComputerType::New();
   this->m_GridScheduleComputer->SetBSplineOrder(m_SplineOrder);
-  if (this->m_SplineOrder == 1)
-  {
-    this->m_DummySubTransform = BSplineTransformLinearType::New();
-  }
-  else if (this->m_SplineOrder == 2)
-  {
-    this->m_DummySubTransform = BSplineTransformQuadraticType::New();
-  }
-  else if (this->m_SplineOrder == 3)
-  {
-    this->m_DummySubTransform = BSplineTransformCubicType::New();
-  }
-  else
-  {
-    itkExceptionMacro(<< "ERROR: The provided spline order is not supported.");
-    return 1;
-  }
+  m_DummySubTransform =
+    ReducedDimensionBSplineTransformBaseType::template Create<itk::AdvancedBSplineDeformableTransform>(m_SplineOrder);
 
   /** Note: periodic B-splines are not supported here as they do not seem to
    * make sense as a subtransform and deliver problems when compiling elastix

--- a/Components/Transforms/RecursiveBSplineTransform/elxRecursiveBSplineTransform.h
+++ b/Components/Transforms/RecursiveBSplineTransform/elxRecursiveBSplineTransform.h
@@ -144,23 +144,6 @@ public:
                                                      BSplineTransformBaseType;
   typedef typename BSplineTransformBaseType::Pointer BSplineTransformBasePointer;
 
-  /** Typedef for supported BSplineTransform types. */
-  typedef itk::RecursiveBSplineTransform<typename elx::TransformBase<TElastix>::CoordRepType, Self::SpaceDimension, 1>
-    BSplineTransformLinearType;
-  typedef itk::RecursiveBSplineTransform<typename elx::TransformBase<TElastix>::CoordRepType, Self::SpaceDimension, 2>
-    BSplineTransformQuadraticType;
-  typedef itk::RecursiveBSplineTransform<typename elx::TransformBase<TElastix>::CoordRepType, Self::SpaceDimension, 3>
-    BSplineTransformCubicType;
-  typedef itk::
-    CyclicBSplineDeformableTransform<typename elx::TransformBase<TElastix>::CoordRepType, Self::SpaceDimension, 1>
-      CyclicBSplineTransformLinearType;
-  typedef itk::
-    CyclicBSplineDeformableTransform<typename elx::TransformBase<TElastix>::CoordRepType, Self::SpaceDimension, 2>
-      CyclicBSplineTransformQuadraticType;
-  typedef itk::
-    CyclicBSplineDeformableTransform<typename elx::TransformBase<TElastix>::CoordRepType, Self::SpaceDimension, 3>
-      CyclicBSplineTransformCubicType;
-
   /** Typedefs inherited from the superclass. */
   using typename Superclass1::ScalarType;
   using typename Superclass1::ParametersType;

--- a/Components/Transforms/RecursiveBSplineTransform/elxRecursiveBSplineTransform.hxx
+++ b/Components/Transforms/RecursiveBSplineTransform/elxRecursiveBSplineTransform.hxx
@@ -39,47 +39,15 @@ RecursiveBSplineTransform<TElastix>::InitializeBSplineTransform(void)
   {
     this->m_GridScheduleComputer = CyclicGridScheduleComputerType::New();
     this->m_GridScheduleComputer->SetBSplineOrder(this->m_SplineOrder);
-
-    if (this->m_SplineOrder == 1)
-    {
-      this->m_BSplineTransform = CyclicBSplineTransformLinearType::New();
-    }
-    else if (this->m_SplineOrder == 2)
-    {
-      this->m_BSplineTransform = CyclicBSplineTransformQuadraticType::New();
-    }
-    else if (this->m_SplineOrder == 3)
-    {
-      this->m_BSplineTransform = CyclicBSplineTransformCubicType::New();
-    }
-    else
-    {
-      itkExceptionMacro(<< "ERROR: The provided spline order is not supported.");
-      return 1;
-    }
+    m_BSplineTransform =
+      BSplineTransformBaseType::template Create<itk::CyclicBSplineDeformableTransform>(m_SplineOrder);
   }
   else
   {
     this->m_GridScheduleComputer = GridScheduleComputerType::New();
     this->m_GridScheduleComputer->SetBSplineOrder(this->m_SplineOrder);
-
-    if (this->m_SplineOrder == 1)
-    {
-      this->m_BSplineTransform = BSplineTransformLinearType::New();
-    }
-    else if (this->m_SplineOrder == 2)
-    {
-      this->m_BSplineTransform = BSplineTransformQuadraticType::New();
-    }
-    else if (this->m_SplineOrder == 3)
-    {
-      this->m_BSplineTransform = BSplineTransformCubicType::New();
-    }
-    else
-    {
-      itkExceptionMacro(<< "ERROR: The provided spline order is not supported.");
-      return 1;
-    }
+    m_BSplineTransform =
+      BSplineTransformBaseType::template Create<itk::AdvancedBSplineDeformableTransform>(m_SplineOrder);
   }
 
   this->SetCurrentTransform(this->m_BSplineTransform);


### PR DESCRIPTION
Removing duplicate code from elastix B-spline Transform components that created a `BSplineDeformableTransform` object, based upon the spline order.

Also removed unnecessary related typedef's.