### PR TITLE
ENH: Upgrade cmake_minimum_required from 3.10.2 to 3.16.3, following ITK

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -1,6 +1,5 @@
-# Minimum CMake version. Equal to ITK 5.0.1 ITK_OLDEST_VALIDATED_POLICIES_VERSION,
-# and to the CMake version used to build the elastix 5.0.0 Linux binaries.
-cmake_minimum_required( VERSION 3.10.2 )
+# Minimum CMake version. Equal to ITK 5.3 ITK_OLDEST_VALIDATED_POLICIES_VERSION.
+cmake_minimum_required( VERSION 3.16.3 )
 
 project( elastix )
 set(CMAKE_CXX_STANDARD 14)

--- a/dox/externalproject/CMakeLists.txt
+++ b/dox/externalproject/CMakeLists.txt
@@ -1,7 +1,8 @@
 # Example project for using elastix code from external projects.
 project( elxExternalProject )
 
-cmake_minimum_required( VERSION 3.10.2 )
+# Minimum CMake version. Intended to correspond with the `cmake_minimum_required` version of elastix.
+cmake_minimum_required( VERSION 3.16.3 )
 
 find_package( Elastix REQUIRED )
 


### PR DESCRIPTION
Follows ITK pull request https://github.com/InsightSoftwareConsortium/ITK/pull/2588 commit https://github.com/InsightSoftwareConsortium/ITK/commit/0c3b8cbf9b0b25f2fed789c1a7effe48f29b6967 "COMP: Increased min cmake from 3.10.2 to 3.16.3" (merged on on June 16, 2021), included with ITK tags v5.3rc03 ... v5.3rc01.

Such an upgrade appears necessary in order to allow a Debug compilation of SimpleITK with `SimpleITK_USE_ELASTIX=ON`, as proposed by pull request https://github.com/SimpleITK/SimpleITK/pull/1611 ("WIP: Support adding Elastix component by CMake SimpleITK_USE_ELASTIX=ON"), especially because of CMake improvements regarding the MSVC runtime library selection flags, introduced with CMake 3.15.