### PR TITLE
COMP: Upgrade Azure Pipelines and GitHub Actions yml files to macOS-11

### DIFF
--- a/.github/workflows/ElastixGitHubActions.yml
+++ b/.github/workflows/ElastixGitHubActions.yml
@@ -13,7 +13,7 @@ jobs:
     strategy:
       max-parallel: 3
       matrix:
-        os: [macos-10.15, ubuntu-18.04, windows-2019]
+        os: [macos-11, ubuntu-18.04, windows-2019]
         include:
           - os: ubuntu-18.04
             c-compiler: "gcc"
@@ -29,7 +29,7 @@ jobs:
             cmake-build-type: "Release"
             ANNLib: "ANNlib-5.0.dll"
             vcvars64: "C:/Program Files (x86)/Microsoft Visual Studio/2019/Enterprise/VC/Auxiliary/Build/vcvars64.bat"
-          - os: macos-10.15
+          - os: macos-11
             c-compiler: "clang"  
             cxx-compiler: "clang++"
             itk-git-tag: "v5.3rc03"
@@ -150,7 +150,7 @@ jobs:
         cat dashboard.cmake
 
     - name: Test MacOs
-      if: matrix.os == 'macos-10.15'
+      if: matrix.os == 'macos-11'
       run: |
        ctest --output-on-failure -VV -j 2 -E "elastix_run_example_COMPARE_IM|elastix_run_3DCT_lung.MI.bspline.ASGD.001_COMPARE_TP|elastix_run_3DCT_lung.NMI.bspline.ASGD.001_COMPARE_TP" -S dashboard.cmake
       

--- a/Testing/CI/Azure/ci.yml
+++ b/Testing/CI/Azure/ci.yml
@@ -118,7 +118,7 @@ jobs:
 - job: macOS
   timeoutInMinutes: 0
   pool:
-    vmImage: 'macOS-10.15'
+    vmImage: 'macOS-11'
   strategy:
     matrix:
       ITKv5:


### PR DESCRIPTION
Addresses a warning at https://dev.azure.com/kaspermarstal/Elastix/_build/results?buildId=3342&view=logs&j=d9d370b1-18a3-5231-ee95-54c0a379145c saying:

> ##[warning]The macOS-10.15 environment is deprecated, consider switching to macos-11(macos-latest), macos-12 instead. For more details see https://github.com/actions/virtual-environments/issues/5583

May also be relevant to issue https://github.com/SuperElastix/elastix/issues/650 "MacOS GitHub Actions, Azure Pipelines fatal error: ‘omp.h’ file not found"