### PR TITLE
ENH: Pass TransformixTest parameters as environment variables to Python

### DIFF
--- a/Testing/PythonTests/CMakeLists.txt
+++ b/Testing/PythonTests/CMakeLists.txt
@@ -18,7 +18,7 @@
 
 if(python_executable)
   add_test(NAME TransformixTest COMMAND ${python_executable}
-    "${CMAKE_CURRENT_LIST_DIR}/transformix_test.py"
-    "$<TARGET_FILE_DIR:transformix_exe>/transformix"
-    "${CMAKE_CURRENT_BINARY_DIR}")
+    "${CMAKE_CURRENT_LIST_DIR}/transformix_test.py")
+  set_tests_properties(TransformixTest PROPERTIES ENVIRONMENT
+    "TRANSFORMIX_EXE=$<TARGET_FILE_DIR:transformix_exe>/transformix;TRANSFORMIX_TEST_TEMP_DIR=${CMAKE_CURRENT_BINARY_DIR}")
 endif()

--- a/Testing/PythonTests/transformix_test.py
+++ b/Testing/PythonTests/transformix_test.py
@@ -18,6 +18,7 @@
 
 """transformix test module."""
 
+import os
 import filecmp
 import pathlib
 import subprocess
@@ -31,8 +32,8 @@ class TransformixTestCase(unittest.TestCase):
     """Tests transformix from https://elastix.lumc.nl"""
 
     version_string = "5.0.1"
-    transformix_exe_file_path = pathlib.Path(sys.argv[1])
-    temporary_directory_path = pathlib.Path(sys.argv[2])
+    transformix_exe_file_path = pathlib.Path(os.environ["TRANSFORMIX_EXE"])
+    temporary_directory_path = pathlib.Path(os.environ["TRANSFORMIX_TEST_TEMP_DIR"])
 
     def create_test_function_output_directory(self):
         """Creates an output directory for the current test function, and returns its path."""


### PR DESCRIPTION
Environment variables are also supported by Visual Studio Test Explorer .runsettings files, for example:

    <?xml version="1.0" encoding="utf-8"?>
    <RunSettings>
      <RunConfiguration>
        <EnvironmentVariables>
          <TRANSFORMIX_EXE>C:\Bin\elastix\bin\Debug\transformix.exe</TRANSFORMIX_EXE>
          <TRANSFORMIX_TEST_TEMP_DIR>C:\src\elastix\Testing\PythonTests\temporary</TRANSFORMIX_TEST_TEMP_DIR>
        </EnvironmentVariables>
      </RunConfiguration>
    </RunSettings>