### PR TITLE
Rename `xoutbase::SetTargetCells(cellmap)` overloads, addressing SimpleITK warnings

### DIFF
--- a/Common/xout/xoutbase.cxx
+++ b/Common/xout/xoutbase.cxx
@@ -145,11 +145,11 @@ xoutbase::RemoveTargetCell(const char * name)
 
 
 /**
- * **************** SetTargetCells (std::ostreams) **************
+ * **************** SetCTargetCells (std::ostreams) **************
  */
 
 void
-xoutbase::SetTargetCells(const CStreamMapType & cellmap)
+xoutbase::SetCTargetCells(const CStreamMapType & cellmap)
 {
   this->m_CTargetCells = cellmap;
 
@@ -157,11 +157,11 @@ xoutbase::SetTargetCells(const CStreamMapType & cellmap)
 
 
 /**
- * **************** SetTargetCells (xout objects) ***************
+ * **************** SetXTargetCells (xout objects) ***************
  */
 
 void
-xoutbase::SetTargetCells(const XStreamMapType & cellmap)
+xoutbase::SetXTargetCells(const XStreamMapType & cellmap)
 {
   this->m_XTargetCells = cellmap;
 

--- a/Common/xout/xoutbase.h
+++ b/Common/xout/xoutbase.h
@@ -138,11 +138,11 @@ protected:
   /** Default-constructor. Only to be used by its derived classes. */
   xoutbase() = default;
 
-  virtual void
-  SetTargetCells(const CStreamMapType & cellmap);
+  void
+  SetCTargetCells(const CStreamMapType & cellmap);
 
   virtual void
-  SetTargetCells(const XStreamMapType & cellmap);
+  SetXTargetCells(const XStreamMapType & cellmap);
 
   /** Maps that contain the outputs. */
   CStreamMapType m_COutputs;

--- a/Common/xout/xoutbase.h
+++ b/Common/xout/xoutbase.h
@@ -111,12 +111,6 @@ public:
   virtual int
   RemoveTargetCell(const char * name);
 
-  virtual void
-  SetTargetCells(const CStreamMapType & cellmap);
-
-  virtual void
-  SetTargetCells(const XStreamMapType & cellmap);
-
   /** Add/Remove an output stream (like cout, or an fstream, or an xout-object).  */
   virtual int
   AddOutput(const char * name, std::ostream * output);
@@ -143,6 +137,12 @@ public:
 protected:
   /** Default-constructor. Only to be used by its derived classes. */
   xoutbase() = default;
+
+  virtual void
+  SetTargetCells(const CStreamMapType & cellmap);
+
+  virtual void
+  SetTargetCells(const XStreamMapType & cellmap);
 
   /** Maps that contain the outputs. */
   CStreamMapType m_COutputs;

--- a/Common/xout/xoutrow.cxx
+++ b/Common/xout/xoutrow.cxx
@@ -114,11 +114,11 @@ xoutrow::RemoveTargetCell(const char * name)
 
 
 /**
- * **************** SetTargetCells (xout objects) ***************
+ * **************** SetXTargetCells (xout objects) ***************
  */
 
 void
-xoutrow::SetTargetCells(const XStreamMapType & cellmap)
+xoutrow::SetXTargetCells(const XStreamMapType & cellmap)
 {
   /** Clean the this->m_CellMap (cells that are created using the
    * AddTarget(const char *) method.
@@ -246,7 +246,7 @@ xoutrow::WriteHeaders()
 {
   /** Copy '*this'. */
   Self headerwriter;
-  headerwriter.SetTargetCells(this->m_XTargetCells);
+  headerwriter.SetXTargetCells(this->m_XTargetCells);
   // no CTargetCells, because they are not used in xoutrow!
   headerwriter.SetOutputs(this->m_COutputs);
   headerwriter.SetOutputs(this->m_XOutputs);

--- a/Common/xout/xoutrow.h
+++ b/Common/xout/xoutrow.h
@@ -70,12 +70,6 @@ public:
   int
   RemoveTargetCell(const char * name) override;
 
-  /** Method to set all targets at once. The outputs of these targets
-   * are not set automatically, so make sure to do it yourself.
-   */
-  void
-  SetTargetCells(const XStreamMapType & cellmap) override;
-
   /** Add/Remove an output stream (like cout, or an fstream, or an xout-object).
    * In addition to the behaviour of the Superclass's methods, these functions
    * set the outputs of the TargetCells as well.
@@ -94,6 +88,13 @@ public:
 
   void
   SetOutputs(const XStreamMapType & outputmap) override;
+
+protected:
+  /** Method to set all targets at once. The outputs of these targets
+   * are not set automatically, so make sure to do it yourself.
+   */
+  void
+  SetTargetCells(const XStreamMapType & cellmap) override;
 
 private:
   std::map<std::string, std::unique_ptr<xoutbase>> m_CellMap;

--- a/Common/xout/xoutrow.h
+++ b/Common/xout/xoutrow.h
@@ -94,7 +94,7 @@ protected:
    * are not set automatically, so make sure to do it yourself.
    */
   void
-  SetTargetCells(const XStreamMapType & cellmap) override;
+  SetXTargetCells(const XStreamMapType & cellmap) override;
 
 private:
   std::map<std::string, std::unique_ptr<xoutbase>> m_CellMap;

--- a/Common/xout/xoutsimple.cxx
+++ b/Common/xout/xoutsimple.cxx
@@ -64,7 +64,7 @@ xoutsimple::RemoveOutput(const char * name)
 void
 xoutsimple::SetOutputs(const CStreamMapType & outputmap)
 {
-  this->SetTargetCells(outputmap);
+  this->SetCTargetCells(outputmap);
 
 } // end SetOutputs
 
@@ -76,7 +76,7 @@ xoutsimple::SetOutputs(const CStreamMapType & outputmap)
 void
 xoutsimple::SetOutputs(const XStreamMapType & outputmap)
 {
-  this->SetTargetCells(outputmap);
+  this->SetXTargetCells(outputmap);
 
 } // end SetOutputs()
 


### PR DESCRIPTION
Renamed the `SetTargetCells` overload for `CStreamMapType` arguments "SetCTargetCells", and the other one "SetXTargetCells", and declared them `protected`, instead of `public`.

Addressed SimpleITK warnings from cfnCentOSAgent_1-Linux, at https://open.cdash.org/viewBuildError.php?type=1&buildid=7819092, saying:

> xoutbase.h:115:3: warning: 'virtual void xoutlibrary::xoutbase::SetTargetCells(const CStreamMapType&)' was hidden [-Woverloaded-virtual]
> xoutrow.h:77:3: warning:   by 'virtual void xoutlibrary::xoutrow::SetTargetCells(const XStreamMapType&)' [-Woverloaded-virtual]

Which appeared with pull request https://github.com/SimpleITK/SimpleITK/pull/1611 "WIP: Support adding Elastix component by CMake SimpleITK_USE_ELASTIX=ON".