### PR TITLE
STYLE: Use `DummyIPPPixelType = unsigned char` everywhere

### DIFF
--- a/Components/Metrics/StatisticalShapePenalty/elxStatisticalShapePenalty.hxx
+++ b/Components/Metrics/StatisticalShapePenalty/elxStatisticalShapePenalty.hxx
@@ -351,8 +351,8 @@ StatisticalShapePenalty<TElastix>::ReadShape(const std::string &                
                                              typename PointSetType::Pointer &       pointSet,
                                              const typename ImageType::ConstPointer image)
 {
-  /** Typedef's. \todo test DummyIPPPixelType=bool. */
-  using DummyIPPPixelType = double;
+  /** Typedef's. */
+  using DummyIPPPixelType = unsigned char;
   using MeshTraitsType =
     DefaultStaticMeshTraits<DummyIPPPixelType, FixedImageDimension, FixedImageDimension, CoordRepType>;
   using MeshType = Mesh<DummyIPPPixelType, FixedImageDimension, MeshTraitsType>;

--- a/Core/ComponentBaseClasses/elxTransformBase.hxx
+++ b/Core/ComponentBaseClasses/elxTransformBase.hxx
@@ -860,8 +860,8 @@ template <class TElastix>
 void
 TransformBase<TElastix>::TransformPointsSomePointsVTK(const std::string & filename) const
 {
-  /** Typedef's. \todo test DummyIPPPixelType=bool. */
-  using DummyIPPPixelType = float;
+  /** Typedef's. */
+  using DummyIPPPixelType = unsigned char;
   using MeshTraitsType =
     itk::DefaultStaticMeshTraits<DummyIPPPixelType, FixedImageDimension, FixedImageDimension, CoordRepType>;
   using MeshType = itk::Mesh<DummyIPPPixelType, FixedImageDimension, MeshTraitsType>;


### PR DESCRIPTION
Removed "todo test DummyIPPPixelType=bool", and consistently used `unsigned char` as dummy pixel type for mesh template instantiations (rather than `float` or `double`).

`DummyIPPPixelType = unsigned char` was being used on three places already.