### PR TITLE
STYLE: Remove `GetNumberOfElements`, now that ITK has FixedArray::size()

### DIFF
--- a/Common/GTesting/elxConversionGTest.cxx
+++ b/Common/GTesting/elxConversionGTest.cxx
@@ -46,12 +46,6 @@ using elx::CoreMainGTestUtilities::CheckNew;
 
 namespace
 {
-template <typename TContainer>
-void
-Expect_GetNumberOfElements_returns_size(const TContainer & container)
-{
-  EXPECT_EQ(Conversion::GetNumberOfElements(container), container.size());
-}
 
 template <typename TParameterValue>
 TParameterValue
@@ -227,23 +221,6 @@ Expect_lossless_round_trip_of_floating_point_parameter_values()
 }
 
 } // namespace
-
-
-GTEST_TEST(Conversion, GetNumberOfParameters)
-{
-  Expect_GetNumberOfElements_returns_size(itk::Size<>{});
-  Expect_GetNumberOfElements_returns_size(itk::Index<>{});
-
-  // Note: Currently we still support ITK 5.1.1, which does not yet have a
-  // size() member function for itk::Point and itk::Vector.
-  EXPECT_EQ(Conversion::GetNumberOfElements(itk::Point<double>{}), 3);
-  EXPECT_EQ(Conversion::GetNumberOfElements(itk::Vector<double>{}), 3);
-
-  for (std::size_t i{}; i <= 2; ++i)
-  {
-    Expect_GetNumberOfElements_returns_size(itk::OptimizerParameters<double>(i));
-  }
-}
 
 
 GTEST_TEST(Conversion, BoolToString)

--- a/Core/Install/elxConversion.h
+++ b/Core/Install/elxConversion.h
@@ -20,8 +20,6 @@
 
 #include "itkMatrix.h"
 
-#include <vnl/vnl_vector.h>
-
 #include <iterator>
 #include <map>
 #include <string>
@@ -49,24 +47,6 @@ public:
   /** Corresponds with typedefs from the elastix class itk::ParameterFileParser. */
   using ParameterValuesType = std::vector<std::string>;
   using ParameterMapType = std::map<std::string, ParameterValuesType>;
-
-  /** Overload set, similar to C++17 `std::size(const TContainer&)` (which can only be
-   * used within the implementation of elastix is upgraded to C++17 or higher).
-   */
-  template <typename TContainer, unsigned NDimension = TContainer::Dimension>
-  static std::size_t
-  GetNumberOfElements(const TContainer &)
-  {
-    return NDimension;
-  }
-
-  template <typename TValue>
-  static std::size_t
-  GetNumberOfElements(const vnl_vector<TValue> & vnlVector)
-  {
-    return vnlVector.size();
-  }
-
 
   /** Convenience function to convert seconds to day, hour, minute, second format. */
   static std::string
@@ -128,9 +108,7 @@ public:
   {
     std::vector<std::string> result;
 
-    // Note: Uses TContainer::Dimension instead of container.size(),
-    // because itk::FixedArray::size() is not yet included with ITK 5.1.1.
-    result.reserve(GetNumberOfElements(container));
+    result.reserve(container.size());
 
     for (const auto element : container)
     {


### PR DESCRIPTION
`itk::FixedArray::size()` is included with ITK from version v5.2rc01, and was added on May 10, 2020, with pull request https://github.com/InsightSoftwareConsortium/ITK/pull/1800  commit https://github.com/InsightSoftwareConsortium/ITK/commit/38939ff86d97777e8d507963c13a2221e86b601e "ENH: Add data() and size() member functions to FixedArray" by Pablo Hernandez-Cerdan.