### PR TITLE
STYLE: Do not use `WeightsType(n)` constructor (related to ITK 5.3)

### DIFF
--- a/Common/Transforms/itkBSplineInterpolationWeightFunctionBase.hxx
+++ b/Common/Transforms/itkBSplineInterpolationWeightFunctionBase.hxx
@@ -148,7 +148,7 @@ BSplineInterpolationWeightFunctionBase<TCoordRep, VSpaceDimension, VSplineOrder>
   const ContinuousIndexType & cindex) const -> WeightsType
 {
   /** Construct arguments for the Evaluate function that really does the work. */
-  WeightsType weights(this->m_NumberOfWeights);
+  WeightsType weights;
   IndexType   startIndex;
   this->ComputeStartIndex(cindex, startIndex);
 

--- a/Common/itkRecursiveBSplineInterpolationWeightFunction.hxx
+++ b/Common/itkRecursiveBSplineInterpolationWeightFunction.hxx
@@ -73,7 +73,7 @@ auto
 RecursiveBSplineInterpolationWeightFunction<TCoordRep, VSpaceDimension, VSplineOrder>::Evaluate(
   const ContinuousIndexType & index) const -> WeightsType
 {
-  WeightsType weights(this->m_NumberOfWeights);
+  WeightsType weights;
   IndexType   startIndex;
 
   this->Evaluate(index, weights, startIndex);

--- a/Testing/itkBSplineInterpolationDerivativeWeightFunctionTest.cxx
+++ b/Testing/itkBSplineInterpolationDerivativeWeightFunctionTest.cxx
@@ -17,6 +17,7 @@
  *=========================================================================*/
 #include "itkBSplineInterpolationDerivativeWeightFunction.h"
 
+#include <array>
 #include <ctime>
 #include <iomanip>
 
@@ -93,24 +94,22 @@ main()
    * These numbers are created by a small Matlab program. So, if this appears
    * to be not a valid check, then we made the same bug twice.
    */
-  WeightsType trueFOWeights(16);
-  trueFOWeights.Fill(0.0);
-  trueFOWeights[0] = -5.400000000000e-4;
-  trueFOWeights[1] = -2.466666666666e-4;
-  trueFOWeights[2] = 7.800000000000e-4;
-  trueFOWeights[3] = 6.666666666666e-6;
-  trueFOWeights[4] = -1.144800000000e-1;
-  trueFOWeights[5] = -5.229333333333e-2;
-  trueFOWeights[6] = 1.653600000000e-1;
-  trueFOWeights[7] = 1.413333333333e-3;
-  trueFOWeights[8] = -2.554200000000e-1;
-  trueFOWeights[9] = -1.166733333333e-1;
-  trueFOWeights[10] = 3.689400000000e-1;
-  trueFOWeights[11] = 3.153333333333e-3;
-  trueFOWeights[12] = -3.456000000000e-2;
-  trueFOWeights[13] = -1.578666666666e-2;
-  trueFOWeights[14] = 4.992000000000e-2;
-  trueFOWeights[15] = 4.266666666666e-4;
+  const std::array<double, WeightsType::Dimension> trueFOWeights = { { -5.400000000000e-4,
+                                                                       -2.466666666666e-4,
+                                                                       7.800000000000e-4,
+                                                                       6.666666666666e-6,
+                                                                       -1.144800000000e-1,
+                                                                       -5.229333333333e-2,
+                                                                       1.653600000000e-1,
+                                                                       1.413333333333e-3,
+                                                                       -2.554200000000e-1,
+                                                                       -1.166733333333e-1,
+                                                                       3.689400000000e-1,
+                                                                       3.153333333333e-3,
+                                                                       -3.456000000000e-2,
+                                                                       -1.578666666666e-2,
+                                                                       4.992000000000e-2,
+                                                                       4.266666666666e-4 } };
 
   /** Compute the distance between the two vectors. */
   double error = 0.0;

--- a/Testing/itkBSplineInterpolationSODerivativeWeightFunctionTest.cxx
+++ b/Testing/itkBSplineInterpolationSODerivativeWeightFunctionTest.cxx
@@ -17,6 +17,7 @@
  *=========================================================================*/
 #include "itkBSplineInterpolationSecondOrderDerivativeWeightFunction.h"
 
+#include <array>
 #include <ctime>
 #include <iomanip>
 
@@ -96,24 +97,22 @@ main()
    * These numbers are created by a small Matlab program. So, if this appears
    * to be not a valid check, then we made the same bug twice.
    */
-  WeightsType trueSOWeights(16);
-  trueSOWeights.Fill(0.0);
-  trueSOWeights[0] = 0.0081;
-  trueSOWeights[1] = 0.0037;
-  trueSOWeights[2] = -0.0117;
-  trueSOWeights[3] = -0.0001;
-  trueSOWeights[4] = 0.2592;
-  trueSOWeights[5] = 0.1184;
-  trueSOWeights[6] = -0.3744;
-  trueSOWeights[7] = -0.0032;
-  trueSOWeights[8] = -0.1377;
-  trueSOWeights[9] = -0.0629;
-  trueSOWeights[10] = 0.1989;
-  trueSOWeights[11] = 0.0017;
-  trueSOWeights[12] = -0.1296;
-  trueSOWeights[13] = -0.0592;
-  trueSOWeights[14] = 0.1872;
-  trueSOWeights[15] = 0.0016;
+  std::array<double, WeightsType::Dimension> trueSOWeights = { { 0.0081,
+                                                                 0.0037,
+                                                                 -0.0117,
+                                                                 -0.0001,
+                                                                 0.2592,
+                                                                 0.1184,
+                                                                 -0.3744,
+                                                                 -0.0032,
+                                                                 -0.1377,
+                                                                 -0.0629,
+                                                                 0.1989,
+                                                                 0.0017,
+                                                                 -0.1296,
+                                                                 -0.0592,
+                                                                 0.1872,
+                                                                 0.0016 } };
 
   /** Compute the distance between the two vectors. */
   double error = 0.0;
@@ -184,23 +183,22 @@ main()
    * These numbers are created by a small Matlab program. So, if this appears
    * to be not a valid check, then we made the same bug twice.
    */
-  trueSOWeights.Fill(0.0);
-  trueSOWeights[0] = 1.200000000000e-3;
-  trueSOWeights[1] = -2.266666666666e-3;
-  trueSOWeights[2] = 9.333333333333e-4;
-  trueSOWeights[3] = 1.333333333333e-4;
-  trueSOWeights[4] = 2.544000000000e-1;
-  trueSOWeights[5] = -4.805333333333e-1;
-  trueSOWeights[6] = 1.978666666666e-1;
-  trueSOWeights[7] = 2.826666666666e-2;
-  trueSOWeights[8] = 5.676000000000e-1;
-  trueSOWeights[9] = -1.072133333333;
-  trueSOWeights[10] = 4.414666666666e-1;
-  trueSOWeights[11] = 6.306666666666e-2;
-  trueSOWeights[12] = 7.680000000000e-2;
-  trueSOWeights[13] = -1.450666666666e-1;
-  trueSOWeights[14] = 5.973333333333e-2;
-  trueSOWeights[15] = 8.533333333333e-3;
+  trueSOWeights = { { 1.200000000000e-3,
+                      -2.266666666666e-3,
+                      9.333333333333e-4,
+                      1.333333333333e-4,
+                      2.544000000000e-1,
+                      -4.805333333333e-1,
+                      1.978666666666e-1,
+                      2.826666666666e-2,
+                      5.676000000000e-1,
+                      -1.072133333333,
+                      4.414666666666e-1,
+                      6.306666666666e-2,
+                      7.680000000000e-2,
+                      -1.450666666666e-1,
+                      5.973333333333e-2,
+                      8.533333333333e-3 } };
 
   /** Compute the distance between the two vectors. */
   error = 0.0;


### PR DESCRIPTION
Code like `WeightsType weights(n)` does not necessarily construct an object of `n` weights, as it did before ITK 5.3. It now fills a fixed array of weights by value `n`.

This behavior change is caused by a change of the definition of `itk::BSplineInterpolationWeightFunction::WeightsType`, by ITK pull request https://github.com/InsightSoftwareConsortium/ITK/pull/2712 commit https://github.com/InsightSoftwareConsortium/ITK/commit/9bf745bda51044c90208c7b0776e87d7c86adb11 "PERF: Use FixedArray for BSplineInterpolationWeightFunction OutputType" (merged on 7 September 2021, included with ITK v5.3rc01).

Follow-up to pull request https://github.com/SuperElastix/elastix/pull/620 commit a0cf5235691ab0e7416600ed29db5abf2ff8ffe2 "COMP: Upgrade ITK from v5.2.0 to v5.3rc03" (merged on 18 February 2022).