### PR TITLE
Add ITK I/O support to BSplineTransform spline order 1 and 2

### DIFF
--- a/Common/CMakeLists.txt
+++ b/Common/CMakeLists.txt
@@ -17,6 +17,7 @@ endif()
 
 set( CommonFiles
   elxDefaultConstructibleSubclass.h
+  elxSupportedImageDimensions.h
   itkAdvancedLinearInterpolateImageFunction.h
   itkAdvancedLinearInterpolateImageFunction.hxx
   itkAdvancedRayCastInterpolateImageFunction.h

--- a/Common/Transforms/elxTransformFactoryRegistration.cxx
+++ b/Common/Transforms/elxTransformFactoryRegistration.cxx
@@ -25,6 +25,7 @@
 
 #include <elxSupportedImageTypes.h>
 
+#include <itkBSplineTransform.h>
 #include <itkTransformFactory.h>
 #include <utility> // For index_sequence
 
@@ -127,15 +128,21 @@ RegisterTransforms()
   (void)registered;
 }
 
-} // namespace
+template <unsigned int NDimension>
+using ItkBSplineTransformOrder1Type = itk::BSplineTransform<double, NDimension, 1>;
+template <unsigned int NDimension>
+using ItkBSplineTransformOrder2Type = itk::BSplineTransform<double, NDimension, 2>;
 
+} // namespace
 
 namespace elastix
 {
 void
 TransformFactoryRegistration::RegisterTransforms()
 {
-  ::RegisterTransforms<itk::AffineLogStackTransform,
+  ::RegisterTransforms<ItkBSplineTransformOrder1Type,
+                       ItkBSplineTransformOrder2Type,
+                       itk::AffineLogStackTransform,
                        itk::BSplineStackTransform,
                        itk::EulerStackTransform,
                        itk::TranslationStackTransform>();

--- a/Common/Transforms/elxTransformFactoryRegistration.cxx
+++ b/Common/Transforms/elxTransformFactoryRegistration.cxx
@@ -30,6 +30,9 @@
 
 namespace
 {
+struct EmptyStruct
+{};
+
 
 template <template <unsigned> class TTransform, std::size_t... VDimension>
 static void
@@ -55,9 +58,6 @@ template <template <unsigned> class... TTransform>
 void
 RegisterTransforms()
 {
-  struct EmptyStruct
-  {};
-
   const EmptyStruct registered[] = { (RegisterTransform<TTransform>(), EmptyStruct())... };
   (void)registered;
 }
@@ -74,12 +74,15 @@ namespace elastix
 void
 TransformFactoryRegistration::RegisterTransforms()
 {
-  ::RegisterTransforms<ItkBSplineTransformOrder1Type,
-                       ItkBSplineTransformOrder2Type,
-                       itk::AffineLogStackTransform,
-                       itk::BSplineStackTransform,
-                       itk::EulerStackTransform,
-                       itk::TranslationStackTransform>();
+  // Use C++11 "magic statics" to ensure that ::RegisterTransforms is called only once, thread-safely.
+  const static EmptyStruct emptyStruct = (::RegisterTransforms<ItkBSplineTransformOrder1Type,
+                                                               ItkBSplineTransformOrder2Type,
+                                                               itk::AffineLogStackTransform,
+                                                               itk::BSplineStackTransform,
+                                                               itk::EulerStackTransform,
+                                                               itk::TranslationStackTransform>(),
+                                          EmptyStruct());
+  (void)emptyStruct;
 }
 
 } // namespace elastix

--- a/Common/elxSupportedImageDimensions.h
+++ b/Common/elxSupportedImageDimensions.h
@@ -1,0 +1,97 @@
+/*=========================================================================
+ *
+ *  Copyright UMC Utrecht and contributors
+ *
+ *  Licensed under the Apache License, Version 2.0 (the "License");
+ *  you may not use this file except in compliance with the License.
+ *  You may obtain a copy of the License at
+ *
+ *        http://www.apache.org/licenses/LICENSE-2.0.txt
+ *
+ *  Unless required by applicable law or agreed to in writing, software
+ *  distributed under the License is distributed on an "AS IS" BASIS,
+ *  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *  See the License for the specific language governing permissions and
+ *  limitations under the License.
+ *
+ *=========================================================================*/
+#ifndef elxSupportedImageDimensions_h
+#define elxSupportedImageDimensions_h
+
+#include <elxSupportedImageTypes.h>
+#include <utility> // For index_sequence
+
+
+namespace elastix
+{
+
+/** The minimum possible supported image dimension (for either fixed or moving images). */
+constexpr unsigned minSupportedImageDimension{ 2 };
+
+/** The maximum possible supported image dimension (for either fixed or moving images). */
+constexpr unsigned maxSupportedImageDimension{ 4 };
+
+
+template <unsigned VDimension, std::size_t... VIndex>
+constexpr bool
+SupportsFixedDimensionByImageTypeIndexSequence(std::index_sequence<VIndex...>)
+{
+  const bool foundEntries[] = { (ElastixTypedef<VIndex + 1>::FixedDimension == VDimension)... };
+
+  for (const bool isDimensionFound : foundEntries)
+  {
+    if (isDimensionFound)
+    {
+      return true;
+    }
+  }
+  return false;
+}
+
+
+// Tells whether any of the supported fixed image types has the specified dimension.
+template <unsigned VDimension>
+constexpr bool
+SupportsFixedDimension()
+{
+  return SupportsFixedDimensionByImageTypeIndexSequence<VDimension>(
+    std::make_index_sequence<NrOfSupportedImageTypes>());
+}
+
+
+template <unsigned VDimension = minSupportedImageDimension>
+struct FixedImageDimensionSupport
+{
+  // Adds those dimensions from the specified `dimensionSequence` that are supported.
+  template <std::size_t... VIndex>
+  constexpr static auto
+  AddSupportedDimensions(std::index_sequence<VIndex...> dimensionSequence)
+  {
+    using AddDimensionIfSupported = std::conditional_t<SupportsFixedDimension<VDimension>(),
+                                                       std::index_sequence<VDimension, VIndex...>,
+                                                       std::index_sequence<VIndex...>>;
+
+    return FixedImageDimensionSupport<VDimension + 1>::AddSupportedDimensions(AddDimensionIfSupported());
+  }
+};
+
+
+template <>
+struct FixedImageDimensionSupport<maxSupportedImageDimension + 1>
+{
+  template <std::size_t... VIndex>
+  constexpr static auto
+  AddSupportedDimensions(std::index_sequence<VIndex...> dimensionSequence)
+  {
+    return dimensionSequence;
+  }
+};
+
+
+/** A sequence of the dimensions of supported fixed images */
+const auto SupportedFixedImageDimensionSequence =
+  FixedImageDimensionSupport<>::AddSupportedDimensions(std::index_sequence<>());
+
+} // namespace elastix
+
+#endif

--- a/Components/Transforms/AdvancedBSplineTransform/elxAdvancedBSplineTransform.hxx
+++ b/Components/Transforms/AdvancedBSplineTransform/elxAdvancedBSplineTransform.hxx
@@ -22,6 +22,7 @@
 
 #include "itkImageRegionExclusionConstIteratorWithIndex.h"
 #include <vnl/vnl_math.h>
+#include <regex>
 
 
 namespace elastix
@@ -415,6 +416,27 @@ AdvancedBSplineTransform<TElastix>::ReadFromFile()
 {
   /** Read spline order and periodicity settings and initialize BSplineTransform. */
   this->m_SplineOrder = 3;
+
+  const std::vector<std::string> parameterValues = this->m_Configuration->GetValuesOfParameter("ITKTransformType");
+
+  if (!parameterValues.empty())
+  {
+    assert(parameterValues.size() == 1);
+
+    // itkTransformTypeAsString should be something like "BSplineTransform_double_2_2" (for a default spline order) or
+    // "BSplineTransform_double_3_3_2" (for a non-default spline order)
+    const auto itkTransformTypeAsString = parameterValues.front();
+
+    if (std::regex_match(itkTransformTypeAsString, std::regex("BSplineTransform_[a-z]+_\\d_\\d_\\d")))
+    {
+      // The last character from `itkTransformTypeAsString` represents a non-default spline order.
+      m_SplineOrder = static_cast<unsigned>(itkTransformTypeAsString.back() - '0');
+
+      // Assert that m_SplineOrder is one of the two supported non-default spline order values.
+      assert(m_SplineOrder == 1 || m_SplineOrder == 2);
+    }
+  }
+
   this->GetConfiguration()->ReadParameter(
     this->m_SplineOrder, "BSplineTransformSplineOrder", this->GetComponentLabel(), 0, 0);
   this->m_Cyclic = false;

--- a/Core/Configuration/elxConfiguration.cxx
+++ b/Core/Configuration/elxConfiguration.cxx
@@ -20,6 +20,7 @@
 
 #include "elxConversion.h"
 #include "elxTransformIO.h"
+#include "elxTransformFactoryRegistration.h"
 
 namespace elastix
 {
@@ -153,6 +154,8 @@ Configuration::BeforeAllTransformix()
 int
 Configuration::Initialize(const CommandLineArgumentMapType & _arg)
 {
+  TransformFactoryRegistration::RegisterTransforms();
+
   /** The first part is getting the command line arguments and setting them
    * in the configuration. From the command line arguments we find the name
    * of the parameter text file. The second part is then to get and set the
@@ -236,6 +239,8 @@ int
 Configuration::Initialize(const CommandLineArgumentMapType &                _arg,
                           const ParameterFileParserType::ParameterMapType & inputMap)
 {
+  TransformFactoryRegistration::RegisterTransforms();
+
   /** The first part is getting the command line arguments and setting them
    * in the configuration. From the command line arguments we find the name
    * of the parameter text file. The second part is then to get and set the

--- a/Core/Kernel/elxElastixMain.cxx
+++ b/Core/Kernel/elxElastixMain.cxx
@@ -26,7 +26,6 @@
 
 #include "elxElastixMain.h"
 #include "elxComponentLoader.h"
-#include "elxTransformFactoryRegistration.h"
 
 #include "elxMacro.h"
 #include "itkPlatformMultiThreader.h"
@@ -188,7 +187,6 @@ ElastixMain::GetComponentDatabase()
 {
   // Improved thread-safety by using C++11 "magic statics".
   static const auto componentDatabase = [] {
-    TransformFactoryRegistration::RegisterTransforms();
     const auto componentDatabase = ComponentDatabase::New();
     const auto componentLoader = ComponentLoader::New();
     componentLoader->SetComponentDatabase(componentDatabase);


### PR DESCRIPTION
Supported writing a b-spline transform from elastix to ITK HDF5 or TFM file, and then reading it back into either elastix or transformix.