### PR TITLE
PERF: Make Jacobian variable in AdvancedTransform Evaluate thread-local

### DIFF
--- a/Common/CostFunctions/itkAdvancedImageToImageMetric.h
+++ b/Common/CostFunctions/itkAdvancedImageToImageMetric.h
@@ -550,7 +550,7 @@ protected:
    * the transform. It returns true if so, and false otherwise.
    */
   virtual bool
-  TransformPoint(const FixedImagePointType & fixedImagePoint, MovingImagePointType & mappedPoint) const;
+  TransformPoint(const FixedImagePointType & fixedImagePoint, MovingImagePointType & mappedPoint) const final;
 
   /** This function returns a reference to the transform Jacobians.
    * This is either a reference to the full TransformJacobian or


### PR DESCRIPTION
Declared the local Jacobian variable within `AdvancedTransform::EvaluateJacobianWithImageGradientProduct` thread-local, as its repetitive creation and destruction appeared to be a major performance bottleneck.

The number of elements of the Jacobian variable depends on the specific (derived) run-time type of the transform:

    4 elements with AdvancedTranslationTransform<double,2>
    6 elements with AdvancedTranslationTransform<double,3>
    6 elements with EulerTransform<double,2>
    18 elements with EulerTransform<double,3>
    36 elements with AdvancedMatrixOffsetTransformBase<double,3,3>

With this commit, the GoogleTest unit test `itkElastixRegistrationMethod.EulerDiscRotation2D` appears to run almost twice as fast (from ~2.5 seconds to ~1.5 second, on GitHub Actions Windows-2109)