### PR TITLE
STYLE: Rename `DefaultConstructibleSubclass` to `DefaultConstruct`

### DIFF
--- a/Common/CMakeLists.txt
+++ b/Common/CMakeLists.txt
@@ -16,7 +16,7 @@ endif()
 # Define lists of files in the subdirectories.
 
 set(CommonFiles
-  elxDefaultConstructibleSubclass.h
+  elxDefaultConstruct.h
   elxSupportedImageDimensions.h
   itkAdvancedLinearInterpolateImageFunction.h
   itkAdvancedLinearInterpolateImageFunction.hxx

--- a/Common/GTesting/CMakeLists.txt
+++ b/Common/GTesting/CMakeLists.txt
@@ -1,6 +1,6 @@
 add_executable(CommonGTest
   elxConversionGTest.cxx
-  elxDefaultConstructibleSubclassGTest.cxx
+  elxDefaultConstructGTest.cxx
   elxElastixMainGTest.cxx
   elxGTestUtilities.h
   elxResampleInterpolatorGTest.cxx

--- a/Common/GTesting/elxDefaultConstructGTest.cxx
+++ b/Common/GTesting/elxDefaultConstructGTest.cxx
@@ -17,20 +17,20 @@
  *=========================================================================*/
 
 // First include the header file to be tested:
-#include "elxDefaultConstructibleSubclass.h"
+#include "elxDefaultConstruct.h"
 #include <itkImage.h>
 #include <gtest/gtest.h>
 #include <type_traits> // For is_base_of and is_default_constructible.
 
 // The class template to be tested:
-using elastix::DefaultConstructibleSubclass;
+using elastix::DefaultConstruct;
 
-// Example type, to be used as template argument of DefaultConstructibleSubclass.
+// Example type, to be used as template argument of DefaultConstruct.
 using ImageType = itk::Image<int>;
 
 namespace
 {
-// A minimal test class, to be used as template argument of DefaultConstructibleSubclass.
+// A minimal test class, to be used as template argument of DefaultConstruct.
 class TestObject : public itk::LightObject
 {
 public:
@@ -62,18 +62,18 @@ private:
 } // namespace
 
 
-static_assert(std::is_base_of<TestObject, DefaultConstructibleSubclass<TestObject>>{} &&
-                std::is_base_of<ImageType, DefaultConstructibleSubclass<ImageType>>{},
-              "DefaultConstructibleSubclass<T> must be a subclass of T! ");
+static_assert(std::is_base_of<TestObject, DefaultConstruct<TestObject>>{} &&
+                std::is_base_of<ImageType, DefaultConstruct<ImageType>>{},
+              "DefaultConstruct<T> must be a subclass of T! ");
 
-static_assert(std::is_default_constructible<DefaultConstructibleSubclass<TestObject>>{} &&
-                std::is_default_constructible<DefaultConstructibleSubclass<ImageType>>{},
-              "DefaultConstructibleSubclass<T> must be default-constructible! ");
+static_assert(std::is_default_constructible<DefaultConstruct<TestObject>>{} &&
+                std::is_default_constructible<DefaultConstruct<ImageType>>{},
+              "DefaultConstruct<T> must be default-constructible! ");
 
-GTEST_TEST(DefaultConstructibleSubclass, Check)
+GTEST_TEST(DefaultConstruct, Check)
 {
-  const DefaultConstructibleSubclass<ImageType>  defaultConstructedImage{};
-  const DefaultConstructibleSubclass<TestObject> defaultConstructedTestObject{};
+  const DefaultConstruct<ImageType>  defaultConstructedImage{};
+  const DefaultConstruct<TestObject> defaultConstructedTestObject{};
 
   EXPECT_EQ(defaultConstructedTestObject, *TestObject::New());
   EXPECT_EQ(defaultConstructedImage, *ImageType::New());

--- a/Common/GTesting/elxTransformIOGTest.cxx
+++ b/Common/GTesting/elxTransformIOGTest.cxx
@@ -22,7 +22,7 @@
 #include "elxTransformIO.h"
 
 #include "elxConversion.h"
-#include "elxDefaultConstructibleSubclass.h"
+#include "elxDefaultConstruct.h"
 #include "elxElastixMain.h" // For xoutManager.
 #include "elxElastixTemplate.h"
 #include "elxGTestUtilities.h"
@@ -114,7 +114,7 @@ struct WithDimension
 
       EXPECT_EQ(elxTransform->elxGetClassName(),
                 elx::TransformIO::ConvertITKNameOfClassToElastixClassName(
-                  elx::DefaultConstructibleSubclass<TExpectedCorrespondingItkTransform>{}.GetNameOfClass()));
+                  elx::DefaultConstruct<TExpectedCorrespondingItkTransform>{}.GetNameOfClass()));
 
       const auto compositeTransform = elx::TransformIO::ConvertToItkCompositeTransform(*elxTransform);
       ASSERT_NE(compositeTransform, nullptr);
@@ -869,7 +869,7 @@ GTEST_TEST(Transform, TransformedPointSameAsITKTranslation2D)
 {
   constexpr auto Dimension = 2U;
 
-  elx::DefaultConstructibleSubclass<itk::TranslationTransform<double, Dimension>> itkTransform;
+  elx::DefaultConstruct<itk::TranslationTransform<double, Dimension>> itkTransform;
   itkTransform.SetOffset(itk::MakeVector(1.0, 2.0));
 
   Expect_elx_TransformPoint_yields_same_point_as_ITK<elx::TranslationTransformElastix>(itkTransform);
@@ -880,7 +880,7 @@ GTEST_TEST(Transform, TransformedPointSameAsITKTranslation3D)
 {
   constexpr auto Dimension = 3U;
 
-  elx::DefaultConstructibleSubclass<itk::TranslationTransform<double, Dimension>> itkTransform;
+  elx::DefaultConstruct<itk::TranslationTransform<double, Dimension>> itkTransform;
   itkTransform.SetOffset(itk::MakeVector(1.0, 2.0, 3.0));
 
   Expect_elx_TransformPoint_yields_same_point_as_ITK<elx::TranslationTransformElastix>(itkTransform);
@@ -891,7 +891,7 @@ GTEST_TEST(Transform, TransformedPointSameAsITKAffine2D)
 {
   constexpr auto Dimension = 2U;
 
-  elx::DefaultConstructibleSubclass<itk::AffineTransform<double, Dimension>> itkTransform;
+  elx::DefaultConstruct<itk::AffineTransform<double, Dimension>> itkTransform;
   itkTransform.SetTranslation(itk::MakeVector(1.0, 2.0));
   itkTransform.Scale(itk::MakeVector(1.5, 1.75));
   itkTransform.SetCenter(itk::MakePoint(0.5, 1.5));
@@ -905,7 +905,7 @@ GTEST_TEST(Transform, TransformedPointSameAsITKAffine3D)
 {
   constexpr auto Dimension = 3U;
 
-  elx::DefaultConstructibleSubclass<itk::AffineTransform<double, Dimension>> itkTransform;
+  elx::DefaultConstruct<itk::AffineTransform<double, Dimension>> itkTransform;
   itkTransform.SetTranslation(itk::MakeVector(1.0, 2.0, 3.0));
   itkTransform.SetCenter(itk::MakePoint(3.0, 2.0, 1.0));
   itkTransform.Scale(itk::MakeVector(1.25, 1.5, 1.75));
@@ -917,7 +917,7 @@ GTEST_TEST(Transform, TransformedPointSameAsITKAffine3D)
 
 GTEST_TEST(Transform, TransformedPointSameAsITKEuler2D)
 {
-  elx::DefaultConstructibleSubclass<itk::Euler2DTransform<double>> itkTransform;
+  elx::DefaultConstruct<itk::Euler2DTransform<double>> itkTransform;
   itkTransform.SetTranslation(itk::MakeVector(1.0, 2.0));
   itkTransform.SetCenter(itk::MakePoint(0.5, 1.5));
   itkTransform.SetAngle(M_PI_4);
@@ -928,7 +928,7 @@ GTEST_TEST(Transform, TransformedPointSameAsITKEuler2D)
 
 GTEST_TEST(Transform, TransformedPointSameAsITKEuler3D)
 {
-  elx::DefaultConstructibleSubclass<itk::Euler3DTransform<double>> itkTransform;
+  elx::DefaultConstruct<itk::Euler3DTransform<double>> itkTransform;
   itkTransform.SetTranslation(itk::MakeVector(1.0, 2.0, 3.0));
   itkTransform.SetCenter(itk::MakePoint(3.0, 2.0, 1.0));
   itkTransform.SetRotation(M_PI_2, M_PI_4, M_PI_4 / 2.0);
@@ -939,7 +939,7 @@ GTEST_TEST(Transform, TransformedPointSameAsITKEuler3D)
 
 GTEST_TEST(Transform, TransformedPointSameAsITKSimilarity2D)
 {
-  elx::DefaultConstructibleSubclass<itk::Similarity2DTransform<double>> itkTransform;
+  elx::DefaultConstruct<itk::Similarity2DTransform<double>> itkTransform;
   itkTransform.SetScale(0.75);
   itkTransform.SetTranslation(itk::MakeVector(1.0, 2.0));
   itkTransform.SetCenter(itk::MakePoint(0.5, 1.5));
@@ -951,7 +951,7 @@ GTEST_TEST(Transform, TransformedPointSameAsITKSimilarity2D)
 
 GTEST_TEST(Transform, TransformedPointSameAsITKSimilarity3D)
 {
-  elx::DefaultConstructibleSubclass<itk::Similarity3DTransform<double>> itkTransform;
+  elx::DefaultConstruct<itk::Similarity3DTransform<double>> itkTransform;
   itkTransform.SetScale(0.75);
   itkTransform.SetTranslation(itk::MakeVector(1.0, 2.0, 3.0));
   itkTransform.SetCenter(itk::MakePoint(3.0, 2.0, 1.0));
@@ -963,7 +963,7 @@ GTEST_TEST(Transform, TransformedPointSameAsITKSimilarity3D)
 
 GTEST_TEST(Transform, TransformedPointSameAsITKBSpline2D)
 {
-  elx::DefaultConstructibleSubclass<itk::BSplineTransform<double, 2>> itkTransform;
+  elx::DefaultConstruct<itk::BSplineTransform<double, 2>> itkTransform;
   itkTransform.SetParameters(GeneratePseudoRandomParameters(itkTransform.GetParameters().size(), -1.0));
 
   Expect_elx_TransformPoint_yields_same_point_as_ITK<elx::AdvancedBSplineTransform>(itkTransform);
@@ -972,7 +972,7 @@ GTEST_TEST(Transform, TransformedPointSameAsITKBSpline2D)
 
 GTEST_TEST(Transform, TransformedPointSameAsITKBSpline3D)
 {
-  elx::DefaultConstructibleSubclass<itk::BSplineTransform<double, 3>> itkTransform;
+  elx::DefaultConstruct<itk::BSplineTransform<double, 3>> itkTransform;
   itkTransform.SetParameters(GeneratePseudoRandomParameters(itkTransform.GetParameters().size(), -1.0));
 
   Expect_elx_TransformPoint_yields_same_point_as_ITK<elx::AdvancedBSplineTransform>(itkTransform);

--- a/Common/ParameterFileParser/itkParameterFileParser.cxx
+++ b/Common/ParameterFileParser/itkParameterFileParser.cxx
@@ -17,7 +17,7 @@
  *=========================================================================*/
 
 #include "itkParameterFileParser.h"
-#include "elxDefaultConstructibleSubclass.h"
+#include "elxDefaultConstruct.h"
 
 #include <itksys/SystemTools.hxx>
 #include <itksys/RegularExpression.hxx>
@@ -400,7 +400,7 @@ ParameterFileParser::ReturnParameterFileAsString()
 auto
 ParameterFileParser::ReadParameterMap(const std::string & fileName) -> ParameterMapType
 {
-  elastix::DefaultConstructibleSubclass<ParameterFileParser> parameterFileParser;
+  elastix::DefaultConstruct<ParameterFileParser> parameterFileParser;
   parameterFileParser.m_ParameterFileName = fileName;
   parameterFileParser.ReadParameterFile();
 

--- a/Common/Transforms/itkRecursiveBSplineTransform.h
+++ b/Common/Transforms/itkRecursiveBSplineTransform.h
@@ -22,7 +22,7 @@
 
 #include "itkRecursiveBSplineInterpolationWeightFunction.h"
 #include "itkRecursiveBSplineTransformImplementation.h"
-#include "elxDefaultConstructibleSubclass.h"
+#include "elxDefaultConstruct.h"
 
 namespace itk
 {
@@ -195,7 +195,7 @@ private:
   using RecursiveBSplineWeightFunctionType =
     itk::RecursiveBSplineInterpolationWeightFunction<TScalarType, NDimensions, VSplineOrder>;
 
-  elastix::DefaultConstructibleSubclass<RecursiveBSplineWeightFunctionType> m_RecursiveBSplineWeightFunction;
+  elastix::DefaultConstruct<RecursiveBSplineWeightFunctionType> m_RecursiveBSplineWeightFunction;
 };
 
 } // end namespace itk

--- a/Common/elxDefaultConstruct.h
+++ b/Common/elxDefaultConstruct.h
@@ -15,8 +15,8 @@
  *  limitations under the License.
  *
  *=========================================================================*/
-#ifndef elxDefaultConstructibleSubclass_h
-#define elxDefaultConstructibleSubclass_h
+#ifndef elxDefaultConstruct_h
+#define elxDefaultConstruct_h
 
 #include <itkLightObject.h>
 
@@ -25,16 +25,16 @@ namespace elastix
 /// Allows default-constructing an `itk::LightObject` derived object without calling `New()`.
 /// May improve the runtime performance, by avoiding heap allocation and pointer indirection.
 template <typename TObject>
-class DefaultConstructibleSubclass : public TObject
+class DefaultConstruct : public TObject
 {
 public:
-  ITK_DISALLOW_COPY_AND_MOVE(DefaultConstructibleSubclass);
+  ITK_DISALLOW_COPY_AND_MOVE(DefaultConstruct);
 
   /// Public default-constructor. Just calls the (typically protected) default-constructor of `TObject`.
-  DefaultConstructibleSubclass() = default;
+  DefaultConstruct() = default;
 
   /// Public destructor. Just calls the (typically protected) destructor of `TObject`.
-  ~DefaultConstructibleSubclass() override
+  ~DefaultConstruct() override
   {
     // Suppress warning "Trying to delete object with non-zero reference count."
     this->itk::LightObject::m_ReferenceCount = 0;

--- a/Core/ComponentBaseClasses/elxTransformBase.h
+++ b/Core/ComponentBaseClasses/elxTransformBase.h
@@ -22,7 +22,7 @@
 #include "elxMacro.h"
 
 #include "elxBaseComponentSE.h"
-#include "elxDefaultConstructibleSubclass.h"
+#include "elxDefaultConstruct.h"
 #include "elxElastixBase.h"
 #include "itkAdvancedTransform.h"
 #include "itkAdvancedCombinationTransform.h"
@@ -267,7 +267,7 @@ public:
   typename TMesh::Pointer
   TransformMesh(const TMesh & mesh) const
   {
-    DefaultConstructibleSubclass<itk::TransformMeshFilter<TMesh, TMesh, CombinationTransformType>> transformMeshFilter;
+    DefaultConstruct<itk::TransformMeshFilter<TMesh, TMesh, CombinationTransformType>> transformMeshFilter;
     transformMeshFilter.SetTransform(&const_cast<CombinationTransformType &>(this->GetSelf()));
     transformMeshFilter.SetInput(&mesh);
     transformMeshFilter.Update();

--- a/Core/Main/GTesting/itkElastixRegistrationMethodGTest.cxx
+++ b/Core/Main/GTesting/itkElastixRegistrationMethodGTest.cxx
@@ -22,7 +22,7 @@
 #include <itkElastixRegistrationMethod.h>
 
 #include "elxCoreMainGTestUtilities.h"
-#include "elxDefaultConstructibleSubclass.h"
+#include "elxDefaultConstruct.h"
 #include "elxTransformIO.h"
 
 // ITK header file:
@@ -74,7 +74,7 @@ Test_WriteBSplineTransformToItkFileFormat(const std::string & rootOutputDirector
   const auto image = CreateImage<PixelType>(itk::Size<NDimension>::Filled(4));
 
   using ItkBSplineTransformType = itk::BSplineTransform<double, NDimension, NSplineOrder>;
-  const elx::DefaultConstructibleSubclass<ItkBSplineTransformType> itkBSplineTransform;
+  const elx::DefaultConstruct<ItkBSplineTransformType> itkBSplineTransform;
 
   const auto defaultFixedParameters = itkBSplineTransform.GetFixedParameters();
 
@@ -145,8 +145,7 @@ GTEST_TEST(itkElastixRegistrationMethod, IsDefaultInitialized)
   using PixelType = float;
   using ImageType = itk::Image<PixelType, ImageDimension>;
 
-  const elx::DefaultConstructibleSubclass<itk::ElastixRegistrationMethod<ImageType, ImageType>>
-    elastixRegistrationMethod;
+  const elx::DefaultConstruct<itk::ElastixRegistrationMethod<ImageType, ImageType>> elastixRegistrationMethod;
 
   EXPECT_EQ(elastixRegistrationMethod.GetInitialTransformParameterFileName(), std::string{});
   EXPECT_EQ(elastixRegistrationMethod.GetFixedPointSetFileName(), std::string{});

--- a/Core/Main/GTesting/itkTransformixFilterGTest.cxx
+++ b/Core/Main/GTesting/itkTransformixFilterGTest.cxx
@@ -24,7 +24,7 @@
 #include <itkParameterFileParser.h>
 
 #include "elxCoreMainGTestUtilities.h"
-#include "elxDefaultConstructibleSubclass.h"
+#include "elxDefaultConstruct.h"
 #include "elxTransformIO.h"
 #include "GTesting/elxGTestUtilities.h"
 
@@ -393,7 +393,7 @@ Test_BSplineViaExternalTransformFile(const std::string & rootOutputDirectoryPath
   const auto imageSize = itk::Size<NDimension>::Filled(4);
   using PixelType = float;
 
-  elx::DefaultConstructibleSubclass<itk::BSplineTransform<double, NDimension, NSplineOrder>> bsplineTransform;
+  elx::DefaultConstruct<itk::BSplineTransform<double, NDimension, NSplineOrder>> bsplineTransform;
   const auto inputImage = CreateImageFilledWithSequenceOfNaturalNumbers<PixelType>(imageSize);
   bsplineTransform.SetTransformDomainPhysicalDimensions(ConvertToItkVector(imageSize));
   bsplineTransform.SetParameters(GeneratePseudoRandomParameters(bsplineTransform.GetParameters().size(), -1.0));
@@ -434,7 +434,7 @@ GTEST_TEST(itkTransformixFilter, IsDefaultInitialized)
   using PixelType = float;
   using TransformixFilterType = itk::TransformixFilter<itk::Image<PixelType, ImageDimension>>;
 
-  const elx::DefaultConstructibleSubclass<TransformixFilterType> transformixFilter;
+  const elx::DefaultConstruct<TransformixFilterType> transformixFilter;
 
   EXPECT_EQ(transformixFilter.GetFixedPointSetFileName(), std::string{});
   EXPECT_EQ(transformixFilter.GetOutputDirectory(), std::string{});
@@ -486,8 +486,8 @@ GTEST_TEST(itkTransformixFilter, MeshTranslation2D)
 
   for (const auto & translationVector : { VectorType{}, VectorType(0.5f), itk::MakeVector(1.0f, -2.0f) })
   {
-    elx::DefaultConstructibleSubclass<TransformixFilterType> transformixFilter;
-    const auto                                               inputMesh = TransformixFilterType::MeshType::New();
+    elx::DefaultConstruct<TransformixFilterType> transformixFilter;
+    const auto                                   inputMesh = TransformixFilterType::MeshType::New();
     inputMesh->SetPoint(0, {});
     inputMesh->SetPoint(1, itk::MakePoint(1.0f, 2.0f));
 
@@ -612,7 +612,7 @@ GTEST_TEST(itkTransformixFilter, ITKTranslationTransform2D)
 {
   constexpr auto ImageDimension = 2U;
 
-  elx::DefaultConstructibleSubclass<itk::TranslationTransform<double, ImageDimension>> itkTransform;
+  elx::DefaultConstruct<itk::TranslationTransform<double, ImageDimension>> itkTransform;
   itkTransform.SetOffset(itk::MakeVector(1.0, -2.0));
 
   Expect_TransformixFilter_output_equals_ResampleImageFilter_output(
@@ -624,7 +624,7 @@ GTEST_TEST(itkTransformixFilter, ITKTranslationTransform3D)
 {
   constexpr auto ImageDimension = 3U;
 
-  elx::DefaultConstructibleSubclass<itk::TranslationTransform<double, ImageDimension>> itkTransform;
+  elx::DefaultConstruct<itk::TranslationTransform<double, ImageDimension>> itkTransform;
   itkTransform.SetOffset(itk::MakeVector(1.0, -2.0, 3.0));
 
   Expect_TransformixFilter_output_equals_ResampleImageFilter_output(
@@ -636,7 +636,7 @@ GTEST_TEST(itkTransformixFilter, ITKAffineTransform2D)
 {
   constexpr auto ImageDimension = 2U;
 
-  elx::DefaultConstructibleSubclass<itk::AffineTransform<double, ImageDimension>> itkTransform;
+  elx::DefaultConstruct<itk::AffineTransform<double, ImageDimension>> itkTransform;
   itkTransform.SetTranslation(itk::MakeVector(1.0, -2.0));
   itkTransform.SetCenter(itk::MakePoint(2.5, 3.0));
   itkTransform.Rotate2D(M_PI_4);
@@ -650,7 +650,7 @@ GTEST_TEST(itkTransformixFilter, ITKAffineTransform3D)
 {
   constexpr auto ImageDimension = 3U;
 
-  elx::DefaultConstructibleSubclass<itk::AffineTransform<double, ImageDimension>> itkTransform;
+  elx::DefaultConstruct<itk::AffineTransform<double, ImageDimension>> itkTransform;
   itkTransform.SetTranslation(itk::MakeVector(1.0, 2.0, 3.0));
   itkTransform.SetCenter(itk::MakePoint(3.0, 2.0, 1.0));
   itkTransform.Rotate3D(itk::Vector<double, ImageDimension>(1.0), M_PI_4);
@@ -662,7 +662,7 @@ GTEST_TEST(itkTransformixFilter, ITKAffineTransform3D)
 
 GTEST_TEST(itkTransformixFilter, ITKEulerTransform2D)
 {
-  elx::DefaultConstructibleSubclass<itk::Euler2DTransform<double>> itkTransform;
+  elx::DefaultConstruct<itk::Euler2DTransform<double>> itkTransform;
   itkTransform.SetTranslation(itk::MakeVector(1.0, -2.0));
   itkTransform.SetCenter(itk::MakePoint(2.5, 3.0));
   itkTransform.SetAngle(M_PI_4);
@@ -674,7 +674,7 @@ GTEST_TEST(itkTransformixFilter, ITKEulerTransform2D)
 
 GTEST_TEST(itkTransformixFilter, ITKEulerTransform3D)
 {
-  elx::DefaultConstructibleSubclass<itk::Euler3DTransform<double>> itkTransform;
+  elx::DefaultConstruct<itk::Euler3DTransform<double>> itkTransform;
   itkTransform.SetTranslation(itk::MakeVector(1.0, -2.0, 3.0));
   itkTransform.SetCenter(itk::MakePoint(3.0, 2.0, 1.0));
   itkTransform.SetRotation(M_PI_2, M_PI_4, M_PI_4 / 2.0);
@@ -686,7 +686,7 @@ GTEST_TEST(itkTransformixFilter, ITKEulerTransform3D)
 
 GTEST_TEST(itkTransformixFilter, ITKSimilarityTransform2D)
 {
-  elx::DefaultConstructibleSubclass<itk::Similarity2DTransform<double>> itkTransform;
+  elx::DefaultConstruct<itk::Similarity2DTransform<double>> itkTransform;
   itkTransform.SetScale(0.75);
   itkTransform.SetTranslation(itk::MakeVector(1.0, -2.0));
   itkTransform.SetCenter(itk::MakePoint(2.5, 3.0));
@@ -699,7 +699,7 @@ GTEST_TEST(itkTransformixFilter, ITKSimilarityTransform2D)
 
 GTEST_TEST(itkTransformixFilter, ITKSimilarityTransform3D)
 {
-  elx::DefaultConstructibleSubclass<itk::Similarity3DTransform<double>> itkTransform;
+  elx::DefaultConstruct<itk::Similarity3DTransform<double>> itkTransform;
   itkTransform.SetScale(0.75);
   itkTransform.SetTranslation(itk::MakeVector(1.0, -2.0, 3.0));
   itkTransform.SetCenter(itk::MakePoint(3.0, 2.0, 1.0));
@@ -712,7 +712,7 @@ GTEST_TEST(itkTransformixFilter, ITKSimilarityTransform3D)
 
 GTEST_TEST(itkTransformixFilter, ITKBSplineTransform2D)
 {
-  elx::DefaultConstructibleSubclass<itk::BSplineTransform<double, 2>> itkTransform;
+  elx::DefaultConstruct<itk::BSplineTransform<double, 2>> itkTransform;
 
   const auto imageSize = itk::MakeSize(5, 6);
 
@@ -727,7 +727,7 @@ GTEST_TEST(itkTransformixFilter, ITKBSplineTransform2D)
 
 GTEST_TEST(itkTransformixFilter, ITKBSplineTransform3D)
 {
-  elx::DefaultConstructibleSubclass<itk::BSplineTransform<double, 3>> itkTransform;
+  elx::DefaultConstruct<itk::BSplineTransform<double, 3>> itkTransform;
 
   const auto imageSize = itk::MakeSize(5, 6, 7);
 
@@ -749,7 +749,7 @@ GTEST_TEST(itkTransformixFilter, CombineTranslationAndDefaultTransform)
   using ParametersValueType = double;
 
   // Create a translated image, which is the expected output image.
-  elx::DefaultConstructibleSubclass<itk::TranslationTransform<ParametersValueType, dimension>> translationTransform;
+  elx::DefaultConstruct<itk::TranslationTransform<ParametersValueType, dimension>> translationTransform;
   translationTransform.SetOffset(itk::MakeVector(1, -2));
   const auto   resampleImageFilter = CreateResampleImageFilter(*inputImage, translationTransform);
   const auto & expectedOutputImage = Deref(resampleImageFilter->GetOutput());
@@ -768,7 +768,7 @@ GTEST_TEST(itkTransformixFilter, CombineTranslationAndDefaultTransform)
     EXPECT_EQ(*actualOutputImage, expectedOutputImage);
   }
 
-  const elx::DefaultConstructibleSubclass<itk::TranslationTransform<ParametersValueType, dimension>> defaultTransform;
+  const elx::DefaultConstruct<itk::TranslationTransform<ParametersValueType, dimension>> defaultTransform;
 
   for (const std::string transformParameterFileName :
        { "TransformParameters-link-to-ITK-tfm-file.txt",
@@ -805,7 +805,7 @@ GTEST_TEST(itkTransformixFilter, CombineTranslationAndInverseTranslation)
 
   // Sanity check: when only an identity transform is applied, the transform from the TransformParameters.txt file
   // makes the output image unequal to the input image.
-  const elx::DefaultConstructibleSubclass<itk::TranslationTransform<ParametersValueType, dimension>> identityTransform;
+  const elx::DefaultConstruct<itk::TranslationTransform<ParametersValueType, dimension>> identityTransform;
 
   EXPECT_NE(*(RetrieveOutputFromTransformixFilter(*inputImage, identityTransform, initialTransformParametersFileName)),
             *inputImage);
@@ -863,20 +863,20 @@ GTEST_TEST(itkTransformixFilter, CombineTranslationAndScale)
   const std::string initialTransformParametersFileName =
     GetDataDirectoryPath() + "/Translation(1,-2)/TransformParameters.txt";
 
-  elx::DefaultConstructibleSubclass<itk::AffineTransform<ParametersValueType, dimension>> scaleTransform;
+  elx::DefaultConstruct<itk::AffineTransform<ParametersValueType, dimension>> scaleTransform;
   scaleTransform.Scale(2.0);
 
-  elx::DefaultConstructibleSubclass<itk::TranslationTransform<ParametersValueType, dimension>> translationTransform;
+  elx::DefaultConstruct<itk::TranslationTransform<ParametersValueType, dimension>> translationTransform;
   translationTransform.SetOffset(itk::MakeVector(1.0, -2.0));
 
   const auto transformixOutput =
     RetrieveOutputFromTransformixFilter(*inputImage, scaleTransform, initialTransformParametersFileName);
 
-  elx::DefaultConstructibleSubclass<itk::CompositeTransform<double, 2>> translationAndScaleTransform;
+  elx::DefaultConstruct<itk::CompositeTransform<double, 2>> translationAndScaleTransform;
   translationAndScaleTransform.AddTransform(&translationTransform);
   translationAndScaleTransform.AddTransform(&scaleTransform);
 
-  elx::DefaultConstructibleSubclass<itk::CompositeTransform<double, 2>> scaleAndTranslationTransform;
+  elx::DefaultConstruct<itk::CompositeTransform<double, 2>> scaleAndTranslationTransform;
   scaleAndTranslationTransform.AddTransform(&scaleTransform);
   scaleAndTranslationTransform.AddTransform(&translationTransform);
 


### PR DESCRIPTION
As it is used quite often now, it appears helpful for readability to shorten its name.