### PR TITLE
COMP: Set CMAKE VISIBILITY_PRESET to hidden

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -15,11 +15,15 @@ cmake_policy( SET CMP0042 NEW )
 #---------------------------------------------------------------------
 include( CTest )
 
-  # The following may make smaller and quicker loading libraries,
-  # that hides unnecessary symbols. Available from CMake 3.0.0.
-  #set( CMAKE_C_VISIBILITY_PRESET hidden )
-  #set( CMAKE_CXX_VISIBILITY_PRESET hidden )
+# The following may make smaller and quicker loading libraries, that hides unnecessary symbols.
+set( CMAKE_C_VISIBILITY_PRESET hidden )
+set( CMAKE_CXX_VISIBILITY_PRESET hidden )
 
+# Prevent MacOS/Clang ld: warning: direct access in function '...' from file '...cxx.o' to global
+# weak symbol 'vtable for ...' from file '....a(...cxx.o)' means the weak symbol cannot be
+# overridden at runtime. This was likely caused by different translation units being compiled with
+# different visibility settings. 
+set(ITK_TEMPLATE_VISIBILITY_DEFAULT OFF)
 #---------------------------------------------------------------------
 option( ELASTIX_USE_OPENCL "Use OpenCL enabled GPU" OFF )
 set(_GPU_depends "")


### PR DESCRIPTION
Suggested by Bradley Lowekamp at "WIP: Support adding Elastix component by CMake SimpleITK_USE_ELASTIX=ON" comment https://github.com/SimpleITK/SimpleITK/pull/1611#discussion_r848584729 referring to https://github.com/SimpleITK/SimpleITK/blob/2681d0689a5922a7f2d1b56b1c7b62361eed9d8d/SuperBuild/External_ITK.cmake#L81-L83

Discussed with Marius Staring at superelastix.slack.com #elastix

Aims to avoid link warnings in SimpleITK (+ Elastix component), like
> ld: warning: direct access in function '...' from file '....cxx.o)' to global weak symbol 'typeinfo for ...' from file '....cxx.o' means the weak symbol cannot be overridden at runtime. This was likely caused by different translation units being compiled with different visibility settings.

At at https://open.cdash.org/viewBuildError.php?type=1&buildid=7827932 ( Azure Pipelines 2-macOS)