### PR TITLE
BUG: Fill `ImageGridSampler::m_SampleGridSpacing` only once, with ones

### DIFF
--- a/Common/GTesting/CMakeLists.txt
+++ b/Common/GTesting/CMakeLists.txt
@@ -7,6 +7,7 @@ add_executable(CommonGTest
   elxResamplerGTest.cxx
   elxTransformIOGTest.cxx
   itkComputeImageExtremaFilterGTest.cxx
+  itkImageGridSamplerGTest.cxx
   itkParameterMapInterfaceTest.cxx
   )
 target_link_libraries(CommonGTest

--- a/Common/GTesting/itkImageGridSamplerGTest.cxx
+++ b/Common/GTesting/itkImageGridSamplerGTest.cxx
@@ -1,0 +1,37 @@
+/*=========================================================================
+ *
+ *  Copyright UMC Utrecht and contributors
+ *
+ *  Licensed under the Apache License, Version 2.0 (the "License");
+ *  you may not use this file except in compliance with the License.
+ *  You may obtain a copy of the License at
+ *
+ *        http://www.apache.org/licenses/LICENSE-2.0.txt
+ *
+ *  Unless required by applicable law or agreed to in writing, software
+ *  distributed under the License is distributed on an "AS IS" BASIS,
+ *  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *  See the License for the specific language governing permissions and
+ *  limitations under the License.
+ *
+ *=========================================================================*/
+
+// First include the header file to be tested:
+#include "itkImageGridSampler.h"
+#include "elxDefaultConstruct.h"
+#include <itkImage.h>
+
+#include <gtest/gtest.h>
+
+// The class to be tested.
+using itk::ImageGridSampler;
+
+
+GTEST_TEST(ImageGridSampler, DefaultConstructFillsSampleGridSpacingWithOne)
+{
+  using ImageType = itk::Image<int>;
+  using ImageGridSamplerType = itk::ImageGridSampler<ImageType>;
+  const elastix::DefaultConstruct<ImageGridSamplerType> imageGridSampler{};
+
+  EXPECT_EQ(imageGridSampler.GetSampleGridSpacing(), itk::MakeFilled<ImageGridSamplerType::SampleGridSpacingType>(1));
+}

--- a/Common/ImageSamplers/itkImageGridSampler.hxx
+++ b/Common/ImageSamplers/itkImageGridSampler.hxx
@@ -34,7 +34,6 @@ ImageGridSampler<TInputImage>::ImageGridSampler()
 {
   this->m_SampleGridSpacing.Fill(1);
   this->m_RequestedNumberOfSamples = 0;
-  this->m_SampleGridSpacing.Fill(static_cast<SampleGridSpacingValueType>(0.0));
 } // end Constructor
 
 


### PR DESCRIPTION
Addresses issue https://github.com/SuperElastix/elastix/issues/722 "ImageGridSampler default-constructor fills its m_SampleGridSpacing twice"

Follow-up to:
 - commit 2fc2c495837f64416263fa7c5d1e2bc4e3e061fa "ENH: HUGE merge of the performance branch", Marius Staring (@mstaring), November 14, 2013
 - commit be9fd66ced2673bd4063879ae529a2f2b9c0ac00 "BUG: Initialize m_SampleGridSpacing with zeros in constructor to prevent Valgrind MemCheck errors", Coert Metz (@coertmetz), May 13, 2013