### PR TITLE
STYLE: Fill `newScales` variables by one, directly during initialization

### DIFF
--- a/Components/Transforms/AdvancedBSplineTransform/elxAdvancedBSplineTransform.hxx
+++ b/Components/Transforms/AdvancedBSplineTransform/elxAdvancedBSplineTransform.hxx
@@ -506,9 +506,8 @@ AdvancedBSplineTransform<TElastix>::SetOptimizerScales(const unsigned int edgeWi
   /** Define new scales. */
   const NumberOfParametersType numberOfParameters = this->m_BSplineTransform->GetNumberOfParameters();
   const unsigned long          offset = numberOfParameters / SpaceDimension;
-  ScalesType                   newScales(numberOfParameters);
-  newScales.Fill(itk::NumericTraits<ScalesValueType>::OneValue());
-  const ScalesValueType infScale = 10000.0;
+  ScalesType                   newScales(numberOfParameters, ScalesValueType{ 1.0 });
+  const ScalesValueType        infScale = 10000.0;
 
   if (edgeWidth == 0)
   {

--- a/Components/Transforms/BSplineStackTransform/elxBSplineStackTransform.hxx
+++ b/Components/Transforms/BSplineStackTransform/elxBSplineStackTransform.hxx
@@ -532,9 +532,8 @@ BSplineStackTransform<TElastix>::SetOptimizerScales(const unsigned int edgeWidth
   /** Define new scales. */
   const NumberOfParametersType numberOfParameters = this->m_DummySubTransform->GetNumberOfParameters();
   const unsigned long          offset = numberOfParameters / SpaceDimension;
-  ScalesType                   newScales(numberOfParameters);
-  newScales.Fill(itk::NumericTraits<ScalesValueType>::OneValue());
-  const ScalesValueType infScale = 10000.0;
+  ScalesType                   newScales(numberOfParameters, ScalesValueType{ 1.0 });
+  const ScalesValueType        infScale = 10000.0;
 
   if (edgeWidth == 0)
   {

--- a/Components/Transforms/MultiBSplineTransformWithNormal/elxMultiBSplineTransformWithNormal.hxx
+++ b/Components/Transforms/MultiBSplineTransformWithNormal/elxMultiBSplineTransformWithNormal.hxx
@@ -625,10 +625,9 @@ MultiBSplineTransformWithNormal<TElastix>::SetOptimizerScales(const unsigned int
   using ScalesValueType = typename ScalesType::ValueType;
 
   /** Define new scales. */
-  const unsigned long numberOfParameters = this->m_MultiBSplineTransformWithNormal->GetNumberOfParameters();
-  const unsigned long offset = numberOfParameters / SpaceDimension;
-  ScalesType          newScales(numberOfParameters);
-  newScales.Fill(itk::NumericTraits<ScalesValueType>::OneValue());
+  const unsigned long   numberOfParameters = this->m_MultiBSplineTransformWithNormal->GetNumberOfParameters();
+  const unsigned long   offset = numberOfParameters / SpaceDimension;
+  ScalesType            newScales(numberOfParameters, ScalesValueType{ 1.0 });
   const ScalesValueType infScale = 10000.0;
 
   if (edgeWidth == 0)

--- a/Components/Transforms/RecursiveBSplineTransform/elxRecursiveBSplineTransform.hxx
+++ b/Components/Transforms/RecursiveBSplineTransform/elxRecursiveBSplineTransform.hxx
@@ -482,9 +482,8 @@ RecursiveBSplineTransform<TElastix>::SetOptimizerScales(const unsigned int edgeW
   /** Define new scales. */
   const NumberOfParametersType numberOfParameters = this->m_BSplineTransform->GetNumberOfParameters();
   const unsigned long          offset = numberOfParameters / SpaceDimension;
-  ScalesType                   newScales(numberOfParameters);
-  newScales.Fill(itk::NumericTraits<ScalesValueType>::One);
-  const ScalesValueType infScale = 10000.0;
+  ScalesType                   newScales(numberOfParameters, ScalesValueType{ 1.0 });
+  const ScalesValueType        infScale = 10000.0;
 
   if (edgeWidth == 0)
   {


### PR DESCRIPTION
Using the `OptimizerParameters(const SizeValueType dimension, const ValueType & value)` constructor, which was added to ITK with pull request https://github.com/InsightSoftwareConsortium/ITK/pull/2248 commit  https://github.com/InsightSoftwareConsortium/ITK/commit/73ce4ca9dd73498a7f8de4d9aca3b72b1f8b59fe (merged on 11 January 2021).