### PR TITLE
BUG: Convert elastix "RecursiveBSplineTransform" to ITK BSplineTransform

### DIFF
--- a/Common/Transforms/elxTransformIO.cxx
+++ b/Common/Transforms/elxTransformIO.cxx
@@ -111,7 +111,7 @@ elastix::TransformIO::ConvertItkTransformBaseToSingleItkTransform(const itk::Tra
     {
       return "AffineTransform";
     }
-    if (name == "AdvancedBSplineDeformableTransform")
+    if (name == "AdvancedBSplineDeformableTransform" || name == "RecursiveBSplineTransform")
     {
       return "BSplineTransform";
     }

--- a/Core/Main/GTesting/itkElastixRegistrationMethodGTest.cxx
+++ b/Core/Main/GTesting/itkElastixRegistrationMethodGTest.cxx
@@ -568,6 +568,7 @@ GTEST_TEST(itkElastixRegistrationMethod, WriteCompositeTransform)
          { NameAndItkTransform{ "AffineTransform", itk::AffineTransform<double, ImageDimension>::New() },
            NameAndItkTransform{ "BSplineTransform", itk::BSplineTransform<double, ImageDimension>::New() },
            NameAndItkTransform{ "EulerTransform", itk::Euler2DTransform<>::New() },
+           NameAndItkTransform{ "RecursiveBSplineTransform", itk::BSplineTransform<double, ImageDimension>::New() },
            NameAndItkTransform{ "SimilarityTransform", itk::Similarity2DTransform<>::New() },
            NameAndItkTransform{ "TranslationTransform", itk::TranslationTransform<double, ImageDimension>::New() } })
     {


### PR DESCRIPTION
Allows writing a composite transform from elastix to ITK, when it contains an elastix "RecursiveBSplineTransform".