### PR TITLE
STYLE: Remove unused variables AdvancedRecursiveBSplineTransformTest

### DIFF
--- a/Testing/itkAdvancedRecursiveBSplineTransformTest.cxx
+++ b/Testing/itkAdvancedRecursiveBSplineTransformTest.cxx
@@ -233,17 +233,7 @@ main(int argc, char * argv[])
    *
    */
 
-  itk::TimeProbesCollectorBase                    timeCollector;
-  TransformType::WeightsType                      weights;
-  RecursiveTransformType::WeightsType             weights2;
-  TransformType::ParameterIndexArrayType          indices;
-  RecursiveTransformType::ParameterIndexArrayType indices2;
-
-  const unsigned int dummyNum = std::pow(static_cast<double>(SplineOrder + 1), static_cast<double>(Dimension));
-  weights.SetSize(dummyNum);
-  indices.SetSize(dummyNum);
-  weights2.SetSize(dummyNum);
-  indices2.SetSize(dummyNum);
+  itk::TimeProbesCollectorBase timeCollector;
 
   // Generate a list of random points
   auto mersenneTwister = MersenneTwisterType::New();


### PR DESCRIPTION
Removed unused local variables, `weights`, `weights2`, `indices`, and `indices2`.

These variables were introduced with commit 5a80b720269e7c6b660283d75bb9a087f6dcb678 "ENH: adding RecursiveBSplineTransform", 9 June 2016 (but then, they were already unused).

Removing them now will ease the upgrade to ITK 5.3, which has a new definition of `WeightsType`.