### PR TITLE
Remove `ConfigurationType` and `ObjectType` typedefs, and `using <superclass>::ConfigurationPointer` declarations

### DIFF
--- a/Components/FixedImagePyramids/FixedGenericPyramid/elxFixedGenericPyramid.h
+++ b/Components/FixedImagePyramids/FixedGenericPyramid/elxFixedGenericPyramid.h
@@ -108,7 +108,6 @@ public:
   /** Typedefs inherited from Elastix. */
   using typename Superclass2::ElastixType;
   using typename Superclass2::ElastixPointer;
-  using typename Superclass2::ConfigurationType;
   using typename Superclass2::ConfigurationPointer;
   using typename Superclass2::RegistrationType;
   using typename Superclass2::RegistrationPointer;

--- a/Components/FixedImagePyramids/FixedGenericPyramid/elxFixedGenericPyramid.h
+++ b/Components/FixedImagePyramids/FixedGenericPyramid/elxFixedGenericPyramid.h
@@ -108,7 +108,6 @@ public:
   /** Typedefs inherited from Elastix. */
   using typename Superclass2::ElastixType;
   using typename Superclass2::ElastixPointer;
-  using typename Superclass2::ConfigurationPointer;
   using typename Superclass2::RegistrationType;
   using typename Superclass2::RegistrationPointer;
   using ITKBaseType = typename Superclass2::ITKBaseType;

--- a/Components/FixedImagePyramids/FixedRecursivePyramid/elxFixedRecursivePyramid.h
+++ b/Components/FixedImagePyramids/FixedRecursivePyramid/elxFixedRecursivePyramid.h
@@ -77,7 +77,6 @@ public:
   /** Typedefs inherited from Elastix. */
   using typename Superclass2::ElastixType;
   using typename Superclass2::ElastixPointer;
-  using typename Superclass2::ConfigurationType;
   using typename Superclass2::ConfigurationPointer;
   using typename Superclass2::RegistrationType;
   using typename Superclass2::RegistrationPointer;

--- a/Components/FixedImagePyramids/FixedRecursivePyramid/elxFixedRecursivePyramid.h
+++ b/Components/FixedImagePyramids/FixedRecursivePyramid/elxFixedRecursivePyramid.h
@@ -77,7 +77,6 @@ public:
   /** Typedefs inherited from Elastix. */
   using typename Superclass2::ElastixType;
   using typename Superclass2::ElastixPointer;
-  using typename Superclass2::ConfigurationPointer;
   using typename Superclass2::RegistrationType;
   using typename Superclass2::RegistrationPointer;
   using ITKBaseType = typename Superclass2::ITKBaseType;

--- a/Components/FixedImagePyramids/FixedShrinkingPyramid/elxFixedShrinkingPyramid.h
+++ b/Components/FixedImagePyramids/FixedShrinkingPyramid/elxFixedShrinkingPyramid.h
@@ -77,7 +77,6 @@ public:
   /** Typedefs inherited from Elastix. */
   using typename Superclass2::ElastixType;
   using typename Superclass2::ElastixPointer;
-  using typename Superclass2::ConfigurationType;
   using typename Superclass2::ConfigurationPointer;
   using typename Superclass2::RegistrationType;
   using typename Superclass2::RegistrationPointer;

--- a/Components/FixedImagePyramids/FixedShrinkingPyramid/elxFixedShrinkingPyramid.h
+++ b/Components/FixedImagePyramids/FixedShrinkingPyramid/elxFixedShrinkingPyramid.h
@@ -77,7 +77,6 @@ public:
   /** Typedefs inherited from Elastix. */
   using typename Superclass2::ElastixType;
   using typename Superclass2::ElastixPointer;
-  using typename Superclass2::ConfigurationPointer;
   using typename Superclass2::RegistrationType;
   using typename Superclass2::RegistrationPointer;
   using ITKBaseType = typename Superclass2::ITKBaseType;

--- a/Components/FixedImagePyramids/FixedSmoothingPyramid/elxFixedSmoothingPyramid.h
+++ b/Components/FixedImagePyramids/FixedSmoothingPyramid/elxFixedSmoothingPyramid.h
@@ -78,7 +78,6 @@ public:
   /** Typedefs inherited from Elastix. */
   using typename Superclass2::ElastixType;
   using typename Superclass2::ElastixPointer;
-  using typename Superclass2::ConfigurationType;
   using typename Superclass2::ConfigurationPointer;
   using typename Superclass2::RegistrationType;
   using typename Superclass2::RegistrationPointer;

--- a/Components/FixedImagePyramids/FixedSmoothingPyramid/elxFixedSmoothingPyramid.h
+++ b/Components/FixedImagePyramids/FixedSmoothingPyramid/elxFixedSmoothingPyramid.h
@@ -78,7 +78,6 @@ public:
   /** Typedefs inherited from Elastix. */
   using typename Superclass2::ElastixType;
   using typename Superclass2::ElastixPointer;
-  using typename Superclass2::ConfigurationPointer;
   using typename Superclass2::RegistrationType;
   using typename Superclass2::RegistrationPointer;
   using ITKBaseType = typename Superclass2::ITKBaseType;

--- a/Components/ImageSamplers/Full/elxFullSampler.h
+++ b/Components/ImageSamplers/Full/elxFullSampler.h
@@ -86,7 +86,6 @@ public:
   /** Typedefs inherited from Elastix. */
   using typename Superclass2::ElastixType;
   using typename Superclass2::ElastixPointer;
-  using typename Superclass2::ConfigurationType;
   using typename Superclass2::ConfigurationPointer;
   using typename Superclass2::RegistrationType;
   using typename Superclass2::RegistrationPointer;

--- a/Components/ImageSamplers/Full/elxFullSampler.h
+++ b/Components/ImageSamplers/Full/elxFullSampler.h
@@ -86,7 +86,6 @@ public:
   /** Typedefs inherited from Elastix. */
   using typename Superclass2::ElastixType;
   using typename Superclass2::ElastixPointer;
-  using typename Superclass2::ConfigurationPointer;
   using typename Superclass2::RegistrationType;
   using typename Superclass2::RegistrationPointer;
   using ITKBaseType = typename Superclass2::ITKBaseType;

--- a/Components/ImageSamplers/Grid/elxGridSampler.h
+++ b/Components/ImageSamplers/Grid/elxGridSampler.h
@@ -93,7 +93,6 @@ public:
   /** Typedefs inherited from Elastix. */
   using typename Superclass2::ElastixType;
   using typename Superclass2::ElastixPointer;
-  using typename Superclass2::ConfigurationType;
   using typename Superclass2::ConfigurationPointer;
   using typename Superclass2::RegistrationType;
   using typename Superclass2::RegistrationPointer;

--- a/Components/ImageSamplers/Grid/elxGridSampler.h
+++ b/Components/ImageSamplers/Grid/elxGridSampler.h
@@ -93,7 +93,6 @@ public:
   /** Typedefs inherited from Elastix. */
   using typename Superclass2::ElastixType;
   using typename Superclass2::ElastixPointer;
-  using typename Superclass2::ConfigurationPointer;
   using typename Superclass2::RegistrationType;
   using typename Superclass2::RegistrationPointer;
   using ITKBaseType = typename Superclass2::ITKBaseType;

--- a/Components/ImageSamplers/MultInputRandomCoordinate/elxMultiInputRandomCoordinateSampler.h
+++ b/Components/ImageSamplers/MultInputRandomCoordinate/elxMultiInputRandomCoordinateSampler.h
@@ -137,7 +137,6 @@ public:
   /** Typedefs inherited from Elastix. */
   using typename Superclass2::ElastixType;
   using typename Superclass2::ElastixPointer;
-  using typename Superclass2::ConfigurationPointer;
   using typename Superclass2::RegistrationType;
   using typename Superclass2::RegistrationPointer;
   using ITKBaseType = typename Superclass2::ITKBaseType;

--- a/Components/ImageSamplers/MultInputRandomCoordinate/elxMultiInputRandomCoordinateSampler.h
+++ b/Components/ImageSamplers/MultInputRandomCoordinate/elxMultiInputRandomCoordinateSampler.h
@@ -137,7 +137,6 @@ public:
   /** Typedefs inherited from Elastix. */
   using typename Superclass2::ElastixType;
   using typename Superclass2::ElastixPointer;
-  using typename Superclass2::ConfigurationType;
   using typename Superclass2::ConfigurationPointer;
   using typename Superclass2::RegistrationType;
   using typename Superclass2::RegistrationPointer;

--- a/Components/ImageSamplers/Random/elxRandomSampler.h
+++ b/Components/ImageSamplers/Random/elxRandomSampler.h
@@ -94,7 +94,6 @@ public:
   /** Typedefs inherited from Elastix. */
   using typename Superclass2::ElastixType;
   using typename Superclass2::ElastixPointer;
-  using typename Superclass2::ConfigurationType;
   using typename Superclass2::ConfigurationPointer;
   using typename Superclass2::RegistrationType;
   using typename Superclass2::RegistrationPointer;

--- a/Components/ImageSamplers/Random/elxRandomSampler.h
+++ b/Components/ImageSamplers/Random/elxRandomSampler.h
@@ -94,7 +94,6 @@ public:
   /** Typedefs inherited from Elastix. */
   using typename Superclass2::ElastixType;
   using typename Superclass2::ElastixPointer;
-  using typename Superclass2::ConfigurationPointer;
   using typename Superclass2::RegistrationType;
   using typename Superclass2::RegistrationPointer;
   using ITKBaseType = typename Superclass2::ITKBaseType;

--- a/Components/ImageSamplers/RandomCoordinate/elxRandomCoordinateSampler.h
+++ b/Components/ImageSamplers/RandomCoordinate/elxRandomCoordinateSampler.h
@@ -130,7 +130,6 @@ public:
   /** Typedefs inherited from Elastix. */
   using typename Superclass2::ElastixType;
   using typename Superclass2::ElastixPointer;
-  using typename Superclass2::ConfigurationPointer;
   using typename Superclass2::RegistrationType;
   using typename Superclass2::RegistrationPointer;
   using ITKBaseType = typename Superclass2::ITKBaseType;

--- a/Components/ImageSamplers/RandomCoordinate/elxRandomCoordinateSampler.h
+++ b/Components/ImageSamplers/RandomCoordinate/elxRandomCoordinateSampler.h
@@ -130,7 +130,6 @@ public:
   /** Typedefs inherited from Elastix. */
   using typename Superclass2::ElastixType;
   using typename Superclass2::ElastixPointer;
-  using typename Superclass2::ConfigurationType;
   using typename Superclass2::ConfigurationPointer;
   using typename Superclass2::RegistrationType;
   using typename Superclass2::RegistrationPointer;

--- a/Components/ImageSamplers/RandomSparseMask/elxRandomSamplerSparseMask.h
+++ b/Components/ImageSamplers/RandomSparseMask/elxRandomSamplerSparseMask.h
@@ -96,7 +96,6 @@ public:
   /** Typedefs inherited from Elastix. */
   using typename Superclass2::ElastixType;
   using typename Superclass2::ElastixPointer;
-  using typename Superclass2::ConfigurationType;
   using typename Superclass2::ConfigurationPointer;
   using typename Superclass2::RegistrationType;
   using typename Superclass2::RegistrationPointer;

--- a/Components/ImageSamplers/RandomSparseMask/elxRandomSamplerSparseMask.h
+++ b/Components/ImageSamplers/RandomSparseMask/elxRandomSamplerSparseMask.h
@@ -96,7 +96,6 @@ public:
   /** Typedefs inherited from Elastix. */
   using typename Superclass2::ElastixType;
   using typename Superclass2::ElastixPointer;
-  using typename Superclass2::ConfigurationPointer;
   using typename Superclass2::RegistrationType;
   using typename Superclass2::RegistrationPointer;
   using ITKBaseType = typename Superclass2::ITKBaseType;

--- a/Components/Interpolators/BSplineInterpolator/elxBSplineInterpolator.h
+++ b/Components/Interpolators/BSplineInterpolator/elxBSplineInterpolator.h
@@ -95,7 +95,6 @@ public:
   /** Typedefs inherited from Elastix. */
   using typename Superclass2::ElastixType;
   using typename Superclass2::ElastixPointer;
-  using typename Superclass2::ConfigurationPointer;
   using typename Superclass2::RegistrationType;
   using typename Superclass2::RegistrationPointer;
   using ITKBaseType = typename Superclass2::ITKBaseType;

--- a/Components/Interpolators/BSplineInterpolator/elxBSplineInterpolator.h
+++ b/Components/Interpolators/BSplineInterpolator/elxBSplineInterpolator.h
@@ -95,7 +95,6 @@ public:
   /** Typedefs inherited from Elastix. */
   using typename Superclass2::ElastixType;
   using typename Superclass2::ElastixPointer;
-  using typename Superclass2::ConfigurationType;
   using typename Superclass2::ConfigurationPointer;
   using typename Superclass2::RegistrationType;
   using typename Superclass2::RegistrationPointer;

--- a/Components/Interpolators/BSplineInterpolatorFloat/elxBSplineInterpolatorFloat.h
+++ b/Components/Interpolators/BSplineInterpolatorFloat/elxBSplineInterpolatorFloat.h
@@ -95,7 +95,6 @@ public:
   /** Typedefs inherited from Elastix. */
   using typename Superclass2::ElastixType;
   using typename Superclass2::ElastixPointer;
-  using typename Superclass2::ConfigurationPointer;
   using typename Superclass2::RegistrationType;
   using typename Superclass2::RegistrationPointer;
   using ITKBaseType = typename Superclass2::ITKBaseType;

--- a/Components/Interpolators/BSplineInterpolatorFloat/elxBSplineInterpolatorFloat.h
+++ b/Components/Interpolators/BSplineInterpolatorFloat/elxBSplineInterpolatorFloat.h
@@ -95,7 +95,6 @@ public:
   /** Typedefs inherited from Elastix. */
   using typename Superclass2::ElastixType;
   using typename Superclass2::ElastixPointer;
-  using typename Superclass2::ConfigurationType;
   using typename Superclass2::ConfigurationPointer;
   using typename Superclass2::RegistrationType;
   using typename Superclass2::RegistrationPointer;

--- a/Components/Interpolators/LinearInterpolator/elxLinearInterpolator.h
+++ b/Components/Interpolators/LinearInterpolator/elxLinearInterpolator.h
@@ -80,7 +80,6 @@ public:
   /** Typedefs inherited from Elastix. */
   using typename Superclass2::ElastixType;
   using typename Superclass2::ElastixPointer;
-  using typename Superclass2::ConfigurationType;
   using typename Superclass2::ConfigurationPointer;
   using typename Superclass2::RegistrationType;
   using typename Superclass2::RegistrationPointer;

--- a/Components/Interpolators/LinearInterpolator/elxLinearInterpolator.h
+++ b/Components/Interpolators/LinearInterpolator/elxLinearInterpolator.h
@@ -80,7 +80,6 @@ public:
   /** Typedefs inherited from Elastix. */
   using typename Superclass2::ElastixType;
   using typename Superclass2::ElastixPointer;
-  using typename Superclass2::ConfigurationPointer;
   using typename Superclass2::RegistrationType;
   using typename Superclass2::RegistrationPointer;
   using ITKBaseType = typename Superclass2::ITKBaseType;

--- a/Components/Interpolators/NearestNeighborInterpolator/elxNearestNeighborInterpolator.h
+++ b/Components/Interpolators/NearestNeighborInterpolator/elxNearestNeighborInterpolator.h
@@ -78,7 +78,6 @@ public:
   /** Typedefs inherited from Elastix. */
   using typename Superclass2::ElastixType;
   using typename Superclass2::ElastixPointer;
-  using typename Superclass2::ConfigurationType;
   using typename Superclass2::ConfigurationPointer;
   using typename Superclass2::RegistrationType;
   using typename Superclass2::RegistrationPointer;

--- a/Components/Interpolators/NearestNeighborInterpolator/elxNearestNeighborInterpolator.h
+++ b/Components/Interpolators/NearestNeighborInterpolator/elxNearestNeighborInterpolator.h
@@ -78,7 +78,6 @@ public:
   /** Typedefs inherited from Elastix. */
   using typename Superclass2::ElastixType;
   using typename Superclass2::ElastixPointer;
-  using typename Superclass2::ConfigurationPointer;
   using typename Superclass2::RegistrationType;
   using typename Superclass2::RegistrationPointer;
   using ITKBaseType = typename Superclass2::ITKBaseType;

--- a/Components/Interpolators/RayCastInterpolator/elxRayCastInterpolator.h
+++ b/Components/Interpolators/RayCastInterpolator/elxRayCastInterpolator.h
@@ -82,7 +82,6 @@ public:
   /** Typedefs inherited from Elastix. */
   using typename Superclass2::ElastixType;
   using typename Superclass2::ElastixPointer;
-  using typename Superclass2::ConfigurationPointer;
   using typename Superclass2::RegistrationType;
   using typename Superclass2::RegistrationPointer;
   using ITKBaseType = typename Superclass2::ITKBaseType;

--- a/Components/Interpolators/RayCastInterpolator/elxRayCastInterpolator.h
+++ b/Components/Interpolators/RayCastInterpolator/elxRayCastInterpolator.h
@@ -82,7 +82,6 @@ public:
   /** Typedefs inherited from Elastix. */
   using typename Superclass2::ElastixType;
   using typename Superclass2::ElastixPointer;
-  using typename Superclass2::ConfigurationType;
   using typename Superclass2::ConfigurationPointer;
   using typename Superclass2::RegistrationType;
   using typename Superclass2::RegistrationPointer;

--- a/Components/Interpolators/ReducedDimensionBSplineInterpolator/elxReducedDimensionBSplineInterpolator.h
+++ b/Components/Interpolators/ReducedDimensionBSplineInterpolator/elxReducedDimensionBSplineInterpolator.h
@@ -94,7 +94,6 @@ public:
   /** Typedefs inherited from Elastix. */
   using typename Superclass2::ElastixType;
   using typename Superclass2::ElastixPointer;
-  using typename Superclass2::ConfigurationType;
   using typename Superclass2::ConfigurationPointer;
   using typename Superclass2::RegistrationType;
   using typename Superclass2::RegistrationPointer;

--- a/Components/Interpolators/ReducedDimensionBSplineInterpolator/elxReducedDimensionBSplineInterpolator.h
+++ b/Components/Interpolators/ReducedDimensionBSplineInterpolator/elxReducedDimensionBSplineInterpolator.h
@@ -94,7 +94,6 @@ public:
   /** Typedefs inherited from Elastix. */
   using typename Superclass2::ElastixType;
   using typename Superclass2::ElastixPointer;
-  using typename Superclass2::ConfigurationPointer;
   using typename Superclass2::RegistrationType;
   using typename Superclass2::RegistrationPointer;
   using ITKBaseType = typename Superclass2::ITKBaseType;

--- a/Components/Metrics/AdvancedKappaStatistic/elxAdvancedKappaStatisticMetric.h
+++ b/Components/Metrics/AdvancedKappaStatistic/elxAdvancedKappaStatisticMetric.h
@@ -122,7 +122,6 @@ public:
   /** Typedef's inherited from Elastix. */
   using typename Superclass2::ElastixType;
   using typename Superclass2::ElastixPointer;
-  using typename Superclass2::ConfigurationPointer;
   using typename Superclass2::RegistrationType;
   using typename Superclass2::RegistrationPointer;
   using ITKBaseType = typename Superclass2::ITKBaseType;

--- a/Components/Metrics/AdvancedKappaStatistic/elxAdvancedKappaStatisticMetric.h
+++ b/Components/Metrics/AdvancedKappaStatistic/elxAdvancedKappaStatisticMetric.h
@@ -122,7 +122,6 @@ public:
   /** Typedef's inherited from Elastix. */
   using typename Superclass2::ElastixType;
   using typename Superclass2::ElastixPointer;
-  using typename Superclass2::ConfigurationType;
   using typename Superclass2::ConfigurationPointer;
   using typename Superclass2::RegistrationType;
   using typename Superclass2::RegistrationPointer;

--- a/Components/Metrics/AdvancedMattesMutualInformation/elxAdvancedMattesMutualInformationMetric.h
+++ b/Components/Metrics/AdvancedMattesMutualInformation/elxAdvancedMattesMutualInformationMetric.h
@@ -174,7 +174,6 @@ public:
   /** Typedef's inherited from Elastix. */
   using typename Superclass2::ElastixType;
   using typename Superclass2::ElastixPointer;
-  using typename Superclass2::ConfigurationPointer;
   using typename Superclass2::RegistrationType;
   using typename Superclass2::RegistrationPointer;
   using ITKBaseType = typename Superclass2::ITKBaseType;

--- a/Components/Metrics/AdvancedMattesMutualInformation/elxAdvancedMattesMutualInformationMetric.h
+++ b/Components/Metrics/AdvancedMattesMutualInformation/elxAdvancedMattesMutualInformationMetric.h
@@ -174,7 +174,6 @@ public:
   /** Typedef's inherited from Elastix. */
   using typename Superclass2::ElastixType;
   using typename Superclass2::ElastixPointer;
-  using typename Superclass2::ConfigurationType;
   using typename Superclass2::ConfigurationPointer;
   using typename Superclass2::RegistrationType;
   using typename Superclass2::RegistrationPointer;

--- a/Components/Metrics/AdvancedMeanSquares/elxAdvancedMeanSquaresMetric.h
+++ b/Components/Metrics/AdvancedMeanSquares/elxAdvancedMeanSquaresMetric.h
@@ -118,7 +118,6 @@ public:
   /** Typedef's inherited from Elastix. */
   using typename Superclass2::ElastixType;
   using typename Superclass2::ElastixPointer;
-  using typename Superclass2::ConfigurationPointer;
   using typename Superclass2::RegistrationType;
   using typename Superclass2::RegistrationPointer;
   using ITKBaseType = typename Superclass2::ITKBaseType;

--- a/Components/Metrics/AdvancedMeanSquares/elxAdvancedMeanSquaresMetric.h
+++ b/Components/Metrics/AdvancedMeanSquares/elxAdvancedMeanSquaresMetric.h
@@ -118,7 +118,6 @@ public:
   /** Typedef's inherited from Elastix. */
   using typename Superclass2::ElastixType;
   using typename Superclass2::ElastixPointer;
-  using typename Superclass2::ConfigurationType;
   using typename Superclass2::ConfigurationPointer;
   using typename Superclass2::RegistrationType;
   using typename Superclass2::RegistrationPointer;

--- a/Components/Metrics/AdvancedNormalizedCorrelation/elxAdvancedNormalizedCorrelationMetric.h
+++ b/Components/Metrics/AdvancedNormalizedCorrelation/elxAdvancedNormalizedCorrelationMetric.h
@@ -118,7 +118,6 @@ public:
   /** Typedef's inherited from Elastix. */
   using typename Superclass2::ElastixType;
   using typename Superclass2::ElastixPointer;
-  using typename Superclass2::ConfigurationPointer;
   using typename Superclass2::RegistrationType;
   using typename Superclass2::RegistrationPointer;
   using ITKBaseType = typename Superclass2::ITKBaseType;

--- a/Components/Metrics/AdvancedNormalizedCorrelation/elxAdvancedNormalizedCorrelationMetric.h
+++ b/Components/Metrics/AdvancedNormalizedCorrelation/elxAdvancedNormalizedCorrelationMetric.h
@@ -118,7 +118,6 @@ public:
   /** Typedef's inherited from Elastix. */
   using typename Superclass2::ElastixType;
   using typename Superclass2::ElastixPointer;
-  using typename Superclass2::ConfigurationType;
   using typename Superclass2::ConfigurationPointer;
   using typename Superclass2::RegistrationType;
   using typename Superclass2::RegistrationPointer;

--- a/Components/Metrics/BendingEnergyPenalty/elxTransformBendingEnergyPenaltyTerm.h
+++ b/Components/Metrics/BendingEnergyPenalty/elxTransformBendingEnergyPenaltyTerm.h
@@ -118,7 +118,6 @@ public:
   /** Typedef's inherited from elastix. */
   using typename Superclass2::ElastixType;
   using typename Superclass2::ElastixPointer;
-  using typename Superclass2::ConfigurationPointer;
   using typename Superclass2::RegistrationType;
   using typename Superclass2::RegistrationPointer;
   using ITKBaseType = typename Superclass2::ITKBaseType;

--- a/Components/Metrics/BendingEnergyPenalty/elxTransformBendingEnergyPenaltyTerm.h
+++ b/Components/Metrics/BendingEnergyPenalty/elxTransformBendingEnergyPenaltyTerm.h
@@ -118,7 +118,6 @@ public:
   /** Typedef's inherited from elastix. */
   using typename Superclass2::ElastixType;
   using typename Superclass2::ElastixPointer;
-  using typename Superclass2::ConfigurationType;
   using typename Superclass2::ConfigurationPointer;
   using typename Superclass2::RegistrationType;
   using typename Superclass2::RegistrationPointer;

--- a/Components/Metrics/CorrespondingPointsEuclideanDistanceMetric/elxCorrespondingPointsEuclideanDistanceMetric.h
+++ b/Components/Metrics/CorrespondingPointsEuclideanDistanceMetric/elxCorrespondingPointsEuclideanDistanceMetric.h
@@ -90,7 +90,6 @@ public:
   /** Typedefs inherited from elastix. */
   using typename Superclass2::ElastixType;
   using typename Superclass2::ElastixPointer;
-  using typename Superclass2::ConfigurationPointer;
   using typename Superclass2::RegistrationType;
   using typename Superclass2::RegistrationPointer;
   using ITKBaseType = typename Superclass2::ITKBaseType;

--- a/Components/Metrics/CorrespondingPointsEuclideanDistanceMetric/elxCorrespondingPointsEuclideanDistanceMetric.h
+++ b/Components/Metrics/CorrespondingPointsEuclideanDistanceMetric/elxCorrespondingPointsEuclideanDistanceMetric.h
@@ -90,7 +90,6 @@ public:
   /** Typedefs inherited from elastix. */
   using typename Superclass2::ElastixType;
   using typename Superclass2::ElastixPointer;
-  using typename Superclass2::ConfigurationType;
   using typename Superclass2::ConfigurationPointer;
   using typename Superclass2::RegistrationType;
   using typename Superclass2::RegistrationPointer;

--- a/Components/Metrics/DisplacementMagnitudePenalty/elxDisplacementMagnitudePenalty.h
+++ b/Components/Metrics/DisplacementMagnitudePenalty/elxDisplacementMagnitudePenalty.h
@@ -115,7 +115,6 @@ public:
   /** Typedef's inherited from elastix. */
   using typename Superclass2::ElastixType;
   using typename Superclass2::ElastixPointer;
-  using typename Superclass2::ConfigurationPointer;
   using typename Superclass2::RegistrationType;
   using typename Superclass2::RegistrationPointer;
   using ITKBaseType = typename Superclass2::ITKBaseType;

--- a/Components/Metrics/DisplacementMagnitudePenalty/elxDisplacementMagnitudePenalty.h
+++ b/Components/Metrics/DisplacementMagnitudePenalty/elxDisplacementMagnitudePenalty.h
@@ -115,7 +115,6 @@ public:
   /** Typedef's inherited from elastix. */
   using typename Superclass2::ElastixType;
   using typename Superclass2::ElastixPointer;
-  using typename Superclass2::ConfigurationType;
   using typename Superclass2::ConfigurationPointer;
   using typename Superclass2::RegistrationType;
   using typename Superclass2::RegistrationPointer;

--- a/Components/Metrics/DistancePreservingRigidityPenalty/elxDistancePreservingRigidityPenaltyTerm.h
+++ b/Components/Metrics/DistancePreservingRigidityPenalty/elxDistancePreservingRigidityPenaltyTerm.h
@@ -136,7 +136,6 @@ public:
   /** Typedef's inherited from elastix. */
   using typename Superclass2::ElastixType;
   using typename Superclass2::ElastixPointer;
-  using typename Superclass2::ConfigurationPointer;
   using typename Superclass2::RegistrationType;
   using typename Superclass2::RegistrationPointer;
   using ITKBaseType = typename Superclass2::ITKBaseType;

--- a/Components/Metrics/DistancePreservingRigidityPenalty/elxDistancePreservingRigidityPenaltyTerm.h
+++ b/Components/Metrics/DistancePreservingRigidityPenalty/elxDistancePreservingRigidityPenaltyTerm.h
@@ -136,7 +136,6 @@ public:
   /** Typedef's inherited from elastix. */
   using typename Superclass2::ElastixType;
   using typename Superclass2::ElastixPointer;
-  using typename Superclass2::ConfigurationType;
   using typename Superclass2::ConfigurationPointer;
   using typename Superclass2::RegistrationType;
   using typename Superclass2::RegistrationPointer;

--- a/Components/Metrics/GradientDifference/elxGradientDifferenceMetric.h
+++ b/Components/Metrics/GradientDifference/elxGradientDifferenceMetric.h
@@ -110,7 +110,6 @@ public:
   /** Typedef's inherited from Elastix. */
   using typename Superclass2::ElastixType;
   using typename Superclass2::ElastixPointer;
-  using typename Superclass2::ConfigurationType;
   using typename Superclass2::ConfigurationPointer;
   using typename Superclass2::RegistrationType;
   using typename Superclass2::RegistrationPointer;

--- a/Components/Metrics/GradientDifference/elxGradientDifferenceMetric.h
+++ b/Components/Metrics/GradientDifference/elxGradientDifferenceMetric.h
@@ -110,7 +110,6 @@ public:
   /** Typedef's inherited from Elastix. */
   using typename Superclass2::ElastixType;
   using typename Superclass2::ElastixPointer;
-  using typename Superclass2::ConfigurationPointer;
   using typename Superclass2::RegistrationType;
   using typename Superclass2::RegistrationPointer;
   using ITKBaseType = typename Superclass2::ITKBaseType;

--- a/Components/Metrics/KNNGraphAlphaMutualInformation/elxKNNGraphAlphaMutualInformationMetric.h
+++ b/Components/Metrics/KNNGraphAlphaMutualInformation/elxKNNGraphAlphaMutualInformationMetric.h
@@ -127,7 +127,6 @@ public:
   /** Typedef's inherited from Elastix. */
   using typename Superclass2::ElastixType;
   using typename Superclass2::ElastixPointer;
-  using typename Superclass2::ConfigurationType;
   using typename Superclass2::ConfigurationPointer;
   using typename Superclass2::RegistrationType;
   using typename Superclass2::RegistrationPointer;

--- a/Components/Metrics/KNNGraphAlphaMutualInformation/elxKNNGraphAlphaMutualInformationMetric.h
+++ b/Components/Metrics/KNNGraphAlphaMutualInformation/elxKNNGraphAlphaMutualInformationMetric.h
@@ -127,7 +127,6 @@ public:
   /** Typedef's inherited from Elastix. */
   using typename Superclass2::ElastixType;
   using typename Superclass2::ElastixPointer;
-  using typename Superclass2::ConfigurationPointer;
   using typename Superclass2::RegistrationType;
   using typename Superclass2::RegistrationPointer;
   using ITKBaseType = typename Superclass2::ITKBaseType;

--- a/Components/Metrics/MissingStructurePenalty/elxMissingStructurePenalty.h
+++ b/Components/Metrics/MissingStructurePenalty/elxMissingStructurePenalty.h
@@ -112,9 +112,6 @@ public:
   using CoordRepType = typename OutputPointType::CoordRepType;
 
   using typename Superclass1::MeshIdType;
-  /** Other typedef's. */
-  using ObjectType = itk::Object;
-
   using CombinationTransformType = itk::AdvancedCombinationTransform<CoordRepType, Self::FixedImageDimension>;
   using InitialTransformType = typename CombinationTransformType::InitialTransformType;
 

--- a/Components/Metrics/MissingStructurePenalty/elxMissingStructurePenalty.h
+++ b/Components/Metrics/MissingStructurePenalty/elxMissingStructurePenalty.h
@@ -121,7 +121,6 @@ public:
   /** Typedefs inherited from elastix. */
   using typename Superclass2::ElastixType;
   using typename Superclass2::ElastixPointer;
-  using typename Superclass2::ConfigurationType;
   using typename Superclass2::ConfigurationPointer;
   using typename Superclass2::RegistrationType;
   using typename Superclass2::RegistrationPointer;

--- a/Components/Metrics/MissingStructurePenalty/elxMissingStructurePenalty.h
+++ b/Components/Metrics/MissingStructurePenalty/elxMissingStructurePenalty.h
@@ -118,7 +118,6 @@ public:
   /** Typedefs inherited from elastix. */
   using typename Superclass2::ElastixType;
   using typename Superclass2::ElastixPointer;
-  using typename Superclass2::ConfigurationPointer;
   using typename Superclass2::RegistrationType;
   using typename Superclass2::RegistrationPointer;
   using ITKBaseType = typename Superclass2::ITKBaseType;

--- a/Components/Metrics/NormalizedGradientCorrelation/elxNormalizedGradientCorrelationMetric.h
+++ b/Components/Metrics/NormalizedGradientCorrelation/elxNormalizedGradientCorrelationMetric.h
@@ -111,7 +111,6 @@ public:
   /** Typedef's inherited from Elastix. */
   using typename Superclass2::ElastixType;
   using typename Superclass2::ElastixPointer;
-  using typename Superclass2::ConfigurationType;
   using typename Superclass2::ConfigurationPointer;
   using typename Superclass2::RegistrationType;
   using typename Superclass2::RegistrationPointer;

--- a/Components/Metrics/NormalizedGradientCorrelation/elxNormalizedGradientCorrelationMetric.h
+++ b/Components/Metrics/NormalizedGradientCorrelation/elxNormalizedGradientCorrelationMetric.h
@@ -111,7 +111,6 @@ public:
   /** Typedef's inherited from Elastix. */
   using typename Superclass2::ElastixType;
   using typename Superclass2::ElastixPointer;
-  using typename Superclass2::ConfigurationPointer;
   using typename Superclass2::RegistrationType;
   using typename Superclass2::RegistrationPointer;
   using ITKBaseType = typename Superclass2::ITKBaseType;

--- a/Components/Metrics/NormalizedMutualInformation/elxNormalizedMutualInformationMetric.h
+++ b/Components/Metrics/NormalizedMutualInformation/elxNormalizedMutualInformationMetric.h
@@ -148,7 +148,6 @@ public:
   /** Typedef's inherited from Elastix. */
   using typename Superclass2::ElastixType;
   using typename Superclass2::ElastixPointer;
-  using typename Superclass2::ConfigurationPointer;
   using typename Superclass2::RegistrationType;
   using typename Superclass2::RegistrationPointer;
   using ITKBaseType = typename Superclass2::ITKBaseType;

--- a/Components/Metrics/NormalizedMutualInformation/elxNormalizedMutualInformationMetric.h
+++ b/Components/Metrics/NormalizedMutualInformation/elxNormalizedMutualInformationMetric.h
@@ -148,7 +148,6 @@ public:
   /** Typedef's inherited from Elastix. */
   using typename Superclass2::ElastixType;
   using typename Superclass2::ElastixPointer;
-  using typename Superclass2::ConfigurationType;
   using typename Superclass2::ConfigurationPointer;
   using typename Superclass2::RegistrationType;
   using typename Superclass2::RegistrationPointer;

--- a/Components/Metrics/PCAMetric/elxPCAMetric.h
+++ b/Components/Metrics/PCAMetric/elxPCAMetric.h
@@ -137,7 +137,6 @@ public:
   /** Typedef's inherited from Elastix. */
   using typename Superclass2::ElastixType;
   using typename Superclass2::ElastixPointer;
-  using typename Superclass2::ConfigurationType;
   using typename Superclass2::ConfigurationPointer;
   using typename Superclass2::RegistrationType;
   using typename Superclass2::RegistrationPointer;

--- a/Components/Metrics/PCAMetric/elxPCAMetric.h
+++ b/Components/Metrics/PCAMetric/elxPCAMetric.h
@@ -137,7 +137,6 @@ public:
   /** Typedef's inherited from Elastix. */
   using typename Superclass2::ElastixType;
   using typename Superclass2::ElastixPointer;
-  using typename Superclass2::ConfigurationPointer;
   using typename Superclass2::RegistrationType;
   using typename Superclass2::RegistrationPointer;
   using ITKBaseType = typename Superclass2::ITKBaseType;

--- a/Components/Metrics/PCAMetric2/elxPCAMetric2.h
+++ b/Components/Metrics/PCAMetric2/elxPCAMetric2.h
@@ -138,7 +138,6 @@ public:
   /** Typedef's inherited from Elastix. */
   using typename Superclass2::ElastixType;
   using typename Superclass2::ElastixPointer;
-  using typename Superclass2::ConfigurationPointer;
   using typename Superclass2::RegistrationType;
   using typename Superclass2::RegistrationPointer;
   using ITKBaseType = typename Superclass2::ITKBaseType;

--- a/Components/Metrics/PCAMetric2/elxPCAMetric2.h
+++ b/Components/Metrics/PCAMetric2/elxPCAMetric2.h
@@ -138,7 +138,6 @@ public:
   /** Typedef's inherited from Elastix. */
   using typename Superclass2::ElastixType;
   using typename Superclass2::ElastixPointer;
-  using typename Superclass2::ConfigurationType;
   using typename Superclass2::ConfigurationPointer;
   using typename Superclass2::RegistrationType;
   using typename Superclass2::RegistrationPointer;

--- a/Components/Metrics/PatternIntensity/elxPatternIntensityMetric.h
+++ b/Components/Metrics/PatternIntensity/elxPatternIntensityMetric.h
@@ -110,7 +110,6 @@ public:
   /** Typedef's inherited from Elastix. */
   using typename Superclass2::ElastixType;
   using typename Superclass2::ElastixPointer;
-  using typename Superclass2::ConfigurationType;
   using typename Superclass2::ConfigurationPointer;
   using typename Superclass2::RegistrationType;
   using typename Superclass2::RegistrationPointer;

--- a/Components/Metrics/PatternIntensity/elxPatternIntensityMetric.h
+++ b/Components/Metrics/PatternIntensity/elxPatternIntensityMetric.h
@@ -110,7 +110,6 @@ public:
   /** Typedef's inherited from Elastix. */
   using typename Superclass2::ElastixType;
   using typename Superclass2::ElastixPointer;
-  using typename Superclass2::ConfigurationPointer;
   using typename Superclass2::RegistrationType;
   using typename Superclass2::RegistrationPointer;
   using ITKBaseType = typename Superclass2::ITKBaseType;

--- a/Components/Metrics/PolydataDummyPenalty/elxPolydataDummyPenalty.h
+++ b/Components/Metrics/PolydataDummyPenalty/elxPolydataDummyPenalty.h
@@ -135,7 +135,6 @@ public:
   /** Typedefs inherited from elastix. */
   using typename Superclass2::ElastixType;
   using typename Superclass2::ElastixPointer;
-  using typename Superclass2::ConfigurationType;
   using typename Superclass2::ConfigurationPointer;
   using typename Superclass2::RegistrationType;
   using typename Superclass2::RegistrationPointer;

--- a/Components/Metrics/PolydataDummyPenalty/elxPolydataDummyPenalty.h
+++ b/Components/Metrics/PolydataDummyPenalty/elxPolydataDummyPenalty.h
@@ -123,7 +123,6 @@ public:
 
   using typename Superclass1::MeshIdType;
   /** Other typedef's. */
-  using ObjectType = itk::Object;
   /*typedef itk::AdvancedTransform<
   CoordRepType,
   itkGetStaticConstMacro( FixedImageDimension ),

--- a/Components/Metrics/PolydataDummyPenalty/elxPolydataDummyPenalty.h
+++ b/Components/Metrics/PolydataDummyPenalty/elxPolydataDummyPenalty.h
@@ -134,7 +134,6 @@ public:
   /** Typedefs inherited from elastix. */
   using typename Superclass2::ElastixType;
   using typename Superclass2::ElastixPointer;
-  using typename Superclass2::ConfigurationPointer;
   using typename Superclass2::RegistrationType;
   using typename Superclass2::RegistrationPointer;
   using ITKBaseType = typename Superclass2::ITKBaseType;

--- a/Components/Metrics/RigidityPenalty/elxTransformRigidityPenaltyTerm.h
+++ b/Components/Metrics/RigidityPenalty/elxTransformRigidityPenaltyTerm.h
@@ -182,7 +182,6 @@ public:
   /** Typedef's inherited from elastix. */
   using typename Superclass2::ElastixType;
   using typename Superclass2::ElastixPointer;
-  using typename Superclass2::ConfigurationType;
   using typename Superclass2::ConfigurationPointer;
   using typename Superclass2::RegistrationType;
   using typename Superclass2::RegistrationPointer;

--- a/Components/Metrics/RigidityPenalty/elxTransformRigidityPenaltyTerm.h
+++ b/Components/Metrics/RigidityPenalty/elxTransformRigidityPenaltyTerm.h
@@ -182,7 +182,6 @@ public:
   /** Typedef's inherited from elastix. */
   using typename Superclass2::ElastixType;
   using typename Superclass2::ElastixPointer;
-  using typename Superclass2::ConfigurationPointer;
   using typename Superclass2::RegistrationType;
   using typename Superclass2::RegistrationPointer;
   using ITKBaseType = typename Superclass2::ITKBaseType;

--- a/Components/Metrics/StatisticalShapePenalty/elxStatisticalShapePenalty.h
+++ b/Components/Metrics/StatisticalShapePenalty/elxStatisticalShapePenalty.h
@@ -119,7 +119,6 @@ public:
   /** Typedefs inherited from elastix. */
   using typename Superclass2::ElastixType;
   using typename Superclass2::ElastixPointer;
-  using typename Superclass2::ConfigurationPointer;
   using typename Superclass2::RegistrationType;
   using typename Superclass2::RegistrationPointer;
   using ITKBaseType = typename Superclass2::ITKBaseType;

--- a/Components/Metrics/StatisticalShapePenalty/elxStatisticalShapePenalty.h
+++ b/Components/Metrics/StatisticalShapePenalty/elxStatisticalShapePenalty.h
@@ -108,7 +108,6 @@ public:
   using VnlVectorType = vnl_vector<CoordRepType>;
 
   /** Other typedef's. */
-  using ObjectType = itk::Object;
   /*typedef itk::AdvancedTransform<
     CoordRepType,
     itkGetStaticConstMacro( FixedImageDimension ),

--- a/Components/Metrics/StatisticalShapePenalty/elxStatisticalShapePenalty.h
+++ b/Components/Metrics/StatisticalShapePenalty/elxStatisticalShapePenalty.h
@@ -120,7 +120,6 @@ public:
   /** Typedefs inherited from elastix. */
   using typename Superclass2::ElastixType;
   using typename Superclass2::ElastixPointer;
-  using typename Superclass2::ConfigurationType;
   using typename Superclass2::ConfigurationPointer;
   using typename Superclass2::RegistrationType;
   using typename Superclass2::RegistrationPointer;

--- a/Components/Metrics/SumOfPairwiseCorrelationsMetric/elxSumOfPairwiseCorrelationCoefficientsMetric.h
+++ b/Components/Metrics/SumOfPairwiseCorrelationsMetric/elxSumOfPairwiseCorrelationCoefficientsMetric.h
@@ -138,7 +138,6 @@ public:
   /** Typedef's inherited from Elastix. */
   using typename Superclass2::ElastixType;
   using typename Superclass2::ElastixPointer;
-  using typename Superclass2::ConfigurationPointer;
   using typename Superclass2::RegistrationType;
   using typename Superclass2::RegistrationPointer;
   using ITKBaseType = typename Superclass2::ITKBaseType;

--- a/Components/Metrics/SumOfPairwiseCorrelationsMetric/elxSumOfPairwiseCorrelationCoefficientsMetric.h
+++ b/Components/Metrics/SumOfPairwiseCorrelationsMetric/elxSumOfPairwiseCorrelationCoefficientsMetric.h
@@ -138,7 +138,6 @@ public:
   /** Typedef's inherited from Elastix. */
   using typename Superclass2::ElastixType;
   using typename Superclass2::ElastixPointer;
-  using typename Superclass2::ConfigurationType;
   using typename Superclass2::ConfigurationPointer;
   using typename Superclass2::RegistrationType;
   using typename Superclass2::RegistrationPointer;

--- a/Components/Metrics/SumSquaredTissueVolumeDifferenceMetric/elxSumSquaredTissueVolumeDifferenceMetric.h
+++ b/Components/Metrics/SumSquaredTissueVolumeDifferenceMetric/elxSumSquaredTissueVolumeDifferenceMetric.h
@@ -124,7 +124,6 @@ public:
   /** Typedef's inherited from Elastix. */
   using typename Superclass2::ElastixType;
   using typename Superclass2::ElastixPointer;
-  using typename Superclass2::ConfigurationPointer;
   using typename Superclass2::RegistrationType;
   using typename Superclass2::RegistrationPointer;
   using ITKBaseType = typename Superclass2::ITKBaseType;

--- a/Components/Metrics/SumSquaredTissueVolumeDifferenceMetric/elxSumSquaredTissueVolumeDifferenceMetric.h
+++ b/Components/Metrics/SumSquaredTissueVolumeDifferenceMetric/elxSumSquaredTissueVolumeDifferenceMetric.h
@@ -124,7 +124,6 @@ public:
   /** Typedef's inherited from Elastix. */
   using typename Superclass2::ElastixType;
   using typename Superclass2::ElastixPointer;
-  using typename Superclass2::ConfigurationType;
   using typename Superclass2::ConfigurationPointer;
   using typename Superclass2::RegistrationType;
   using typename Superclass2::RegistrationPointer;

--- a/Components/Metrics/VarianceOverLastDimension/elxVarianceOverLastDimensionMetric.h
+++ b/Components/Metrics/VarianceOverLastDimension/elxVarianceOverLastDimensionMetric.h
@@ -142,7 +142,6 @@ public:
   /** Typedef's inherited from Elastix. */
   using typename Superclass2::ElastixType;
   using typename Superclass2::ElastixPointer;
-  using typename Superclass2::ConfigurationType;
   using typename Superclass2::ConfigurationPointer;
   using typename Superclass2::RegistrationType;
   using typename Superclass2::RegistrationPointer;

--- a/Components/Metrics/VarianceOverLastDimension/elxVarianceOverLastDimensionMetric.h
+++ b/Components/Metrics/VarianceOverLastDimension/elxVarianceOverLastDimensionMetric.h
@@ -142,7 +142,6 @@ public:
   /** Typedef's inherited from Elastix. */
   using typename Superclass2::ElastixType;
   using typename Superclass2::ElastixPointer;
-  using typename Superclass2::ConfigurationPointer;
   using typename Superclass2::RegistrationType;
   using typename Superclass2::RegistrationPointer;
   using ITKBaseType = typename Superclass2::ITKBaseType;

--- a/Components/MovingImagePyramids/MovingGenericPyramid/elxMovingGenericPyramid.h
+++ b/Components/MovingImagePyramids/MovingGenericPyramid/elxMovingGenericPyramid.h
@@ -108,7 +108,6 @@ public:
   /** Typedefs inherited from Elastix. */
   using typename Superclass2::ElastixType;
   using typename Superclass2::ElastixPointer;
-  using typename Superclass2::ConfigurationType;
   using typename Superclass2::ConfigurationPointer;
   using typename Superclass2::RegistrationType;
   using typename Superclass2::RegistrationPointer;

--- a/Components/MovingImagePyramids/MovingGenericPyramid/elxMovingGenericPyramid.h
+++ b/Components/MovingImagePyramids/MovingGenericPyramid/elxMovingGenericPyramid.h
@@ -108,7 +108,6 @@ public:
   /** Typedefs inherited from Elastix. */
   using typename Superclass2::ElastixType;
   using typename Superclass2::ElastixPointer;
-  using typename Superclass2::ConfigurationPointer;
   using typename Superclass2::RegistrationType;
   using typename Superclass2::RegistrationPointer;
   using ITKBaseType = typename Superclass2::ITKBaseType;

--- a/Components/MovingImagePyramids/MovingRecursivePyramid/elxMovingRecursivePyramid.h
+++ b/Components/MovingImagePyramids/MovingRecursivePyramid/elxMovingRecursivePyramid.h
@@ -76,7 +76,6 @@ public:
   /** Typedefs inherited from Elastix. */
   using typename Superclass2::ElastixType;
   using typename Superclass2::ElastixPointer;
-  using typename Superclass2::ConfigurationType;
   using typename Superclass2::ConfigurationPointer;
   using typename Superclass2::RegistrationType;
   using typename Superclass2::RegistrationPointer;

--- a/Components/MovingImagePyramids/MovingRecursivePyramid/elxMovingRecursivePyramid.h
+++ b/Components/MovingImagePyramids/MovingRecursivePyramid/elxMovingRecursivePyramid.h
@@ -76,7 +76,6 @@ public:
   /** Typedefs inherited from Elastix. */
   using typename Superclass2::ElastixType;
   using typename Superclass2::ElastixPointer;
-  using typename Superclass2::ConfigurationPointer;
   using typename Superclass2::RegistrationType;
   using typename Superclass2::RegistrationPointer;
   using ITKBaseType = typename Superclass2::ITKBaseType;

--- a/Components/MovingImagePyramids/MovingShrinkingPyramid/elxMovingShrinkingPyramid.h
+++ b/Components/MovingImagePyramids/MovingShrinkingPyramid/elxMovingShrinkingPyramid.h
@@ -77,7 +77,6 @@ public:
   /** Typedefs inherited from Elastix. */
   using typename Superclass2::ElastixType;
   using typename Superclass2::ElastixPointer;
-  using typename Superclass2::ConfigurationType;
   using typename Superclass2::ConfigurationPointer;
   using typename Superclass2::RegistrationType;
   using typename Superclass2::RegistrationPointer;

--- a/Components/MovingImagePyramids/MovingShrinkingPyramid/elxMovingShrinkingPyramid.h
+++ b/Components/MovingImagePyramids/MovingShrinkingPyramid/elxMovingShrinkingPyramid.h
@@ -77,7 +77,6 @@ public:
   /** Typedefs inherited from Elastix. */
   using typename Superclass2::ElastixType;
   using typename Superclass2::ElastixPointer;
-  using typename Superclass2::ConfigurationPointer;
   using typename Superclass2::RegistrationType;
   using typename Superclass2::RegistrationPointer;
   using ITKBaseType = typename Superclass2::ITKBaseType;

--- a/Components/MovingImagePyramids/MovingSmoothingPyramid/elxMovingSmoothingPyramid.h
+++ b/Components/MovingImagePyramids/MovingSmoothingPyramid/elxMovingSmoothingPyramid.h
@@ -77,7 +77,6 @@ public:
   /** Typedefs inherited from Elastix. */
   using typename Superclass2::ElastixType;
   using typename Superclass2::ElastixPointer;
-  using typename Superclass2::ConfigurationType;
   using typename Superclass2::ConfigurationPointer;
   using typename Superclass2::RegistrationType;
   using typename Superclass2::RegistrationPointer;

--- a/Components/MovingImagePyramids/MovingSmoothingPyramid/elxMovingSmoothingPyramid.h
+++ b/Components/MovingImagePyramids/MovingSmoothingPyramid/elxMovingSmoothingPyramid.h
@@ -77,7 +77,6 @@ public:
   /** Typedefs inherited from Elastix. */
   using typename Superclass2::ElastixType;
   using typename Superclass2::ElastixPointer;
-  using typename Superclass2::ConfigurationPointer;
   using typename Superclass2::RegistrationType;
   using typename Superclass2::RegistrationPointer;
   using ITKBaseType = typename Superclass2::ITKBaseType;

--- a/Components/Optimizers/AdaGrad/elxAdaGrad.h
+++ b/Components/Optimizers/AdaGrad/elxAdaGrad.h
@@ -219,7 +219,6 @@ public:
   /** Typedef's inherited from Superclass2. */
   using typename Superclass2::ElastixType;
   using typename Superclass2::ElastixPointer;
-  using typename Superclass2::ConfigurationType;
   using typename Superclass2::ConfigurationPointer;
   using typename Superclass2::RegistrationType;
   using typename Superclass2::RegistrationPointer;

--- a/Components/Optimizers/AdaGrad/elxAdaGrad.h
+++ b/Components/Optimizers/AdaGrad/elxAdaGrad.h
@@ -219,7 +219,6 @@ public:
   /** Typedef's inherited from Superclass2. */
   using typename Superclass2::ElastixType;
   using typename Superclass2::ElastixPointer;
-  using typename Superclass2::ConfigurationPointer;
   using typename Superclass2::RegistrationType;
   using typename Superclass2::RegistrationPointer;
   using ITKBaseType = typename Superclass2::ITKBaseType;

--- a/Components/Optimizers/AdaptiveStochasticGradientDescent/elxAdaptiveStochasticGradientDescent.h
+++ b/Components/Optimizers/AdaptiveStochasticGradientDescent/elxAdaptiveStochasticGradientDescent.h
@@ -222,7 +222,6 @@ public:
   /** Typedef's inherited from Superclass2. */
   using typename Superclass2::ElastixType;
   using typename Superclass2::ElastixPointer;
-  using typename Superclass2::ConfigurationPointer;
   using typename Superclass2::RegistrationType;
   using typename Superclass2::RegistrationPointer;
   using ITKBaseType = typename Superclass2::ITKBaseType;

--- a/Components/Optimizers/AdaptiveStochasticGradientDescent/elxAdaptiveStochasticGradientDescent.h
+++ b/Components/Optimizers/AdaptiveStochasticGradientDescent/elxAdaptiveStochasticGradientDescent.h
@@ -222,7 +222,6 @@ public:
   /** Typedef's inherited from Superclass2. */
   using typename Superclass2::ElastixType;
   using typename Superclass2::ElastixPointer;
-  using typename Superclass2::ConfigurationType;
   using typename Superclass2::ConfigurationPointer;
   using typename Superclass2::RegistrationType;
   using typename Superclass2::RegistrationPointer;

--- a/Components/Optimizers/AdaptiveStochasticLBFGS/elxAdaptiveStochasticLBFGS.h
+++ b/Components/Optimizers/AdaptiveStochasticLBFGS/elxAdaptiveStochasticLBFGS.h
@@ -132,7 +132,6 @@ public:
   /** Typedef's inherited from Superclass2. */
   using typename Superclass2::ElastixType;
   using typename Superclass2::ElastixPointer;
-  using typename Superclass2::ConfigurationType;
   using typename Superclass2::ConfigurationPointer;
   using typename Superclass2::RegistrationType;
   using typename Superclass2::RegistrationPointer;

--- a/Components/Optimizers/AdaptiveStochasticLBFGS/elxAdaptiveStochasticLBFGS.h
+++ b/Components/Optimizers/AdaptiveStochasticLBFGS/elxAdaptiveStochasticLBFGS.h
@@ -132,7 +132,6 @@ public:
   /** Typedef's inherited from Superclass2. */
   using typename Superclass2::ElastixType;
   using typename Superclass2::ElastixPointer;
-  using typename Superclass2::ConfigurationPointer;
   using typename Superclass2::RegistrationType;
   using typename Superclass2::RegistrationPointer;
   using ITKBaseType = typename Superclass2::ITKBaseType;

--- a/Components/Optimizers/AdaptiveStochasticVarianceReducedGradient/elxAdaptiveStochasticVarianceReducedGradient.h
+++ b/Components/Optimizers/AdaptiveStochasticVarianceReducedGradient/elxAdaptiveStochasticVarianceReducedGradient.h
@@ -222,7 +222,6 @@ public:
   /** Typedef's inherited from Superclass2. */
   using typename Superclass2::ElastixType;
   using typename Superclass2::ElastixPointer;
-  using typename Superclass2::ConfigurationPointer;
   using typename Superclass2::RegistrationType;
   using typename Superclass2::RegistrationPointer;
   using ITKBaseType = typename Superclass2::ITKBaseType;

--- a/Components/Optimizers/AdaptiveStochasticVarianceReducedGradient/elxAdaptiveStochasticVarianceReducedGradient.h
+++ b/Components/Optimizers/AdaptiveStochasticVarianceReducedGradient/elxAdaptiveStochasticVarianceReducedGradient.h
@@ -222,7 +222,6 @@ public:
   /** Typedef's inherited from Superclass2. */
   using typename Superclass2::ElastixType;
   using typename Superclass2::ElastixPointer;
-  using typename Superclass2::ConfigurationType;
   using typename Superclass2::ConfigurationPointer;
   using typename Superclass2::RegistrationType;
   using typename Superclass2::RegistrationPointer;

--- a/Components/Optimizers/CMAEvolutionStrategy/elxCMAEvolutionStrategy.h
+++ b/Components/Optimizers/CMAEvolutionStrategy/elxCMAEvolutionStrategy.h
@@ -147,7 +147,6 @@ public:
   /** Typedef's inherited from Elastix.*/
   using typename Superclass2::ElastixType;
   using typename Superclass2::ElastixPointer;
-  using typename Superclass2::ConfigurationType;
   using typename Superclass2::ConfigurationPointer;
   using typename Superclass2::RegistrationType;
   using typename Superclass2::RegistrationPointer;

--- a/Components/Optimizers/CMAEvolutionStrategy/elxCMAEvolutionStrategy.h
+++ b/Components/Optimizers/CMAEvolutionStrategy/elxCMAEvolutionStrategy.h
@@ -147,7 +147,6 @@ public:
   /** Typedef's inherited from Elastix.*/
   using typename Superclass2::ElastixType;
   using typename Superclass2::ElastixPointer;
-  using typename Superclass2::ConfigurationPointer;
   using typename Superclass2::RegistrationType;
   using typename Superclass2::RegistrationPointer;
   using ITKBaseType = typename Superclass2::ITKBaseType;

--- a/Components/Optimizers/ConjugateGradient/elxConjugateGradient.h
+++ b/Components/Optimizers/ConjugateGradient/elxConjugateGradient.h
@@ -123,7 +123,6 @@ public:
   /** Typedef's inherited from Elastix.*/
   using typename Superclass2::ElastixType;
   using typename Superclass2::ElastixPointer;
-  using typename Superclass2::ConfigurationType;
   using typename Superclass2::ConfigurationPointer;
   using typename Superclass2::RegistrationType;
   using typename Superclass2::RegistrationPointer;

--- a/Components/Optimizers/ConjugateGradient/elxConjugateGradient.h
+++ b/Components/Optimizers/ConjugateGradient/elxConjugateGradient.h
@@ -123,7 +123,6 @@ public:
   /** Typedef's inherited from Elastix.*/
   using typename Superclass2::ElastixType;
   using typename Superclass2::ElastixPointer;
-  using typename Superclass2::ConfigurationPointer;
   using typename Superclass2::RegistrationType;
   using typename Superclass2::RegistrationPointer;
   using ITKBaseType = typename Superclass2::ITKBaseType;

--- a/Components/Optimizers/ConjugateGradientFRPR/elxConjugateGradientFRPR.h
+++ b/Components/Optimizers/ConjugateGradientFRPR/elxConjugateGradientFRPR.h
@@ -103,7 +103,6 @@ public:
   /** Typedef's inherited from Elastix.*/
   using typename Superclass2::ElastixType;
   using typename Superclass2::ElastixPointer;
-  using typename Superclass2::ConfigurationPointer;
   using typename Superclass2::RegistrationType;
   using typename Superclass2::RegistrationPointer;
   using ITKBaseType = typename Superclass2::ITKBaseType;

--- a/Components/Optimizers/ConjugateGradientFRPR/elxConjugateGradientFRPR.h
+++ b/Components/Optimizers/ConjugateGradientFRPR/elxConjugateGradientFRPR.h
@@ -103,7 +103,6 @@ public:
   /** Typedef's inherited from Elastix.*/
   using typename Superclass2::ElastixType;
   using typename Superclass2::ElastixPointer;
-  using typename Superclass2::ConfigurationType;
   using typename Superclass2::ConfigurationPointer;
   using typename Superclass2::RegistrationType;
   using typename Superclass2::RegistrationPointer;

--- a/Components/Optimizers/FiniteDifferenceGradientDescent/elxFiniteDifferenceGradientDescent.h
+++ b/Components/Optimizers/FiniteDifferenceGradientDescent/elxFiniteDifferenceGradientDescent.h
@@ -109,7 +109,6 @@ public:
   /** Typedef's inherited from Elastix.*/
   using typename Superclass2::ElastixType;
   using typename Superclass2::ElastixPointer;
-  using typename Superclass2::ConfigurationType;
   using typename Superclass2::ConfigurationPointer;
   using typename Superclass2::RegistrationType;
   using typename Superclass2::RegistrationPointer;

--- a/Components/Optimizers/FiniteDifferenceGradientDescent/elxFiniteDifferenceGradientDescent.h
+++ b/Components/Optimizers/FiniteDifferenceGradientDescent/elxFiniteDifferenceGradientDescent.h
@@ -109,7 +109,6 @@ public:
   /** Typedef's inherited from Elastix.*/
   using typename Superclass2::ElastixType;
   using typename Superclass2::ElastixPointer;
-  using typename Superclass2::ConfigurationPointer;
   using typename Superclass2::RegistrationType;
   using typename Superclass2::RegistrationPointer;
   using ITKBaseType = typename Superclass2::ITKBaseType;

--- a/Components/Optimizers/FullSearch/elxFullSearchOptimizer.h
+++ b/Components/Optimizers/FullSearch/elxFullSearchOptimizer.h
@@ -96,7 +96,6 @@ public:
   /** Typedef's inherited from Elastix.*/
   using typename Superclass2::ElastixType;
   using typename Superclass2::ElastixPointer;
-  using typename Superclass2::ConfigurationType;
   using typename Superclass2::ConfigurationPointer;
   using typename Superclass2::RegistrationType;
   using typename Superclass2::RegistrationPointer;

--- a/Components/Optimizers/FullSearch/elxFullSearchOptimizer.h
+++ b/Components/Optimizers/FullSearch/elxFullSearchOptimizer.h
@@ -96,7 +96,6 @@ public:
   /** Typedef's inherited from Elastix.*/
   using typename Superclass2::ElastixType;
   using typename Superclass2::ElastixPointer;
-  using typename Superclass2::ConfigurationPointer;
   using typename Superclass2::RegistrationType;
   using typename Superclass2::RegistrationPointer;
   using ITKBaseType = typename Superclass2::ITKBaseType;

--- a/Components/Optimizers/Powell/elxPowell.h
+++ b/Components/Optimizers/Powell/elxPowell.h
@@ -69,7 +69,6 @@ public:
   /** Typedef's inherited from Elastix.*/
   using typename Superclass2::ElastixType;
   using typename Superclass2::ElastixPointer;
-  using typename Superclass2::ConfigurationType;
   using typename Superclass2::ConfigurationPointer;
   using typename Superclass2::RegistrationType;
   using typename Superclass2::RegistrationPointer;

--- a/Components/Optimizers/Powell/elxPowell.h
+++ b/Components/Optimizers/Powell/elxPowell.h
@@ -69,7 +69,6 @@ public:
   /** Typedef's inherited from Elastix.*/
   using typename Superclass2::ElastixType;
   using typename Superclass2::ElastixPointer;
-  using typename Superclass2::ConfigurationPointer;
   using typename Superclass2::RegistrationType;
   using typename Superclass2::RegistrationPointer;
   using ITKBaseType = typename Superclass2::ITKBaseType;

--- a/Components/Optimizers/PreconditionedGradientDescent/elxPreconditionedGradientDescent.h
+++ b/Components/Optimizers/PreconditionedGradientDescent/elxPreconditionedGradientDescent.h
@@ -101,7 +101,6 @@ public:
   /** Typedef's inherited from Superclass2, the elastix OptimizerBase. */
   using typename Superclass2::ElastixType;
   using typename Superclass2::ElastixPointer;
-  using typename Superclass2::ConfigurationType;
   using typename Superclass2::ConfigurationPointer;
   using typename Superclass2::RegistrationType;
   using typename Superclass2::RegistrationPointer;

--- a/Components/Optimizers/PreconditionedGradientDescent/elxPreconditionedGradientDescent.h
+++ b/Components/Optimizers/PreconditionedGradientDescent/elxPreconditionedGradientDescent.h
@@ -101,7 +101,6 @@ public:
   /** Typedef's inherited from Superclass2, the elastix OptimizerBase. */
   using typename Superclass2::ElastixType;
   using typename Superclass2::ElastixPointer;
-  using typename Superclass2::ConfigurationPointer;
   using typename Superclass2::RegistrationType;
   using typename Superclass2::RegistrationPointer;
   using ITKBaseType = typename Superclass2::ITKBaseType;

--- a/Components/Optimizers/PreconditionedStochasticGradientDescent/elxPreconditionedStochasticGradientDescent.h
+++ b/Components/Optimizers/PreconditionedStochasticGradientDescent/elxPreconditionedStochasticGradientDescent.h
@@ -207,7 +207,6 @@ public:
   /** Typedef's inherited from Superclass2. */
   using typename Superclass2::ElastixType;
   using typename Superclass2::ElastixPointer;
-  using typename Superclass2::ConfigurationPointer;
   using typename Superclass2::RegistrationType;
   using typename Superclass2::RegistrationPointer;
   using ITKBaseType = typename Superclass2::ITKBaseType;

--- a/Components/Optimizers/PreconditionedStochasticGradientDescent/elxPreconditionedStochasticGradientDescent.h
+++ b/Components/Optimizers/PreconditionedStochasticGradientDescent/elxPreconditionedStochasticGradientDescent.h
@@ -207,7 +207,6 @@ public:
   /** Typedef's inherited from Superclass2. */
   using typename Superclass2::ElastixType;
   using typename Superclass2::ElastixPointer;
-  using typename Superclass2::ConfigurationType;
   using typename Superclass2::ConfigurationPointer;
   using typename Superclass2::RegistrationType;
   using typename Superclass2::RegistrationPointer;

--- a/Components/Optimizers/QuasiNewtonLBFGS/elxQuasiNewtonLBFGS.h
+++ b/Components/Optimizers/QuasiNewtonLBFGS/elxQuasiNewtonLBFGS.h
@@ -120,7 +120,6 @@ public:
   /** Typedef's inherited from Elastix.*/
   using typename Superclass2::ElastixType;
   using typename Superclass2::ElastixPointer;
-  using typename Superclass2::ConfigurationPointer;
   using typename Superclass2::RegistrationType;
   using typename Superclass2::RegistrationPointer;
   using ITKBaseType = typename Superclass2::ITKBaseType;

--- a/Components/Optimizers/QuasiNewtonLBFGS/elxQuasiNewtonLBFGS.h
+++ b/Components/Optimizers/QuasiNewtonLBFGS/elxQuasiNewtonLBFGS.h
@@ -120,7 +120,6 @@ public:
   /** Typedef's inherited from Elastix.*/
   using typename Superclass2::ElastixType;
   using typename Superclass2::ElastixPointer;
-  using typename Superclass2::ConfigurationType;
   using typename Superclass2::ConfigurationPointer;
   using typename Superclass2::RegistrationType;
   using typename Superclass2::RegistrationPointer;

--- a/Components/Optimizers/RSGDEachParameterApart/elxRSGDEachParameterApart.h
+++ b/Components/Optimizers/RSGDEachParameterApart/elxRSGDEachParameterApart.h
@@ -100,7 +100,6 @@ public:
   /** Typedef's inherited from Elastix.*/
   using typename Superclass2::ElastixType;
   using typename Superclass2::ElastixPointer;
-  using typename Superclass2::ConfigurationType;
   using typename Superclass2::ConfigurationPointer;
   using typename Superclass2::RegistrationType;
   using typename Superclass2::RegistrationPointer;

--- a/Components/Optimizers/RSGDEachParameterApart/elxRSGDEachParameterApart.h
+++ b/Components/Optimizers/RSGDEachParameterApart/elxRSGDEachParameterApart.h
@@ -100,7 +100,6 @@ public:
   /** Typedef's inherited from Elastix.*/
   using typename Superclass2::ElastixType;
   using typename Superclass2::ElastixPointer;
-  using typename Superclass2::ConfigurationPointer;
   using typename Superclass2::RegistrationType;
   using typename Superclass2::RegistrationPointer;
   using ITKBaseType = typename Superclass2::ITKBaseType;

--- a/Components/Optimizers/RegularStepGradientDescent/elxRegularStepGradientDescent.h
+++ b/Components/Optimizers/RegularStepGradientDescent/elxRegularStepGradientDescent.h
@@ -93,7 +93,6 @@ public:
   /** Typedef's inherited from Elastix.*/
   using typename Superclass2::ElastixType;
   using typename Superclass2::ElastixPointer;
-  using typename Superclass2::ConfigurationType;
   using typename Superclass2::ConfigurationPointer;
   using typename Superclass2::RegistrationType;
   using typename Superclass2::RegistrationPointer;

--- a/Components/Optimizers/RegularStepGradientDescent/elxRegularStepGradientDescent.h
+++ b/Components/Optimizers/RegularStepGradientDescent/elxRegularStepGradientDescent.h
@@ -93,7 +93,6 @@ public:
   /** Typedef's inherited from Elastix.*/
   using typename Superclass2::ElastixType;
   using typename Superclass2::ElastixPointer;
-  using typename Superclass2::ConfigurationPointer;
   using typename Superclass2::RegistrationType;
   using typename Superclass2::RegistrationPointer;
   using ITKBaseType = typename Superclass2::ITKBaseType;

--- a/Components/Optimizers/Simplex/elxSimplex.h
+++ b/Components/Optimizers/Simplex/elxSimplex.h
@@ -69,7 +69,6 @@ public:
   /** Typedef's inherited from Elastix.*/
   using typename Superclass2::ElastixType;
   using typename Superclass2::ElastixPointer;
-  using typename Superclass2::ConfigurationType;
   using typename Superclass2::ConfigurationPointer;
   using typename Superclass2::RegistrationType;
   using typename Superclass2::RegistrationPointer;

--- a/Components/Optimizers/Simplex/elxSimplex.h
+++ b/Components/Optimizers/Simplex/elxSimplex.h
@@ -69,7 +69,6 @@ public:
   /** Typedef's inherited from Elastix.*/
   using typename Superclass2::ElastixType;
   using typename Superclass2::ElastixPointer;
-  using typename Superclass2::ConfigurationPointer;
   using typename Superclass2::RegistrationType;
   using typename Superclass2::RegistrationPointer;
   using ITKBaseType = typename Superclass2::ITKBaseType;

--- a/Components/Optimizers/SimultaneousPerturbation/elxSimultaneousPerturbation.h
+++ b/Components/Optimizers/SimultaneousPerturbation/elxSimultaneousPerturbation.h
@@ -111,7 +111,6 @@ public:
   /** Typedef's inherited from Elastix.*/
   using typename Superclass2::ElastixType;
   using typename Superclass2::ElastixPointer;
-  using typename Superclass2::ConfigurationType;
   using typename Superclass2::ConfigurationPointer;
   using typename Superclass2::RegistrationType;
   using typename Superclass2::RegistrationPointer;

--- a/Components/Optimizers/SimultaneousPerturbation/elxSimultaneousPerturbation.h
+++ b/Components/Optimizers/SimultaneousPerturbation/elxSimultaneousPerturbation.h
@@ -111,7 +111,6 @@ public:
   /** Typedef's inherited from Elastix.*/
   using typename Superclass2::ElastixType;
   using typename Superclass2::ElastixPointer;
-  using typename Superclass2::ConfigurationPointer;
   using typename Superclass2::RegistrationType;
   using typename Superclass2::RegistrationPointer;
   using ITKBaseType = typename Superclass2::ITKBaseType;

--- a/Components/Optimizers/StandardGradientDescent/elxStandardGradientDescent.h
+++ b/Components/Optimizers/StandardGradientDescent/elxStandardGradientDescent.h
@@ -97,7 +97,6 @@ public:
   /** Typedef's inherited from Superclass2, the elastix OptimizerBase .*/
   using typename Superclass2::ElastixType;
   using typename Superclass2::ElastixPointer;
-  using typename Superclass2::ConfigurationType;
   using typename Superclass2::ConfigurationPointer;
   using typename Superclass2::RegistrationType;
   using typename Superclass2::RegistrationPointer;

--- a/Components/Optimizers/StandardGradientDescent/elxStandardGradientDescent.h
+++ b/Components/Optimizers/StandardGradientDescent/elxStandardGradientDescent.h
@@ -97,7 +97,6 @@ public:
   /** Typedef's inherited from Superclass2, the elastix OptimizerBase .*/
   using typename Superclass2::ElastixType;
   using typename Superclass2::ElastixPointer;
-  using typename Superclass2::ConfigurationPointer;
   using typename Superclass2::RegistrationType;
   using typename Superclass2::RegistrationPointer;
   using ITKBaseType = typename Superclass2::ITKBaseType;

--- a/Components/Registrations/MultiMetricMultiResolutionRegistration/elxMultiMetricMultiResolutionRegistration.h
+++ b/Components/Registrations/MultiMetricMultiResolutionRegistration/elxMultiMetricMultiResolutionRegistration.h
@@ -170,7 +170,6 @@ public:
   /** Typedef's from Elastix. */
   using typename Superclass2::ElastixType;
   using typename Superclass2::ElastixPointer;
-  using typename Superclass2::ConfigurationPointer;
   using RegistrationType = typename Superclass2::RegistrationType;
   using typename Superclass2::RegistrationPointer;
   using ITKBaseType = typename Superclass2::ITKBaseType;

--- a/Components/Registrations/MultiMetricMultiResolutionRegistration/elxMultiMetricMultiResolutionRegistration.h
+++ b/Components/Registrations/MultiMetricMultiResolutionRegistration/elxMultiMetricMultiResolutionRegistration.h
@@ -170,7 +170,6 @@ public:
   /** Typedef's from Elastix. */
   using typename Superclass2::ElastixType;
   using typename Superclass2::ElastixPointer;
-  using typename Superclass2::ConfigurationType;
   using typename Superclass2::ConfigurationPointer;
   using RegistrationType = typename Superclass2::RegistrationType;
   using typename Superclass2::RegistrationPointer;

--- a/Components/Registrations/MultiResolutionRegistration/elxMultiResolutionRegistration.h
+++ b/Components/Registrations/MultiResolutionRegistration/elxMultiResolutionRegistration.h
@@ -108,7 +108,6 @@ public:
   /** Typedef's from Elastix. */
   using typename Superclass2::ElastixType;
   using typename Superclass2::ElastixPointer;
-  using typename Superclass2::ConfigurationPointer;
   using RegistrationType = typename Superclass2::RegistrationType;
   using typename Superclass2::RegistrationPointer;
   using ITKBaseType = typename Superclass2::ITKBaseType;

--- a/Components/Registrations/MultiResolutionRegistration/elxMultiResolutionRegistration.h
+++ b/Components/Registrations/MultiResolutionRegistration/elxMultiResolutionRegistration.h
@@ -108,7 +108,6 @@ public:
   /** Typedef's from Elastix. */
   using typename Superclass2::ElastixType;
   using typename Superclass2::ElastixPointer;
-  using typename Superclass2::ConfigurationType;
   using typename Superclass2::ConfigurationPointer;
   using RegistrationType = typename Superclass2::RegistrationType;
   using typename Superclass2::RegistrationPointer;

--- a/Components/Registrations/MultiResolutionRegistrationWithFeatures/elxMultiResolutionRegistrationWithFeatures.h
+++ b/Components/Registrations/MultiResolutionRegistrationWithFeatures/elxMultiResolutionRegistrationWithFeatures.h
@@ -124,7 +124,6 @@ public:
   /** Typedef's from Elastix. */
   using typename Superclass2::ElastixType;
   using typename Superclass2::ElastixPointer;
-  using typename Superclass2::ConfigurationType;
   using typename Superclass2::ConfigurationPointer;
   using RegistrationType = typename Superclass2::RegistrationType;
   using typename Superclass2::RegistrationPointer;

--- a/Components/Registrations/MultiResolutionRegistrationWithFeatures/elxMultiResolutionRegistrationWithFeatures.h
+++ b/Components/Registrations/MultiResolutionRegistrationWithFeatures/elxMultiResolutionRegistrationWithFeatures.h
@@ -124,7 +124,6 @@ public:
   /** Typedef's from Elastix. */
   using typename Superclass2::ElastixType;
   using typename Superclass2::ElastixPointer;
-  using typename Superclass2::ConfigurationPointer;
   using RegistrationType = typename Superclass2::RegistrationType;
   using typename Superclass2::RegistrationPointer;
   using ITKBaseType = typename Superclass2::ITKBaseType;

--- a/Components/ResampleInterpolators/BSplineResampleInterpolator/elxBSplineResampleInterpolator.h
+++ b/Components/ResampleInterpolators/BSplineResampleInterpolator/elxBSplineResampleInterpolator.h
@@ -99,7 +99,6 @@ public:
   /** Typedef's from ResampleInterpolatorBase. */
   using typename Superclass2::ElastixType;
   using typename Superclass2::ElastixPointer;
-  using typename Superclass2::ConfigurationType;
   using typename Superclass2::ConfigurationPointer;
   using typename Superclass2::RegistrationType;
   using typename Superclass2::RegistrationPointer;

--- a/Components/ResampleInterpolators/BSplineResampleInterpolator/elxBSplineResampleInterpolator.h
+++ b/Components/ResampleInterpolators/BSplineResampleInterpolator/elxBSplineResampleInterpolator.h
@@ -99,7 +99,6 @@ public:
   /** Typedef's from ResampleInterpolatorBase. */
   using typename Superclass2::ElastixType;
   using typename Superclass2::ElastixPointer;
-  using typename Superclass2::ConfigurationPointer;
   using typename Superclass2::RegistrationType;
   using typename Superclass2::RegistrationPointer;
   using ITKBaseType = typename Superclass2::ITKBaseType;

--- a/Components/ResampleInterpolators/BSplineResampleInterpolatorFloat/elxBSplineResampleInterpolatorFloat.h
+++ b/Components/ResampleInterpolators/BSplineResampleInterpolatorFloat/elxBSplineResampleInterpolatorFloat.h
@@ -99,7 +99,6 @@ public:
   /** Typedef's from ResampleInterpolatorBase. */
   using typename Superclass2::ElastixType;
   using typename Superclass2::ElastixPointer;
-  using typename Superclass2::ConfigurationType;
   using typename Superclass2::ConfigurationPointer;
   using typename Superclass2::RegistrationType;
   using typename Superclass2::RegistrationPointer;

--- a/Components/ResampleInterpolators/BSplineResampleInterpolatorFloat/elxBSplineResampleInterpolatorFloat.h
+++ b/Components/ResampleInterpolators/BSplineResampleInterpolatorFloat/elxBSplineResampleInterpolatorFloat.h
@@ -99,7 +99,6 @@ public:
   /** Typedef's from ResampleInterpolatorBase. */
   using typename Superclass2::ElastixType;
   using typename Superclass2::ElastixPointer;
-  using typename Superclass2::ConfigurationPointer;
   using typename Superclass2::RegistrationType;
   using typename Superclass2::RegistrationPointer;
   using ITKBaseType = typename Superclass2::ITKBaseType;

--- a/Components/ResampleInterpolators/LinearResampleInterpolator/elxLinearResampleInterpolator.h
+++ b/Components/ResampleInterpolators/LinearResampleInterpolator/elxLinearResampleInterpolator.h
@@ -79,7 +79,6 @@ public:
   /** Typedef's from ResampleInterpolatorBase. */
   using typename Superclass2::ElastixType;
   using typename Superclass2::ElastixPointer;
-  using typename Superclass2::ConfigurationType;
   using typename Superclass2::ConfigurationPointer;
   using typename Superclass2::RegistrationType;
   using typename Superclass2::RegistrationPointer;

--- a/Components/ResampleInterpolators/LinearResampleInterpolator/elxLinearResampleInterpolator.h
+++ b/Components/ResampleInterpolators/LinearResampleInterpolator/elxLinearResampleInterpolator.h
@@ -79,7 +79,6 @@ public:
   /** Typedef's from ResampleInterpolatorBase. */
   using typename Superclass2::ElastixType;
   using typename Superclass2::ElastixPointer;
-  using typename Superclass2::ConfigurationPointer;
   using typename Superclass2::RegistrationType;
   using typename Superclass2::RegistrationPointer;
   using ITKBaseType = typename Superclass2::ITKBaseType;

--- a/Components/ResampleInterpolators/NearestNeighborResampleInterpolator/elxNearestNeighborResampleInterpolator.h
+++ b/Components/ResampleInterpolators/NearestNeighborResampleInterpolator/elxNearestNeighborResampleInterpolator.h
@@ -80,7 +80,6 @@ public:
   /** Typedef's from ResampleInterpolatorBase. */
   using typename Superclass2::ElastixType;
   using typename Superclass2::ElastixPointer;
-  using typename Superclass2::ConfigurationType;
   using typename Superclass2::ConfigurationPointer;
   using typename Superclass2::RegistrationType;
   using typename Superclass2::RegistrationPointer;

--- a/Components/ResampleInterpolators/NearestNeighborResampleInterpolator/elxNearestNeighborResampleInterpolator.h
+++ b/Components/ResampleInterpolators/NearestNeighborResampleInterpolator/elxNearestNeighborResampleInterpolator.h
@@ -80,7 +80,6 @@ public:
   /** Typedef's from ResampleInterpolatorBase. */
   using typename Superclass2::ElastixType;
   using typename Superclass2::ElastixPointer;
-  using typename Superclass2::ConfigurationPointer;
   using typename Superclass2::RegistrationType;
   using typename Superclass2::RegistrationPointer;
   using ITKBaseType = typename Superclass2::ITKBaseType;

--- a/Components/ResampleInterpolators/RDBSplineResampleInterpolator/elxRDBSplineResampleInterpolator.h
+++ b/Components/ResampleInterpolators/RDBSplineResampleInterpolator/elxRDBSplineResampleInterpolator.h
@@ -101,7 +101,6 @@ public:
   /** Typedef's from ResampleInterpolatorBase. */
   using typename Superclass2::ElastixType;
   using typename Superclass2::ElastixPointer;
-  using typename Superclass2::ConfigurationType;
   using typename Superclass2::ConfigurationPointer;
   using typename Superclass2::RegistrationType;
   using typename Superclass2::RegistrationPointer;

--- a/Components/ResampleInterpolators/RDBSplineResampleInterpolator/elxRDBSplineResampleInterpolator.h
+++ b/Components/ResampleInterpolators/RDBSplineResampleInterpolator/elxRDBSplineResampleInterpolator.h
@@ -101,7 +101,6 @@ public:
   /** Typedef's from ResampleInterpolatorBase. */
   using typename Superclass2::ElastixType;
   using typename Superclass2::ElastixPointer;
-  using typename Superclass2::ConfigurationPointer;
   using typename Superclass2::RegistrationType;
   using typename Superclass2::RegistrationPointer;
   using ITKBaseType = typename Superclass2::ITKBaseType;

--- a/Components/ResampleInterpolators/RayCastResampleInterpolator/elxRayCastResampleInterpolator.h
+++ b/Components/ResampleInterpolators/RayCastResampleInterpolator/elxRayCastResampleInterpolator.h
@@ -77,7 +77,6 @@ public:
   /** Typedef's from ResampleInterpolatorBase. */
   using typename Superclass2::ElastixType;
   using typename Superclass2::ElastixPointer;
-  using typename Superclass2::ConfigurationPointer;
   using typename Superclass2::RegistrationType;
   using typename Superclass2::RegistrationPointer;
   using ITKBaseType = typename Superclass2::ITKBaseType;

--- a/Components/ResampleInterpolators/RayCastResampleInterpolator/elxRayCastResampleInterpolator.h
+++ b/Components/ResampleInterpolators/RayCastResampleInterpolator/elxRayCastResampleInterpolator.h
@@ -77,7 +77,6 @@ public:
   /** Typedef's from ResampleInterpolatorBase. */
   using typename Superclass2::ElastixType;
   using typename Superclass2::ElastixPointer;
-  using typename Superclass2::ConfigurationType;
   using typename Superclass2::ConfigurationPointer;
   using typename Superclass2::RegistrationType;
   using typename Superclass2::RegistrationPointer;

--- a/Components/Resamplers/MyStandardResampler/elxMyStandardResampler.h
+++ b/Components/Resamplers/MyStandardResampler/elxMyStandardResampler.h
@@ -80,7 +80,6 @@ public:
   /** Typedef's from the ResamplerBase. */
   using typename Superclass2::ElastixType;
   using typename Superclass2::ElastixPointer;
-  using typename Superclass2::ConfigurationType;
   using typename Superclass2::ConfigurationPointer;
   using typename Superclass2::RegistrationType;
   using typename Superclass2::RegistrationPointer;

--- a/Components/Resamplers/MyStandardResampler/elxMyStandardResampler.h
+++ b/Components/Resamplers/MyStandardResampler/elxMyStandardResampler.h
@@ -80,7 +80,6 @@ public:
   /** Typedef's from the ResamplerBase. */
   using typename Superclass2::ElastixType;
   using typename Superclass2::ElastixPointer;
-  using typename Superclass2::ConfigurationPointer;
   using typename Superclass2::RegistrationType;
   using typename Superclass2::RegistrationPointer;
   using ITKBaseType = typename Superclass2::ITKBaseType;

--- a/Components/Transforms/AdvancedAffineTransform/elxAdvancedAffineTransform.h
+++ b/Components/Transforms/AdvancedAffineTransform/elxAdvancedAffineTransform.h
@@ -128,7 +128,6 @@ public:
   using typename Superclass2::ElastixType;
   using typename Superclass2::ElastixPointer;
   using typename Superclass2::ParameterMapType;
-  using typename Superclass2::ConfigurationPointer;
   using typename Superclass2::RegistrationType;
   using typename Superclass2::RegistrationPointer;
   using typename Superclass2::CoordRepType;

--- a/Components/Transforms/AdvancedAffineTransform/elxAdvancedAffineTransform.h
+++ b/Components/Transforms/AdvancedAffineTransform/elxAdvancedAffineTransform.h
@@ -128,7 +128,6 @@ public:
   using typename Superclass2::ElastixType;
   using typename Superclass2::ElastixPointer;
   using typename Superclass2::ParameterMapType;
-  using typename Superclass2::ConfigurationType;
   using typename Superclass2::ConfigurationPointer;
   using typename Superclass2::RegistrationType;
   using typename Superclass2::RegistrationPointer;

--- a/Components/Transforms/AdvancedBSplineTransform/elxAdvancedBSplineTransform.h
+++ b/Components/Transforms/AdvancedBSplineTransform/elxAdvancedBSplineTransform.h
@@ -173,7 +173,6 @@ public:
   /** Typedef's from TransformBase. */
   using typename Superclass2::ElastixType;
   using typename Superclass2::ElastixPointer;
-  using typename Superclass2::ConfigurationPointer;
   using typename Superclass2::RegistrationType;
   using typename Superclass2::RegistrationPointer;
   using typename Superclass2::CoordRepType;

--- a/Components/Transforms/AdvancedBSplineTransform/elxAdvancedBSplineTransform.h
+++ b/Components/Transforms/AdvancedBSplineTransform/elxAdvancedBSplineTransform.h
@@ -173,7 +173,6 @@ public:
   /** Typedef's from TransformBase. */
   using typename Superclass2::ElastixType;
   using typename Superclass2::ElastixPointer;
-  using typename Superclass2::ConfigurationType;
   using typename Superclass2::ConfigurationPointer;
   using typename Superclass2::RegistrationType;
   using typename Superclass2::RegistrationPointer;

--- a/Components/Transforms/AffineDTITransform/elxAffineDTITransform.h
+++ b/Components/Transforms/AffineDTITransform/elxAffineDTITransform.h
@@ -133,7 +133,6 @@ public:
   using typename Superclass2::ElastixType;
   using typename Superclass2::ElastixPointer;
   using typename Superclass2::ParameterMapType;
-  using typename Superclass2::ConfigurationPointer;
   using typename Superclass2::RegistrationType;
   using typename Superclass2::RegistrationPointer;
   using typename Superclass2::CoordRepType;

--- a/Components/Transforms/AffineDTITransform/elxAffineDTITransform.h
+++ b/Components/Transforms/AffineDTITransform/elxAffineDTITransform.h
@@ -133,7 +133,6 @@ public:
   using typename Superclass2::ElastixType;
   using typename Superclass2::ElastixPointer;
   using typename Superclass2::ParameterMapType;
-  using typename Superclass2::ConfigurationType;
   using typename Superclass2::ConfigurationPointer;
   using typename Superclass2::RegistrationType;
   using typename Superclass2::RegistrationPointer;

--- a/Components/Transforms/AffineLogStackTransform/elxAffineLogStackTransform.h
+++ b/Components/Transforms/AffineLogStackTransform/elxAffineLogStackTransform.h
@@ -89,7 +89,6 @@ public:
   using typename Superclass2::ElastixType;
   using typename Superclass2::ElastixPointer;
   using typename Superclass2::ParameterMapType;
-  using typename Superclass2::ConfigurationType;
   using typename Superclass2::ConfigurationPointer;
   using typename Superclass2::RegistrationType;
   using typename Superclass2::RegistrationPointer;

--- a/Components/Transforms/AffineLogStackTransform/elxAffineLogStackTransform.h
+++ b/Components/Transforms/AffineLogStackTransform/elxAffineLogStackTransform.h
@@ -89,7 +89,6 @@ public:
   using typename Superclass2::ElastixType;
   using typename Superclass2::ElastixPointer;
   using typename Superclass2::ParameterMapType;
-  using typename Superclass2::ConfigurationPointer;
   using typename Superclass2::RegistrationType;
   using typename Superclass2::RegistrationPointer;
   using typename Superclass2::CoordRepType;

--- a/Components/Transforms/AffineLogTransform/elxAffineLogTransform.h
+++ b/Components/Transforms/AffineLogTransform/elxAffineLogTransform.h
@@ -96,7 +96,6 @@ public:
   using typename Superclass2::ElastixType;
   using typename Superclass2::ElastixPointer;
   using typename Superclass2::ParameterMapType;
-  using typename Superclass2::ConfigurationPointer;
   using typename Superclass2::RegistrationType;
   using typename Superclass2::RegistrationPointer;
   using typename Superclass2::CoordRepType;

--- a/Components/Transforms/AffineLogTransform/elxAffineLogTransform.h
+++ b/Components/Transforms/AffineLogTransform/elxAffineLogTransform.h
@@ -96,7 +96,6 @@ public:
   using typename Superclass2::ElastixType;
   using typename Superclass2::ElastixPointer;
   using typename Superclass2::ParameterMapType;
-  using typename Superclass2::ConfigurationType;
   using typename Superclass2::ConfigurationPointer;
   using typename Superclass2::RegistrationType;
   using typename Superclass2::RegistrationPointer;

--- a/Components/Transforms/BSplineDeformableTransformWithDiffusion/elxBSplineTransformWithDiffusion.h
+++ b/Components/Transforms/BSplineDeformableTransformWithDiffusion/elxBSplineTransformWithDiffusion.h
@@ -233,7 +233,6 @@ public:
   using typename Superclass2::ElastixType;
   using typename Superclass2::ElastixPointer;
   using typename Superclass2::ParameterMapType;
-  using typename Superclass2::ConfigurationType;
   using typename Superclass2::ConfigurationPointer;
   using typename Superclass2::RegistrationType;
   using typename Superclass2::RegistrationPointer;

--- a/Components/Transforms/BSplineDeformableTransformWithDiffusion/elxBSplineTransformWithDiffusion.h
+++ b/Components/Transforms/BSplineDeformableTransformWithDiffusion/elxBSplineTransformWithDiffusion.h
@@ -233,7 +233,6 @@ public:
   using typename Superclass2::ElastixType;
   using typename Superclass2::ElastixPointer;
   using typename Superclass2::ParameterMapType;
-  using typename Superclass2::ConfigurationPointer;
   using typename Superclass2::RegistrationType;
   using typename Superclass2::RegistrationPointer;
   using typename Superclass2::CoordRepType;

--- a/Components/Transforms/BSplineStackTransform/elxBSplineStackTransform.h
+++ b/Components/Transforms/BSplineStackTransform/elxBSplineStackTransform.h
@@ -172,7 +172,6 @@ public:
   /** Typedef's from TransformBase. */
   using typename Superclass2::ElastixType;
   using typename Superclass2::ElastixPointer;
-  using typename Superclass2::ConfigurationPointer;
   using typename Superclass2::RegistrationType;
   using typename Superclass2::RegistrationPointer;
   using typename Superclass2::CoordRepType;

--- a/Components/Transforms/BSplineStackTransform/elxBSplineStackTransform.h
+++ b/Components/Transforms/BSplineStackTransform/elxBSplineStackTransform.h
@@ -172,7 +172,6 @@ public:
   /** Typedef's from TransformBase. */
   using typename Superclass2::ElastixType;
   using typename Superclass2::ElastixPointer;
-  using typename Superclass2::ConfigurationType;
   using typename Superclass2::ConfigurationPointer;
   using typename Superclass2::RegistrationType;
   using typename Superclass2::RegistrationPointer;

--- a/Components/Transforms/DeformationFieldTransform/elxDeformationFieldTransform.h
+++ b/Components/Transforms/DeformationFieldTransform/elxDeformationFieldTransform.h
@@ -114,7 +114,6 @@ public:
   using typename Superclass2::ElastixType;
   using typename Superclass2::ElastixPointer;
   using typename Superclass2::ParameterMapType;
-  using typename Superclass2::ConfigurationType;
   using typename Superclass2::ConfigurationPointer;
   using typename Superclass2::RegistrationType;
   using typename Superclass2::RegistrationPointer;

--- a/Components/Transforms/DeformationFieldTransform/elxDeformationFieldTransform.h
+++ b/Components/Transforms/DeformationFieldTransform/elxDeformationFieldTransform.h
@@ -114,7 +114,6 @@ public:
   using typename Superclass2::ElastixType;
   using typename Superclass2::ElastixPointer;
   using typename Superclass2::ParameterMapType;
-  using typename Superclass2::ConfigurationPointer;
   using typename Superclass2::RegistrationType;
   using typename Superclass2::RegistrationPointer;
   using typename Superclass2::CoordRepType;

--- a/Components/Transforms/EulerStackTransform/elxEulerStackTransform.h
+++ b/Components/Transforms/EulerStackTransform/elxEulerStackTransform.h
@@ -132,7 +132,6 @@ public:
   using typename Superclass2::ElastixType;
   using typename Superclass2::ElastixPointer;
   using typename Superclass2::ParameterMapType;
-  using typename Superclass2::ConfigurationPointer;
   using typename Superclass2::RegistrationType;
   using typename Superclass2::RegistrationPointer;
   using typename Superclass2::CoordRepType;

--- a/Components/Transforms/EulerStackTransform/elxEulerStackTransform.h
+++ b/Components/Transforms/EulerStackTransform/elxEulerStackTransform.h
@@ -132,7 +132,6 @@ public:
   using typename Superclass2::ElastixType;
   using typename Superclass2::ElastixPointer;
   using typename Superclass2::ParameterMapType;
-  using typename Superclass2::ConfigurationType;
   using typename Superclass2::ConfigurationPointer;
   using typename Superclass2::RegistrationType;
   using typename Superclass2::RegistrationPointer;

--- a/Components/Transforms/EulerTransform/elxEulerTransform.h
+++ b/Components/Transforms/EulerTransform/elxEulerTransform.h
@@ -133,7 +133,6 @@ public:
   using typename Superclass2::ElastixType;
   using typename Superclass2::ElastixPointer;
   using typename Superclass2::ParameterMapType;
-  using typename Superclass2::ConfigurationPointer;
   using typename Superclass2::RegistrationType;
   using typename Superclass2::RegistrationPointer;
   using typename Superclass2::CoordRepType;

--- a/Components/Transforms/EulerTransform/elxEulerTransform.h
+++ b/Components/Transforms/EulerTransform/elxEulerTransform.h
@@ -133,7 +133,6 @@ public:
   using typename Superclass2::ElastixType;
   using typename Superclass2::ElastixPointer;
   using typename Superclass2::ParameterMapType;
-  using typename Superclass2::ConfigurationType;
   using typename Superclass2::ConfigurationPointer;
   using typename Superclass2::RegistrationType;
   using typename Superclass2::RegistrationPointer;

--- a/Components/Transforms/MultiBSplineTransformWithNormal/elxMultiBSplineTransformWithNormal.h
+++ b/Components/Transforms/MultiBSplineTransformWithNormal/elxMultiBSplineTransformWithNormal.h
@@ -169,7 +169,6 @@ public:
   using typename Superclass2::ElastixType;
   using typename Superclass2::ElastixPointer;
   using typename Superclass2::ParameterMapType;
-  using typename Superclass2::ConfigurationType;
   using typename Superclass2::ConfigurationPointer;
   using typename Superclass2::RegistrationType;
   using typename Superclass2::RegistrationPointer;

--- a/Components/Transforms/MultiBSplineTransformWithNormal/elxMultiBSplineTransformWithNormal.h
+++ b/Components/Transforms/MultiBSplineTransformWithNormal/elxMultiBSplineTransformWithNormal.h
@@ -169,7 +169,6 @@ public:
   using typename Superclass2::ElastixType;
   using typename Superclass2::ElastixPointer;
   using typename Superclass2::ParameterMapType;
-  using typename Superclass2::ConfigurationPointer;
   using typename Superclass2::RegistrationType;
   using typename Superclass2::RegistrationPointer;
   using typename Superclass2::CoordRepType;

--- a/Components/Transforms/RecursiveBSplineTransform/elxRecursiveBSplineTransform.h
+++ b/Components/Transforms/RecursiveBSplineTransform/elxRecursiveBSplineTransform.h
@@ -173,7 +173,6 @@ public:
   /** Typedef's from TransformBase. */
   using typename Superclass2::ElastixType;
   using typename Superclass2::ElastixPointer;
-  using typename Superclass2::ConfigurationPointer;
   using typename Superclass2::RegistrationType;
   using typename Superclass2::RegistrationPointer;
   using typename Superclass2::CoordRepType;

--- a/Components/Transforms/RecursiveBSplineTransform/elxRecursiveBSplineTransform.h
+++ b/Components/Transforms/RecursiveBSplineTransform/elxRecursiveBSplineTransform.h
@@ -173,7 +173,6 @@ public:
   /** Typedef's from TransformBase. */
   using typename Superclass2::ElastixType;
   using typename Superclass2::ElastixPointer;
-  using typename Superclass2::ConfigurationType;
   using typename Superclass2::ConfigurationPointer;
   using typename Superclass2::RegistrationType;
   using typename Superclass2::RegistrationPointer;

--- a/Components/Transforms/SimilarityTransform/elxSimilarityTransform.h
+++ b/Components/Transforms/SimilarityTransform/elxSimilarityTransform.h
@@ -135,7 +135,6 @@ public:
   using typename Superclass2::ElastixType;
   using typename Superclass2::ElastixPointer;
   using typename Superclass2::ParameterMapType;
-  using typename Superclass2::ConfigurationPointer;
   using typename Superclass2::RegistrationType;
   using typename Superclass2::RegistrationPointer;
   using typename Superclass2::CoordRepType;

--- a/Components/Transforms/SimilarityTransform/elxSimilarityTransform.h
+++ b/Components/Transforms/SimilarityTransform/elxSimilarityTransform.h
@@ -135,7 +135,6 @@ public:
   using typename Superclass2::ElastixType;
   using typename Superclass2::ElastixPointer;
   using typename Superclass2::ParameterMapType;
-  using typename Superclass2::ConfigurationType;
   using typename Superclass2::ConfigurationPointer;
   using typename Superclass2::RegistrationType;
   using typename Superclass2::RegistrationPointer;

--- a/Components/Transforms/SplineKernelTransform/elxSplineKernelTransform.h
+++ b/Components/Transforms/SplineKernelTransform/elxSplineKernelTransform.h
@@ -165,7 +165,6 @@ public:
   using typename Superclass2::ElastixType;
   using typename Superclass2::ElastixPointer;
   using typename Superclass2::ParameterMapType;
-  using typename Superclass2::ConfigurationType;
   using typename Superclass2::ConfigurationPointer;
   using typename Superclass2::RegistrationType;
   using typename Superclass2::RegistrationPointer;

--- a/Components/Transforms/SplineKernelTransform/elxSplineKernelTransform.h
+++ b/Components/Transforms/SplineKernelTransform/elxSplineKernelTransform.h
@@ -165,7 +165,6 @@ public:
   using typename Superclass2::ElastixType;
   using typename Superclass2::ElastixPointer;
   using typename Superclass2::ParameterMapType;
-  using typename Superclass2::ConfigurationPointer;
   using typename Superclass2::RegistrationType;
   using typename Superclass2::RegistrationPointer;
   using typename Superclass2::CoordRepType;

--- a/Components/Transforms/TranslationStackTransform/elxTranslationStackTransform.h
+++ b/Components/Transforms/TranslationStackTransform/elxTranslationStackTransform.h
@@ -104,7 +104,6 @@ public:
   using typename Superclass2::ElastixType;
   using typename Superclass2::ElastixPointer;
   using typename Superclass2::ParameterMapType;
-  using typename Superclass2::ConfigurationType;
   using typename Superclass2::ConfigurationPointer;
   using typename Superclass2::RegistrationType;
   using typename Superclass2::RegistrationPointer;

--- a/Components/Transforms/TranslationStackTransform/elxTranslationStackTransform.h
+++ b/Components/Transforms/TranslationStackTransform/elxTranslationStackTransform.h
@@ -104,7 +104,6 @@ public:
   using typename Superclass2::ElastixType;
   using typename Superclass2::ElastixPointer;
   using typename Superclass2::ParameterMapType;
-  using typename Superclass2::ConfigurationPointer;
   using typename Superclass2::RegistrationType;
   using typename Superclass2::RegistrationPointer;
   using typename Superclass2::CoordRepType;

--- a/Components/Transforms/TranslationTransform/elxTranslationTransform.h
+++ b/Components/Transforms/TranslationTransform/elxTranslationTransform.h
@@ -103,7 +103,6 @@ public:
   using typename Superclass2::ElastixType;
   using typename Superclass2::ElastixPointer;
   using typename Superclass2::ParameterMapType;
-  using typename Superclass2::ConfigurationPointer;
   using typename Superclass2::RegistrationType;
   using typename Superclass2::RegistrationPointer;
   using typename Superclass2::CoordRepType;

--- a/Components/Transforms/TranslationTransform/elxTranslationTransform.h
+++ b/Components/Transforms/TranslationTransform/elxTranslationTransform.h
@@ -103,7 +103,6 @@ public:
   using typename Superclass2::ElastixType;
   using typename Superclass2::ElastixPointer;
   using typename Superclass2::ParameterMapType;
-  using typename Superclass2::ConfigurationType;
   using typename Superclass2::ConfigurationPointer;
   using typename Superclass2::RegistrationType;
   using typename Superclass2::RegistrationPointer;

--- a/Components/Transforms/WeightedCombinationTransform/elxWeightedCombinationTransform.h
+++ b/Components/Transforms/WeightedCombinationTransform/elxWeightedCombinationTransform.h
@@ -136,7 +136,6 @@ public:
   using typename Superclass2::ElastixType;
   using typename Superclass2::ElastixPointer;
   using typename Superclass2::ParameterMapType;
-  using typename Superclass2::ConfigurationType;
   using typename Superclass2::ConfigurationPointer;
   using typename Superclass2::RegistrationType;
   using typename Superclass2::RegistrationPointer;

--- a/Components/Transforms/WeightedCombinationTransform/elxWeightedCombinationTransform.h
+++ b/Components/Transforms/WeightedCombinationTransform/elxWeightedCombinationTransform.h
@@ -136,7 +136,6 @@ public:
   using typename Superclass2::ElastixType;
   using typename Superclass2::ElastixPointer;
   using typename Superclass2::ParameterMapType;
-  using typename Superclass2::ConfigurationPointer;
   using typename Superclass2::RegistrationType;
   using typename Superclass2::RegistrationPointer;
   using typename Superclass2::CoordRepType;

--- a/Components/Transforms/WeightedCombinationTransform/elxWeightedCombinationTransform.hxx
+++ b/Components/Transforms/WeightedCombinationTransform/elxWeightedCombinationTransform.hxx
@@ -226,7 +226,7 @@ WeightedCombinationTransformElastix<TElastix>::LoadSubTransforms()
 
     /** Create a new configuration, which will be initialized with
      * the subtransformFileName. */
-    ConfigurationPointer configurationSubTransform = ConfigurationType::New();
+    ConfigurationPointer configurationSubTransform = Configuration::New();
 
     /** Create argmapInitialTransform. */
     CommandLineArgumentMapType argmapSubTransform;

--- a/Components/Transforms/WeightedCombinationTransform/elxWeightedCombinationTransform.hxx
+++ b/Components/Transforms/WeightedCombinationTransform/elxWeightedCombinationTransform.hxx
@@ -225,7 +225,7 @@ WeightedCombinationTransformElastix<TElastix>::LoadSubTransforms()
 
     /** Create a new configuration, which will be initialized with
      * the subtransformFileName. */
-    ConfigurationPointer configurationSubTransform = Configuration::New();
+    const auto configurationSubTransform = Configuration::New();
 
     /** Create argmapInitialTransform. */
     CommandLineArgumentMapType argmapSubTransform;

--- a/Components/Transforms/WeightedCombinationTransform/elxWeightedCombinationTransform.hxx
+++ b/Components/Transforms/WeightedCombinationTransform/elxWeightedCombinationTransform.hxx
@@ -243,12 +243,9 @@ WeightedCombinationTransformElastix<TElastix>::LoadSubTransforms()
     configurationSubTransform->ReadParameter(subTransformName, "Transform", 0);
 
     /** Create a SubTransform. */
-    typename ObjectType::Pointer subTransform;
-    PtrToCreator                 testcreator = nullptr;
-    testcreator = ElastixMain::GetComponentDatabase().GetCreator(subTransformName, this->m_Elastix->GetDBIndex());
-
-    // Note that ObjectType::Pointer() yields a default-constructed SmartPointer (null).
-    subTransform = testcreator ? testcreator() : typename ObjectType::Pointer();
+    const PtrToCreator testcreator =
+      ElastixMain::GetComponentDatabase().GetCreator(subTransformName, this->m_Elastix->GetDBIndex());
+    const typename ObjectType::Pointer subTransform = (testcreator == nullptr) ? nullptr : testcreator();
 
     /** Cast to TransformBase */
     Superclass2 * elx_subTransform = dynamic_cast<Superclass2 *>(subTransform.GetPointer());

--- a/Components/Transforms/WeightedCombinationTransform/elxWeightedCombinationTransform.hxx
+++ b/Components/Transforms/WeightedCombinationTransform/elxWeightedCombinationTransform.hxx
@@ -196,7 +196,6 @@ WeightedCombinationTransformElastix<TElastix>::LoadSubTransforms()
   /** Typedef's from ComponentDatabase. */
   using ComponentDescriptionType = typename Superclass2::ComponentDescriptionType;
   using PtrToCreator = typename Superclass2::PtrToCreator;
-  using ObjectType = typename Superclass2::ObjectType;
 
   const std::size_t N = this->m_Configuration->CountNumberOfParameterEntries("SubTransforms");
 
@@ -245,7 +244,7 @@ WeightedCombinationTransformElastix<TElastix>::LoadSubTransforms()
     /** Create a SubTransform. */
     const PtrToCreator testcreator =
       ElastixMain::GetComponentDatabase().GetCreator(subTransformName, this->m_Elastix->GetDBIndex());
-    const typename ObjectType::Pointer subTransform = (testcreator == nullptr) ? nullptr : testcreator();
+    const itk::Object::Pointer subTransform = (testcreator == nullptr) ? nullptr : testcreator();
 
     /** Cast to TransformBase */
     Superclass2 * elx_subTransform = dynamic_cast<Superclass2 *>(subTransform.GetPointer());

--- a/Core/ComponentBaseClasses/elxFixedImagePyramidBase.h
+++ b/Core/ComponentBaseClasses/elxFixedImagePyramidBase.h
@@ -68,7 +68,6 @@ public:
   /** Typedefs inherited from the superclass. */
   using typename Superclass::ElastixType;
   using typename Superclass::ElastixPointer;
-  using typename Superclass::ConfigurationPointer;
   using typename Superclass::RegistrationType;
   using typename Superclass::RegistrationPointer;
 

--- a/Core/ComponentBaseClasses/elxFixedImagePyramidBase.h
+++ b/Core/ComponentBaseClasses/elxFixedImagePyramidBase.h
@@ -68,7 +68,6 @@ public:
   /** Typedefs inherited from the superclass. */
   using typename Superclass::ElastixType;
   using typename Superclass::ElastixPointer;
-  using typename Superclass::ConfigurationType;
   using typename Superclass::ConfigurationPointer;
   using typename Superclass::RegistrationType;
   using typename Superclass::RegistrationPointer;

--- a/Core/ComponentBaseClasses/elxImageSamplerBase.h
+++ b/Core/ComponentBaseClasses/elxImageSamplerBase.h
@@ -54,7 +54,6 @@ public:
   /** Typedefs inherited from Elastix. */
   using typename Superclass::ElastixType;
   using typename Superclass::ElastixPointer;
-  using typename Superclass::ConfigurationType;
   using typename Superclass::ConfigurationPointer;
   using typename Superclass::RegistrationType;
   using typename Superclass::RegistrationPointer;

--- a/Core/ComponentBaseClasses/elxImageSamplerBase.h
+++ b/Core/ComponentBaseClasses/elxImageSamplerBase.h
@@ -54,7 +54,6 @@ public:
   /** Typedefs inherited from Elastix. */
   using typename Superclass::ElastixType;
   using typename Superclass::ElastixPointer;
-  using typename Superclass::ConfigurationPointer;
   using typename Superclass::RegistrationType;
   using typename Superclass::RegistrationPointer;
 

--- a/Core/ComponentBaseClasses/elxInterpolatorBase.h
+++ b/Core/ComponentBaseClasses/elxInterpolatorBase.h
@@ -54,7 +54,6 @@ public:
   /** Typedefs inherited from Elastix. */
   using typename Superclass::ElastixType;
   using typename Superclass::ElastixPointer;
-  using typename Superclass::ConfigurationType;
   using typename Superclass::ConfigurationPointer;
   using typename Superclass::RegistrationType;
   using typename Superclass::RegistrationPointer;

--- a/Core/ComponentBaseClasses/elxInterpolatorBase.h
+++ b/Core/ComponentBaseClasses/elxInterpolatorBase.h
@@ -54,7 +54,6 @@ public:
   /** Typedefs inherited from Elastix. */
   using typename Superclass::ElastixType;
   using typename Superclass::ElastixPointer;
-  using typename Superclass::ConfigurationPointer;
   using typename Superclass::RegistrationType;
   using typename Superclass::RegistrationPointer;
 

--- a/Core/ComponentBaseClasses/elxMetricBase.h
+++ b/Core/ComponentBaseClasses/elxMetricBase.h
@@ -82,7 +82,6 @@ public:
   /** Typedef's inherited from Elastix. */
   using typename Superclass::ElastixType;
   using typename Superclass::ElastixPointer;
-  using typename Superclass::ConfigurationType;
   using typename Superclass::ConfigurationPointer;
   using typename Superclass::RegistrationType;
   using typename Superclass::RegistrationPointer;

--- a/Core/ComponentBaseClasses/elxMetricBase.h
+++ b/Core/ComponentBaseClasses/elxMetricBase.h
@@ -82,7 +82,6 @@ public:
   /** Typedef's inherited from Elastix. */
   using typename Superclass::ElastixType;
   using typename Superclass::ElastixPointer;
-  using typename Superclass::ConfigurationPointer;
   using typename Superclass::RegistrationType;
   using typename Superclass::RegistrationPointer;
 

--- a/Core/ComponentBaseClasses/elxMovingImagePyramidBase.h
+++ b/Core/ComponentBaseClasses/elxMovingImagePyramidBase.h
@@ -70,7 +70,6 @@ public:
   /** Typedefs inherited from the superclass. */
   using typename Superclass::ElastixType;
   using typename Superclass::ElastixPointer;
-  using typename Superclass::ConfigurationType;
   using typename Superclass::ConfigurationPointer;
   using typename Superclass::RegistrationType;
   using typename Superclass::RegistrationPointer;

--- a/Core/ComponentBaseClasses/elxMovingImagePyramidBase.h
+++ b/Core/ComponentBaseClasses/elxMovingImagePyramidBase.h
@@ -70,7 +70,6 @@ public:
   /** Typedefs inherited from the superclass. */
   using typename Superclass::ElastixType;
   using typename Superclass::ElastixPointer;
-  using typename Superclass::ConfigurationPointer;
   using typename Superclass::RegistrationType;
   using typename Superclass::RegistrationPointer;
 

--- a/Core/ComponentBaseClasses/elxOptimizerBase.h
+++ b/Core/ComponentBaseClasses/elxOptimizerBase.h
@@ -63,7 +63,6 @@ public:
   /** Typedefs inherited from Elastix. */
   using typename Superclass::ElastixType;
   using typename Superclass::ElastixPointer;
-  using typename Superclass::ConfigurationType;
   using typename Superclass::ConfigurationPointer;
   using typename Superclass::RegistrationType;
   using typename Superclass::RegistrationPointer;

--- a/Core/ComponentBaseClasses/elxOptimizerBase.h
+++ b/Core/ComponentBaseClasses/elxOptimizerBase.h
@@ -63,7 +63,6 @@ public:
   /** Typedefs inherited from Elastix. */
   using typename Superclass::ElastixType;
   using typename Superclass::ElastixPointer;
-  using typename Superclass::ConfigurationPointer;
   using typename Superclass::RegistrationType;
   using typename Superclass::RegistrationPointer;
 

--- a/Core/ComponentBaseClasses/elxRegistrationBase.h
+++ b/Core/ComponentBaseClasses/elxRegistrationBase.h
@@ -85,7 +85,6 @@ public:
   /** Typedef's from Elastix. */
   using typename Superclass::ElastixType;
   using typename Superclass::ElastixPointer;
-  using typename Superclass::ConfigurationType;
   using typename Superclass::ConfigurationPointer;
   using typename Superclass::RegistrationType;
   using typename Superclass::RegistrationPointer;

--- a/Core/ComponentBaseClasses/elxRegistrationBase.h
+++ b/Core/ComponentBaseClasses/elxRegistrationBase.h
@@ -85,7 +85,6 @@ public:
   /** Typedef's from Elastix. */
   using typename Superclass::ElastixType;
   using typename Superclass::ElastixPointer;
-  using typename Superclass::ConfigurationPointer;
   using typename Superclass::RegistrationType;
   using typename Superclass::RegistrationPointer;
 

--- a/Core/ComponentBaseClasses/elxResampleInterpolatorBase.h
+++ b/Core/ComponentBaseClasses/elxResampleInterpolatorBase.h
@@ -53,7 +53,6 @@ public:
   /** Typedef's from superclass. */
   using typename Superclass::ElastixType;
   using typename Superclass::ElastixPointer;
-  using typename Superclass::ConfigurationType;
   using typename Superclass::ConfigurationPointer;
   using typename Superclass::RegistrationType;
   using typename Superclass::RegistrationPointer;

--- a/Core/ComponentBaseClasses/elxResampleInterpolatorBase.h
+++ b/Core/ComponentBaseClasses/elxResampleInterpolatorBase.h
@@ -53,7 +53,6 @@ public:
   /** Typedef's from superclass. */
   using typename Superclass::ElastixType;
   using typename Superclass::ElastixPointer;
-  using typename Superclass::ConfigurationPointer;
   using typename Superclass::RegistrationType;
   using typename Superclass::RegistrationPointer;
 

--- a/Core/ComponentBaseClasses/elxResamplerBase.h
+++ b/Core/ComponentBaseClasses/elxResamplerBase.h
@@ -86,7 +86,6 @@ public:
   /** Typedef's from superclass. */
   using typename Superclass::ElastixType;
   using typename Superclass::ElastixPointer;
-  using typename Superclass::ConfigurationType;
   using typename Superclass::ConfigurationPointer;
   using typename Superclass::RegistrationType;
   using typename Superclass::RegistrationPointer;

--- a/Core/ComponentBaseClasses/elxResamplerBase.h
+++ b/Core/ComponentBaseClasses/elxResamplerBase.h
@@ -86,7 +86,6 @@ public:
   /** Typedef's from superclass. */
   using typename Superclass::ElastixType;
   using typename Superclass::ElastixPointer;
-  using typename Superclass::ConfigurationPointer;
   using typename Superclass::RegistrationType;
   using typename Superclass::RegistrationPointer;
 

--- a/Core/ComponentBaseClasses/elxTransformBase.h
+++ b/Core/ComponentBaseClasses/elxTransformBase.h
@@ -166,7 +166,6 @@ public:
   itkStaticConstMacro(MovingImageDimension, unsigned int, MovingImageType::ImageDimension);
 
   /** Other typedef's. */
-  using ObjectType = itk::Object;
   using CombinationTransformType = itk::AdvancedCombinationTransform<CoordRepType, Self::FixedImageDimension>;
   using ITKBaseType = CombinationTransformType;
   using InitialTransformType = typename CombinationTransformType::InitialTransformType;

--- a/Core/ComponentBaseClasses/elxTransformBase.hxx
+++ b/Core/ComponentBaseClasses/elxTransformBase.hxx
@@ -428,7 +428,7 @@ TransformBase<TElastix>::ReadInitialTransformFromConfiguration(
   /** Create an InitialTransform. */
   const PtrToCreator testcreator =
     ElastixMain::GetComponentDatabase().GetCreator(initialTransformName, this->m_Elastix->GetDBIndex());
-  const ObjectType::Pointer initialTransform = (testcreator == nullptr) ? nullptr : testcreator();
+  const itk::Object::Pointer initialTransform = (testcreator == nullptr) ? nullptr : testcreator();
 
   const auto elx_initialTransform = dynamic_cast<Self *>(initialTransform.GetPointer());
 

--- a/Core/Install/elxBaseComponentSE.h
+++ b/Core/Install/elxBaseComponentSE.h
@@ -57,8 +57,7 @@ public:
   using ElastixType = TElastix;
   using ElastixPointer = itk::WeakPointer<ElastixType>;
 
-  /** ConfigurationType. */
-  using ConfigurationType = Configuration;
+  /** Configuration pointer type. */
   using ConfigurationPointer = Configuration::Pointer;
 
   /** RegistrationType; NB: this is the elx::RegistrationBase
@@ -109,11 +108,11 @@ public:
     return this->m_Elastix->AddTargetCellToIterationInfo(name);
   }
 
-  /** itkGetModifiableObjectMacro(Configuration, ConfigurationType);
+  /** itkGetModifiableObjectMacro(Configuration, Configuration);
    * The configuration object provides functionality to
    * read parameters and command line arguments.
    */
-  ConfigurationType *
+  Configuration *
   GetConfiguration() const
   {
     return this->m_Configuration.GetPointer();
@@ -122,7 +121,7 @@ public:
 
   /** Set the configuration. Added for transformix. */
   void
-  SetConfiguration(ConfigurationType * _arg);
+  SetConfiguration(Configuration * _arg);
 
   /** Get a pointer to the Registration component.
    * This is a convenience function, since the registration

--- a/Core/Install/elxBaseComponentSE.hxx
+++ b/Core/Install/elxBaseComponentSE.hxx
@@ -57,7 +57,7 @@ BaseComponentSE<TElastix>::SetElastix(TElastix * const _arg)
 
 template <class TElastix>
 void
-BaseComponentSE<TElastix>::SetConfiguration(ConfigurationType * const _arg)
+BaseComponentSE<TElastix>::SetConfiguration(Configuration * const _arg)
 {
   /** If this->m_Configuration is not set, then set it.*/
   if (this->m_Configuration != _arg)

--- a/Core/Install/elxComponentDatabase.h
+++ b/Core/Install/elxComponentDatabase.h
@@ -65,8 +65,7 @@ public:
   using IndexType = unsigned int;
 
   /** Typedefs for the CreatorMap*/
-  using ObjectType = itk::Object;
-  using ObjectPointer = ObjectType::Pointer;
+  using ObjectPointer = itk::Object::Pointer;
 
   /** PtrToCreator is a pointer to a function which
    * outputs an ObjectPointer and has no input arguments.

--- a/Core/Install/elxInstallFunctions.h
+++ b/Core/Install/elxInstallFunctions.h
@@ -51,7 +51,6 @@ public:
   using AnyItkObjectType = TAnyItkObject;
 
   /** The baseclass of all objects that are returned by the Creator. */
-  using ObjectType = ComponentDatabase::ObjectType;
   using ObjectPointer = ComponentDatabase::ObjectPointer;
 
   /** The type of the index in the component database.

--- a/Core/Kernel/elxElastixBase.h
+++ b/Core/Kernel/elxElastixBase.h
@@ -151,8 +151,7 @@ public:
 
   /** Typedefs used in this class. */
   using ConfigurationPointer = Configuration::Pointer;
-  using ObjectType = itk::Object; // for the components
-  using ObjectPointer = ObjectType::Pointer;
+  using ObjectPointer = itk::Object::Pointer;
   using DataObjectType = itk::DataObject; // for the images
   using DataObjectPointer = DataObjectType::Pointer;
   using ObjectContainerType = itk::VectorContainer<unsigned int, ObjectPointer>;
@@ -286,20 +285,20 @@ public:
   elxGetNumberOfMacro(ResultDeformationField);
 
   /** Set/Get the initial transform
-   * The type is ObjectType, but the pointer should actually point
+   * The type is itk::Object, but the pointer should actually point
    * to an itk::Transform type (or inherited from that one).
    */
-  elxSetObjectMacro(InitialTransform, ObjectType);
-  elxGetObjectMacro(InitialTransform, ObjectType);
+  elxSetObjectMacro(InitialTransform, itk::Object);
+  elxGetObjectMacro(InitialTransform, itk::Object);
 
   /** Set/Get the final transform
-   * The type is ObjectType, but the pointer should actually point
+   * The type is itk::Object, but the pointer should actually point
    * to an itk::Transform type (or inherited from that one).
    * You can use this to set it as an initial transform in another
    * ElastixBase instantiation.
    */
-  elxSetObjectMacro(FinalTransform, ObjectType);
-  elxGetObjectMacro(FinalTransform, ObjectType);
+  elxSetObjectMacro(FinalTransform, itk::Object);
+  elxGetObjectMacro(FinalTransform, itk::Object);
 
   /** Empty Run()-function to be overridden. */
   virtual int

--- a/Core/Kernel/elxElastixBase.h
+++ b/Core/Kernel/elxElastixBase.h
@@ -150,8 +150,7 @@ public:
   using Superclass = BaseComponent;
 
   /** Typedefs used in this class. */
-  using ConfigurationType = Configuration;
-  using ConfigurationPointer = ConfigurationType::Pointer;
+  using ConfigurationPointer = Configuration::Pointer;
   using ObjectType = itk::Object; // for the components
   using ObjectPointer = ObjectType::Pointer;
   using DataObjectType = itk::DataObject; // for the images
@@ -185,8 +184,8 @@ public:
   using TimerType = itk::TimeProbe;
 
   /** Set/Get the Configuration Object. */
-  elxGetObjectMacro(Configuration, ConfigurationType);
-  elxSetObjectMacro(Configuration, ConfigurationType);
+  elxGetObjectMacro(Configuration, Configuration);
+  elxSetObjectMacro(Configuration, Configuration);
 
   /** Set the database index of the instantiated elastix object. */
   void

--- a/Core/Kernel/elxElastixMain.cxx
+++ b/Core/Kernel/elxElastixMain.cxx
@@ -750,11 +750,8 @@ ElastixMain::ObjectPointer
 ElastixMain::CreateComponent(const ComponentDescriptionType & name)
 {
   /** A pointer to the New() function. */
-  PtrToCreator testcreator = nullptr;
-  testcreator = GetComponentDatabase().GetCreator(name, this->m_DBIndex);
-
-  // Note that ObjectPointer() yields a default-constructed SmartPointer (null).
-  ObjectPointer testpointer = testcreator ? testcreator() : ObjectPointer();
+  const PtrToCreator  testcreator = GetComponentDatabase().GetCreator(name, this->m_DBIndex);
+  const ObjectPointer testpointer = (testcreator == nullptr) ? nullptr : testcreator();
 
   if (testpointer.IsNull())
   {

--- a/Core/Kernel/elxElastixMain.cxx
+++ b/Core/Kernel/elxElastixMain.cxx
@@ -151,7 +151,7 @@ xoutManager::Guard::~Guard()
 ElastixMain::ElastixMain()
 {
   /** Initialize the components. */
-  this->m_Configuration = ConfigurationType::New();
+  this->m_Configuration = Configuration::New();
 
   this->m_Elastix = nullptr;
 
@@ -271,7 +271,7 @@ ElastixMain::EnterCommandLineArguments(const ArgumentMapType & argmap, const std
     /** Initialize the configuration object with the
      * command line parameters entered by the user.
      */
-    this->m_Configurations[i] = ConfigurationType::New();
+    this->m_Configurations[i] = Configuration::New();
     int dummy = this->m_Configurations[i]->Initialize(argmap, inputMaps[i]);
     if (dummy)
     {

--- a/Core/Kernel/elxElastixMain.h
+++ b/Core/Kernel/elxElastixMain.h
@@ -141,8 +141,7 @@ public:
   /** Typedef's.*/
 
   /** ITK base objects. */
-  using ObjectType = itk::Object;
-  using ObjectPointer = ObjectType::Pointer;
+  using ObjectPointer = itk::Object::Pointer;
   using DataObjectType = itk::DataObject;
   using DataObjectPointer = DataObjectType::Pointer;
 
@@ -216,7 +215,7 @@ public:
    * The components are returned as Object::Pointer.
    * Before calling this functions, call run().
    */
-  itkGetModifiableObjectMacro(Elastix, ObjectType);
+  itkGetModifiableObjectMacro(Elastix, itk::Object);
 
   /** Convenience function that returns the elastix component as
    * a pointer to an ElastixBaseType. Use only after having called run()!
@@ -229,14 +228,14 @@ public:
    * of ElastixMain.
    * Only valid after calling Run()!
    */
-  itkGetModifiableObjectMacro(FinalTransform, ObjectType);
+  itkGetModifiableObjectMacro(FinalTransform, itk::Object);
 
   /** Set/Get the initial transform
-   * the type is ObjectType, but the pointer should actually point
+   * the type is itk::Object, but the pointer should actually point
    * to an itk::Transform type (or inherited from that one).
    */
-  itkSetObjectMacro(InitialTransform, ObjectType);
-  itkGetModifiableObjectMacro(InitialTransform, ObjectType);
+  itkSetObjectMacro(InitialTransform, itk::Object);
+  itkGetModifiableObjectMacro(InitialTransform, itk::Object);
 
   /** Set/Get the original fixed image direction as a flat array
    * (d11 d21 d31 d21 d22 etc ) */

--- a/Core/Kernel/elxElastixMain.h
+++ b/Core/Kernel/elxElastixMain.h
@@ -148,9 +148,8 @@ public:
 
   /** elastix components. */
   using ElastixBaseType = ElastixBase;
-  using ConfigurationType = ElastixBase::ConfigurationType;
-  using ArgumentMapType = ConfigurationType::CommandLineArgumentMapType;
-  using ConfigurationPointer = ConfigurationType::Pointer;
+  using ArgumentMapType = Configuration::CommandLineArgumentMapType;
+  using ConfigurationPointer = Configuration::Pointer;
   using ObjectContainerType = ElastixBase::ObjectContainerType;
   using DataObjectContainerType = ElastixBase::DataObjectContainerType;
   using ObjectContainerPointer = ElastixBase::ObjectContainerPointer;
@@ -210,8 +209,8 @@ public:
   itkGetModifiableObjectMacro(ResultDeformationFieldContainer, DataObjectContainerType);
 
   /** Set/Get the configuration object. */
-  itkSetObjectMacro(Configuration, ConfigurationType);
-  itkGetModifiableObjectMacro(Configuration, ConfigurationType);
+  itkSetObjectMacro(Configuration, Configuration);
+  itkGetModifiableObjectMacro(Configuration, Configuration);
 
   /** Functions to get pointers to the elastix components.
    * The components are returned as Object::Pointer.

--- a/Core/Kernel/elxTransformixMain.h
+++ b/Core/Kernel/elxTransformixMain.h
@@ -60,7 +60,6 @@ public:
   /** Elastix components. */
   using Superclass::ElastixBaseType;
   using Superclass::ArgumentMapType;
-  using Superclass::ConfigurationPointer;
   using Superclass::ObjectContainerType;
   using Superclass::DataObjectContainerType;
   using Superclass::ObjectContainerPointer;

--- a/Core/Kernel/elxTransformixMain.h
+++ b/Core/Kernel/elxTransformixMain.h
@@ -60,7 +60,6 @@ public:
 
   /** Elastix components. */
   using Superclass::ElastixBaseType;
-  using Superclass::ConfigurationType;
   using Superclass::ArgumentMapType;
   using Superclass::ConfigurationPointer;
   using Superclass::ObjectContainerType;

--- a/Core/Kernel/elxTransformixMain.h
+++ b/Core/Kernel/elxTransformixMain.h
@@ -53,7 +53,6 @@ public:
   /** Typedef's from Superclass. */
 
   /** typedef's from itk base Object. */
-  using ObjectType = Superclass::ObjectType;
   using Superclass::ObjectPointer;
   using Superclass::DataObjectType;
   using Superclass::DataObjectPointer;


### PR DESCRIPTION
The `ConfigurationType` and `ObjectType` typedefs appear rarely used, while they had many `using-declarations`. The `using <superclass>::ConfigurationPointer` declarations did not appear necessary either.

