### PR TITLE
STYLE: Replace postfix with prefix increment, decrement (`++`, `--`)

### DIFF
--- a/Common/CostFunctions/itkParzenWindowHistogramImageToImageMetric.hxx
+++ b/Common/CostFunctions/itkParzenWindowHistogramImageToImageMetric.hxx
@@ -1156,7 +1156,7 @@ ParzenWindowHistogramImageToImageMetric<TFixedImage, TMovingImage>::ThreadedComp
 
     if (sampleOk)
     {
-      numberOfPixelsCounted++;
+      ++numberOfPixelsCounted;
 
       /** Get the fixed image value. */
       RealType fixedImageValue = static_cast<RealType>((*fiter).Value().m_ImageValue);

--- a/Common/ImageSamplers/itkImageSamplerBase.hxx
+++ b/Common/ImageSamplers/itkImageSamplerBase.hxx
@@ -347,8 +347,8 @@ ImageSamplerBase<TInputImage>::CropInputImageRegion()
     while (itCW != cornersWorld->end())
     {
       *itCI = inputImage->template TransformPhysicalPointToContinuousIndex<InputImagePointValueType>(*itCW);
-      itCI++;
-      itCW++;
+      ++itCI;
+      ++itCW;
     }
     bbIndex->SetPoints(cornersIndex);
     bbIndex->ComputeBoundingBox();

--- a/Common/OpenCL/Filters/itkGPUResampleImageFilter.hxx
+++ b/Common/OpenCL/Filters/itkGPUResampleImageFilter.hxx
@@ -683,7 +683,7 @@ GPUResampleImageFilter<TInputImage, TOutputImage, TInterpolatorPrecisionType>::S
   this->m_PreKernelManager->SetKernelArgWithImage(
     this->m_FilterPreGPUKernelHandle, argidx++, this->m_DeformationFieldBuffer);
 
-  argidx++; // skip deformation field size for now
+  ++argidx; // skip deformation field size for now
 
   // Set output image index_to_physical_point to the kernel
   OpenCLKernelToImageBridge<OutputImageType>::SetDirection(preKernel, argidx++, outputImage->GetIndexToPhysicalPoint());
@@ -732,7 +732,7 @@ GPUResampleImageFilter<TInputImage, TOutputImage, TInterpolatorPrecisionType>::S
     // Set deformation field buffer to the kernel
     this->m_LoopKernelManager->SetKernelArgWithImage(handleId, argidx++, this->m_DeformationFieldBuffer);
 
-    argidx++; // skip deformation field size for now
+    ++argidx; // skip deformation field size for now
 
     // Set output image size to the kernel
     OpenCLKernelToImageBridge<OutputImageType>::SetSize(
@@ -876,7 +876,7 @@ GPUResampleImageFilter<TInputImage, TOutputImage, TInterpolatorPrecisionType>::S
   this->m_PostKernelManager->SetKernelArgWithImage(
     this->m_FilterPostGPUKernelHandle, argidx++, this->m_DeformationFieldBuffer);
 
-  argidx++; // skip deformation field size for now
+  ++argidx; // skip deformation field size for now
 
   // Most interpolators work on the input image.
   // The B-spline interpolator however, works on the coefficients image,

--- a/Common/OpenCL/ITKimprovements/itkOpenCLKernel.cxx
+++ b/Common/OpenCL/ITKimprovements/itkOpenCLKernel.cxx
@@ -1123,7 +1123,7 @@ OpenCLKernel::SetArg(const cl_uint index, const MatrixFloat2x2Type & value)
     for (unsigned int j = 0; j < nColumns; ++j)
     {
       values.s[id] = value[i][j];
-      id++;
+      ++id;
     }
   }
   return this->SetArg(index, values);
@@ -1146,7 +1146,7 @@ OpenCLKernel::SetArg(const cl_uint index, const MatrixDouble2x2Type & value)
       for (unsigned int j = 0; j < nColumns; ++j)
       {
         values.s[id] = value[i][j];
-        id++;
+        ++id;
       }
     }
     return this->SetArg(index, values);
@@ -1159,7 +1159,7 @@ OpenCLKernel::SetArg(const cl_uint index, const MatrixDouble2x2Type & value)
       for (unsigned int j = 0; j < nColumns; ++j)
       {
         values.s[id] = static_cast<float>(value[i][j]);
-        id++;
+        ++id;
       }
     }
     return this->SetArg(index, values);
@@ -1182,7 +1182,7 @@ OpenCLKernel::SetArg(const cl_uint index, const MatrixFloat3x3Type & value)
     for (unsigned int j = 0; j < nColumns; ++j)
     {
       values.s[id] = value[i][j];
-      id++;
+      ++id;
     }
   }
   return this->SetArg(index, values);
@@ -1206,7 +1206,7 @@ OpenCLKernel::SetArg(const cl_uint index, const MatrixDouble3x3Type & value)
       for (unsigned int j = 0; j < nColumns; ++j)
       {
         values.s[id] = value[i][j];
-        id++;
+        ++id;
       }
     }
     return this->SetArg(index, values);
@@ -1220,7 +1220,7 @@ OpenCLKernel::SetArg(const cl_uint index, const MatrixDouble3x3Type & value)
       for (unsigned int j = 0; j < nColumns; ++j)
       {
         values.s[id] = static_cast<float>(value[i][j]);
-        id++;
+        ++id;
       }
     }
     return this->SetArg(index, values);
@@ -1243,7 +1243,7 @@ OpenCLKernel::SetArg(const cl_uint index, const MatrixFloat4x4Type & value)
     for (unsigned int j = 0; j < nColumns; ++j)
     {
       values.s[id] = value[i][j];
-      id++;
+      ++id;
     }
   }
   return this->SetArg(index, values);
@@ -1267,7 +1267,7 @@ OpenCLKernel::SetArg(const cl_uint index, const MatrixDouble4x4Type & value)
       for (unsigned int j = 0; j < nColumns; ++j)
       {
         values.s[id] = value[i][j];
-        id++;
+        ++id;
       }
     }
     return this->SetArg(index, values);
@@ -1281,7 +1281,7 @@ OpenCLKernel::SetArg(const cl_uint index, const MatrixDouble4x4Type & value)
       for (unsigned int j = 0; j < nColumns; ++j)
       {
         values.s[id] = static_cast<float>(value[i][j]);
-        id++;
+        ++id;
       }
     }
     return this->SetArg(index, values);

--- a/Common/OpenCL/ITKimprovements/itkOpenCLKernelToImageBridge.hxx
+++ b/Common/OpenCL/ITKimprovements/itkOpenCLKernelToImageBridge.hxx
@@ -223,7 +223,7 @@ OpenCLKernelToImageBridge<TImage>::SetImageMetaData(OpenCLKernel &              
             imageBase2D.Direction.s[index] = static_cast<float>(direction[i][j]);
             imageBase2D.IndexToPhysicalPoint.s[index] = static_cast<float>(i2pp[i][j]);
             imageBase2D.PhysicalPointToIndex.s[index] = static_cast<float>(pp2i[i][j]);
-            index++;
+            ++index;
           }
         }
       }
@@ -280,7 +280,7 @@ OpenCLKernelToImageBridge<TImage>::SetImageMetaData(OpenCLKernel &              
             imageBase3D.Direction.s[index] = static_cast<float>(direction[i][j]);
             imageBase3D.IndexToPhysicalPoint.s[index] = static_cast<float>(i2pp[i][j]);
             imageBase3D.PhysicalPointToIndex.s[index] = static_cast<float>(pp2i[i][j]);
-            index++;
+            ++index;
           }
         }
         for (unsigned int i = 9; i < 16; ++i)

--- a/Common/OpenCL/ITKimprovements/itkOpenCLStringUtils.cxx
+++ b/Common/OpenCL/ITKimprovements/itkOpenCLStringUtils.cxx
@@ -60,7 +60,7 @@ opencl_simplified(const std::string & str)
   {
     while (from != fromend && opencl_isspace(char(*from)))
     {
-      from++;
+      ++from;
     }
     while (from != fromend && !opencl_isspace(char(*from)))
     {
@@ -77,7 +77,7 @@ opencl_simplified(const std::string & str)
   }
   if (outc > 0 && to[outc - 1] == ' ')
   {
-    outc--;
+    --outc;
   }
   result.resize(outc);
 

--- a/Common/OpenCL/itkGPUKernelManagerHelperFunctions.h
+++ b/Common/OpenCL/itkGPUKernelManagerHelperFunctions.h
@@ -93,7 +93,7 @@ SetKernelWithDirection(const typename ImageType::DirectionType & dir,
       for (unsigned int j = 0; j < ImageDim; ++j)
       {
         direction[index] = static_cast<float>(dir[i][j]);
-        index++;
+        ++index;
       }
     }
     for (unsigned int i = 0; i < 4; ++i)
@@ -111,7 +111,7 @@ SetKernelWithDirection(const typename ImageType::DirectionType & dir,
       for (unsigned int j = 0; j < ImageDim; ++j)
       {
         direction[index] = static_cast<float>(dir[i][j]);
-        index++;
+        ++index;
       }
     }
     for (unsigned int i = 9; i < 16; ++i)

--- a/Common/ParameterFileParser/itkParameterFileParser.cxx
+++ b/Common/ParameterFileParser/itkParameterFileParser.cxx
@@ -312,8 +312,8 @@ ParameterFileParser::SplitLine(const std::string &        fullLine,
     {
       /** Start a new element. */
       splittedLine.push_back("");
-      index++;
-      numQuotes++;
+      ++index;
+      ++numQuotes;
     }
     else if (currentChar == ' ')
     {
@@ -323,7 +323,7 @@ ParameterFileParser::SplitLine(const std::string &        fullLine,
       if (numQuotes % 2 == 0)
       {
         splittedLine.push_back("");
-        index++;
+        ++index;
       }
       else
       {

--- a/Common/ParameterFileParser/itkParameterMapInterface.h
+++ b/Common/ParameterFileParser/itkParameterMapInterface.h
@@ -339,7 +339,7 @@ public:
     {
       /** Cast the string to type T. */
       bool castSuccesful = Self::StringCast(vec[i], parameterValues[j]);
-      j++;
+      ++j;
 
       /** Check if the cast was successful. */
       if (!castSuccesful)

--- a/Common/Transforms/itkAdvancedBSplineDeformableTransform.hxx
+++ b/Common/Transforms/itkAdvancedBSplineDeformableTransform.hxx
@@ -1118,7 +1118,7 @@ AdvancedBSplineDeformableTransform<TScalarType, NDimensions, VSplineOrder>::GetJ
 
       /** Remember the weights. */
       std::copy_n(weights.begin(), numberOfWeights, weightVector + count * numberOfWeights);
-      count++;
+      ++count;
 
       /** Reset coeffs iterator */
       auto itCoeffs = coeffs.cbegin();

--- a/Common/Transforms/itkAdvancedCombinationTransform.hxx
+++ b/Common/Transforms/itkAdvancedCombinationTransform.hxx
@@ -90,7 +90,7 @@ AdvancedCombinationTransform<TScalarType, NDimensions>::GetNumberOfTransforms() 
     }
     else
     {
-      num++;
+      ++num;
     }
   }
 

--- a/Common/Transforms/itkAdvancedImageMomentsCalculator.hxx
+++ b/Common/Transforms/itkAdvancedImageMomentsCalculator.hxx
@@ -307,7 +307,7 @@ AdvancedImageMomentsCalculator<TImage>::ThreadedCompute(ThreadIdType threadId)
           Cm[i][j] += weight;
         }
       }
-      numberOfPixelsCounted++;
+      ++numberOfPixelsCounted;
     }
   }
   /** Update the thread struct once. */

--- a/Common/itkAdvancedRayCastInterpolateImageFunction.hxx
+++ b/Common/itkAdvancedRayCastInterpolateImageFunction.hxx
@@ -657,7 +657,7 @@ RayCastHelper<TInputImage, TCoordRep>::CalcRayIntercepts()
 
           || (cross[0][i] >= 0 && cross[1][i] >= 0 && cross[2][i] >= 0 && cross[3][i] >= 0))
       {
-        crossFlag++;
+        ++crossFlag;
       }
     }
 
@@ -666,7 +666,7 @@ RayCastHelper<TInputImage, TCoordRep>::CalcRayIntercepts()
       cubeInter[nSidesCrossed][0] = interceptx[j];
       cubeInter[nSidesCrossed][1] = intercepty[j];
       cubeInter[nSidesCrossed][2] = interceptz[j];
-      nSidesCrossed++;
+      ++nSidesCrossed;
     }
 
   } // end of loop over all four planes
@@ -1032,7 +1032,7 @@ RayCastHelper<TInputImage, TCoordRep>::AdjustRayLength()
       m_RayVoxelStartPosition[1] += m_VoxelIncrement[1];
       m_RayVoxelStartPosition[2] += m_VoxelIncrement[2];
 
-      m_TotalRayVoxelPlanes--;
+      --m_TotalRayVoxelPlanes;
     }
 
     Istart[0] = (int)std::floor(m_RayVoxelStartPosition[0] + m_TotalRayVoxelPlanes * m_VoxelIncrement[0]);
@@ -1050,7 +1050,7 @@ RayCastHelper<TInputImage, TCoordRep>::AdjustRayLength()
     }
     else
     {
-      m_TotalRayVoxelPlanes--;
+      --m_TotalRayVoxelPlanes;
     }
 
   } while ((!(startOK && endOK)) && (m_TotalRayVoxelPlanes > 1));

--- a/Common/itkComputeDisplacementDistribution.hxx
+++ b/Common/itkComputeDisplacementDistribution.hxx
@@ -417,7 +417,7 @@ ComputeDisplacementDistribution<TFixedImage, TTransform>::ThreadedCompute(Thread
     jggMagnitude = Jgg.magnitude();
     displacement += jggMagnitude;
     displacementSquared += vnl_math::sqr(jggMagnitude);
-    numberOfPixelsCounted++;
+    ++numberOfPixelsCounted;
   }
 
   /** Update the thread struct once. */

--- a/Components/Metrics/AdvancedKappaStatistic/itkAdvancedKappaStatisticImageToImageMetric.hxx
+++ b/Components/Metrics/AdvancedKappaStatistic/itkAdvancedKappaStatisticImageToImageMetric.hxx
@@ -178,30 +178,30 @@ AdvancedKappaStatisticImageToImageMetric<TFixedImage, TMovingImage>::GetValue(
         const RealType diffMoving = std::abs(movingImageValue - this->m_ForegroundValue);
         if (diffFixed < this->m_Epsilon)
         {
-          fixedForegroundArea++;
+          ++fixedForegroundArea;
         }
         if (diffMoving < this->m_Epsilon)
         {
-          movingForegroundArea++;
+          ++movingForegroundArea;
         }
         if (diffFixed < this->m_Epsilon && diffMoving < this->m_Epsilon)
         {
-          intersection++;
+          ++intersection;
         }
       }
       else
       {
         if (fixedImageValue > this->m_Epsilon)
         {
-          fixedForegroundArea++;
+          ++fixedForegroundArea;
         }
         if (movingImageValue > this->m_Epsilon)
         {
-          movingForegroundArea++;
+          ++movingForegroundArea;
         }
         if (fixedImageValue > this->m_Epsilon && movingImageValue > this->m_Epsilon)
         {
-          intersection++;
+          ++intersection;
         }
       }
 
@@ -516,7 +516,7 @@ AdvancedKappaStatisticImageToImageMetric<TFixedImage, TMovingImage>::ThreadedGet
     /** Do the actual calculation of the metric value. */
     if (sampleOk)
     {
-      numberOfPixelsCounted++;
+      ++numberOfPixelsCounted;
 
       /** Get the fixed image value. */
       const RealType & fixedImageValue = static_cast<RealType>((*fiter).Value().m_ImageValue);
@@ -719,32 +719,32 @@ AdvancedKappaStatisticImageToImageMetric<TFixedImage, TMovingImage>::UpdateValue
     const RealType diffMoving = std::abs(movingImageValue - this->m_ForegroundValue);
     if (diffFixed < this->m_Epsilon)
     {
-      fixedForegroundArea++;
+      ++fixedForegroundArea;
       usableFixedSample = true;
     }
     if (diffMoving < this->m_Epsilon)
     {
-      movingForegroundArea++;
+      ++movingForegroundArea;
     }
     if (diffFixed < this->m_Epsilon && diffMoving < this->m_Epsilon)
     {
-      intersection++;
+      ++intersection;
     }
   }
   else
   {
     if (fixedImageValue > this->m_Epsilon)
     {
-      fixedForegroundArea++;
+      ++fixedForegroundArea;
       usableFixedSample = true;
     }
     if (movingImageValue > this->m_Epsilon)
     {
-      movingForegroundArea++;
+      ++movingForegroundArea;
     }
     if (fixedImageValue > this->m_Epsilon && movingImageValue > this->m_Epsilon)
     {
-      intersection++;
+      ++intersection;
     }
   }
 

--- a/Components/Metrics/AdvancedMeanSquares/itkAdvancedMeanSquaresImageToImageMetric.hxx
+++ b/Components/Metrics/AdvancedMeanSquares/itkAdvancedMeanSquaresImageToImageMetric.hxx
@@ -359,7 +359,7 @@ AdvancedMeanSquaresImageToImageMetric<TFixedImage, TMovingImage>::ThreadedGetVal
 
     if (sampleOk)
     {
-      numberOfPixelsCounted++;
+      ++numberOfPixelsCounted;
 
       /** Get the fixed image value. */
       const RealType & fixedImageValue = static_cast<RealType>((*threader_fiter).Value().m_ImageValue);
@@ -668,7 +668,7 @@ AdvancedMeanSquaresImageToImageMetric<TFixedImage, TMovingImage>::ThreadedGetVal
 
     if (sampleOk)
     {
-      numberOfPixelsCounted++;
+      ++numberOfPixelsCounted;
 
       /** Get the fixed image value. */
       const RealType & fixedImageValue = static_cast<RealType>((*threader_fiter).Value().m_ImageValue);

--- a/Components/Metrics/AdvancedNormalizedCorrelation/itkAdvancedNormalizedCorrelationImageToImageMetric.hxx
+++ b/Components/Metrics/AdvancedNormalizedCorrelation/itkAdvancedNormalizedCorrelationImageToImageMetric.hxx
@@ -566,7 +566,7 @@ AdvancedNormalizedCorrelationImageToImageMetric<TFixedImage, TMovingImage>::Thre
 
     if (sampleOk)
     {
-      numberOfPixelsCounted++;
+      ++numberOfPixelsCounted;
 
       /** Get the fixed image value. */
       const RealType & fixedImageValue = static_cast<RealType>((*threader_fiter).Value().m_ImageValue);

--- a/Components/Metrics/BendingEnergyPenalty/itkTransformBendingEnergyPenaltyTerm.hxx
+++ b/Components/Metrics/BendingEnergyPenalty/itkTransformBendingEnergyPenaltyTerm.hxx
@@ -456,7 +456,7 @@ TransformBendingEnergyPenaltyTerm<TFixedImage, TScalarType>::ThreadedGetValueAnd
 
     if (sampleOk)
     {
-      numberOfPixelsCounted++;
+      ++numberOfPixelsCounted;
 
       /** Get the spatial Hessian of the transformation at the current point.
        * This is needed to compute the bending energy.

--- a/Components/Metrics/CorrespondingPointsEuclideanDistanceMetric/elxCorrespondingPointsEuclideanDistanceMetric.hxx
+++ b/Components/Metrics/CorrespondingPointsEuclideanDistanceMetric/elxCorrespondingPointsEuclideanDistanceMetric.hxx
@@ -61,7 +61,7 @@ CorrespondingPointsEuclideanDistanceMetric<TElastix>::BeforeAllBase()
     this->m_Configuration->ReadParameter(metricName, "Metric", i);
     if (metricName == "CorrespondingPointsEuclideanDistanceMetric")
     {
-      count++;
+      ++count;
     }
   }
   if (count == 0)

--- a/Components/Metrics/DistancePreservingRigidityPenalty/itkDistancePreservingRigidityPenaltyTerm.hxx
+++ b/Components/Metrics/DistancePreservingRigidityPenalty/itkDistancePreservingRigidityPenaltyTerm.hxx
@@ -230,7 +230,7 @@ DistancePreservingRigidityPenaltyTerm<TFixedImage, TScalarType>::GetValue(const 
 
           if (pixelValue == pixelValueNeighbor)
           {
-            numberOfRigidGridsNeighbor++;
+            ++numberOfRigidGridsNeighbor;
           }
         }
 
@@ -392,7 +392,7 @@ DistancePreservingRigidityPenaltyTerm<TFixedImage, TScalarType>::GetValueAndDeri
 
           if (pixelValue == pixelValueNeighbor)
           {
-            numberOfRigidGridsNeighbor++;
+            ++numberOfRigidGridsNeighbor;
           }
         }
 

--- a/Components/Metrics/GradientDifference/itkGradientDifferenceImageToImageMetric2.hxx
+++ b/Components/Metrics/GradientDifference/itkGradientDifferenceImageToImageMetric2.hxx
@@ -280,7 +280,7 @@ GradientDifferenceImageToImageMetric<TFixedImage, TMovingImage>::ComputeVariance
           this->m_MinFixedGradient[iDimension] = gradient;
         }
 
-        nPixels++;
+        ++nPixels;
 
       } // end if sampleOK
 

--- a/Components/Metrics/KNNGraphAlphaMutualInformation/KNN/ann_1.1/include/ANN/ANNperf.h
+++ b/Components/Metrics/KNNGraphAlphaMutualInformation/KNN/ann_1.1/include/ANN/ANNperf.h
@@ -110,7 +110,7 @@ public:
   void
   operator+=(double x) // add sample
   {
-    n++;
+    ++n;
     sum += x;
     sum2 += x * x;
     if (x < minVal)

--- a/Components/Metrics/KNNGraphAlphaMutualInformation/KNN/ann_1.1/src/pr_queue.h
+++ b/Components/Metrics/KNNGraphAlphaMutualInformation/KNN/ann_1.1/src/pr_queue.h
@@ -136,7 +136,7 @@ public:
       ANN_FLOP(2) // increment floating ops
                   // set r to smaller child of p
       if (r < n && pq[r].key > pq[r + 1].key)
-        r++;
+        ++r;
       if (kn <= pq[r].key) // in proper order
         break;
       pq[p] = pq[r]; // else swap with child

--- a/Components/Metrics/KNNGraphAlphaMutualInformation/KNN/ann_1.1/src/pr_queue_k.h
+++ b/Components/Metrics/KNNGraphAlphaMutualInformation/KNN/ann_1.1/src/pr_queue_k.h
@@ -129,7 +129,7 @@ public:
     mk[i].key = kv; // store element here
     mk[i].info = inf;
     if (n < k)
-      n++;              // increment number of items
+      ++n;              // increment number of items
     ANN_FLOP(k - i + 1) // increment floating ops
   }
 };

--- a/Components/Metrics/KNNGraphAlphaMutualInformation/KNN/itkANNBinaryTreeCreator.cxx
+++ b/Components/Metrics/KNNGraphAlphaMutualInformation/KNN/itkANNBinaryTreeCreator.cxx
@@ -103,7 +103,7 @@ ANNBinaryTreeCreator::DeleteANNBruteForceTree(ANNBruteForceTreeType *& tree)
 void
 ANNBinaryTreeCreator::IncreaseReferenceCount()
 {
-  m_NumberOfANNBinaryTrees++;
+  ++m_NumberOfANNBinaryTrees;
 } // end IncreaseReferenceCount
 
 
@@ -114,7 +114,7 @@ ANNBinaryTreeCreator::IncreaseReferenceCount()
 void
 ANNBinaryTreeCreator::DecreaseReferenceCount()
 {
-  m_NumberOfANNBinaryTrees--;
+  --m_NumberOfANNBinaryTrees;
   if (m_NumberOfANNBinaryTrees == 0)
   {
     annClose();

--- a/Components/Metrics/KNNGraphAlphaMutualInformation/itkKNNGraphAlphaMutualInformationImageToImageMetric.hxx
+++ b/Components/Metrics/KNNGraphAlphaMutualInformation/itkKNNGraphAlphaMutualInformationImageToImageMetric.hxx
@@ -872,7 +872,7 @@ KNNGraphAlphaMutualInformationImageToImageMetric<TFixedImage, TMovingImage>::
       /** Update the NumberOfPixelsCounted. */
       this->m_NumberOfPixelsCounted++;
 
-      ii++;
+      ++ii;
 
     } // end if sampleOk
 

--- a/Components/Metrics/MissingStructurePenalty/elxMissingStructurePenalty.hxx
+++ b/Components/Metrics/MissingStructurePenalty/elxMissingStructurePenalty.hxx
@@ -70,7 +70,7 @@ MissingStructurePenalty<TElastix>::BeforeAllBase()
     this->m_Configuration->ReadParameter(metricName, "Metric", i);
     if (metricName == "MissingStructurePenalty")
     {
-      count++;
+      ++count;
     }
   }
   if (count == 0)

--- a/Components/Metrics/NormalizedGradientCorrelation/itkNormalizedGradientCorrelationImageToImageMetric.hxx
+++ b/Components/Metrics/NormalizedGradientCorrelation/itkNormalizedGradientCorrelationImageToImageMetric.hxx
@@ -194,7 +194,7 @@ NormalizedGradientCorrelationImageToImageMetric<TFixedImage, TMovingImage>::Comp
     {
       fixedGradient[0] += fixedIteratorx.Get();
       fixedGradient[1] += fixedIteratory.Get();
-      nPixels++;
+      ++nPixels;
     }
 
     ++fixedIteratorx;
@@ -270,7 +270,7 @@ NormalizedGradientCorrelationImageToImageMetric<TFixedImage, TMovingImage>::Comp
     {
       movedGradient[0] += movedIteratorx.Get();
       movedGradient[1] += movedIteratory.Get();
-      nPixels++;
+      ++nPixels;
     } // end if sampleOK
 
     ++movedIteratorx;

--- a/Components/Metrics/PCAMetric/itkPCAMetric.hxx
+++ b/Components/Metrics/PCAMetric/itkPCAMetric.hxx
@@ -267,7 +267,7 @@ PCAMetric<TFixedImage, TMovingImage>::GetValue(const TransformParametersType & p
 
       if (sampleOk)
       {
-        numSamplesOk++;
+        ++numSamplesOk;
         datablock(pixelIndex, d) = movingImageValue;
       }
 
@@ -275,7 +275,7 @@ PCAMetric<TFixedImage, TMovingImage>::GetValue(const TransformParametersType & p
 
     if (numSamplesOk == realNumLastDimPositions)
     {
-      pixelIndex++;
+      ++pixelIndex;
       this->m_NumberOfPixelsCounted++;
     }
 
@@ -513,7 +513,7 @@ PCAMetric<TFixedImage, TMovingImage>::GetValueAndDerivative(const TransformParam
 
       if (sampleOk)
       {
-        numSamplesOk++;
+        ++numSamplesOk;
         datablock(pixelIndex, d) = movingImageValue;
       } // end if sampleOk
 
@@ -521,7 +521,7 @@ PCAMetric<TFixedImage, TMovingImage>::GetValueAndDerivative(const TransformParam
     if (numSamplesOk == G)
     {
       SamplesOK.push_back(fixedPoint);
-      pixelIndex++;
+      ++pixelIndex;
       this->m_NumberOfPixelsCounted++;
     }
 
@@ -683,7 +683,7 @@ PCAMetric<TFixedImage, TMovingImage>::GetValueAndDerivative(const TransformParam
   {
     /** Read fixed coordinates. */
     FixedImagePointType fixedPoint = SamplesOK[startSamplesOK];
-    startSamplesOK++;
+    ++startSamplesOK;
 
     /** Transform sampled point to voxel coordinates. */
     FixedImageContinuousIndexType voxelCoord;

--- a/Components/Metrics/PCAMetric/itkPCAMetric_F_multithreaded.hxx
+++ b/Components/Metrics/PCAMetric/itkPCAMetric_F_multithreaded.hxx
@@ -230,7 +230,7 @@ PCAMetric<TFixedImage, TMovingImage>::GetValue(const TransformParametersType & p
 
       if (sampleOk)
       {
-        numSamplesOk++;
+        ++numSamplesOk;
         datablock(pixelIndex, d) = movingImageValue;
       }
 
@@ -238,7 +238,7 @@ PCAMetric<TFixedImage, TMovingImage>::GetValue(const TransformParametersType & p
 
     if (numSamplesOk == this->m_G)
     {
-      pixelIndex++;
+      ++pixelIndex;
       this->m_NumberOfPixelsCounted++;
     }
 
@@ -411,7 +411,7 @@ PCAMetric<TFixedImage, TMovingImage>::GetValueAndDerivativeSingleThreaded(const 
 
       if (sampleOk)
       {
-        numSamplesOk++;
+        ++numSamplesOk;
         datablock(pixelIndex, d) = movingImageValue;
       } // end if sampleOk
 
@@ -419,7 +419,7 @@ PCAMetric<TFixedImage, TMovingImage>::GetValueAndDerivativeSingleThreaded(const 
     if (numSamplesOk == this->m_G)
     {
       SamplesOK.push_back(fixedPoint);
-      pixelIndex++;
+      ++pixelIndex;
       this->m_NumberOfPixelsCounted++;
     }
 
@@ -750,7 +750,7 @@ PCAMetric<TFixedImage, TMovingImage>::ThreadedGetSamples(ThreadIdType threadId)
 
       if (sampleOk)
       {
-        numSamplesOk++;
+        ++numSamplesOk;
         datablock(pixelIndex, d) = movingImageValue;
       } // end if sampleOk
 
@@ -758,7 +758,7 @@ PCAMetric<TFixedImage, TMovingImage>::ThreadedGetSamples(ThreadIdType threadId)
     if (numSamplesOk == m_G)
     {
       SamplesOK.push_back(fixedPoint);
-      pixelIndex++;
+      ++pixelIndex;
     }
 
   } /** end first loop over image sample container */
@@ -977,7 +977,7 @@ PCAMetric<TFixedImage, TMovingImage>::ThreadedComputeDerivative(ThreadIdType thr
       } // end loop over non-zero jacobian indices
 
     } // end loop over last dimension
-    dummyindex++;
+    ++dummyindex;
 
   } // end second for loop over sample container
 

--- a/Components/Metrics/PCAMetric2/itkPCAMetric2.hxx
+++ b/Components/Metrics/PCAMetric2/itkPCAMetric2.hxx
@@ -235,7 +235,7 @@ PCAMetric2<TFixedImage, TMovingImage>::GetValue(const TransformParametersType & 
 
       if (sampleOk)
       {
-        numSamplesOk++;
+        ++numSamplesOk;
         datablock(pixelIndex, d) = movingImageValue;
       }
 
@@ -243,7 +243,7 @@ PCAMetric2<TFixedImage, TMovingImage>::GetValue(const TransformParametersType & 
 
     if (numSamplesOk == G)
     {
-      pixelIndex++;
+      ++pixelIndex;
       this->m_NumberOfPixelsCounted++;
     }
 
@@ -440,7 +440,7 @@ PCAMetric2<TFixedImage, TMovingImage>::GetValueAndDerivative(const TransformPara
 
       if (sampleOk)
       {
-        numSamplesOk++;
+        ++numSamplesOk;
         datablock(pixelIndex, d) = movingImageValue;
       } // end if sampleOk
 
@@ -448,7 +448,7 @@ PCAMetric2<TFixedImage, TMovingImage>::GetValueAndDerivative(const TransformPara
     if (numSamplesOk == G)
     {
       SamplesOK.push_back(fixedPoint);
-      pixelIndex++;
+      ++pixelIndex;
       this->m_NumberOfPixelsCounted++;
     }
   }
@@ -543,7 +543,7 @@ PCAMetric2<TFixedImage, TMovingImage>::GetValueAndDerivative(const TransformPara
   {
     /** Read fixed coordinates. */
     FixedImagePointType fixedPoint = SamplesOK[startSamplesOK];
-    startSamplesOK++;
+    ++startSamplesOK;
 
     /** Transform sampled point to voxel coordinates. */
     auto voxelCoord =

--- a/Components/Metrics/PolydataDummyPenalty/elxPolydataDummyPenalty.hxx
+++ b/Components/Metrics/PolydataDummyPenalty/elxPolydataDummyPenalty.hxx
@@ -70,7 +70,7 @@ PolydataDummyPenalty<TElastix>::BeforeAllBase()
     this->m_Configuration->ReadParameter(metricName, "Metric", i);
     if (metricName == this->elxGetClassName())
     {
-      count++;
+      ++count;
     }
   }
   if (count == 0)

--- a/Components/Metrics/RigidityPenalty/itkTransformRigidityPenaltyTerm.hxx
+++ b/Components/Metrics/RigidityPenalty/itkTransformRigidityPenaltyTerm.hxx
@@ -1902,7 +1902,7 @@ TransformRigidityPenaltyTerm<TFixedImage, TScalarType>::GetValueAndDerivative(co
     {
       derivative[j] = itDIs[i].Get() / rigidityCoefficientSum;
       ++itDIs[i];
-      j++;
+      ++j;
     } // end while
   }   // end for
 

--- a/Components/Metrics/SumOfPairwiseCorrelationsMetric/itkSumOfPairwiseCorrelationCoefficientsMetric.hxx
+++ b/Components/Metrics/SumOfPairwiseCorrelationsMetric/itkSumOfPairwiseCorrelationCoefficientsMetric.hxx
@@ -209,7 +209,7 @@ SumOfPairwiseCorrelationCoefficientsMetric<TFixedImage, TMovingImage>::GetValue(
 
       if (sampleOk)
       {
-        numSamplesOk++;
+        ++numSamplesOk;
         datablock(pixelIndex, d) = movingImageValue;
       }
 
@@ -217,7 +217,7 @@ SumOfPairwiseCorrelationCoefficientsMetric<TFixedImage, TMovingImage>::GetValue(
 
     if (numSamplesOk == G)
     {
-      pixelIndex++;
+      ++pixelIndex;
       this->m_NumberOfPixelsCounted++;
     }
 
@@ -386,7 +386,7 @@ SumOfPairwiseCorrelationCoefficientsMetric<TFixedImage, TMovingImage>::GetValueA
 
       if (sampleOk)
       {
-        numSamplesOk++;
+        ++numSamplesOk;
         datablock(pixelIndex, d) = movingImageValue;
 
       } // end if sampleOk
@@ -396,7 +396,7 @@ SumOfPairwiseCorrelationCoefficientsMetric<TFixedImage, TMovingImage>::GetValueA
     if (numSamplesOk == G)
     {
       SamplesOK.push_back(fixedPoint);
-      pixelIndex++;
+      ++pixelIndex;
       this->m_NumberOfPixelsCounted++;
     }
 

--- a/Components/Metrics/SumSquaredTissueVolumeDifferenceMetric/itkSumSquaredTissueVolumeDifferenceImageToImageMetric.hxx
+++ b/Components/Metrics/SumSquaredTissueVolumeDifferenceMetric/itkSumSquaredTissueVolumeDifferenceImageToImageMetric.hxx
@@ -252,7 +252,7 @@ SumSquaredTissueVolumeDifferenceImageToImageMetric<TFixedImage, TMovingImage>::T
 
     if (sampleOk)
     {
-      numberOfPixelsCounted++;
+      ++numberOfPixelsCounted;
 
       /** Get the fixed image value. */
       const RealType & fixedImageValue = static_cast<RealType>((*threader_fiter).Value().m_ImageValue);
@@ -572,7 +572,7 @@ SumSquaredTissueVolumeDifferenceImageToImageMetric<TFixedImage, TMovingImage>::T
 
     if (sampleOk)
     {
-      numberOfPixelsCounted++;
+      ++numberOfPixelsCounted;
 
       /** Get the fixed image value. */
       const RealType & fixedImageValue = static_cast<RealType>((*threader_fiter).Value().m_ImageValue);

--- a/Components/Metrics/VarianceOverLastDimension/itkVarianceOverLastDimensionImageMetric.hxx
+++ b/Components/Metrics/VarianceOverLastDimension/itkVarianceOverLastDimensionImageMetric.hxx
@@ -87,7 +87,7 @@ VarianceOverLastDimensionImageMetric<TFixedImage, TMovingImage>::Initialize()
     /** Compute expected value (mean) and variance. */
     float expectedValue = sum / static_cast<float>(numlast);
     sumvar += sumsq / static_cast<float>(numlast) - expectedValue * expectedValue;
-    num++;
+    ++num;
 
     it.NextLine();
   }
@@ -284,7 +284,7 @@ VarianceOverLastDimensionImageMetric<TFixedImage, TMovingImage>::GetValue(
 
       if (sampleOk)
       {
-        numSamplesOk++;
+        ++numSamplesOk;
         sumValues += movingImageValue;
         sumValuesSquared += movingImageValue * movingImageValue;
       } // end if sampleOk
@@ -465,7 +465,7 @@ VarianceOverLastDimensionImageMetric<TFixedImage, TMovingImage>::GetValueAndDeri
       if (sampleOk)
       {
         /** Update value terms **/
-        numSamplesOk++;
+        ++numSamplesOk;
         sumValues += movingImageValue;
         sumValuesSquared += movingImageValue * movingImageValue;
 

--- a/Components/Optimizers/ConjugateGradient/itkGenericConjugateGradientOptimizer.cxx
+++ b/Components/Optimizers/ConjugateGradient/itkGenericConjugateGradientOptimizer.cxx
@@ -175,7 +175,7 @@ GenericConjugateGradientOptimizer::ResumeOptimization()
         // this->m_CurrentGradient[limitCount] = 1.0;
         // \todo gives errors (way to large gradient), should update
         // initial steplength estimate maybe
-        limitCount++;
+        ++limitCount;
       }
       else
       {

--- a/Components/Optimizers/FullSearch/elxFullSearchOptimizer.hxx
+++ b/Components/Optimizers/FullSearch/elxFullSearchOptimizer.hxx
@@ -96,31 +96,31 @@ FullSearch<TElastix>::BeforeEachResolution()
     {
       found = this->GetConfiguration()->ReadParameter(name, fullFieldName, entry_nr, false);
       realGood = this->CheckSearchSpaceRangeDefinition(fullFieldName, found, entry_nr);
-      entry_nr++;
+      ++entry_nr;
     }
     if (realGood && found)
     {
       found = this->GetConfiguration()->ReadParameter(param_nr, fullFieldName, entry_nr, false);
       realGood = this->CheckSearchSpaceRangeDefinition(fullFieldName, found, entry_nr);
-      entry_nr++;
+      ++entry_nr;
     }
     if (realGood && found)
     {
       found = this->GetConfiguration()->ReadParameter(minimum, fullFieldName, entry_nr, false);
       realGood = this->CheckSearchSpaceRangeDefinition(fullFieldName, found, entry_nr);
-      entry_nr++;
+      ++entry_nr;
     }
     if (realGood && found)
     {
       found = this->GetConfiguration()->ReadParameter(maximum, fullFieldName, entry_nr, false);
       realGood = this->CheckSearchSpaceRangeDefinition(fullFieldName, found, entry_nr);
-      entry_nr++;
+      ++entry_nr;
     }
     if (realGood && found)
     {
       found = this->GetConfiguration()->ReadParameter(stepsize, fullFieldName, entry_nr, false);
       realGood = this->CheckSearchSpaceRangeDefinition(fullFieldName, found, entry_nr);
-      entry_nr++;
+      ++entry_nr;
     }
 
     /** Setup this search range. */
@@ -196,7 +196,7 @@ FullSearch<TElastix>::AfterEachIteration()
   for (unsigned int dim = 0; dim < nrOfSSDims; ++dim)
   {
     this->GetIterationInfoAt(name_it->second.c_str()) << currentPoint[dim];
-    name_it++;
+    ++name_it;
   }
 
 } // end AfterEachIteration()
@@ -279,7 +279,7 @@ FullSearch<TElastix>::AfterEachResolution()
   for (unsigned int dim = 0; dim < nrOfSSDims; ++dim)
   {
     this->RemoveTargetCellFromIterationInfo(name_it->second.c_str());
-    name_it++;
+    ++name_it;
   }
 
   /** Clear the dimension names of the previous resolution's search space. */

--- a/Components/Optimizers/FullSearch/itkFullSearchOptimizer.cxx
+++ b/Components/Optimizers/FullSearch/itkFullSearchOptimizer.cxx
@@ -115,7 +115,7 @@ FullSearchOptimizer::ResumeOptimization()
     this->InvokeEvent(IterationEvent());
 
     /** Prepare for next step */
-    m_CurrentIteration++;
+    ++m_CurrentIteration;
 
     if (m_CurrentIteration >= this->GetNumberOfIterations())
     {
@@ -222,7 +222,7 @@ FullSearchOptimizer::UpdateCurrentPosition()
 
     /** Update the array of parameters. */
     currentPosition[it.Index()] = m_CurrentPointInSearchSpace[ssdim];
-    it++;
+    ++it;
   } // end for
 
 } // end UpdateCurrentPosition
@@ -254,7 +254,7 @@ FullSearchOptimizer::ProcessSearchSpaceChanges()
     {
       RangeType range = it.Value();
       m_SearchSpaceSize[ssdim] = static_cast<unsigned long>((range[1] - range[0]) / range[2]) + 1;
-      it++;
+      ++it;
     }
 
   } // end if search space modified
@@ -384,7 +384,7 @@ FullSearchOptimizer::PointToPosition(const SearchSpacePointType & point)
     param[it.Index()] = point[ssdim];
 
     /** go to next dimension in search space */
-    it++;
+    ++it;
   }
 
   return param;
@@ -423,7 +423,7 @@ FullSearchOptimizer::IndexToPoint(const SearchSpaceIndexType & index)
     point[ssdim] = range[0] + static_cast<double>(range[2] * index[ssdim]);
 
     /** go to next dimension in search space */
-    it++;
+    ++it;
   } // end for
 
   return point;

--- a/Components/Optimizers/RSGDEachParameterApart/itkRSGDEachParameterApartBaseOptimizer.cxx
+++ b/Components/Optimizers/RSGDEachParameterApart/itkRSGDEachParameterApartBaseOptimizer.cxx
@@ -109,7 +109,7 @@ RSGDEachParameterApartBaseOptimizer::ResumeOptimization()
 
     this->AdvanceOneStep();
 
-    m_CurrentIteration++;
+    ++m_CurrentIteration;
 
     if (m_CurrentIteration == m_NumberOfIterations)
     {

--- a/Components/Registrations/MultiMetricMultiResolutionRegistration/elxMultiMetricMultiResolutionRegistration.hxx
+++ b/Components/Registrations/MultiMetricMultiResolutionRegistration/elxMultiMetricMultiResolutionRegistration.hxx
@@ -82,7 +82,7 @@ MultiMetricMultiResolutionRegistration<TElastix>::BeforeRegistration()
   unsigned int       width = 0;
   for (unsigned int i = nrOfMetrics; i > 0; i /= 10)
   {
-    width++;
+    ++width;
   }
   for (unsigned int i = 0; i < nrOfMetrics; ++i)
   {
@@ -129,7 +129,7 @@ MultiMetricMultiResolutionRegistration<TElastix>::AfterEachIteration()
   unsigned int       width = 0;
   for (unsigned int i = nrOfMetrics; i > 0; i /= 10)
   {
-    width++;
+    ++width;
   }
   for (unsigned int i = 0; i < nrOfMetrics; ++i)
   {

--- a/Components/Transforms/SplineKernelTransform/itkKernelTransform2.hxx
+++ b/Components/Transforms/SplineKernelTransform/itkKernelTransform2.hxx
@@ -227,9 +227,9 @@ KernelTransform2<TScalarType, NDimensions>::ComputeD()
   while (sp != end)
   {
     vt->Value() = tp->Value() - sp->Value();
-    vt++;
-    sp++;
-    tp++;
+    ++vt;
+    ++sp;
+    ++tp;
   }
 
 } // end ComputeD()
@@ -382,8 +382,8 @@ KernelTransform2<TScalarType, NDimensions>::ComputeK()
     // Can ignore GMatrix, since p1 - p1 = 0
     this->ComputeReflexiveG(p1, G);
     this->m_KMatrix.update(G_ref, i * NDimensions, i * NDimensions);
-    p2++;
-    j++;
+    ++p2;
+    ++j;
 
     // Compute the upper (and copy into lower) triangular part of K
     while (p2 != end)
@@ -393,11 +393,11 @@ KernelTransform2<TScalarType, NDimensions>::ComputeK()
       // write value in upper and lower triangle of matrix
       this->m_KMatrix.update(G_ref, i * NDimensions, j * NDimensions);
       this->m_KMatrix.update(G_ref, j * NDimensions, i * NDimensions);
-      p2++;
-      j++;
+      ++p2;
+      ++j;
     }
-    p1++;
-    i++;
+    ++p1;
+    ++i;
   }
 
 } // end ComputeK()
@@ -460,7 +460,7 @@ KernelTransform2<TScalarType, NDimensions>::ComputeY()
     {
       this->m_YMatrix.put(i * NDimensions + j, 0, displacement.Value()[j]);
     }
-    displacement++;
+    ++displacement;
   }
 
   for (unsigned int i = 0; i < NDimensions * (NDimensions + 1); ++i)
@@ -591,10 +591,10 @@ KernelTransform2<TScalarType, NDimensions>::SetParameters(const ParametersType &
     for (unsigned int dim = 0; dim < NDimensions; ++dim)
     {
       landMark[dim] = parameters[pcounter];
-      pcounter++;
+      ++pcounter;
     }
     itr.Value() = landMark;
-    itr++;
+    ++itr;
   }
 
   this->m_TargetLandmarks->SetPoints(landmarks);
@@ -636,10 +636,10 @@ KernelTransform2<TScalarType, NDimensions>::SetFixedParameters(const ParametersT
     for (unsigned int dim = 0; dim < NDimensions; ++dim)
     {
       landMark[dim] = parameters[pcounter];
-      pcounter++;
+      ++pcounter;
     }
     itr.Value() = landMark;
-    itr++;
+    ++itr;
   }
 
   this->m_SourceLandmarks->SetPoints(landmarks);
@@ -676,9 +676,9 @@ KernelTransform2<TScalarType, NDimensions>::UpdateParameters()
     for (unsigned int dim = 0; dim < NDimensions; ++dim)
     {
       this->m_Parameters[pcounter] = landmark[dim];
-      pcounter++;
+      ++pcounter;
     }
-    itr++;
+    ++itr;
   }
 
 } // end UpdateParameters()
@@ -714,9 +714,9 @@ KernelTransform2<TScalarType, NDimensions>::GetFixedParameters() const -> const 
     for (unsigned int dim = 0; dim < NDimensions; ++dim)
     {
       this->m_FixedParameters[pcounter] = landmark[dim];
-      pcounter++;
+      ++pcounter;
     }
-    itr++;
+    ++itr;
   }
 
   return this->m_FixedParameters;

--- a/Core/ComponentBaseClasses/elxResamplerBase.hxx
+++ b/Core/ComponentBaseClasses/elxResamplerBase.hxx
@@ -599,7 +599,7 @@ ResamplerBase<TElastix>::ReadFromFile()
   {
     if (size[i] == 0)
     {
-      sum++;
+      ++sum;
     }
   }
   if (sum > 0)

--- a/Core/Main/elxElastixFilter.hxx
+++ b/Core/Main/elxElastixFilter.hxx
@@ -435,7 +435,7 @@ ElastixFilter<TFixedImage, TMovingImage>::GetFixedImage(const unsigned int index
         return itkDynamicCastInDebugMode<const TFixedImage *>(this->GetInput(inputNames[i]));
       }
 
-      n++;
+      ++n;
     }
   }
 
@@ -524,7 +524,7 @@ ElastixFilter<TFixedImage, TMovingImage>::GetMovingImage(const unsigned int inde
         return itkDynamicCastInDebugMode<const TMovingImage *>(this->GetInput(inputNames[i]));
       }
 
-      n++;
+      ++n;
     }
   }
 
@@ -601,7 +601,7 @@ ElastixFilter<TFixedImage, TMovingImage>::GetFixedMask(const unsigned int index)
         return itkDynamicCastInDebugMode<const FixedMaskType *>(this->GetInput(inputNames[i]));
       }
 
-      n++;
+      ++n;
     }
   }
 
@@ -691,7 +691,7 @@ ElastixFilter<TFixedImage, TMovingImage>::GetMovingMask(const unsigned int index
         return itkDynamicCastInDebugMode<const MovingMaskType *>(this->GetInput(inputNames[i]));
       }
 
-      n++;
+      ++n;
     }
   }
 
@@ -789,7 +789,7 @@ ElastixFilter<TFixedImage, TMovingImage>::GetNumberOfInputsOfType(const DataObje
   {
     if (this->IsInputOfType(inputType, inputNames[i]))
     {
-      n++;
+      ++n;
     }
   }
 

--- a/Core/Main/elxParameterObject.cxx
+++ b/Core/Main/elxParameterObject.cxx
@@ -288,7 +288,7 @@ ParameterObject::WriteParameterFile(const ParameterMapType &      parameterMap,
       }
 
       parameterFile << ")" << std::endl;
-      parameterMapIterator++;
+      ++parameterMapIterator;
     }
   }
   catch (std::stringstream::failure e)

--- a/Core/Main/itkElastixRegistrationMethod.hxx
+++ b/Core/Main/itkElastixRegistrationMethod.hxx
@@ -457,7 +457,7 @@ ElastixRegistrationMethod<TFixedImage, TMovingImage>::GetFixedImage(const unsign
         return itkDynamicCastInDebugMode<const TFixedImage *>(this->ProcessObject::GetInput(inputNames[i]));
       }
 
-      n++;
+      ++n;
     }
   }
 
@@ -527,7 +527,7 @@ ElastixRegistrationMethod<TFixedImage, TMovingImage>::GetMovingImage(const unsig
         return itkDynamicCastInDebugMode<const TMovingImage *>(this->ProcessObject::GetInput(inputNames[i]));
       }
 
-      n++;
+      ++n;
     }
   }
 
@@ -585,7 +585,7 @@ ElastixRegistrationMethod<TFixedImage, TMovingImage>::GetFixedMask(const unsigne
         return itkDynamicCastInDebugMode<const FixedMaskType *>(this->ProcessObject::GetInput(inputNames[i]));
       }
 
-      n++;
+      ++n;
     }
   }
 
@@ -651,7 +651,7 @@ ElastixRegistrationMethod<TFixedImage, TMovingImage>::GetMovingMask(const unsign
         return itkDynamicCastInDebugMode<const MovingMaskType *>(this->ProcessObject::GetInput(inputNames[i]));
       }
 
-      n++;
+      ++n;
     }
   }
 
@@ -777,7 +777,7 @@ ElastixRegistrationMethod<TFixedImage, TMovingImage>::GetNumberOfInputsOfType(
   {
     if (this->IsInputOfType(inputType, inputNames[i]))
     {
-      n++;
+      ++n;
     }
   }
 

--- a/Testing/itkCommandLineArgumentParser.cxx
+++ b/Testing/itkCommandLineArgumentParser.cxx
@@ -117,7 +117,7 @@ CommandLineArgumentParser::ExactlyOneExists(const std::vector<std::string> & key
   {
     if (this->ArgumentExists(keys[i]))
     {
-      counter++;
+      ++counter;
     }
   }
 

--- a/Testing/itkTestHelper.h
+++ b/Testing/itkTestHelper.h
@@ -382,7 +382,7 @@ ComputeRMSE(const CPUImageType *  cpuImage,
       TScalarType err = cpu - static_cast<TScalarType>(git.Get());
       rmse += err * err;
       sumCPUSquared += cpu * cpu;
-      count++;
+      ++count;
     }
   }
 


### PR DESCRIPTION
Applied to the root of elastix source tree, at the GNU bash prompt:

    find . \( -iname *.cxx -or -iname *.hxx -or -iname *.h \) -exec perl -pi -w -e 's/  (\w+)\+\+;/  ++$1;/g;' {} \;
    find . \( -iname *.cxx -or -iname *.hxx -or -iname *.h \) -exec perl -pi -w -e 's/  (\w+)\-\-;/  --$1;/g;' {} \;

Following ITK pull request https://github.com/InsightSoftwareConsortium/ITK/pull/3484 commit https://github.com/InsightSoftwareConsortium/ITK/commit/ec510c1749476438b3634a61b9fd7e21c81861fd

In accordance with common C++ guidelines, including:

Google C++ Style Guide: "Use the prefix form (++i) of the increment and decrement operators unless you need postfix semantics."
https://google.github.io/styleguide/cppguide.html#Preincrement_and_Predecrement

Herb Sutter, Andrei Alexandrescu - C++ Coding Standards: 101 Rules, Guidelines, and Best Practices: "Prefer the canonical form of ++ and --. Prefer calling the prefix forms"
https://www.oreilly.com/library/view/c-coding-standards/0321113586/ch29.html