### PR TITLE
STYLE: Declare "PerThreadVariables" data members as `std::vector` (4x)

### DIFF
--- a/Common/CostFunctions/itkParzenWindowHistogramImageToImageMetric.h
+++ b/Common/CostFunctions/itkParzenWindowHistogramImageToImageMetric.h
@@ -20,6 +20,7 @@
 
 #include "itkAdvancedImageToImageMetric.h"
 #include "itkKernelFunctionBase2.h"
+#include <vector>
 
 
 namespace itk
@@ -217,7 +218,7 @@ protected:
   ParzenWindowHistogramImageToImageMetric();
 
   /** The destructor. */
-  ~ParzenWindowHistogramImageToImageMetric() override;
+  ~ParzenWindowHistogramImageToImageMetric() override = default;
 
   /** Print Self. */
   void
@@ -501,9 +502,8 @@ private:
   itkAlignedTypedef(ITK_CACHE_LINE_ALIGNMENT,
                     PaddedParzenWindowHistogramGetValueAndDerivativePerThreadStruct,
                     AlignedParzenWindowHistogramGetValueAndDerivativePerThreadStruct);
-  mutable AlignedParzenWindowHistogramGetValueAndDerivativePerThreadStruct *
-                       m_ParzenWindowHistogramGetValueAndDerivativePerThreadVariables;
-  mutable ThreadIdType m_ParzenWindowHistogramGetValueAndDerivativePerThreadVariablesSize;
+  mutable std::vector<AlignedParzenWindowHistogramGetValueAndDerivativePerThreadStruct>
+    m_ParzenWindowHistogramGetValueAndDerivativePerThreadVariables;
 
   /** Variables that can/should be accessed by their Set/Get functions. */
   unsigned long m_NumberOfFixedHistogramBins;

--- a/Common/CostFunctions/itkParzenWindowHistogramImageToImageMetric.hxx
+++ b/Common/CostFunctions/itkParzenWindowHistogramImageToImageMetric.hxx
@@ -71,22 +71,7 @@ ParzenWindowHistogramImageToImageMetric<TFixedImage, TMovingImage>::ParzenWindow
   /** Initialize the m_ParzenWindowHistogramThreaderParameters */
   this->m_ParzenWindowHistogramThreaderParameters.m_Metric = this;
 
-  // Multi-threading structs
-  this->m_ParzenWindowHistogramGetValueAndDerivativePerThreadVariables = nullptr;
-  this->m_ParzenWindowHistogramGetValueAndDerivativePerThreadVariablesSize = 0;
-
 } // end Constructor
-
-
-/**
- * ******************* Destructor *******************
- */
-
-template <class TFixedImage, class TMovingImage>
-ParzenWindowHistogramImageToImageMetric<TFixedImage, TMovingImage>::~ParzenWindowHistogramImageToImageMetric()
-{
-  delete[] this->m_ParzenWindowHistogramGetValueAndDerivativePerThreadVariables;
-} // end Destructor
 
 
 /**
@@ -458,22 +443,15 @@ ParzenWindowHistogramImageToImageMetric<TFixedImage, TMovingImage>::InitializeTh
   const ThreadIdType numberOfThreads = Self::GetNumberOfWorkUnits();
 
   /** Only resize the array of structs when needed. */
-  if (this->m_ParzenWindowHistogramGetValueAndDerivativePerThreadVariablesSize != numberOfThreads)
-  {
-    delete[] this->m_ParzenWindowHistogramGetValueAndDerivativePerThreadVariables;
-    this->m_ParzenWindowHistogramGetValueAndDerivativePerThreadVariables =
-      new AlignedParzenWindowHistogramGetValueAndDerivativePerThreadStruct[numberOfThreads];
-    this->m_ParzenWindowHistogramGetValueAndDerivativePerThreadVariablesSize = numberOfThreads;
-  }
+  m_ParzenWindowHistogramGetValueAndDerivativePerThreadVariables.resize(numberOfThreads);
 
   /** Some initialization. */
-  for (ThreadIdType i = 0; i < numberOfThreads; ++i)
+  for (auto & perThreadVariable : m_ParzenWindowHistogramGetValueAndDerivativePerThreadVariables)
   {
-    this->m_ParzenWindowHistogramGetValueAndDerivativePerThreadVariables[i].st_NumberOfPixelsCounted =
-      NumericTraits<SizeValueType>::Zero;
+    perThreadVariable.st_NumberOfPixelsCounted = NumericTraits<SizeValueType>::Zero;
 
     // Initialize the joint pdf
-    JointPDFPointer & jointPDF = this->m_ParzenWindowHistogramGetValueAndDerivativePerThreadVariables[i].st_JointPDF;
+    JointPDFPointer & jointPDF = perThreadVariable.st_JointPDF;
     if (jointPDF.IsNull())
     {
       jointPDF = JointPDFType::New();

--- a/Components/Metrics/AdvancedKappaStatistic/itkAdvancedKappaStatisticImageToImageMetric.h
+++ b/Components/Metrics/AdvancedKappaStatistic/itkAdvancedKappaStatisticImageToImageMetric.h
@@ -19,6 +19,7 @@
 #define itkAdvancedKappaStatisticImageToImageMetric_h
 
 #include "itkAdvancedImageToImageMetric.h"
+#include <vector>
 
 namespace itk
 {
@@ -168,7 +169,7 @@ public:
 
 protected:
   AdvancedKappaStatisticImageToImageMetric();
-  ~AdvancedKappaStatisticImageToImageMetric() override;
+  ~AdvancedKappaStatisticImageToImageMetric() override = default;
 
   /** PrintSelf. */
   void
@@ -259,8 +260,7 @@ private:
   itkAlignedTypedef(ITK_CACHE_LINE_ALIGNMENT,
                     PaddedKappaGetValueAndDerivativePerThreadStruct,
                     AlignedKappaGetValueAndDerivativePerThreadStruct);
-  mutable AlignedKappaGetValueAndDerivativePerThreadStruct * m_KappaGetValueAndDerivativePerThreadVariables;
-  mutable ThreadIdType                                       m_KappaGetValueAndDerivativePerThreadVariablesSize;
+  mutable std::vector<AlignedKappaGetValueAndDerivativePerThreadStruct> m_KappaGetValueAndDerivativePerThreadVariables;
 };
 
 } // end namespace itk

--- a/Components/Metrics/AdvancedNormalizedCorrelation/itkAdvancedNormalizedCorrelationImageToImageMetric.h
+++ b/Components/Metrics/AdvancedNormalizedCorrelation/itkAdvancedNormalizedCorrelationImageToImageMetric.h
@@ -19,6 +19,7 @@
 #define itkAdvancedNormalizedCorrelationImageToImageMetric_h
 
 #include "itkAdvancedImageToImageMetric.h"
+#include <vector>
 
 namespace itk
 {
@@ -184,7 +185,7 @@ public:
 
 protected:
   AdvancedNormalizedCorrelationImageToImageMetric();
-  ~AdvancedNormalizedCorrelationImageToImageMetric() override;
+  ~AdvancedNormalizedCorrelationImageToImageMetric() override = default;
 
   void
   PrintSelf(std::ostream & os, Indent indent) const override;
@@ -275,8 +276,8 @@ private:
   itkAlignedTypedef(ITK_CACHE_LINE_ALIGNMENT,
                     PaddedCorrelationGetValueAndDerivativePerThreadStruct,
                     AlignedCorrelationGetValueAndDerivativePerThreadStruct);
-  mutable AlignedCorrelationGetValueAndDerivativePerThreadStruct * m_CorrelationGetValueAndDerivativePerThreadVariables;
-  mutable ThreadIdType m_CorrelationGetValueAndDerivativePerThreadVariablesSize;
+  mutable std::vector<AlignedCorrelationGetValueAndDerivativePerThreadStruct>
+    m_CorrelationGetValueAndDerivativePerThreadVariables;
 };
 
 } // end namespace itk

--- a/Components/Metrics/AdvancedNormalizedCorrelation/itkAdvancedNormalizedCorrelationImageToImageMetric.hxx
+++ b/Components/Metrics/AdvancedNormalizedCorrelation/itkAdvancedNormalizedCorrelationImageToImageMetric.hxx
@@ -41,23 +41,7 @@ AdvancedNormalizedCorrelationImageToImageMetric<TFixedImage,
   this->SetUseFixedImageLimiter(false);
   this->SetUseMovingImageLimiter(false);
 
-  // Multi-threading structs
-  this->m_CorrelationGetValueAndDerivativePerThreadVariables = nullptr;
-  this->m_CorrelationGetValueAndDerivativePerThreadVariablesSize = 0;
-
 } // end Constructor
-
-
-/**
- * ******************* Destructor *******************
- */
-
-template <class TFixedImage, class TMovingImage>
-AdvancedNormalizedCorrelationImageToImageMetric<TFixedImage,
-                                                TMovingImage>::~AdvancedNormalizedCorrelationImageToImageMetric()
-{
-  delete[] this->m_CorrelationGetValueAndDerivativePerThreadVariables;
-} // end Destructor
 
 
 /**
@@ -78,34 +62,26 @@ AdvancedNormalizedCorrelationImageToImageMetric<TFixedImage, TMovingImage>::Init
    */
 
   /** Only resize the array of structs when needed. */
-  if (this->m_CorrelationGetValueAndDerivativePerThreadVariablesSize != numberOfThreads)
-  {
-    delete[] this->m_CorrelationGetValueAndDerivativePerThreadVariables;
-    this->m_CorrelationGetValueAndDerivativePerThreadVariables =
-      new AlignedCorrelationGetValueAndDerivativePerThreadStruct[numberOfThreads];
-    this->m_CorrelationGetValueAndDerivativePerThreadVariablesSize = numberOfThreads;
-  }
+  m_CorrelationGetValueAndDerivativePerThreadVariables.resize(numberOfThreads);
 
   /** Some initialization. */
   const AccumulateType      zero1 = NumericTraits<AccumulateType>::Zero;
   const DerivativeValueType zero2 = NumericTraits<DerivativeValueType>::Zero;
   const auto                numberOfParameters = this->GetNumberOfParameters();
-  for (ThreadIdType i = 0; i < numberOfThreads; ++i)
+  for (auto & perThreadVariable : m_CorrelationGetValueAndDerivativePerThreadVariables)
   {
-    this->m_CorrelationGetValueAndDerivativePerThreadVariables[i].st_NumberOfPixelsCounted =
-      NumericTraits<SizeValueType>::Zero;
-    this->m_CorrelationGetValueAndDerivativePerThreadVariables[i].st_Sff = zero1;
-    this->m_CorrelationGetValueAndDerivativePerThreadVariables[i].st_Smm = zero1;
-    this->m_CorrelationGetValueAndDerivativePerThreadVariables[i].st_Sfm = zero1;
-    this->m_CorrelationGetValueAndDerivativePerThreadVariables[i].st_Sf = zero1;
-    this->m_CorrelationGetValueAndDerivativePerThreadVariables[i].st_Sm = zero1;
-    this->m_CorrelationGetValueAndDerivativePerThreadVariables[i].st_DerivativeF.SetSize(numberOfParameters);
-    this->m_CorrelationGetValueAndDerivativePerThreadVariables[i].st_DerivativeM.SetSize(numberOfParameters);
-    this->m_CorrelationGetValueAndDerivativePerThreadVariables[i].st_Differential.SetSize(
-      this->GetNumberOfParameters());
-    this->m_CorrelationGetValueAndDerivativePerThreadVariables[i].st_DerivativeF.Fill(zero2);
-    this->m_CorrelationGetValueAndDerivativePerThreadVariables[i].st_DerivativeM.Fill(zero2);
-    this->m_CorrelationGetValueAndDerivativePerThreadVariables[i].st_Differential.Fill(zero2);
+    perThreadVariable.st_NumberOfPixelsCounted = NumericTraits<SizeValueType>::Zero;
+    perThreadVariable.st_Sff = zero1;
+    perThreadVariable.st_Smm = zero1;
+    perThreadVariable.st_Sfm = zero1;
+    perThreadVariable.st_Sf = zero1;
+    perThreadVariable.st_Sm = zero1;
+    perThreadVariable.st_DerivativeF.SetSize(numberOfParameters);
+    perThreadVariable.st_DerivativeM.SetSize(numberOfParameters);
+    perThreadVariable.st_Differential.SetSize(this->GetNumberOfParameters());
+    perThreadVariable.st_DerivativeF.Fill(zero2);
+    perThreadVariable.st_DerivativeM.Fill(zero2);
+    perThreadVariable.st_Differential.Fill(zero2);
   }
 
 } // end InitializeThreadingParameters()

--- a/Components/Metrics/PCAMetric/itkPCAMetric_F_multithreaded.h
+++ b/Components/Metrics/PCAMetric/itkPCAMetric_F_multithreaded.h
@@ -24,6 +24,7 @@
 #include "itkImageRandomCoordinateSampler.h"
 #include "itkNearestNeighborInterpolateImageFunction.h"
 #include "itkExtractImageFilter.h"
+#include <vector>
 
 namespace itk
 {
@@ -135,7 +136,7 @@ public:
 
 protected:
   PCAMetric();
-  ~PCAMetric() override;
+  ~PCAMetric() override = default;
   void
   PrintSelf(std::ostream & os, Indent indent) const override;
 
@@ -221,8 +222,7 @@ private:
                     PaddedPCAMetricGetSamplesPerThreadStruct,
                     AlignedPCAMetricGetSamplesPerThreadStruct);
 
-  mutable AlignedPCAMetricGetSamplesPerThreadStruct * m_PCAMetricGetSamplesPerThreadVariables;
-  mutable ThreadIdType                                m_PCAMetricGetSamplesPerThreadVariablesSize;
+  mutable std::vector<AlignedPCAMetricGetSamplesPerThreadStruct> m_PCAMetricGetSamplesPerThreadVariables;
 
   unsigned int m_G;
   unsigned int m_LastDimIndex;

--- a/Components/Metrics/PCAMetric/itkPCAMetric_F_multithreaded.hxx
+++ b/Components/Metrics/PCAMetric/itkPCAMetric_F_multithreaded.hxx
@@ -46,24 +46,9 @@ PCAMetric<TFixedImage, TMovingImage>::PCAMetric()
   this->SetUseFixedImageLimiter(false);
   this->SetUseMovingImageLimiter(false);
 
-  // Multi-threading structs
-  this->m_PCAMetricGetSamplesPerThreadVariables = nullptr;
-  this->m_PCAMetricGetSamplesPerThreadVariablesSize = 0;
-
   /** Initialize the m_ParzenWindowHistogramThreaderParameters. */
   this->m_PCAMetricThreaderParameters.m_Metric = this;
 } // end constructor
-
-
-/**
- * ******************* Destructor *******************
- */
-
-template <class TFixedImage, class TMovingImage>
-PCAMetric<TFixedImage, TMovingImage>::~PCAMetric()
-{
-  delete[] this->m_PCAMetricGetSamplesPerThreadVariables;
-} // end Destructor
 
 
 /**
@@ -120,18 +105,13 @@ PCAMetric<TFixedImage, TMovingImage>::InitializeThreadingParameters() const
    */
 
   /** Only resize the array of structs when needed. */
-  if (this->m_PCAMetricGetSamplesPerThreadVariablesSize != numberOfThreads)
-  {
-    delete[] this->m_PCAMetricGetSamplesPerThreadVariables;
-    this->m_PCAMetricGetSamplesPerThreadVariables = new AlignedPCAMetricGetSamplesPerThreadStruct[numberOfThreads];
-    this->m_PCAMetricGetSamplesPerThreadVariablesSize = numberOfThreads;
-  }
+  m_PCAMetricGetSamplesPerThreadVariables.resize(numberOfThreads);
 
   /** Some initialization. */
-  for (ThreadIdType i = 0; i < numberOfThreads; ++i)
+  for (auto & perThreadVariable : m_PCAMetricGetSamplesPerThreadVariables)
   {
-    this->m_PCAMetricGetSamplesPerThreadVariables[i].st_NumberOfPixelsCounted = NumericTraits<SizeValueType>::Zero;
-    this->m_PCAMetricGetSamplesPerThreadVariables[i].st_Derivative.SetSize(this->GetNumberOfParameters());
+    perThreadVariable.st_NumberOfPixelsCounted = NumericTraits<SizeValueType>::Zero;
+    perThreadVariable.st_Derivative.SetSize(this->GetNumberOfParameters());
   }
 
   this->m_PixelStartIndex.resize(numberOfThreads);


### PR DESCRIPTION
Instead of declaring these "PerThreadVariables" data members as raw pointers, of four `Metric` types. Removed the corresponding "PerThreadVariablesSize" data members. Defaulted ( `= default`) their destructors.Replaced `for (ThreadIdType i = 0; i < numberOfThreads; ++i)` loops by range-based for-loops.

Follow-up to pull request https://github.com/SuperElastix/elastix/pull/644 commit 398cea90b14bf00c8d150ad9737f70fe2bcb13e0 "STYLE: Declared `m_ComputePerThreadVariables` as an `std::vector` (2 x)"