### PR TITLE
PERF: Make Jacobian variable in AdvancedTransform thread-local (2nd try)

### DIFF
--- a/Common/Transforms/itkAdvancedTransform.hxx
+++ b/Common/Transforms/itkAdvancedTransform.hxx
@@ -79,8 +79,9 @@ AdvancedTransform<TScalarType, NInputDimensions, NOutputDimensions>::EvaluateJac
   DerivativeType &                imageJacobian,
   NonZeroJacobianIndicesType &    nonZeroJacobianIndices) const
 {
-  /** Obtain the Jacobian. */
-  JacobianType jacobian; //( SpaceDimension, );
+  /** Obtain the Jacobian. Using thread-local storage, so that both the allocation and the deallocation of the internal
+   * data occurs only once per thread, as it has appeared as a major performance bottleneck. */
+  thread_local JacobianType jacobian;
   this->GetJacobian(ipp, jacobian, nonZeroJacobianIndices);
 
   /** Perform a full multiplication. */


### PR DESCRIPTION
Declared the local Jacobian variable within `AdvancedTransform::EvaluateJacobianWithImageGradientProduct` thread-local, as its repetitive creation and destruction appeared to be a major performance bottleneck.

The number of elements of the Jacobian variable depends on the specific (derived) run-time type of the transform:

    4 elements with AdvancedTranslationTransform<double,2>
    6 elements with AdvancedTranslationTransform<double,3>
    6 elements with EulerTransform<double,2>
    18 elements with EulerTransform<double,3>
    36 elements with AdvancedMatrixOffsetTransformBase<double,3,3>

With this commit, the GoogleTest unit test `itkElastixRegistrationMethod.EulerDiscRotation2D` appears to run almost twice as fast (from ~2.5 seconds to ~1.5 second, on GitHub Actions Windows-2109)