### PR TITLE
STYLE: Call `DirectionType::GetIdentity()` (part 2)

### DIFF
--- a/Common/Transforms/itkAdvancedCombinationTransform.hxx
+++ b/Common/Transforms/itkAdvancedCombinationTransform.hxx
@@ -850,11 +850,10 @@ void
 AdvancedCombinationTransform<TScalarType, NDimensions>::GetSpatialJacobianUseAddition(const InputPointType & ipp,
                                                                                       SpatialJacobianType &  sj) const
 {
-  SpatialJacobianType sj0, sj1, identity;
+  SpatialJacobianType sj0, sj1;
   this->m_InitialTransform->GetSpatialJacobian(ipp, sj0);
   this->m_CurrentTransform->GetSpatialJacobian(ipp, sj1);
-  identity.SetIdentity();
-  sj = sj0 + sj1 - identity;
+  sj = sj0 + sj1 - SpatialJacobianType::GetIdentity();
 
 } // end GetSpatialJacobianUseAddition()
 

--- a/Components/Metrics/DistancePreservingRigidityPenalty/elxDistancePreservingRigidityPenaltyTerm.hxx
+++ b/Components/Metrics/DistancePreservingRigidityPenalty/elxDistancePreservingRigidityPenaltyTerm.hxx
@@ -54,9 +54,7 @@ DistancePreservingRigidityPenalty<TElastix>::BeforeRegistration()
 
   /** Possibly overrule the direction cosines. */
   ChangeInfoFilterPointer infoChanger = ChangeInfoFilterType::New();
-  DirectionType           direction;
-  direction.SetIdentity();
-  infoChanger->SetOutputDirection(direction);
+  infoChanger->SetOutputDirection(DirectionType::GetIdentity());
   infoChanger->SetChangeDirection(!this->GetElastix()->GetUseDirectionCosines());
   infoChanger->SetInput(segmentedImageReader->GetOutput());
 

--- a/Components/Metrics/RigidityPenalty/elxTransformRigidityPenaltyTerm.hxx
+++ b/Components/Metrics/RigidityPenalty/elxTransformRigidityPenaltyTerm.hxx
@@ -57,9 +57,7 @@ TransformRigidityPenalty<TElastix>::BeforeRegistration()
 
     /** Possibly overrule the direction cosines. */
     ChangeInfoFilterPointer infoChanger = ChangeInfoFilterType::New();
-    DirectionType           direction;
-    direction.SetIdentity();
-    infoChanger->SetOutputDirection(direction);
+    infoChanger->SetOutputDirection(DirectionType::GetIdentity());
     infoChanger->SetChangeDirection(!this->GetElastix()->GetUseDirectionCosines());
     infoChanger->SetInput(fixedRigidityReader->GetOutput());
 
@@ -104,9 +102,7 @@ TransformRigidityPenalty<TElastix>::BeforeRegistration()
 
     /** Possibly overrule the direction cosines. */
     ChangeInfoFilterPointer infoChanger = ChangeInfoFilterType::New();
-    DirectionType           direction;
-    direction.SetIdentity();
-    infoChanger->SetOutputDirection(direction);
+    infoChanger->SetOutputDirection(DirectionType::GetIdentity());
     infoChanger->SetChangeDirection(!this->GetElastix()->GetUseDirectionCosines());
     infoChanger->SetInput(movingRigidityReader->GetOutput());
 

--- a/Components/Transforms/DeformationFieldTransform/elxDeformationFieldTransform.hxx
+++ b/Components/Transforms/DeformationFieldTransform/elxDeformationFieldTransform.hxx
@@ -83,9 +83,7 @@ DeformationFieldTransform<TElastix>::ReadFromFile()
 
   /** Possibly overrule the direction cosines. */
   ChangeInfoFilterPointer infoChanger = ChangeInfoFilterType::New();
-  DirectionType           direction;
-  direction.SetIdentity();
-  infoChanger->SetOutputDirection(direction);
+  infoChanger->SetOutputDirection(DirectionType::GetIdentity());
   infoChanger->SetChangeDirection(!this->GetElastix()->GetUseDirectionCosines());
   infoChanger->SetInput(vectorReader->GetOutput());
 


### PR DESCRIPTION
Follow-up to pull request https://github.com/SuperElastix/elastix/pull/639 commit 073ddd55e5a614897dbab412b9164357865911ea "STYLE: Call `DirectionType::GetIdentity()`, instead of `SetIdentity()`