### PR TITLE
COMP: Work around SimpleITK/GCC overloaded-virtual/hidden warnings

### DIFF
--- a/Core/Main/elxTransformixFilter.h
+++ b/Core/Main/elxTransformixFilter.h
@@ -189,6 +189,9 @@ private:
   using itk::ProcessObject::GetInput;
   using itk::ProcessObject::RemoveInput;
 
+  /** Private using-declaration, just to avoid GCC compilation warnings: '...' was hidden [-Woverloaded-virtual] */
+  using Superclass::MakeOutput;
+
   std::string m_FixedPointSetFileName;
   bool        m_ComputeSpatialJacobian;
   bool        m_ComputeDeterminantOfSpatialJacobian;

--- a/Core/Main/itkElastixRegistrationMethod.h
+++ b/Core/Main/itkElastixRegistrationMethod.h
@@ -275,6 +275,9 @@ private:
   void
   RemoveInputsOfType(const DataObjectIdentifierType & inputName);
 
+  /** Private using-declaration, just to avoid GCC compilation warnings: '...' was hidden [-Woverloaded-virtual] */
+  using Superclass::SetInput;
+
   std::string m_InitialTransformParameterFileName;
   std::string m_FixedPointSetFileName;
   std::string m_MovingPointSetFileName;

--- a/Core/Main/itkTransformixFilter.h
+++ b/Core/Main/itkTransformixFilter.h
@@ -209,6 +209,10 @@ private:
   void
   operator=(const Self &) = delete;
 
+  /** Private using-declarations, just to avoid GCC compilation warnings: '...' was hidden [-Woverloaded-virtual] */
+  using Superclass::SetInput;
+  using Superclass::MakeOutput;
+
   /** IsEmpty. */
   static bool
   IsEmpty(const InputImageType * inputImage);


### PR DESCRIPTION
Added private using-declarations, to work around warnings from SimpleITK/cfnCentOSAgent_2-Linux CI at https://open.cdash.org/viewBuildError.php?type=1&buildid=7820245 like:

> itkTransformixFilter.hxx:402:1: warning:   by 'itk::TransformixFilter<itk::Image<float, 2> >::SetInput' [-Woverloaded-virtual]

Which appeared from pull request https://github.com/SimpleITK/SimpleITK/pull/1611 "WIP: Support adding Elastix component by CMake SimpleITK_USE_ELASTIX=ON"