### PR TITLE
Remove redundant `GetElxResamplerBase()->GetAsITKBaseType()` calls, and do other style improvements

### DIFF
--- a/Components/Metrics/CorrespondingPointsEuclideanDistanceMetric/elxCorrespondingPointsEuclideanDistanceMetric.hxx
+++ b/Components/Metrics/CorrespondingPointsEuclideanDistanceMetric/elxCorrespondingPointsEuclideanDistanceMetric.hxx
@@ -159,7 +159,7 @@ CorrespondingPointsEuclideanDistanceMetric<TElastix>::ReadLandmarks(const std::s
   {
     reader->Update();
   }
-  catch (itk::ExceptionObject & err)
+  catch (const itk::ExceptionObject & err)
   {
     xl::xout["error"] << "  Error while opening " << landmarkFileName << std::endl;
     xl::xout["error"] << err << std::endl;

--- a/Components/Metrics/MissingStructurePenalty/elxMissingStructurePenalty.hxx
+++ b/Components/Metrics/MissingStructurePenalty/elxMissingStructurePenalty.hxx
@@ -461,16 +461,18 @@ the sequence of points to form a 2d connected polydata contour.
   std::vector<MovingImageIndexType>  outputindexmovingvec(nrofpoints);
   std::vector<DeformationVectorType> deformationvec(nrofpoints);
 
+  const auto & resampleImageFilter = *(this->m_Elastix->GetElxResamplerBase()->GetAsITKBaseType());
+
   /** Make a temporary image with the right region info,
    * which we can use to convert between points and indices.
    * By taking the image from the resampler output, the UseDirectionCosines
    * parameter is automatically taken into account. */
   FixedImageRegionType    region;
-  FixedImageOriginType    origin = this->m_Elastix->GetElxResamplerBase()->GetAsITKBaseType()->GetOutputOrigin();
-  FixedImageSpacingType   spacing = this->m_Elastix->GetElxResamplerBase()->GetAsITKBaseType()->GetOutputSpacing();
-  FixedImageDirectionType direction = this->m_Elastix->GetElxResamplerBase()->GetAsITKBaseType()->GetOutputDirection();
-  region.SetIndex(this->m_Elastix->GetElxResamplerBase()->GetAsITKBaseType()->GetOutputStartIndex());
-  region.SetSize(this->m_Elastix->GetElxResamplerBase()->GetAsITKBaseType()->GetSize());
+  FixedImageOriginType    origin = resampleImageFilter.GetOutputOrigin();
+  FixedImageSpacingType   spacing = resampleImageFilter.GetOutputSpacing();
+  FixedImageDirectionType direction = resampleImageFilter.GetOutputDirection();
+  region.SetIndex(resampleImageFilter.GetOutputStartIndex());
+  region.SetSize(resampleImageFilter.GetSize());
 
   auto dummyImage = FixedImageType::New();
   dummyImage->SetRegions(region);

--- a/Components/Metrics/MissingStructurePenalty/elxMissingStructurePenalty.hxx
+++ b/Components/Metrics/MissingStructurePenalty/elxMissingStructurePenalty.hxx
@@ -467,18 +467,12 @@ the sequence of points to form a 2d connected polydata contour.
    * which we can use to convert between points and indices.
    * By taking the image from the resampler output, the UseDirectionCosines
    * parameter is automatically taken into account. */
-  FixedImageRegionType    region;
-  FixedImageOriginType    origin = resampleImageFilter.GetOutputOrigin();
-  FixedImageSpacingType   spacing = resampleImageFilter.GetOutputSpacing();
-  FixedImageDirectionType direction = resampleImageFilter.GetOutputDirection();
-  region.SetIndex(resampleImageFilter.GetOutputStartIndex());
-  region.SetSize(resampleImageFilter.GetSize());
-
   auto dummyImage = FixedImageType::New();
-  dummyImage->SetRegions(region);
-  dummyImage->SetOrigin(origin);
-  dummyImage->SetSpacing(spacing);
-  dummyImage->SetDirection(direction);
+  dummyImage->SetRegions(
+    FixedImageRegionType(resampleImageFilter.GetOutputStartIndex(), resampleImageFilter.GetSize()));
+  dummyImage->SetOrigin(resampleImageFilter.GetOutputOrigin());
+  dummyImage->SetSpacing(resampleImageFilter.GetOutputSpacing());
+  dummyImage->SetDirection(resampleImageFilter.GetOutputDirection());
 
   /** Temp vars */
   FixedImageContinuousIndexType fixedcindex;

--- a/Components/Metrics/MissingStructurePenalty/elxMissingStructurePenalty.hxx
+++ b/Components/Metrics/MissingStructurePenalty/elxMissingStructurePenalty.hxx
@@ -212,7 +212,7 @@ MissingStructurePenalty<TElastix>::AfterEachIteration()
       {
         this->WriteResultMesh(makeFileName.str().c_str(), meshId);
       }
-      catch (itk::ExceptionObject & excp)
+      catch (const itk::ExceptionObject & excp)
       {
         xl::xout["error"] << "Exception caught: " << std::endl;
         xl::xout["error"] << excp << "Resuming elastix." << std::endl;
@@ -260,7 +260,7 @@ MissingStructurePenalty<TElastix>::AfterEachResolution()
       {
         this->WriteResultMesh(makeFileName.str().c_str(), meshId);
       }
-      catch (itk::ExceptionObject & excp)
+      catch (const itk::ExceptionObject & excp)
       {
         xl::xout["error"] << "Exception caught: " << std::endl;
         xl::xout["error"] << excp << "Resuming elastix." << std::endl;
@@ -289,7 +289,7 @@ MissingStructurePenalty<TElastix>::ReadMesh(const std::string & meshFileName, ty
   {
     meshReader->UpdateLargestPossibleRegion();
   }
-  catch (itk::ExceptionObject & err)
+  catch (const itk::ExceptionObject & err)
   {
     xl::xout["error"] << "  Error while opening input mesh file." << std::endl;
     xl::xout["error"] << err << std::endl;
@@ -430,7 +430,7 @@ the sequence of points to form a 2d connected polydata contour.
   {
     ippReader->Update();
   }
-  catch (itk::ExceptionObject & err)
+  catch (const itk::ExceptionObject & err)
   {
     xl::xout["error"] << "  Error while opening input point file." << std::endl;
     xl::xout["error"] << err << std::endl;

--- a/Components/Metrics/MissingStructurePenalty/elxMissingStructurePenalty.hxx
+++ b/Components/Metrics/MissingStructurePenalty/elxMissingStructurePenalty.hxx
@@ -491,8 +491,7 @@ the sequence of points to form a 2d connected polydata contour.
     for (unsigned int j = 0; j < nrofpoints; ++j)
     {
       /** Compute index of nearest voxel in fixed image. */
-      InputPointType point;
-      point.Fill(0.0f);
+      InputPointType point{};
       inputPointSet->GetPoint(j, &point);
       inputpointvec[j] = point;
       dummyImage->TransformPhysicalPointToContinuousIndex(point, fixedcindex);
@@ -509,8 +508,7 @@ the sequence of points to form a 2d connected polydata contour.
       /** The read point from the inutPointSet is actually an index
        * Cast to the proper type.
        */
-      InputPointType point;
-      point.Fill(0.0f);
+      InputPointType point{};
       inputPointSet->GetPoint(j, &point);
       for (unsigned int i = 0; i < FixedImageDimension; ++i)
       {

--- a/Components/Metrics/PolydataDummyPenalty/elxPolydataDummyPenalty.hxx
+++ b/Components/Metrics/PolydataDummyPenalty/elxPolydataDummyPenalty.hxx
@@ -461,8 +461,7 @@ PolydataDummyPenalty<TElastix>::ReadTransformixPoints(const std::string &       
     for (unsigned int j = 0; j < nrofpoints; ++j)
     {
       /** Compute index of nearest voxel in fixed image. */
-      InputPointType point;
-      point.Fill(0.0f);
+      InputPointType point{};
       inputPointSet->GetPoint(j, &point);
       inputpointvec[j] = point;
       dummyImage->TransformPhysicalPointToContinuousIndex(point, fixedcindex);
@@ -479,8 +478,7 @@ PolydataDummyPenalty<TElastix>::ReadTransformixPoints(const std::string &       
       /** The read point from the inutPointSet is actually an index
        * Cast to the proper type.
        */
-      InputPointType point;
-      point.Fill(0.0f);
+      InputPointType point{};
       inputPointSet->GetPoint(j, &point);
       for (unsigned int i = 0; i < FixedImageDimension; ++i)
       {

--- a/Components/Metrics/PolydataDummyPenalty/elxPolydataDummyPenalty.hxx
+++ b/Components/Metrics/PolydataDummyPenalty/elxPolydataDummyPenalty.hxx
@@ -438,17 +438,19 @@ PolydataDummyPenalty<TElastix>::ReadTransformixPoints(const std::string &       
   std::vector<MovingImageIndexType>  outputindexmovingvec(nrofpoints);
   std::vector<DeformationVectorType> deformationvec(nrofpoints);
 
+  const auto & resampleImageFilter = *(this->m_Elastix->GetElxResamplerBase()->GetAsITKBaseType());
+
   /** Make a temporary image with the right region info,
    * which we can use to convert between points and indices.
    * By taking the image from the resampler output, the UseDirectionCosines
    * parameter is automatically taken into account.
    */
   FixedImageRegionType    region;
-  FixedImageOriginType    origin = this->m_Elastix->GetElxResamplerBase()->GetAsITKBaseType()->GetOutputOrigin();
-  FixedImageSpacingType   spacing = this->m_Elastix->GetElxResamplerBase()->GetAsITKBaseType()->GetOutputSpacing();
-  FixedImageDirectionType direction = this->m_Elastix->GetElxResamplerBase()->GetAsITKBaseType()->GetOutputDirection();
-  region.SetIndex(this->m_Elastix->GetElxResamplerBase()->GetAsITKBaseType()->GetOutputStartIndex());
-  region.SetSize(this->m_Elastix->GetElxResamplerBase()->GetAsITKBaseType()->GetSize());
+  FixedImageOriginType    origin = resampleImageFilter.GetOutputOrigin();
+  FixedImageSpacingType   spacing = resampleImageFilter.GetOutputSpacing();
+  FixedImageDirectionType direction = resampleImageFilter.GetOutputDirection();
+  region.SetIndex(resampleImageFilter.GetOutputStartIndex());
+  region.SetSize(resampleImageFilter.GetSize());
 
   auto dummyImage = FixedImageType::New();
   dummyImage->SetRegions(region);

--- a/Components/Metrics/PolydataDummyPenalty/elxPolydataDummyPenalty.hxx
+++ b/Components/Metrics/PolydataDummyPenalty/elxPolydataDummyPenalty.hxx
@@ -445,18 +445,12 @@ PolydataDummyPenalty<TElastix>::ReadTransformixPoints(const std::string &       
    * By taking the image from the resampler output, the UseDirectionCosines
    * parameter is automatically taken into account.
    */
-  FixedImageRegionType    region;
-  FixedImageOriginType    origin = resampleImageFilter.GetOutputOrigin();
-  FixedImageSpacingType   spacing = resampleImageFilter.GetOutputSpacing();
-  FixedImageDirectionType direction = resampleImageFilter.GetOutputDirection();
-  region.SetIndex(resampleImageFilter.GetOutputStartIndex());
-  region.SetSize(resampleImageFilter.GetSize());
-
   auto dummyImage = FixedImageType::New();
-  dummyImage->SetRegions(region);
-  dummyImage->SetOrigin(origin);
-  dummyImage->SetSpacing(spacing);
-  dummyImage->SetDirection(direction);
+  dummyImage->SetRegions(
+    FixedImageRegionType(resampleImageFilter.GetOutputStartIndex(), resampleImageFilter.GetSize()));
+  dummyImage->SetOrigin(resampleImageFilter.GetOutputOrigin());
+  dummyImage->SetSpacing(resampleImageFilter.GetOutputSpacing());
+  dummyImage->SetDirection(resampleImageFilter.GetOutputDirection());
 
   /** Temp vars */
   FixedImageContinuousIndexType fixedcindex;

--- a/Components/Metrics/PolydataDummyPenalty/elxPolydataDummyPenalty.hxx
+++ b/Components/Metrics/PolydataDummyPenalty/elxPolydataDummyPenalty.hxx
@@ -199,7 +199,7 @@ PolydataDummyPenalty<TElastix>::AfterEachIteration()
       {
         this->WriteResultMesh(makeFileName.str().c_str(), meshId);
       }
-      catch (itk::ExceptionObject & excp)
+      catch (const itk::ExceptionObject & excp)
       {
         xl::xout["error"] << "Exception caught: " << std::endl;
         xl::xout["error"] << excp << "Resuming elastix." << std::endl;
@@ -247,7 +247,7 @@ PolydataDummyPenalty<TElastix>::AfterEachResolution()
       {
         this->WriteResultMesh(makeFileName.str().c_str(), meshId);
       }
-      catch (itk::ExceptionObject & excp)
+      catch (const itk::ExceptionObject & excp)
       {
         xl::xout["error"] << "Exception caught: " << std::endl;
         xl::xout["error"] << excp << "Resuming elastix." << std::endl;
@@ -279,7 +279,7 @@ PolydataDummyPenalty<TElastix>::ReadMesh(const std::string & meshFileName, typen
     // meshReader->Update();
     meshReader->UpdateLargestPossibleRegion();
   }
-  catch (itk::ExceptionObject & err)
+  catch (const itk::ExceptionObject & err)
   {
     xl::xout["error"] << "  Error while opening input mesh file." << std::endl;
     xl::xout["error"] << err << std::endl;
@@ -410,7 +410,7 @@ PolydataDummyPenalty<TElastix>::ReadTransformixPoints(const std::string &       
   {
     ippReader->Update();
   }
-  catch (itk::ExceptionObject & err)
+  catch (const itk::ExceptionObject & err)
   {
     xl::xout["error"] << "  Error while opening input point file." << std::endl;
     xl::xout["error"] << err << std::endl;

--- a/Components/Metrics/RigidityPenalty/itkTransformRigidityPenaltyTerm.hxx
+++ b/Components/Metrics/RigidityPenalty/itkTransformRigidityPenaltyTerm.hxx
@@ -345,8 +345,7 @@ TransformRigidityPenaltyTerm<TFixedImage, TScalarType>::FillRigidityCoefficientI
 
   /** Fill m_RigidityCoefficientImage. */
   RigidityPixelType      fixedValue, movingValue, in;
-  RigidityImagePointType point;
-  point.Fill(0.0f);
+  RigidityImagePointType point{};
   RigidityImageIndexType index1, index2;
   index1.Fill(0);
   index2.Fill(0);

--- a/Components/Metrics/StatisticalShapePenalty/elxStatisticalShapePenalty.hxx
+++ b/Components/Metrics/StatisticalShapePenalty/elxStatisticalShapePenalty.hxx
@@ -290,7 +290,7 @@ StatisticalShapePenalty<TElastix>::ReadLandmarks(const std::string &            
   {
     reader->Update();
   }
-  catch (itk::ExceptionObject & err)
+  catch (const itk::ExceptionObject & err)
   {
     xl::xout["error"] << "  Error while opening " << landmarkFileName << std::endl;
     xl::xout["error"] << err << std::endl;

--- a/Components/Optimizers/AdaptiveStochasticGradientDescent/elxAdaptiveStochasticGradientDescent.hxx
+++ b/Components/Optimizers/AdaptiveStochasticGradientDescent/elxAdaptiveStochasticGradientDescent.hxx
@@ -1021,7 +1021,7 @@ AdaptiveStochasticGradientDescent<TElastix>::GetScaledDerivativeWithExceptionHan
   {
     this->GetScaledValueAndDerivative(parameters, dummyvalue, derivative);
   }
-  catch (itk::ExceptionObject & err)
+  catch (const itk::ExceptionObject & err)
   {
     this->m_StopCondition = MetricError;
     this->StopOptimization();

--- a/Components/Optimizers/ConjugateGradient/elxConjugateGradient.hxx
+++ b/Components/Optimizers/ConjugateGradient/elxConjugateGradient.hxx
@@ -124,7 +124,7 @@ ConjugateGradient<TElastix>::LineSearch(const ParametersType searchDir,
   {
     this->Superclass1::LineSearch(searchDir, step, x, f, g);
   }
-  catch (itk::ExceptionObject & err)
+  catch (const itk::ExceptionObject & err)
   {
     if (this->GetLineSearchOptimizer() == nullptr)
     {
@@ -366,7 +366,7 @@ ConjugateGradient<TElastix>::AfterEachIteration()
         this->GetScaledValueAndDerivative(
           this->GetScaledCurrentPosition(), this->m_CurrentValue, this->m_CurrentGradient);
       }
-      catch (itk::ExceptionObject & err)
+      catch (const itk::ExceptionObject & err)
       {
         this->m_StopCondition = MetricError;
         this->StopOptimization();

--- a/Components/Optimizers/FullSearch/elxFullSearchOptimizer.hxx
+++ b/Components/Optimizers/FullSearch/elxFullSearchOptimizer.hxx
@@ -243,7 +243,7 @@ FullSearch<TElastix>::AfterEachResolution()
       elxout << "\nThe scanned optimization surface is saved as: " << this->m_OptimizationSurface->GetOutputFileName()
              << std::endl;
     }
-    catch (itk::ExceptionObject & err)
+    catch (const itk::ExceptionObject & err)
     {
       xl::xout["error"] << "ERROR: Saving " << this->m_OptimizationSurface->GetOutputFileName() << " failed."
                         << std::endl;

--- a/Components/Optimizers/PreconditionedStochasticGradientDescent/elxPreconditionedStochasticGradientDescent.hxx
+++ b/Components/Optimizers/PreconditionedStochasticGradientDescent/elxPreconditionedStochasticGradientDescent.hxx
@@ -975,7 +975,7 @@ PreconditionedStochasticGradientDescent<TElastix>::GetScaledDerivativeWithExcept
   {
     this->GetScaledValueAndDerivative(parameters, dummyvalue, derivative);
   }
-  catch (itk::ExceptionObject & err)
+  catch (const itk::ExceptionObject & err)
   {
     this->m_StopCondition = MetricError;
     this->StopOptimization();

--- a/Components/Optimizers/QuasiNewtonLBFGS/elxQuasiNewtonLBFGS.hxx
+++ b/Components/Optimizers/QuasiNewtonLBFGS/elxQuasiNewtonLBFGS.hxx
@@ -124,7 +124,7 @@ QuasiNewtonLBFGS<TElastix>::LineSearch(const ParametersType searchDir,
   {
     this->Superclass1::LineSearch(searchDir, step, x, f, g);
   }
-  catch (itk::ExceptionObject & err)
+  catch (const itk::ExceptionObject & err)
   {
     if (this->GetLineSearchOptimizer() == nullptr)
     {
@@ -354,7 +354,7 @@ QuasiNewtonLBFGS<TElastix>::AfterEachIteration()
         this->GetScaledValueAndDerivative(
           this->GetScaledCurrentPosition(), this->m_CurrentValue, this->m_CurrentGradient);
       }
-      catch (itk::ExceptionObject & err)
+      catch (const itk::ExceptionObject & err)
       {
         this->m_StopCondition = MetricError;
         this->StopOptimization();

--- a/Components/Transforms/SplineKernelTransform/elxSplineKernelTransform.hxx
+++ b/Components/Transforms/SplineKernelTransform/elxSplineKernelTransform.hxx
@@ -296,7 +296,7 @@ SplineKernelTransform<TElastix>::ReadLandmarkFile(const std::string & filename,
   {
     landmarkReader->Update();
   }
-  catch (itk::ExceptionObject & err)
+  catch (const itk::ExceptionObject & err)
   {
     xl::xout["error"] << "  Error while opening landmark file." << std::endl;
     xl::xout["error"] << err << std::endl;

--- a/Core/ComponentBaseClasses/elxFixedImagePyramidBase.hxx
+++ b/Core/ComponentBaseClasses/elxFixedImagePyramidBase.hxx
@@ -73,7 +73,7 @@ FixedImagePyramidBase<TElastix>::BeforeEachResolutionBase()
     {
       this->WritePyramidImage(makeFileName.str(), level);
     }
-    catch (itk::ExceptionObject & excp)
+    catch (const itk::ExceptionObject & excp)
     {
       xl::xout["error"] << "Exception caught: " << std::endl;
       xl::xout["error"] << excp << "Resuming elastix." << std::endl;

--- a/Core/ComponentBaseClasses/elxMovingImagePyramidBase.hxx
+++ b/Core/ComponentBaseClasses/elxMovingImagePyramidBase.hxx
@@ -74,7 +74,7 @@ MovingImagePyramidBase<TElastix>::BeforeEachResolutionBase()
     {
       this->WritePyramidImage(makeFileName.str(), level);
     }
-    catch (itk::ExceptionObject & excp)
+    catch (const itk::ExceptionObject & excp)
     {
       xl::xout["error"] << "Exception caught: " << std::endl;
       xl::xout["error"] << excp << "Resuming elastix." << std::endl;

--- a/Core/ComponentBaseClasses/elxResamplerBase.hxx
+++ b/Core/ComponentBaseClasses/elxResamplerBase.hxx
@@ -118,7 +118,7 @@ ResamplerBase<TElastix>::AfterEachResolutionBase()
     {
       this->ResampleAndWriteResultImage(makeFileName.str().c_str());
     }
-    catch (itk::ExceptionObject & excp)
+    catch (const itk::ExceptionObject & excp)
     {
       xl::xout["error"] << "Exception caught: " << std::endl;
       xl::xout["error"] << excp << "Resuming elastix." << std::endl;
@@ -171,7 +171,7 @@ ResamplerBase<TElastix>::AfterEachIterationBase()
     {
       this->ResampleAndWriteResultImage(makeFileName.str().c_str(), false);
     }
-    catch (itk::ExceptionObject & excp)
+    catch (const itk::ExceptionObject & excp)
     {
       xl::xout["error"] << "Exception caught: " << std::endl;
       xl::xout["error"] << excp << "Resuming elastix." << std::endl;
@@ -248,7 +248,7 @@ ResamplerBase<TElastix>::AfterRegistrationBase()
       {
         this->ResampleAndWriteResultImage(makeFileName.str().c_str(), this->m_ShowProgress);
       }
-      catch (itk::ExceptionObject & excp)
+      catch (const itk::ExceptionObject & excp)
       {
         xl::xout["error"] << "Exception caught: " << std::endl;
         xl::xout["error"] << excp << "Resuming elastix." << std::endl;

--- a/Core/ComponentBaseClasses/elxTransformBase.hxx
+++ b/Core/ComponentBaseClasses/elxTransformBase.hxx
@@ -749,8 +749,7 @@ TransformBase<TElastix>::TransformPointsSomePoints(const std::string & filename)
     for (unsigned int j = 0; j < nrofpoints; ++j)
     {
       /** Compute index of nearest voxel in fixed image. */
-      InputPointType point;
-      point.Fill(0.0f);
+      InputPointType point{};
       inputPointSet->GetPoint(j, &point);
       inputpointvec[j] = point;
       dummyImage->TransformPhysicalPointToContinuousIndex(point, fixedcindex);
@@ -767,8 +766,7 @@ TransformBase<TElastix>::TransformPointsSomePoints(const std::string & filename)
       /** The read point from the inutPointSet is actually an index
        * Cast to the proper type.
        */
-      InputPointType point;
-      point.Fill(0.0f);
+      InputPointType point{};
       inputPointSet->GetPoint(j, &point);
       for (unsigned int i = 0; i < FixedImageDimension; ++i)
       {

--- a/Core/ComponentBaseClasses/elxTransformBase.hxx
+++ b/Core/ComponentBaseClasses/elxTransformBase.hxx
@@ -718,16 +718,18 @@ TransformBase<TElastix>::TransformPointsSomePoints(const std::string & filename)
   std::vector<MovingImageIndexType>  outputindexmovingvec(nrofpoints);
   std::vector<DeformationVectorType> deformationvec(nrofpoints);
 
+  const auto & resampleImageFilter = *(this->m_Elastix->GetElxResamplerBase()->GetAsITKBaseType());
+
   /** Make a temporary image with the right region info,
    * which we can use to convert between points and indices.
    * By taking the image from the resampler output, the UseDirectionCosines
    * parameter is automatically taken into account. */
   FixedImageRegionType region;
-  const auto           origin = this->m_Elastix->GetElxResamplerBase()->GetAsITKBaseType()->GetOutputOrigin();
-  const auto           spacing = this->m_Elastix->GetElxResamplerBase()->GetAsITKBaseType()->GetOutputSpacing();
-  const auto           direction = this->m_Elastix->GetElxResamplerBase()->GetAsITKBaseType()->GetOutputDirection();
-  region.SetIndex(this->m_Elastix->GetElxResamplerBase()->GetAsITKBaseType()->GetOutputStartIndex());
-  region.SetSize(this->m_Elastix->GetElxResamplerBase()->GetAsITKBaseType()->GetSize());
+  const auto           origin = resampleImageFilter.GetOutputOrigin();
+  const auto           spacing = resampleImageFilter.GetOutputSpacing();
+  const auto           direction = resampleImageFilter.GetOutputDirection();
+  region.SetIndex(resampleImageFilter.GetOutputStartIndex());
+  region.SetSize(resampleImageFilter.GetSize());
 
   const auto dummyImage = FixedImageType::New();
   dummyImage->SetRegions(region);
@@ -993,13 +995,15 @@ TransformBase<TElastix>::GenerateDeformationFieldImage() const -> typename Defor
     itk::TransformToDisplacementFieldFilter<DeformationFieldImageType, CoordRepType>;
   using ChangeInfoFilterType = itk::ChangeInformationImageFilter<DeformationFieldImageType>;
 
+  const auto & resampleImageFilter = *(this->m_Elastix->GetElxResamplerBase()->GetAsITKBaseType());
+
   /** Create an setup deformation field generator. */
   const auto defGenerator = DeformationFieldGeneratorType::New();
-  defGenerator->SetSize(this->m_Elastix->GetElxResamplerBase()->GetAsITKBaseType()->GetSize());
-  defGenerator->SetOutputSpacing(this->m_Elastix->GetElxResamplerBase()->GetAsITKBaseType()->GetOutputSpacing());
-  defGenerator->SetOutputOrigin(this->m_Elastix->GetElxResamplerBase()->GetAsITKBaseType()->GetOutputOrigin());
-  defGenerator->SetOutputStartIndex(this->m_Elastix->GetElxResamplerBase()->GetAsITKBaseType()->GetOutputStartIndex());
-  defGenerator->SetOutputDirection(this->m_Elastix->GetElxResamplerBase()->GetAsITKBaseType()->GetOutputDirection());
+  defGenerator->SetSize(resampleImageFilter.GetSize());
+  defGenerator->SetOutputSpacing(resampleImageFilter.GetOutputSpacing());
+  defGenerator->SetOutputOrigin(resampleImageFilter.GetOutputOrigin());
+  defGenerator->SetOutputStartIndex(resampleImageFilter.GetOutputStartIndex());
+  defGenerator->SetOutputDirection(resampleImageFilter.GetOutputDirection());
   defGenerator->SetTransform(const_cast<const ITKBaseType *>(this->GetAsITKBaseType()));
 
   /** Possibly change direction cosines to their original value, as specified
@@ -1102,14 +1106,16 @@ TransformBase<TElastix>::ComputeDeterminantOfSpatialJacobian() const
   using ChangeInfoFilterType = itk::ChangeInformationImageFilter<JacobianImageType>;
   using FixedImageDirectionType = typename FixedImageType::DirectionType;
 
+  const auto & resampleImageFilter = *(this->m_Elastix->GetElxResamplerBase()->GetAsITKBaseType());
+
   /** Create an setup Jacobian generator. */
   const auto jacGenerator = JacobianGeneratorType::New();
   jacGenerator->SetTransform(const_cast<const ITKBaseType *>(this->GetAsITKBaseType()));
-  jacGenerator->SetOutputSize(this->m_Elastix->GetElxResamplerBase()->GetAsITKBaseType()->GetSize());
-  jacGenerator->SetOutputSpacing(this->m_Elastix->GetElxResamplerBase()->GetAsITKBaseType()->GetOutputSpacing());
-  jacGenerator->SetOutputOrigin(this->m_Elastix->GetElxResamplerBase()->GetAsITKBaseType()->GetOutputOrigin());
-  jacGenerator->SetOutputIndex(this->m_Elastix->GetElxResamplerBase()->GetAsITKBaseType()->GetOutputStartIndex());
-  jacGenerator->SetOutputDirection(this->m_Elastix->GetElxResamplerBase()->GetAsITKBaseType()->GetOutputDirection());
+  jacGenerator->SetOutputSize(resampleImageFilter.GetSize());
+  jacGenerator->SetOutputSpacing(resampleImageFilter.GetOutputSpacing());
+  jacGenerator->SetOutputOrigin(resampleImageFilter.GetOutputOrigin());
+  jacGenerator->SetOutputIndex(resampleImageFilter.GetOutputStartIndex());
+  jacGenerator->SetOutputDirection(resampleImageFilter.GetOutputDirection());
   // NOTE: We can not use the following, since the fixed image does not exist in transformix
   //   jacGenerator->SetOutputParametersFromImage(
   //     this->GetRegistration()->GetAsITKBaseType()->GetFixedImage() );
@@ -1181,14 +1187,16 @@ TransformBase<TElastix>::ComputeSpatialJacobian() const
   using ChangeInfoFilterType = itk::ChangeInformationImageFilter<JacobianImageType>;
   using FixedImageDirectionType = typename FixedImageType::DirectionType;
 
+  const auto & resampleImageFilter = *(this->m_Elastix->GetElxResamplerBase()->GetAsITKBaseType());
+
   /** Create an setup Jacobian generator. */
   const auto jacGenerator = JacobianGeneratorType::New();
   jacGenerator->SetTransform(const_cast<const ITKBaseType *>(this->GetAsITKBaseType()));
-  jacGenerator->SetOutputSize(this->m_Elastix->GetElxResamplerBase()->GetAsITKBaseType()->GetSize());
-  jacGenerator->SetOutputSpacing(this->m_Elastix->GetElxResamplerBase()->GetAsITKBaseType()->GetOutputSpacing());
-  jacGenerator->SetOutputOrigin(this->m_Elastix->GetElxResamplerBase()->GetAsITKBaseType()->GetOutputOrigin());
-  jacGenerator->SetOutputIndex(this->m_Elastix->GetElxResamplerBase()->GetAsITKBaseType()->GetOutputStartIndex());
-  jacGenerator->SetOutputDirection(this->m_Elastix->GetElxResamplerBase()->GetAsITKBaseType()->GetOutputDirection());
+  jacGenerator->SetOutputSize(resampleImageFilter.GetSize());
+  jacGenerator->SetOutputSpacing(resampleImageFilter.GetOutputSpacing());
+  jacGenerator->SetOutputOrigin(resampleImageFilter.GetOutputOrigin());
+  jacGenerator->SetOutputIndex(resampleImageFilter.GetOutputStartIndex());
+  jacGenerator->SetOutputDirection(resampleImageFilter.GetOutputDirection());
   // NOTE: We can not use the following, since the fixed image does not exist in transformix
   //   jacGenerator->SetOutputParametersFromImage(
   //     this->GetRegistration()->GetAsITKBaseType()->GetFixedImage() );

--- a/Core/ComponentBaseClasses/elxTransformBase.hxx
+++ b/Core/ComponentBaseClasses/elxTransformBase.hxx
@@ -724,18 +724,12 @@ TransformBase<TElastix>::TransformPointsSomePoints(const std::string & filename)
    * which we can use to convert between points and indices.
    * By taking the image from the resampler output, the UseDirectionCosines
    * parameter is automatically taken into account. */
-  FixedImageRegionType region;
-  const auto           origin = resampleImageFilter.GetOutputOrigin();
-  const auto           spacing = resampleImageFilter.GetOutputSpacing();
-  const auto           direction = resampleImageFilter.GetOutputDirection();
-  region.SetIndex(resampleImageFilter.GetOutputStartIndex());
-  region.SetSize(resampleImageFilter.GetSize());
-
   const auto dummyImage = FixedImageType::New();
-  dummyImage->SetRegions(region);
-  dummyImage->SetOrigin(origin);
-  dummyImage->SetSpacing(spacing);
-  dummyImage->SetDirection(direction);
+  dummyImage->SetRegions(
+    FixedImageRegionType(resampleImageFilter.GetOutputStartIndex(), resampleImageFilter.GetSize()));
+  dummyImage->SetOrigin(resampleImageFilter.GetOutputOrigin());
+  dummyImage->SetSpacing(resampleImageFilter.GetOutputSpacing());
+  dummyImage->SetDirection(resampleImageFilter.GetOutputDirection());
 
   /** Temp vars */
   FixedImageContinuousIndexType  fixedcindex;

--- a/Core/ComponentBaseClasses/elxTransformBase.hxx
+++ b/Core/ComponentBaseClasses/elxTransformBase.hxx
@@ -689,7 +689,7 @@ TransformBase<TElastix>::TransformPointsSomePoints(const std::string & filename)
   {
     ippReader->Update();
   }
-  catch (itk::ExceptionObject & err)
+  catch (const itk::ExceptionObject & err)
   {
     xl::xout["error"] << "  Error while opening input point file." << std::endl;
     xl::xout["error"] << err << std::endl;
@@ -898,7 +898,7 @@ TransformBase<TElastix>::TransformPointsSomePointsVTK(const std::string & filena
   {
     meshReader->Update();
   }
-  catch (itk::ExceptionObject & err)
+  catch (const itk::ExceptionObject & err)
   {
     xl::xout["error"] << "  Error while opening input point file." << std::endl;
     xl::xout["error"] << err << std::endl;
@@ -918,7 +918,7 @@ TransformBase<TElastix>::TransformPointsSomePointsVTK(const std::string & filena
   {
     meshTransformer->Update();
   }
-  catch (itk::ExceptionObject & err)
+  catch (const itk::ExceptionObject & err)
   {
     xl::xout["error"] << "  Error while transforming points." << std::endl;
     xl::xout["error"] << err << std::endl;
@@ -936,7 +936,7 @@ TransformBase<TElastix>::TransformPointsSomePointsVTK(const std::string & filena
   {
     meshWriter->Update();
   }
-  catch (itk::ExceptionObject & err)
+  catch (const itk::ExceptionObject & err)
   {
     xl::xout["error"] << "  Error while saving points." << std::endl;
     xl::xout["error"] << err << std::endl;

--- a/Core/Configuration/elxConfiguration.cxx
+++ b/Core/Configuration/elxConfiguration.cxx
@@ -206,7 +206,7 @@ Configuration::Initialize(const CommandLineArgumentMapType & _arg)
     xl::xout["standard"] << "Reading the elastix parameters from file ...\n" << std::endl;
     this->m_ParameterFileParser->ReadParameterFile();
   }
-  catch (itk::ExceptionObject & excp)
+  catch (const itk::ExceptionObject & excp)
   {
     xl::xout["error"] << "ERROR: when reading the parameter file:\n" << excp << std::endl;
     return 1;

--- a/Core/Kernel/elxElastixMain.cxx
+++ b/Core/Kernel/elxElastixMain.cxx
@@ -313,7 +313,7 @@ ElastixMain::Run()
     /** Key "Elastix", see elxComponentLoader::InstallSupportedImageTypes(). */
     this->m_Elastix = this->CreateComponent("Elastix");
   }
-  catch (itk::ExceptionObject & excp)
+  catch (const itk::ExceptionObject & excp)
   {
     /** We just print the exception and let the program quit. */
     xl::xout["error"] << excp << std::endl;
@@ -410,7 +410,7 @@ ElastixMain::Run()
   {
     errorCode = elastixBase.Run();
   }
-  catch (itk::ExceptionObject & excp1)
+  catch (const itk::ExceptionObject & excp1)
   {
     /** We just print the itk::exception and let the program quit. */
     xl::xout["error"] << excp1 << std::endl;
@@ -524,7 +524,7 @@ ElastixMain::InitDBIndex()
         {
           this->GetImageInformationFromFile(fixedImageFileName, this->m_FixedImageDimension);
         }
-        catch (itk::ExceptionObject & err)
+        catch (const itk::ExceptionObject & err)
         {
           xl::xout["error"] << "ERROR: could not read fixed image." << std::endl;
           xl::xout["error"] << err << std::endl;
@@ -601,7 +601,7 @@ ElastixMain::InitDBIndex()
         {
           this->GetImageInformationFromFile(movingImageFileName, this->m_MovingImageDimension);
         }
-        catch (itk::ExceptionObject & err)
+        catch (const itk::ExceptionObject & err)
         {
           xl::xout["error"] << "ERROR: could not read moving image." << std::endl;
           xl::xout["error"] << err << std::endl;
@@ -809,7 +809,7 @@ ElastixMain::CreateComponents(const std::string &              key,
   {
     objectContainer->CreateElementAt(componentnr) = this->CreateComponent(componentName);
   }
-  catch (itk::ExceptionObject & excp)
+  catch (const itk::ExceptionObject & excp)
   {
     xl::xout["error"] << "ERROR: error occurred while creating " << key << " " << componentnr << "." << std::endl;
     xl::xout["error"] << excp << std::endl;
@@ -828,7 +828,7 @@ ElastixMain::CreateComponents(const std::string &              key,
       {
         objectContainer->CreateElementAt(componentnr) = this->CreateComponent(componentName);
       }
-      catch (itk::ExceptionObject & excp)
+      catch (const itk::ExceptionObject & excp)
       {
         xl::xout["error"] << "ERROR: error occurred while creating " << key << " " << componentnr << "." << std::endl;
         xl::xout["error"] << excp << std::endl;

--- a/Core/Kernel/elxElastixTemplate.hxx
+++ b/Core/Kernel/elxElastixTemplate.hxx
@@ -319,7 +319,7 @@ ElastixTemplate<TFixedImage, TMovingImage>::ApplyTransform()
   {
     this->GetElxTransformBase()->TransformPoints();
   }
-  catch (itk::ExceptionObject & excp)
+  catch (const itk::ExceptionObject & excp)
   {
     xl::xout["error"] << excp << std::endl;
     xl::xout["error"] << "However, transformix continues anyway." << std::endl;
@@ -338,7 +338,7 @@ ElastixTemplate<TFixedImage, TMovingImage>::ApplyTransform()
   {
     this->GetElxTransformBase()->ComputeDeterminantOfSpatialJacobian();
   }
-  catch (itk::ExceptionObject & excp)
+  catch (const itk::ExceptionObject & excp)
   {
     xl::xout["error"] << excp << std::endl;
     xl::xout["error"] << "However, transformix continues anyway." << std::endl;
@@ -358,7 +358,7 @@ ElastixTemplate<TFixedImage, TMovingImage>::ApplyTransform()
   {
     this->GetElxTransformBase()->ComputeSpatialJacobian();
   }
-  catch (itk::ExceptionObject & excp)
+  catch (const itk::ExceptionObject & excp)
   {
     xl::xout["error"] << excp << std::endl;
     xl::xout["error"] << "However, transformix continues anyway." << std::endl;

--- a/Core/Kernel/elxTransformixMain.cxx
+++ b/Core/Kernel/elxTransformixMain.cxx
@@ -63,7 +63,7 @@ TransformixMain::Run()
     /** Key "Elastix", see elxComponentLoader::InstallSupportedImageTypes(). */
     this->m_Elastix = this->CreateComponent("Elastix");
   }
-  catch (itk::ExceptionObject & excp)
+  catch (const itk::ExceptionObject & excp)
   {
     /** We just print the exception and let the program quit. */
     xl::xout["error"] << excp << std::endl;
@@ -138,7 +138,7 @@ TransformixMain::Run()
   {
     errorCode = elastixBase.ApplyTransform();
   }
-  catch (itk::ExceptionObject & excp)
+  catch (const itk::ExceptionObject & excp)
   {
     /** We just print the exception and let the program quit. */
     xl::xout["error"] << '\n'

--- a/Testing/elxComputeOverlap.cxx
+++ b/Testing/elxComputeOverlap.cxx
@@ -108,7 +108,7 @@ main(int argc, char ** argv)
 
     ANDFilter->Update();
   }
-  catch (itk::ExceptionObject & excp)
+  catch (const itk::ExceptionObject & excp)
   {
     std::cerr << excp << std::endl;
     return EXIT_FAILURE;

--- a/Testing/elxImageCompare.cxx
+++ b/Testing/elxImageCompare.cxx
@@ -98,7 +98,7 @@ main(int argc, char ** argv)
   {
     baselineReader->Update();
   }
-  catch (itk::ExceptionObject & err)
+  catch (const itk::ExceptionObject & err)
   {
     std::cerr << "Error during reading baseline image: " << err << std::endl;
     return EXIT_FAILURE;
@@ -111,7 +111,7 @@ main(int argc, char ** argv)
   {
     testReader->Update();
   }
-  catch (itk::ExceptionObject & err)
+  catch (const itk::ExceptionObject & err)
   {
     std::cerr << "Error during reading test image: " << err << std::endl;
     return EXIT_FAILURE;
@@ -141,7 +141,7 @@ main(int argc, char ** argv)
   {
     comparisonFilter->Update();
   }
-  catch (itk::ExceptionObject & err)
+  catch (const itk::ExceptionObject & err)
   {
     std::cerr << "Error during comparing image: " << err << std::endl;
     return EXIT_FAILURE;
@@ -166,7 +166,7 @@ main(int argc, char ** argv)
     {
       itk::WriteImage(comparisonFilter->GetOutput(), diffImageFileName);
     }
-    catch (itk::ExceptionObject & err)
+    catch (const itk::ExceptionObject & err)
     {
       std::cerr << "Error during writing difference image: " << err << std::endl;
       return EXIT_FAILURE;

--- a/Testing/elxInvertTransform.cxx
+++ b/Testing/elxInvertTransform.cxx
@@ -138,7 +138,7 @@ main(int argc, char * argv[])
   {
     testReader->UpdateOutputInformation();
   }
-  catch (itk::ExceptionObject & e)
+  catch (const itk::ExceptionObject & e)
   {
     std::cerr << "ERROR: Caught ITK exception: " << e << std::endl;
     return EXIT_FAILURE;
@@ -208,7 +208,7 @@ main(int argc, char * argv[])
       return EXIT_FAILURE;
     }
   }
-  catch (itk::ExceptionObject & e)
+  catch (const itk::ExceptionObject & e)
   {
     std::cerr << "ERROR: Caught ITK exception: " << e << std::endl;
     return EXIT_FAILURE;

--- a/Testing/elxTransformParametersCompare.cxx
+++ b/Testing/elxTransformParametersCompare.cxx
@@ -129,7 +129,7 @@ main(int argc, char ** argv)
   {
     parameterFileParser->ReadParameterFile();
   }
-  catch (itk::ExceptionObject & err)
+  catch (const itk::ExceptionObject & err)
   {
     std::cerr << "Error during reading test transform parameters: " << err << std::endl;
     return EXIT_FAILURE;
@@ -148,7 +148,7 @@ main(int argc, char ** argv)
   {
     parameterFileParser->ReadParameterFile();
   }
-  catch (itk::ExceptionObject & err)
+  catch (const itk::ExceptionObject & err)
   {
     std::cerr << "Error during reading baseline transform parameters: " << err << std::endl;
     return EXIT_FAILURE;
@@ -321,7 +321,7 @@ main(int argc, char ** argv)
       {
         itk::WriteImage(coefImage, diffImageFileName);
       }
-      catch (itk::ExceptionObject & err)
+      catch (const itk::ExceptionObject & err)
       {
         std::cerr << "Error during writing difference image: " << err << std::endl;
         return EXIT_FAILURE;

--- a/Testing/itkMevisDicomTiffImageIOTest.cxx
+++ b/Testing/itkMevisDicomTiffImageIOTest.cxx
@@ -137,7 +137,7 @@ testMevis()
   {
     inputImage->Allocate();
   }
-  catch (itk::ExceptionObject & err)
+  catch (const itk::ExceptionObject & err)
   {
     std::cerr << "ERROR: Failed to allocate test image" << std::endl;
     std::cerr << err << std::endl;
@@ -168,7 +168,7 @@ testMevis()
     task = "Reading";
     reader->Update();
   }
-  catch (itk::ExceptionObject & err)
+  catch (const itk::ExceptionObject & err)
   {
     std::cerr << "ERROR: " << task << " mevis dicomtiff failed." << std::endl;
     std::cerr << err << std::endl;

--- a/Testing/itkThinPlateSplineTransformPerformanceTest.cxx
+++ b/Testing/itkThinPlateSplineTransformPerformanceTest.cxx
@@ -134,7 +134,7 @@ main(int argc, char * argv[])
   {
     ippReader->Update();
   }
-  catch (itk::ExceptionObject & excp)
+  catch (const itk::ExceptionObject & excp)
   {
     std::cerr << "  Error while opening input point file." << std::endl;
     std::cerr << excp << std::endl;

--- a/Testing/itkThinPlateSplineTransformTest.cxx
+++ b/Testing/itkThinPlateSplineTransformTest.cxx
@@ -67,7 +67,7 @@ main(int argc, char * argv[])
   {
     landmarkReader->Update();
   }
-  catch (itk::ExceptionObject & excp)
+  catch (const itk::ExceptionObject & excp)
   {
     std::cerr << "  Error while opening landmark file." << std::endl;
     std::cerr << excp << std::endl;


### PR DESCRIPTION
Various style improvements, preparing to reuse code from `elx::TransformBase<TElastix>::TransformPointsSomePoints` (as needed to re-implement the transformix executable in terms of the library)