### PR TITLE
ENH: Support CMake based client project to build against the install dir

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -594,10 +594,33 @@ foreach( LIB IN LISTS AllComponentLibs )
   elastix_export_target( ${LIB} )
 endforeach()
 
+# ELASTIX_ITK_DIR -- used (only) for the Config.cmake file in the build tree
 # It appears necessary for Windows Azure Pipelines, to replace backslashes by
 # forward slashes before using the ITK bin directory.
 string(REPLACE "\\" "/" ELASTIX_ITK_DIR ${ITK_DIR})
 
-configure_file( ${elastix_SOURCE_DIR}/ElastixConfig.cmake.in ${elastix_BINARY_DIR}/ElastixConfig.cmake @ONLY )
-configure_file( ${elastix_SOURCE_DIR}/ElastixConfigVersion.cmake.in ${elastix_BINARY_DIR}/ElastixConfigVersion.cmake @ONLY )
-configure_file( ${elastix_SOURCE_DIR}/UseElastix.cmake.in ${elastix_BINARY_DIR}/UseElastix.cmake @ONLY )
+# Create the Config.cmake file for the build tree:
+set(ELX_CONFIG_INCLUDE_DIRECTORIES "${elxINCLUDE_DIRECTORIES}")
+configure_file( ElastixConfig.cmake.in ElastixConfig.cmake @ONLY )
+
+# Create the Config.cmake file for the install tree:
+set(ELX_CONFIG_INCLUDE_DIRECTORIES "\${CMAKE_CURRENT_LIST_DIR}/../../../include")
+foreach( ELX_INCLUDE_DIR IN ITEMS ${elxINCLUDE_DIRECTORIES} )
+  if (NOT ELX_INCLUDE_DIR STREQUAL CMAKE_BINARY_DIR)
+    string(REPLACE ${CMAKE_SOURCE_DIR} "" ELX_INCLUDE_DIR ${ELX_INCLUDE_DIR})
+    list(APPEND ELX_CONFIG_INCLUDE_DIRECTORIES "\${CMAKE_CURRENT_LIST_DIR}/../../../include${ELX_INCLUDE_DIR}")
+  endif()
+endforeach()
+
+# The Config.cmake file for the install tree should not specify the ITK_DIR.
+unset(ELASTIX_ITK_DIR)
+configure_file( ElastixConfig.cmake.in "${PROJECT_BINARY_DIR}${CMAKE_FILES_DIRECTORY}/ElastixConfig.cmake" @ONLY )
+
+configure_file( ElastixConfigVersion.cmake.in ElastixConfigVersion.cmake @ONLY )
+configure_file( UseElastix.cmake.in UseElastix.cmake @ONLY )
+
+install(FILES
+  "${PROJECT_BINARY_DIR}${CMAKE_FILES_DIRECTORY}/ElastixConfig.cmake"
+  "${PROJECT_BINARY_DIR}/ElastixConfigVersion.cmake"
+  "${PROJECT_BINARY_DIR}/UseElastix.cmake"
+  DESTINATION lib/cmake/elastix)

--- a/Core/CMakeLists.txt
+++ b/Core/CMakeLists.txt
@@ -93,7 +93,10 @@ source_group( "ProgressCommand" FILES ${ProgressCommandFiles} )
 configure_file(
   elxVersionMacros.h.in
   elxVersionMacros.h)
-
+  
+install( FILES
+  ${CMAKE_CURRENT_BINARY_DIR}/elxVersionMacros.h
+  DESTINATION ${CMAKE_INSTALL_PREFIX}/include/Core )
 #---------------------------------------------------------------------
 # Create the elxCore library.
 

--- a/ElastixConfig.cmake.in
+++ b/ElastixConfig.cmake.in
@@ -1,7 +1,7 @@
 set( Elastix_DIR @PROJECT_BINARY_DIR@ )
 
 # Add include directories needed to use SuperElastix
-set( ELASTIX_INCLUDE_DIRS @elxINCLUDE_DIRECTORIES@ )
+set( ELASTIX_INCLUDE_DIRS @ELX_CONFIG_INCLUDE_DIRECTORIES@ )
 
 # Add list of Elastix library directories
 set( ELASTIX_LIBRARY_DIRS @LIBRARY_OUTPUT_PATH@ )
@@ -20,7 +20,10 @@ set( ELASTIX_USE_OPENCL @ELASTIX_USE_OPENCL@ )
 set( ELASTIX_USE_MEVISDICOMTIFF @ELASTIX_USE_MEVISDICOMTIFF@ )
 set( ELASTIX_DOX_DIR @ELASTIX_DOX_DIR@ )
 set( ELASTIX_HELP_DIR @ELASTIX_HELP_DIR@ )
-set( ELASTIX_ITK_DIR @ELASTIX_ITK_DIR@ )
+
+if (NOT "@ELASTIX_ITK_DIR@" EQUAL "")
+  set( ELASTIX_ITK_DIR @ELASTIX_ITK_DIR@ )
+endif()
 
 # Maintain backwards compatibility by also exporting old-style target information
 set( ELASTIX_ALL_COMPONENT_LIBS @AllComponentLibs@ )

--- a/dox/externalproject/CMakeLists.txt
+++ b/dox/externalproject/CMakeLists.txt
@@ -13,7 +13,9 @@ if( OPENMP_FOUND )
 endif()
 
 # Use the version of ITK from Elastix.
-set( ITK_DIR ${ELASTIX_ITK_DIR} )
+if ( DEFINED ELASTIX_ITK_DIR )
+  set( ITK_DIR "${ELASTIX_ITK_DIR}" CACHE PATH "ITK_DIR from Elastix" FORCE )
+endif()
 find_package( ITK REQUIRED )
 
 include(${ELASTIX_CONFIG_TARGETS_FILE})


### PR DESCRIPTION
Added ElastixConfig.cmake file to CMake generated install directory (e.g., "C:\Program Files\elastix\lib\cmake\elastix").

Allowed a CMake based client project to build against this install directory, even after removing the source directory and the build directory of Elastix itself.

Triggered by feedback from Bradley Lowekamp comment https://github.com/SimpleITK/SimpleITK/pull/1611#issuecomment-1102761584 at SimpleITK pull request 1611 ("WIP: Support adding Elastix component by CMake SimpleITK_USE_ELASTIX=ON")