### PR TITLE
STYLE: Pass parameters of fundamental types by value, not by `const` ref

### DIFF
--- a/Common/CostFunctions/itkParzenWindowHistogramImageToImageMetric.h
+++ b/Common/CostFunctions/itkParzenWindowHistogramImageToImageMetric.h
@@ -369,21 +369,19 @@ protected:
                             const NonZeroJacobianIndicesType & nzji) const;
 
   /** Multiply the pdf entries by the given normalization factor. */
-  virtual void
-  NormalizeJointPDF(JointPDFType * pdf, const double & factor) const;
+  void
+  NormalizeJointPDF(JointPDFType * pdf, const double factor) const;
 
   /** Multiply the pdf derivatives entries by the given normalization factor. */
-  virtual void
-  NormalizeJointPDFDerivatives(JointPDFDerivativesType * pdf, const double & factor) const;
+  void
+  NormalizeJointPDFDerivatives(JointPDFDerivativesType * pdf, const double factor) const;
 
   /** Compute marginal pdfs by summing over the joint pdf
    * direction = 0: fixed marginal pdf
    * direction = 1: moving marginal pdf
    */
-  virtual void
-  ComputeMarginalPDF(const JointPDFType * jointPDF,
-                     MarginalPDFType &    marginalPDF,
-                     const unsigned int & direction) const;
+  void
+  ComputeMarginalPDF(const JointPDFType * jointPDF, MarginalPDFType & marginalPDF, const unsigned int direction) const;
 
   /** Compute incremental marginal pdfs. Integrates the incremental PDF
    * to obtain the fixed and moving marginal pdfs at once.

--- a/Common/CostFunctions/itkParzenWindowHistogramImageToImageMetric.hxx
+++ b/Common/CostFunctions/itkParzenWindowHistogramImageToImageMetric.hxx
@@ -665,7 +665,7 @@ ParzenWindowHistogramImageToImageMetric<TFixedImage, TMovingImage>::UpdateJointP
 template <class TFixedImage, class TMovingImage>
 void
 ParzenWindowHistogramImageToImageMetric<TFixedImage, TMovingImage>::NormalizeJointPDF(JointPDFType * pdf,
-                                                                                      const double & factor) const
+                                                                                      const double   factor) const
 {
   using JointPDFIteratorType = ImageScanlineIterator<JointPDFType>;
   JointPDFIteratorType it(pdf, pdf->GetBufferedRegion());
@@ -691,7 +691,7 @@ template <class TFixedImage, class TMovingImage>
 void
 ParzenWindowHistogramImageToImageMetric<TFixedImage, TMovingImage>::NormalizeJointPDFDerivatives(
   JointPDFDerivativesType * pdf,
-  const double &            factor) const
+  const double              factor) const
 {
   using JointPDFDerivativesIteratorType = ImageScanlineIterator<JointPDFDerivativesType>;
   JointPDFDerivativesIteratorType it(pdf, pdf->GetBufferedRegion());
@@ -718,7 +718,7 @@ void
 ParzenWindowHistogramImageToImageMetric<TFixedImage, TMovingImage>::ComputeMarginalPDF(
   const JointPDFType * itkNotUsed(jointPDF),
   MarginalPDFType &    marginalPDF,
-  const unsigned int & direction) const
+  const unsigned int   direction) const
 {
   using JointPDFLinearIterator = ImageLinearIteratorWithIndex<JointPDFType>;
   // \todo: bug? shouldn't this be over the function argument jointPDF ?

--- a/Common/LineSearchOptimizers/itkMoreThuenteLineSearchOptimizer.cxx
+++ b/Common/LineSearchOptimizers/itkMoreThuenteLineSearchOptimizer.cxx
@@ -575,18 +575,18 @@ MoreThuenteLineSearchOptimizer::ForceSufficientDecreaseInIntervalWidth()
  */
 
 int
-MoreThuenteLineSearchOptimizer::SafeGuardedStep(double &       stx,
-                                                double &       fx,
-                                                double &       dx,
-                                                double &       sty,
-                                                double &       fy,
-                                                double &       dy,
-                                                double &       stp,
-                                                const double & fp,
-                                                const double & dp,
-                                                bool &         brackt,
-                                                const double & stpmin,
-                                                const double & stpmax) const
+MoreThuenteLineSearchOptimizer::SafeGuardedStep(double &     stx,
+                                                double &     fx,
+                                                double &     dx,
+                                                double &     sty,
+                                                double &     fy,
+                                                double &     dy,
+                                                double &     stp,
+                                                const double fp,
+                                                const double dp,
+                                                bool &       brackt,
+                                                const double stpmin,
+                                                const double stpmax) const
 {
   /** This function is largely just a copy of the following function
    * taken from netlib/lbfgs.c */

--- a/Common/LineSearchOptimizers/itkMoreThuenteLineSearchOptimizer.h
+++ b/Common/LineSearchOptimizers/itkMoreThuenteLineSearchOptimizer.h
@@ -233,18 +233,18 @@ protected:
    * the interval of uncertainty.
    */
   virtual int
-  SafeGuardedStep(double &       stx,
-                  double &       fx,
-                  double &       dx,
-                  double &       sty,
-                  double &       fy,
-                  double &       dy,
-                  double &       stp,
-                  const double & fp,
-                  const double & dp,
-                  bool &         brackt,
-                  const double & stpmin,
-                  const double & stpmax) const;
+  SafeGuardedStep(double &     stx,
+                  double &     fx,
+                  double &     dx,
+                  double &     sty,
+                  double &     fy,
+                  double &     dy,
+                  double &     stp,
+                  const double fp,
+                  const double dp,
+                  bool &       brackt,
+                  const double stpmin,
+                  const double stpmax) const;
 
   double m_step;
   double m_stepx;

--- a/Common/Transforms/itkBSplineDerivativeKernelFunction2.h
+++ b/Common/Transforms/itkBSplineDerivativeKernelFunction2.h
@@ -134,7 +134,7 @@ private:
 
   /** First order spline */
   inline static double
-  Evaluate(const Dispatch<1> &, const double & u)
+  Evaluate(const Dispatch<1> &, const double u)
   {
     const double absValue = std::abs(u);
 
@@ -154,7 +154,7 @@ private:
 
 
   inline static void
-  Evaluate(const Dispatch<1> &, const double & u, double * weights)
+  Evaluate(const Dispatch<1> &, const double u, double * weights)
   {
     // MS \todo: check
     const double absValue = std::abs(u);
@@ -179,7 +179,7 @@ private:
 
   /** Second order spline. */
   inline static double
-  Evaluate(const Dispatch<2> &, const double & u)
+  Evaluate(const Dispatch<2> &, const double u)
   {
     double absValue = std::abs(u);
 
@@ -199,7 +199,7 @@ private:
 
 
   inline static void
-  Evaluate(const Dispatch<2> &, const double & u, double * weights)
+  Evaluate(const Dispatch<2> &, const double u, double * weights)
   {
     // MS \todo: check
     weights[0] = u - 1.5;
@@ -210,7 +210,7 @@ private:
 
   /**  Third order spline. */
   inline static double
-  Evaluate(const Dispatch<3> &, const double & u)
+  Evaluate(const Dispatch<3> &, const double u)
   {
     const double absValue = std::abs(u);
     const double sqrValue = u * u;
@@ -249,7 +249,7 @@ private:
 
 
   inline static void
-  Evaluate(const Dispatch<3> &, const double & u, double * weights)
+  Evaluate(const Dispatch<3> &, const double u, double * weights)
   {
     const double absValue = std::abs(u);
     const double sqrValue = u * u;

--- a/Common/Transforms/itkBSplineKernelFunction2.h
+++ b/Common/Transforms/itkBSplineKernelFunction2.h
@@ -141,7 +141,7 @@ private:
 
   /** Zeroth order spline. */
   inline static double
-  Evaluate(const Dispatch<0> &, const double & u)
+  Evaluate(const Dispatch<0> &, const double u)
   {
     const double absValue = std::abs(u);
 
@@ -162,7 +162,7 @@ private:
 
   /** First order spline */
   inline static double
-  Evaluate(const Dispatch<1> &, const double & u)
+  Evaluate(const Dispatch<1> &, const double u)
   {
     const double absValue = std::abs(u);
 
@@ -179,7 +179,7 @@ private:
 
   /** Second order spline. */
   inline static double
-  Evaluate(const Dispatch<2> &, const double & u)
+  Evaluate(const Dispatch<2> &, const double u)
   {
     const double absValue = std::abs(u);
 
@@ -200,7 +200,7 @@ private:
 
   /** Third order spline. */
   inline static double
-  Evaluate(const Dispatch<3> &, const double & u)
+  Evaluate(const Dispatch<3> &, const double u)
   {
     const double absValue = std::abs(u);
     const double sqrValue = u * u;
@@ -226,7 +226,7 @@ private:
 
   /** Zeroth order spline. */
   inline static void
-  Evaluate(const Dispatch<0> &, const double & u, double * weights)
+  Evaluate(const Dispatch<0> &, const double u, double * weights)
   {
     const double absValue = std::abs(u);
 
@@ -247,7 +247,7 @@ private:
 
   /** First order spline */
   inline static void
-  Evaluate(const Dispatch<1> &, const double & u, double * weights)
+  Evaluate(const Dispatch<1> &, const double u, double * weights)
   {
     const double absValue = std::abs(u);
 
@@ -258,7 +258,7 @@ private:
 
   /** Second order spline. */
   inline static void
-  Evaluate(const Dispatch<2> &, const double & u, double * weights)
+  Evaluate(const Dispatch<2> &, const double u, double * weights)
   {
     const double absValue = std::abs(u);
     const double sqrValue = u * u;
@@ -271,7 +271,7 @@ private:
 
   /**  Third order spline. */
   inline static void
-  Evaluate(const Dispatch<3> &, const double & u, double * weights)
+  Evaluate(const Dispatch<3> &, const double u, double * weights)
   {
     const double absValue = std::abs(u);
     const double sqrValue = u * u;

--- a/Common/Transforms/itkBSplineSecondOrderDerivativeKernelFunction2.h
+++ b/Common/Transforms/itkBSplineSecondOrderDerivativeKernelFunction2.h
@@ -86,7 +86,7 @@ public:
 
   /** Evaluate the function. */
   inline void
-  Evaluate(const double & u, double * weights) const
+  Evaluate(const double u, double * weights) const
   {
     Self::FastEvaluate(u, weights);
   }
@@ -124,7 +124,7 @@ private:
 
   /** Second order spline. */
   inline static double
-  Evaluate(const Dispatch<2> &, const double & u)
+  Evaluate(const Dispatch<2> &, const double u)
   {
     double absValue = std::abs(u);
 
@@ -152,7 +152,7 @@ private:
 
 
   inline static void
-  Evaluate(const Dispatch<2> &, const double & u, double * weights)
+  Evaluate(const Dispatch<2> &, const double u, double * weights)
   {
     weights[0] = 1.0;
     weights[1] = -2.0;
@@ -162,7 +162,7 @@ private:
 
   /**  Third order spline. */
   inline static double
-  Evaluate(const Dispatch<3> &, const double & u)
+  Evaluate(const Dispatch<3> &, const double u)
   {
     const double absValue = std::abs(u);
 
@@ -182,7 +182,7 @@ private:
 
 
   inline static void
-  Evaluate(const Dispatch<3> &, const double & u, double * weights)
+  Evaluate(const Dispatch<3> &, const double u, double * weights)
   {
     weights[0] = -u + 2.0;
     weights[1] = 3.0 * u - 5.0;
@@ -193,14 +193,14 @@ private:
 
   /** Unimplemented spline order */
   inline static double
-  Evaluate(const DispatchBase &, const double &)
+  Evaluate(const DispatchBase &, const double)
   {
     itkGenericExceptionMacro("Evaluate not implemented for spline order " << SplineOrder);
   }
 
 
   inline static void
-  Evaluate(const DispatchBase &, const double &, double *)
+  Evaluate(const DispatchBase &, const double, double *)
   {
     itkGenericExceptionMacro("Evaluate not implemented for spline order " << SplineOrder);
   }

--- a/Common/itkComputePreconditionerUsingDisplacementDistribution.h
+++ b/Common/itkComputePreconditionerUsingDisplacementDistribution.h
@@ -98,11 +98,8 @@ public:
   /** The main function that performs the computation.
    * B-spline specific thing we tried. Can be removed later.
    */
-  virtual void
-  ComputeForBSplineOnly(const ParametersType & mu,
-                        const double &         delta,
-                        double &               maxJJ,
-                        ParametersType &       preconditioner);
+  void
+  ComputeForBSplineOnly(const ParametersType & mu, const double delta, double & maxJJ, ParametersType & preconditioner);
 
   /** The main function that performs the computation.
    * The aims to be a generic function, working for all transformations.

--- a/Common/itkComputePreconditionerUsingDisplacementDistribution.hxx
+++ b/Common/itkComputePreconditionerUsingDisplacementDistribution.hxx
@@ -87,7 +87,7 @@ template <class TFixedImage, class TTransform>
 void
 ComputePreconditionerUsingDisplacementDistribution<TFixedImage, TTransform>::ComputeForBSplineOnly(
   const ParametersType & mu,
-  const double &         delta,
+  const double           delta,
   double &               maxJJ,
   ParametersType &       preconditioner)
 {

--- a/Components/Metrics/KNNGraphAlphaMutualInformation/itkKNNGraphAlphaMutualInformationImageToImageMetric.h
+++ b/Components/Metrics/KNNGraphAlphaMutualInformation/itkKNNGraphAlphaMutualInformationImageToImageMetric.h
@@ -302,11 +302,11 @@ private:
    * - The sparse Jacobian of the transformation (dT/dmu).
    * - The spatial derivatives of the moving (feature) images (dm/dx).
    */
-  virtual void
+  void
   ComputeListSampleValuesAndDerivativePlusJacobian(const ListSamplePointer &               listSampleFixed,
                                                    const ListSamplePointer &               listSampleMoving,
                                                    const ListSamplePointer &               listSampleJoint,
-                                                   const bool &                            doDerivative,
+                                                   const bool                              doDerivative,
                                                    TransformJacobianContainerType &        jacobians,
                                                    TransformJacobianIndicesContainerType & jacobiansIndices,
                                                    SpatialDerivativeContainerType &        spatialDerivatives) const;

--- a/Components/Metrics/KNNGraphAlphaMutualInformation/itkKNNGraphAlphaMutualInformationImageToImageMetric.hxx
+++ b/Components/Metrics/KNNGraphAlphaMutualInformation/itkKNNGraphAlphaMutualInformationImageToImageMetric.hxx
@@ -734,7 +734,7 @@ KNNGraphAlphaMutualInformationImageToImageMetric<TFixedImage, TMovingImage>::
   ComputeListSampleValuesAndDerivativePlusJacobian(const ListSamplePointer &               listSampleFixed,
                                                    const ListSamplePointer &               listSampleMoving,
                                                    const ListSamplePointer &               listSampleJoint,
-                                                   const bool &                            doDerivative,
+                                                   const bool                              doDerivative,
                                                    TransformJacobianContainerType &        jacobianContainer,
                                                    TransformJacobianIndicesContainerType & jacobianIndicesContainer,
                                                    SpatialDerivativeContainerType & spatialDerivativesContainer) const

--- a/Components/Transforms/SplineKernelTransform/elxSplineKernelTransform.h
+++ b/Components/Transforms/SplineKernelTransform/elxSplineKernelTransform.h
@@ -228,10 +228,8 @@ protected:
   DetermineTargetLandmarks();
 
   /** General function to read all landmarks. */
-  virtual void
-  ReadLandmarkFile(const std::string & filename,
-                   PointSetPointer &   landmarkPointSet,
-                   const bool &        landmarksInFixedImage);
+  void
+  ReadLandmarkFile(const std::string & filename, PointSetPointer & landmarkPointSet, const bool landmarksInFixedImage);
 
   /** The itk kernel transform. */
   KernelTransformPointer m_KernelTransform;

--- a/Components/Transforms/SplineKernelTransform/elxSplineKernelTransform.hxx
+++ b/Components/Transforms/SplineKernelTransform/elxSplineKernelTransform.hxx
@@ -283,7 +283,7 @@ template <class TElastix>
 void
 SplineKernelTransform<TElastix>::ReadLandmarkFile(const std::string & filename,
                                                   PointSetPointer &   landmarkPointSet,
-                                                  const bool &        landmarksInFixedImage)
+                                                  const bool          landmarksInFixedImage)
 {
   /** Typedef's. */
   using IndexType = typename FixedImageType::IndexType;

--- a/Core/ComponentBaseClasses/elxFixedImagePyramidBase.h
+++ b/Core/ComponentBaseClasses/elxFixedImagePyramidBase.h
@@ -112,9 +112,9 @@ public:
   SetFixedSchedule();
 
   /** Method to write the pyramid image. */
-  virtual void
-  WritePyramidImage(const std::string &  filename,
-                    const unsigned int & level); // const;
+  void
+  WritePyramidImage(const std::string & filename,
+                    const unsigned int  level); // const;
 
 protected:
   /** The constructor. */

--- a/Core/ComponentBaseClasses/elxFixedImagePyramidBase.hxx
+++ b/Core/ComponentBaseClasses/elxFixedImagePyramidBase.hxx
@@ -150,8 +150,8 @@ FixedImagePyramidBase<TElastix>::SetFixedSchedule()
 
 template <class TElastix>
 void
-FixedImagePyramidBase<TElastix>::WritePyramidImage(const std::string &  filename,
-                                                   const unsigned int & level) // const
+FixedImagePyramidBase<TElastix>::WritePyramidImage(const std::string & filename,
+                                                   const unsigned int  level) // const
 {
   /** Read output pixeltype from parameter the file. Replace possible " " with "_". */
   std::string resultImagePixelType = "short";

--- a/Core/ComponentBaseClasses/elxMovingImagePyramidBase.h
+++ b/Core/ComponentBaseClasses/elxMovingImagePyramidBase.h
@@ -114,9 +114,9 @@ public:
   SetMovingSchedule();
 
   /** Method to write the pyramid image. */
-  virtual void
-  WritePyramidImage(const std::string &  filename,
-                    const unsigned int & level); // const;
+  void
+  WritePyramidImage(const std::string & filename,
+                    const unsigned int  level); // const;
 
 protected:
   /** The constructor. */

--- a/Core/ComponentBaseClasses/elxMovingImagePyramidBase.hxx
+++ b/Core/ComponentBaseClasses/elxMovingImagePyramidBase.hxx
@@ -153,8 +153,8 @@ MovingImagePyramidBase<TElastix>::SetMovingSchedule()
 
 template <class TElastix>
 void
-MovingImagePyramidBase<TElastix>::WritePyramidImage(const std::string &  filename,
-                                                    const unsigned int & level) // const
+MovingImagePyramidBase<TElastix>::WritePyramidImage(const std::string & filename,
+                                                    const unsigned int  level) // const
 {
   /** Read output pixeltype from parameter the file. Replace possible " " with "_". */
   std::string resultImagePixelType = "short";

--- a/Core/ComponentBaseClasses/elxResamplerBase.h
+++ b/Core/ComponentBaseClasses/elxResamplerBase.h
@@ -181,12 +181,12 @@ public:
   CreateTransformParametersMap(ParameterMapType & parameterMap) const;
 
   /** Function to perform resample and write the result output image to a file. */
-  virtual void
-  ResampleAndWriteResultImage(const char * filename, const bool & showProgress = true);
+  void
+  ResampleAndWriteResultImage(const char * filename, const bool showProgress = true);
 
   /** Function to write the result output image to a file. */
-  virtual void
-  WriteResultImage(OutputImageType * imageimage, const char * filename, const bool & showProgress = true);
+  void
+  WriteResultImage(OutputImageType * imageimage, const char * filename, const bool showProgress = true);
 
   /** Function to create the result image in the format of an itk::Image. */
   virtual void

--- a/Core/ComponentBaseClasses/elxResamplerBase.hxx
+++ b/Core/ComponentBaseClasses/elxResamplerBase.hxx
@@ -294,7 +294,7 @@ ResamplerBase<TElastix>::SetComponents()
 
 template <class TElastix>
 void
-ResamplerBase<TElastix>::ResampleAndWriteResultImage(const char * filename, const bool & showProgress)
+ResamplerBase<TElastix>::ResampleAndWriteResultImage(const char * filename, const bool showProgress)
 {
   /** Make sure the resampler is updated. */
   this->GetAsITKBaseType()->Modified();
@@ -343,7 +343,7 @@ ResamplerBase<TElastix>::ResampleAndWriteResultImage(const char * filename, cons
 
 template <class TElastix>
 void
-ResamplerBase<TElastix>::WriteResultImage(OutputImageType * image, const char * filename, const bool & showProgress)
+ResamplerBase<TElastix>::WriteResultImage(OutputImageType * image, const char * filename, const bool showProgress)
 {
   /** Check if ResampleInterpolator is the RayCastResampleInterpolator  */
   const auto testptr = dynamic_cast<itk::AdvancedRayCastInterpolateImageFunction<InputImageType, CoordRepType> *>(

--- a/Core/ComponentBaseClasses/elxTransformBase.h
+++ b/Core/ComponentBaseClasses/elxTransformBase.h
@@ -288,7 +288,7 @@ protected:
    * \li Scales_i = 1/N sum_x || dT / dmu_i ||^2
    */
   void
-  AutomaticScalesEstimationStackTransform(const unsigned int & numSubTransforms, ScalesType & scales) const;
+  AutomaticScalesEstimationStackTransform(const unsigned int numSubTransforms, ScalesType & scales) const;
 
 private:
   elxDeclarePureVirtualGetSelfMacro(ITKBaseType);

--- a/Core/ComponentBaseClasses/elxTransformBase.hxx
+++ b/Core/ComponentBaseClasses/elxTransformBase.hxx
@@ -1401,8 +1401,8 @@ TransformBase<TElastix>::AutomaticScalesEstimation(ScalesType & scales) const
 
 template <class TElastix>
 void
-TransformBase<TElastix>::AutomaticScalesEstimationStackTransform(const unsigned int & numberOfSubTransforms,
-                                                                 ScalesType &         scales) const
+TransformBase<TElastix>::AutomaticScalesEstimationStackTransform(const unsigned int numberOfSubTransforms,
+                                                                 ScalesType &       scales) const
 {
   using FixedImageRegionType = typename FixedImageType::RegionType;
   using FixedImageIndexType = typename FixedImageType::IndexType;

--- a/Core/Main/elxParameterObject.cxx
+++ b/Core/Main/elxParameterObject.cxx
@@ -44,7 +44,7 @@ ParameterObject::SetParameterMap(const ParameterMapType & parameterMap)
  */
 
 void
-ParameterObject::SetParameterMap(const unsigned int & index, const ParameterMapType & parameterMap)
+ParameterObject::SetParameterMap(const unsigned int index, const ParameterMapType & parameterMap)
 {
   this->m_ParameterMap[index] = parameterMap;
 }
@@ -82,7 +82,7 @@ ParameterObject::AddParameterMap(const ParameterMapType & parameterMap)
  */
 
 const ParameterObject::ParameterMapType &
-ParameterObject::GetParameterMap(const unsigned int & index) const
+ParameterObject::GetParameterMap(const unsigned int index) const
 {
   return this->m_ParameterMap[index];
 }
@@ -93,9 +93,7 @@ ParameterObject::GetParameterMap(const unsigned int & index) const
  */
 
 void
-ParameterObject::SetParameter(const unsigned int &       index,
-                              const ParameterKeyType &   key,
-                              const ParameterValueType & value)
+ParameterObject::SetParameter(const unsigned int index, const ParameterKeyType & key, const ParameterValueType & value)
 {
   this->m_ParameterMap[index][key] = ParameterValueVectorType(1, value);
 }
@@ -106,7 +104,7 @@ ParameterObject::SetParameter(const unsigned int &       index,
  */
 
 void
-ParameterObject::SetParameter(const unsigned int &             index,
+ParameterObject::SetParameter(const unsigned int               index,
                               const ParameterKeyType &         key,
                               const ParameterValueVectorType & value)
 {
@@ -147,7 +145,7 @@ ParameterObject::SetParameter(const ParameterKeyType & key, const ParameterValue
  */
 
 const ParameterObject::ParameterValueVectorType &
-ParameterObject::GetParameter(const unsigned int & index, const ParameterKeyType & key)
+ParameterObject::GetParameter(const unsigned int index, const ParameterKeyType & key)
 {
   return this->m_ParameterMap[index][key];
 }
@@ -158,7 +156,7 @@ ParameterObject::GetParameter(const unsigned int & index, const ParameterKeyType
  */
 
 void
-ParameterObject::RemoveParameter(const unsigned int & index, const ParameterKeyType & key)
+ParameterObject::RemoveParameter(const unsigned int index, const ParameterKeyType & key)
 {
   this->m_ParameterMap[index].erase(key);
 }
@@ -379,9 +377,9 @@ ParameterObject::WriteParameterFile(const ParameterFileNameVectorType & paramete
  */
 
 const ParameterObject::ParameterMapType
-ParameterObject::GetDefaultParameterMap(const std::string &  transformName,
-                                        const unsigned int & numberOfResolutions,
-                                        const double &       finalGridSpacingInPhysicalUnits)
+ParameterObject::GetDefaultParameterMap(const std::string & transformName,
+                                        const unsigned int  numberOfResolutions,
+                                        const double        finalGridSpacingInPhysicalUnits)
 {
   // Parameters that depend on size and number of resolutions
   ParameterMapType parameterMap = ParameterMapType();

--- a/Core/Main/elxParameterObject.h
+++ b/Core/Main/elxParameterObject.h
@@ -56,13 +56,13 @@ public:
   void
   SetParameterMap(const ParameterMapType & parameterMap);
   void
-  SetParameterMap(const unsigned int & index, const ParameterMapType & parameterMap);
+  SetParameterMap(const unsigned int index, const ParameterMapType & parameterMap);
   void
   SetParameterMap(const ParameterMapVectorType & parameterMap);
   void
   AddParameterMap(const ParameterMapType & parameterMap);
   const ParameterMapType &
-  GetParameterMap(const unsigned int & index) const;
+  GetParameterMap(const unsigned int index) const;
   itkGetConstReferenceMacro(ParameterMap, ParameterMapVectorType);
   unsigned int
   GetNumberOfParameterMaps() const
@@ -71,17 +71,17 @@ public:
   }
 
   void
-  SetParameter(const unsigned int & index, const ParameterKeyType & key, const ParameterValueType & value);
+  SetParameter(const unsigned int index, const ParameterKeyType & key, const ParameterValueType & value);
   void
-  SetParameter(const unsigned int & index, const ParameterKeyType & key, const ParameterValueVectorType & value);
+  SetParameter(const unsigned int index, const ParameterKeyType & key, const ParameterValueVectorType & value);
   void
   SetParameter(const ParameterKeyType & key, const ParameterValueType & value);
   void
   SetParameter(const ParameterKeyType & key, const ParameterValueVectorType & value);
   const ParameterValueVectorType &
-  GetParameter(const unsigned int & index, const ParameterKeyType & key);
+  GetParameter(const unsigned int index, const ParameterKeyType & key);
   void
-  RemoveParameter(const unsigned int & index, const ParameterKeyType & key);
+  RemoveParameter(const unsigned int index, const ParameterKeyType & key);
   void
   RemoveParameter(const ParameterKeyType & key);
 
@@ -106,9 +106,9 @@ public:
 
   /* Get preconfigured parameter maps. */
   static const ParameterMapType
-  GetDefaultParameterMap(const std::string &  transformName,
-                         const unsigned int & numberOfResolutions = 4u,
-                         const double &       finalGridSpacingInPhysicalUnits = 10.0);
+  GetDefaultParameterMap(const std::string & transformName,
+                         const unsigned int  numberOfResolutions = 4u,
+                         const double        finalGridSpacingInPhysicalUnits = 10.0);
 
 protected:
   void

--- a/Core/elxProgressCommand.cxx
+++ b/Core/elxProgressCommand.cxx
@@ -179,7 +179,7 @@ ProgressCommand::Execute(const itk::Object * caller, const itk::EventObject & ev
  */
 
 void
-ProgressCommand::PrintProgress(const float & progress) const
+ProgressCommand::PrintProgress(const float progress) const
 {
   /** Print the progress to the screen. */
   const int progressInt = itk::Math::Round<float>(100 * progress);
@@ -200,7 +200,7 @@ ProgressCommand::PrintProgress(const float & progress) const
  */
 
 void
-ProgressCommand::UpdateAndPrintProgress(const unsigned long & currentVoxelNumber) const
+ProgressCommand::UpdateAndPrintProgress(const unsigned long currentVoxelNumber) const
 {
   if (this->m_StreamOutputIsConsole)
   {

--- a/Core/elxProgressCommand.h
+++ b/Core/elxProgressCommand.h
@@ -126,16 +126,16 @@ public:
   /** Print the progress to screen. A float value between 0.0 and 1.0
    * is expected as input.
    */
-  virtual void
-  PrintProgress(const float & progress) const;
+  void
+  PrintProgress(const float progress) const;
 
   /** Update and possibly print the progress to screen.
    * The progress information on screen is refreshed according to the
    * UpdateFrequency, which is assumed being specified beforehand using the
    * SetUpdateFrequency function.
    */
-  virtual void
-  UpdateAndPrintProgress(const unsigned long & currentVoxelNumber) const;
+  void
+  UpdateAndPrintProgress(const unsigned long currentVoxelNumber) const;
 
   /** Set and get the string starting each progress report. */
   itkSetStringMacro(StartString);


### PR DESCRIPTION
Removed the ampersand (`&`) from declarations of "in" (`const`) parameters of a fundamental type (bool, unsigned int, unsigned long, float, double).

Following C++ Core Guidelines, April 10, 2022, "For “in” parameters, pass cheaply-copied types by value and others by reference to `const`":
https://isocpp.github.io/CppCoreGuidelines/CppCoreGuidelines#f16-for-in-parameters-pass-cheaply-copied-types-by-value-and-others-by-reference-to-const

Also removed any `virtual` keyword from the declarations of those member functions, as the change from pass by-reference to pass by-value would break any possible `override` anyway. (But no such `override` was found anyway). Following the guideline, "Don’t make a function virtual without reason"