### PR TITLE
Replace VTKPolyDataReader with itk::MeshFileReader, remove mesh reader/writer typefdefs

### DIFF
--- a/Components/Metrics/MissingStructurePenalty/elxMissingStructurePenalty.hxx
+++ b/Components/Metrics/MissingStructurePenalty/elxMissingStructurePenalty.hxx
@@ -279,10 +279,8 @@ template <class TElastix>
 unsigned int
 MissingStructurePenalty<TElastix>::ReadMesh(const std::string & meshFileName, typename FixedMeshType::Pointer & mesh)
 {
-  using MeshReaderType = itk::MeshFileReader<MeshType>;
-
   /** Read the input mesh. */
-  auto meshReader = MeshReaderType::New();
+  auto meshReader = itk::MeshFileReader<MeshType>::New();
   meshReader->SetFileName(meshFileName.c_str());
   elxout << "  Reading input mesh file: " << meshFileName << std::endl;
   try
@@ -312,11 +310,8 @@ template <class TElastix>
 void
 MissingStructurePenalty<TElastix>::WriteResultMesh(const char * filename, MeshIdType meshId)
 {
-  /** Typedef's for writing the output mesh. */
-  using MeshWriterType = itk::MeshFileWriter<MeshType>;
-
   /** Create writer. */
-  auto meshWriter = MeshWriterType::New();
+  auto meshWriter = itk::MeshFileWriter<MeshType>::New();
 
   /** Setup the pipeline. */
 

--- a/Components/Metrics/PolydataDummyPenalty/elxPolydataDummyPenalty.hxx
+++ b/Components/Metrics/PolydataDummyPenalty/elxPolydataDummyPenalty.hxx
@@ -266,11 +266,8 @@ template <class TElastix>
 unsigned int
 PolydataDummyPenalty<TElastix>::ReadMesh(const std::string & meshFileName, typename FixedMeshType::Pointer & mesh)
 {
-
-  using MeshReaderType = itk::MeshFileReader<MeshType>;
-
   /** Read the input mesh. */
-  auto meshReader = MeshReaderType::New();
+  auto meshReader = itk::MeshFileReader<MeshType>::New();
   meshReader->SetFileName(meshFileName.c_str());
 
   elxout << "  Reading input mesh file: " << meshFileName << std::endl;
@@ -302,10 +299,8 @@ template <class TElastix>
 void
 PolydataDummyPenalty<TElastix>::WriteResultMesh(const char * filename, MeshIdType meshId)
 {
-  /** Typedef's for writing the output mesh. */
-  using MeshWriterType = itk::MeshFileWriter<MeshType>;
   /** Create writer. */
-  auto meshWriter = MeshWriterType::New();
+  auto meshWriter = itk::MeshFileWriter<MeshType>::New();
 
   /** Set the points of the latest transformation. */
   const MappedMeshContainerPointer mappedMeshContainer = this->GetModifiableMappedMeshContainer();

--- a/Components/Metrics/StatisticalShapePenalty/elxStatisticalShapePenalty.hxx
+++ b/Components/Metrics/StatisticalShapePenalty/elxStatisticalShapePenalty.hxx
@@ -23,10 +23,9 @@
 
 #include "itkPointSet.h"
 #include "itkDefaultStaticMeshTraits.h"
-#include "itkVTKPolyDataReader.h"
-#include "itkVTKPolyDataWriter.h"
 #include "itkTransformMeshFilter.h"
 #include <itkMesh.h>
+#include <itkMeshFileReader.h>
 
 #include <fstream>
 #include <typeinfo>
@@ -357,10 +356,9 @@ StatisticalShapePenalty<TElastix>::ReadShape(const std::string &                
   using MeshTraitsType =
     DefaultStaticMeshTraits<DummyIPPPixelType, FixedImageDimension, FixedImageDimension, CoordRepType>;
   using MeshType = Mesh<DummyIPPPixelType, FixedImageDimension, MeshTraitsType>;
-  using MeshReaderType = VTKPolyDataReader<MeshType>;
 
   /** Read the input points. */
-  auto meshReader = MeshReaderType::New();
+  auto meshReader = MeshFileReader<MeshType>::New();
   meshReader->SetFileName(ShapeFileName.c_str());
   elxout << "  Reading input point file: " << ShapeFileName << std::endl;
   try

--- a/Core/ComponentBaseClasses/elxTransformBase.hxx
+++ b/Core/ComponentBaseClasses/elxTransformBase.hxx
@@ -865,12 +865,10 @@ TransformBase<TElastix>::TransformPointsSomePointsVTK(const std::string & filena
   using MeshTraitsType =
     itk::DefaultStaticMeshTraits<DummyIPPPixelType, FixedImageDimension, FixedImageDimension, CoordRepType>;
   using MeshType = itk::Mesh<DummyIPPPixelType, FixedImageDimension, MeshTraitsType>;
-  using MeshReaderType = itk::MeshFileReader<MeshType>;
-  using MeshWriterType = itk::MeshFileWriter<MeshType>;
   using TransformMeshFilterType = itk::TransformMeshFilter<MeshType, MeshType, CombinationTransformType>;
 
   /** Read the input points. */
-  const auto meshReader = MeshReaderType::New();
+  const auto meshReader = itk::MeshFileReader<MeshType>::New();
   meshReader->SetFileName(filename.c_str());
   elxout << "  Reading input point file: " << filename << std::endl;
   try
@@ -906,7 +904,7 @@ TransformBase<TElastix>::TransformPointsSomePointsVTK(const std::string & filena
   /** Create filename and file stream. */
   const std::string outputPointsFileName = this->m_Configuration->GetCommandLineArgument("-out") + "outputpoints.vtk";
   elxout << "  The transformed points are saved in: " << outputPointsFileName << std::endl;
-  const auto meshWriter = MeshWriterType::New();
+  const auto meshWriter = itk::MeshFileWriter<MeshType>::New();
   meshWriter->SetFileName(outputPointsFileName.c_str());
   meshWriter->SetInput(meshTransformer->GetOutput());
 


### PR DESCRIPTION
Related to issue #698 "Double-check limitations of vtk file support"