### PR TITLE
BUG: Avoid undefined behavior ResamplerBase when "Size" isn't specified

### DIFF
--- a/Core/ComponentBaseClasses/elxResamplerBase.hxx
+++ b/Core/ComponentBaseClasses/elxResamplerBase.hxx
@@ -567,7 +567,7 @@ ResamplerBase<TElastix>::ReadFromFile()
   SpacingType     spacing;
   IndexType       index;
   OriginPointType origin;
-  SizeType        size;
+  SizeType        size = { { 0 } };
   auto            direction = DirectionType::GetIdentity();
   for (unsigned int i = 0; i < ImageDimension; ++i)
   {
@@ -604,7 +604,7 @@ ResamplerBase<TElastix>::ReadFromFile()
   }
   if (sum > 0)
   {
-    xl::xout["error"] << "ERROR: One or more image sizes are 0!" << std::endl;
+    xl::xout["error"] << "ERROR: One or more image sizes are 0 or unspecified!" << std::endl;
     /** \todo quit program nicely. */
   }
 


### PR DESCRIPTION
When the parameter map does not have a "Size" parameters, `ResamplerBase::ReadFromFile()` had undefined behavior, when trying to retrieve the values from an uninitialized local `size` variable. Transformix would then typically produce output like:

> WARNING: The parameter "Size", requested at entry number 1, does not exist at all.
> The default value "14757395258967641292" is used instead.

...

> itk::ExceptionObject
> Location: "ResamplerBase - WriteResultImage()"
> File: Modules\Core\Common\include\itkImportImageContainer.hxx
> Description: Failed to allocate memory for image.
> Error occurred while resampling the image.

Fixed, by zero-initializing the local `size` variable. Accordingly, also adjusted the error message for the case where one or more size values are zero.

Note that with the fix, another error may still occur, but it would be a slightly clearer one:

> ITK ERROR: ImageFileCastWriter: Largest possible region does not fully contain requested paste IO regionPaste IO region: ImageIORegion
>
>  Dimension: 2
>  Index: 0 0
>  Size: 0 0