### PR TITLE
STYLE: Call `DirectionType::GetIdentity()`, instead of `SetIdentity()`

### DIFF
--- a/Components/Transforms/SimilarityTransform/elxSimilarityTransform.hxx
+++ b/Components/Transforms/SimilarityTransform/elxSimilarityTransform.hxx
@@ -362,12 +362,11 @@ SimilarityTransformElastix<TElastix>::ReadCenterOfRotationIndex(InputPointType &
    * We put this in a dummy image, so that we can correctly
    * calculate the center of rotation in world coordinates.
    */
-  SpacingType   spacing;
-  IndexType     index;
-  PointType     origin;
-  SizeType      size;
-  DirectionType direction;
-  direction.SetIdentity();
+  SpacingType spacing;
+  IndexType   index;
+  PointType   origin;
+  SizeType    size;
+  auto        direction = DirectionType::GetIdentity();
   for (unsigned int i = 0; i < SpaceDimension; ++i)
   {
     /** Read size from the parameter file. Zero by default, which is illegal. */

--- a/Core/ComponentBaseClasses/elxResamplerBase.hxx
+++ b/Core/ComponentBaseClasses/elxResamplerBase.hxx
@@ -561,8 +561,7 @@ ResamplerBase<TElastix>::ReadFromFile()
   IndexType       index;
   OriginPointType origin;
   SizeType        size;
-  DirectionType   direction;
-  direction.SetIdentity();
+  auto            direction = DirectionType::GetIdentity();
   for (unsigned int i = 0; i < ImageDimension; ++i)
   {
     /** No default size. Read size from the parameter file. */

--- a/Core/Kernel/elxElastixBase.h
+++ b/Core/Kernel/elxElastixBase.h
@@ -453,10 +453,8 @@ protected:
         /** Setup reader. */
         const auto imageReader = itk::ImageFileReader<TImage>::New();
         imageReader->SetFileName(fileName);
-        const auto    infoChanger = itk::ChangeInformationImageFilter<TImage>::New();
-        DirectionType direction;
-        direction.SetIdentity();
-        infoChanger->SetOutputDirection(direction);
+        const auto infoChanger = itk::ChangeInformationImageFilter<TImage>::New();
+        infoChanger->SetOutputDirection(DirectionType::GetIdentity());
         infoChanger->SetChangeDirection(!useDirectionCosines);
         infoChanger->SetInput(imageReader->GetOutput());
 

--- a/Testing/elxTransformParametersCompare.cxx
+++ b/Testing/elxTransformParametersCompare.cxx
@@ -218,8 +218,7 @@ main(int argc, char ** argv)
     gridSpacing.Fill(1.0);
     OriginType gridOrigin;
     gridOrigin.Fill(0.0);
-    DirectionType gridDirection;
-    gridDirection.SetIdentity();
+    auto gridDirection = DirectionType::GetIdentity();
     for (unsigned int i = 0; i < dimension; ++i)
     {
       config->ReadParameter(gridSize[i], "GridSize", i, true, dummyErrorMessage);

--- a/Testing/itkAdvancedBSplineDeformableTransformTest.cxx
+++ b/Testing/itkAdvancedBSplineDeformableTransformTest.cxx
@@ -108,8 +108,7 @@ main(int argc, char * argv[])
   gridOrigin[0] = -237.6759555555;
   gridOrigin[1] = -239.9488431747;
   gridOrigin[2] = -344.2315805162;
-  DirectionType gridDirection;
-  gridDirection.SetIdentity();
+  const auto gridDirection = DirectionType::GetIdentity();
 
   transform->SetGridOrigin(gridOrigin);
   transform->SetGridSpacing(gridSpacing);

--- a/Testing/itkAdvancedRecursiveBSplineTransformTest.cxx
+++ b/Testing/itkAdvancedRecursiveBSplineTransformTest.cxx
@@ -133,8 +133,7 @@ main(int argc, char * argv[])
   gridOrigin[0] = -237.6759555555;
   gridOrigin[1] = -239.9488431747;
   gridOrigin[2] = -344.2315805162;
-  DirectionType gridDirection;
-  gridDirection.SetIdentity();
+  auto gridDirection = DirectionType::GetIdentity();
   gridDirection(0, 1) = 0.02;
   gridDirection(0, 2) = 0.06;
   gridDirection(1, 0) = 0.03;

--- a/Testing/itkBSplineJacobianGradientPerformanceTest.cxx
+++ b/Testing/itkBSplineJacobianGradientPerformanceTest.cxx
@@ -103,8 +103,7 @@ main(int argc, char * argv[])
   gridOrigin[0] = -237.6759555555;
   gridOrigin[1] = -239.9488431747;
   gridOrigin[2] = -344.2315805162;
-  DirectionType gridDirection;
-  gridDirection.SetIdentity();
+  const auto gridDirection = DirectionType::GetIdentity();
 
   transform->SetGridOrigin(gridOrigin);
   transform->SetGridSpacing(gridSpacing);

--- a/Testing/itkBSplineTransformPointPerformanceTest.cxx
+++ b/Testing/itkBSplineTransformPointPerformanceTest.cxx
@@ -227,13 +227,11 @@ main(int argc, char * argv[])
   gridOrigin[0] = -237.6759555555;
   gridOrigin[1] = -239.9488431747;
   gridOrigin[2] = -344.2315805162;
-  DirectionType gridDirection;
-  gridDirection.SetIdentity();
 
   transform->SetGridOrigin(gridOrigin);
   transform->SetGridSpacing(gridSpacing);
   transform->SetGridRegion(gridRegion);
-  transform->SetGridDirection(gridDirection);
+  transform->SetGridDirection(DirectionType::GetIdentity());
 
   /** Now read the parameters as defined in the file par.txt. */
   ParametersType parameters(transform->GetNumberOfParameters());


### PR DESCRIPTION
Called `DirectionType::GetIdentity()` whenever it did simplify the code.

Follow-up to ITK pull request https://github.com/InsightSoftwareConsortium/ITK/pull/2460 commit https://github.com/InsightSoftwareConsortium/ITK/commit/f8ad6cfdee624591c74ce24512ba211c7154a5b4 "ENH: Add static member function, `itk::Matrix::GetIdentity()`", merged on 1 April 2021, and included with ITK v5.2.0.