### PR TITLE
ENH: Support transforming points of Mesh objects by itk::Transformix API

### DIFF
--- a/Core/ComponentBaseClasses/elxTransformBase.h
+++ b/Core/ComponentBaseClasses/elxTransformBase.h
@@ -22,6 +22,7 @@
 #include "elxMacro.h"
 
 #include "elxBaseComponentSE.h"
+#include "elxDefaultConstructibleSubclass.h"
 #include "elxElastixBase.h"
 #include "itkAdvancedTransform.h"
 #include "itkAdvancedCombinationTransform.h"
@@ -31,6 +32,8 @@
 // ITK header files:
 #include <itkImage.h>
 #include <itkOptimizerParameters.h>
+#include <itkTransformMeshFilter.h>
+
 
 namespace elastix
 {
@@ -257,6 +260,19 @@ public:
    */
   void
   SetFinalParameters();
+
+  /** Transforms the specified mesh.
+   */
+  template <typename TMesh>
+  typename TMesh::Pointer
+  TransformMesh(const TMesh & mesh) const
+  {
+    DefaultConstructibleSubclass<itk::TransformMeshFilter<TMesh, TMesh, CombinationTransformType>> transformMeshFilter;
+    transformMeshFilter.SetTransform(&const_cast<CombinationTransformType &>(this->GetSelf()));
+    transformMeshFilter.SetInput(&mesh);
+    transformMeshFilter.Update();
+    return transformMeshFilter.GetOutput();
+  }
 
 protected:
   /** The default-constructor. */

--- a/Core/Main/itkTransformixFilter.h
+++ b/Core/Main/itkTransformixFilter.h
@@ -36,6 +36,7 @@
 #define itkTransformixFilter_h
 
 #include "itkImageSource.h"
+#include "itkMesh.h"
 
 #include "elxTransformixMain.h"
 #include "elxParameterObject.h"
@@ -85,6 +86,8 @@ public:
   using ParameterObjectConstPointer = typename ParameterObjectType::ConstPointer;
 
   using typename Superclass::OutputImageType;
+  using typename Superclass::OutputImagePixelType;
+
   using OutputDeformationFieldType =
     typename itk::Image<itk::Vector<float, TMovingImage::ImageDimension>, TMovingImage::ImageDimension>;
 
@@ -92,6 +95,8 @@ public:
 
   using InputImageType = TMovingImage;
   itkStaticConstMacro(MovingImageDimension, unsigned int, TMovingImage::ImageDimension);
+
+  using MeshType = Mesh<OutputImagePixelType, MovingImageDimension>;
 
   /** Set/Get/Add moving image. */
   virtual void
@@ -195,6 +200,24 @@ public:
     m_EnableOutput = false;
   }
 
+  /** Sets an (optional) input mesh. An Update() will transform its points, and store them in the output mesh.  */
+  void
+  SetInputMesh(typename MeshType::ConstPointer mesh)
+  {
+    if (mesh != m_InputMesh)
+    {
+      m_InputMesh = mesh;
+      this->Modified();
+    }
+  }
+
+  /** Retrieves the output mesh, produced by an Update(), when an input mesh was specified.  */
+  const MeshType *
+  GetOutputMesh() const
+  {
+    return m_OutputMesh;
+  }
+
 protected:
   TransformixFilter();
 
@@ -240,6 +263,9 @@ private:
   bool m_EnableOutput{ true };
   bool m_LogToConsole;
   bool m_LogToFile;
+
+  typename MeshType::ConstPointer m_InputMesh;
+  typename MeshType::Pointer      m_OutputMesh;
 };
 
 } // namespace itk

--- a/Core/Main/itkTransformixFilter.hxx
+++ b/Core/Main/itkTransformixFilter.hxx
@@ -35,8 +35,10 @@
 #ifndef itkTransformixFilter_hxx
 #define itkTransformixFilter_hxx
 
+#include "elxElastixTemplate.h"
 #include "itkTransformixFilter.h"
 #include "elxPixelType.h"
+#include "elxTransformBase.h"
 #include <memory> // For unique_ptr.
 
 namespace itk
@@ -206,6 +208,24 @@ TransformixFilter<TMovingImage>::GenerateData()
   try
   {
     isError = transformix->Run(argumentMap, transformParameterMapVector);
+
+    if (m_InputMesh)
+    {
+      m_OutputMesh = nullptr;
+
+      const auto * const transformContainer = transformix->GetElastixBase().GetTransformContainer();
+
+      if ((transformContainer != nullptr) && (!transformContainer->empty()))
+      {
+        const auto transformBase = dynamic_cast<elx::TransformBase<elx::ElastixTemplate<TMovingImage, TMovingImage>> *>(
+          transformContainer->front().GetPointer());
+
+        if (transformBase)
+        {
+          m_OutputMesh = transformBase->TransformMesh(*m_InputMesh);
+        }
+      }
+    }
   }
   catch (itk::ExceptionObject & e)
   {


### PR DESCRIPTION
Supported transforming points as follows:

    transformixFilter.SetInputMesh(inputMesh);
    transformixFilter.Update();
    outputMesh = transformixFilter.GetOutputMesh();

Using the OutputImagePixelType of TransformixFilter as `TPixelType` template argument of the mesh type, as was suggested by Matt McCormick (@thewtex).
