### PR TITLE
STYLE: Declared `m_ComputePerThreadVariables` as an `std::vector` (2 x)

### DIFF
--- a/Common/Transforms/itkAdvancedImageMomentsCalculator.h
+++ b/Common/Transforms/itkAdvancedImageMomentsCalculator.h
@@ -32,6 +32,8 @@
 
 #include "itkPlatformMultiThreader.h"
 
+#include <vector>
+
 namespace itk
 {
 /** \class AdvancedImageMomentsCalculator
@@ -250,7 +252,7 @@ public:
 
 protected:
   AdvancedImageMomentsCalculator();
-  ~AdvancedImageMomentsCalculator() override;
+  ~AdvancedImageMomentsCalculator() override = default;
   void
   PrintSelf(std::ostream & os, Indent indent) const override;
 
@@ -310,10 +312,9 @@ private:
 
   mutable MultiThreaderParameterType m_ThreaderParameters;
 
-  mutable AlignedComputePerThreadStruct * m_ComputePerThreadVariables;
-  mutable ThreadIdType                    m_ComputePerThreadVariablesSize;
-  bool                                    m_UseMultiThread;
-  SizeValueType                           m_NumberOfPixelsCounted;
+  mutable std::vector<AlignedComputePerThreadStruct> m_ComputePerThreadVariables;
+  bool                                               m_UseMultiThread;
+  SizeValueType                                      m_NumberOfPixelsCounted;
 
   SizeValueType               m_NumberOfSamplesForCenteredTransformInitialization;
   InputPixelType              m_LowerThresholdForCenterGravity;

--- a/Common/itkComputeDisplacementDistribution.h
+++ b/Common/itkComputeDisplacementDistribution.h
@@ -26,6 +26,8 @@
 #include "itkImageFullSampler.h"
 #include "itkPlatformMultiThreader.h"
 
+#include <vector>
+
 namespace itk
 {
 /**\class ComputeDisplacementDistribution
@@ -132,7 +134,7 @@ public:
 
 protected:
   ComputeDisplacementDistribution();
-  ~ComputeDisplacementDistribution() override;
+  ~ComputeDisplacementDistribution() override = default;
 
   /** Typedefs for multi-threading. */
   using ThreaderType = itk::PlatformMultiThreader;
@@ -214,8 +216,7 @@ protected:
 private:
   mutable MultiThreaderParameterType m_ThreaderParameters;
 
-  mutable AlignedComputePerThreadStruct * m_ComputePerThreadVariables;
-  mutable ThreadIdType                    m_ComputePerThreadVariablesSize;
+  mutable std::vector<AlignedComputePerThreadStruct> m_ComputePerThreadVariables;
 
   SizeValueType               m_NumberOfPixelsCounted;
   bool                        m_UseMultiThread;


### PR DESCRIPTION
Declared m_ComputePerThreadVariables of both as `AdvancedImageMomentsCalculator` and `ComputeDisplacementDistribution` as an `std::vector<AlignedComputePerThreadStruct>`, instead of a raw pointer to the structs. Simplified zero-initialization of the structs. Removed manual `delete[]` statements.

Based on the second commit of pull request https://github.com/SuperElastix/elastix/pull/132 "Improved style of m_ComputePerThreadVariable data members".

Follows C++ Core Guidelines (April 10, 2022): "Avoid calling new and delete explicitly" http://isocpp.github.io/CppCoreGuidelines/CppCoreGuidelines#Rr-ptr