### PR TITLE
Remove nested ParameterFileParser, ParameterMapInterface, ComponentDatabase, ElastixBase, RegistrationPointer, ElastixPointer typedefs

### DIFF
--- a/Components/FixedImagePyramids/FixedGenericPyramid/elxFixedGenericPyramid.h
+++ b/Components/FixedImagePyramids/FixedGenericPyramid/elxFixedGenericPyramid.h
@@ -107,7 +107,6 @@ public:
 
   /** Typedefs inherited from Elastix. */
   using typename Superclass2::ElastixType;
-  using typename Superclass2::ElastixPointer;
   using typename Superclass2::RegistrationType;
   using ITKBaseType = typename Superclass2::ITKBaseType;
 

--- a/Components/FixedImagePyramids/FixedGenericPyramid/elxFixedGenericPyramid.h
+++ b/Components/FixedImagePyramids/FixedGenericPyramid/elxFixedGenericPyramid.h
@@ -109,7 +109,6 @@ public:
   using typename Superclass2::ElastixType;
   using typename Superclass2::ElastixPointer;
   using typename Superclass2::RegistrationType;
-  using typename Superclass2::RegistrationPointer;
   using ITKBaseType = typename Superclass2::ITKBaseType;
 
   /** Method for setting the schedule. Override from FixedImagePyramidBase,

--- a/Components/FixedImagePyramids/FixedRecursivePyramid/elxFixedRecursivePyramid.h
+++ b/Components/FixedImagePyramids/FixedRecursivePyramid/elxFixedRecursivePyramid.h
@@ -78,7 +78,6 @@ public:
   using typename Superclass2::ElastixType;
   using typename Superclass2::ElastixPointer;
   using typename Superclass2::RegistrationType;
-  using typename Superclass2::RegistrationPointer;
   using ITKBaseType = typename Superclass2::ITKBaseType;
 
 protected:

--- a/Components/FixedImagePyramids/FixedRecursivePyramid/elxFixedRecursivePyramid.h
+++ b/Components/FixedImagePyramids/FixedRecursivePyramid/elxFixedRecursivePyramid.h
@@ -76,7 +76,6 @@ public:
 
   /** Typedefs inherited from Elastix. */
   using typename Superclass2::ElastixType;
-  using typename Superclass2::ElastixPointer;
   using typename Superclass2::RegistrationType;
   using ITKBaseType = typename Superclass2::ITKBaseType;
 

--- a/Components/FixedImagePyramids/FixedShrinkingPyramid/elxFixedShrinkingPyramid.h
+++ b/Components/FixedImagePyramids/FixedShrinkingPyramid/elxFixedShrinkingPyramid.h
@@ -78,7 +78,6 @@ public:
   using typename Superclass2::ElastixType;
   using typename Superclass2::ElastixPointer;
   using typename Superclass2::RegistrationType;
-  using typename Superclass2::RegistrationPointer;
   using ITKBaseType = typename Superclass2::ITKBaseType;
 
 protected:

--- a/Components/FixedImagePyramids/FixedShrinkingPyramid/elxFixedShrinkingPyramid.h
+++ b/Components/FixedImagePyramids/FixedShrinkingPyramid/elxFixedShrinkingPyramid.h
@@ -76,7 +76,6 @@ public:
 
   /** Typedefs inherited from Elastix. */
   using typename Superclass2::ElastixType;
-  using typename Superclass2::ElastixPointer;
   using typename Superclass2::RegistrationType;
   using ITKBaseType = typename Superclass2::ITKBaseType;
 

--- a/Components/FixedImagePyramids/FixedSmoothingPyramid/elxFixedSmoothingPyramid.h
+++ b/Components/FixedImagePyramids/FixedSmoothingPyramid/elxFixedSmoothingPyramid.h
@@ -77,7 +77,6 @@ public:
 
   /** Typedefs inherited from Elastix. */
   using typename Superclass2::ElastixType;
-  using typename Superclass2::ElastixPointer;
   using typename Superclass2::RegistrationType;
   using ITKBaseType = typename Superclass2::ITKBaseType;
 

--- a/Components/FixedImagePyramids/FixedSmoothingPyramid/elxFixedSmoothingPyramid.h
+++ b/Components/FixedImagePyramids/FixedSmoothingPyramid/elxFixedSmoothingPyramid.h
@@ -79,7 +79,6 @@ public:
   using typename Superclass2::ElastixType;
   using typename Superclass2::ElastixPointer;
   using typename Superclass2::RegistrationType;
-  using typename Superclass2::RegistrationPointer;
   using ITKBaseType = typename Superclass2::ITKBaseType;
 
 protected:

--- a/Components/ImageSamplers/Full/elxFullSampler.h
+++ b/Components/ImageSamplers/Full/elxFullSampler.h
@@ -87,7 +87,6 @@ public:
   using typename Superclass2::ElastixType;
   using typename Superclass2::ElastixPointer;
   using typename Superclass2::RegistrationType;
-  using typename Superclass2::RegistrationPointer;
   using ITKBaseType = typename Superclass2::ITKBaseType;
 
 protected:

--- a/Components/ImageSamplers/Full/elxFullSampler.h
+++ b/Components/ImageSamplers/Full/elxFullSampler.h
@@ -85,7 +85,6 @@ public:
 
   /** Typedefs inherited from Elastix. */
   using typename Superclass2::ElastixType;
-  using typename Superclass2::ElastixPointer;
   using typename Superclass2::RegistrationType;
   using ITKBaseType = typename Superclass2::ITKBaseType;
 

--- a/Components/ImageSamplers/Grid/elxGridSampler.h
+++ b/Components/ImageSamplers/Grid/elxGridSampler.h
@@ -92,7 +92,6 @@ public:
 
   /** Typedefs inherited from Elastix. */
   using typename Superclass2::ElastixType;
-  using typename Superclass2::ElastixPointer;
   using typename Superclass2::RegistrationType;
   using ITKBaseType = typename Superclass2::ITKBaseType;
 

--- a/Components/ImageSamplers/Grid/elxGridSampler.h
+++ b/Components/ImageSamplers/Grid/elxGridSampler.h
@@ -94,7 +94,6 @@ public:
   using typename Superclass2::ElastixType;
   using typename Superclass2::ElastixPointer;
   using typename Superclass2::RegistrationType;
-  using typename Superclass2::RegistrationPointer;
   using ITKBaseType = typename Superclass2::ITKBaseType;
 
   /** Execute stuff before each resolution:

--- a/Components/ImageSamplers/MultInputRandomCoordinate/elxMultiInputRandomCoordinateSampler.h
+++ b/Components/ImageSamplers/MultInputRandomCoordinate/elxMultiInputRandomCoordinateSampler.h
@@ -136,7 +136,6 @@ public:
 
   /** Typedefs inherited from Elastix. */
   using typename Superclass2::ElastixType;
-  using typename Superclass2::ElastixPointer;
   using typename Superclass2::RegistrationType;
   using ITKBaseType = typename Superclass2::ITKBaseType;
 

--- a/Components/ImageSamplers/MultInputRandomCoordinate/elxMultiInputRandomCoordinateSampler.h
+++ b/Components/ImageSamplers/MultInputRandomCoordinate/elxMultiInputRandomCoordinateSampler.h
@@ -138,7 +138,6 @@ public:
   using typename Superclass2::ElastixType;
   using typename Superclass2::ElastixPointer;
   using typename Superclass2::RegistrationType;
-  using typename Superclass2::RegistrationPointer;
   using ITKBaseType = typename Superclass2::ITKBaseType;
 
   /** Execute stuff before each resolution:

--- a/Components/ImageSamplers/Random/elxRandomSampler.h
+++ b/Components/ImageSamplers/Random/elxRandomSampler.h
@@ -95,7 +95,6 @@ public:
   using typename Superclass2::ElastixType;
   using typename Superclass2::ElastixPointer;
   using typename Superclass2::RegistrationType;
-  using typename Superclass2::RegistrationPointer;
   using ITKBaseType = typename Superclass2::ITKBaseType;
 
   /** Execute stuff before each resolution:

--- a/Components/ImageSamplers/Random/elxRandomSampler.h
+++ b/Components/ImageSamplers/Random/elxRandomSampler.h
@@ -93,7 +93,6 @@ public:
 
   /** Typedefs inherited from Elastix. */
   using typename Superclass2::ElastixType;
-  using typename Superclass2::ElastixPointer;
   using typename Superclass2::RegistrationType;
   using ITKBaseType = typename Superclass2::ITKBaseType;
 

--- a/Components/ImageSamplers/RandomCoordinate/elxRandomCoordinateSampler.h
+++ b/Components/ImageSamplers/RandomCoordinate/elxRandomCoordinateSampler.h
@@ -131,7 +131,6 @@ public:
   using typename Superclass2::ElastixType;
   using typename Superclass2::ElastixPointer;
   using typename Superclass2::RegistrationType;
-  using typename Superclass2::RegistrationPointer;
   using ITKBaseType = typename Superclass2::ITKBaseType;
 
   /** Execute stuff before each resolution:

--- a/Components/ImageSamplers/RandomCoordinate/elxRandomCoordinateSampler.h
+++ b/Components/ImageSamplers/RandomCoordinate/elxRandomCoordinateSampler.h
@@ -129,7 +129,6 @@ public:
 
   /** Typedefs inherited from Elastix. */
   using typename Superclass2::ElastixType;
-  using typename Superclass2::ElastixPointer;
   using typename Superclass2::RegistrationType;
   using ITKBaseType = typename Superclass2::ITKBaseType;
 

--- a/Components/ImageSamplers/RandomSparseMask/elxRandomSamplerSparseMask.h
+++ b/Components/ImageSamplers/RandomSparseMask/elxRandomSamplerSparseMask.h
@@ -95,7 +95,6 @@ public:
 
   /** Typedefs inherited from Elastix. */
   using typename Superclass2::ElastixType;
-  using typename Superclass2::ElastixPointer;
   using typename Superclass2::RegistrationType;
   using ITKBaseType = typename Superclass2::ITKBaseType;
 

--- a/Components/ImageSamplers/RandomSparseMask/elxRandomSamplerSparseMask.h
+++ b/Components/ImageSamplers/RandomSparseMask/elxRandomSamplerSparseMask.h
@@ -97,7 +97,6 @@ public:
   using typename Superclass2::ElastixType;
   using typename Superclass2::ElastixPointer;
   using typename Superclass2::RegistrationType;
-  using typename Superclass2::RegistrationPointer;
   using ITKBaseType = typename Superclass2::ITKBaseType;
 
   /** Execute stuff before each resolution:

--- a/Components/Interpolators/BSplineInterpolator/elxBSplineInterpolator.h
+++ b/Components/Interpolators/BSplineInterpolator/elxBSplineInterpolator.h
@@ -94,7 +94,6 @@ public:
 
   /** Typedefs inherited from Elastix. */
   using typename Superclass2::ElastixType;
-  using typename Superclass2::ElastixPointer;
   using typename Superclass2::RegistrationType;
   using ITKBaseType = typename Superclass2::ITKBaseType;
 

--- a/Components/Interpolators/BSplineInterpolator/elxBSplineInterpolator.h
+++ b/Components/Interpolators/BSplineInterpolator/elxBSplineInterpolator.h
@@ -96,7 +96,6 @@ public:
   using typename Superclass2::ElastixType;
   using typename Superclass2::ElastixPointer;
   using typename Superclass2::RegistrationType;
-  using typename Superclass2::RegistrationPointer;
   using ITKBaseType = typename Superclass2::ITKBaseType;
 
   /** Execute stuff before each new pyramid resolution:

--- a/Components/Interpolators/BSplineInterpolatorFloat/elxBSplineInterpolatorFloat.h
+++ b/Components/Interpolators/BSplineInterpolatorFloat/elxBSplineInterpolatorFloat.h
@@ -94,7 +94,6 @@ public:
 
   /** Typedefs inherited from Elastix. */
   using typename Superclass2::ElastixType;
-  using typename Superclass2::ElastixPointer;
   using typename Superclass2::RegistrationType;
   using ITKBaseType = typename Superclass2::ITKBaseType;
 

--- a/Components/Interpolators/BSplineInterpolatorFloat/elxBSplineInterpolatorFloat.h
+++ b/Components/Interpolators/BSplineInterpolatorFloat/elxBSplineInterpolatorFloat.h
@@ -96,7 +96,6 @@ public:
   using typename Superclass2::ElastixType;
   using typename Superclass2::ElastixPointer;
   using typename Superclass2::RegistrationType;
-  using typename Superclass2::RegistrationPointer;
   using ITKBaseType = typename Superclass2::ITKBaseType;
 
   /** Execute stuff before each new pyramid resolution:

--- a/Components/Interpolators/LinearInterpolator/elxLinearInterpolator.h
+++ b/Components/Interpolators/LinearInterpolator/elxLinearInterpolator.h
@@ -79,7 +79,6 @@ public:
 
   /** Typedefs inherited from Elastix. */
   using typename Superclass2::ElastixType;
-  using typename Superclass2::ElastixPointer;
   using typename Superclass2::RegistrationType;
   using ITKBaseType = typename Superclass2::ITKBaseType;
 

--- a/Components/Interpolators/LinearInterpolator/elxLinearInterpolator.h
+++ b/Components/Interpolators/LinearInterpolator/elxLinearInterpolator.h
@@ -81,7 +81,6 @@ public:
   using typename Superclass2::ElastixType;
   using typename Superclass2::ElastixPointer;
   using typename Superclass2::RegistrationType;
-  using typename Superclass2::RegistrationPointer;
   using ITKBaseType = typename Superclass2::ITKBaseType;
 
 protected:

--- a/Components/Interpolators/NearestNeighborInterpolator/elxNearestNeighborInterpolator.h
+++ b/Components/Interpolators/NearestNeighborInterpolator/elxNearestNeighborInterpolator.h
@@ -77,7 +77,6 @@ public:
 
   /** Typedefs inherited from Elastix. */
   using typename Superclass2::ElastixType;
-  using typename Superclass2::ElastixPointer;
   using typename Superclass2::RegistrationType;
   using ITKBaseType = typename Superclass2::ITKBaseType;
 

--- a/Components/Interpolators/NearestNeighborInterpolator/elxNearestNeighborInterpolator.h
+++ b/Components/Interpolators/NearestNeighborInterpolator/elxNearestNeighborInterpolator.h
@@ -79,7 +79,6 @@ public:
   using typename Superclass2::ElastixType;
   using typename Superclass2::ElastixPointer;
   using typename Superclass2::RegistrationType;
-  using typename Superclass2::RegistrationPointer;
   using ITKBaseType = typename Superclass2::ITKBaseType;
 
 protected:

--- a/Components/Interpolators/RayCastInterpolator/elxRayCastInterpolator.h
+++ b/Components/Interpolators/RayCastInterpolator/elxRayCastInterpolator.h
@@ -83,7 +83,6 @@ public:
   using typename Superclass2::ElastixType;
   using typename Superclass2::ElastixPointer;
   using typename Superclass2::RegistrationType;
-  using typename Superclass2::RegistrationPointer;
   using ITKBaseType = typename Superclass2::ITKBaseType;
 
   /** Typedef's for CombinationTransform */

--- a/Components/Interpolators/RayCastInterpolator/elxRayCastInterpolator.h
+++ b/Components/Interpolators/RayCastInterpolator/elxRayCastInterpolator.h
@@ -81,7 +81,6 @@ public:
 
   /** Typedefs inherited from Elastix. */
   using typename Superclass2::ElastixType;
-  using typename Superclass2::ElastixPointer;
   using typename Superclass2::RegistrationType;
   using ITKBaseType = typename Superclass2::ITKBaseType;
 

--- a/Components/Interpolators/ReducedDimensionBSplineInterpolator/elxReducedDimensionBSplineInterpolator.h
+++ b/Components/Interpolators/ReducedDimensionBSplineInterpolator/elxReducedDimensionBSplineInterpolator.h
@@ -95,7 +95,6 @@ public:
   using typename Superclass2::ElastixType;
   using typename Superclass2::ElastixPointer;
   using typename Superclass2::RegistrationType;
-  using typename Superclass2::RegistrationPointer;
   using ITKBaseType = typename Superclass2::ITKBaseType;
 
   /** Execute stuff before each new pyramid resolution:

--- a/Components/Interpolators/ReducedDimensionBSplineInterpolator/elxReducedDimensionBSplineInterpolator.h
+++ b/Components/Interpolators/ReducedDimensionBSplineInterpolator/elxReducedDimensionBSplineInterpolator.h
@@ -93,7 +93,6 @@ public:
 
   /** Typedefs inherited from Elastix. */
   using typename Superclass2::ElastixType;
-  using typename Superclass2::ElastixPointer;
   using typename Superclass2::RegistrationType;
   using ITKBaseType = typename Superclass2::ITKBaseType;
 

--- a/Components/Metrics/AdvancedKappaStatistic/elxAdvancedKappaStatisticMetric.h
+++ b/Components/Metrics/AdvancedKappaStatistic/elxAdvancedKappaStatisticMetric.h
@@ -121,7 +121,6 @@ public:
 
   /** Typedef's inherited from Elastix. */
   using typename Superclass2::ElastixType;
-  using typename Superclass2::ElastixPointer;
   using typename Superclass2::RegistrationType;
   using ITKBaseType = typename Superclass2::ITKBaseType;
 

--- a/Components/Metrics/AdvancedKappaStatistic/elxAdvancedKappaStatisticMetric.h
+++ b/Components/Metrics/AdvancedKappaStatistic/elxAdvancedKappaStatisticMetric.h
@@ -123,7 +123,6 @@ public:
   using typename Superclass2::ElastixType;
   using typename Superclass2::ElastixPointer;
   using typename Superclass2::RegistrationType;
-  using typename Superclass2::RegistrationPointer;
   using ITKBaseType = typename Superclass2::ITKBaseType;
 
   /** Sets up a timer to measure the initialization time and

--- a/Components/Metrics/AdvancedMattesMutualInformation/elxAdvancedMattesMutualInformationMetric.h
+++ b/Components/Metrics/AdvancedMattesMutualInformation/elxAdvancedMattesMutualInformationMetric.h
@@ -173,7 +173,6 @@ public:
 
   /** Typedef's inherited from Elastix. */
   using typename Superclass2::ElastixType;
-  using typename Superclass2::ElastixPointer;
   using typename Superclass2::RegistrationType;
   using ITKBaseType = typename Superclass2::ITKBaseType;
 

--- a/Components/Metrics/AdvancedMattesMutualInformation/elxAdvancedMattesMutualInformationMetric.h
+++ b/Components/Metrics/AdvancedMattesMutualInformation/elxAdvancedMattesMutualInformationMetric.h
@@ -175,7 +175,6 @@ public:
   using typename Superclass2::ElastixType;
   using typename Superclass2::ElastixPointer;
   using typename Superclass2::RegistrationType;
-  using typename Superclass2::RegistrationPointer;
   using ITKBaseType = typename Superclass2::ITKBaseType;
 
   /** Execute stuff before each new pyramid resolution:

--- a/Components/Metrics/AdvancedMeanSquares/elxAdvancedMeanSquaresMetric.h
+++ b/Components/Metrics/AdvancedMeanSquares/elxAdvancedMeanSquaresMetric.h
@@ -119,7 +119,6 @@ public:
   using typename Superclass2::ElastixType;
   using typename Superclass2::ElastixPointer;
   using typename Superclass2::RegistrationType;
-  using typename Superclass2::RegistrationPointer;
   using ITKBaseType = typename Superclass2::ITKBaseType;
 
   /** Sets up a timer to measure the initialization time and

--- a/Components/Metrics/AdvancedMeanSquares/elxAdvancedMeanSquaresMetric.h
+++ b/Components/Metrics/AdvancedMeanSquares/elxAdvancedMeanSquaresMetric.h
@@ -117,7 +117,6 @@ public:
 
   /** Typedef's inherited from Elastix. */
   using typename Superclass2::ElastixType;
-  using typename Superclass2::ElastixPointer;
   using typename Superclass2::RegistrationType;
   using ITKBaseType = typename Superclass2::ITKBaseType;
 

--- a/Components/Metrics/AdvancedNormalizedCorrelation/elxAdvancedNormalizedCorrelationMetric.h
+++ b/Components/Metrics/AdvancedNormalizedCorrelation/elxAdvancedNormalizedCorrelationMetric.h
@@ -119,7 +119,6 @@ public:
   using typename Superclass2::ElastixType;
   using typename Superclass2::ElastixPointer;
   using typename Superclass2::RegistrationType;
-  using typename Superclass2::RegistrationPointer;
   using ITKBaseType = typename Superclass2::ITKBaseType;
 
   /** Execute stuff before each new pyramid resolution:

--- a/Components/Metrics/AdvancedNormalizedCorrelation/elxAdvancedNormalizedCorrelationMetric.h
+++ b/Components/Metrics/AdvancedNormalizedCorrelation/elxAdvancedNormalizedCorrelationMetric.h
@@ -117,7 +117,6 @@ public:
 
   /** Typedef's inherited from Elastix. */
   using typename Superclass2::ElastixType;
-  using typename Superclass2::ElastixPointer;
   using typename Superclass2::RegistrationType;
   using ITKBaseType = typename Superclass2::ITKBaseType;
 

--- a/Components/Metrics/BendingEnergyPenalty/elxTransformBendingEnergyPenaltyTerm.h
+++ b/Components/Metrics/BendingEnergyPenalty/elxTransformBendingEnergyPenaltyTerm.h
@@ -119,7 +119,6 @@ public:
   using typename Superclass2::ElastixType;
   using typename Superclass2::ElastixPointer;
   using typename Superclass2::RegistrationType;
-  using typename Superclass2::RegistrationPointer;
   using ITKBaseType = typename Superclass2::ITKBaseType;
 
   /** Sets up a timer to measure the initialization time and

--- a/Components/Metrics/BendingEnergyPenalty/elxTransformBendingEnergyPenaltyTerm.h
+++ b/Components/Metrics/BendingEnergyPenalty/elxTransformBendingEnergyPenaltyTerm.h
@@ -117,7 +117,6 @@ public:
 
   /** Typedef's inherited from elastix. */
   using typename Superclass2::ElastixType;
-  using typename Superclass2::ElastixPointer;
   using typename Superclass2::RegistrationType;
   using ITKBaseType = typename Superclass2::ITKBaseType;
 

--- a/Components/Metrics/CorrespondingPointsEuclideanDistanceMetric/elxCorrespondingPointsEuclideanDistanceMetric.h
+++ b/Components/Metrics/CorrespondingPointsEuclideanDistanceMetric/elxCorrespondingPointsEuclideanDistanceMetric.h
@@ -91,7 +91,6 @@ public:
   using typename Superclass2::ElastixType;
   using typename Superclass2::ElastixPointer;
   using typename Superclass2::RegistrationType;
-  using typename Superclass2::RegistrationPointer;
   using ITKBaseType = typename Superclass2::ITKBaseType;
   using typename Superclass2::FixedImageType;
   using typename Superclass2::MovingImageType;

--- a/Components/Metrics/CorrespondingPointsEuclideanDistanceMetric/elxCorrespondingPointsEuclideanDistanceMetric.h
+++ b/Components/Metrics/CorrespondingPointsEuclideanDistanceMetric/elxCorrespondingPointsEuclideanDistanceMetric.h
@@ -89,7 +89,6 @@ public:
 
   /** Typedefs inherited from elastix. */
   using typename Superclass2::ElastixType;
-  using typename Superclass2::ElastixPointer;
   using typename Superclass2::RegistrationType;
   using ITKBaseType = typename Superclass2::ITKBaseType;
   using typename Superclass2::FixedImageType;

--- a/Components/Metrics/DisplacementMagnitudePenalty/elxDisplacementMagnitudePenalty.h
+++ b/Components/Metrics/DisplacementMagnitudePenalty/elxDisplacementMagnitudePenalty.h
@@ -116,7 +116,6 @@ public:
   using typename Superclass2::ElastixType;
   using typename Superclass2::ElastixPointer;
   using typename Superclass2::RegistrationType;
-  using typename Superclass2::RegistrationPointer;
   using ITKBaseType = typename Superclass2::ITKBaseType;
 
   /** Sets up a timer to measure the initialization time and

--- a/Components/Metrics/DisplacementMagnitudePenalty/elxDisplacementMagnitudePenalty.h
+++ b/Components/Metrics/DisplacementMagnitudePenalty/elxDisplacementMagnitudePenalty.h
@@ -114,7 +114,6 @@ public:
 
   /** Typedef's inherited from elastix. */
   using typename Superclass2::ElastixType;
-  using typename Superclass2::ElastixPointer;
   using typename Superclass2::RegistrationType;
   using ITKBaseType = typename Superclass2::ITKBaseType;
 

--- a/Components/Metrics/DistancePreservingRigidityPenalty/elxDistancePreservingRigidityPenaltyTerm.h
+++ b/Components/Metrics/DistancePreservingRigidityPenalty/elxDistancePreservingRigidityPenaltyTerm.h
@@ -137,7 +137,6 @@ public:
   using typename Superclass2::ElastixType;
   using typename Superclass2::ElastixPointer;
   using typename Superclass2::RegistrationType;
-  using typename Superclass2::RegistrationPointer;
   using ITKBaseType = typename Superclass2::ITKBaseType;
 
   /** Typedef for multi-resolution pyramid of segmented image */

--- a/Components/Metrics/DistancePreservingRigidityPenalty/elxDistancePreservingRigidityPenaltyTerm.h
+++ b/Components/Metrics/DistancePreservingRigidityPenalty/elxDistancePreservingRigidityPenaltyTerm.h
@@ -135,7 +135,6 @@ public:
 
   /** Typedef's inherited from elastix. */
   using typename Superclass2::ElastixType;
-  using typename Superclass2::ElastixPointer;
   using typename Superclass2::RegistrationType;
   using ITKBaseType = typename Superclass2::ITKBaseType;
 

--- a/Components/Metrics/GradientDifference/elxGradientDifferenceMetric.h
+++ b/Components/Metrics/GradientDifference/elxGradientDifferenceMetric.h
@@ -111,7 +111,6 @@ public:
   using typename Superclass2::ElastixType;
   using typename Superclass2::ElastixPointer;
   using typename Superclass2::RegistrationType;
-  using typename Superclass2::RegistrationPointer;
   using ITKBaseType = typename Superclass2::ITKBaseType;
 
   /** Sets up a timer to measure the initialization time and

--- a/Components/Metrics/GradientDifference/elxGradientDifferenceMetric.h
+++ b/Components/Metrics/GradientDifference/elxGradientDifferenceMetric.h
@@ -109,7 +109,6 @@ public:
 
   /** Typedef's inherited from Elastix. */
   using typename Superclass2::ElastixType;
-  using typename Superclass2::ElastixPointer;
   using typename Superclass2::RegistrationType;
   using ITKBaseType = typename Superclass2::ITKBaseType;
 

--- a/Components/Metrics/KNNGraphAlphaMutualInformation/elxKNNGraphAlphaMutualInformationMetric.h
+++ b/Components/Metrics/KNNGraphAlphaMutualInformation/elxKNNGraphAlphaMutualInformationMetric.h
@@ -126,7 +126,6 @@ public:
 
   /** Typedef's inherited from Elastix. */
   using typename Superclass2::ElastixType;
-  using typename Superclass2::ElastixPointer;
   using typename Superclass2::RegistrationType;
   using ITKBaseType = typename Superclass2::ITKBaseType;
 

--- a/Components/Metrics/KNNGraphAlphaMutualInformation/elxKNNGraphAlphaMutualInformationMetric.h
+++ b/Components/Metrics/KNNGraphAlphaMutualInformation/elxKNNGraphAlphaMutualInformationMetric.h
@@ -128,7 +128,6 @@ public:
   using typename Superclass2::ElastixType;
   using typename Superclass2::ElastixPointer;
   using typename Superclass2::RegistrationType;
-  using typename Superclass2::RegistrationPointer;
   using ITKBaseType = typename Superclass2::ITKBaseType;
 
   /** Typedefs for feature images. */

--- a/Components/Metrics/MissingStructurePenalty/elxMissingStructurePenalty.h
+++ b/Components/Metrics/MissingStructurePenalty/elxMissingStructurePenalty.h
@@ -117,7 +117,6 @@ public:
 
   /** Typedefs inherited from elastix. */
   using typename Superclass2::ElastixType;
-  using typename Superclass2::ElastixPointer;
   using typename Superclass2::RegistrationType;
   using ITKBaseType = typename Superclass2::ITKBaseType;
   using typename Superclass2::FixedImageType;

--- a/Components/Metrics/MissingStructurePenalty/elxMissingStructurePenalty.h
+++ b/Components/Metrics/MissingStructurePenalty/elxMissingStructurePenalty.h
@@ -119,7 +119,6 @@ public:
   using typename Superclass2::ElastixType;
   using typename Superclass2::ElastixPointer;
   using typename Superclass2::RegistrationType;
-  using typename Superclass2::RegistrationPointer;
   using ITKBaseType = typename Superclass2::ITKBaseType;
   using typename Superclass2::FixedImageType;
   using typename Superclass2::MovingImageType;

--- a/Components/Metrics/NormalizedGradientCorrelation/elxNormalizedGradientCorrelationMetric.h
+++ b/Components/Metrics/NormalizedGradientCorrelation/elxNormalizedGradientCorrelationMetric.h
@@ -112,7 +112,6 @@ public:
   using typename Superclass2::ElastixType;
   using typename Superclass2::ElastixPointer;
   using typename Superclass2::RegistrationType;
-  using typename Superclass2::RegistrationPointer;
   using ITKBaseType = typename Superclass2::ITKBaseType;
 
   /** Sets up a timer to measure the initialization time and

--- a/Components/Metrics/NormalizedGradientCorrelation/elxNormalizedGradientCorrelationMetric.h
+++ b/Components/Metrics/NormalizedGradientCorrelation/elxNormalizedGradientCorrelationMetric.h
@@ -110,7 +110,6 @@ public:
 
   /** Typedef's inherited from Elastix. */
   using typename Superclass2::ElastixType;
-  using typename Superclass2::ElastixPointer;
   using typename Superclass2::RegistrationType;
   using ITKBaseType = typename Superclass2::ITKBaseType;
 

--- a/Components/Metrics/NormalizedMutualInformation/elxNormalizedMutualInformationMetric.h
+++ b/Components/Metrics/NormalizedMutualInformation/elxNormalizedMutualInformationMetric.h
@@ -147,7 +147,6 @@ public:
 
   /** Typedef's inherited from Elastix. */
   using typename Superclass2::ElastixType;
-  using typename Superclass2::ElastixPointer;
   using typename Superclass2::RegistrationType;
   using ITKBaseType = typename Superclass2::ITKBaseType;
 

--- a/Components/Metrics/NormalizedMutualInformation/elxNormalizedMutualInformationMetric.h
+++ b/Components/Metrics/NormalizedMutualInformation/elxNormalizedMutualInformationMetric.h
@@ -149,7 +149,6 @@ public:
   using typename Superclass2::ElastixType;
   using typename Superclass2::ElastixPointer;
   using typename Superclass2::RegistrationType;
-  using typename Superclass2::RegistrationPointer;
   using ITKBaseType = typename Superclass2::ITKBaseType;
 
   /** Execute stuff before each new pyramid resolution:

--- a/Components/Metrics/PCAMetric/elxPCAMetric.h
+++ b/Components/Metrics/PCAMetric/elxPCAMetric.h
@@ -136,7 +136,6 @@ public:
 
   /** Typedef's inherited from Elastix. */
   using typename Superclass2::ElastixType;
-  using typename Superclass2::ElastixPointer;
   using typename Superclass2::RegistrationType;
   using ITKBaseType = typename Superclass2::ITKBaseType;
 

--- a/Components/Metrics/PCAMetric/elxPCAMetric.h
+++ b/Components/Metrics/PCAMetric/elxPCAMetric.h
@@ -138,7 +138,6 @@ public:
   using typename Superclass2::ElastixType;
   using typename Superclass2::ElastixPointer;
   using typename Superclass2::RegistrationType;
-  using typename Superclass2::RegistrationPointer;
   using ITKBaseType = typename Superclass2::ITKBaseType;
 
   /** Typedef's for the B-spline transform. */

--- a/Components/Metrics/PCAMetric2/elxPCAMetric2.h
+++ b/Components/Metrics/PCAMetric2/elxPCAMetric2.h
@@ -139,7 +139,6 @@ public:
   using typename Superclass2::ElastixType;
   using typename Superclass2::ElastixPointer;
   using typename Superclass2::RegistrationType;
-  using typename Superclass2::RegistrationPointer;
   using ITKBaseType = typename Superclass2::ITKBaseType;
 
   /** Typedef's for the B-spline transform. */

--- a/Components/Metrics/PCAMetric2/elxPCAMetric2.h
+++ b/Components/Metrics/PCAMetric2/elxPCAMetric2.h
@@ -137,7 +137,6 @@ public:
 
   /** Typedef's inherited from Elastix. */
   using typename Superclass2::ElastixType;
-  using typename Superclass2::ElastixPointer;
   using typename Superclass2::RegistrationType;
   using ITKBaseType = typename Superclass2::ITKBaseType;
 

--- a/Components/Metrics/PatternIntensity/elxPatternIntensityMetric.h
+++ b/Components/Metrics/PatternIntensity/elxPatternIntensityMetric.h
@@ -111,7 +111,6 @@ public:
   using typename Superclass2::ElastixType;
   using typename Superclass2::ElastixPointer;
   using typename Superclass2::RegistrationType;
-  using typename Superclass2::RegistrationPointer;
   using ITKBaseType = typename Superclass2::ITKBaseType;
 
   /** Sets up a timer to measure the initialization time and

--- a/Components/Metrics/PatternIntensity/elxPatternIntensityMetric.h
+++ b/Components/Metrics/PatternIntensity/elxPatternIntensityMetric.h
@@ -109,7 +109,6 @@ public:
 
   /** Typedef's inherited from Elastix. */
   using typename Superclass2::ElastixType;
-  using typename Superclass2::ElastixPointer;
   using typename Superclass2::RegistrationType;
   using ITKBaseType = typename Superclass2::ITKBaseType;
 

--- a/Components/Metrics/PolydataDummyPenalty/elxPolydataDummyPenalty.h
+++ b/Components/Metrics/PolydataDummyPenalty/elxPolydataDummyPenalty.h
@@ -133,7 +133,6 @@ public:
 
   /** Typedefs inherited from elastix. */
   using typename Superclass2::ElastixType;
-  using typename Superclass2::ElastixPointer;
   using typename Superclass2::RegistrationType;
   using ITKBaseType = typename Superclass2::ITKBaseType;
   using typename Superclass2::FixedImageType;

--- a/Components/Metrics/PolydataDummyPenalty/elxPolydataDummyPenalty.h
+++ b/Components/Metrics/PolydataDummyPenalty/elxPolydataDummyPenalty.h
@@ -135,7 +135,6 @@ public:
   using typename Superclass2::ElastixType;
   using typename Superclass2::ElastixPointer;
   using typename Superclass2::RegistrationType;
-  using typename Superclass2::RegistrationPointer;
   using ITKBaseType = typename Superclass2::ITKBaseType;
   using typename Superclass2::FixedImageType;
   using typename Superclass2::MovingImageType;

--- a/Components/Metrics/RigidityPenalty/elxTransformRigidityPenaltyTerm.h
+++ b/Components/Metrics/RigidityPenalty/elxTransformRigidityPenaltyTerm.h
@@ -181,7 +181,6 @@ public:
 
   /** Typedef's inherited from elastix. */
   using typename Superclass2::ElastixType;
-  using typename Superclass2::ElastixPointer;
   using typename Superclass2::RegistrationType;
   using ITKBaseType = typename Superclass2::ITKBaseType;
 

--- a/Components/Metrics/RigidityPenalty/elxTransformRigidityPenaltyTerm.h
+++ b/Components/Metrics/RigidityPenalty/elxTransformRigidityPenaltyTerm.h
@@ -183,7 +183,6 @@ public:
   using typename Superclass2::ElastixType;
   using typename Superclass2::ElastixPointer;
   using typename Superclass2::RegistrationType;
-  using typename Superclass2::RegistrationPointer;
   using ITKBaseType = typename Superclass2::ITKBaseType;
 
   /** Sets up a timer to measure the initialization time and

--- a/Components/Metrics/StatisticalShapePenalty/elxStatisticalShapePenalty.h
+++ b/Components/Metrics/StatisticalShapePenalty/elxStatisticalShapePenalty.h
@@ -120,7 +120,6 @@ public:
   using typename Superclass2::ElastixType;
   using typename Superclass2::ElastixPointer;
   using typename Superclass2::RegistrationType;
-  using typename Superclass2::RegistrationPointer;
   using ITKBaseType = typename Superclass2::ITKBaseType;
   using typename Superclass2::FixedImageType;
   using typename Superclass2::MovingImageType;

--- a/Components/Metrics/StatisticalShapePenalty/elxStatisticalShapePenalty.h
+++ b/Components/Metrics/StatisticalShapePenalty/elxStatisticalShapePenalty.h
@@ -118,7 +118,6 @@ public:
 
   /** Typedefs inherited from elastix. */
   using typename Superclass2::ElastixType;
-  using typename Superclass2::ElastixPointer;
   using typename Superclass2::RegistrationType;
   using ITKBaseType = typename Superclass2::ITKBaseType;
   using typename Superclass2::FixedImageType;

--- a/Components/Metrics/SumOfPairwiseCorrelationsMetric/elxSumOfPairwiseCorrelationCoefficientsMetric.h
+++ b/Components/Metrics/SumOfPairwiseCorrelationsMetric/elxSumOfPairwiseCorrelationCoefficientsMetric.h
@@ -139,7 +139,6 @@ public:
   using typename Superclass2::ElastixType;
   using typename Superclass2::ElastixPointer;
   using typename Superclass2::RegistrationType;
-  using typename Superclass2::RegistrationPointer;
   using ITKBaseType = typename Superclass2::ITKBaseType;
 
   /** Typedef's for the B-spline transform. */

--- a/Components/Metrics/SumOfPairwiseCorrelationsMetric/elxSumOfPairwiseCorrelationCoefficientsMetric.h
+++ b/Components/Metrics/SumOfPairwiseCorrelationsMetric/elxSumOfPairwiseCorrelationCoefficientsMetric.h
@@ -137,7 +137,6 @@ public:
 
   /** Typedef's inherited from Elastix. */
   using typename Superclass2::ElastixType;
-  using typename Superclass2::ElastixPointer;
   using typename Superclass2::RegistrationType;
   using ITKBaseType = typename Superclass2::ITKBaseType;
 

--- a/Components/Metrics/SumSquaredTissueVolumeDifferenceMetric/elxSumSquaredTissueVolumeDifferenceMetric.h
+++ b/Components/Metrics/SumSquaredTissueVolumeDifferenceMetric/elxSumSquaredTissueVolumeDifferenceMetric.h
@@ -123,7 +123,6 @@ public:
 
   /** Typedef's inherited from Elastix. */
   using typename Superclass2::ElastixType;
-  using typename Superclass2::ElastixPointer;
   using typename Superclass2::RegistrationType;
   using ITKBaseType = typename Superclass2::ITKBaseType;
 

--- a/Components/Metrics/SumSquaredTissueVolumeDifferenceMetric/elxSumSquaredTissueVolumeDifferenceMetric.h
+++ b/Components/Metrics/SumSquaredTissueVolumeDifferenceMetric/elxSumSquaredTissueVolumeDifferenceMetric.h
@@ -125,7 +125,6 @@ public:
   using typename Superclass2::ElastixType;
   using typename Superclass2::ElastixPointer;
   using typename Superclass2::RegistrationType;
-  using typename Superclass2::RegistrationPointer;
   using ITKBaseType = typename Superclass2::ITKBaseType;
 
 

--- a/Components/Metrics/VarianceOverLastDimension/elxVarianceOverLastDimensionMetric.h
+++ b/Components/Metrics/VarianceOverLastDimension/elxVarianceOverLastDimensionMetric.h
@@ -141,7 +141,6 @@ public:
 
   /** Typedef's inherited from Elastix. */
   using typename Superclass2::ElastixType;
-  using typename Superclass2::ElastixPointer;
   using typename Superclass2::RegistrationType;
   using ITKBaseType = typename Superclass2::ITKBaseType;
 

--- a/Components/Metrics/VarianceOverLastDimension/elxVarianceOverLastDimensionMetric.h
+++ b/Components/Metrics/VarianceOverLastDimension/elxVarianceOverLastDimensionMetric.h
@@ -143,7 +143,6 @@ public:
   using typename Superclass2::ElastixType;
   using typename Superclass2::ElastixPointer;
   using typename Superclass2::RegistrationType;
-  using typename Superclass2::RegistrationPointer;
   using ITKBaseType = typename Superclass2::ITKBaseType;
 
   /** Typedef's for the B-spline transform. */

--- a/Components/MovingImagePyramids/MovingGenericPyramid/elxMovingGenericPyramid.h
+++ b/Components/MovingImagePyramids/MovingGenericPyramid/elxMovingGenericPyramid.h
@@ -109,7 +109,6 @@ public:
   using typename Superclass2::ElastixType;
   using typename Superclass2::ElastixPointer;
   using typename Superclass2::RegistrationType;
-  using typename Superclass2::RegistrationPointer;
   using ITKBaseType = typename Superclass2::ITKBaseType;
 
   /** Method for setting the schedule. Override from MovingImagePyramidBase,

--- a/Components/MovingImagePyramids/MovingGenericPyramid/elxMovingGenericPyramid.h
+++ b/Components/MovingImagePyramids/MovingGenericPyramid/elxMovingGenericPyramid.h
@@ -107,7 +107,6 @@ public:
 
   /** Typedefs inherited from Elastix. */
   using typename Superclass2::ElastixType;
-  using typename Superclass2::ElastixPointer;
   using typename Superclass2::RegistrationType;
   using ITKBaseType = typename Superclass2::ITKBaseType;
 

--- a/Components/MovingImagePyramids/MovingRecursivePyramid/elxMovingRecursivePyramid.h
+++ b/Components/MovingImagePyramids/MovingRecursivePyramid/elxMovingRecursivePyramid.h
@@ -75,7 +75,6 @@ public:
 
   /** Typedefs inherited from Elastix. */
   using typename Superclass2::ElastixType;
-  using typename Superclass2::ElastixPointer;
   using typename Superclass2::RegistrationType;
   using ITKBaseType = typename Superclass2::ITKBaseType;
 

--- a/Components/MovingImagePyramids/MovingRecursivePyramid/elxMovingRecursivePyramid.h
+++ b/Components/MovingImagePyramids/MovingRecursivePyramid/elxMovingRecursivePyramid.h
@@ -77,7 +77,6 @@ public:
   using typename Superclass2::ElastixType;
   using typename Superclass2::ElastixPointer;
   using typename Superclass2::RegistrationType;
-  using typename Superclass2::RegistrationPointer;
   using ITKBaseType = typename Superclass2::ITKBaseType;
 
 protected:

--- a/Components/MovingImagePyramids/MovingShrinkingPyramid/elxMovingShrinkingPyramid.h
+++ b/Components/MovingImagePyramids/MovingShrinkingPyramid/elxMovingShrinkingPyramid.h
@@ -78,7 +78,6 @@ public:
   using typename Superclass2::ElastixType;
   using typename Superclass2::ElastixPointer;
   using typename Superclass2::RegistrationType;
-  using typename Superclass2::RegistrationPointer;
   using ITKBaseType = typename Superclass2::ITKBaseType;
 
 protected:

--- a/Components/MovingImagePyramids/MovingShrinkingPyramid/elxMovingShrinkingPyramid.h
+++ b/Components/MovingImagePyramids/MovingShrinkingPyramid/elxMovingShrinkingPyramid.h
@@ -76,7 +76,6 @@ public:
 
   /** Typedefs inherited from Elastix. */
   using typename Superclass2::ElastixType;
-  using typename Superclass2::ElastixPointer;
   using typename Superclass2::RegistrationType;
   using ITKBaseType = typename Superclass2::ITKBaseType;
 

--- a/Components/MovingImagePyramids/MovingSmoothingPyramid/elxMovingSmoothingPyramid.h
+++ b/Components/MovingImagePyramids/MovingSmoothingPyramid/elxMovingSmoothingPyramid.h
@@ -78,7 +78,6 @@ public:
   using typename Superclass2::ElastixType;
   using typename Superclass2::ElastixPointer;
   using typename Superclass2::RegistrationType;
-  using typename Superclass2::RegistrationPointer;
   using ITKBaseType = typename Superclass2::ITKBaseType;
 
 protected:

--- a/Components/MovingImagePyramids/MovingSmoothingPyramid/elxMovingSmoothingPyramid.h
+++ b/Components/MovingImagePyramids/MovingSmoothingPyramid/elxMovingSmoothingPyramid.h
@@ -76,7 +76,6 @@ public:
 
   /** Typedefs inherited from Elastix. */
   using typename Superclass2::ElastixType;
-  using typename Superclass2::ElastixPointer;
   using typename Superclass2::RegistrationType;
   using ITKBaseType = typename Superclass2::ITKBaseType;
 

--- a/Components/Optimizers/AdaGrad/elxAdaGrad.h
+++ b/Components/Optimizers/AdaGrad/elxAdaGrad.h
@@ -218,7 +218,6 @@ public:
 
   /** Typedef's inherited from Superclass2. */
   using typename Superclass2::ElastixType;
-  using typename Superclass2::ElastixPointer;
   using typename Superclass2::RegistrationType;
   using ITKBaseType = typename Superclass2::ITKBaseType;
   using SizeValueType = itk::SizeValueType;

--- a/Components/Optimizers/AdaGrad/elxAdaGrad.h
+++ b/Components/Optimizers/AdaGrad/elxAdaGrad.h
@@ -220,7 +220,6 @@ public:
   using typename Superclass2::ElastixType;
   using typename Superclass2::ElastixPointer;
   using typename Superclass2::RegistrationType;
-  using typename Superclass2::RegistrationPointer;
   using ITKBaseType = typename Superclass2::ITKBaseType;
   using SizeValueType = itk::SizeValueType;
 

--- a/Components/Optimizers/AdaptiveStochasticGradientDescent/elxAdaptiveStochasticGradientDescent.h
+++ b/Components/Optimizers/AdaptiveStochasticGradientDescent/elxAdaptiveStochasticGradientDescent.h
@@ -223,7 +223,6 @@ public:
   using typename Superclass2::ElastixType;
   using typename Superclass2::ElastixPointer;
   using typename Superclass2::RegistrationType;
-  using typename Superclass2::RegistrationPointer;
   using ITKBaseType = typename Superclass2::ITKBaseType;
   using SizeValueType = itk::SizeValueType;
 

--- a/Components/Optimizers/AdaptiveStochasticGradientDescent/elxAdaptiveStochasticGradientDescent.h
+++ b/Components/Optimizers/AdaptiveStochasticGradientDescent/elxAdaptiveStochasticGradientDescent.h
@@ -221,7 +221,6 @@ public:
 
   /** Typedef's inherited from Superclass2. */
   using typename Superclass2::ElastixType;
-  using typename Superclass2::ElastixPointer;
   using typename Superclass2::RegistrationType;
   using ITKBaseType = typename Superclass2::ITKBaseType;
   using SizeValueType = itk::SizeValueType;

--- a/Components/Optimizers/AdaptiveStochasticLBFGS/elxAdaptiveStochasticLBFGS.h
+++ b/Components/Optimizers/AdaptiveStochasticLBFGS/elxAdaptiveStochasticLBFGS.h
@@ -131,7 +131,6 @@ public:
 
   /** Typedef's inherited from Superclass2. */
   using typename Superclass2::ElastixType;
-  using typename Superclass2::ElastixPointer;
   using typename Superclass2::RegistrationType;
   using ITKBaseType = typename Superclass2::ITKBaseType;
   using SizeValueType = itk::SizeValueType;

--- a/Components/Optimizers/AdaptiveStochasticLBFGS/elxAdaptiveStochasticLBFGS.h
+++ b/Components/Optimizers/AdaptiveStochasticLBFGS/elxAdaptiveStochasticLBFGS.h
@@ -133,7 +133,6 @@ public:
   using typename Superclass2::ElastixType;
   using typename Superclass2::ElastixPointer;
   using typename Superclass2::RegistrationType;
-  using typename Superclass2::RegistrationPointer;
   using ITKBaseType = typename Superclass2::ITKBaseType;
   using SizeValueType = itk::SizeValueType;
 

--- a/Components/Optimizers/AdaptiveStochasticVarianceReducedGradient/elxAdaptiveStochasticVarianceReducedGradient.h
+++ b/Components/Optimizers/AdaptiveStochasticVarianceReducedGradient/elxAdaptiveStochasticVarianceReducedGradient.h
@@ -223,7 +223,6 @@ public:
   using typename Superclass2::ElastixType;
   using typename Superclass2::ElastixPointer;
   using typename Superclass2::RegistrationType;
-  using typename Superclass2::RegistrationPointer;
   using ITKBaseType = typename Superclass2::ITKBaseType;
   using SizeValueType = itk::SizeValueType;
 

--- a/Components/Optimizers/AdaptiveStochasticVarianceReducedGradient/elxAdaptiveStochasticVarianceReducedGradient.h
+++ b/Components/Optimizers/AdaptiveStochasticVarianceReducedGradient/elxAdaptiveStochasticVarianceReducedGradient.h
@@ -221,7 +221,6 @@ public:
 
   /** Typedef's inherited from Superclass2. */
   using typename Superclass2::ElastixType;
-  using typename Superclass2::ElastixPointer;
   using typename Superclass2::RegistrationType;
   using ITKBaseType = typename Superclass2::ITKBaseType;
   using SizeValueType = itk::SizeValueType;

--- a/Components/Optimizers/CMAEvolutionStrategy/elxCMAEvolutionStrategy.h
+++ b/Components/Optimizers/CMAEvolutionStrategy/elxCMAEvolutionStrategy.h
@@ -146,7 +146,6 @@ public:
 
   /** Typedef's inherited from Elastix.*/
   using typename Superclass2::ElastixType;
-  using typename Superclass2::ElastixPointer;
   using typename Superclass2::RegistrationType;
   using ITKBaseType = typename Superclass2::ITKBaseType;
 

--- a/Components/Optimizers/CMAEvolutionStrategy/elxCMAEvolutionStrategy.h
+++ b/Components/Optimizers/CMAEvolutionStrategy/elxCMAEvolutionStrategy.h
@@ -148,7 +148,6 @@ public:
   using typename Superclass2::ElastixType;
   using typename Superclass2::ElastixPointer;
   using typename Superclass2::RegistrationType;
-  using typename Superclass2::RegistrationPointer;
   using ITKBaseType = typename Superclass2::ITKBaseType;
 
   /** Check if any scales are set, and set the UseScales flag on or off;

--- a/Components/Optimizers/ConjugateGradient/elxConjugateGradient.h
+++ b/Components/Optimizers/ConjugateGradient/elxConjugateGradient.h
@@ -122,7 +122,6 @@ public:
 
   /** Typedef's inherited from Elastix.*/
   using typename Superclass2::ElastixType;
-  using typename Superclass2::ElastixPointer;
   using typename Superclass2::RegistrationType;
   using ITKBaseType = typename Superclass2::ITKBaseType;
 

--- a/Components/Optimizers/ConjugateGradient/elxConjugateGradient.h
+++ b/Components/Optimizers/ConjugateGradient/elxConjugateGradient.h
@@ -124,7 +124,6 @@ public:
   using typename Superclass2::ElastixType;
   using typename Superclass2::ElastixPointer;
   using typename Superclass2::RegistrationType;
-  using typename Superclass2::RegistrationPointer;
   using ITKBaseType = typename Superclass2::ITKBaseType;
 
   /** Extra typedefs */

--- a/Components/Optimizers/ConjugateGradientFRPR/elxConjugateGradientFRPR.h
+++ b/Components/Optimizers/ConjugateGradientFRPR/elxConjugateGradientFRPR.h
@@ -102,7 +102,6 @@ public:
 
   /** Typedef's inherited from Elastix.*/
   using typename Superclass2::ElastixType;
-  using typename Superclass2::ElastixPointer;
   using typename Superclass2::RegistrationType;
   using ITKBaseType = typename Superclass2::ITKBaseType;
 

--- a/Components/Optimizers/ConjugateGradientFRPR/elxConjugateGradientFRPR.h
+++ b/Components/Optimizers/ConjugateGradientFRPR/elxConjugateGradientFRPR.h
@@ -104,7 +104,6 @@ public:
   using typename Superclass2::ElastixType;
   using typename Superclass2::ElastixPointer;
   using typename Superclass2::RegistrationType;
-  using typename Superclass2::RegistrationPointer;
   using ITKBaseType = typename Superclass2::ITKBaseType;
 
   /** Methods to set parameters and print output at different stages

--- a/Components/Optimizers/FiniteDifferenceGradientDescent/elxFiniteDifferenceGradientDescent.h
+++ b/Components/Optimizers/FiniteDifferenceGradientDescent/elxFiniteDifferenceGradientDescent.h
@@ -108,7 +108,6 @@ public:
 
   /** Typedef's inherited from Elastix.*/
   using typename Superclass2::ElastixType;
-  using typename Superclass2::ElastixPointer;
   using typename Superclass2::RegistrationType;
   using ITKBaseType = typename Superclass2::ITKBaseType;
 

--- a/Components/Optimizers/FiniteDifferenceGradientDescent/elxFiniteDifferenceGradientDescent.h
+++ b/Components/Optimizers/FiniteDifferenceGradientDescent/elxFiniteDifferenceGradientDescent.h
@@ -110,7 +110,6 @@ public:
   using typename Superclass2::ElastixType;
   using typename Superclass2::ElastixPointer;
   using typename Superclass2::RegistrationType;
-  using typename Superclass2::RegistrationPointer;
   using ITKBaseType = typename Superclass2::ITKBaseType;
 
   /** Typedef for the ParametersType. */

--- a/Components/Optimizers/FullSearch/elxFullSearchOptimizer.h
+++ b/Components/Optimizers/FullSearch/elxFullSearchOptimizer.h
@@ -95,7 +95,6 @@ public:
 
   /** Typedef's inherited from Elastix.*/
   using typename Superclass2::ElastixType;
-  using typename Superclass2::ElastixPointer;
   using typename Superclass2::RegistrationType;
   using ITKBaseType = typename Superclass2::ITKBaseType;
 

--- a/Components/Optimizers/FullSearch/elxFullSearchOptimizer.h
+++ b/Components/Optimizers/FullSearch/elxFullSearchOptimizer.h
@@ -97,7 +97,6 @@ public:
   using typename Superclass2::ElastixType;
   using typename Superclass2::ElastixPointer;
   using typename Superclass2::RegistrationType;
-  using typename Superclass2::RegistrationPointer;
   using ITKBaseType = typename Superclass2::ITKBaseType;
 
   /** To store the results of the full search */

--- a/Components/Optimizers/Powell/elxPowell.h
+++ b/Components/Optimizers/Powell/elxPowell.h
@@ -70,7 +70,6 @@ public:
   using typename Superclass2::ElastixType;
   using typename Superclass2::ElastixPointer;
   using typename Superclass2::RegistrationType;
-  using typename Superclass2::RegistrationPointer;
   using ITKBaseType = typename Superclass2::ITKBaseType;
 
   /** Typedef for the ParametersType. */

--- a/Components/Optimizers/Powell/elxPowell.h
+++ b/Components/Optimizers/Powell/elxPowell.h
@@ -68,7 +68,6 @@ public:
 
   /** Typedef's inherited from Elastix.*/
   using typename Superclass2::ElastixType;
-  using typename Superclass2::ElastixPointer;
   using typename Superclass2::RegistrationType;
   using ITKBaseType = typename Superclass2::ITKBaseType;
 

--- a/Components/Optimizers/PreconditionedGradientDescent/elxPreconditionedGradientDescent.h
+++ b/Components/Optimizers/PreconditionedGradientDescent/elxPreconditionedGradientDescent.h
@@ -102,7 +102,6 @@ public:
   using typename Superclass2::ElastixType;
   using typename Superclass2::ElastixPointer;
   using typename Superclass2::RegistrationType;
-  using typename Superclass2::RegistrationPointer;
   using ITKBaseType = typename Superclass2::ITKBaseType;
 
   /** Typedef for the ParametersType. */

--- a/Components/Optimizers/PreconditionedGradientDescent/elxPreconditionedGradientDescent.h
+++ b/Components/Optimizers/PreconditionedGradientDescent/elxPreconditionedGradientDescent.h
@@ -100,7 +100,6 @@ public:
 
   /** Typedef's inherited from Superclass2, the elastix OptimizerBase. */
   using typename Superclass2::ElastixType;
-  using typename Superclass2::ElastixPointer;
   using typename Superclass2::RegistrationType;
   using ITKBaseType = typename Superclass2::ITKBaseType;
 

--- a/Components/Optimizers/PreconditionedStochasticGradientDescent/elxPreconditionedStochasticGradientDescent.h
+++ b/Components/Optimizers/PreconditionedStochasticGradientDescent/elxPreconditionedStochasticGradientDescent.h
@@ -206,7 +206,6 @@ public:
 
   /** Typedef's inherited from Superclass2. */
   using typename Superclass2::ElastixType;
-  using typename Superclass2::ElastixPointer;
   using typename Superclass2::RegistrationType;
   using ITKBaseType = typename Superclass2::ITKBaseType;
   using SizeValueType = itk::SizeValueType;

--- a/Components/Optimizers/PreconditionedStochasticGradientDescent/elxPreconditionedStochasticGradientDescent.h
+++ b/Components/Optimizers/PreconditionedStochasticGradientDescent/elxPreconditionedStochasticGradientDescent.h
@@ -208,7 +208,6 @@ public:
   using typename Superclass2::ElastixType;
   using typename Superclass2::ElastixPointer;
   using typename Superclass2::RegistrationType;
-  using typename Superclass2::RegistrationPointer;
   using ITKBaseType = typename Superclass2::ITKBaseType;
   using SizeValueType = itk::SizeValueType;
 

--- a/Components/Optimizers/QuasiNewtonLBFGS/elxQuasiNewtonLBFGS.h
+++ b/Components/Optimizers/QuasiNewtonLBFGS/elxQuasiNewtonLBFGS.h
@@ -121,7 +121,6 @@ public:
   using typename Superclass2::ElastixType;
   using typename Superclass2::ElastixPointer;
   using typename Superclass2::RegistrationType;
-  using typename Superclass2::RegistrationPointer;
   using ITKBaseType = typename Superclass2::ITKBaseType;
 
   /** Extra typedefs */

--- a/Components/Optimizers/QuasiNewtonLBFGS/elxQuasiNewtonLBFGS.h
+++ b/Components/Optimizers/QuasiNewtonLBFGS/elxQuasiNewtonLBFGS.h
@@ -119,7 +119,6 @@ public:
 
   /** Typedef's inherited from Elastix.*/
   using typename Superclass2::ElastixType;
-  using typename Superclass2::ElastixPointer;
   using typename Superclass2::RegistrationType;
   using ITKBaseType = typename Superclass2::ITKBaseType;
 

--- a/Components/Optimizers/RSGDEachParameterApart/elxRSGDEachParameterApart.h
+++ b/Components/Optimizers/RSGDEachParameterApart/elxRSGDEachParameterApart.h
@@ -99,7 +99,6 @@ public:
 
   /** Typedef's inherited from Elastix.*/
   using typename Superclass2::ElastixType;
-  using typename Superclass2::ElastixPointer;
   using typename Superclass2::RegistrationType;
   using ITKBaseType = typename Superclass2::ITKBaseType;
 

--- a/Components/Optimizers/RSGDEachParameterApart/elxRSGDEachParameterApart.h
+++ b/Components/Optimizers/RSGDEachParameterApart/elxRSGDEachParameterApart.h
@@ -101,7 +101,6 @@ public:
   using typename Superclass2::ElastixType;
   using typename Superclass2::ElastixPointer;
   using typename Superclass2::RegistrationType;
-  using typename Superclass2::RegistrationPointer;
   using ITKBaseType = typename Superclass2::ITKBaseType;
 
   /** Typedef for the ParametersType. */

--- a/Components/Optimizers/RegularStepGradientDescent/elxRegularStepGradientDescent.h
+++ b/Components/Optimizers/RegularStepGradientDescent/elxRegularStepGradientDescent.h
@@ -92,7 +92,6 @@ public:
 
   /** Typedef's inherited from Elastix.*/
   using typename Superclass2::ElastixType;
-  using typename Superclass2::ElastixPointer;
   using typename Superclass2::RegistrationType;
   using ITKBaseType = typename Superclass2::ITKBaseType;
 

--- a/Components/Optimizers/RegularStepGradientDescent/elxRegularStepGradientDescent.h
+++ b/Components/Optimizers/RegularStepGradientDescent/elxRegularStepGradientDescent.h
@@ -94,7 +94,6 @@ public:
   using typename Superclass2::ElastixType;
   using typename Superclass2::ElastixPointer;
   using typename Superclass2::RegistrationType;
-  using typename Superclass2::RegistrationPointer;
   using ITKBaseType = typename Superclass2::ITKBaseType;
 
   /** Typedef for the ParametersType. */

--- a/Components/Optimizers/Simplex/elxSimplex.h
+++ b/Components/Optimizers/Simplex/elxSimplex.h
@@ -70,7 +70,6 @@ public:
   using typename Superclass2::ElastixType;
   using typename Superclass2::ElastixPointer;
   using typename Superclass2::RegistrationType;
-  using typename Superclass2::RegistrationPointer;
   using ITKBaseType = typename Superclass2::ITKBaseType;
 
   /** Typedef for the ParametersType. */

--- a/Components/Optimizers/Simplex/elxSimplex.h
+++ b/Components/Optimizers/Simplex/elxSimplex.h
@@ -68,7 +68,6 @@ public:
 
   /** Typedef's inherited from Elastix.*/
   using typename Superclass2::ElastixType;
-  using typename Superclass2::ElastixPointer;
   using typename Superclass2::RegistrationType;
   using ITKBaseType = typename Superclass2::ITKBaseType;
 

--- a/Components/Optimizers/SimultaneousPerturbation/elxSimultaneousPerturbation.h
+++ b/Components/Optimizers/SimultaneousPerturbation/elxSimultaneousPerturbation.h
@@ -112,7 +112,6 @@ public:
   using typename Superclass2::ElastixType;
   using typename Superclass2::ElastixPointer;
   using typename Superclass2::RegistrationType;
-  using typename Superclass2::RegistrationPointer;
   using ITKBaseType = typename Superclass2::ITKBaseType;
 
   /** Typedef for the ParametersType. */

--- a/Components/Optimizers/SimultaneousPerturbation/elxSimultaneousPerturbation.h
+++ b/Components/Optimizers/SimultaneousPerturbation/elxSimultaneousPerturbation.h
@@ -110,7 +110,6 @@ public:
 
   /** Typedef's inherited from Elastix.*/
   using typename Superclass2::ElastixType;
-  using typename Superclass2::ElastixPointer;
   using typename Superclass2::RegistrationType;
   using ITKBaseType = typename Superclass2::ITKBaseType;
 

--- a/Components/Optimizers/StandardGradientDescent/elxStandardGradientDescent.h
+++ b/Components/Optimizers/StandardGradientDescent/elxStandardGradientDescent.h
@@ -96,7 +96,6 @@ public:
 
   /** Typedef's inherited from Superclass2, the elastix OptimizerBase .*/
   using typename Superclass2::ElastixType;
-  using typename Superclass2::ElastixPointer;
   using typename Superclass2::RegistrationType;
   using ITKBaseType = typename Superclass2::ITKBaseType;
 

--- a/Components/Optimizers/StandardGradientDescent/elxStandardGradientDescent.h
+++ b/Components/Optimizers/StandardGradientDescent/elxStandardGradientDescent.h
@@ -98,7 +98,6 @@ public:
   using typename Superclass2::ElastixType;
   using typename Superclass2::ElastixPointer;
   using typename Superclass2::RegistrationType;
-  using typename Superclass2::RegistrationPointer;
   using ITKBaseType = typename Superclass2::ITKBaseType;
 
   /** Typedef for the ParametersType. */

--- a/Components/Registrations/MultiMetricMultiResolutionRegistration/elxMultiMetricMultiResolutionRegistration.h
+++ b/Components/Registrations/MultiMetricMultiResolutionRegistration/elxMultiMetricMultiResolutionRegistration.h
@@ -169,7 +169,6 @@ public:
 
   /** Typedef's from Elastix. */
   using typename Superclass2::ElastixType;
-  using typename Superclass2::ElastixPointer;
   using RegistrationType = typename Superclass2::RegistrationType;
   using ITKBaseType = typename Superclass2::ITKBaseType;
   using typename Superclass2::UseMaskErosionArrayType;

--- a/Components/Registrations/MultiMetricMultiResolutionRegistration/elxMultiMetricMultiResolutionRegistration.h
+++ b/Components/Registrations/MultiMetricMultiResolutionRegistration/elxMultiMetricMultiResolutionRegistration.h
@@ -171,7 +171,6 @@ public:
   using typename Superclass2::ElastixType;
   using typename Superclass2::ElastixPointer;
   using RegistrationType = typename Superclass2::RegistrationType;
-  using typename Superclass2::RegistrationPointer;
   using ITKBaseType = typename Superclass2::ITKBaseType;
   using typename Superclass2::UseMaskErosionArrayType;
 

--- a/Components/Registrations/MultiResolutionRegistration/elxMultiResolutionRegistration.h
+++ b/Components/Registrations/MultiResolutionRegistration/elxMultiResolutionRegistration.h
@@ -107,7 +107,6 @@ public:
 
   /** Typedef's from Elastix. */
   using typename Superclass2::ElastixType;
-  using typename Superclass2::ElastixPointer;
   using RegistrationType = typename Superclass2::RegistrationType;
   using ITKBaseType = typename Superclass2::ITKBaseType;
   using typename Superclass2::UseMaskErosionArrayType;

--- a/Components/Registrations/MultiResolutionRegistration/elxMultiResolutionRegistration.h
+++ b/Components/Registrations/MultiResolutionRegistration/elxMultiResolutionRegistration.h
@@ -109,7 +109,6 @@ public:
   using typename Superclass2::ElastixType;
   using typename Superclass2::ElastixPointer;
   using RegistrationType = typename Superclass2::RegistrationType;
-  using typename Superclass2::RegistrationPointer;
   using ITKBaseType = typename Superclass2::ITKBaseType;
   using typename Superclass2::UseMaskErosionArrayType;
 

--- a/Components/Registrations/MultiResolutionRegistrationWithFeatures/elxMultiResolutionRegistrationWithFeatures.h
+++ b/Components/Registrations/MultiResolutionRegistrationWithFeatures/elxMultiResolutionRegistrationWithFeatures.h
@@ -125,7 +125,6 @@ public:
   using typename Superclass2::ElastixType;
   using typename Superclass2::ElastixPointer;
   using RegistrationType = typename Superclass2::RegistrationType;
-  using typename Superclass2::RegistrationPointer;
   using ITKBaseType = typename Superclass2::ITKBaseType;
   using typename Superclass2::UseMaskErosionArrayType;
 

--- a/Components/Registrations/MultiResolutionRegistrationWithFeatures/elxMultiResolutionRegistrationWithFeatures.h
+++ b/Components/Registrations/MultiResolutionRegistrationWithFeatures/elxMultiResolutionRegistrationWithFeatures.h
@@ -123,7 +123,6 @@ public:
 
   /** Typedef's from Elastix. */
   using typename Superclass2::ElastixType;
-  using typename Superclass2::ElastixPointer;
   using RegistrationType = typename Superclass2::RegistrationType;
   using ITKBaseType = typename Superclass2::ITKBaseType;
   using typename Superclass2::UseMaskErosionArrayType;

--- a/Components/ResampleInterpolators/BSplineResampleInterpolator/elxBSplineResampleInterpolator.h
+++ b/Components/ResampleInterpolators/BSplineResampleInterpolator/elxBSplineResampleInterpolator.h
@@ -100,7 +100,6 @@ public:
   using typename Superclass2::ElastixType;
   using typename Superclass2::ElastixPointer;
   using typename Superclass2::RegistrationType;
-  using typename Superclass2::RegistrationPointer;
   using ITKBaseType = typename Superclass2::ITKBaseType;
 
   /** Typedef that is used in the elastix dll version. */

--- a/Components/ResampleInterpolators/BSplineResampleInterpolator/elxBSplineResampleInterpolator.h
+++ b/Components/ResampleInterpolators/BSplineResampleInterpolator/elxBSplineResampleInterpolator.h
@@ -98,7 +98,6 @@ public:
 
   /** Typedef's from ResampleInterpolatorBase. */
   using typename Superclass2::ElastixType;
-  using typename Superclass2::ElastixPointer;
   using typename Superclass2::RegistrationType;
   using ITKBaseType = typename Superclass2::ITKBaseType;
 

--- a/Components/ResampleInterpolators/BSplineResampleInterpolatorFloat/elxBSplineResampleInterpolatorFloat.h
+++ b/Components/ResampleInterpolators/BSplineResampleInterpolatorFloat/elxBSplineResampleInterpolatorFloat.h
@@ -98,7 +98,6 @@ public:
 
   /** Typedef's from ResampleInterpolatorBase. */
   using typename Superclass2::ElastixType;
-  using typename Superclass2::ElastixPointer;
   using typename Superclass2::RegistrationType;
   using ITKBaseType = typename Superclass2::ITKBaseType;
   using typename Superclass2::ParameterMapType;

--- a/Components/ResampleInterpolators/BSplineResampleInterpolatorFloat/elxBSplineResampleInterpolatorFloat.h
+++ b/Components/ResampleInterpolators/BSplineResampleInterpolatorFloat/elxBSplineResampleInterpolatorFloat.h
@@ -100,7 +100,6 @@ public:
   using typename Superclass2::ElastixType;
   using typename Superclass2::ElastixPointer;
   using typename Superclass2::RegistrationType;
-  using typename Superclass2::RegistrationPointer;
   using ITKBaseType = typename Superclass2::ITKBaseType;
   using typename Superclass2::ParameterMapType;
 

--- a/Components/ResampleInterpolators/LinearResampleInterpolator/elxLinearResampleInterpolator.h
+++ b/Components/ResampleInterpolators/LinearResampleInterpolator/elxLinearResampleInterpolator.h
@@ -78,7 +78,6 @@ public:
 
   /** Typedef's from ResampleInterpolatorBase. */
   using typename Superclass2::ElastixType;
-  using typename Superclass2::ElastixPointer;
   using typename Superclass2::RegistrationType;
   using ITKBaseType = typename Superclass2::ITKBaseType;
 

--- a/Components/ResampleInterpolators/LinearResampleInterpolator/elxLinearResampleInterpolator.h
+++ b/Components/ResampleInterpolators/LinearResampleInterpolator/elxLinearResampleInterpolator.h
@@ -80,7 +80,6 @@ public:
   using typename Superclass2::ElastixType;
   using typename Superclass2::ElastixPointer;
   using typename Superclass2::RegistrationType;
-  using typename Superclass2::RegistrationPointer;
   using ITKBaseType = typename Superclass2::ITKBaseType;
 
 protected:

--- a/Components/ResampleInterpolators/NearestNeighborResampleInterpolator/elxNearestNeighborResampleInterpolator.h
+++ b/Components/ResampleInterpolators/NearestNeighborResampleInterpolator/elxNearestNeighborResampleInterpolator.h
@@ -79,7 +79,6 @@ public:
 
   /** Typedef's from ResampleInterpolatorBase. */
   using typename Superclass2::ElastixType;
-  using typename Superclass2::ElastixPointer;
   using typename Superclass2::RegistrationType;
   using ITKBaseType = typename Superclass2::ITKBaseType;
 

--- a/Components/ResampleInterpolators/NearestNeighborResampleInterpolator/elxNearestNeighborResampleInterpolator.h
+++ b/Components/ResampleInterpolators/NearestNeighborResampleInterpolator/elxNearestNeighborResampleInterpolator.h
@@ -81,7 +81,6 @@ public:
   using typename Superclass2::ElastixType;
   using typename Superclass2::ElastixPointer;
   using typename Superclass2::RegistrationType;
-  using typename Superclass2::RegistrationPointer;
   using ITKBaseType = typename Superclass2::ITKBaseType;
 
 protected:

--- a/Components/ResampleInterpolators/RDBSplineResampleInterpolator/elxRDBSplineResampleInterpolator.h
+++ b/Components/ResampleInterpolators/RDBSplineResampleInterpolator/elxRDBSplineResampleInterpolator.h
@@ -100,7 +100,6 @@ public:
 
   /** Typedef's from ResampleInterpolatorBase. */
   using typename Superclass2::ElastixType;
-  using typename Superclass2::ElastixPointer;
   using typename Superclass2::RegistrationType;
   using ITKBaseType = typename Superclass2::ITKBaseType;
   using typename Superclass2::ParameterMapType;

--- a/Components/ResampleInterpolators/RDBSplineResampleInterpolator/elxRDBSplineResampleInterpolator.h
+++ b/Components/ResampleInterpolators/RDBSplineResampleInterpolator/elxRDBSplineResampleInterpolator.h
@@ -102,7 +102,6 @@ public:
   using typename Superclass2::ElastixType;
   using typename Superclass2::ElastixPointer;
   using typename Superclass2::RegistrationType;
-  using typename Superclass2::RegistrationPointer;
   using ITKBaseType = typename Superclass2::ITKBaseType;
   using typename Superclass2::ParameterMapType;
 

--- a/Components/ResampleInterpolators/RayCastResampleInterpolator/elxRayCastResampleInterpolator.h
+++ b/Components/ResampleInterpolators/RayCastResampleInterpolator/elxRayCastResampleInterpolator.h
@@ -76,7 +76,6 @@ public:
 
   /** Typedef's from ResampleInterpolatorBase. */
   using typename Superclass2::ElastixType;
-  using typename Superclass2::ElastixPointer;
   using typename Superclass2::RegistrationType;
   using ITKBaseType = typename Superclass2::ITKBaseType;
 

--- a/Components/ResampleInterpolators/RayCastResampleInterpolator/elxRayCastResampleInterpolator.h
+++ b/Components/ResampleInterpolators/RayCastResampleInterpolator/elxRayCastResampleInterpolator.h
@@ -78,7 +78,6 @@ public:
   using typename Superclass2::ElastixType;
   using typename Superclass2::ElastixPointer;
   using typename Superclass2::RegistrationType;
-  using typename Superclass2::RegistrationPointer;
   using ITKBaseType = typename Superclass2::ITKBaseType;
 
   /** Typedef's for CombinationTransform */

--- a/Components/Resamplers/MyStandardResampler/elxMyStandardResampler.h
+++ b/Components/Resamplers/MyStandardResampler/elxMyStandardResampler.h
@@ -81,7 +81,6 @@ public:
   using typename Superclass2::ElastixType;
   using typename Superclass2::ElastixPointer;
   using typename Superclass2::RegistrationType;
-  using typename Superclass2::RegistrationPointer;
   using ITKBaseType = typename Superclass2::ITKBaseType;
 
   /* Nothing to add. In the baseclass already everything is done what should be done. */

--- a/Components/Resamplers/MyStandardResampler/elxMyStandardResampler.h
+++ b/Components/Resamplers/MyStandardResampler/elxMyStandardResampler.h
@@ -79,7 +79,6 @@ public:
 
   /** Typedef's from the ResamplerBase. */
   using typename Superclass2::ElastixType;
-  using typename Superclass2::ElastixPointer;
   using typename Superclass2::RegistrationType;
   using ITKBaseType = typename Superclass2::ITKBaseType;
 

--- a/Components/Transforms/AdvancedAffineTransform/elxAdvancedAffineTransform.h
+++ b/Components/Transforms/AdvancedAffineTransform/elxAdvancedAffineTransform.h
@@ -129,7 +129,6 @@ public:
   using typename Superclass2::ElastixPointer;
   using typename Superclass2::ParameterMapType;
   using typename Superclass2::RegistrationType;
-  using typename Superclass2::RegistrationPointer;
   using typename Superclass2::CoordRepType;
   using typename Superclass2::FixedImageType;
   using typename Superclass2::MovingImageType;

--- a/Components/Transforms/AdvancedAffineTransform/elxAdvancedAffineTransform.h
+++ b/Components/Transforms/AdvancedAffineTransform/elxAdvancedAffineTransform.h
@@ -126,7 +126,6 @@ public:
 
   /** Typedef's from the TransformBase class. */
   using typename Superclass2::ElastixType;
-  using typename Superclass2::ElastixPointer;
   using typename Superclass2::ParameterMapType;
   using typename Superclass2::RegistrationType;
   using typename Superclass2::CoordRepType;

--- a/Components/Transforms/AdvancedBSplineTransform/elxAdvancedBSplineTransform.h
+++ b/Components/Transforms/AdvancedBSplineTransform/elxAdvancedBSplineTransform.h
@@ -172,7 +172,6 @@ public:
 
   /** Typedef's from TransformBase. */
   using typename Superclass2::ElastixType;
-  using typename Superclass2::ElastixPointer;
   using typename Superclass2::RegistrationType;
   using typename Superclass2::CoordRepType;
   using typename Superclass2::FixedImageType;

--- a/Components/Transforms/AdvancedBSplineTransform/elxAdvancedBSplineTransform.h
+++ b/Components/Transforms/AdvancedBSplineTransform/elxAdvancedBSplineTransform.h
@@ -174,7 +174,6 @@ public:
   using typename Superclass2::ElastixType;
   using typename Superclass2::ElastixPointer;
   using typename Superclass2::RegistrationType;
-  using typename Superclass2::RegistrationPointer;
   using typename Superclass2::CoordRepType;
   using typename Superclass2::FixedImageType;
   using typename Superclass2::MovingImageType;

--- a/Components/Transforms/AffineDTITransform/elxAffineDTITransform.h
+++ b/Components/Transforms/AffineDTITransform/elxAffineDTITransform.h
@@ -134,7 +134,6 @@ public:
   using typename Superclass2::ElastixPointer;
   using typename Superclass2::ParameterMapType;
   using typename Superclass2::RegistrationType;
-  using typename Superclass2::RegistrationPointer;
   using typename Superclass2::CoordRepType;
   using typename Superclass2::FixedImageType;
   using typename Superclass2::MovingImageType;

--- a/Components/Transforms/AffineDTITransform/elxAffineDTITransform.h
+++ b/Components/Transforms/AffineDTITransform/elxAffineDTITransform.h
@@ -131,7 +131,6 @@ public:
 
   /** Typedef's inherited from TransformBase. */
   using typename Superclass2::ElastixType;
-  using typename Superclass2::ElastixPointer;
   using typename Superclass2::ParameterMapType;
   using typename Superclass2::RegistrationType;
   using typename Superclass2::CoordRepType;

--- a/Components/Transforms/AffineLogStackTransform/elxAffineLogStackTransform.h
+++ b/Components/Transforms/AffineLogStackTransform/elxAffineLogStackTransform.h
@@ -90,7 +90,6 @@ public:
   using typename Superclass2::ElastixPointer;
   using typename Superclass2::ParameterMapType;
   using typename Superclass2::RegistrationType;
-  using typename Superclass2::RegistrationPointer;
   using typename Superclass2::CoordRepType;
   using typename Superclass2::FixedImageType;
   using typename Superclass2::MovingImageType;

--- a/Components/Transforms/AffineLogStackTransform/elxAffineLogStackTransform.h
+++ b/Components/Transforms/AffineLogStackTransform/elxAffineLogStackTransform.h
@@ -87,7 +87,6 @@ public:
 
   /** Typedef's from TransformBase. */
   using typename Superclass2::ElastixType;
-  using typename Superclass2::ElastixPointer;
   using typename Superclass2::ParameterMapType;
   using typename Superclass2::RegistrationType;
   using typename Superclass2::CoordRepType;

--- a/Components/Transforms/AffineLogTransform/elxAffineLogTransform.h
+++ b/Components/Transforms/AffineLogTransform/elxAffineLogTransform.h
@@ -97,7 +97,6 @@ public:
   using typename Superclass2::ElastixPointer;
   using typename Superclass2::ParameterMapType;
   using typename Superclass2::RegistrationType;
-  using typename Superclass2::RegistrationPointer;
   using typename Superclass2::CoordRepType;
   using typename Superclass2::FixedImageType;
   using typename Superclass2::MovingImageType;

--- a/Components/Transforms/AffineLogTransform/elxAffineLogTransform.h
+++ b/Components/Transforms/AffineLogTransform/elxAffineLogTransform.h
@@ -94,7 +94,6 @@ public:
 
   /** Typedef's inherited from TransformBase. */
   using typename Superclass2::ElastixType;
-  using typename Superclass2::ElastixPointer;
   using typename Superclass2::ParameterMapType;
   using typename Superclass2::RegistrationType;
   using typename Superclass2::CoordRepType;

--- a/Components/Transforms/BSplineDeformableTransformWithDiffusion/elxBSplineTransformWithDiffusion.h
+++ b/Components/Transforms/BSplineDeformableTransformWithDiffusion/elxBSplineTransformWithDiffusion.h
@@ -231,7 +231,6 @@ public:
 
   /** Typedef's from TransformBase. */
   using typename Superclass2::ElastixType;
-  using typename Superclass2::ElastixPointer;
   using typename Superclass2::ParameterMapType;
   using typename Superclass2::RegistrationType;
   using typename Superclass2::CoordRepType;

--- a/Components/Transforms/BSplineDeformableTransformWithDiffusion/elxBSplineTransformWithDiffusion.h
+++ b/Components/Transforms/BSplineDeformableTransformWithDiffusion/elxBSplineTransformWithDiffusion.h
@@ -234,7 +234,6 @@ public:
   using typename Superclass2::ElastixPointer;
   using typename Superclass2::ParameterMapType;
   using typename Superclass2::RegistrationType;
-  using typename Superclass2::RegistrationPointer;
   using typename Superclass2::CoordRepType;
   using typename Superclass2::FixedImageType;
   using typename Superclass2::MovingImageType;

--- a/Components/Transforms/BSplineStackTransform/elxBSplineStackTransform.h
+++ b/Components/Transforms/BSplineStackTransform/elxBSplineStackTransform.h
@@ -173,7 +173,6 @@ public:
   using typename Superclass2::ElastixType;
   using typename Superclass2::ElastixPointer;
   using typename Superclass2::RegistrationType;
-  using typename Superclass2::RegistrationPointer;
   using typename Superclass2::CoordRepType;
   using typename Superclass2::FixedImageType;
   using typename Superclass2::MovingImageType;

--- a/Components/Transforms/BSplineStackTransform/elxBSplineStackTransform.h
+++ b/Components/Transforms/BSplineStackTransform/elxBSplineStackTransform.h
@@ -171,7 +171,6 @@ public:
 
   /** Typedef's from TransformBase. */
   using typename Superclass2::ElastixType;
-  using typename Superclass2::ElastixPointer;
   using typename Superclass2::RegistrationType;
   using typename Superclass2::CoordRepType;
   using typename Superclass2::FixedImageType;

--- a/Components/Transforms/DeformationFieldTransform/elxDeformationFieldTransform.h
+++ b/Components/Transforms/DeformationFieldTransform/elxDeformationFieldTransform.h
@@ -112,7 +112,6 @@ public:
 
   /** Typedef's from TransformBase. */
   using typename Superclass2::ElastixType;
-  using typename Superclass2::ElastixPointer;
   using typename Superclass2::ParameterMapType;
   using typename Superclass2::RegistrationType;
   using typename Superclass2::CoordRepType;

--- a/Components/Transforms/DeformationFieldTransform/elxDeformationFieldTransform.h
+++ b/Components/Transforms/DeformationFieldTransform/elxDeformationFieldTransform.h
@@ -115,7 +115,6 @@ public:
   using typename Superclass2::ElastixPointer;
   using typename Superclass2::ParameterMapType;
   using typename Superclass2::RegistrationType;
-  using typename Superclass2::RegistrationPointer;
   using typename Superclass2::CoordRepType;
   using typename Superclass2::FixedImageType;
   using typename Superclass2::MovingImageType;

--- a/Components/Transforms/EulerStackTransform/elxEulerStackTransform.h
+++ b/Components/Transforms/EulerStackTransform/elxEulerStackTransform.h
@@ -133,7 +133,6 @@ public:
   using typename Superclass2::ElastixPointer;
   using typename Superclass2::ParameterMapType;
   using typename Superclass2::RegistrationType;
-  using typename Superclass2::RegistrationPointer;
   using typename Superclass2::CoordRepType;
   using typename Superclass2::FixedImageType;
   using typename Superclass2::MovingImageType;

--- a/Components/Transforms/EulerStackTransform/elxEulerStackTransform.h
+++ b/Components/Transforms/EulerStackTransform/elxEulerStackTransform.h
@@ -130,7 +130,6 @@ public:
 
   /** Typedef's from TransformBase. */
   using typename Superclass2::ElastixType;
-  using typename Superclass2::ElastixPointer;
   using typename Superclass2::ParameterMapType;
   using typename Superclass2::RegistrationType;
   using typename Superclass2::CoordRepType;

--- a/Components/Transforms/EulerTransform/elxEulerTransform.h
+++ b/Components/Transforms/EulerTransform/elxEulerTransform.h
@@ -134,7 +134,6 @@ public:
   using typename Superclass2::ElastixPointer;
   using typename Superclass2::ParameterMapType;
   using typename Superclass2::RegistrationType;
-  using typename Superclass2::RegistrationPointer;
   using typename Superclass2::CoordRepType;
   using typename Superclass2::FixedImageType;
   using typename Superclass2::MovingImageType;

--- a/Components/Transforms/EulerTransform/elxEulerTransform.h
+++ b/Components/Transforms/EulerTransform/elxEulerTransform.h
@@ -131,7 +131,6 @@ public:
 
   /** Typedef's inherited from TransformBase. */
   using typename Superclass2::ElastixType;
-  using typename Superclass2::ElastixPointer;
   using typename Superclass2::ParameterMapType;
   using typename Superclass2::RegistrationType;
   using typename Superclass2::CoordRepType;

--- a/Components/Transforms/MultiBSplineTransformWithNormal/elxMultiBSplineTransformWithNormal.h
+++ b/Components/Transforms/MultiBSplineTransformWithNormal/elxMultiBSplineTransformWithNormal.h
@@ -167,7 +167,6 @@ public:
 
   /** Typedef's from TransformBase. */
   using typename Superclass2::ElastixType;
-  using typename Superclass2::ElastixPointer;
   using typename Superclass2::ParameterMapType;
   using typename Superclass2::RegistrationType;
   using typename Superclass2::CoordRepType;

--- a/Components/Transforms/MultiBSplineTransformWithNormal/elxMultiBSplineTransformWithNormal.h
+++ b/Components/Transforms/MultiBSplineTransformWithNormal/elxMultiBSplineTransformWithNormal.h
@@ -170,7 +170,6 @@ public:
   using typename Superclass2::ElastixPointer;
   using typename Superclass2::ParameterMapType;
   using typename Superclass2::RegistrationType;
-  using typename Superclass2::RegistrationPointer;
   using typename Superclass2::CoordRepType;
   using typename Superclass2::FixedImageType;
   using typename Superclass2::MovingImageType;

--- a/Components/Transforms/RecursiveBSplineTransform/elxRecursiveBSplineTransform.h
+++ b/Components/Transforms/RecursiveBSplineTransform/elxRecursiveBSplineTransform.h
@@ -172,7 +172,6 @@ public:
 
   /** Typedef's from TransformBase. */
   using typename Superclass2::ElastixType;
-  using typename Superclass2::ElastixPointer;
   using typename Superclass2::RegistrationType;
   using typename Superclass2::CoordRepType;
   using typename Superclass2::FixedImageType;

--- a/Components/Transforms/RecursiveBSplineTransform/elxRecursiveBSplineTransform.h
+++ b/Components/Transforms/RecursiveBSplineTransform/elxRecursiveBSplineTransform.h
@@ -174,7 +174,6 @@ public:
   using typename Superclass2::ElastixType;
   using typename Superclass2::ElastixPointer;
   using typename Superclass2::RegistrationType;
-  using typename Superclass2::RegistrationPointer;
   using typename Superclass2::CoordRepType;
   using typename Superclass2::FixedImageType;
   using typename Superclass2::MovingImageType;

--- a/Components/Transforms/SimilarityTransform/elxSimilarityTransform.h
+++ b/Components/Transforms/SimilarityTransform/elxSimilarityTransform.h
@@ -133,7 +133,6 @@ public:
 
   /** Typedef's inherited from TransformBase. */
   using typename Superclass2::ElastixType;
-  using typename Superclass2::ElastixPointer;
   using typename Superclass2::ParameterMapType;
   using typename Superclass2::RegistrationType;
   using typename Superclass2::CoordRepType;

--- a/Components/Transforms/SimilarityTransform/elxSimilarityTransform.h
+++ b/Components/Transforms/SimilarityTransform/elxSimilarityTransform.h
@@ -136,7 +136,6 @@ public:
   using typename Superclass2::ElastixPointer;
   using typename Superclass2::ParameterMapType;
   using typename Superclass2::RegistrationType;
-  using typename Superclass2::RegistrationPointer;
   using typename Superclass2::CoordRepType;
   using typename Superclass2::FixedImageType;
   using typename Superclass2::MovingImageType;

--- a/Components/Transforms/SplineKernelTransform/elxSplineKernelTransform.h
+++ b/Components/Transforms/SplineKernelTransform/elxSplineKernelTransform.h
@@ -163,7 +163,6 @@ public:
 
   /** Typedef's from the TransformBase class. */
   using typename Superclass2::ElastixType;
-  using typename Superclass2::ElastixPointer;
   using typename Superclass2::ParameterMapType;
   using typename Superclass2::RegistrationType;
   using typename Superclass2::CoordRepType;

--- a/Components/Transforms/SplineKernelTransform/elxSplineKernelTransform.h
+++ b/Components/Transforms/SplineKernelTransform/elxSplineKernelTransform.h
@@ -166,7 +166,6 @@ public:
   using typename Superclass2::ElastixPointer;
   using typename Superclass2::ParameterMapType;
   using typename Superclass2::RegistrationType;
-  using typename Superclass2::RegistrationPointer;
   using typename Superclass2::CoordRepType;
   using typename Superclass2::FixedImageType;
   using typename Superclass2::MovingImageType;

--- a/Components/Transforms/TranslationStackTransform/elxTranslationStackTransform.h
+++ b/Components/Transforms/TranslationStackTransform/elxTranslationStackTransform.h
@@ -105,7 +105,6 @@ public:
   using typename Superclass2::ElastixPointer;
   using typename Superclass2::ParameterMapType;
   using typename Superclass2::RegistrationType;
-  using typename Superclass2::RegistrationPointer;
   using typename Superclass2::CoordRepType;
   using typename Superclass2::FixedImageType;
   using typename Superclass2::MovingImageType;

--- a/Components/Transforms/TranslationStackTransform/elxTranslationStackTransform.h
+++ b/Components/Transforms/TranslationStackTransform/elxTranslationStackTransform.h
@@ -102,7 +102,6 @@ public:
 
   /** Typedef's from TransformBase. */
   using typename Superclass2::ElastixType;
-  using typename Superclass2::ElastixPointer;
   using typename Superclass2::ParameterMapType;
   using typename Superclass2::RegistrationType;
   using typename Superclass2::CoordRepType;

--- a/Components/Transforms/TranslationTransform/elxTranslationTransform.h
+++ b/Components/Transforms/TranslationTransform/elxTranslationTransform.h
@@ -101,7 +101,6 @@ public:
 
   /** Typedef's from the TransformBase class. */
   using typename Superclass2::ElastixType;
-  using typename Superclass2::ElastixPointer;
   using typename Superclass2::ParameterMapType;
   using typename Superclass2::RegistrationType;
   using typename Superclass2::CoordRepType;

--- a/Components/Transforms/TranslationTransform/elxTranslationTransform.h
+++ b/Components/Transforms/TranslationTransform/elxTranslationTransform.h
@@ -104,7 +104,6 @@ public:
   using typename Superclass2::ElastixPointer;
   using typename Superclass2::ParameterMapType;
   using typename Superclass2::RegistrationType;
-  using typename Superclass2::RegistrationPointer;
   using typename Superclass2::CoordRepType;
   using typename Superclass2::FixedImageType;
   using typename Superclass2::MovingImageType;

--- a/Components/Transforms/WeightedCombinationTransform/elxWeightedCombinationTransform.h
+++ b/Components/Transforms/WeightedCombinationTransform/elxWeightedCombinationTransform.h
@@ -134,7 +134,6 @@ public:
 
   /** Typedef's from the TransformBase class. */
   using typename Superclass2::ElastixType;
-  using typename Superclass2::ElastixPointer;
   using typename Superclass2::ParameterMapType;
   using typename Superclass2::RegistrationType;
   using typename Superclass2::CoordRepType;

--- a/Components/Transforms/WeightedCombinationTransform/elxWeightedCombinationTransform.h
+++ b/Components/Transforms/WeightedCombinationTransform/elxWeightedCombinationTransform.h
@@ -137,7 +137,6 @@ public:
   using typename Superclass2::ElastixPointer;
   using typename Superclass2::ParameterMapType;
   using typename Superclass2::RegistrationType;
-  using typename Superclass2::RegistrationPointer;
   using typename Superclass2::CoordRepType;
   using typename Superclass2::FixedImageType;
   using typename Superclass2::MovingImageType;

--- a/Core/ComponentBaseClasses/elxFixedImagePyramidBase.h
+++ b/Core/ComponentBaseClasses/elxFixedImagePyramidBase.h
@@ -67,7 +67,6 @@ public:
 
   /** Typedefs inherited from the superclass. */
   using typename Superclass::ElastixType;
-  using typename Superclass::ElastixPointer;
   using typename Superclass::RegistrationType;
 
   /** Typedefs inherited from Elastix. */

--- a/Core/ComponentBaseClasses/elxFixedImagePyramidBase.h
+++ b/Core/ComponentBaseClasses/elxFixedImagePyramidBase.h
@@ -69,7 +69,6 @@ public:
   using typename Superclass::ElastixType;
   using typename Superclass::ElastixPointer;
   using typename Superclass::RegistrationType;
-  using typename Superclass::RegistrationPointer;
 
   /** Typedefs inherited from Elastix. */
   using InputImageType = typename ElastixType::FixedImageType;

--- a/Core/ComponentBaseClasses/elxImageSamplerBase.h
+++ b/Core/ComponentBaseClasses/elxImageSamplerBase.h
@@ -53,7 +53,6 @@ public:
 
   /** Typedefs inherited from Elastix. */
   using typename Superclass::ElastixType;
-  using typename Superclass::ElastixPointer;
   using typename Superclass::RegistrationType;
 
   /** Other typedef's. */

--- a/Core/ComponentBaseClasses/elxImageSamplerBase.h
+++ b/Core/ComponentBaseClasses/elxImageSamplerBase.h
@@ -55,7 +55,6 @@ public:
   using typename Superclass::ElastixType;
   using typename Superclass::ElastixPointer;
   using typename Superclass::RegistrationType;
-  using typename Superclass::RegistrationPointer;
 
   /** Other typedef's. */
   using InputImageType = typename ElastixType::FixedImageType;

--- a/Core/ComponentBaseClasses/elxInterpolatorBase.h
+++ b/Core/ComponentBaseClasses/elxInterpolatorBase.h
@@ -55,7 +55,6 @@ public:
   using typename Superclass::ElastixType;
   using typename Superclass::ElastixPointer;
   using typename Superclass::RegistrationType;
-  using typename Superclass::RegistrationPointer;
 
   /** Other typedef's. */
   using InputImageType = typename ElastixType::MovingImageType;

--- a/Core/ComponentBaseClasses/elxInterpolatorBase.h
+++ b/Core/ComponentBaseClasses/elxInterpolatorBase.h
@@ -53,7 +53,6 @@ public:
 
   /** Typedefs inherited from Elastix. */
   using typename Superclass::ElastixType;
-  using typename Superclass::ElastixPointer;
   using typename Superclass::RegistrationType;
 
   /** Other typedef's. */

--- a/Core/ComponentBaseClasses/elxMetricBase.h
+++ b/Core/ComponentBaseClasses/elxMetricBase.h
@@ -83,7 +83,6 @@ public:
   using typename Superclass::ElastixType;
   using typename Superclass::ElastixPointer;
   using typename Superclass::RegistrationType;
-  using typename Superclass::RegistrationPointer;
 
   /** Other typedef's. */
   using FixedImageType = typename ElastixType::FixedImageType;

--- a/Core/ComponentBaseClasses/elxMetricBase.h
+++ b/Core/ComponentBaseClasses/elxMetricBase.h
@@ -81,7 +81,6 @@ public:
 
   /** Typedef's inherited from Elastix. */
   using typename Superclass::ElastixType;
-  using typename Superclass::ElastixPointer;
   using typename Superclass::RegistrationType;
 
   /** Other typedef's. */

--- a/Core/ComponentBaseClasses/elxMovingImagePyramidBase.h
+++ b/Core/ComponentBaseClasses/elxMovingImagePyramidBase.h
@@ -69,7 +69,6 @@ public:
 
   /** Typedefs inherited from the superclass. */
   using typename Superclass::ElastixType;
-  using typename Superclass::ElastixPointer;
   using typename Superclass::RegistrationType;
 
   /** Typedefs inherited from Elastix. */

--- a/Core/ComponentBaseClasses/elxMovingImagePyramidBase.h
+++ b/Core/ComponentBaseClasses/elxMovingImagePyramidBase.h
@@ -71,7 +71,6 @@ public:
   using typename Superclass::ElastixType;
   using typename Superclass::ElastixPointer;
   using typename Superclass::RegistrationType;
-  using typename Superclass::RegistrationPointer;
 
   /** Typedefs inherited from Elastix. */
   using InputImageType = typename ElastixType::MovingImageType;

--- a/Core/ComponentBaseClasses/elxOptimizerBase.h
+++ b/Core/ComponentBaseClasses/elxOptimizerBase.h
@@ -64,7 +64,6 @@ public:
   using typename Superclass::ElastixType;
   using typename Superclass::ElastixPointer;
   using typename Superclass::RegistrationType;
-  using typename Superclass::RegistrationPointer;
 
   /** ITKBaseType. */
   using ITKBaseType = itk::Optimizer;

--- a/Core/ComponentBaseClasses/elxOptimizerBase.h
+++ b/Core/ComponentBaseClasses/elxOptimizerBase.h
@@ -62,7 +62,6 @@ public:
 
   /** Typedefs inherited from Elastix. */
   using typename Superclass::ElastixType;
-  using typename Superclass::ElastixPointer;
   using typename Superclass::RegistrationType;
 
   /** ITKBaseType. */

--- a/Core/ComponentBaseClasses/elxRegistrationBase.h
+++ b/Core/ComponentBaseClasses/elxRegistrationBase.h
@@ -86,7 +86,6 @@ public:
   using typename Superclass::ElastixType;
   using typename Superclass::ElastixPointer;
   using typename Superclass::RegistrationType;
-  using typename Superclass::RegistrationPointer;
 
   /** Other typedef's. */
   using FixedImageType = typename ElastixType::FixedImageType;

--- a/Core/ComponentBaseClasses/elxRegistrationBase.h
+++ b/Core/ComponentBaseClasses/elxRegistrationBase.h
@@ -84,7 +84,6 @@ public:
 
   /** Typedef's from Elastix. */
   using typename Superclass::ElastixType;
-  using typename Superclass::ElastixPointer;
   using typename Superclass::RegistrationType;
 
   /** Other typedef's. */

--- a/Core/ComponentBaseClasses/elxResampleInterpolatorBase.h
+++ b/Core/ComponentBaseClasses/elxResampleInterpolatorBase.h
@@ -52,7 +52,6 @@ public:
 
   /** Typedef's from superclass. */
   using typename Superclass::ElastixType;
-  using typename Superclass::ElastixPointer;
   using typename Superclass::RegistrationType;
 
   /** Typedef's from elastix. */

--- a/Core/ComponentBaseClasses/elxResampleInterpolatorBase.h
+++ b/Core/ComponentBaseClasses/elxResampleInterpolatorBase.h
@@ -54,7 +54,6 @@ public:
   using typename Superclass::ElastixType;
   using typename Superclass::ElastixPointer;
   using typename Superclass::RegistrationType;
-  using typename Superclass::RegistrationPointer;
 
   /** Typedef's from elastix. */
   using InputImageType = typename ElastixType::MovingImageType;

--- a/Core/ComponentBaseClasses/elxResamplerBase.h
+++ b/Core/ComponentBaseClasses/elxResamplerBase.h
@@ -85,7 +85,6 @@ public:
 
   /** Typedef's from superclass. */
   using typename Superclass::ElastixType;
-  using typename Superclass::ElastixPointer;
   using typename Superclass::RegistrationType;
 
   /** Typedef's from elastix.

--- a/Core/ComponentBaseClasses/elxResamplerBase.h
+++ b/Core/ComponentBaseClasses/elxResamplerBase.h
@@ -87,7 +87,6 @@ public:
   using typename Superclass::ElastixType;
   using typename Superclass::ElastixPointer;
   using typename Superclass::RegistrationType;
-  using typename Superclass::RegistrationPointer;
 
   /** Typedef's from elastix.
    * NB: it is assumed that fixed and moving image dimension are equal!  */

--- a/Core/ComponentBaseClasses/elxTransformBase.h
+++ b/Core/ComponentBaseClasses/elxTransformBase.h
@@ -152,8 +152,7 @@ public:
   using MovingImageType = typename TElastix::MovingImageType;
 
   /** Typedef's from ComponentDatabase. */
-  using ComponentDatabaseType = ComponentDatabase;
-  using ComponentDescriptionType = ComponentDatabaseType::ComponentDescriptionType;
+  using ComponentDescriptionType = ComponentDatabase::ComponentDescriptionType;
   using PtrToCreator = ComponentDatabase::PtrToCreator;
 
   /** Typedef for the ProgressCommand. */

--- a/Core/Configuration/elxConfiguration.cxx
+++ b/Core/Configuration/elxConfiguration.cxx
@@ -80,8 +80,8 @@ Configuration::Configuration()
 {
   /** Initialize stuff. */
   this->m_ParameterFileName = "";
-  this->m_ParameterFileParser = ParameterFileParserType::New();
-  this->m_ParameterMapInterface = ParameterMapInterfaceType::New();
+  this->m_ParameterFileParser = itk::ParameterFileParser::New();
+  this->m_ParameterMapInterface = itk::ParameterMapInterface::New();
 
   this->m_IsInitialized = false;
   this->m_ElastixLevel = 0;
@@ -236,8 +236,8 @@ Configuration::Initialize(const CommandLineArgumentMapType & _arg)
  */
 
 int
-Configuration::Initialize(const CommandLineArgumentMapType &                _arg,
-                          const ParameterFileParserType::ParameterMapType & inputMap)
+Configuration::Initialize(const CommandLineArgumentMapType &                 _arg,
+                          const itk::ParameterFileParser::ParameterMapType & inputMap)
 {
   TransformFactoryRegistration::RegisterTransforms();
 

--- a/Core/Configuration/elxConfiguration.h
+++ b/Core/Configuration/elxConfiguration.h
@@ -69,12 +69,6 @@ public:
   using CommandLineArgumentMapType = std::map<std::string, std::string>;
   using CommandLineEntryType = CommandLineArgumentMapType::value_type;
 
-  /** Typedefs for the parameter file. */
-  using ParameterFileParserType = itk::ParameterFileParser;
-  using ParameterFileParserPointer = ParameterFileParserType::Pointer;
-  using ParameterMapInterfaceType = itk::ParameterMapInterface;
-  using ParameterMapInterfacePointer = ParameterMapInterfaceType::Pointer;
-
   /** Get and Set CommandLine arguments into the argument map. */
   std::string
   GetCommandLineArgument(const std::string & key) const;
@@ -97,7 +91,7 @@ public:
   Initialize(const CommandLineArgumentMapType & _arg);
 
   virtual int
-  Initialize(const CommandLineArgumentMapType & _arg, const ParameterFileParserType::ParameterMapType & inputMap);
+  Initialize(const CommandLineArgumentMapType & _arg, const itk::ParameterFileParser::ParameterMapType & inputMap);
 
   /** True, if Initialize was successfully called. */
   virtual bool
@@ -293,10 +287,10 @@ private:
   void
   operator=(const Self &) = delete;
 
-  CommandLineArgumentMapType   m_CommandLineArgumentMap;
-  std::string                  m_ParameterFileName;
-  ParameterFileParserPointer   m_ParameterFileParser;
-  ParameterMapInterfacePointer m_ParameterMapInterface;
+  CommandLineArgumentMapType          m_CommandLineArgumentMap;
+  std::string                         m_ParameterFileName;
+  itk::ParameterFileParser::Pointer   m_ParameterFileParser;
+  itk::ParameterMapInterface::Pointer m_ParameterMapInterface;
 
   bool         m_IsInitialized;
   unsigned int m_ElastixLevel;

--- a/Core/Install/elxBaseComponentSE.h
+++ b/Core/Install/elxBaseComponentSE.h
@@ -64,7 +64,6 @@ public:
    * not an itk::Object or something like that.
    */
   using RegistrationType = typename ElastixType::RegistrationBaseType;
-  using RegistrationPointer = RegistrationType *;
 
   /**
    * Get/Set functions for Elastix.
@@ -128,7 +127,7 @@ public:
    * component is needed often by other components.
    * It could be accessed also via GetElastix->GetElxRegistrationBase().
    */
-  RegistrationPointer
+  RegistrationType *
   GetRegistration() const
   {
     return this->m_Registration;
@@ -141,7 +140,7 @@ protected:
 
   ElastixPointer       m_Elastix{};
   ConfigurationPointer m_Configuration{};
-  RegistrationPointer  m_Registration{};
+  RegistrationType *   m_Registration{};
 
 private:
   virtual const itk::Object &

--- a/Core/Install/elxBaseComponentSE.h
+++ b/Core/Install/elxBaseComponentSE.h
@@ -53,9 +53,8 @@ public:
   using Self = BaseComponentSE;
   using Superclass = BaseComponent;
 
-  /** Elastix typedef's. */
+  /** Elastix typedef. */
   using ElastixType = TElastix;
-  using ElastixPointer = itk::WeakPointer<ElastixType>;
 
   /** Configuration pointer type. */
   using ConfigurationPointer = Configuration::Pointer;
@@ -138,9 +137,9 @@ protected:
   BaseComponentSE() = default;
   ~BaseComponentSE() override = default;
 
-  ElastixPointer       m_Elastix{};
-  ConfigurationPointer m_Configuration{};
-  RegistrationType *   m_Registration{};
+  itk::WeakPointer<TElastix> m_Elastix{};
+  ConfigurationPointer       m_Configuration{};
+  RegistrationType *         m_Registration{};
 
 private:
   virtual const itk::Object &

--- a/Core/Install/elxComponentLoader.h
+++ b/Core/Install/elxComponentLoader.h
@@ -52,12 +52,11 @@ public:
   itkTypeMacro(ComponentLoader, Object);
 
   /** Typedef's. */
-  using ComponentDatabaseType = ComponentDatabase;
-  using ComponentDatabasePointer = ComponentDatabaseType::Pointer;
+  using ComponentDatabasePointer = ComponentDatabase::Pointer;
 
   /** Set and get the ComponentDatabase. */
-  itkSetObjectMacro(ComponentDatabase, ComponentDatabaseType);
-  itkGetModifiableObjectMacro(ComponentDatabase, ComponentDatabaseType);
+  itkSetObjectMacro(ComponentDatabase, ComponentDatabase);
+  itkGetModifiableObjectMacro(ComponentDatabase, ComponentDatabase);
 
   /** Function to load components. */
   int

--- a/Core/Kernel/elxElastixBase.h
+++ b/Core/Kernel/elxElastixBase.h
@@ -168,9 +168,8 @@ public:
   using ResultDeformationFieldType = itk::DataObject;
 
   /** Other typedef's. */
-  using ComponentDatabaseType = ComponentDatabase;
-  using ComponentDatabasePointer = ComponentDatabaseType::Pointer;
-  using DBIndexType = ComponentDatabaseType::IndexType;
+  using ComponentDatabasePointer = ComponentDatabase::Pointer;
+  using DBIndexType = ComponentDatabase::IndexType;
   using FlatDirectionCosinesType = std::vector<double>;
 
   /** Type for representation of the transform coordinates. */

--- a/Core/Kernel/elxElastixMain.cxx
+++ b/Core/Kernel/elxElastixMain.cxx
@@ -727,11 +727,11 @@ ElastixMain::GetTotalNumberOfElastixLevels()
  * ************************* GetElastixBase ***************************
  */
 
-ElastixMain::ElastixBaseType &
+ElastixBase &
 ElastixMain::GetElastixBase() const
 {
-  /** Convert ElastixAsObject to a pointer to an ElastixBaseType. */
-  const auto testpointer = dynamic_cast<ElastixBaseType *>(this->m_Elastix.GetPointer());
+  /** Convert ElastixAsObject to a pointer to an ElastixBase. */
+  const auto testpointer = dynamic_cast<ElastixBase *>(this->m_Elastix.GetPointer());
   if (testpointer == nullptr)
   {
     itkExceptionMacro(<< "Probably GetElastixBase() is called before having called Run()");

--- a/Core/Kernel/elxElastixMain.h
+++ b/Core/Kernel/elxElastixMain.h
@@ -146,7 +146,6 @@ public:
   using DataObjectPointer = DataObjectType::Pointer;
 
   /** elastix components. */
-  using ElastixBaseType = ElastixBase;
   using ArgumentMapType = Configuration::CommandLineArgumentMapType;
   using ConfigurationPointer = Configuration::Pointer;
   using ObjectContainerType = ElastixBase::ObjectContainerType;
@@ -158,13 +157,12 @@ public:
   /** Typedefs for the database that holds pointers to New() functions.
    * Those functions are used to instantiate components, such as the metric etc.
    */
-  using ComponentDatabaseType = ComponentDatabase;
-  using ComponentDatabasePointer = ComponentDatabaseType::Pointer;
-  using PtrToCreator = ComponentDatabaseType::PtrToCreator;
-  using ComponentDescriptionType = ComponentDatabaseType::ComponentDescriptionType;
-  using PixelTypeDescriptionType = ComponentDatabaseType::PixelTypeDescriptionType;
-  using ImageDimensionType = ComponentDatabaseType::ImageDimensionType;
-  using DBIndexType = ComponentDatabaseType::IndexType;
+  using ComponentDatabasePointer = ComponentDatabase::Pointer;
+  using PtrToCreator = ComponentDatabase::PtrToCreator;
+  using ComponentDescriptionType = ComponentDatabase::ComponentDescriptionType;
+  using PixelTypeDescriptionType = ComponentDatabase::PixelTypeDescriptionType;
+  using ImageDimensionType = ComponentDatabase::ImageDimensionType;
+  using DBIndexType = ComponentDatabase::IndexType;
 
   /** Typedef that is used in the elastix dll version. */
   using ParameterMapType = itk::ParameterMapInterface::ParameterMapType;
@@ -218,9 +216,9 @@ public:
   itkGetModifiableObjectMacro(Elastix, itk::Object);
 
   /** Convenience function that returns the elastix component as
-   * a pointer to an ElastixBaseType. Use only after having called run()!
+   * a pointer to an ElastixBase. Use only after having called run()!
    */
-  ElastixBaseType &
+  ElastixBase &
   GetElastixBase() const;
 
   /** Get the final transform (the result of running elastix).

--- a/Core/Kernel/elxTransformixMain.h
+++ b/Core/Kernel/elxTransformixMain.h
@@ -58,7 +58,6 @@ public:
   using Superclass::DataObjectPointer;
 
   /** Elastix components. */
-  using Superclass::ElastixBaseType;
   using Superclass::ArgumentMapType;
   using Superclass::ObjectContainerType;
   using Superclass::DataObjectContainerType;
@@ -68,7 +67,6 @@ public:
   /** Typedefs for the database that holds pointers to New() functions.
    * Those functions are used to instantiate components, such as the metric etc.
    */
-  using Superclass::ComponentDatabaseType;
   using Superclass::ComponentDatabasePointer;
   using Superclass::PtrToCreator;
   using Superclass::ComponentDescriptionType;

--- a/Core/Main/elxParameterObject.cxx
+++ b/Core/Main/elxParameterObject.cxx
@@ -18,6 +18,8 @@
 
 #include "elxParameterObject.h"
 
+#include "itkParameterFileParser.h"
+
 #include "itkFileTools.h"
 #include <fstream>
 #include <iostream>
@@ -183,7 +185,7 @@ ParameterObject::RemoveParameter(const ParameterKeyType & key)
 void
 ParameterObject::ReadParameterFile(const ParameterFileNameType & parameterFileName)
 {
-  this->SetParameterMap(ParameterMapVectorType{ ParameterFileParserType::ReadParameterMap(parameterFileName) });
+  this->SetParameterMap(ParameterMapVectorType{ itk::ParameterFileParser::ReadParameterMap(parameterFileName) });
 }
 
 
@@ -220,7 +222,7 @@ ParameterObject::ReadParameterFile(const ParameterFileNameVectorType & parameter
 void
 ParameterObject::AddParameterFile(const ParameterFileNameType & parameterFileName)
 {
-  this->m_ParameterMap.push_back(ParameterFileParserType::ReadParameterMap(parameterFileName));
+  this->m_ParameterMap.push_back(itk::ParameterFileParser::ReadParameterMap(parameterFileName));
 }
 
 

--- a/Core/Main/elxParameterObject.h
+++ b/Core/Main/elxParameterObject.h
@@ -22,8 +22,6 @@
 #include "itkDataObject.h"
 #include "elxMacro.h"
 
-#include "itkParameterFileParser.h"
-
 namespace elastix
 {
 
@@ -52,8 +50,6 @@ public:
   using ParameterFileNameVectorType = std::vector<ParameterFileNameType>;
   using ParameterFileNameVectorIterator = ParameterFileNameVectorType::iterator;
   using ParameterFileNameVectorConstIterator = ParameterFileNameVectorType::const_iterator;
-  using ParameterFileParserType = itk::ParameterFileParser;
-  using ParameterFileParserPointer = ParameterFileParserType::Pointer;
 
   /* Set/Get/Add parameter map or vector of parameter maps. */
   // TODO: Use itkSetMacro for ParameterMapVectorType


### PR DESCRIPTION
Removed a few unnecessary typedef's (`using` type aliases) and `using` declarations, to improve code readibility.