### PR TITLE
ENH: Test TransformixFilter, ElastixRegistrationMethod default init

### DIFF
--- a/Core/Main/GTesting/itkElastixRegistrationMethodGTest.cxx
+++ b/Core/Main/GTesting/itkElastixRegistrationMethodGTest.cxx
@@ -139,6 +139,26 @@ Test_WriteBSplineTransformToItkFileFormat(const std::string & rootOutputDirector
 } // namespace
 
 
+GTEST_TEST(itkElastixRegistrationMethod, IsDefaultInitialized)
+{
+  constexpr auto ImageDimension = 2U;
+  using PixelType = float;
+  using ImageType = itk::Image<PixelType, ImageDimension>;
+
+  const elx::DefaultConstructibleSubclass<itk::ElastixRegistrationMethod<ImageType, ImageType>>
+    elastixRegistrationMethod;
+
+  EXPECT_EQ(elastixRegistrationMethod.GetInitialTransformParameterFileName(), std::string{});
+  EXPECT_EQ(elastixRegistrationMethod.GetFixedPointSetFileName(), std::string{});
+  EXPECT_EQ(elastixRegistrationMethod.GetMovingPointSetFileName(), std::string{});
+  EXPECT_EQ(elastixRegistrationMethod.GetOutputDirectory(), std::string{});
+  EXPECT_EQ(elastixRegistrationMethod.GetLogFileName(), std::string{});
+  EXPECT_FALSE(elastixRegistrationMethod.GetLogToConsole());
+  EXPECT_FALSE(elastixRegistrationMethod.GetLogToFile());
+  EXPECT_EQ(elastixRegistrationMethod.GetNumberOfThreads(), 0);
+}
+
+
 // Tests registering two small (5x6) binary images, which are translated with respect to each other.
 GTEST_TEST(itkElastixRegistrationMethod, Translation)
 {

--- a/Core/Main/GTesting/itkTransformixFilterGTest.cxx
+++ b/Core/Main/GTesting/itkTransformixFilterGTest.cxx
@@ -428,6 +428,26 @@ Test_BSplineViaExternalTransformFile(const std::string & rootOutputDirectoryPath
 } // namespace
 
 
+GTEST_TEST(itkTransformixFilter, IsDefaultInitialized)
+{
+  constexpr auto ImageDimension = 2U;
+  using PixelType = float;
+  using TransformixFilterType = itk::TransformixFilter<itk::Image<PixelType, ImageDimension>>;
+
+  const elx::DefaultConstructibleSubclass<TransformixFilterType> transformixFilter;
+
+  EXPECT_EQ(transformixFilter.GetFixedPointSetFileName(), std::string{});
+  EXPECT_EQ(transformixFilter.GetOutputDirectory(), std::string{});
+  EXPECT_FALSE(transformixFilter.GetComputeSpatialJacobian());
+  EXPECT_FALSE(transformixFilter.GetComputeDeterminantOfSpatialJacobian());
+  EXPECT_FALSE(transformixFilter.GetComputeDeformationField());
+  EXPECT_EQ(transformixFilter.GetLogFileName(), std::string{});
+  EXPECT_FALSE(transformixFilter.GetLogToConsole());
+  EXPECT_FALSE(transformixFilter.GetLogToFile());
+  EXPECT_EQ(transformixFilter.GetOutputMesh(), nullptr);
+}
+
+
 // Tests translating a small (5x6) binary image, having a 2x2 white square.
 GTEST_TEST(itkTransformixFilter, Translation2D)
 {


### PR DESCRIPTION
Checks the publicly accessible properties of a default-initialized TransformixFilter or ElastixRegistrationMethod object.