### PR TITLE
STYLE: Remove `GetConstNumber` "hacks", use Math::UnsignedPower instead

### DIFF
--- a/Common/Transforms/itkBSplineInterpolationWeightFunctionBase.h
+++ b/Common/Transforms/itkBSplineInterpolationWeightFunctionBase.h
@@ -22,6 +22,7 @@
 #include "itkContinuousIndex.h"
 #include "itkArray.h"
 #include "itkArray2D.h"
+#include "itkMath.h"
 #include "itkMatrix.h"
 #include "itkBSplineKernelFunction2.h"
 #include "itkBSplineDerivativeKernelFunction.h"
@@ -29,24 +30,6 @@
 
 namespace itk
 {
-
-/** Recursive template to retrieve the number of Bspline weights at compile time. */
-template <unsigned int SplineOrder, unsigned int Dimension>
-class ITK_TEMPLATE_EXPORT GetConstNumberOfWeightsHack
-{
-public:
-  typedef GetConstNumberOfWeightsHack<SplineOrder, Dimension - 1> OneDimensionLess;
-  itkStaticConstMacro(Value, unsigned long, (SplineOrder + 1) * OneDimensionLess::Value);
-};
-
-/** Partial template specialization to terminate the recursive loop. */
-template <unsigned int SplineOrder>
-class ITK_TEMPLATE_EXPORT GetConstNumberOfWeightsHack<SplineOrder, 0>
-{
-public:
-  itkStaticConstMacro(Value, unsigned long, 1);
-};
-
 /** \class BSplineInterpolationWeightFunctionBase
  * \brief Returns the weights over the support region used for B-spline
  * interpolation/reconstruction.
@@ -84,8 +67,7 @@ public:
   itkStaticConstMacro(SplineOrder, unsigned int, VSplineOrder);
 
   /** The number of weights as a static const. */
-  typedef GetConstNumberOfWeightsHack<Self::SplineOrder, Self::SpaceDimension> GetConstNumberOfWeightsHackType;
-  itkStaticConstMacro(NumberOfWeights, unsigned long, GetConstNumberOfWeightsHackType::Value);
+  static constexpr unsigned long NumberOfWeights = Math::UnsignedPower(VSplineOrder + 1, VSpaceDimension);
 
   /** OutputType typedef support. */
   typedef Array<double> WeightsType;

--- a/Common/itkRecursiveBSplineInterpolationWeightFunction.h
+++ b/Common/itkRecursiveBSplineInterpolationWeightFunction.h
@@ -23,33 +23,10 @@
 #include "itkBSplineKernelFunction2.h"
 #include "itkBSplineDerivativeKernelFunction2.h"
 #include "itkBSplineSecondOrderDerivativeKernelFunction2.h"
+#include "itkMath.h"
 
 namespace itk
 {
-/** Recursive template to retrieve the number of B-spline indices at compile time. */
-template <unsigned int SplineOrder, unsigned int Dimension>
-class ITK_TEMPLATE_EXPORT GetConstNumberOfIndicesHack
-{
-public:
-  typedef GetConstNumberOfIndicesHack<SplineOrder, Dimension - 1> OneDimensionLess;
-  itkStaticConstMacro(Value, unsigned int, (SplineOrder + 1) * OneDimensionLess::Value);
-};
-
-template <unsigned int SplineOrder>
-class ITK_TEMPLATE_EXPORT GetConstNumberOfIndicesHack<SplineOrder, 0>
-{
-public:
-  itkStaticConstMacro(Value, unsigned int, 1);
-};
-
-/** Recursive template to retrieve the number of B-spline weights at compile time. */
-template <unsigned int SplineOrder, unsigned int Dimension>
-class ITK_TEMPLATE_EXPORT GetConstNumberOfWeightsHackRecursiveBSpline
-{
-public:
-  itkStaticConstMacro(Value, unsigned int, (SplineOrder + 1) * Dimension);
-};
-
 /** \class RecursiveBSplineInterpolationWeightFunction
  * \brief Returns the weights over the support region used for B-spline
  * interpolation/reconstruction.
@@ -96,12 +73,11 @@ public:
   using typename Superclass::SizeType;
   using typename Superclass::ContinuousIndexType;
 
-  /** Get number of hacks. */
-  typedef GetConstNumberOfWeightsHackRecursiveBSpline<Self::SplineOrder, Self::SpaceDimension>
-    GetConstNumberOfWeightsHackRecursiveBSplineType;
-  itkStaticConstMacro(NumberOfWeights, unsigned int, GetConstNumberOfWeightsHackRecursiveBSplineType::Value);
-  typedef GetConstNumberOfIndicesHack<Self::SplineOrder, Self::SpaceDimension> GetConstNumberOfIndicesHackType;
-  itkStaticConstMacro(NumberOfIndices, unsigned int, GetConstNumberOfIndicesHackType::Value);
+  /** The number of weights. */
+  static constexpr unsigned NumberOfWeights = (VSplineOrder + 1) * VSpaceDimension;
+
+  /** The number of indices. */
+  static constexpr unsigned NumberOfIndices = Math::UnsignedPower(VSplineOrder + 1, VSpaceDimension);
 
   /** Get number of indices. */
   itkGetConstMacro(NumberOfIndices, unsigned int);


### PR DESCRIPTION
`itk::Math::UnsignedPower(base, exponent)` may be evaluated at compile-time, just like the original `GetConstNumberOf...Hack<SplineOrder, Dimension>::Value` expressions.