### PR TITLE
Install ElastixTargets.cmake file

### DIFF
--- a/CMake/elastixExportTarget.cmake
+++ b/CMake/elastixExportTarget.cmake
@@ -27,5 +27,12 @@ function(elastix_export_target tgt)
 
   export(TARGETS ${tgt}
     APPEND FILE "${elastix_BINARY_DIR}/ElastixTargets.cmake"
-  )
+    )
+
+  install(TARGETS ${tgt}
+    EXPORT ElastixTargets
+    RUNTIME DESTINATION ${ELASTIX_INSTALL_RUNTIME_DIR}
+    LIBRARY DESTINATION ${ELASTIX_INSTALL_LIBRARY_DIR}
+    ARCHIVE DESTINATION ${ELASTIX_INSTALL_ARCHIVE_DIR}
+    )
 endfunction()

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -197,6 +197,9 @@ set( ELASTIX_LIBRARY_DIR "lib"      CACHE STRING
   "Directory for installing library files; path is relative to CMAKE_INSTALL_PREFIX" )
 set( ELASTIX_RUNTIME_DIR "bin"      CACHE STRING
   "Directory for installing runtime files; path is relative to CMAKE_INSTALL_PREFIX" )
+if(NOT ELASTIX_INSTALL_PACKAGE_DIR)
+  set(ELASTIX_INSTALL_PACKAGE_DIR "${ELASTIX_LIBRARY_DIR}/cmake/elastix")
+endif()
 
 #---------------------------------------------------------------------
 # Check if Mevis DicomTiff support is desired
@@ -598,15 +601,30 @@ endforeach()
 string(REPLACE "\\" "/" ELASTIX_ITK_DIR ${ITK_DIR})
 
 # Create the Config.cmake file for the build tree:
+set(ElastixConfig_TREE "build")
+set(ElastixConfig_CODE "if( NOT DEFINED ITK_DIR)
+  set(ITK_DIR \"${ELASTIX_ITK_DIR}\")
+endif()
+")
 set(ELX_CONFIG_INCLUDE_DIRECTORIES "${elxINCLUDE_DIRECTORIES}")
 configure_file( ElastixConfig.cmake.in ElastixConfig.cmake @ONLY )
 
 # Create the Config.cmake file for the install tree:
-set(ELX_CONFIG_INCLUDE_DIRECTORIES "\${CMAKE_CURRENT_LIST_DIR}/../../../include")
+set(ElastixConfig_TREE "install")
+set(ElastixConfig_CODE "set(Elastix_INSTALL_PREFIX \"\${_ELASTIXConfig_DIR}\")")
+# Construct the proper number of get_filename_component(... PATH)
+# calls to compute the installation prefix.
+string(REGEX REPLACE "/" ";" _count "${ELASTIX_INSTALL_PACKAGE_DIR}")
+foreach(p ${_count})
+  set(ElastixConfig_CODE "${ElastixConfig_CODE}
+get_filename_component(Elastix_INSTALL_PREFIX \"\${Elastix_INSTALL_PREFIX}\" PATH)")
+endforeach(p)
+
+set(ELX_CONFIG_INCLUDE_DIRECTORIES "\${Elastix_INSTALL_PREFIX}/include")
 foreach( ELX_INCLUDE_DIR IN ITEMS ${elxINCLUDE_DIRECTORIES} )
   if (NOT ELX_INCLUDE_DIR STREQUAL CMAKE_BINARY_DIR)
     string(REPLACE ${CMAKE_SOURCE_DIR} "" ELX_INCLUDE_DIR ${ELX_INCLUDE_DIR})
-    list(APPEND ELX_CONFIG_INCLUDE_DIRECTORIES "\${CMAKE_CURRENT_LIST_DIR}/../../../include${ELX_INCLUDE_DIR}")
+    list(APPEND ELX_CONFIG_INCLUDE_DIRECTORIES "\${Elastix_INSTALL_PREFIX}/include${ELX_INCLUDE_DIR}")
   endif()
 endforeach()
 
@@ -621,4 +639,11 @@ install(FILES
   "${PROJECT_BINARY_DIR}${CMAKE_FILES_DIRECTORY}/ElastixConfig.cmake"
   "${PROJECT_BINARY_DIR}/ElastixConfigVersion.cmake"
   "${PROJECT_BINARY_DIR}/UseElastix.cmake"
-  DESTINATION lib/cmake/elastix)
+  DESTINATION ${ELASTIX_INSTALL_PACKAGE_DIR}
+  COMPONENT Development
+  )
+
+install(EXPORT ElastixTargets
+  DESTINATION ${ELASTIX_INSTALL_PACKAGE_DIR}
+  COMPONENT Development
+  )

--- a/ElastixConfig.cmake.in
+++ b/ElastixConfig.cmake.in
@@ -1,29 +1,47 @@
-set( Elastix_DIR @PROJECT_BINARY_DIR@ )
+# ElastixConfig.cmake - Elastix CMake configuration file for external
+# projects.
+#
+
+# This ElastixConfig file is  configured for the @ElastixConfig_TREE@
+# tree.
+
+# Compute this installation's prefix from this file's location:
+get_filename_component(_ELASTIXConfig_DIR "${CMAKE_CURRENT_LIST_FILE}" PATH)
+@ElastixConfig_CODE@
 
 # Add include directories needed to use SuperElastix
 set( ELASTIX_INCLUDE_DIRS @ELX_CONFIG_INCLUDE_DIRECTORIES@ )
 
 # Add list of Elastix library directories
-set( ELASTIX_LIBRARY_DIRS @LIBRARY_OUTPUT_PATH@ )
+set( ELASTIX_LIBRARY_DIRS "${Elastix_INSTALL_PREFIX}/@ELASTIX_LIBRARY_DIR@" )
 
 # Add list of SuperElastix libraries
 set( ELASTIX_LIBRARIES @ELASTIX_LIBRARIES@ )
 
 # The location of the Elastix use-file
-set( ELASTIX_USE_FILE "${Elastix_DIR}/UseElastix.cmake" )
+set( ELASTIX_USE_FILE "${_ELASTIXConfig_DIR}/UseElastix.cmake" )
 
-set( ELASTIX_CONFIG_TARGETS_FILE "${Elastix_DIR}/ElastixTargets.cmake" )
+if(NOT ITK_CONFIG_TARGETS_FILE)
+  find_package(ITK "@ITK_VERSION@" EXACT REQUIRED)
+endif()
+
+
+# Import ELASTIX targets.
+set( ELASTIX_CONFIG_TARGETS_FILE "${_ELASTIXConfig_DIR}/ElastixTargets.cmake")
+if(NOT ELASTIX_TARGETS_IMPORTED)
+  set(ELASTIX_TARGETS_IMPORTED 1)
+  include("${ELASTIX_CONFIG_TARGETS_FILE}")
+endif()
+
 
 # Set some variables that the user might want to use
 set( ELASTIX_USE_OPENMP @ELASTIX_USE_OPENMP@ )
 set( ELASTIX_USE_OPENCL @ELASTIX_USE_OPENCL@ )
 set( ELASTIX_USE_MEVISDICOMTIFF @ELASTIX_USE_MEVISDICOMTIFF@ )
+
+# FIXME - These variable refer to the source and build directories
 set( ELASTIX_DOX_DIR @ELASTIX_DOX_DIR@ )
 set( ELASTIX_HELP_DIR @ELASTIX_HELP_DIR@ )
-
-if (NOT "@ELASTIX_ITK_DIR@" EQUAL "")
-  set( ELASTIX_ITK_DIR @ELASTIX_ITK_DIR@ )
-endif()
 
 # Maintain backwards compatibility by also exporting old-style target information
 set( ELASTIX_ALL_COMPONENT_LIBS @AllComponentLibs@ )


### PR DESCRIPTION
Created variables in ElastixConfig.cmake to specify installation path
and build path uniformly.