### PR TITLE
ENH: Add DisableOutput() to itkElastixRegistration/itkTransformix

### DIFF
--- a/Core/Main/itkElastixRegistrationMethod.h
+++ b/Core/Main/itkElastixRegistrationMethod.h
@@ -240,6 +240,13 @@ public:
   itkGetConstReferenceMacro(LogToFile, bool);
   itkBooleanMacro(LogToFile);
 
+  /** Disables output to log and standard output. */
+  void
+  DisableOutput()
+  {
+    m_EnableOutput = false;
+  }
+
   itkSetMacro(NumberOfThreads, int);
   itkGetConstMacro(NumberOfThreads, int);
 
@@ -285,6 +292,7 @@ private:
   std::string m_OutputDirectory;
   std::string m_LogFileName;
 
+  bool m_EnableOutput{ true };
   bool m_LogToConsole;
   bool m_LogToFile;
 

--- a/Core/Main/itkElastixRegistrationMethod.hxx
+++ b/Core/Main/itkElastixRegistrationMethod.hxx
@@ -39,6 +39,7 @@
 #include "itkElastixRegistrationMethod.h"
 
 #include <algorithm> // For find.
+#include <memory>    // For unique_ptr.
 
 namespace itk
 {
@@ -217,7 +218,10 @@ ElastixRegistrationMethod<TFixedImage, TMovingImage>::GenerateData()
   }
 
   // Setup xout
-  const elastix::xoutManager manager(logFileName, this->GetLogToFile(), this->GetLogToConsole());
+  const auto manager =
+    m_EnableOutput
+      ? std::make_unique<const elx::xoutManager>(logFileName, this->GetLogToFile(), this->GetLogToConsole())
+      : std::unique_ptr<const elx::xoutManager>();
 
   // Run the (possibly multiple) registration(s)
   for (unsigned int i = 0; i < parameterMapVector.size(); ++i)

--- a/Core/Main/itkTransformixFilter.h
+++ b/Core/Main/itkTransformixFilter.h
@@ -188,6 +188,13 @@ public:
   itkGetConstMacro(LogToFile, bool);
   itkBooleanMacro(LogToFile);
 
+  /** Disables output to log and standard output. */
+  void
+  DisableOutput()
+  {
+    m_EnableOutput = false;
+  }
+
 protected:
   TransformixFilter();
 
@@ -230,6 +237,7 @@ private:
   std::string m_OutputDirectory;
   std::string m_LogFileName;
 
+  bool m_EnableOutput{ true };
   bool m_LogToConsole;
   bool m_LogToFile;
 };

--- a/Core/Main/itkTransformixFilter.hxx
+++ b/Core/Main/itkTransformixFilter.hxx
@@ -37,6 +37,7 @@
 
 #include "itkTransformixFilter.h"
 #include "elxPixelType.h"
+#include <memory> // For unique_ptr.
 
 namespace itk
 {
@@ -156,7 +157,10 @@ TransformixFilter<TMovingImage>::GenerateData()
   }
 
   // Setup xout
-  const elx::xoutManager manager(logFileName, this->GetLogToFile(), this->GetLogToConsole());
+  const auto manager =
+    m_EnableOutput
+      ? std::make_unique<const elx::xoutManager>(logFileName, this->GetLogToFile(), this->GetLogToConsole())
+      : std::unique_ptr<const elx::xoutManager>();
 
   // Instantiate transformix
   TransformixMainPointer transformix = TransformixMainType::New();


### PR DESCRIPTION
The same functionality was added in Elastix/TransformixFilter in commit cf968a92abb00a12aa419671f09d9c7c97d78ed8 for thread safety.