### PR TITLE
STYLE: Make threading related data of metrics private

### DIFF
--- a/Common/CostFunctions/itkParzenWindowHistogramImageToImageMetric.h
+++ b/Common/CostFunctions/itkParzenWindowHistogramImageToImageMetric.h
@@ -294,33 +294,6 @@ protected:
   KernelFunctionPointer m_MovingKernel;
   KernelFunctionPointer m_DerivativeMovingKernel;
 
-  /** Threading related parameters. */
-  mutable std::vector<JointPDFPointer> m_ThreaderJointPDFs;
-
-  /** Helper structs that multi-threads the computation of
-   * the metric derivative using ITK threads.
-   */
-  struct ParzenWindowHistogramMultiThreaderParameterType // can't we use the one from AdvancedImageToImageMetric ?
-  {
-    Self * m_Metric;
-  };
-  ParzenWindowHistogramMultiThreaderParameterType m_ParzenWindowHistogramThreaderParameters;
-
-  struct ParzenWindowHistogramGetValueAndDerivativePerThreadStruct
-  {
-    SizeValueType   st_NumberOfPixelsCounted;
-    JointPDFPointer st_JointPDF;
-  };
-  itkPadStruct(ITK_CACHE_LINE_ALIGNMENT,
-               ParzenWindowHistogramGetValueAndDerivativePerThreadStruct,
-               PaddedParzenWindowHistogramGetValueAndDerivativePerThreadStruct);
-  itkAlignedTypedef(ITK_CACHE_LINE_ALIGNMENT,
-                    PaddedParzenWindowHistogramGetValueAndDerivativePerThreadStruct,
-                    AlignedParzenWindowHistogramGetValueAndDerivativePerThreadStruct);
-  mutable AlignedParzenWindowHistogramGetValueAndDerivativePerThreadStruct *
-                       m_ParzenWindowHistogramGetValueAndDerivativePerThreadVariables;
-  mutable ThreadIdType m_ParzenWindowHistogramGetValueAndDerivativePerThreadVariablesSize;
-
   /** Initialize threading related parameters. */
   void
   InitializeThreadingParameters() const override;
@@ -504,6 +477,33 @@ private:
   /** The deleted assignment operator. */
   void
   operator=(const Self &) = delete;
+
+  /** Threading related parameters. */
+  mutable std::vector<JointPDFPointer> m_ThreaderJointPDFs;
+
+  /** Helper structs that multi-threads the computation of
+   * the metric derivative using ITK threads.
+   */
+  struct ParzenWindowHistogramMultiThreaderParameterType // can't we use the one from AdvancedImageToImageMetric ?
+  {
+    Self * m_Metric;
+  };
+  ParzenWindowHistogramMultiThreaderParameterType m_ParzenWindowHistogramThreaderParameters;
+
+  struct ParzenWindowHistogramGetValueAndDerivativePerThreadStruct
+  {
+    SizeValueType   st_NumberOfPixelsCounted;
+    JointPDFPointer st_JointPDF;
+  };
+  itkPadStruct(ITK_CACHE_LINE_ALIGNMENT,
+               ParzenWindowHistogramGetValueAndDerivativePerThreadStruct,
+               PaddedParzenWindowHistogramGetValueAndDerivativePerThreadStruct);
+  itkAlignedTypedef(ITK_CACHE_LINE_ALIGNMENT,
+                    PaddedParzenWindowHistogramGetValueAndDerivativePerThreadStruct,
+                    AlignedParzenWindowHistogramGetValueAndDerivativePerThreadStruct);
+  mutable AlignedParzenWindowHistogramGetValueAndDerivativePerThreadStruct *
+                       m_ParzenWindowHistogramGetValueAndDerivativePerThreadVariables;
+  mutable ThreadIdType m_ParzenWindowHistogramGetValueAndDerivativePerThreadVariablesSize;
 
   /** Variables that can/should be accessed by their Set/Get functions. */
   unsigned long m_NumberOfFixedHistogramBins;

--- a/Components/Metrics/PCAMetric/itkPCAMetric_F_multithreaded.h
+++ b/Components/Metrics/PCAMetric/itkPCAMetric_F_multithreaded.h
@@ -163,30 +163,6 @@ protected:
                                         const MovingImageDerivativeType & movingImageDerivative,
                                         DerivativeType &                  imageJacobian) const override;
 
-  struct PCAMetricMultiThreaderParameterType
-  {
-    Self * m_Metric;
-  };
-
-  PCAMetricMultiThreaderParameterType m_PCAMetricThreaderParameters;
-
-  struct PCAMetricGetSamplesPerThreadStruct
-  {
-    SizeValueType                    st_NumberOfPixelsCounted;
-    MatrixType                       st_DataBlock;
-    std::vector<FixedImagePointType> st_ApprovedSamples;
-    DerivativeType                   st_Derivative;
-  };
-
-  itkPadStruct(ITK_CACHE_LINE_ALIGNMENT, PCAMetricGetSamplesPerThreadStruct, PaddedPCAMetricGetSamplesPerThreadStruct);
-
-  itkAlignedTypedef(ITK_CACHE_LINE_ALIGNMENT,
-                    PaddedPCAMetricGetSamplesPerThreadStruct,
-                    AlignedPCAMetricGetSamplesPerThreadStruct);
-
-  mutable AlignedPCAMetricGetSamplesPerThreadStruct * m_PCAMetricGetSamplesPerThreadVariables;
-  mutable ThreadIdType                                m_PCAMetricGetSamplesPerThreadVariablesSize;
-
   /** Get value and derivatives for each thread. */
   inline void
   ThreadedGetSamples(ThreadIdType threadID);
@@ -223,6 +199,30 @@ private:
   PCAMetric(const Self &) = delete;
   void
   operator=(const Self &) = delete;
+
+  struct PCAMetricMultiThreaderParameterType
+  {
+    Self * m_Metric;
+  };
+
+  PCAMetricMultiThreaderParameterType m_PCAMetricThreaderParameters;
+
+  struct PCAMetricGetSamplesPerThreadStruct
+  {
+    SizeValueType                    st_NumberOfPixelsCounted;
+    MatrixType                       st_DataBlock;
+    std::vector<FixedImagePointType> st_ApprovedSamples;
+    DerivativeType                   st_Derivative;
+  };
+
+  itkPadStruct(ITK_CACHE_LINE_ALIGNMENT, PCAMetricGetSamplesPerThreadStruct, PaddedPCAMetricGetSamplesPerThreadStruct);
+
+  itkAlignedTypedef(ITK_CACHE_LINE_ALIGNMENT,
+                    PaddedPCAMetricGetSamplesPerThreadStruct,
+                    AlignedPCAMetricGetSamplesPerThreadStruct);
+
+  mutable AlignedPCAMetricGetSamplesPerThreadStruct * m_PCAMetricGetSamplesPerThreadVariables;
+  mutable ThreadIdType                                m_PCAMetricGetSamplesPerThreadVariablesSize;
 
   unsigned int m_G;
   unsigned int m_LastDimIndex;


### PR DESCRIPTION
Applies to both `PCAMetric` and `ParzenWindowHistogramImageToImageMetric`.

Follow-up to pull request https://github.com/SuperElastix/elastix/pull/643 commit ab0c8df174fd3485f5626caf06dea8edd66fff92 "STYLE: Make data ImageMomentsCalculator, ComputeDisplacementDist private"