### PR TITLE
ENH: Add NumberOfWorkUnits to ElastixMain, used by CreateComponent

### DIFF
--- a/Core/Kernel/elxElastixMain.cxx
+++ b/Core/Kernel/elxElastixMain.cxx
@@ -730,6 +730,16 @@ ElastixMain::CreateComponent(const ComponentDescriptionType & name)
     itkExceptionMacro(<< "The following component could not be created: " << name);
   }
 
+  if (m_NumberOfWorkUnits > 0)
+  {
+    const auto processObject = dynamic_cast<itk::ProcessObject *>(component.GetPointer());
+
+    if (processObject)
+    {
+      processObject->SetNumberOfWorkUnits(m_NumberOfWorkUnits);
+    }
+  }
+
   return component;
 
 } // end CreateComponent()

--- a/Core/Kernel/elxElastixMain.h
+++ b/Core/Kernel/elxElastixMain.h
@@ -313,6 +313,13 @@ public:
   virtual ParameterMapType
   GetTransformParametersMap() const;
 
+  void
+  SetNumberOfWorkUnits(const itk::ThreadIdType newValue)
+  {
+    m_NumberOfWorkUnits = newValue;
+  }
+
+
 protected:
   ElastixMain();
   ~ElastixMain() override;
@@ -399,6 +406,8 @@ private:
   ElastixMain(const Self &) = delete;
   void
   operator=(const Self &) = delete;
+
+  itk::ThreadIdType m_NumberOfWorkUnits{ 0 };
 };
 
 } // end namespace elastix

--- a/Core/Main/itkElastixRegistrationMethod.hxx
+++ b/Core/Main/itkElastixRegistrationMethod.hxx
@@ -227,6 +227,7 @@ ElastixRegistrationMethod<TFixedImage, TMovingImage>::GenerateData()
 
     // Create new instance of ElastixMain
     elx::DefaultConstruct<ElastixMainType> elastixMain;
+    elastixMain.SetNumberOfWorkUnits(this->GetNumberOfWorkUnits());
 
     // Set elastix levels
     elastixMain.SetElastixLevel(i);

--- a/Core/Main/itkTransformixFilter.hxx
+++ b/Core/Main/itkTransformixFilter.hxx
@@ -154,6 +154,7 @@ TransformixFilter<TMovingImage>::GenerateData()
 
   // Instantiate transformix
   elx::DefaultConstruct<TransformixMainType> transformixMain;
+  transformixMain.SetNumberOfWorkUnits(this->GetNumberOfWorkUnits());
 
   // Setup transformix for warping input image if given
   DataObjectContainerPointer inputImageContainer = nullptr;


### PR DESCRIPTION
With this commit, the GenerateData() member function of both `TransformixFilter` and `ElastixRegistrationMethod` pass their NumberOfWorkUnits to their corresponding ElastixMain/TransformixMain object, which passed this NumberOfWorkUnits to each component that is an `itk::ProcessObject`.

Related to issue https://github.com/InsightSoftwareConsortium/ITKElastix/issues/163 "No option to set number of threads for Transformix", by Sebastian (@Svdvoort)