### PR TITLE
STYLE: Make data ImageMomentsCalculator, ComputeDisplacementDist private

### DIFF
--- a/Common/Transforms/itkAdvancedImageMomentsCalculator.h
+++ b/Common/Transforms/itkAdvancedImageMomentsCalculator.h
@@ -257,7 +257,6 @@ protected:
   /** Typedefs for multi-threading. */
   using ThreaderType = itk::PlatformMultiThreader;
   using ThreadInfoType = ThreaderType::WorkUnitInfo;
-  ThreaderType::Pointer m_Threader;
 
   /** Launch MultiThread Compute. */
   void
@@ -280,7 +279,6 @@ protected:
   {
     Self * st_Self;
   };
-  mutable MultiThreaderParameterType m_ThreaderParameters;
 
   struct ComputePerThreadStruct
   {
@@ -294,18 +292,9 @@ protected:
   };
   itkPadStruct(ITK_CACHE_LINE_ALIGNMENT, ComputePerThreadStruct, PaddedComputePerThreadStruct);
   itkAlignedTypedef(ITK_CACHE_LINE_ALIGNMENT, PaddedComputePerThreadStruct, AlignedComputePerThreadStruct);
-  mutable AlignedComputePerThreadStruct * m_ComputePerThreadVariables;
-  mutable ThreadIdType                    m_ComputePerThreadVariablesSize;
-  bool                                    m_UseMultiThread;
-  SizeValueType                           m_NumberOfPixelsCounted;
 
   /** The type of region used for multithreading */
   using ThreadRegionType = typename ImageType::RegionType;
-
-  SizeValueType               m_NumberOfSamplesForCenteredTransformInitialization;
-  InputPixelType              m_LowerThresholdForCenterGravity;
-  bool                        m_CenterOfGravityUsesLowerThreshold;
-  ImageSampleContainerPointer m_SampleContainer;
 
 private:
   /** Internal helper function. Does post processing at the end of
@@ -316,6 +305,20 @@ private:
   AdvancedImageMomentsCalculator(const Self &);
   void
   operator=(const Self &);
+
+  ThreaderType::Pointer m_Threader;
+
+  mutable MultiThreaderParameterType m_ThreaderParameters;
+
+  mutable AlignedComputePerThreadStruct * m_ComputePerThreadVariables;
+  mutable ThreadIdType                    m_ComputePerThreadVariablesSize;
+  bool                                    m_UseMultiThread;
+  SizeValueType                           m_NumberOfPixelsCounted;
+
+  SizeValueType               m_NumberOfSamplesForCenteredTransformInitialization;
+  InputPixelType              m_LowerThresholdForCenterGravity;
+  bool                        m_CenterOfGravityUsesLowerThreshold;
+  ImageSampleContainerPointer m_SampleContainer;
 
   bool       m_Valid; // Have moments been computed yet?
   ScalarType m_M0;    // Zeroth moment

--- a/Common/itkComputeDisplacementDistribution.h
+++ b/Common/itkComputeDisplacementDistribution.h
@@ -200,8 +200,6 @@ protected:
   {
     Self * st_Self;
   };
-  mutable MultiThreaderParameterType m_ThreaderParameters;
-
   struct ComputePerThreadStruct
   {
     /**  Used for accumulating variables. */
@@ -212,6 +210,10 @@ protected:
   };
   itkPadStruct(ITK_CACHE_LINE_ALIGNMENT, ComputePerThreadStruct, PaddedComputePerThreadStruct);
   itkAlignedTypedef(ITK_CACHE_LINE_ALIGNMENT, PaddedComputePerThreadStruct, AlignedComputePerThreadStruct);
+
+private:
+  mutable MultiThreaderParameterType m_ThreaderParameters;
+
   mutable AlignedComputePerThreadStruct * m_ComputePerThreadVariables;
   mutable ThreadIdType                    m_ComputePerThreadVariablesSize;
 
@@ -219,7 +221,6 @@ protected:
   bool                        m_UseMultiThread;
   ImageSampleContainerPointer m_SampleContainer;
 
-private:
   ComputeDisplacementDistribution(const Self &) = delete;
   void
   operator=(const Self &) = delete;


### PR DESCRIPTION
Made data members of `AdvancedImageMomentsCalculator` and `ComputeDisplacementDistribution` private, including their `m_ComputePerThreadVariables` member.

Based on the first commit of pull request https://github.com/SuperElastix/elastix/pull/132 "Improved style of m_ComputePerThreadVariable data members".

Follows C++ Core Guidelines (April 10, 2022): "C.133: Avoid protected data" http://isocpp.github.io/CppCoreGuidelines/CppCoreGuidelines#Rh-protected