### PR TITLE
ENH: Add git revision info to commandline output of `--extended-version`

### DIFF
--- a/Core/CMakeLists.txt
+++ b/Core/CMakeLists.txt
@@ -98,6 +98,28 @@ install(FILES
   ${CMAKE_CURRENT_BINARY_DIR}/elxVersionMacros.h
   DESTINATION ${CMAKE_INSTALL_PREFIX}/include/Core)
 #---------------------------------------------------------------------
+
+# Originally based on the answer by Naszta at
+# https://stackoverflow.com/questions/6526451/how-to-include-git-commit-number-into-a-c-executable
+find_package(Git)
+if(GIT_FOUND)
+  execute_process(
+    COMMAND ${GIT_EXECUTABLE} log -1 --format=%cd
+    WORKING_DIRECTORY "${CMAKE_CURRENT_SOURCE_DIR}"
+    OUTPUT_VARIABLE ELX_GIT_REVISION_DATE
+    ERROR_QUIET
+    OUTPUT_STRIP_TRAILING_WHITESPACE)
+  execute_process(
+    COMMAND ${GIT_EXECUTABLE} rev-parse HEAD
+    WORKING_DIRECTORY "${CMAKE_CURRENT_SOURCE_DIR}"
+    OUTPUT_VARIABLE ELX_GIT_REVISION_SHA
+    ERROR_QUIET
+    OUTPUT_STRIP_TRAILING_WHITESPACE)
+endif()
+
+configure_file(elxGitRevisionInfo.h.in elxGitRevisionInfo.h @ONLY)
+
+#---------------------------------------------------------------------
 # Create the elxCore library.
 
 add_library(elxCore STATIC

--- a/Core/Main/elastix.cxx
+++ b/Core/Main/elastix.cxx
@@ -110,7 +110,7 @@ main(int argc, char ** argv)
       }
       else if (argument == "--extended-version")
       {
-        elx::PrintExtendedVersionInformation("elastix");
+        std::cout << elx::GetExtendedVersionInformation("elastix");
         return 0;
       }
       else

--- a/Core/Main/elastix.cxx
+++ b/Core/Main/elastix.cxx
@@ -240,8 +240,10 @@ main(int argc, char ** argv)
     totaltimer.Start();
     elxout << "elastix is started at " << GetCurrentDateAndTime() << ".\n" << std::endl;
 
-    /** Print where elastix was run. */
-    elxout << "which elastix:   " << argv[0] << std::endl;
+    // Print where elastix was run, and print its version information.
+    elxout << "which elastix:   " << argv[0] << '\n'
+           << elx::GetExtendedVersionInformation("elastix", "  ") << std::flush;
+
     itksys::SystemInformation info;
     info.RunCPUCheck();
     info.RunOSCheck();

--- a/Core/Main/elxMainExeUtilities.cxx
+++ b/Core/Main/elxMainExeUtilities.cxx
@@ -20,6 +20,7 @@
 #include "elxMainExeUtilities.h"
 
 #include "xoutmain.h"
+#include <Core/elxGitRevisionInfo.h>
 #include <Core/elxVersionMacros.h>
 #include <itkMacro.h>
 
@@ -68,26 +69,44 @@ elastix::ReportTerminatingException(const char * const executableName, const std
 }
 
 
-void
-elastix::PrintExtendedVersionInformation(const char * const executableName)
+std::string
+elastix::GetExtendedVersionInformation(const char * const executableName)
 {
-  std::cout << executableName << " version: " ELASTIX_VERSION_STRING << "\nITK version: " << ITK_VERSION_MAJOR << '.'
-            << ITK_VERSION_MINOR << '.' << ITK_VERSION_PATCH << "\nBuild date: " << __DATE__ << ' ' << __TIME__
+  std::ostringstream outputStringStream;
+  outputStringStream << executableName << " version: " ELASTIX_VERSION_STRING;
+
+  static_assert(gitRevisionSha, "gitRevisionSha should never be null!");
+  static_assert(gitRevisionDate, "gitRevisionDate should never be null!");
+
+  if (*gitRevisionSha != '\0')
+  {
+    outputStringStream << "\nGit revision SHA: " << gitRevisionSha;
+  }
+
+  if (*gitRevisionDate != '\0')
+  {
+    outputStringStream << "\nGit revision date: " << gitRevisionDate;
+  }
+
+  outputStringStream << "\nBuild date: " << __DATE__ << ' ' << __TIME__
 #ifdef _MSC_FULL_VER
-            << "\nCompiler: Visual C++ version " << _MSC_FULL_VER << '.' << _MSC_BUILD
+                     << "\nCompiler: Visual C++ version " << _MSC_FULL_VER << '.' << _MSC_BUILD
 #endif
 #ifdef __clang__
-            << "\nCompiler: Clang"
+                     << "\nCompiler: Clang"
 #  ifdef __VERSION__
-            << " version " << __VERSION__
+                     << " version " << __VERSION__
 #  endif
 #endif
 #if defined(__GNUC__)
-            << "\nCompiler: GCC"
+                     << "\nCompiler: GCC"
 #  ifdef __VERSION__
-            << " version " << __VERSION__
+                     << " version " << __VERSION__
 #  endif
 #endif
-            << "\nMemory address size: " << std::numeric_limits<std::size_t>::digits
-            << "-bit\nCMake version: " << ELX_CMAKE_VERSION << std::endl;
+                     << "\nMemory address size: " << std::numeric_limits<std::size_t>::digits
+                     << "-bit\nCMake version: " ELX_CMAKE_VERSION "\nITK version: " << ITK_VERSION_MAJOR << '.'
+                     << ITK_VERSION_MINOR << '.' << ITK_VERSION_PATCH << '\n';
+
+  return outputStringStream.str();
 }

--- a/Core/Main/elxMainExeUtilities.cxx
+++ b/Core/Main/elxMainExeUtilities.cxx
@@ -70,43 +70,45 @@ elastix::ReportTerminatingException(const char * const executableName, const std
 
 
 std::string
-elastix::GetExtendedVersionInformation(const char * const executableName)
+elastix::GetExtendedVersionInformation(const char * const executableName, const char * const indentation)
 {
   std::ostringstream outputStringStream;
-  outputStringStream << executableName << " version: " ELASTIX_VERSION_STRING;
+  outputStringStream << indentation << executableName << " version: " ELASTIX_VERSION_STRING;
 
+  const std::string newline = '\n' + std::string(indentation);
   static_assert(gitRevisionSha, "gitRevisionSha should never be null!");
   static_assert(gitRevisionDate, "gitRevisionDate should never be null!");
 
   if (*gitRevisionSha != '\0')
   {
-    outputStringStream << "\nGit revision SHA: " << gitRevisionSha;
+    outputStringStream << newline << "Git revision SHA: " << gitRevisionSha;
   }
 
   if (*gitRevisionDate != '\0')
   {
-    outputStringStream << "\nGit revision date: " << gitRevisionDate;
+    outputStringStream << newline << "Git revision date: " << gitRevisionDate;
   }
 
-  outputStringStream << "\nBuild date: " << __DATE__ << ' ' << __TIME__
+  outputStringStream << newline << "Build date: " << __DATE__ << ' ' << __TIME__
 #ifdef _MSC_FULL_VER
-                     << "\nCompiler: Visual C++ version " << _MSC_FULL_VER << '.' << _MSC_BUILD
+                     << newline << "Compiler: Visual C++ version " << _MSC_FULL_VER << '.' << _MSC_BUILD
 #endif
 #ifdef __clang__
-                     << "\nCompiler: Clang"
+                     << newline << "Compiler: Clang"
 #  ifdef __VERSION__
                      << " version " << __VERSION__
 #  endif
 #endif
 #if defined(__GNUC__)
-                     << "\nCompiler: GCC"
+                     << newline << "Compiler: GCC"
 #  ifdef __VERSION__
                      << " version " << __VERSION__
 #  endif
 #endif
-                     << "\nMemory address size: " << std::numeric_limits<std::size_t>::digits
-                     << "-bit\nCMake version: " ELX_CMAKE_VERSION "\nITK version: " << ITK_VERSION_MAJOR << '.'
-                     << ITK_VERSION_MINOR << '.' << ITK_VERSION_PATCH << '\n';
+                     << newline << "Memory address size: " << std::numeric_limits<std::size_t>::digits << "-bit"
+                     << newline << "CMake version: " ELX_CMAKE_VERSION << newline
+                     << "ITK version: " << ITK_VERSION_MAJOR << '.' << ITK_VERSION_MINOR << '.' << ITK_VERSION_PATCH
+                     << '\n';
 
   return outputStringStream.str();
 }

--- a/Core/Main/elxMainExeUtilities.h
+++ b/Core/Main/elxMainExeUtilities.h
@@ -30,7 +30,7 @@ ReportTerminatingException(const char * const executableName, const std::excepti
 
 /** Prints extended version information to standard output. */
 std::string
-GetExtendedVersionInformation(const char * const executableName);
+GetExtendedVersionInformation(const char * const executableName, const char * const indentation = "");
 
 } // namespace elastix
 

--- a/Core/Main/elxMainExeUtilities.h
+++ b/Core/Main/elxMainExeUtilities.h
@@ -19,6 +19,7 @@
 #define elxMainExeUtilities_h
 
 #include <exception>
+#include <string>
 
 
 namespace elastix
@@ -28,8 +29,8 @@ void
 ReportTerminatingException(const char * const executableName, const std::exception & stdException) noexcept;
 
 /** Prints extended version information to standard output. */
-void
-PrintExtendedVersionInformation(const char * const executableName);
+std::string
+GetExtendedVersionInformation(const char * const executableName);
 
 } // namespace elastix
 

--- a/Core/Main/transformix.cxx
+++ b/Core/Main/transformix.cxx
@@ -232,8 +232,10 @@ main(int argc, char ** argv)
     totaltimer.Start();
     elxout << "transformix is started at " << GetCurrentDateAndTime() << ".\n" << std::endl;
 
-    /** Print where transformix was run. */
-    elxout << "which transformix:   " << argv[0] << std::endl;
+    // Print where transformix was run, and print its version information.
+    elxout << "which transformix:   " << argv[0] << '\n'
+           << elx::GetExtendedVersionInformation("transformix", "  ") << std::flush;
+
     itksys::SystemInformation info;
     info.RunCPUCheck();
     info.RunOSCheck();

--- a/Core/Main/transformix.cxx
+++ b/Core/Main/transformix.cxx
@@ -104,7 +104,7 @@ main(int argc, char ** argv)
       }
       else if (argument == "--extended-version")
       {
-        elx::PrintExtendedVersionInformation("transformix");
+        std::cout << elx::GetExtendedVersionInformation("transformix");
         return 0;
       }
       else

--- a/Core/elxGitRevisionInfo.h.in
+++ b/Core/elxGitRevisionInfo.h.in
@@ -1,0 +1,30 @@
+/*=========================================================================
+*
+*  Copyright Leiden University Medical Center, Erasmus University Medical
+*  Center and contributors
+*
+*  Licensed under the Apache License, Version 2.0 (the "License");
+*  you may not use this file except in compliance with the License.
+*  You may obtain a copy of the License at
+*
+*        http://www.apache.org/licenses/LICENSE-2.0.txt
+*
+*  Unless required by applicable law or agreed to in writing, software
+*  distributed under the License is distributed on an "AS IS" BASIS,
+*  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+*  See the License for the specific language governing permissions and
+*  limitations under the License.
+*
+*=========================================================================*/
+
+#ifndef elxGitRevisionSha_h
+#define elxGitRevisionSha_h
+
+namespace elastix
+{
+constexpr const char* gitRevisionSha = "@ELX_GIT_REVISION_SHA@";
+constexpr const char* gitRevisionDate = "@ELX_GIT_REVISION_DATE@";
+
+}
+
+#endif

--- a/Testing/PythonTests/transformix_test.py
+++ b/Testing/PythonTests/transformix_test.py
@@ -111,9 +111,11 @@ class TransformixTestCase(unittest.TestCase):
 
         output: str = completed.stdout.decode()
         self.assertTrue("transformix version: " in output)
-        self.assertTrue("ITK version: " in output)
+        self.assertTrue("Git revision SHA: " in output)
+        self.assertTrue("Git revision date: " in output)
         self.assertTrue("Memory address size: " in output)
         self.assertTrue("CMake version: " in output)
+        self.assertTrue("ITK version: " in output)
 
     def test_missing_tp_commandline_option(self) -> None:
         """Tests missing -tp commandline option"""


### PR DESCRIPTION
With this commit, the output of `elastix.exe --extended-version` will look something like this:

    elastix version: 5.0.1
    Git revision SHA: 81eb3b35e0fe24db05679254b2394b4201b047e2
    Git revision date: Fri Jul 8 11:46:04 2022 +0200
    Build date: Jul  8 2022 15:15:40
    Compiler: Visual C++ version 192930145.0
    Memory address size: 64-bit
    CMake version: 3.23.1
    ITK version: 5.3.0

Triggered by issue #671 "Version numbering of develop branch", submitted by Sebastian van der Voort (@Svdvoort).