### PR TITLE
STYLE: Use `itk::ReadImage` instead of `itk::ImageFileReader`

### DIFF
--- a/Components/Metrics/DistancePreservingRigidityPenalty/elxDistancePreservingRigidityPenaltyTerm.hxx
+++ b/Components/Metrics/DistancePreservingRigidityPenalty/elxDistancePreservingRigidityPenaltyTerm.hxx
@@ -41,26 +41,21 @@ DistancePreservingRigidityPenalty<TElastix>::BeforeRegistration()
     segmentedImageName, "SegmentedImageName", this->GetComponentLabel(), 0, -1, false);
 
   using SegmentedImageType = typename Superclass1::SegmentedImageType;
-  using SegmentedImageReaderType = itk::ImageFileReader<SegmentedImageType>;
   using ChangeInfoFilterType = itk::ChangeInformationImageFilter<SegmentedImageType>;
   using ChangeInfoFilterPointer = typename ChangeInfoFilterType::Pointer;
   using DirectionType = typename SegmentedImageType::DirectionType;
   using SizeValueType = typename SegmentedImageType::SizeType::SizeValueType;
 
-  /** Create the reader and set the filename. */
-  auto segmentedImageReader = SegmentedImageReaderType::New();
-  segmentedImageReader->SetFileName(segmentedImageName);
-  segmentedImageReader->Update();
-
   /** Possibly overrule the direction cosines. */
   ChangeInfoFilterPointer infoChanger = ChangeInfoFilterType::New();
   infoChanger->SetOutputDirection(DirectionType::GetIdentity());
   infoChanger->SetChangeDirection(!this->GetElastix()->GetUseDirectionCosines());
-  infoChanger->SetInput(segmentedImageReader->GetOutput());
 
   /** Do the reading. */
   try
   {
+    const auto image = itk::ReadImage<SegmentedImageType>(segmentedImageName);
+    infoChanger->SetInput(image);
     infoChanger->Update();
   }
   catch (itk::ExceptionObject & excp)

--- a/Components/Metrics/RigidityPenalty/elxTransformRigidityPenaltyTerm.hxx
+++ b/Components/Metrics/RigidityPenalty/elxTransformRigidityPenaltyTerm.hxx
@@ -40,8 +40,6 @@ TransformRigidityPenalty<TElastix>::BeforeRegistration()
     fixedRigidityImageName, "FixedRigidityImageName", this->GetComponentLabel(), 0, -1, false);
 
   using RigidityImageType = typename Superclass1::RigidityImageType;
-  using RigidityImageReaderType = itk::ImageFileReader<RigidityImageType>;
-  typename RigidityImageReaderType::Pointer fixedRigidityReader;
   using ChangeInfoFilterType = itk::ChangeInformationImageFilter<RigidityImageType>;
   using ChangeInfoFilterPointer = typename ChangeInfoFilterType::Pointer;
   using DirectionType = typename RigidityImageType::DirectionType;
@@ -51,19 +49,16 @@ TransformRigidityPenalty<TElastix>::BeforeRegistration()
     /** Use the FixedRigidityImage. */
     this->SetUseFixedRigidityImage(true);
 
-    /** Create the reader and set the filename. */
-    fixedRigidityReader = RigidityImageReaderType::New();
-    fixedRigidityReader->SetFileName(fixedRigidityImageName);
-
     /** Possibly overrule the direction cosines. */
     ChangeInfoFilterPointer infoChanger = ChangeInfoFilterType::New();
     infoChanger->SetOutputDirection(DirectionType::GetIdentity());
     infoChanger->SetChangeDirection(!this->GetElastix()->GetUseDirectionCosines());
-    infoChanger->SetInput(fixedRigidityReader->GetOutput());
 
     /** Do the reading. */
     try
     {
+      const auto image = itk::ReadImage<RigidityImageType>(fixedRigidityImageName);
+      infoChanger->SetInput(image);
       infoChanger->Update();
     }
     catch (itk::ExceptionObject & excp)
@@ -90,25 +85,21 @@ TransformRigidityPenalty<TElastix>::BeforeRegistration()
   this->GetConfiguration()->ReadParameter(
     movingRigidityImageName, "MovingRigidityImageName", this->GetComponentLabel(), 0, -1, false);
 
-  typename RigidityImageReaderType::Pointer movingRigidityReader;
   if (!movingRigidityImageName.empty())
   {
     /** Use the movingRigidityImage. */
     this->SetUseMovingRigidityImage(true);
 
-    /** Create the reader and set the filename. */
-    movingRigidityReader = RigidityImageReaderType::New();
-    movingRigidityReader->SetFileName(movingRigidityImageName);
-
     /** Possibly overrule the direction cosines. */
     ChangeInfoFilterPointer infoChanger = ChangeInfoFilterType::New();
     infoChanger->SetOutputDirection(DirectionType::GetIdentity());
     infoChanger->SetChangeDirection(!this->GetElastix()->GetUseDirectionCosines());
-    infoChanger->SetInput(movingRigidityReader->GetOutput());
 
     /** Do the reading. */
     try
     {
+      const auto image = itk::ReadImage<RigidityImageType>(movingRigidityImageName);
+      infoChanger->SetInput(image);
       infoChanger->Update();
     }
     catch (itk::ExceptionObject & excp)

--- a/Components/Transforms/MultiBSplineTransformWithNormal/elxMultiBSplineTransformWithNormal.hxx
+++ b/Components/Transforms/MultiBSplineTransformWithNormal/elxMultiBSplineTransformWithNormal.hxx
@@ -86,10 +86,7 @@ MultiBSplineTransformWithNormal<TElastix>::BeforeAll()
   this->m_LabelsPath = this->m_Configuration->GetCommandLineArgument("-labels");
   if (!this->m_LabelsPath.empty())
   {
-    typename itk::ImageFileReader<ImageLabelType>::Pointer reader = itk::ImageFileReader<ImageLabelType>::New();
-    reader->SetFileName(this->m_LabelsPath);
-    reader->Update();
-    this->m_Labels = reader->GetOutput();
+    m_Labels = itk::ReadImage<ImageLabelType>(m_LabelsPath);
   }
   else
   {
@@ -567,10 +564,7 @@ MultiBSplineTransformWithNormal<TElastix>::ReadFromFile()
     this->m_LabelsPath, "MultiBSplineTransformWithNormalLabels", this->GetComponentLabel(), 0, 0);
   if (!this->m_LabelsPath.empty())
   {
-    typename itk::ImageFileReader<ImageLabelType>::Pointer reader = itk::ImageFileReader<ImageLabelType>::New();
-    reader->SetFileName(this->m_LabelsPath);
-    reader->Update();
-    this->m_Labels = reader->GetOutput();
+    this->m_Labels = itk::ReadImage<ImageLabelType>(m_LabelsPath);
   }
   this->m_MultiBSplineTransformWithNormal->SetLabels(this->m_Labels);
   this->m_MultiBSplineTransformWithNormal->UpdateLocalBases();

--- a/Testing/elxComputeOverlap.cxx
+++ b/Testing/elxComputeOverlap.cxx
@@ -92,26 +92,22 @@ main(int argc, char ** argv)
 
   /** Typedefs. */
   using ImageType = itk::Image<PixelType, Dimension>;
-  using ImageReaderType = itk::ImageFileReader<ImageType>;
-  using ImageReaderPointer = ImageReaderType::Pointer;
   using AndFilterType = itk::AndImageFilter<ImageType, ImageType, ImageType>;
   using AndFilterPointer = AndFilterType::Pointer;
   using IteratorType = itk::ImageRegionConstIterator<ImageType>;
 
-  /** Create readers and an AND filter. */
-  ImageReaderPointer reader1 = ImageReaderType::New();
-  reader1->SetFileName(inputFileNames[0]);
-  ImageReaderPointer reader2 = ImageReaderType::New();
-  reader2->SetFileName(inputFileNames[1]);
   AndFilterPointer ANDFilter = AndFilterType::New();
-  ANDFilter->SetInput1(reader2->GetOutput());
-  ANDFilter->SetInput2(reader1->GetOutput());
-  // finalANDFilter->SetCoordinateTolerance( tolerance );
-  // finalANDFilter->SetDirectionTolerance( tolerance );
 
   /** Do the AND operation. */
   try
   {
+    const auto image1 = itk::ReadImage<ImageType>(inputFileNames[0]);
+    const auto image2 = itk::ReadImage<ImageType>(inputFileNames[1]);
+    ANDFilter->SetInput1(image1);
+    ANDFilter->SetInput2(image2);
+    // finalANDFilter->SetCoordinateTolerance( tolerance );
+    // finalANDFilter->SetDirectionTolerance( tolerance );
+
     ANDFilter->Update();
   }
   catch (itk::ExceptionObject & excp)

--- a/Testing/elxTransformParametersCompare.cxx
+++ b/Testing/elxTransformParametersCompare.cxx
@@ -74,7 +74,6 @@ main(int argc, char ** argv)
   using WriterType = itk::ImageFileWriter<CoefficientImageType>;
 
   using MaskImageType = itk::Image<unsigned char, ITK_TEST_DIMENSION_MAX>;
-  using MaskReaderType = itk::ImageFileReader<MaskImageType>;
   using MaskIteratorType = itk::ImageRegionIteratorWithIndex<MaskImageType>;
 
   /** Create command line argument parser. */
@@ -247,10 +246,7 @@ main(int argc, char ** argv)
     MaskIteratorType       itM;
     if (!maskFileName.empty())
     {
-      auto maskReader = MaskReaderType::New();
-      maskReader->SetFileName(maskFileName);
-      maskReader->Update();
-      maskImage = maskReader->GetOutput();
+      maskImage = itk::ReadImage<MaskImageType>(maskFileName);
 
       itM = MaskIteratorType(maskImage, maskImage->GetLargestPossibleRegion());
     }

--- a/Testing/itkTransformixFilterTest.cxx
+++ b/Testing/itkTransformixFilterTest.cxx
@@ -41,13 +41,10 @@ main(int argc, char * argv[])
   const char * transformParametersFile = argv[2];
   const char * transformedImageFile = argv[3];
 
-  /** Other typedefs. */
+  /** Other typedef. */
   using ImageType = itk::Image<PixelType, Dimension>;
 
-  using ImageReaderType = itk::ImageFileReader<ImageType>;
-  auto imageReader = ImageReaderType::New();
-  imageReader->SetFileName(movingImageFile);
-  auto movingImage = imageReader->GetOutput();
+  auto movingImage = itk::ReadImage<ImageType>(movingImageFile);
 
   auto parameterObject = elastix::ParameterObject::New();
   parameterObject->ReadParameterFile(transformParametersFile);


### PR DESCRIPTION
Follow-up to ITK pull request https://github.com/InsightSoftwareConsortium/ITK/pull/2184 commit https://github.com/InsightSoftwareConsortium/ITK/commit/aeea88b1925e400fa6df099871b149a37f1dee17 "ENH: Add convenience function ReadImage", merged on on 22 December 2020, and included with ITK v5.2rc01.