### PR TITLE
STYLE: Sync `AdvancedMatrixOffsetTransformBase` constructor with ITK 5.3

### DIFF
--- a/Common/Transforms/itkAdvancedMatrixOffsetTransformBase.h
+++ b/Common/Transforms/itkAdvancedMatrixOffsetTransformBase.h
@@ -378,8 +378,7 @@ protected:
    * omitted, then the AdvancedMatrixOffsetTransformBase is initialized to an identity
    * transformation in the appropriate number of dimensions.
    */
-  explicit AdvancedMatrixOffsetTransformBase(unsigned int paramDims);
-  AdvancedMatrixOffsetTransformBase();
+  explicit AdvancedMatrixOffsetTransformBase(const unsigned int paramDims = ParametersDimension);
 
   /** Destroy an AdvancedMatrixOffsetTransformBase object. */
   ~AdvancedMatrixOffsetTransformBase() override = default;
@@ -435,13 +434,13 @@ private:
 
 
   /** Member variables. */
-  MatrixType                m_Matrix;        // Matrix of the transformation
-  OutputVectorType          m_Offset;        // Offset of the transformation
-  mutable InverseMatrixType m_InverseMatrix; // Inverse of the matrix
-  mutable bool              m_Singular;      // Is m_Inverse singular?
+  MatrixType                m_Matrix{ MatrixType::GetIdentity() };               // Matrix of the transformation
+  OutputVectorType          m_Offset{};                                          // Offset of the transformation
+  mutable InverseMatrixType m_InverseMatrix{ InverseMatrixType::GetIdentity() }; // Inverse of the matrix
+  mutable bool              m_Singular{ false };                                 // Is m_Inverse singular?
 
-  InputPointType   m_Center;
-  OutputVectorType m_Translation;
+  InputPointType   m_Center{};
+  OutputVectorType m_Translation{};
 
   /** To avoid recomputation of the inverse if not needed. */
   TimeStamp         m_MatrixMTime;

--- a/Common/Transforms/itkAdvancedMatrixOffsetTransformBase.hxx
+++ b/Common/Transforms/itkAdvancedMatrixOffsetTransformBase.hxx
@@ -44,38 +44,14 @@ namespace itk
 
 // Constructor with default arguments
 template <class TScalarType, unsigned int NInputDimensions, unsigned int NOutputDimensions>
-AdvancedMatrixOffsetTransformBase<TScalarType, NInputDimensions, NOutputDimensions>::AdvancedMatrixOffsetTransformBase()
-  : Superclass(ParametersDimension)
-{
-  this->m_Matrix.SetIdentity();
-  this->m_MatrixMTime.Modified();
-  this->m_Offset.Fill(0);
-  this->m_Center.Fill(0);
-  this->m_Translation.Fill(0);
-  this->m_Singular = false;
-  this->m_InverseMatrix.SetIdentity();
-  this->m_InverseMatrixMTime = this->m_MatrixMTime;
-  this->m_FixedParameters.SetSize(NInputDimensions);
-  this->m_FixedParameters.Fill(0.0);
-
-  this->PrecomputeJacobians(ParametersDimension);
-}
-
-
-// Constructor with default arguments
-template <class TScalarType, unsigned int NInputDimensions, unsigned int NOutputDimensions>
 AdvancedMatrixOffsetTransformBase<TScalarType, NInputDimensions, NOutputDimensions>::AdvancedMatrixOffsetTransformBase(
   unsigned int paramDims)
   : Superclass(paramDims)
 {
-  this->m_Matrix.SetIdentity();
-  this->m_MatrixMTime.Modified();
-  this->m_Offset.Fill(0);
-  this->m_Center.Fill(0);
-  this->m_Translation.Fill(0);
-  this->m_Singular = false;
-  this->m_InverseMatrix.SetIdentity();
-  this->m_InverseMatrixMTime = this->m_MatrixMTime;
+  m_MatrixMTime.Modified();
+  m_InverseMatrixMTime = m_MatrixMTime;
+  this->m_FixedParameters.SetSize(NInputDimensions);
+  this->m_FixedParameters.Fill(0.0);
 
   this->PrecomputeJacobians(paramDims);
 }


### PR DESCRIPTION
Use in-class default member-initializers in `AdvancedMatrixOffsetTransformBase`, just like in ITK's "itkMatrixOffsetTransformBase.h":
https://github.com/InsightSoftwareConsortium/ITK/blob/v5.3rc01/Modules/Core/Transform/include/itkMatrixOffsetTransformBase.h#L579-L585

Following pull request https://github.com/InsightSoftwareConsortium/ITK/pull/2491 commit https://github.com/InsightSoftwareConsortium/ITK/commit/e6f5f969751dd2a018ff3bc1cc16c7e9f709737b "STYLE: Combine code MatrixOffsetTransformBase constructors"

Resized `m_FixedParameters`, just like in commit https://github.com/InsightSoftwareConsortium/ITK/commit/168f84f1ac3e209cc46d1c9b07a896fc895cdd8a
 "BUG: MatrixOffsetTransformBase::GetFixedParameters not thread safe."