### PR TITLE
STYLE: Make conversion from value to itk::Point or itk::Vector explicit

### DIFF
--- a/Common/GTesting/elxTransformIOGTest.cxx
+++ b/Common/GTesting/elxTransformIOGTest.cxx
@@ -308,8 +308,8 @@ struct WithDimension
 
       const auto imageContainer = elx::ElastixBase::DataObjectContainerType::New();
       const auto image = itk::Image<float, NDimension>::New();
-      image->SetOrigin(testValue);
-      image->SetSpacing(testValue);
+      image->SetOrigin(itk::Point<double, NDimension>(testValue));
+      image->SetSpacing(itk::Vector<double, NDimension>(testValue));
       imageContainer->push_back(image);
 
       elastixObject->SetFixedImageContainer(imageContainer);


### PR DESCRIPTION
Allowing ITK_LEGACY_REMOVE=0N for ITK version >= 5.3rc04, which made those constructors `explicit`:

 - ITK pull request https://github.com/InsightSoftwareConsortium/ITK/pull/3237 commit https://github.com/InsightSoftwareConsortium/ITK/commit/8825834406356a66705437b74c843a54a47c57c3 "ENH: Declare converting `Point(v)` constructors `explicit`"
 - ITK pull request https://github.com/InsightSoftwareConsortium/ITK/pull/3255 commit https://github.com/InsightSoftwareConsortium/ITK/commit/abb88ccc48e79656e1481ad3ad995ae3d370539d "ENH: Make Vector constructor from scalar explicit, unless LEGACY enabled"