### PR TITLE
STYLE: Replace `itk::MeshFileWriter` with `itk::WriteMesh` (3x)

### DIFF
--- a/Components/Metrics/MissingStructurePenalty/elxMissingStructurePenalty.hxx
+++ b/Components/Metrics/MissingStructurePenalty/elxMissingStructurePenalty.hxx
@@ -310,9 +310,6 @@ template <class TElastix>
 void
 MissingStructurePenalty<TElastix>::WriteResultMesh(const char * filename, MeshIdType meshId)
 {
-  /** Create writer. */
-  auto meshWriter = itk::MeshFileWriter<MeshType>::New();
-
   /** Setup the pipeline. */
 
   /** Set the points of the latest transformation. */
@@ -346,12 +343,9 @@ MissingStructurePenalty<TElastix>::WriteResultMesh(const char * filename, MeshId
   mappedMesh->Modified();
   mappedMesh->Update();
 
-  meshWriter->SetInput(mappedMesh);
-  meshWriter->SetFileName(filename);
-
   try
   {
-    meshWriter->Update();
+    itk::WriteMesh(mappedMesh, filename);
   }
   catch (itk::ExceptionObject & excp)
   {

--- a/Components/Metrics/PolydataDummyPenalty/elxPolydataDummyPenalty.hxx
+++ b/Components/Metrics/PolydataDummyPenalty/elxPolydataDummyPenalty.hxx
@@ -299,9 +299,6 @@ template <class TElastix>
 void
 PolydataDummyPenalty<TElastix>::WriteResultMesh(const char * filename, MeshIdType meshId)
 {
-  /** Create writer. */
-  auto meshWriter = itk::MeshFileWriter<MeshType>::New();
-
   /** Set the points of the latest transformation. */
   const MappedMeshContainerPointer mappedMeshContainer = this->GetModifiableMappedMeshContainer();
   FixedMeshPointer                 mappedMesh = mappedMeshContainer->ElementAt(meshId);
@@ -331,12 +328,9 @@ PolydataDummyPenalty<TElastix>::WriteResultMesh(const char * filename, MeshIdTyp
   mappedMesh->Modified();
   mappedMesh->Update();
 
-  meshWriter->SetInput(mappedMesh);
-  meshWriter->SetFileName(filename);
-
   try
   {
-    meshWriter->Update();
+    itk::WriteMesh(mappedMesh, filename);
   }
   catch (itk::ExceptionObject & excp)
   {

--- a/Core/ComponentBaseClasses/elxTransformBase.hxx
+++ b/Core/ComponentBaseClasses/elxTransformBase.hxx
@@ -904,13 +904,10 @@ TransformBase<TElastix>::TransformPointsSomePointsVTK(const std::string & filena
   /** Create filename and file stream. */
   const std::string outputPointsFileName = this->m_Configuration->GetCommandLineArgument("-out") + "outputpoints.vtk";
   elxout << "  The transformed points are saved in: " << outputPointsFileName << std::endl;
-  const auto meshWriter = itk::MeshFileWriter<MeshType>::New();
-  meshWriter->SetFileName(outputPointsFileName.c_str());
-  meshWriter->SetInput(meshTransformer->GetOutput());
 
   try
   {
-    meshWriter->Update();
+    itk::WriteMesh(meshTransformer->GetOutput(), outputPointsFileName);
   }
   catch (const itk::ExceptionObject & err)
   {


### PR DESCRIPTION
`itk::WriteMesh` was introduced with ITK v5.3rc03 by pull request https://github.com/InsightSoftwareConsortium/ITK/pull/2880 commit
https://github.com/InsightSoftwareConsortium/ITK/commit/bd2a2e484dc5fd7e59082736f75efd18a95fd1e3 "ENH: Add itk::WriteMesh", by Matt McCormick.