### PR TITLE
Replace NumericTraits::ZeroValue() by 0.0, and NumericTraits::ZeroValue() by 1.0

### DIFF
--- a/Common/LineSearchOptimizers/itkLineSearchOptimizer.cxx
+++ b/Common/LineSearchOptimizers/itkLineSearchOptimizer.cxx
@@ -31,7 +31,7 @@ LineSearchOptimizer::LineSearchOptimizer()
   this->m_CurrentStepLength = 0.0;
   this->m_MinimumStepLength = 0.0;
   this->m_MaximumStepLength = NumericTraits<double>::max();
-  this->m_InitialStepLengthEstimate = NumericTraits<double>::One;
+  this->m_InitialStepLengthEstimate = 1.0;
 
 } // end Constructor
 

--- a/Common/LineSearchOptimizers/itkLineSearchOptimizer.cxx
+++ b/Common/LineSearchOptimizers/itkLineSearchOptimizer.cxx
@@ -28,8 +28,8 @@ namespace itk
 
 LineSearchOptimizer::LineSearchOptimizer()
 {
-  this->m_CurrentStepLength = NumericTraits<double>::Zero;
-  this->m_MinimumStepLength = NumericTraits<double>::Zero;
+  this->m_CurrentStepLength = 0.0;
+  this->m_MinimumStepLength = 0.0;
   this->m_MaximumStepLength = NumericTraits<double>::max();
   this->m_InitialStepLengthEstimate = NumericTraits<double>::One;
 

--- a/Common/MevisDicomTiff/itkMevisDicomTiffImageIO.cxx
+++ b/Common/MevisDicomTiff/itkMevisDicomTiffImageIO.cxx
@@ -77,10 +77,10 @@ MevisDicomTiffImageIO ::MevisDicomTiffImageIO()
   , m_TileDepth(0)
   , m_NumberOfTiles(0)
   , m_RescaleSlope(NumericTraits<double>::OneValue())
-  , m_RescaleIntercept(NumericTraits<double>::ZeroValue())
-  , m_GantryTilt(NumericTraits<double>::ZeroValue())
-  , m_EstimatedMinimum(NumericTraits<double>::ZeroValue())
-  , m_EstimatedMaximum(NumericTraits<double>::ZeroValue())
+  , m_RescaleIntercept(0.0)
+  , m_GantryTilt(0.0)
+  , m_EstimatedMinimum(0.0)
+  , m_EstimatedMaximum(0.0)
 {
   // this->SetNumberOfDimensions(4);
   this->SetFileType(Binary);
@@ -593,19 +593,19 @@ MevisDicomTiffImageIO::ReadImageInformation()
       row[0] = row3[0];
       row[1] = row3[1];
       row[2] = row3[2];
-      row[3] = itk::NumericTraits<double>::Zero;
+      row[3] = 0.0;
 
       col[0] = col3[0];
       col[1] = col3[1];
       col[2] = col3[2];
-      col[3] = itk::NumericTraits<double>::Zero;
+      col[3] = 0.0;
 
       slice[0] = slice3[0];
       slice[1] = slice3[1];
       slice[2] = slice3[2];
-      slice[3] = itk::NumericTraits<double>::Zero;
+      slice[3] = 0.0;
 
-      dum[0] = dum[1] = dum[2] = itk::NumericTraits<double>::Zero;
+      dum[0] = dum[1] = dum[2] = 0.0;
       dum[3] = itk::NumericTraits<double>::One;
 
       this->SetDirection(0, row);
@@ -631,7 +631,7 @@ MevisDicomTiffImageIO::ReadImageInformation()
   {
     // not necessary to throw an exception for this.
     itkDebugMacro(<< "mevisIO:readimageinformation(): warning: intercept (0x0028,0x1052) not found in dcm header!");
-    m_RescaleIntercept = NumericTraits<double>::Zero; // default
+    m_RescaleIntercept = 0.0; // default
   }
 
   // slope
@@ -658,7 +658,7 @@ MevisDicomTiffImageIO::ReadImageInformation()
   {
     // not necessary to throw an exception for this.
     itkDebugMacro(<< "mevisIO: readimageinformation(): warning: gantry tilt (0x0018,0x1120) not found in dcm header!");
-    m_GantryTilt = NumericTraits<double>::Zero; // default
+    m_GantryTilt = 0.0; // default
   }
 
   // HEADER in MetaDICT

--- a/Common/MevisDicomTiff/itkMevisDicomTiffImageIO.cxx
+++ b/Common/MevisDicomTiff/itkMevisDicomTiffImageIO.cxx
@@ -76,7 +76,7 @@ MevisDicomTiffImageIO ::MevisDicomTiffImageIO()
   , m_TileLength(0)
   , m_TileDepth(0)
   , m_NumberOfTiles(0)
-  , m_RescaleSlope(NumericTraits<double>::OneValue())
+  , m_RescaleSlope(1.0)
   , m_RescaleIntercept(0.0)
   , m_GantryTilt(0.0)
   , m_EstimatedMinimum(0.0)
@@ -606,7 +606,7 @@ MevisDicomTiffImageIO::ReadImageInformation()
       slice[3] = 0.0;
 
       dum[0] = dum[1] = dum[2] = 0.0;
-      dum[3] = itk::NumericTraits<double>::One;
+      dum[3] = 1.0;
 
       this->SetDirection(0, row);
       this->SetDirection(1, col);
@@ -645,7 +645,7 @@ MevisDicomTiffImageIO::ReadImageInformation()
   {
     // not necessary to throw an exception for this.
     itkDebugMacro(<< "mevisIO:readimageinformation(): warning: slope (0x0028,0x1053) not found in dcm header!");
-    m_RescaleSlope = NumericTraits<double>::One; // default
+    m_RescaleSlope = 1.0; // default
   }
   // gantry tilt
   gdcm::Attribute<0x0018, 0x1120> atgantry;

--- a/Common/Transforms/itkBSplineDerivativeKernelFunction2.h
+++ b/Common/Transforms/itkBSplineDerivativeKernelFunction2.h
@@ -138,11 +138,11 @@ private:
   {
     const double absValue = std::abs(u);
 
-    if (absValue < NumericTraits<double>::OneValue())
+    if (absValue < 1.0)
     {
       return -vnl_math::sgn(u);
     }
-    else if (absValue == NumericTraits<double>::OneValue())
+    else if (absValue == 1.0)
     {
       return -vnl_math::sgn(u) / 2.0;
     }

--- a/Common/Transforms/itkBSplineDerivativeKernelFunction2.h
+++ b/Common/Transforms/itkBSplineDerivativeKernelFunction2.h
@@ -148,7 +148,7 @@ private:
     }
     else
     {
-      return NumericTraits<double>::ZeroValue();
+      return 0.0;
     }
   }
 
@@ -193,7 +193,7 @@ private:
     }
     else
     {
-      return NumericTraits<double>::ZeroValue();
+      return 0.0;
     }
   }
 

--- a/Common/Transforms/itkBSplineKernelFunction2.h
+++ b/Common/Transforms/itkBSplineKernelFunction2.h
@@ -147,7 +147,7 @@ private:
 
     if (absValue < 0.5)
     {
-      return NumericTraits<double>::OneValue();
+      return 1.0;
     }
     else if (absValue == 0.5)
     {
@@ -168,7 +168,7 @@ private:
 
     if (absValue < 1.0)
     {
-      return NumericTraits<double>::OneValue() - absValue;
+      return 1.0 - absValue;
     }
     else
     {
@@ -232,7 +232,7 @@ private:
 
     if (absValue < 0.5)
     {
-      weights[0] = NumericTraits<double>::OneValue();
+      weights[0] = 1.0;
     }
     else if (absValue == 0.5)
     {
@@ -251,7 +251,7 @@ private:
   {
     const double absValue = std::abs(u);
 
-    weights[0] = NumericTraits<double>::OneValue() - absValue;
+    weights[0] = 1.0 - absValue;
     weights[1] = absValue;
   }
 

--- a/Common/Transforms/itkBSplineKernelFunction2.h
+++ b/Common/Transforms/itkBSplineKernelFunction2.h
@@ -155,7 +155,7 @@ private:
     }
     else
     {
-      return NumericTraits<double>::ZeroValue();
+      return 0.0;
     }
   }
 
@@ -172,7 +172,7 @@ private:
     }
     else
     {
-      return NumericTraits<double>::ZeroValue();
+      return 0.0;
     }
   }
 
@@ -193,7 +193,7 @@ private:
     }
     else
     {
-      return NumericTraits<double>::ZeroValue();
+      return 0.0;
     }
   }
 
@@ -215,7 +215,7 @@ private:
     }
     else
     {
-      return NumericTraits<double>::ZeroValue();
+      return 0.0;
     }
   }
 
@@ -240,7 +240,7 @@ private:
     }
     else
     {
-      weights[0] = NumericTraits<double>::ZeroValue();
+      weights[0] = 0.0;
     }
   }
 

--- a/Common/itkComputeDisplacementDistribution.hxx
+++ b/Common/itkComputeDisplacementDistribution.hxx
@@ -104,9 +104,9 @@ ComputeDisplacementDistribution<TFixedImage, TTransform>::InitializeThreadingPar
   /** Some initialization. */
   for (ThreadIdType i = 0; i < numberOfThreads; ++i)
   {
-    this->m_ComputePerThreadVariables[i].st_MaxJJ = NumericTraits<double>::Zero;
-    this->m_ComputePerThreadVariables[i].st_Displacement = NumericTraits<double>::Zero;
-    this->m_ComputePerThreadVariables[i].st_DisplacementSquared = NumericTraits<double>::Zero;
+    this->m_ComputePerThreadVariables[i].st_MaxJJ = 0.0;
+    this->m_ComputePerThreadVariables[i].st_Displacement = 0.0;
+    this->m_ComputePerThreadVariables[i].st_DisplacementSquared = 0.0;
     this->m_ComputePerThreadVariables[i].st_NumberOfPixelsCounted = NumericTraits<SizeValueType>::Zero;
   }
 

--- a/Components/Metrics/AdvancedMattesMutualInformation/itkParzenWindowMutualInformationImageToImageMetric.hxx
+++ b/Components/Metrics/AdvancedMattesMutualInformation/itkParzenWindowMutualInformationImageToImageMetric.hxx
@@ -154,7 +154,7 @@ ParzenWindowMutualInformationImageToImageMetric<TFixedImage, TMovingImage>::GetV
   /** Initialize some variables. */
   value = NumericTraits<MeasureType>::Zero;
   derivative = DerivativeType(this->GetNumberOfParameters());
-  derivative.Fill(NumericTraits<double>::ZeroValue());
+  derivative.Fill(0.0);
 
   /** Construct the JointPDF, JointPDFDerivatives, Alpha and its derivatives. */
   this->ComputePDFsAndPDFDerivatives(parameters);
@@ -289,7 +289,7 @@ ParzenWindowMutualInformationImageToImageMetric<TFixedImage, TMovingImage>::Comp
   NonZeroJacobianIndicesType   nzji = NonZeroJacobianIndicesType(nnzji);
   DerivativeType               imageJacobian(nzji.size());
   TransformJacobianType        jacobian;
-  derivative.Fill(NumericTraits<double>::ZeroValue());
+  derivative.Fill(0.0);
 
   /** Declare and allocate arrays for Jacobian preconditioning. */
   DerivativeType jacobianPreconditioner, preconditioningDivisor;
@@ -834,7 +834,7 @@ ParzenWindowMutualInformationImageToImageMetric<TFixedImage, TMovingImage>::GetV
   /** Initialize some variables. */
   value = NumericTraits<MeasureType>::Zero;
   derivative = DerivativeType(this->GetNumberOfParameters());
-  derivative.Fill(NumericTraits<double>::ZeroValue());
+  derivative.Fill(0.0);
 
   /** Construct the JointPDF, JointPDFDerivatives, Alpha and its derivatives. */
   this->ComputePDFsAndIncrementalPDFs(parameters);

--- a/Components/Metrics/NormalizedMutualInformation/itkParzenWindowNormalizedMutualInformationImageToImageMetric.hxx
+++ b/Components/Metrics/NormalizedMutualInformation/itkParzenWindowNormalizedMutualInformationImageToImageMetric.hxx
@@ -180,7 +180,7 @@ ParzenWindowNormalizedMutualInformationImageToImageMetric<TFixedImage, TMovingIm
   /** Initialize some variables */
   value = NumericTraits<MeasureType>::Zero;
   derivative = DerivativeType(this->GetNumberOfParameters());
-  derivative.Fill(NumericTraits<double>::ZeroValue());
+  derivative.Fill(0.0);
 
   /** Construct the JointPDF, JointPDFDerivatives, and Alpha. */
   this->ComputePDFsAndPDFDerivatives(parameters);

--- a/Components/Metrics/RigidityPenalty/itkTransformRigidityPenaltyTerm.hxx
+++ b/Components/Metrics/RigidityPenalty/itkTransformRigidityPenaltyTerm.hxx
@@ -1959,7 +1959,7 @@ TransformRigidityPenaltyTerm<TFixedImage, TScalarType>::Create1DOperator(
 {
   /** Create an operator size and set it in the operator. */
   NeighborhoodSizeType r;
-  r.Fill(NumericTraits<unsigned int>::ZeroValue());
+  r.Fill(0U);
   r[WhichDimension - 1] = 1;
   F.SetRadius(r);
 

--- a/Components/Metrics/SumOfPairwiseCorrelationsMetric/itkSumOfPairwiseCorrelationCoefficientsMetric.hxx
+++ b/Components/Metrics/SumOfPairwiseCorrelationsMetric/itkSumOfPairwiseCorrelationCoefficientsMetric.hxx
@@ -355,7 +355,7 @@ SumOfPairwiseCorrelationCoefficientsMetric<TFixedImage, TMovingImage>::GetValueA
   unsigned int pixelIndex = 0;
 
   /** Initialize image sample matrix . */
-  datablock.fill(itk::NumericTraits<double>::Zero);
+  datablock.fill(0.0);
 
   for (fiter = fbegin; fiter != fend; ++fiter)
   {

--- a/Components/Transforms/BSplineDeformableTransformWithDiffusion/elxBSplineTransformWithDiffusion.hxx
+++ b/Components/Transforms/BSplineDeformableTransformWithDiffusion/elxBSplineTransformWithDiffusion.hxx
@@ -355,7 +355,7 @@ BSplineTransformWithDiffusion<TElastix>::BeforeRegistration()
   }
 
   /** Get the default pixel value. */
-  float defaultPixelValueForGVI = itk::NumericTraits<float>::Zero;
+  float defaultPixelValueForGVI = 0.0f;
   if (this->m_UseMovingSegmentation && !this->m_ThresholdBool)
   {
     this->m_Configuration->ReadParameter(defaultPixelValueForGVI, "DefaultPixelValueForGVI", 0);

--- a/Components/Transforms/BSplineDeformableTransformWithDiffusion/itkVectorMeanDiffusionImageFilter.hxx
+++ b/Components/Transforms/BSplineDeformableTransformWithDiffusion/itkVectorMeanDiffusionImageFilter.hxx
@@ -222,7 +222,7 @@ VectorMeanDiffusionImageFilter<TInputImage, TGrayValueImage>::GenerateData()
         /** Initialize the sum to 0. */
         for (j = 0; j < InputImageDimension; ++j)
         {
-          sum[j] = NumericTraits<double>::Zero;
+          sum[j] = 0.0;
         }
 
         /** Initialize sumc. */

--- a/Core/ComponentBaseClasses/elxResamplerBase.hxx
+++ b/Core/ComponentBaseClasses/elxResamplerBase.hxx
@@ -665,7 +665,7 @@ ResamplerBase<TElastix>::ReadFromFile()
   /** Set the DefaultPixelValue (for pixels in the resampled image
    * that come from outside the original (moving) image.
    */
-  double defaultPixelValue = itk::NumericTraits<double>::Zero;
+  double defaultPixelValue = 0.0;
   bool   found = this->m_Configuration->ReadParameter(defaultPixelValue, "DefaultPixelValue", 0, false);
 
   if (found)


### PR DESCRIPTION
Follow-up to the merged pull request https://github.com/InsightSoftwareConsortium/ITK/pull/3146 "STYLE: Replace `NumericTraits<double>::ZeroValue()` and `NumericTraits<double>::OneValue()` calls by `0.0` and `1.0`, respectively"