### PR TITLE
COMP: Add /bigobj to any MSVC WIN32 configuration (including MinSizeRel)

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -315,9 +315,7 @@ if( MSVC )
 
   # Increases address capacity
   if( WIN32 )
-    set( CMAKE_CXX_FLAGS_DEBUG "${CMAKE_CXX_FLAGS_DEBUG} /bigobj" )
-    set( CMAKE_CXX_FLAGS_RELEASE "${CMAKE_CXX_FLAGS_RELEASE} /bigobj" )
-    set( CMAKE_CXX_FLAGS_RELWITHDEBINFO "${CMAKE_CXX_FLAGS_RELWITHDEBINFO} /bigobj" )
+    add_compile_options( /bigobj )
   endif()
 endif()
 


### PR DESCRIPTION
The `/bigobj` compile option (introduced with MSVC 2005) still appears useful nowadays, and there appear no downsides to enabling /bigobj", according to "Enable /bigobj by default", Machiel van Hooren, May 14, 2020, https://developercommunity.visualstudio.com/t/Enable-bigobj-by-default/1031214

Marius Staring confirmed that there was no specific reason to avoid adding `/bigobj` for MinSizeRel.