### PR TITLE
STYLE: Implement ElastixMain, Configuration constructors by `= default`

### DIFF
--- a/Core/Configuration/elxConfiguration.cxx
+++ b/Core/Configuration/elxConfiguration.cxx
@@ -76,18 +76,7 @@ AddDataFromExternalTransformFile(const std::string &                        para
  * ********************* Constructor ****************************
  */
 
-Configuration::Configuration()
-{
-  /** Initialize stuff. */
-  this->m_ParameterFileName = "";
-  this->m_ParameterFileParser = itk::ParameterFileParser::New();
-  this->m_ParameterMapInterface = itk::ParameterMapInterface::New();
-
-  this->m_IsInitialized = false;
-  this->m_ElastixLevel = 0;
-  this->m_TotalNumberOfElastixLevels = 1;
-
-} // end Constructor()
+Configuration::Configuration() = default;
 
 
 /**

--- a/Core/Configuration/elxConfiguration.h
+++ b/Core/Configuration/elxConfiguration.h
@@ -287,14 +287,14 @@ private:
   void
   operator=(const Self &) = delete;
 
-  CommandLineArgumentMapType          m_CommandLineArgumentMap;
-  std::string                         m_ParameterFileName;
-  itk::ParameterFileParser::Pointer   m_ParameterFileParser;
-  itk::ParameterMapInterface::Pointer m_ParameterMapInterface;
+  CommandLineArgumentMapType          m_CommandLineArgumentMap{};
+  std::string                         m_ParameterFileName{};
+  itk::ParameterFileParser::Pointer   m_ParameterFileParser{ itk::ParameterFileParser::New() };
+  itk::ParameterMapInterface::Pointer m_ParameterMapInterface{ itk::ParameterMapInterface::New() };
 
-  bool         m_IsInitialized;
-  unsigned int m_ElastixLevel;
-  unsigned int m_TotalNumberOfElastixLevels;
+  bool         m_IsInitialized{ false };
+  unsigned int m_ElastixLevel{ 0 };
+  unsigned int m_TotalNumberOfElastixLevels{ 1 };
 };
 
 } // end namespace elastix

--- a/Core/Kernel/elxElastixMain.cxx
+++ b/Core/Kernel/elxElastixMain.cxx
@@ -148,35 +148,7 @@ xoutManager::Guard::~Guard()
  * ********************* Constructor ****************************
  */
 
-ElastixMain::ElastixMain()
-{
-  /** Initialize the components. */
-  this->m_Configuration = Configuration::New();
-
-  this->m_Elastix = nullptr;
-
-  this->m_FixedImagePixelType = "";
-  this->m_FixedImageDimension = 0;
-
-  this->m_MovingImagePixelType = "";
-  this->m_MovingImageDimension = 0;
-
-  this->m_DBIndex = 0;
-
-  this->m_FixedImageContainer = nullptr;
-  this->m_MovingImageContainer = nullptr;
-
-  this->m_FixedMaskContainer = nullptr;
-  this->m_MovingMaskContainer = nullptr;
-
-  this->m_ResultImageContainer = nullptr;
-
-  this->m_FinalTransform = nullptr;
-  this->m_InitialTransform = nullptr;
-  this->m_TransformParametersMap.clear();
-
-} // end Constructor
-
+ElastixMain::ElastixMain() = default;
 
 /**
  * ****************** GetComponentDatabase *********

--- a/Core/Kernel/elxElastixMain.h
+++ b/Core/Kernel/elxElastixMain.h
@@ -320,41 +320,42 @@ protected:
   /** A pointer to elastix as an itk::object. In run() this
    * pointer will be assigned to an ElastixTemplate<>.
    */
-  ObjectPointer m_Elastix;
+  ObjectPointer m_Elastix{ nullptr };
 
   /** The configuration object, containing the parameters and command-line arguments. */
-  ConfigurationPointer m_Configuration;
+  ConfigurationPointer m_Configuration{ Configuration::New() };
 
   /** A vector of configuration objects, needed when transformix is used as library. */
-  std::vector<ConfigurationPointer> m_Configurations;
+  std::vector<ConfigurationPointer> m_Configurations{};
 
   /** Description of the ImageTypes. */
-  PixelTypeDescriptionType m_FixedImagePixelType;
-  ImageDimensionType       m_FixedImageDimension;
-  PixelTypeDescriptionType m_MovingImagePixelType;
-  ImageDimensionType       m_MovingImageDimension;
+  PixelTypeDescriptionType m_FixedImagePixelType{};
+  ImageDimensionType       m_FixedImageDimension{ 0 };
+  PixelTypeDescriptionType m_MovingImagePixelType{};
+  ImageDimensionType       m_MovingImageDimension{ 0 };
 
-  DBIndexType m_DBIndex;
+  DBIndexType m_DBIndex{ 0 };
 
   /** The images and masks. */
-  DataObjectContainerPointer m_FixedImageContainer;
-  DataObjectContainerPointer m_MovingImageContainer;
-  DataObjectContainerPointer m_FixedMaskContainer;
-  DataObjectContainerPointer m_MovingMaskContainer;
-  DataObjectContainerPointer m_ResultImageContainer;
-  DataObjectContainerPointer m_ResultDeformationFieldContainer;
+  DataObjectContainerPointer m_FixedImageContainer{ nullptr };
+  DataObjectContainerPointer m_MovingImageContainer{ nullptr };
+  DataObjectContainerPointer m_FixedMaskContainer{ nullptr };
+  DataObjectContainerPointer m_MovingMaskContainer{ nullptr };
+  DataObjectContainerPointer m_ResultImageContainer{ nullptr };
+  DataObjectContainerPointer m_ResultDeformationFieldContainer{ nullptr };
 
   /** A transform that is the result of registration. */
-  ObjectPointer m_FinalTransform;
+  ObjectPointer m_FinalTransform{ nullptr };
 
   /** The initial transform. */
-  ObjectPointer m_InitialTransform;
+  ObjectPointer m_InitialTransform{ nullptr };
+
   /** Transformation parameters map containing parameters that is the
    *  result of registration.
    */
-  ParameterMapType m_TransformParametersMap;
+  ParameterMapType m_TransformParametersMap{};
 
-  FlatDirectionCosinesType m_OriginalFixedImageDirection;
+  FlatDirectionCosinesType m_OriginalFixedImageDirection{};
 
   /** InitDBIndex sets m_DBIndex by asking the ImageTypes
    * from the Configuration object and obtaining the corresponding


### PR DESCRIPTION
Follows C++ Core Guidelines (July 13, 2022), "Prefer initialization to assignment in constructors", at
https://github.com/isocpp/CppCoreGuidelines/blob/master/CppCoreGuidelines.md#c49-prefer-initialization-to-assignment-in-constructors