### PR TITLE
COMP: Fix OPENCL errors GetInverseMatrix() and GetOffset() (issue #647)

### DIFF
--- a/Common/OpenCL/Filters/itkGPUAdvancedEuler2DTransform.h
+++ b/Common/OpenCL/Filters/itkGPUAdvancedEuler2DTransform.h
@@ -65,13 +65,6 @@ public:
     return this->GetMatrix();
   }
 
-  /** Get CPU inverse matrix of an MatrixOffsetTransformBase. */
-  const CPUInverseMatrixType &
-  GetCPUInverseMatrix() const override
-  {
-    return this->GetInverseMatrix();
-  }
-
   /** Get CPU offset of an MatrixOffsetTransformBase. */
   const CPUOutputVectorType &
   GetCPUOffset() const override

--- a/Common/OpenCL/Filters/itkGPUAdvancedEuler3DTransform.h
+++ b/Common/OpenCL/Filters/itkGPUAdvancedEuler3DTransform.h
@@ -65,13 +65,6 @@ public:
     return this->GetMatrix();
   }
 
-  /** Get CPU inverse matrix of an MatrixOffsetTransformBase. */
-  const CPUInverseMatrixType &
-  GetCPUInverseMatrix() const override
-  {
-    return this->GetInverseMatrix();
-  }
-
   /** Get CPU offset of an MatrixOffsetTransformBase. */
   const CPUOutputVectorType &
   GetCPUOffset() const override

--- a/Common/OpenCL/Filters/itkGPUAdvancedMatrixOffsetTransformBase.h
+++ b/Common/OpenCL/Filters/itkGPUAdvancedMatrixOffsetTransformBase.h
@@ -67,13 +67,6 @@ public:
     return this->GetMatrix();
   }
 
-  /** Get CPU inverse matrix of an MatrixOffsetTransformBase. */
-  const CPUInverseMatrixType &
-  GetCPUInverseMatrix() const override
-  {
-    return this->GetInverseMatrix();
-  }
-
   /** Get CPU offset of an MatrixOffsetTransformBase. */
   const CPUOutputVectorType &
   GetCPUOffset() const override

--- a/Common/OpenCL/Filters/itkGPUAdvancedSimilarity2DTransform.h
+++ b/Common/OpenCL/Filters/itkGPUAdvancedSimilarity2DTransform.h
@@ -65,13 +65,6 @@ public:
     return this->GetMatrix();
   }
 
-  /** Get CPU inverse matrix of an MatrixOffsetTransformBase. */
-  const CPUInverseMatrixType &
-  GetCPUInverseMatrix() const override
-  {
-    return this->GetInverseMatrix();
-  }
-
   /** Get CPU offset of an MatrixOffsetTransformBase. */
   const CPUOutputVectorType &
   GetCPUOffset() const override

--- a/Common/OpenCL/Filters/itkGPUAdvancedSimilarity3DTransform.h
+++ b/Common/OpenCL/Filters/itkGPUAdvancedSimilarity3DTransform.h
@@ -65,13 +65,6 @@ public:
     return this->GetMatrix();
   }
 
-  /** Get CPU inverse matrix of an MatrixOffsetTransformBase. */
-  const CPUInverseMatrixType &
-  GetCPUInverseMatrix() const override
-  {
-    return this->GetInverseMatrix();
-  }
-
   /** Get CPU offset of an MatrixOffsetTransformBase. */
   const CPUOutputVectorType &
   GetCPUOffset() const override

--- a/Common/OpenCL/Filters/itkGPUAffineTransform.h
+++ b/Common/OpenCL/Filters/itkGPUAffineTransform.h
@@ -68,13 +68,6 @@ public:
     return this->GetMatrix();
   }
 
-  /** Get CPU inverse matrix of an MatrixOffsetTransformBase. */
-  virtual const CPUInverseMatrixType &
-  GetCPUInverseMatrix() const
-  {
-    return this->GetInverseMatrix();
-  }
-
   /** Get CPU offset of an MatrixOffsetTransformBase. */
   virtual const CPUOutputVectorType &
   GetCPUOffset() const

--- a/Common/OpenCL/Filters/itkGPUEuler2DTransform.h
+++ b/Common/OpenCL/Filters/itkGPUEuler2DTransform.h
@@ -65,13 +65,6 @@ public:
     return this->GetMatrix();
   }
 
-  /** Get CPU inverse matrix of an MatrixOffsetTransformBase. */
-  virtual const CPUInverseMatrixType &
-  GetCPUInverseMatrix() const
-  {
-    return this->GetInverseMatrix();
-  }
-
   /** Get CPU offset of an MatrixOffsetTransformBase. */
   virtual const CPUOutputVectorType &
   GetCPUOffset() const

--- a/Common/OpenCL/Filters/itkGPUEuler3DTransform.h
+++ b/Common/OpenCL/Filters/itkGPUEuler3DTransform.h
@@ -65,13 +65,6 @@ public:
     return this->GetMatrix();
   }
 
-  /** Get CPU inverse matrix of an MatrixOffsetTransformBase. */
-  virtual const CPUInverseMatrixType &
-  GetCPUInverseMatrix() const
-  {
-    return this->GetInverseMatrix();
-  }
-
   /** Get CPU offset of an MatrixOffsetTransformBase. */
   virtual const CPUOutputVectorType &
   GetCPUOffset() const

--- a/Common/OpenCL/Filters/itkGPUMatrixOffsetTransformBase.h
+++ b/Common/OpenCL/Filters/itkGPUMatrixOffsetTransformBase.h
@@ -75,10 +75,6 @@ public:
   virtual const CPUMatrixType &
   GetCPUMatrix() const = 0;
 
-  /** Get CPU inverse matrix of an MatrixOffsetTransformBase. */
-  virtual const CPUInverseMatrixType &
-  GetCPUInverseMatrix() const = 0;
-
   /** Get CPU offset of an MatrixOffsetTransformBase. */
   virtual const CPUOutputVectorType &
   GetCPUOffset() const = 0;

--- a/Common/OpenCL/Filters/itkGPUMatrixOffsetTransformBase.hxx
+++ b/Common/OpenCL/Filters/itkGPUMatrixOffsetTransformBase.hxx
@@ -235,7 +235,6 @@ GPUMatrixOffsetTransformBase<TScalarType, NInputDimensions, NOutputDimensions>::
       GPUMatrixOffsetTransformBase1D transformBase;
       SetMatrix1<ScalarType>(GetCPUMatrix(), transformBase.matrix, odim, idim);
       SetOffset1<ScalarType>(GetCPUOffset(), transformBase.offset, odim);
-      SetMatrix1<ScalarType>(GetCPUInverseMatrix(), transformBase.inverse_matrix, idim, odim);
       this->m_ParametersDataManager->SetCPUBufferPointer(&transformBase);
     }
     break;
@@ -244,7 +243,6 @@ GPUMatrixOffsetTransformBase<TScalarType, NInputDimensions, NOutputDimensions>::
       GPUMatrixOffsetTransformBase2D transformBase;
       SetMatrix2<ScalarType>(GetCPUMatrix(), transformBase.matrix, odim, idim);
       SetOffset2<ScalarType>(GetCPUOffset(), transformBase.offset, odim);
-      SetMatrix2<ScalarType>(GetCPUInverseMatrix(), transformBase.inverse_matrix, idim, odim);
       this->m_ParametersDataManager->SetCPUBufferPointer(&transformBase);
     }
     break;
@@ -253,7 +251,6 @@ GPUMatrixOffsetTransformBase<TScalarType, NInputDimensions, NOutputDimensions>::
       GPUMatrixOffsetTransformBase3D transformBase;
       SetMatrix3<ScalarType>(GetCPUMatrix(), transformBase.matrix, odim, idim);
       SetOffset3<ScalarType>(GetCPUOffset(), transformBase.offset, odim);
-      SetMatrix3<ScalarType>(GetCPUInverseMatrix(), transformBase.inverse_matrix, idim, odim);
       this->m_ParametersDataManager->SetCPUBufferPointer(&transformBase);
     }
     break;

--- a/Common/OpenCL/Filters/itkGPUSimilarity2DTransform.h
+++ b/Common/OpenCL/Filters/itkGPUSimilarity2DTransform.h
@@ -65,13 +65,6 @@ public:
     return this->GetMatrix();
   }
 
-  /** Get CPU inverse matrix of an MatrixOffsetTransformBase. */
-  virtual const CPUInverseMatrixType &
-  GetCPUInverseMatrix() const
-  {
-    return this->GetInverseMatrix();
-  }
-
   /** Get CPU offset of an MatrixOffsetTransformBase. */
   virtual const CPUOutputVectorType &
   GetCPUOffset() const

--- a/Common/OpenCL/Filters/itkGPUSimilarity3DTransform.h
+++ b/Common/OpenCL/Filters/itkGPUSimilarity3DTransform.h
@@ -65,13 +65,6 @@ public:
     return this->GetMatrix();
   }
 
-  /** Get CPU inverse matrix of an MatrixOffsetTransformBase. */
-  virtual const CPUInverseMatrixType &
-  GetCPUInverseMatrix() const
-  {
-    return this->GetInverseMatrix();
-  }
-
   /** Get CPU offset of an MatrixOffsetTransformBase. */
   virtual const CPUOutputVectorType &
   GetCPUOffset() const

--- a/Common/OpenCL/Kernels/GPUMatrixOffsetTransformBase.cl
+++ b/Common/OpenCL/Kernels/GPUMatrixOffsetTransformBase.cl
@@ -29,7 +29,6 @@
 #ifdef DIM_1
 typedef struct {
   float matrix;
-  float inverse_matrix;
   float offset;
 } GPUMatrixOffsetTransformBase1D;
 #endif // DIM_1
@@ -37,7 +36,6 @@ typedef struct {
 #ifdef DIM_2
 typedef struct {
   float4 matrix;
-  float4 inverse_matrix;
   float2 offset;
 } GPUMatrixOffsetTransformBase2D;
 #endif // DIM_2
@@ -45,7 +43,6 @@ typedef struct {
 #ifdef DIM_3
 typedef struct {
   float16 matrix;         // OpenCL does not have float9
-  float16 inverse_matrix; // OpenCL does not have float9
   float3  offset;
 } GPUMatrixOffsetTransformBase3D;
 #endif // DIM_3

--- a/Common/Transforms/itkAdvancedMatrixOffsetTransformBase.h
+++ b/Common/Transforms/itkAdvancedMatrixOffsetTransformBase.h
@@ -412,6 +412,18 @@ protected:
   virtual void
   ComputeOffset();
 
+  /** Get offset of an AdvancedMatrixOffsetTransformBase
+   *
+   * This method returns the offset value of the AdvancedMatrixOffsetTransformBase.
+   * To define an affine transform, you must set the matrix,
+   * center, and translation OR the matrix and offset.
+   */
+  const OutputVectorType &
+  GetOffset() const
+  {
+    return this->m_Offset;
+  }
+
   /** (spatial) Jacobians and Hessians can mostly be precomputed by this transform.
    * Store them in these member variables.
    * SpatialJacobian is simply m_Matrix */


### PR DESCRIPTION
Addressed the compile errors reported by Georg Walther (@georg-walther), issue #647 "[GPU] Compilation fails with ELASTIX_USE_OPENCL: ON", including:

> error: ‘GetInverseMatrix()’ is private within this context
> error: ‘GPUAdvancedEuler3DTransform’ has no member named ‘GetOffset’

`GetInverseMatrix()` was used only to pass the inverse matrix to the `inverse_matrix` data members of `GPUMatrixOffsetTransformBase` (the OpenCL implementation), but these data members were never actually used, so they could simply be removed. All `GetCPUInverseMatrix()` member functions then also appeared unnecessary.

`AdvancedMatrixOffsetTransformBase::GetOffset()` needed to be restored (albeit only `protected`), as it was removed by pull request https://github.com/SuperElastix/elastix/pull/544 commit 15a3c3f07669fa811fc5896b9b01863a33c4b73b "STYLE: Remove unused AdvancedMatrixOffsetTransformBase member functions", October 29, 2021.

With help from Denis P. Shamonin (@dpshamonin).