### PR TITLE
ENH: Report any exception from elastix and transformix `main` functions

### DIFF
--- a/Core/CMakeLists.txt
+++ b/Core/CMakeLists.txt
@@ -146,6 +146,8 @@ endif()
 add_executable(elastix_exe
   Main/elastix.cxx
   Main/elastix.h
+  Main/elxMainExeUtilities.cxx
+  Main/elxMainExeUtilities.h
   Kernel/elxElastixMain.cxx
   Kernel/elxElastixMain.h
   ${InstallFilesForExecutables}
@@ -175,6 +177,8 @@ target_link_libraries(elastix_lib ${ELASTIX_TARGET_LINK_LIBRARIES})
 add_executable(transformix_exe
   Main/transformix.cxx
   Main/elastix.h
+  Main/elxMainExeUtilities.cxx
+  Main/elxMainExeUtilities.h
   Kernel/elxElastixMain.cxx
   Kernel/elxElastixMain.h
   Kernel/elxTransformixMain.cxx

--- a/Core/Main/elastix.cxx
+++ b/Core/Main/elastix.cxx
@@ -20,6 +20,7 @@
 #include "elastix.h"
 #include "elxConversion.h"
 #include "elxElastixMain.h"
+#include "elxMainExeUtilities.h"
 #include <Core/elxVersionMacros.h>
 #include "itkUseMevisDicomTiff.h"
 
@@ -83,290 +84,302 @@ constexpr const char * elastixHelpText =
 int
 main(int argc, char ** argv)
 {
-  elastix::BaseComponent::InitializeElastixExecutable();
-  assert(!elastix::BaseComponent::IsElastixLibrary());
+  try
+  {
+    elastix::BaseComponent::InitializeElastixExecutable();
+    assert(!elastix::BaseComponent::IsElastixLibrary());
 
-  /** Check if "--help" or "--version" was asked for. */
-  if (argc == 1)
-  {
-    std::cout << "Use \"elastix --help\" for information about elastix-usage." << std::endl;
-    return 0;
-  }
-  else if (argc == 2)
-  {
-    std::string argument(argv[1]);
-    if (argument == "-help" || argument == "--help" || argument == "-h")
-    {
-      std::cout << elastixHelpText << std::endl;
-      return 0;
-    }
-    else if (argument == "--version")
-    {
-      std::cout << "elastix version: " ELASTIX_VERSION_STRING << std::endl;
-      return 0;
-    }
-    else if (argument == "--extended-version")
-    {
-      std::cout << "elastix version: " ELASTIX_VERSION_STRING << "\nITK version: " << ITK_VERSION_MAJOR << '.'
-                << ITK_VERSION_MINOR << '.' << ITK_VERSION_PATCH << "\nBuild date: " << __DATE__ << ' ' << __TIME__
-#ifdef _MSC_FULL_VER
-                << "\nCompiler: Visual C++ version " << _MSC_FULL_VER << '.' << _MSC_BUILD
-#endif
-#ifdef __clang__
-                << "\nCompiler: Clang"
-#  ifdef __VERSION__
-                << " version " << __VERSION__
-#  endif
-#endif
-#if defined(__GNUC__)
-                << "\nCompiler: GCC"
-#  ifdef __VERSION__
-                << " version " << __VERSION__
-#  endif
-#endif
-                << "\nMemory address size: " << std::numeric_limits<std::size_t>::digits
-                << "-bit\nCMake version: " << ELX_CMAKE_VERSION << std::endl;
-      return 0;
-    }
-    else
+    /** Check if "--help" or "--version" was asked for. */
+    if (argc == 1)
     {
       std::cout << "Use \"elastix --help\" for information about elastix-usage." << std::endl;
       return 0;
     }
-  }
-
-  /** Some typedef's. */
-  using ElastixMainType = elx::ElastixMain;
-  using ObjectPointer = ElastixMainType::ObjectPointer;
-  using DataObjectContainerPointer = ElastixMainType::DataObjectContainerPointer;
-  using FlatDirectionCosinesType = ElastixMainType::FlatDirectionCosinesType;
-
-  using ArgumentMapType = ElastixMainType::ArgumentMapType;
-  using ArgumentMapEntryType = ArgumentMapType::value_type;
-
-  /** Support Mevis Dicom Tiff (if selected in cmake) */
-  RegisterMevisDicomTiff();
-
-  ArgumentMapType         argMap;
-  std::queue<std::string> parameterFileList;
-  std::string             outFolder;
-
-  /** Put command line parameters into parameterFileList. */
-  for (unsigned int i = 1; static_cast<long>(i) < (argc - 1); i += 2)
-  {
-    std::string key(argv[i]);
-    std::string value(argv[i + 1]);
-
-    if (key == "-p")
+    else if (argc == 2)
     {
-      /** Queue the ParameterFileNames. */
-      parameterFileList.push(value);
-      /** The different '-p' are stored in the argMap, with
-       * keys p(1), p(2), etc. */
-      std::ostringstream tempPname;
-      tempPname << "-p(" << parameterFileList.size() << ")";
-      std::string tempPName = tempPname.str();
-      argMap.insert(ArgumentMapEntryType(tempPName, value));
-    }
-    else
-    {
-      if (key == "-out")
+      std::string argument(argv[1]);
+      if (argument == "-help" || argument == "--help" || argument == "-h")
       {
-        /** Make sure that last character of the output folder equals a '/' or '\'. */
-        const char last = value.back();
-        if (last != '/' && last != '\\')
-        {
-          value.append("/");
-        }
-        value = elx::Conversion::ToNativePathNameSeparators(value);
-
-        /** Save this information. */
-        outFolder = value;
-
-      } // end if key == "-out"
-
-      /** Attempt to save the arguments in the ArgumentMap. */
-      if (argMap.count(key) == 0)
+        std::cout << elastixHelpText << std::endl;
+        return 0;
+      }
+      else if (argument == "--version")
       {
-        argMap.insert(ArgumentMapEntryType(key, value));
+        std::cout << "elastix version: " ELASTIX_VERSION_STRING << std::endl;
+        return 0;
+      }
+      else if (argument == "--extended-version")
+      {
+        std::cout << "elastix version: " ELASTIX_VERSION_STRING << "\nITK version: " << ITK_VERSION_MAJOR << '.'
+                  << ITK_VERSION_MINOR << '.' << ITK_VERSION_PATCH << "\nBuild date: " << __DATE__ << ' ' << __TIME__
+#ifdef _MSC_FULL_VER
+                  << "\nCompiler: Visual C++ version " << _MSC_FULL_VER << '.' << _MSC_BUILD
+#endif
+#ifdef __clang__
+                  << "\nCompiler: Clang"
+#  ifdef __VERSION__
+                  << " version " << __VERSION__
+#  endif
+#endif
+#if defined(__GNUC__)
+                  << "\nCompiler: GCC"
+#  ifdef __VERSION__
+                  << " version " << __VERSION__
+#  endif
+#endif
+                  << "\nMemory address size: " << std::numeric_limits<std::size_t>::digits
+                  << "-bit\nCMake version: " << ELX_CMAKE_VERSION << std::endl;
+        return 0;
       }
       else
       {
-        /** Duplicate arguments. */
-        std::cerr << "WARNING!" << std::endl;
-        std::cerr << "Argument " << key << "is only required once." << std::endl;
-        std::cerr << "Arguments " << key << " " << value << "are ignored" << std::endl;
+        std::cout << "Use \"elastix --help\" for information about elastix-usage." << std::endl;
+        return 0;
       }
+    }
 
-    } // end else (so, if key does not equal "-p")
+    /** Some typedef's. */
+    using ElastixMainType = elx::ElastixMain;
+    using ObjectPointer = ElastixMainType::ObjectPointer;
+    using DataObjectContainerPointer = ElastixMainType::DataObjectContainerPointer;
+    using FlatDirectionCosinesType = ElastixMainType::FlatDirectionCosinesType;
 
-  } // end for loop
+    using ArgumentMapType = ElastixMainType::ArgumentMapType;
+    using ArgumentMapEntryType = ArgumentMapType::value_type;
 
-  /** The argv0 argument, required for finding the component.dll/so's. */
-  argMap.insert(ArgumentMapEntryType("-argv0", argv[0]));
+    /** Support Mevis Dicom Tiff (if selected in cmake) */
+    RegisterMevisDicomTiff();
 
-  int returndummy{};
+    ArgumentMapType         argMap;
+    std::queue<std::string> parameterFileList;
+    std::string             outFolder;
 
-  /** Check if at least once the option "-p" is given. */
-  if (parameterFileList.empty())
-  {
-    std::cerr << "ERROR: No CommandLine option \"-p\" given!" << std::endl;
-    returndummy |= -1;
-  }
-
-  /** Check if the -out option is given. */
-  if (!outFolder.empty())
-  {
-    /** Check if the output directory exists. */
-    if (!itksys::SystemTools::FileIsDirectory(outFolder))
+    /** Put command line parameters into parameterFileList. */
+    for (unsigned int i = 1; static_cast<long>(i) < (argc - 1); i += 2)
     {
-      std::cerr << "ERROR: the output directory \"" << outFolder << "\" does not exist." << std::endl;
-      std::cerr << "You are responsible for creating it." << std::endl;
-      returndummy |= -2;
+      std::string key(argv[i]);
+      std::string value(argv[i + 1]);
+
+      if (key == "-p")
+      {
+        /** Queue the ParameterFileNames. */
+        parameterFileList.push(value);
+        /** The different '-p' are stored in the argMap, with
+         * keys p(1), p(2), etc. */
+        std::ostringstream tempPname;
+        tempPname << "-p(" << parameterFileList.size() << ")";
+        std::string tempPName = tempPname.str();
+        argMap.insert(ArgumentMapEntryType(tempPName, value));
+      }
+      else
+      {
+        if (key == "-out")
+        {
+          /** Make sure that last character of the output folder equals a '/' or '\'. */
+          const char last = value.back();
+          if (last != '/' && last != '\\')
+          {
+            value.append("/");
+          }
+          value = elx::Conversion::ToNativePathNameSeparators(value);
+
+          /** Save this information. */
+          outFolder = value;
+
+        } // end if key == "-out"
+
+        /** Attempt to save the arguments in the ArgumentMap. */
+        if (argMap.count(key) == 0)
+        {
+          argMap.insert(ArgumentMapEntryType(key, value));
+        }
+        else
+        {
+          /** Duplicate arguments. */
+          std::cerr << "WARNING!" << std::endl;
+          std::cerr << "Argument " << key << "is only required once." << std::endl;
+          std::cerr << "Arguments " << key << " " << value << "are ignored" << std::endl;
+        }
+
+      } // end else (so, if key does not equal "-p")
+
+    } // end for loop
+
+    /** The argv0 argument, required for finding the component.dll/so's. */
+    argMap.insert(ArgumentMapEntryType("-argv0", argv[0]));
+
+    int returndummy{};
+
+    /** Check if at least once the option "-p" is given. */
+    if (parameterFileList.empty())
+    {
+      std::cerr << "ERROR: No CommandLine option \"-p\" given!" << std::endl;
+      returndummy |= -1;
+    }
+
+    /** Check if the -out option is given. */
+    if (!outFolder.empty())
+    {
+      /** Check if the output directory exists. */
+      if (!itksys::SystemTools::FileIsDirectory(outFolder))
+      {
+        std::cerr << "ERROR: the output directory \"" << outFolder << "\" does not exist." << std::endl;
+        std::cerr << "You are responsible for creating it." << std::endl;
+        returndummy |= -2;
+      }
+      else
+      {
+        /** Setup xout. */
+        const std::string logFileName = outFolder + "elastix.log";
+        const int         returndummy2{ elx::xoutSetup(logFileName.c_str(), true, true) };
+        if (returndummy2 != 0)
+        {
+          std::cerr << "ERROR while setting up xout." << std::endl;
+        }
+        returndummy |= returndummy2;
+      }
     }
     else
     {
-      /** Setup xout. */
-      const std::string logFileName = outFolder + "elastix.log";
-      const int         returndummy2{ elx::xoutSetup(logFileName.c_str(), true, true) };
-      if (returndummy2 != 0)
-      {
-        std::cerr << "ERROR while setting up xout." << std::endl;
-      }
-      returndummy |= returndummy2;
+      returndummy = -2;
+      std::cerr << "ERROR: No CommandLine option \"-out\" given!" << std::endl;
     }
-  }
-  else
-  {
-    returndummy = -2;
-    std::cerr << "ERROR: No CommandLine option \"-out\" given!" << std::endl;
-  }
 
-  /** Stop if some fatal errors occurred. */
-  if (returndummy != 0)
-  {
-    return returndummy;
-  }
-
-  elxout << std::endl;
-
-  /** Declare a timer, start it and print the start time. */
-  itk::TimeProbe totaltimer;
-  totaltimer.Start();
-  elxout << "elastix is started at " << GetCurrentDateAndTime() << ".\n" << std::endl;
-
-  /** Print where elastix was run. */
-  elxout << "which elastix:   " << argv[0] << std::endl;
-  itksys::SystemInformation info;
-  info.RunCPUCheck();
-  info.RunOSCheck();
-  info.RunMemoryCheck();
-  elxout << "elastix runs at: " << info.GetHostname() << std::endl;
-  elxout << "  " << info.GetOSName() << " " << info.GetOSRelease() << (info.Is64Bits() ? " (x64), " : ", ")
-         << info.GetOSVersion() << std::endl;
-  elxout << "  with " << info.GetTotalPhysicalMemory() << " MB memory, and " << info.GetNumberOfPhysicalCPU()
-         << " cores @ " << static_cast<unsigned int>(info.GetProcessorClockFrequency()) << " MHz." << std::endl;
-
-
-  ObjectPointer              transform = nullptr;
-  DataObjectContainerPointer fixedImageContainer = nullptr;
-  DataObjectContainerPointer movingImageContainer = nullptr;
-  DataObjectContainerPointer fixedMaskContainer = nullptr;
-  DataObjectContainerPointer movingMaskContainer = nullptr;
-  FlatDirectionCosinesType   fixedImageOriginalDirection;
-
-  /**
-   * ********************* START REGISTRATION *********************
-   *
-   * Do the (possibly multiple) registration(s).
-   */
-
-  const auto nrOfParameterFiles = parameterFileList.size();
-  assert(nrOfParameterFiles <= UINT_MAX);
-
-  for (unsigned i{}; i < static_cast<unsigned>(nrOfParameterFiles); ++i)
-  {
-    /** Create another instance of ElastixMain. */
-    const auto elastixMain = ElastixMainType::New();
-
-    /** Set stuff we get from a former registration. */
-    elastixMain->SetInitialTransform(transform);
-    elastixMain->SetFixedImageContainer(fixedImageContainer);
-    elastixMain->SetMovingImageContainer(movingImageContainer);
-    elastixMain->SetFixedMaskContainer(fixedMaskContainer);
-    elastixMain->SetMovingMaskContainer(movingMaskContainer);
-    elastixMain->SetOriginalFixedImageDirectionFlat(fixedImageOriginalDirection);
-
-    /** Set the current elastix-level. */
-    elastixMain->SetElastixLevel(i);
-    elastixMain->SetTotalNumberOfElastixLevels(nrOfParameterFiles);
-
-    /** Get the argMap entry for the parameter file, and exchange its file name
-     * with the first file name in the list.
-     */
-    std::string & parameterFileName = argMap["-p"];
-    parameterFileName.swap(parameterFileList.front());
-    parameterFileList.pop();
-
-    /** Print a start message. */
-    elxout << "-------------------------------------------------------------------------\n" << std::endl;
-    elxout << "Running elastix with parameter file " << i << ": \"" << parameterFileName << "\".\n" << std::endl;
-
-    /** Declare a timer, start it and print the start time. */
-    itk::TimeProbe timer;
-    timer.Start();
-    elxout << "Current time: " << GetCurrentDateAndTime() << "." << std::endl;
-
-    /** Start registration. */
-    returndummy = elastixMain->Run(argMap);
-
-    /** Check for errors. */
+    /** Stop if some fatal errors occurred. */
     if (returndummy != 0)
     {
-      xl::xout["error"] << "Errors occurred!" << std::endl;
       return returndummy;
     }
 
-    /** Get the transform, the fixedImage and the movingImage
-     * in order to put it in the (possibly) next registration.
+    elxout << std::endl;
+
+    /** Declare a timer, start it and print the start time. */
+    itk::TimeProbe totaltimer;
+    totaltimer.Start();
+    elxout << "elastix is started at " << GetCurrentDateAndTime() << ".\n" << std::endl;
+
+    /** Print where elastix was run. */
+    elxout << "which elastix:   " << argv[0] << std::endl;
+    itksys::SystemInformation info;
+    info.RunCPUCheck();
+    info.RunOSCheck();
+    info.RunMemoryCheck();
+    elxout << "elastix runs at: " << info.GetHostname() << std::endl;
+    elxout << "  " << info.GetOSName() << " " << info.GetOSRelease() << (info.Is64Bits() ? " (x64), " : ", ")
+           << info.GetOSVersion() << std::endl;
+    elxout << "  with " << info.GetTotalPhysicalMemory() << " MB memory, and " << info.GetNumberOfPhysicalCPU()
+           << " cores @ " << static_cast<unsigned int>(info.GetProcessorClockFrequency()) << " MHz." << std::endl;
+
+
+    ObjectPointer              transform = nullptr;
+    DataObjectContainerPointer fixedImageContainer = nullptr;
+    DataObjectContainerPointer movingImageContainer = nullptr;
+    DataObjectContainerPointer fixedMaskContainer = nullptr;
+    DataObjectContainerPointer movingMaskContainer = nullptr;
+    FlatDirectionCosinesType   fixedImageOriginalDirection;
+
+    /**
+     * ********************* START REGISTRATION *********************
+     *
+     * Do the (possibly multiple) registration(s).
      */
-    transform = elastixMain->GetModifiableFinalTransform();
-    fixedImageContainer = elastixMain->GetModifiableFixedImageContainer();
-    movingImageContainer = elastixMain->GetModifiableMovingImageContainer();
-    fixedMaskContainer = elastixMain->GetModifiableFixedMaskContainer();
-    movingMaskContainer = elastixMain->GetModifiableMovingMaskContainer();
-    fixedImageOriginalDirection = elastixMain->GetOriginalFixedImageDirectionFlat();
 
-    /** Print a finish message. */
-    elxout << "Running elastix with parameter file " << i << ": \"" << parameterFileName << "\", has finished.\n"
-           << std::endl;
+    const auto nrOfParameterFiles = parameterFileList.size();
+    assert(nrOfParameterFiles <= UINT_MAX);
 
-    /** Stop timer and print it. */
-    timer.Stop();
-    elxout << "\nCurrent time: " << GetCurrentDateAndTime() << "." << std::endl;
-    elxout << "Time used for running elastix with this parameter file:\n  " << ConvertSecondsToDHMS(timer.GetMean(), 1)
-           << ".\n"
-           << std::endl;
-  } // end loop over registrations
+    for (unsigned i{}; i < static_cast<unsigned>(nrOfParameterFiles); ++i)
+    {
+      /** Create another instance of ElastixMain. */
+      const auto elastixMain = ElastixMainType::New();
 
-  elxout << "-------------------------------------------------------------------------\n" << std::endl;
+      /** Set stuff we get from a former registration. */
+      elastixMain->SetInitialTransform(transform);
+      elastixMain->SetFixedImageContainer(fixedImageContainer);
+      elastixMain->SetMovingImageContainer(movingImageContainer);
+      elastixMain->SetFixedMaskContainer(fixedMaskContainer);
+      elastixMain->SetMovingMaskContainer(movingMaskContainer);
+      elastixMain->SetOriginalFixedImageDirectionFlat(fixedImageOriginalDirection);
 
-  /** Stop totaltimer and print it. */
-  totaltimer.Stop();
-  elxout << "Total time elapsed: " << ConvertSecondsToDHMS(totaltimer.GetMean(), 1) << ".\n" << std::endl;
+      /** Set the current elastix-level. */
+      elastixMain->SetElastixLevel(i);
+      elastixMain->SetTotalNumberOfElastixLevels(nrOfParameterFiles);
 
-  /**
-   * Make sure all the components that are defined in a Module (.DLL/.so)
-   * are deleted before the modules are closed.
-   */
+      /** Get the argMap entry for the parameter file, and exchange its file name
+       * with the first file name in the list.
+       */
+      std::string & parameterFileName = argMap["-p"];
+      parameterFileName.swap(parameterFileList.front());
+      parameterFileList.pop();
 
-  transform = nullptr;
-  fixedImageContainer = nullptr;
-  movingImageContainer = nullptr;
-  fixedMaskContainer = nullptr;
-  movingMaskContainer = nullptr;
+      /** Print a start message. */
+      elxout << "-------------------------------------------------------------------------\n" << std::endl;
+      elxout << "Running elastix with parameter file " << i << ": \"" << parameterFileName << "\".\n" << std::endl;
 
-  /** Exit and return the error code. */
-  return 0;
+      /** Declare a timer, start it and print the start time. */
+      itk::TimeProbe timer;
+      timer.Start();
+      elxout << "Current time: " << GetCurrentDateAndTime() << "." << std::endl;
+
+      /** Start registration. */
+      returndummy = elastixMain->Run(argMap);
+
+      /** Check for errors. */
+      if (returndummy != 0)
+      {
+        xl::xout["error"] << "Errors occurred!" << std::endl;
+        return returndummy;
+      }
+
+      /** Get the transform, the fixedImage and the movingImage
+       * in order to put it in the (possibly) next registration.
+       */
+      transform = elastixMain->GetModifiableFinalTransform();
+      fixedImageContainer = elastixMain->GetModifiableFixedImageContainer();
+      movingImageContainer = elastixMain->GetModifiableMovingImageContainer();
+      fixedMaskContainer = elastixMain->GetModifiableFixedMaskContainer();
+      movingMaskContainer = elastixMain->GetModifiableMovingMaskContainer();
+      fixedImageOriginalDirection = elastixMain->GetOriginalFixedImageDirectionFlat();
+
+      /** Print a finish message. */
+      elxout << "Running elastix with parameter file " << i << ": \"" << parameterFileName << "\", has finished.\n"
+             << std::endl;
+
+      /** Stop timer and print it. */
+      timer.Stop();
+      elxout << "\nCurrent time: " << GetCurrentDateAndTime() << "." << std::endl;
+      elxout << "Time used for running elastix with this parameter file:\n  "
+             << ConvertSecondsToDHMS(timer.GetMean(), 1) << ".\n"
+             << std::endl;
+    } // end loop over registrations
+
+    elxout << "-------------------------------------------------------------------------\n" << std::endl;
+
+    /** Stop totaltimer and print it. */
+    totaltimer.Stop();
+    elxout << "Total time elapsed: " << ConvertSecondsToDHMS(totaltimer.GetMean(), 1) << ".\n" << std::endl;
+
+    /**
+     * Make sure all the components that are defined in a Module (.DLL/.so)
+     * are deleted before the modules are closed.
+     */
+
+    transform = nullptr;
+    fixedImageContainer = nullptr;
+    movingImageContainer = nullptr;
+    fixedMaskContainer = nullptr;
+    movingMaskContainer = nullptr;
+
+    /** Exit and return the error code. */
+    return 0;
+  }
+  catch (const std::exception & stdException)
+  {
+    elx::ReportTerminatingException("elastix", stdException);
+  }
+  catch (...)
+  {
+    assert(!"Exceptions should be derived from std::exception!");
+  }
+  return EXIT_FAILURE;
 
 } // end main

--- a/Core/Main/elxMainExeUtilities.cxx
+++ b/Core/Main/elxMainExeUtilities.cxx
@@ -1,0 +1,66 @@
+/*=========================================================================
+ *
+ *  Copyright UMC Utrecht and contributors
+ *
+ *  Licensed under the Apache License, Version 2.0 (the "License");
+ *  you may not use this file except in compliance with the License.
+ *  You may obtain a copy of the License at
+ *
+ *        http://www.apache.org/licenses/LICENSE-2.0.txt
+ *
+ *  Unless required by applicable law or agreed to in writing, software
+ *  distributed under the License is distributed on an "AS IS" BASIS,
+ *  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *  See the License for the specific language governing permissions and
+ *  limitations under the License.
+ *
+ *=========================================================================*/
+
+// Its own header file:
+#include "elxMainExeUtilities.h"
+
+#include "xoutmain.h"
+#include <itkMacro.h>
+
+// Standard Library header files:
+#include <cassert>
+#include <exception>
+#include <sstream>
+#include <typeinfo>
+
+
+void
+elastix::ReportTerminatingException(const char * const executableName, const std::exception & stdException) noexcept
+{
+  try
+  {
+    std::ostringstream outputStringStream;
+
+    outputStringStream << "ERROR: " << executableName
+                       << " terminated because of the following exception:\nException type: "
+                       << typeid(stdException).name();
+
+    const auto itkExceptionObject = dynamic_cast<const itk::ExceptionObject *>(&stdException);
+
+    if (itkExceptionObject)
+    {
+      // itk::ExceptionObject provides the most information by inserting the object directly, instead of calling what().
+      outputStringStream << *itkExceptionObject;
+    }
+    else
+    {
+      outputStringStream << "\nWhat message: " << stdException.what() << '\n';
+    }
+
+    const std::string message = outputStringStream.str();
+
+    // Insert the message into the standard error stream, as well as into xout, because xout might not yet be set up.
+    std::cerr << message;
+    xl::xout["error"] << message << std::flush;
+  }
+  catch (...)
+  {
+    // Enforce that this function itself will never throw any exception.
+    assert(!"Unhandled exception!");
+  }
+}

--- a/Core/Main/elxMainExeUtilities.h
+++ b/Core/Main/elxMainExeUtilities.h
@@ -1,0 +1,32 @@
+/*=========================================================================
+ *
+ *  Copyright UMC Utrecht and contributors
+ *
+ *  Licensed under the Apache License, Version 2.0 (the "License");
+ *  you may not use this file except in compliance with the License.
+ *  You may obtain a copy of the License at
+ *
+ *        http://www.apache.org/licenses/LICENSE-2.0.txt
+ *
+ *  Unless required by applicable law or agreed to in writing, software
+ *  distributed under the License is distributed on an "AS IS" BASIS,
+ *  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *  See the License for the specific language governing permissions and
+ *  limitations under the License.
+ *
+ *=========================================================================*/
+#ifndef elxMainExeUtilities_h
+#define elxMainExeUtilities_h
+
+#include <exception>
+
+
+namespace elastix
+{
+/** Reports the exception that is terminating the process to the user. */
+void
+ReportTerminatingException(const char * const executableName, const std::exception & stdException) noexcept;
+
+} // namespace elastix
+
+#endif

--- a/Core/Main/transformix.cxx
+++ b/Core/Main/transformix.cxx
@@ -19,6 +19,7 @@
 // Elastix header files:
 #include "elastix.h"
 #include "elxConversion.h"
+#include "elxMainExeUtilities.h"
 #include "elxTransformixMain.h"
 #include <Core/elxVersionMacros.h>
 #include "itkUseMevisDicomTiff.h"
@@ -77,194 +78,206 @@ constexpr const char * transformixHelpText =
 int
 main(int argc, char ** argv)
 {
-  elastix::BaseComponent::InitializeElastixExecutable();
-  assert(!elastix::BaseComponent::IsElastixLibrary());
+  try
+  {
+    elastix::BaseComponent::InitializeElastixExecutable();
+    assert(!elastix::BaseComponent::IsElastixLibrary());
 
-  /** Check if "-help" or "--version" was asked for.*/
-  if (argc == 1)
-  {
-    std::cout << "Use \"transformix --help\" for information about transformix-usage." << std::endl;
-    return 0;
-  }
-  else if (argc == 2)
-  {
-    std::string argument(argv[1]);
-    if (argument == "-help" || argument == "--help" || argument == "-h")
-    {
-      std::cout << transformixHelpText << std::endl;
-      return 0;
-    }
-    else if (argument == "--version")
-    {
-      std::cout << "transformix version: " ELASTIX_VERSION_STRING << std::endl;
-      return 0;
-    }
-    else
+    /** Check if "-help" or "--version" was asked for.*/
+    if (argc == 1)
     {
       std::cout << "Use \"transformix --help\" for information about transformix-usage." << std::endl;
       return 0;
     }
-  }
-
-  /** Some typedef's.*/
-  using TransformixMainType = elx::TransformixMain;
-  using TransformixMainPointer = TransformixMainType::Pointer;
-  using ArgumentMapType = TransformixMainType::ArgumentMapType;
-  using ArgumentMapEntryType = ArgumentMapType::value_type;
-
-  /** Support Mevis Dicom Tiff (if selected in cmake) */
-  RegisterMevisDicomTiff();
-
-  /** Declare an instance of the Transformix class. */
-  TransformixMainPointer transformix;
-
-  /** Initialize. */
-  int             returndummy = 0;
-  ArgumentMapType argMap;
-  bool            outFolderPresent = false;
-  std::string     outFolder = "";
-  std::string     logFileName = "";
-
-  /** Put command line parameters into parameterFileList. */
-  for (unsigned int i = 1; static_cast<long>(i) < argc - 1; i += 2)
-  {
-    std::string key(argv[i]);
-    std::string value(argv[i + 1]);
-
-    if (key == "-out")
+    else if (argc == 2)
     {
-      /** Make sure that last character of the output folder equals a '/' or '\'. */
-      const char last = value.back();
-      if (last != '/' && last != '\\')
+      std::string argument(argv[1]);
+      if (argument == "-help" || argument == "--help" || argument == "-h")
       {
-        value.append("/");
+        std::cout << transformixHelpText << std::endl;
+        return 0;
       }
-      value = elx::Conversion::ToNativePathNameSeparators(value);
+      else if (argument == "--version")
+      {
+        std::cout << "transformix version: " ELASTIX_VERSION_STRING << std::endl;
+        return 0;
+      }
+      else
+      {
+        std::cout << "Use \"transformix --help\" for information about transformix-usage." << std::endl;
+        return 0;
+      }
+    }
 
-      /** Save this information. */
-      outFolderPresent = true;
-      outFolder = value;
+    /** Some typedef's.*/
+    using TransformixMainType = elx::TransformixMain;
+    using TransformixMainPointer = TransformixMainType::Pointer;
+    using ArgumentMapType = TransformixMainType::ArgumentMapType;
+    using ArgumentMapEntryType = ArgumentMapType::value_type;
 
-    } // end if key == "-out"
+    /** Support Mevis Dicom Tiff (if selected in cmake) */
+    RegisterMevisDicomTiff();
 
-    /** Attempt to save the arguments in the ArgumentMap. */
-    if (argMap.count(key) == 0)
+    /** Declare an instance of the Transformix class. */
+    TransformixMainPointer transformix;
+
+    /** Initialize. */
+    int             returndummy = 0;
+    ArgumentMapType argMap;
+    bool            outFolderPresent = false;
+    std::string     outFolder = "";
+    std::string     logFileName = "";
+
+    /** Put command line parameters into parameterFileList. */
+    for (unsigned int i = 1; static_cast<long>(i) < argc - 1; i += 2)
     {
-      argMap.insert(ArgumentMapEntryType(key.c_str(), value.c_str()));
+      std::string key(argv[i]);
+      std::string value(argv[i + 1]);
+
+      if (key == "-out")
+      {
+        /** Make sure that last character of the output folder equals a '/' or '\'. */
+        const char last = value.back();
+        if (last != '/' && last != '\\')
+        {
+          value.append("/");
+        }
+        value = elx::Conversion::ToNativePathNameSeparators(value);
+
+        /** Save this information. */
+        outFolderPresent = true;
+        outFolder = value;
+
+      } // end if key == "-out"
+
+      /** Attempt to save the arguments in the ArgumentMap. */
+      if (argMap.count(key) == 0)
+      {
+        argMap.insert(ArgumentMapEntryType(key.c_str(), value.c_str()));
+      }
+      else
+      {
+        /** Duplicate arguments. */
+        std::cerr << "WARNING!" << std::endl;
+        std::cerr << "Argument " << key.c_str() << "is only required once." << std::endl;
+        std::cerr << "Arguments " << key.c_str() << " " << value.c_str() << "are ignored" << std::endl;
+      }
+
+    } // end for loop
+
+    /** The argv0 argument, required for finding the component.dll/so's. */
+    argMap.insert(ArgumentMapEntryType("-argv0", argv[0]));
+
+    /** Check that the option "-tp" is given. */
+    if (argMap.count("-tp") == 0)
+    {
+      std::cerr << "ERROR: No CommandLine option \"-tp\" given!" << std::endl;
+      returndummy |= -1;
+    }
+
+    /** Check that at least one of the following options is given. */
+    if (argMap.count("-in") == 0 && argMap.count("-ipp") == 0 && argMap.count("-def") == 0 &&
+        argMap.count("-jac") == 0 && argMap.count("-jacmat") == 0)
+    {
+      std::cerr
+        << "ERROR: At least one of the CommandLine options \"-in\", \"-def\", \"-jac\", or \"-jacmat\" should be given!"
+        << std::endl;
+      returndummy |= -1;
+    }
+
+    /** Check if the -out option is given and setup xout. */
+    if (outFolderPresent)
+    {
+      /** Check if the output directory exists. */
+      bool outFolderExists = itksys::SystemTools::FileIsDirectory(outFolder);
+      if (!outFolderExists)
+      {
+        std::cerr << "ERROR: the output directory \"" << outFolder << "\" does not exist." << std::endl;
+        std::cerr << "You are responsible for creating it." << std::endl;
+        returndummy |= -2;
+      }
+      else
+      {
+        /** Setup xout. */
+        logFileName = argMap["-out"] + "transformix.log";
+        int returndummy2 = elx::xoutSetup(logFileName.c_str(), true, true);
+        if (returndummy2)
+        {
+          std::cerr << "ERROR while setting up xout." << std::endl;
+        }
+        returndummy |= returndummy2;
+      }
     }
     else
     {
-      /** Duplicate arguments. */
-      std::cerr << "WARNING!" << std::endl;
-      std::cerr << "Argument " << key.c_str() << "is only required once." << std::endl;
-      std::cerr << "Arguments " << key.c_str() << " " << value.c_str() << "are ignored" << std::endl;
+      returndummy = -2;
+      std::cerr << "ERROR: No CommandLine option \"-out\" given!" << std::endl;
     }
 
-  } // end for loop
-
-  /** The argv0 argument, required for finding the component.dll/so's. */
-  argMap.insert(ArgumentMapEntryType("-argv0", argv[0]));
-
-  /** Check that the option "-tp" is given. */
-  if (argMap.count("-tp") == 0)
-  {
-    std::cerr << "ERROR: No CommandLine option \"-tp\" given!" << std::endl;
-    returndummy |= -1;
-  }
-
-  /** Check that at least one of the following options is given. */
-  if (argMap.count("-in") == 0 && argMap.count("-ipp") == 0 && argMap.count("-def") == 0 && argMap.count("-jac") == 0 &&
-      argMap.count("-jacmat") == 0)
-  {
-    std::cerr
-      << "ERROR: At least one of the CommandLine options \"-in\", \"-def\", \"-jac\", or \"-jacmat\" should be given!"
-      << std::endl;
-    returndummy |= -1;
-  }
-
-  /** Check if the -out option is given and setup xout. */
-  if (outFolderPresent)
-  {
-    /** Check if the output directory exists. */
-    bool outFolderExists = itksys::SystemTools::FileIsDirectory(outFolder);
-    if (!outFolderExists)
+    /** Stop if some fatal errors occurred. */
+    if (returndummy)
     {
-      std::cerr << "ERROR: the output directory \"" << outFolder << "\" does not exist." << std::endl;
-      std::cerr << "You are responsible for creating it." << std::endl;
-      returndummy |= -2;
+      return returndummy;
     }
-    else
-    {
-      /** Setup xout. */
-      logFileName = argMap["-out"] + "transformix.log";
-      int returndummy2 = elx::xoutSetup(logFileName.c_str(), true, true);
-      if (returndummy2)
-      {
-        std::cerr << "ERROR while setting up xout." << std::endl;
-      }
-      returndummy |= returndummy2;
-    }
-  }
-  else
-  {
-    returndummy = -2;
-    std::cerr << "ERROR: No CommandLine option \"-out\" given!" << std::endl;
-  }
 
-  /** Stop if some fatal errors occurred. */
-  if (returndummy)
-  {
+    elxout << std::endl;
+
+    /** Declare a timer, start it and print the start time. */
+    itk::TimeProbe totaltimer;
+    totaltimer.Start();
+    elxout << "transformix is started at " << GetCurrentDateAndTime() << ".\n" << std::endl;
+
+    /** Print where transformix was run. */
+    elxout << "which transformix:   " << argv[0] << std::endl;
+    itksys::SystemInformation info;
+    info.RunCPUCheck();
+    info.RunOSCheck();
+    info.RunMemoryCheck();
+    elxout << "transformix runs at: " << info.GetHostname() << std::endl;
+    elxout << "  " << info.GetOSName() << " " << info.GetOSRelease() << (info.Is64Bits() ? " (x64), " : ", ")
+           << info.GetOSVersion() << std::endl;
+    elxout << "  with " << info.GetTotalPhysicalMemory() << " MB memory, and " << info.GetNumberOfPhysicalCPU()
+           << " cores @ " << static_cast<unsigned int>(info.GetProcessorClockFrequency()) << " MHz." << std::endl;
+
+    /**
+     * ********************* START TRANSFORMATION *******************
+     */
+
+    /** Set transformix. */
+    transformix = TransformixMainType::New();
+
+    /** Print a start message. */
+    elxout << "Running transformix with parameter file \"" << argMap["-tp"] << "\".\n" << std::endl;
+
+    /** Run transformix. */
+    returndummy = transformix->Run(argMap);
+
+    /** Check if transformix run without errors. */
+    if (returndummy != 0)
+    {
+      xl::xout["error"] << "Errors occurred" << std::endl;
+      return returndummy;
+    }
+
+    /** Stop timer and print it. */
+    totaltimer.Stop();
+    elxout << "\ntransformix has finished at " << GetCurrentDateAndTime() << "." << std::endl;
+    elxout << "Total time elapsed: " << ConvertSecondsToDHMS(totaltimer.GetMean(), 1) << ".\n" << std::endl;
+
+    /** Clean up. */
+    transformix = nullptr;
+
+    /** Exit and return the error code. */
     return returndummy;
   }
-
-  elxout << std::endl;
-
-  /** Declare a timer, start it and print the start time. */
-  itk::TimeProbe totaltimer;
-  totaltimer.Start();
-  elxout << "transformix is started at " << GetCurrentDateAndTime() << ".\n" << std::endl;
-
-  /** Print where transformix was run. */
-  elxout << "which transformix:   " << argv[0] << std::endl;
-  itksys::SystemInformation info;
-  info.RunCPUCheck();
-  info.RunOSCheck();
-  info.RunMemoryCheck();
-  elxout << "transformix runs at: " << info.GetHostname() << std::endl;
-  elxout << "  " << info.GetOSName() << " " << info.GetOSRelease() << (info.Is64Bits() ? " (x64), " : ", ")
-         << info.GetOSVersion() << std::endl;
-  elxout << "  with " << info.GetTotalPhysicalMemory() << " MB memory, and " << info.GetNumberOfPhysicalCPU()
-         << " cores @ " << static_cast<unsigned int>(info.GetProcessorClockFrequency()) << " MHz." << std::endl;
-
-  /**
-   * ********************* START TRANSFORMATION *******************
-   */
-
-  /** Set transformix. */
-  transformix = TransformixMainType::New();
-
-  /** Print a start message. */
-  elxout << "Running transformix with parameter file \"" << argMap["-tp"] << "\".\n" << std::endl;
-
-  /** Run transformix. */
-  returndummy = transformix->Run(argMap);
-
-  /** Check if transformix run without errors. */
-  if (returndummy != 0)
+  catch (const std::exception & stdException)
   {
-    xl::xout["error"] << "Errors occurred" << std::endl;
-    return returndummy;
+    elx::ReportTerminatingException("transformix", stdException);
   }
-
-  /** Stop timer and print it. */
-  totaltimer.Stop();
-  elxout << "\ntransformix has finished at " << GetCurrentDateAndTime() << "." << std::endl;
-  elxout << "Total time elapsed: " << ConvertSecondsToDHMS(totaltimer.GetMean(), 1) << ".\n" << std::endl;
-
-  /** Clean up. */
-  transformix = nullptr;
-
-  /** Exit and return the error code. */
-  return returndummy;
+  catch (...)
+  {
+    assert(!"Exceptions should be derived from std::exception!");
+  }
+  return EXIT_FAILURE;
 
 } // end main


### PR DESCRIPTION
Caught and reported exceptions from the `main` function of elastix and transformix, which would otherwise just cause the program to terminate unexpectedly.

Addressed LLVM 14.03 LLVM clang-tidy check `bugprone-exception-escape` regarding `main`:

> Finds functions which may throw an exception directly or indirectly, but they should not.

https://releases.llvm.org/14.0.0/tools/clang/tools/extra/docs/clang-tidy/checks/bugprone-exception-escape.html