### PR TITLE
Remove m_SplineOrderOdd and add GetSplineOrder() to AdvancedBSplineDeformableTransformBase

### DIFF
--- a/Common/Transforms/itkAdvancedBSplineDeformableTransform.hxx
+++ b/Common/Transforms/itkAdvancedBSplineDeformableTransform.hxx
@@ -51,7 +51,7 @@ namespace itk
 // Constructor with default arguments
 template <class TScalarType, unsigned int NDimensions, unsigned int VSplineOrder>
 AdvancedBSplineDeformableTransform<TScalarType, NDimensions, VSplineOrder>::AdvancedBSplineDeformableTransform()
-  : Superclass()
+  : Superclass(VSplineOrder)
 {
   // Instantiate weights functions
   this->m_WeightsFunction = WeightsFunctionType::New();

--- a/Common/Transforms/itkAdvancedBSplineDeformableTransform.hxx
+++ b/Common/Transforms/itkAdvancedBSplineDeformableTransform.hxx
@@ -87,14 +87,6 @@ AdvancedBSplineDeformableTransform<TScalarType, NDimensions, VSplineOrder>::Adva
 
   // Setup variables for computing interpolation
   this->m_Offset = SplineOrder / 2;
-  if (SplineOrder % 2)
-  {
-    this->m_SplineOrderOdd = true;
-  }
-  else
-  {
-    this->m_SplineOrderOdd = false;
-  }
   this->m_ValidRegion = this->m_GridRegion;
 
   /** Fixed Parameters store the following information:

--- a/Common/Transforms/itkAdvancedBSplineDeformableTransformBase.h
+++ b/Common/Transforms/itkAdvancedBSplineDeformableTransformBase.h
@@ -373,9 +373,6 @@ protected:
   ContinuousIndexType m_ValidRegionBegin;
   ContinuousIndexType m_ValidRegionEnd;
 
-  /** Odd or even order B-spline. */
-  bool m_SplineOrderOdd;
-
   /** Keep a pointer to the input parameters. */
   const ParametersType * m_InputParametersPointer;
 

--- a/Common/Transforms/itkAdvancedBSplineDeformableTransformBase.h
+++ b/Common/Transforms/itkAdvancedBSplineDeformableTransformBase.h
@@ -104,6 +104,14 @@ public:
     itkGenericExceptionMacro(<< "ERROR: The provided spline order (" << splineOrder << ") is not supported.");
   }
 
+
+  unsigned
+  GetSplineOrder() const
+  {
+    return m_SplineOrder;
+  }
+
+
   /** This method sets the parameters of the transform.
    * For a B-spline deformation transform, the parameters are the BSpline
    * coefficients on a sparse grid.
@@ -322,7 +330,8 @@ protected:
   void
   PrintSelf(std::ostream & os, Indent indent) const override;
 
-  AdvancedBSplineDeformableTransformBase();
+  AdvancedBSplineDeformableTransformBase() = delete;
+  explicit AdvancedBSplineDeformableTransformBase(const unsigned splineOrder);
   ~AdvancedBSplineDeformableTransformBase() override = default;
 
   /** Wrap flat array into images of coefficients. */
@@ -344,6 +353,10 @@ protected:
   virtual bool
   InsideValidRegion(const ContinuousIndexType & index) const;
 
+private:
+  const unsigned m_SplineOrder;
+
+protected:
   /** Array of images representing the B-spline coefficients
    *  in each dimension.
    */

--- a/Common/Transforms/itkAdvancedBSplineDeformableTransformBase.hxx
+++ b/Common/Transforms/itkAdvancedBSplineDeformableTransformBase.hxx
@@ -28,8 +28,10 @@ namespace itk
 
 // Constructor with default arguments
 template <class TScalarType, unsigned int NDimensions>
-AdvancedBSplineDeformableTransformBase<TScalarType, NDimensions>::AdvancedBSplineDeformableTransformBase()
+AdvancedBSplineDeformableTransformBase<TScalarType, NDimensions>::AdvancedBSplineDeformableTransformBase(
+  const unsigned splineOrder)
   : Superclass(SpaceDimension)
+  , m_SplineOrder(splineOrder)
 {
   this->m_InternalParametersBuffer = ParametersType(0);
   // Make sure the parameters pointer is not NULL after construction.


### PR DESCRIPTION
Paving the way to support reading and writing BSpline transforms with a spline order 1 or 2 (rather than just the default spline order = 3).