### PR TITLE
COMP: Rename `xoutrow` member "AddTargetCell" to "AddNewTargetCell"

### DIFF
--- a/Common/xout/xoutbase.h
+++ b/Common/xout/xoutbase.h
@@ -109,11 +109,6 @@ public:
   AddTargetCell(const char * name, Self * cell);
 
   virtual int
-  AddTargetCell(const char * /** name */)
-  {
-    return 1;
-  }
-  virtual int
   RemoveTargetCell(const char * name);
 
   virtual void

--- a/Common/xout/xoutrow.cxx
+++ b/Common/xout/xoutrow.cxx
@@ -57,11 +57,11 @@ xoutrow::WriteBufferedData()
 
 
 /**
- * ******************** AddTargetCell ***************************
+ * ******************** AddNewTargetCell ***************************
  */
 
 int
-xoutrow::AddTargetCell(const char * name)
+xoutrow::AddNewTargetCell(const char * name)
 {
   if (this->m_CellMap.count(name) == 0)
   {

--- a/Common/xout/xoutrow.h
+++ b/Common/xout/xoutrow.h
@@ -62,9 +62,9 @@ public:
   virtual void
   WriteHeaders();
 
-  /** This method adds an xoutcell to the map of Targets. */
+  /** This method adds a new xoutcell to the map of Targets. */
   int
-  AddTargetCell(const char * name) override;
+  AddNewTargetCell(const char * name);
 
   /** This method removes an xoutcell to the map of Targets. */
   int

--- a/Core/Kernel/elxElastixBase.h
+++ b/Core/Kernel/elxElastixBase.h
@@ -394,7 +394,7 @@ public:
   void
   AddTargetCellToIterationInfo(const char * const name)
   {
-    m_IterationInfo.AddTargetCell(name);
+    m_IterationInfo.AddNewTargetCell(name);
   }
 
 protected:


### PR DESCRIPTION
Also removed the dummy implementation of `AddTargetCell(const char *)` from its base class. Declared the new `xoutrow::AddNewTargetCell(const char *)` non-virtual.

Aims to fix warnings from cfnCentOSAgent_2-Linux, saying:

> xoutbase.h:109:3: warning: 'virtual int xoutlibrary::xoutbase::AddTargetCell(const char*, xoutlibrary::xoutbase::Self*)' was hidden [-Woverloaded-virtual]
> xoutrow.h:67:3: warning:   by 'virtual int xoutlibrary::xoutrow::AddTargetCell(const char*)' [-Woverloaded-virtual]

From https://open.cdash.org/viewBuildError.php?type=1&buildid=7807857

Triggered by pull request https://github.com/SimpleITK/SimpleITK/pull/1611 "Support adding Elastix component by CMake SimpleITK_USE_ELASTIX=ON"