### PR TITLE
STYLE: Use `itk::WriteImage` instead of `itk::ImageFileWriter`

### DIFF
--- a/Components/Transforms/BSplineDeformableTransformWithDiffusion/elxBSplineTransformWithDiffusion.h
+++ b/Components/Transforms/BSplineDeformableTransformWithDiffusion/elxBSplineTransformWithDiffusion.h
@@ -274,8 +274,6 @@ public:
   using InterpolatorPointer = typename InterpolatorType::Pointer;
   using GrayValueImageReaderType = itk::ImageFileReader<GrayValueImageType>;
   using GrayValueImageReaderPointer = typename GrayValueImageReaderType::Pointer;
-  using GrayValueImageWriterType = itk::ImageFileWriter<GrayValueImageType>;
-  using DeformationFieldWriterType = itk::ImageFileWriter<VectorImageType>;
 
   /** Execute stuff before the actual registration:
    * \li Create an initial B-spline grid.

--- a/Components/Transforms/BSplineDeformableTransformWithDiffusion/elxBSplineTransformWithDiffusion.hxx
+++ b/Components/Transforms/BSplineDeformableTransformWithDiffusion/elxBSplineTransformWithDiffusion.hxx
@@ -980,14 +980,9 @@ void
 BSplineTransformWithDiffusion<TElastix>::WriteDerivedTransformDataToFile() const
 {
   /** Write the deformation field image. */
-  auto writer = DeformationFieldWriterType::New();
-  writer->SetFileName(TransformIO::MakeDeformationFieldFileName(*this));
-  writer->SetInput(this->m_DiffusedField);
-
-  /** Do the writing. */
   try
   {
-    writer->Update();
+    itk::WriteImage(m_DiffusedField, TransformIO::MakeDeformationFieldFileName(*this));
   }
   catch (itk::ExceptionObject & excp)
   {
@@ -1279,14 +1274,11 @@ BSplineTransformWithDiffusion<TElastix>::DiffuseDeformationField()
 
     /** Write the deformationFieldImage. */
     makeFileName1 << begin.str() << "deformationField" << end.str();
-    auto deformationFieldWriter = DeformationFieldWriterType::New();
-    deformationFieldWriter->SetFileName(makeFileName1.str().c_str());
-    deformationFieldWriter->SetInput(this->m_DeformationField);
 
     /** Do the writing. */
     try
     {
-      deformationFieldWriter->Update();
+      itk::WriteImage(m_DeformationField, makeFileName1.str());
     }
     catch (itk::ExceptionObject & excp)
     {
@@ -1302,21 +1294,12 @@ BSplineTransformWithDiffusion<TElastix>::DiffuseDeformationField()
     /** Write the GrayValueImage. */
     std::ostringstream makeFileName2("");
     makeFileName2 << begin.str() << "GrayValueImage" << end.str();
-    auto grayValueImageWriter = GrayValueImageWriterType::New();
-    grayValueImageWriter->SetFileName(makeFileName2.str().c_str());
-    if (this->m_AlsoFixed || this->m_UseFixedSegmentation)
-    {
-      grayValueImageWriter->SetInput(this->m_GrayValueImage2);
-    }
-    else
-    {
-      grayValueImageWriter->SetInput(this->m_GrayValueImage1);
-    }
 
     /** Do the writing. */
     try
     {
-      grayValueImageWriter->Update();
+      const auto image = (m_AlsoFixed || m_UseFixedSegmentation) ? m_GrayValueImage2 : m_GrayValueImage1;
+      itk::WriteImage(image, makeFileName2.str());
     }
     catch (itk::ExceptionObject & excp)
     {
@@ -1332,14 +1315,11 @@ BSplineTransformWithDiffusion<TElastix>::DiffuseDeformationField()
     /** Write the diffusedFieldImage. */
     std::ostringstream makeFileName3("");
     makeFileName3 << begin.str() << "diffusedField" << end.str();
-    auto diffusedFieldWriter = DeformationFieldWriterType::New();
-    diffusedFieldWriter->SetFileName(makeFileName3.str().c_str());
-    diffusedFieldWriter->SetInput(this->m_DiffusedField);
 
     /** Do the writing. */
     try
     {
-      diffusedFieldWriter->Update();
+      itk::WriteImage(m_DiffusedField, makeFileName3.str());
     }
     catch (itk::ExceptionObject & excp)
     {

--- a/Components/Transforms/DeformationFieldTransform/elxDeformationFieldTransform.hxx
+++ b/Components/Transforms/DeformationFieldTransform/elxDeformationFieldTransform.hxx
@@ -160,15 +160,9 @@ DeformationFieldTransform<TElastix>::WriteDerivedTransformDataToFile() const
   infoChanger->SetInput(this->m_DeformationFieldInterpolatingTransform->GetDeformationField());
 
   /** Write the deformation field image. */
-  using VectorWriterType = itk::ImageFileWriter<DeformationFieldType>;
-  auto writer = VectorWriterType::New();
-  writer->SetFileName(TransformIO::MakeDeformationFieldFileName(*this));
-  writer->SetInput(infoChanger->GetOutput());
-
-  /** Do the writing. */
   try
   {
-    writer->Update();
+    itk::WriteImage(infoChanger->GetOutput(), TransformIO::MakeDeformationFieldFileName(*this));
   }
   catch (itk::ExceptionObject & excp)
   {

--- a/Core/ComponentBaseClasses/elxTransformBase.hxx
+++ b/Core/ComponentBaseClasses/elxTransformBase.hxx
@@ -1048,8 +1048,6 @@ void
 TransformBase<TElastix>::WriteDeformationFieldImage(
   typename TransformBase<TElastix>::DeformationFieldImageType::Pointer deformationfield) const
 {
-  using DeformationFieldWriterType = itk::ImageFileWriter<DeformationFieldImageType>;
-
   /** Create a name for the deformation field file. */
   std::string resultImageFormat = "mhd";
   this->m_Configuration->ReadParameter(resultImageFormat, "ResultImageFormat", 0, false);
@@ -1057,15 +1055,10 @@ TransformBase<TElastix>::WriteDeformationFieldImage(
   makeFileName << this->m_Configuration->GetCommandLineArgument("-out") << "deformationField." << resultImageFormat;
 
   /** Write outputImage to disk. */
-  const auto defWriter = DeformationFieldWriterType::New();
-  defWriter->SetInput(deformationfield);
-  defWriter->SetFileName(makeFileName.str().c_str());
-
-  /** Do the writing. */
   elxout << "  Computing and writing the deformation field ..." << std::endl;
   try
   {
-    defWriter->Update();
+    itk::WriteImage(deformationfield, makeFileName.str());
   }
   catch (itk::ExceptionObject & excp)
   {
@@ -1144,15 +1137,10 @@ TransformBase<TElastix>::ComputeDeterminantOfSpatialJacobian() const
   makeFileName << this->m_Configuration->GetCommandLineArgument("-out") << "spatialJacobian." << resultImageFormat;
 
   /** Write outputImage to disk. */
-  const auto jacWriter = itk::ImageFileWriter<JacobianImageType>::New();
-  jacWriter->SetInput(infoChanger->GetOutput());
-  jacWriter->SetFileName(makeFileName.str().c_str());
-
-  /** Do the writing. */
   elxout << "  Computing and writing the spatial Jacobian determinant..." << std::endl;
   try
   {
-    jacWriter->Update();
+    itk::WriteImage(infoChanger->GetOutput(), makeFileName.str());
   }
   catch (itk::ExceptionObject & excp)
   {

--- a/Testing/elxImageCompare.cxx
+++ b/Testing/elxImageCompare.cxx
@@ -164,13 +164,9 @@ main(int argc, char ** argv)
     diffImageFileName += "_DIFF";
     diffImageFileName += itksys::SystemTools::GetFilenameLastExtension(testImageFileName);
 
-    using WriterType = itk::ImageFileWriter<ImageType>;
-    auto writer = WriterType::New();
-    writer->SetFileName(diffImageFileName);
-    writer->SetInput(comparisonFilter->GetOutput());
     try
     {
-      writer->Write();
+      itk::WriteImage(comparisonFilter->GetOutput(), diffImageFileName);
     }
     catch (itk::ExceptionObject & err)
     {

--- a/Testing/elxTransformParametersCompare.cxx
+++ b/Testing/elxTransformParametersCompare.cxx
@@ -71,7 +71,6 @@ main(int argc, char ** argv)
   using OriginType = CoefficientImageType::PointType;
   using DirectionType = CoefficientImageType::DirectionType;
   using IteratorType = itk::ImageRegionIteratorWithIndex<CoefficientImageType>;
-  using WriterType = itk::ImageFileWriter<CoefficientImageType>;
 
   using MaskImageType = itk::Image<unsigned char, ITK_TEST_DIMENSION_MAX>;
   using MaskIteratorType = itk::ImageRegionIteratorWithIndex<MaskImageType>;
@@ -320,12 +319,9 @@ main(int argc, char ** argv)
     /** Write the difference image. */
     if (diffNormNormalized > 1e-10)
     {
-      auto writer = WriterType::New();
-      writer->SetFileName(diffImageFileName);
-      writer->SetInput(coefImage);
       try
       {
-        writer->Write();
+        itk::WriteImage(coefImage, diffImageFileName);
       }
       catch (itk::ExceptionObject & err)
       {

--- a/Testing/itkMevisDicomTiffImageIOTest.cxx
+++ b/Testing/itkMevisDicomTiffImageIOTest.cxx
@@ -44,7 +44,6 @@ testMevis()
   using PixelType = unsigned char;
 
   using ImageType = itk::Image<PixelType, Dimension>;
-  using WriterType = itk::ImageFileWriter<ImageType>;
   using ReaderType = itk::ImageFileReader<ImageType>;
   using ComparisonFilterType = itk::Testing::ComparisonImageFilter<ImageType, ImageType>;
   using SizeType = typename ImageType::SizeType;
@@ -53,7 +52,6 @@ testMevis()
   using DirectionType = typename ImageType::DirectionType;
   using IteratorType = itk::ImageRegionIterator<ImageType>;
 
-  auto          writer = WriterType::New();
   auto          reader = ReaderType::New();
   auto          inputImage = ImageType::New();
   SizeType      size;
@@ -160,15 +158,13 @@ testMevis()
   }
 
   std::string testfile("testimageMevisDicomTiff.tif");
-  writer->SetFileName(testfile);
-  writer->SetInput(inputImage);
   reader->SetFileName(testfile);
 
   std::string task("");
   try
   {
     task = "Writing";
-    writer->Update();
+    itk::WriteImage(inputImage, testfile);
     task = "Reading";
     reader->Update();
   }

--- a/Testing/itkTransformixFilterTest.cxx
+++ b/Testing/itkTransformixFilterTest.cxx
@@ -57,11 +57,7 @@ main(int argc, char * argv[])
   transformix->SetLogToConsole(true);
   ImageType::Pointer resultImage = transformix->GetOutput();
 
-  using ImageWriterType = itk::ImageFileWriter<ImageType>;
-  auto imageWriter = ImageWriterType::New();
-  imageWriter->SetFileName(transformedImageFile);
-  imageWriter->SetInput(resultImage);
-  imageWriter->Update();
+  itk::WriteImage(resultImage, transformedImageFile);
 
   /** Return a value. */
   return 0;


### PR DESCRIPTION
Follow-up to ITK pull request https://github.com/InsightSoftwareConsortium/ITK/pull/2160 commit https://github.com/InsightSoftwareConsortium/ITK/commit/60b0984d4196841844424e33963e161f3f0c709d "ENH: add a convenience function WriteImage", merged on 9 December 2020, and included with ITK v5.2rc01.