### PR TITLE
PERF: Set MaximumNumberOfIterations = 2 in GoogleTest `ElastixLib.TransformParametersAreZeroWhenFixedImageIsMovingImage`

### DIFF
--- a/Core/Main/GTesting/ElastixLibGTest.cxx
+++ b/Core/Main/GTesting/ElastixLibGTest.cxx
@@ -209,6 +209,7 @@ GTEST_TEST(ElastixLib, TransformParametersAreZeroWhenFixedImageIsMovingImage)
     const auto parameterMap =
       CreateParameterMap<Dimension>({ { "ImageSampler", "Full" },
                                       { "FixedInternalImagePixelType", GetPixelTypeName<PixelType>() },
+                                      { "MaximumNumberOfIterations", "2" },
                                       { "Metric", "AdvancedNormalizedCorrelation" },
                                       { "MovingInternalImagePixelType", GetPixelTypeName<PixelType>() },
                                       { "Optimizer", "AdaptiveStochasticGradientDescent" },


### PR DESCRIPTION
Two optimization iterations appear sufficient to check that the `TransformParameters` are all zero, when the fixed is equal to the moving image.

Reduced the duration of GoogleTest unit test `ElastixLib.TransformParametersAreZeroWhenFixedImageIsMovingImage`, from more than 1500 ms down to less than 500 ms (locally, VS2019 Debug build).