### PR TITLE
ENH: Add ITK I/O support to BSplineStackTransform spline order 1 and 2

### DIFF
--- a/Common/Transforms/elxTransformFactoryRegistration.cxx
+++ b/Common/Transforms/elxTransformFactoryRegistration.cxx
@@ -67,6 +67,14 @@ using ItkBSplineTransformOrder1Type = itk::BSplineTransform<double, NDimension, 
 template <unsigned int NDimension>
 using ItkBSplineTransformOrder2Type = itk::BSplineTransform<double, NDimension, 2>;
 
+template <unsigned int NDimension>
+using ItBSplineStackTransformOrder1Type = itk::BSplineStackTransform<NDimension, 1>;
+template <unsigned int NDimension>
+using ItBSplineStackTransformOrder2Type = itk::BSplineStackTransform<NDimension, 2>;
+template <unsigned int NDimension>
+using ItBSplineStackTransformOrder3Type = itk::BSplineStackTransform<NDimension, 3>;
+
+
 } // namespace
 
 namespace elastix
@@ -78,7 +86,9 @@ TransformFactoryRegistration::RegisterTransforms()
   const static EmptyStruct emptyStruct = (::RegisterTransforms<ItkBSplineTransformOrder1Type,
                                                                ItkBSplineTransformOrder2Type,
                                                                itk::AffineLogStackTransform,
-                                                               itk::BSplineStackTransform,
+                                                               ItBSplineStackTransformOrder1Type,
+                                                               ItBSplineStackTransformOrder2Type,
+                                                               ItBSplineStackTransformOrder3Type,
                                                                itk::EulerStackTransform,
                                                                itk::TranslationStackTransform>(),
                                           EmptyStruct());

--- a/Components/Transforms/BSplineStackTransform/elxBSplineStackTransform.h
+++ b/Components/Transforms/BSplineStackTransform/elxBSplineStackTransform.h
@@ -281,10 +281,10 @@ private:
   operator=(const Self &) = delete;
 
   /** Typedef for stack transform. */
-  using StackTransformType = itk::BSplineStackTransform<SpaceDimension>;
+  using AbstractStackTransformType = itk::AbstractBSplineStackTransform<SpaceDimension>;
 
   /** The B-spline stack transform. */
-  const typename StackTransformType::Pointer m_StackTransform{ StackTransformType::New() };
+  typename AbstractStackTransformType::Pointer m_StackTransform;
 
   /** Dummy sub transform to be used to set sub transforms of stack transform. */
   ReducedDimensionBSplineTransformBasePointer m_DummySubTransform;

--- a/Core/Main/GTesting/itkTransformixFilterGTest.cxx
+++ b/Core/Main/GTesting/itkTransformixFilterGTest.cxx
@@ -855,3 +855,40 @@ GTEST_TEST(itkTransformixFilter, OutputEqualsRegistrationOutputForStackTransform
     }
   }
 }
+
+
+GTEST_TEST(itkTransformixFilter, OutputEqualsRegistrationOutputForBSplineStackTransform)
+{
+  using PixelType = float;
+  enum
+  {
+    ImageDimension = 3,
+    imageSizeX = 5,
+    imageSizeY = 6,
+    imageSizeZ = 4
+  };
+
+  const auto image =
+    CreateImageFilledWithSequenceOfNaturalNumbers<PixelType, ImageDimension>({ imageSizeX, imageSizeY, imageSizeZ });
+  const std::string transformName = "BSplineStackTransform";
+  for (const unsigned splineOrder : { 1, 2, 3 })
+  {
+    for (const std::string fileNameExtension : { "", "h5", "tfm" })
+    {
+      Expect_Transformix_output_equals_registration_output_from_file(
+        *this,
+        "SplineOrder=" + std::to_string(splineOrder) + (fileNameExtension.empty() ? "" : ('_' + fileNameExtension)),
+        *image,
+        *image,
+        ParameterMapType{ // Parameters in alphabetic order:
+                          { "AutomaticTransformInitialization", { "false" } },
+                          { "BSplineTransformSplineOrder", { std::to_string(splineOrder) } },
+                          { "ImageSampler", { "Full" } },
+                          { "MaximumNumberOfIterations", { "2" } },
+                          { "Metric", { "VarianceOverLastDimensionMetric" } },
+                          { "Optimizer", { "AdaptiveStochasticGradientDescent" } },
+                          { "ITKTransformOutputFileNameExtension", { fileNameExtension } },
+                          { "Transform", { transformName } } });
+    }
+  }
+}


### PR DESCRIPTION
By appending the spline order to the transform name, just like ITK's `BSplineTransform<TParametersValueType, NDimensions, VSplineOrder>::GetTransformTypeAsString()` at https://github.com/InsightSoftwareConsortium/ITK/blob/v5.2.0/Modules/Core/Transform/include/itkBSplineTransform.hxx#L69-L80