### PR TITLE
COMP: Remove double underscores from include guards of "*h.in" files

### DIFF
--- a/Common/OpenCL/ITKimprovements/itkOpenCLKernels.h.in
+++ b/Common/OpenCL/ITKimprovements/itkOpenCLKernels.h.in
@@ -15,8 +15,8 @@
  *  limitations under the License.
  *
  *=========================================================================*/
-#ifndef __itkOpenCLKernels_h
-#define __itkOpenCLKernels_h
+#ifndef itkOpenCLKernels_h
+#define itkOpenCLKernels_h
 
 /** \class OpenCLKernels Debug support file.
  * \brief The directory for OpenCL debug kernel files.
@@ -27,4 +27,4 @@ namespace itk
   const char* const OpenCLKernelsDebugDirectory = "@OPENCL_KERNELS_DEBUG_DIR@";
 } // end namespace itk
 
-#endif /* __itkOpenCLKernels_h */
+#endif /* itkOpenCLKernels_h */

--- a/Core/Install/elxOpenCLSupportedImageTypes.h.in
+++ b/Core/Install/elxOpenCLSupportedImageTypes.h.in
@@ -15,8 +15,8 @@
  *  limitations under the License.
  *
  *=========================================================================*/
-#ifndef __elxOpenCLSupportedImageTypes_h
-#define __elxOpenCLSupportedImageTypes_h
+#ifndef elxOpenCLSupportedImageTypes_h
+#define elxOpenCLSupportedImageTypes_h
 
 #include "itkMacro.h"
 #include "TypeList.h"
@@ -42,4 +42,4 @@ namespace elastix
 
 } // end namespace elastix
 
-#endif // end #ifndef __elxOpenCLSupportedImageTypes_h
+#endif // end #ifndef elxOpenCLSupportedImageTypes_h

--- a/Core/Install/elxSupportedImageTypes.h.in
+++ b/Core/Install/elxSupportedImageTypes.h.in
@@ -16,8 +16,8 @@
  *
  *=========================================================================*/
 
-#ifndef __elxSupportedImageTypes_h
-#define __elxSupportedImageTypes_h
+#ifndef elxSupportedImageTypes_h
+#define elxSupportedImageTypes_h
 
 #include "elxInstallFunctions.h"
 #include "elxPrepareImageTypeSupport.h"
@@ -54,5 +54,5 @@ namespace elastix
 
 } // end namespace elastix
 
-#endif // end #ifndef __elxSupportedImageTypes_h
+#endif // end #ifndef elxSupportedImageTypes_h
 


### PR DESCRIPTION
Follow-up to pull request https://github.com/SuperElastix/elastix/pull/339 commit 505bb39c7349ae786b4d61f5d7450ac606d8c2fa "COMP: Remove double underscores from include guards of header files", 29 October 2020.