### PR TITLE
Fix MacOS CI errors, "‘omp.h’ file not found", "Undefined symbols"

### DIFF
--- a/.github/workflows/ElastixGitHubActions.yml
+++ b/.github/workflows/ElastixGitHubActions.yml
@@ -124,24 +124,12 @@ jobs:
         if(WIN32)
           set(ENV{PATH} "\${CTEST_DASHBOARD_ROOT}/ITK-build/bin;\$ENV{PATH}")
         endif()
-        if(APPLE)
-          # Switch off OpenMP, to work around macOS specific CI errors, saying:
-          # > fatal error: ‘omp.h’ file not found
-          set(dashboard_cache "
-          ITK_DIR:PATH=\${CTEST_DASHBOARD_ROOT}/ITK-build
-          ELASTIX_USE_GTEST:BOOL=ON
-          ELASTIX_USE_OPENMP:BOOL=OFF
-          USE_ALL_COMPONENTS:BOOL=ON
-          BUILD_TESTING:BOOL=ON
-          ")
-        else()
-          set(dashboard_cache "
-          ITK_DIR:PATH=\${CTEST_DASHBOARD_ROOT}/ITK-build
-          ELASTIX_USE_GTEST:BOOL=ON
-          USE_ALL_COMPONENTS:BOOL=ON
-          BUILD_TESTING:BOOL=ON
-          ")
-        endif()
+        set(dashboard_cache "
+        ITK_DIR:PATH=\${CTEST_DASHBOARD_ROOT}/ITK-build
+        ELASTIX_USE_GTEST:BOOL=ON
+        USE_ALL_COMPONENTS:BOOL=ON
+        BUILD_TESTING:BOOL=ON
+        ")
         string(TIMESTAMP build_date "%Y-%m-%d")
         message("CDash Build Identifier: \${build_date} \${CTEST_BUILD_NAME}")
         message("CTEST_SITE= \${CTEST_SITE}")

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -125,6 +125,8 @@ if(ELASTIX_USE_OPENMP)
     set(CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} ${OpenMP_CXX_FLAGS}")
     #  set(CMAKE_EXE_LINKER_FLAGS "${CMAKE_EXE_LINKER_FLAGS}
     #  ${OpenMP_EXE_LINKER_FLAGS}")
+    include_directories(${OpenMP_CXX_INCLUDE_DIRS})
+    link_libraries(${OpenMP_CXX_LIBRARIES})
     add_definitions(-DELASTIX_USE_OPENMP)
   endif()
 endif()


### PR DESCRIPTION
By adding CMake variables ${OpenMP_CXX_INCLUDE_DIRS} and ${OpenMP_CXX_LIBRARIES}