### PR TITLE
BUG: Revert making `AdvancedImageToImageMetric::TransformPoint` final

### DIFF
--- a/Common/CostFunctions/itkAdvancedImageToImageMetric.h
+++ b/Common/CostFunctions/itkAdvancedImageToImageMetric.h
@@ -550,7 +550,7 @@ protected:
    * the transform. It returns true if so, and false otherwise.
    */
   virtual bool
-  TransformPoint(const FixedImagePointType & fixedImagePoint, MovingImagePointType & mappedPoint) const final;
+  TransformPoint(const FixedImagePointType & fixedImagePoint, MovingImagePointType & mappedPoint) const;
 
   /** This function returns a reference to the transform Jacobians.
    * This is either a reference to the full TransformJacobian or


### PR DESCRIPTION
This reverts commit 63227d6ef640cde96de02358c5e78fb87b83a7c0 which was only meant for a local experiment, and was accidentally committed.

So pull request https://github.com/SuperElastix/elastix/pull/604/ "PERF: Make Jacobian variable in AdvancedTransform Evaluate thread-local" had the wrong code change, eventually!