### PR TITLE
ENH: Replaced occurrences of git branch name "develop" with "main"

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -27,9 +27,9 @@
 
 ### Did you write a patch that fixes a bug? ###
 
-* Open a new [GitHub pull request](https://github.com/SuperElastix/elastix/pull/new/develop) (PR) with the patch.
+* Open a new [GitHub pull request](https://github.com/SuperElastix/elastix/pull/new/main) (PR) with the patch.
 
-* Make sure the PR is done with respect to the [develop branch](https://github.com/SuperElastix/elastix/tree/develop).
+* Make sure the PR is done with respect to the [main branch](https://github.com/SuperElastix/elastix/tree/main).
 
 * Ensure the PR description (log message) _clearly describes the problem and solution_. Include the relevant issue number if applicable. One-line messages are fine for small changes, but bigger changes should look like this:
     $ git commit -m "ENH: A brief summary of the commit

--- a/README.md
+++ b/README.md
@@ -1,5 +1,5 @@
 <a href="https://elastix.lumc.nl/">
-  <img src="https://github.com/SuperElastix/elastix/blob/develop/dox/art/elastix_logo_full_small.bmp" alt="elastix logo" title="elastix" align="right" height="80" />
+  <img src="https://github.com/SuperElastix/elastix/blob/main/dox/art/elastix_logo_full_small.bmp" alt="elastix logo" title="elastix" align="right" height="80" />
 </a>
 
 # elastix image registration toolbox #

--- a/Testing/Dashboard/elxDashboardCommon.cmake
+++ b/Testing/Dashboard/elxDashboardCommon.cmake
@@ -64,7 +64,7 @@ endif()
 
 # Select branch to use
 if(NOT DEFINED dashboard_git_branch)
-  set(dashboard_git_branch develop)
+  set(dashboard_git_branch main)
 endif()
 
 # Select a source directory name.

--- a/Testing/elx_nightly_dashboard.py
+++ b/Testing/elx_nightly_dashboard.py
@@ -66,11 +66,11 @@ def main():
   # Argument to select the elastix branch (optional)
   # e.g. -b performance_ITK4
   #parser.add_argument( "-b", "--branch",
-  #  default='develop', dest='branch',
+  #  default='main', dest='branch',
   #  help='select elastix branch' );
   # This is currently hard-coded in elxDashboardCommon.cmake,
   # and cannot be an option here atm.
-  branch = "develop";
+  branch = "main";
 
   options = parser.parse_args();
 
@@ -109,7 +109,7 @@ def main():
   # elastix.git can be approached as follows:
   # svn export https://github.com/SuperElastix/elastix/trunk/path/to/file
   # for the main branch 'master'. Branches can be approached like:
-  # svn export https://github.com/SuperElastix/elastix/branches/develop/path/to/file
+  # svn export https://github.com/SuperElastix/elastix/branches/main/path/to/file
 
   # Create local temporary directory to checkout dashboard scripts to
   shutil.rmtree( tmpdir, True );


### PR DESCRIPTION
Part of issue https://github.com/SuperElastix/elastix/issues/718 Rename the default branch of elastix git from "develop" to "main"