### PR TITLE
BUG: Fix OpenCL pyramids (original: https://github.com/SuperElastix/elastix/pull/243)

### DIFF
--- a/Common/OpenCL/Factories/itkGPUResampleImageFilterFactory.h
+++ b/Common/OpenCL/Factories/itkGPUResampleImageFilterFactory.h
@@ -73,72 +73,144 @@ public:
     using GPUOutputImageType = GPUImage<TTypeOut, VImageDimension>;
 
     // Override default
-    this->RegisterOverride(typeid(ResampleImageFilter<InputImageType, OutputImageType, float>).name(),
-                           typeid(GPUResampleImageFilter<InputImageType, OutputImageType, float>).name(),
-                           "GPU ResampleImageFilter override default, interpolator float",
+    this->RegisterOverride(typeid(ResampleImageFilter<InputImageType, OutputImageType, float, float>).name(),
+                           typeid(GPUResampleImageFilter<InputImageType, OutputImageType, float, float>).name(),
+                           "GPU ResampleImageFilter override default, interpolator float and transform float",
                            true,
                            CreateObjectFunction<GPUResampleImageFilter<InputImageType, OutputImageType, float>>::New());
 
     // Override default
-    // With interpolator precision type as double, on GPU as float
-    this->RegisterOverride(typeid(ResampleImageFilter<InputImageType, OutputImageType, double>).name(),
-                           typeid(GPUResampleImageFilter<InputImageType, OutputImageType, float>).name(),
-                           "GPU ResampleImageFilter override default, interpolator double",
-                           true,
-                           CreateObjectFunction<GPUResampleImageFilter<InputImageType, OutputImageType, float>>::New());
+    // With interpolator precision type as double and transform precision type as double, on GPU as float
+    this->RegisterOverride(
+      typeid(ResampleImageFilter<InputImageType, OutputImageType, double, double>).name(),
+      typeid(GPUResampleImageFilter<InputImageType, OutputImageType, float, float>).name(),
+      "GPU ResampleImageFilter override default, interpolator double  and transform double",
+      true,
+      CreateObjectFunction<GPUResampleImageFilter<InputImageType, OutputImageType, float, float>>::New());
+
+    // Override default
+    // With interpolator precision type as float and transform precision type as double, on GPU as float
+    this->RegisterOverride(
+      typeid(ResampleImageFilter<InputImageType, OutputImageType, float, double>).name(),
+      typeid(GPUResampleImageFilter<InputImageType, OutputImageType, float, float>).name(),
+      "GPU ResampleImageFilter override default, interpolator float and transform double",
+      true,
+      CreateObjectFunction<GPUResampleImageFilter<InputImageType, OutputImageType, float, float>>::New());
+
+    // Override default
+    // With interpolator precision type as double and transform precision type as float, on GPU as float
+    this->RegisterOverride(
+      typeid(ResampleImageFilter<InputImageType, OutputImageType, double, float>).name(),
+      typeid(GPUResampleImageFilter<InputImageType, OutputImageType, float, float>).name(),
+      "GPU ResampleImageFilter override default, interpolator double and transform float",
+      true,
+      CreateObjectFunction<GPUResampleImageFilter<InputImageType, OutputImageType, float, float>>::New());
 
     // Override when itkGPUImage is first template argument
     this->RegisterOverride(
-      typeid(ResampleImageFilter<GPUInputImageType, OutputImageType, float>).name(),
-      typeid(GPUResampleImageFilter<GPUInputImageType, OutputImageType, float>).name(),
-      "GPU ResampleImageFilter override GPUImage first, interpolator float",
+      typeid(ResampleImageFilter<GPUInputImageType, OutputImageType, float, float>).name(),
+      typeid(GPUResampleImageFilter<GPUInputImageType, OutputImageType, float, float>).name(),
+      "GPU ResampleImageFilter override GPUImage first, interpolator float and transform float",
       true,
-      CreateObjectFunction<GPUResampleImageFilter<GPUInputImageType, OutputImageType, float>>::New());
+      CreateObjectFunction<GPUResampleImageFilter<GPUInputImageType, OutputImageType, float, float>>::New());
 
     // Override when itkGPUImage is first template argument
-    // With interpolator precision type as double, on GPU as float
+    // With interpolator precision type as double and transform as double, on GPU as float
     this->RegisterOverride(
-      typeid(ResampleImageFilter<GPUInputImageType, OutputImageType, double>).name(),
-      typeid(GPUResampleImageFilter<GPUInputImageType, OutputImageType, float>).name(),
-      "GPU ResampleImageFilter override GPUImage first, interpolator double",
+      typeid(ResampleImageFilter<GPUInputImageType, OutputImageType, double, double>).name(),
+      typeid(GPUResampleImageFilter<GPUInputImageType, OutputImageType, float, float>).name(),
+      "GPU ResampleImageFilter override GPUImage first, interpolator double and transform double",
       true,
-      CreateObjectFunction<GPUResampleImageFilter<GPUInputImageType, OutputImageType, float>>::New());
+      CreateObjectFunction<GPUResampleImageFilter<GPUInputImageType, OutputImageType, float, float>>::New());
+
+    // Override when itkGPUImage is first template argument
+    // With interpolator precision type as double and transform as float, on GPU as float
+    this->RegisterOverride(
+      typeid(ResampleImageFilter<GPUInputImageType, OutputImageType, double, float>).name(),
+      typeid(GPUResampleImageFilter<GPUInputImageType, OutputImageType, float, float>).name(),
+      "GPU ResampleImageFilter override GPUImage first, interpolator double and transform float",
+      true,
+      CreateObjectFunction<GPUResampleImageFilter<GPUInputImageType, OutputImageType, float, float>>::New());
+
+    // Override when itkGPUImage is first template argument
+    // With interpolator precision type as float and transform as double, on GPU as float
+    this->RegisterOverride(
+      typeid(ResampleImageFilter<GPUInputImageType, OutputImageType, float, double>).name(),
+      typeid(GPUResampleImageFilter<GPUInputImageType, OutputImageType, float, float>).name(),
+      "GPU ResampleImageFilter override GPUImage first, interpolator float and transform double",
+      true,
+      CreateObjectFunction<GPUResampleImageFilter<GPUInputImageType, OutputImageType, float, float>>::New());
 
     // Override when itkGPUImage is second template argument
     this->RegisterOverride(
-      typeid(ResampleImageFilter<InputImageType, GPUOutputImageType, float>).name(),
-      typeid(GPUResampleImageFilter<InputImageType, GPUOutputImageType, float>).name(),
-      "GPU ResampleImageFilter override GPUImage second, interpolator float",
+      typeid(ResampleImageFilter<InputImageType, GPUOutputImageType, float, float>).name(),
+      typeid(GPUResampleImageFilter<InputImageType, GPUOutputImageType, float, float>).name(),
+      "GPU ResampleImageFilter override GPUImage second, interpolator float and transform float",
       true,
-      CreateObjectFunction<GPUResampleImageFilter<InputImageType, GPUOutputImageType, float>>::New());
+      CreateObjectFunction<GPUResampleImageFilter<InputImageType, GPUOutputImageType, float, float>>::New());
 
     // Override when itkGPUImage is second template argument
-    // With interpolator precision type as double, on GPU as float
+    // With interpolator precision type as double and transform as double, on GPU as float
     this->RegisterOverride(
-      typeid(ResampleImageFilter<InputImageType, GPUOutputImageType, double>).name(),
-      typeid(GPUResampleImageFilter<InputImageType, GPUOutputImageType, float>).name(),
-      "GPU ResampleImageFilter override GPUImage second, interpolator double",
+      typeid(ResampleImageFilter<InputImageType, GPUOutputImageType, double, double>).name(),
+      typeid(GPUResampleImageFilter<InputImageType, GPUOutputImageType, float, float>).name(),
+      "GPU ResampleImageFilter override GPUImage second, interpolator double and transform double",
       true,
-      CreateObjectFunction<GPUResampleImageFilter<InputImageType, GPUOutputImageType, float>>::New());
+      CreateObjectFunction<GPUResampleImageFilter<InputImageType, GPUOutputImageType, float, float>>::New());
+
+    // Override when itkGPUImage is second template argument
+    // With interpolator precision type as float and transform as double, on GPU as float
+    this->RegisterOverride(
+      typeid(ResampleImageFilter<InputImageType, GPUOutputImageType, float, double>).name(),
+      typeid(GPUResampleImageFilter<InputImageType, GPUOutputImageType, float, float>).name(),
+      "GPU ResampleImageFilter override GPUImage second, interpolator float and transform double",
+      true,
+      CreateObjectFunction<GPUResampleImageFilter<InputImageType, GPUOutputImageType, float, float>>::New());
+
+    // Override when itkGPUImage is second template argument
+    // With interpolator precision type as double and transform as float, on GPU as float
+    this->RegisterOverride(
+      typeid(ResampleImageFilter<InputImageType, GPUOutputImageType, double, float>).name(),
+      typeid(GPUResampleImageFilter<InputImageType, GPUOutputImageType, float, float>).name(),
+      "GPU ResampleImageFilter override GPUImage second, interpolator double and transform float",
+      true,
+      CreateObjectFunction<GPUResampleImageFilter<InputImageType, GPUOutputImageType, float, float>>::New());
 
     // Override when itkGPUImage is first and second template arguments
     this->RegisterOverride(
-      typeid(ResampleImageFilter<GPUInputImageType, GPUOutputImageType, float>).name(),
-      typeid(GPUResampleImageFilter<GPUInputImageType, GPUOutputImageType, float>).name(),
-      "GPU ResampleImageFilter override GPUImage first and second, interpolator float",
+      typeid(ResampleImageFilter<GPUInputImageType, GPUOutputImageType, float, float>).name(),
+      typeid(GPUResampleImageFilter<GPUInputImageType, GPUOutputImageType, float, float>).name(),
+      "GPU ResampleImageFilter override GPUImage first and second, interpolator float and transform float",
       true,
-      CreateObjectFunction<GPUResampleImageFilter<GPUInputImageType, GPUOutputImageType, float>>::New());
+      CreateObjectFunction<GPUResampleImageFilter<GPUInputImageType, GPUOutputImageType, float, float>>::New());
 
     // Override when itkGPUImage is first and second template arguments
-    // With interpolator precision type as double, on GPU as float
+    // With interpolator precision type as double and transform double, on GPU as float
     this->RegisterOverride(
-      typeid(ResampleImageFilter<GPUInputImageType, GPUOutputImageType, double>).name(),
-      typeid(GPUResampleImageFilter<GPUInputImageType, GPUOutputImageType, float>).name(),
-      "GPU ResampleImageFilter override GPUImage first and second, interpolator double",
+      typeid(ResampleImageFilter<GPUInputImageType, GPUOutputImageType, double, double>).name(),
+      typeid(GPUResampleImageFilter<GPUInputImageType, GPUOutputImageType, float, float>).name(),
+      "GPU ResampleImageFilter override GPUImage first and second, interpolator double and transform double",
       true,
-      CreateObjectFunction<GPUResampleImageFilter<GPUInputImageType, GPUOutputImageType, float>>::New());
+      CreateObjectFunction<GPUResampleImageFilter<GPUInputImageType, GPUOutputImageType, float, float>>::New());
+
+    // Override when itkGPUImage is first and second template arguments
+    // With interpolator precision type as float and transform double, on GPU as float
+    this->RegisterOverride(
+      typeid(ResampleImageFilter<GPUInputImageType, GPUOutputImageType, float, double>).name(),
+      typeid(GPUResampleImageFilter<GPUInputImageType, GPUOutputImageType, float, float>).name(),
+      "GPU ResampleImageFilter override GPUImage first and second, interpolator float and transform double",
+      true,
+      CreateObjectFunction<GPUResampleImageFilter<GPUInputImageType, GPUOutputImageType, float, float>>::New());
+
+    // Override when itkGPUImage is first and second template arguments
+    // With interpolator precision type as double and transform float, on GPU as float
+    this->RegisterOverride(
+      typeid(ResampleImageFilter<GPUInputImageType, GPUOutputImageType, double, float>).name(),
+      typeid(GPUResampleImageFilter<GPUInputImageType, GPUOutputImageType, float, float>).name(),
+      "GPU ResampleImageFilter override GPUImage first and second, interpolator double and transform float",
+      true,
+      CreateObjectFunction<GPUResampleImageFilter<GPUInputImageType, GPUOutputImageType, float, float>>::New());
   }
-
 
 protected:
   GPUResampleImageFilterFactory2();

--- a/Common/OpenCL/Factories/itkGPUResampleImageFilterFactory.h
+++ b/Common/OpenCL/Factories/itkGPUResampleImageFilterFactory.h
@@ -73,36 +73,10 @@ public:
     using GPUOutputImageType = GPUImage<TTypeOut, VImageDimension>;
 
     // Override default
-    this->RegisterOverride(typeid(ResampleImageFilter<InputImageType, OutputImageType, float, float>).name(),
-                           typeid(GPUResampleImageFilter<InputImageType, OutputImageType, float, float>).name(),
-                           "GPU ResampleImageFilter override default, interpolator float and transform float",
-                           true,
-                           CreateObjectFunction<GPUResampleImageFilter<InputImageType, OutputImageType, float>>::New());
-
-    // Override default
-    // With interpolator precision type as double and transform precision type as double, on GPU as float
     this->RegisterOverride(
-      typeid(ResampleImageFilter<InputImageType, OutputImageType, double, double>).name(),
+      typeid(ResampleImageFilter<InputImageType, OutputImageType, float, float>).name(),
       typeid(GPUResampleImageFilter<InputImageType, OutputImageType, float, float>).name(),
-      "GPU ResampleImageFilter override default, interpolator double  and transform double",
-      true,
-      CreateObjectFunction<GPUResampleImageFilter<InputImageType, OutputImageType, float, float>>::New());
-
-    // Override default
-    // With interpolator precision type as float and transform precision type as double, on GPU as float
-    this->RegisterOverride(
-      typeid(ResampleImageFilter<InputImageType, OutputImageType, float, double>).name(),
-      typeid(GPUResampleImageFilter<InputImageType, OutputImageType, float, float>).name(),
-      "GPU ResampleImageFilter override default, interpolator float and transform double",
-      true,
-      CreateObjectFunction<GPUResampleImageFilter<InputImageType, OutputImageType, float, float>>::New());
-
-    // Override default
-    // With interpolator precision type as double and transform precision type as float, on GPU as float
-    this->RegisterOverride(
-      typeid(ResampleImageFilter<InputImageType, OutputImageType, double, float>).name(),
-      typeid(GPUResampleImageFilter<InputImageType, OutputImageType, float, float>).name(),
-      "GPU ResampleImageFilter override default, interpolator double and transform float",
+      "GPU ResampleImageFilter override default, interpolator float and transform float",
       true,
       CreateObjectFunction<GPUResampleImageFilter<InputImageType, OutputImageType, float, float>>::New());
 
@@ -114,33 +88,6 @@ public:
       true,
       CreateObjectFunction<GPUResampleImageFilter<GPUInputImageType, OutputImageType, float, float>>::New());
 
-    // Override when itkGPUImage is first template argument
-    // With interpolator precision type as double and transform as double, on GPU as float
-    this->RegisterOverride(
-      typeid(ResampleImageFilter<GPUInputImageType, OutputImageType, double, double>).name(),
-      typeid(GPUResampleImageFilter<GPUInputImageType, OutputImageType, float, float>).name(),
-      "GPU ResampleImageFilter override GPUImage first, interpolator double and transform double",
-      true,
-      CreateObjectFunction<GPUResampleImageFilter<GPUInputImageType, OutputImageType, float, float>>::New());
-
-    // Override when itkGPUImage is first template argument
-    // With interpolator precision type as double and transform as float, on GPU as float
-    this->RegisterOverride(
-      typeid(ResampleImageFilter<GPUInputImageType, OutputImageType, double, float>).name(),
-      typeid(GPUResampleImageFilter<GPUInputImageType, OutputImageType, float, float>).name(),
-      "GPU ResampleImageFilter override GPUImage first, interpolator double and transform float",
-      true,
-      CreateObjectFunction<GPUResampleImageFilter<GPUInputImageType, OutputImageType, float, float>>::New());
-
-    // Override when itkGPUImage is first template argument
-    // With interpolator precision type as float and transform as double, on GPU as float
-    this->RegisterOverride(
-      typeid(ResampleImageFilter<GPUInputImageType, OutputImageType, float, double>).name(),
-      typeid(GPUResampleImageFilter<GPUInputImageType, OutputImageType, float, float>).name(),
-      "GPU ResampleImageFilter override GPUImage first, interpolator float and transform double",
-      true,
-      CreateObjectFunction<GPUResampleImageFilter<GPUInputImageType, OutputImageType, float, float>>::New());
-
     // Override when itkGPUImage is second template argument
     this->RegisterOverride(
       typeid(ResampleImageFilter<InputImageType, GPUOutputImageType, float, float>).name(),
@@ -149,65 +96,11 @@ public:
       true,
       CreateObjectFunction<GPUResampleImageFilter<InputImageType, GPUOutputImageType, float, float>>::New());
 
-    // Override when itkGPUImage is second template argument
-    // With interpolator precision type as double and transform as double, on GPU as float
-    this->RegisterOverride(
-      typeid(ResampleImageFilter<InputImageType, GPUOutputImageType, double, double>).name(),
-      typeid(GPUResampleImageFilter<InputImageType, GPUOutputImageType, float, float>).name(),
-      "GPU ResampleImageFilter override GPUImage second, interpolator double and transform double",
-      true,
-      CreateObjectFunction<GPUResampleImageFilter<InputImageType, GPUOutputImageType, float, float>>::New());
-
-    // Override when itkGPUImage is second template argument
-    // With interpolator precision type as float and transform as double, on GPU as float
-    this->RegisterOverride(
-      typeid(ResampleImageFilter<InputImageType, GPUOutputImageType, float, double>).name(),
-      typeid(GPUResampleImageFilter<InputImageType, GPUOutputImageType, float, float>).name(),
-      "GPU ResampleImageFilter override GPUImage second, interpolator float and transform double",
-      true,
-      CreateObjectFunction<GPUResampleImageFilter<InputImageType, GPUOutputImageType, float, float>>::New());
-
-    // Override when itkGPUImage is second template argument
-    // With interpolator precision type as double and transform as float, on GPU as float
-    this->RegisterOverride(
-      typeid(ResampleImageFilter<InputImageType, GPUOutputImageType, double, float>).name(),
-      typeid(GPUResampleImageFilter<InputImageType, GPUOutputImageType, float, float>).name(),
-      "GPU ResampleImageFilter override GPUImage second, interpolator double and transform float",
-      true,
-      CreateObjectFunction<GPUResampleImageFilter<InputImageType, GPUOutputImageType, float, float>>::New());
-
     // Override when itkGPUImage is first and second template arguments
     this->RegisterOverride(
       typeid(ResampleImageFilter<GPUInputImageType, GPUOutputImageType, float, float>).name(),
       typeid(GPUResampleImageFilter<GPUInputImageType, GPUOutputImageType, float, float>).name(),
       "GPU ResampleImageFilter override GPUImage first and second, interpolator float and transform float",
-      true,
-      CreateObjectFunction<GPUResampleImageFilter<GPUInputImageType, GPUOutputImageType, float, float>>::New());
-
-    // Override when itkGPUImage is first and second template arguments
-    // With interpolator precision type as double and transform double, on GPU as float
-    this->RegisterOverride(
-      typeid(ResampleImageFilter<GPUInputImageType, GPUOutputImageType, double, double>).name(),
-      typeid(GPUResampleImageFilter<GPUInputImageType, GPUOutputImageType, float, float>).name(),
-      "GPU ResampleImageFilter override GPUImage first and second, interpolator double and transform double",
-      true,
-      CreateObjectFunction<GPUResampleImageFilter<GPUInputImageType, GPUOutputImageType, float, float>>::New());
-
-    // Override when itkGPUImage is first and second template arguments
-    // With interpolator precision type as float and transform double, on GPU as float
-    this->RegisterOverride(
-      typeid(ResampleImageFilter<GPUInputImageType, GPUOutputImageType, float, double>).name(),
-      typeid(GPUResampleImageFilter<GPUInputImageType, GPUOutputImageType, float, float>).name(),
-      "GPU ResampleImageFilter override GPUImage first and second, interpolator float and transform double",
-      true,
-      CreateObjectFunction<GPUResampleImageFilter<GPUInputImageType, GPUOutputImageType, float, float>>::New());
-
-    // Override when itkGPUImage is first and second template arguments
-    // With interpolator precision type as double and transform float, on GPU as float
-    this->RegisterOverride(
-      typeid(ResampleImageFilter<GPUInputImageType, GPUOutputImageType, double, float>).name(),
-      typeid(GPUResampleImageFilter<GPUInputImageType, GPUOutputImageType, float, float>).name(),
-      "GPU ResampleImageFilter override GPUImage first and second, interpolator double and transform float",
       true,
       CreateObjectFunction<GPUResampleImageFilter<GPUInputImageType, GPUOutputImageType, float, float>>::New());
   }

--- a/Common/OpenCL/Filters/itkGPUResampleImageFilter.h
+++ b/Common/OpenCL/Filters/itkGPUResampleImageFilter.h
@@ -43,18 +43,23 @@ itkGPUKernelClassMacro(GPUResampleImageFilterKernel);
  *
  * \ingroup GPUCommon
  */
-template <typename TInputImage, typename TOutputImage, typename TInterpolatorPrecisionType = float>
+template <typename TInputImage,
+          typename TOutputImage,
+          typename TInterpolatorPrecisionType = float,
+          typename TTransformPrecisionType = TInterpolatorPrecisionType>
 class ITK_EXPORT GPUResampleImageFilter
-  : public GPUImageToImageFilter<TInputImage,
-                                 TOutputImage,
-                                 ResampleImageFilter<TInputImage, TOutputImage, TInterpolatorPrecisionType>>
+  : public GPUImageToImageFilter<
+      TInputImage,
+      TOutputImage,
+      ResampleImageFilter<TInputImage, TOutputImage, TInterpolatorPrecisionType, TTransformPrecisionType>>
 {
 public:
   ITK_DISALLOW_COPY_AND_MOVE(GPUResampleImageFilter);
 
   /** Standard class typedefs. */
   using Self = GPUResampleImageFilter;
-  using CPUSuperclass = ResampleImageFilter<TInputImage, TOutputImage, TInterpolatorPrecisionType>;
+  using CPUSuperclass =
+    ResampleImageFilter<TInputImage, TOutputImage, TInterpolatorPrecisionType, TTransformPrecisionType>;
   using GPUSuperclass = GPUImageToImageFilter<TInputImage, TOutputImage, CPUSuperclass>;
   using Pointer = SmartPointer<Self>;
   using ConstPointer = SmartPointer<const Self>;

--- a/Common/OpenCL/Filters/itkGPUResampleImageFilter.hxx
+++ b/Common/OpenCL/Filters/itkGPUResampleImageFilter.hxx
@@ -48,8 +48,12 @@ namespace itk
  * ***************** Constructor ***********************
  */
 
-template <typename TInputImage, typename TOutputImage, typename TInterpolatorPrecisionType>
-GPUResampleImageFilter<TInputImage, TOutputImage, TInterpolatorPrecisionType>::GPUResampleImageFilter()
+template <typename TInputImage,
+          typename TOutputImage,
+          typename TInterpolatorPrecisionType,
+          typename TTransformPrecisionType>
+GPUResampleImageFilter<TInputImage, TOutputImage, TInterpolatorPrecisionType, TTransformPrecisionType>::
+  GPUResampleImageFilter()
 {
   this->m_PreKernelManager = OpenCLKernelManager::New();
   this->m_LoopKernelManager = OpenCLKernelManager::New();
@@ -143,9 +147,13 @@ GPUResampleImageFilter<TInputImage, TOutputImage, TInterpolatorPrecisionType>::G
  * ***************** SetInterpolator ***********************
  */
 
-template <typename TInputImage, typename TOutputImage, typename TInterpolatorPrecisionType>
+template <typename TInputImage,
+          typename TOutputImage,
+          typename TInterpolatorPrecisionType,
+          typename TTransformPrecisionType>
 void
-GPUResampleImageFilter<TInputImage, TOutputImage, TInterpolatorPrecisionType>::SetInterpolator(InterpolatorType * _arg)
+GPUResampleImageFilter<TInputImage, TOutputImage, TInterpolatorPrecisionType, TTransformPrecisionType>::SetInterpolator(
+  InterpolatorType * _arg)
 {
   itkDebugMacro("setting Interpolator to " << _arg);
   CPUSuperclass::SetInterpolator(_arg);
@@ -214,9 +222,13 @@ GPUResampleImageFilter<TInputImage, TOutputImage, TInterpolatorPrecisionType>::S
  * ***************** SetExtrapolator ***********************
  */
 
-template <typename TInputImage, typename TOutputImage, typename TInterpolatorPrecisionType>
+template <typename TInputImage,
+          typename TOutputImage,
+          typename TInterpolatorPrecisionType,
+          typename TTransformPrecisionType>
 void
-GPUResampleImageFilter<TInputImage, TOutputImage, TInterpolatorPrecisionType>::SetExtrapolator(ExtrapolatorType * _arg)
+GPUResampleImageFilter<TInputImage, TOutputImage, TInterpolatorPrecisionType, TTransformPrecisionType>::SetExtrapolator(
+  ExtrapolatorType * _arg)
 {
   // CPUSuperclass::SetExtrapolator( _arg );
   itkWarningMacro(<< "Setting Extrapolator for GPUResampleImageFilter not supported yet.");
@@ -227,9 +239,13 @@ GPUResampleImageFilter<TInputImage, TOutputImage, TInterpolatorPrecisionType>::S
  * ***************** SetTransform ***********************
  */
 
-template <typename TInputImage, typename TOutputImage, typename TInterpolatorPrecisionType>
+template <typename TInputImage,
+          typename TOutputImage,
+          typename TInterpolatorPrecisionType,
+          typename TTransformPrecisionType>
 void
-GPUResampleImageFilter<TInputImage, TOutputImage, TInterpolatorPrecisionType>::SetTransform(const TransformType * _arg)
+GPUResampleImageFilter<TInputImage, TOutputImage, TInterpolatorPrecisionType, TTransformPrecisionType>::SetTransform(
+  const TransformType * _arg)
 {
   itkDebugMacro("setting Transform to " << _arg);
   CPUSuperclass::SetTransform(_arg);
@@ -371,9 +387,13 @@ GPUResampleImageFilter<TInputImage, TOutputImage, TInterpolatorPrecisionType>::S
  * ***************** GPUGenerateData ***********************
  */
 
-template <typename TInputImage, typename TOutputImage, typename TInterpolatorPrecisionType>
+template <typename TInputImage,
+          typename TOutputImage,
+          typename TInterpolatorPrecisionType,
+          typename TTransformPrecisionType>
 void
-GPUResampleImageFilter<TInputImage, TOutputImage, TInterpolatorPrecisionType>::GPUGenerateData()
+GPUResampleImageFilter<TInputImage, TOutputImage, TInterpolatorPrecisionType, TTransformPrecisionType>::
+  GPUGenerateData()
 {
   itkDebugMacro(<< "GPUResampleImageFilter::GPUGenerateData() called");
 
@@ -668,10 +688,13 @@ GPUResampleImageFilter<TInputImage, TOutputImage, TInterpolatorPrecisionType>::G
  * ***************** SetArgumentsForPreKernelManager ***********************
  */
 
-template <typename TInputImage, typename TOutputImage, typename TInterpolatorPrecisionType>
+template <typename TInputImage,
+          typename TOutputImage,
+          typename TInterpolatorPrecisionType,
+          typename TTransformPrecisionType>
 void
-GPUResampleImageFilter<TInputImage, TOutputImage, TInterpolatorPrecisionType>::SetArgumentsForPreKernelManager(
-  const typename GPUOutputImage::Pointer & outputImage)
+GPUResampleImageFilter<TInputImage, TOutputImage, TInterpolatorPrecisionType, TTransformPrecisionType>::
+  SetArgumentsForPreKernelManager(const typename GPUOutputImage::Pointer & outputImage)
 {
   itkDebugMacro(<< "GPUResampleImageFilter::SetArgumentsForPreKernelManager called");
 
@@ -703,11 +726,14 @@ GPUResampleImageFilter<TInputImage, TOutputImage, TInterpolatorPrecisionType>::S
  * ***************** SetArgumentsForLoopKernelManager ***********************
  */
 
-template <typename TInputImage, typename TOutputImage, typename TInterpolatorPrecisionType>
+template <typename TInputImage,
+          typename TOutputImage,
+          typename TInterpolatorPrecisionType,
+          typename TTransformPrecisionType>
 void
-GPUResampleImageFilter<TInputImage, TOutputImage, TInterpolatorPrecisionType>::SetArgumentsForLoopKernelManager(
-  const typename GPUInputImage::Pointer &  input,
-  const typename GPUOutputImage::Pointer & output)
+GPUResampleImageFilter<TInputImage, TOutputImage, TInterpolatorPrecisionType, TTransformPrecisionType>::
+  SetArgumentsForLoopKernelManager(const typename GPUInputImage::Pointer &  input,
+                                   const typename GPUOutputImage::Pointer & output)
 {
   itkDebugMacro(<< "GPUResampleImageFilter::SetArgumentsForLoopKernelManager(" << input->GetNameOfClass() << ", "
                 << output->GetNameOfClass() << ") called");
@@ -747,9 +773,12 @@ GPUResampleImageFilter<TInputImage, TOutputImage, TInterpolatorPrecisionType>::S
  * ***************** SetTransformArgumentsForLoopKernelManager ***********************
  */
 
-template <typename TInputImage, typename TOutputImage, typename TInterpolatorPrecisionType>
+template <typename TInputImage,
+          typename TOutputImage,
+          typename TInterpolatorPrecisionType,
+          typename TTransformPrecisionType>
 void
-GPUResampleImageFilter<TInputImage, TOutputImage, TInterpolatorPrecisionType>::
+GPUResampleImageFilter<TInputImage, TOutputImage, TInterpolatorPrecisionType, TTransformPrecisionType>::
   SetTransformParametersForLoopKernelManager(const std::size_t transformIndex)
 {
   itkDebugMacro(<< "GPUResampleImageFilter::SetTransformArgumentsForLoopKernelManager(" << transformIndex
@@ -793,10 +822,13 @@ GPUResampleImageFilter<TInputImage, TOutputImage, TInterpolatorPrecisionType>::
  * ***************** SetBSplineTransformCoefficientsToGPU ***********************
  */
 
-template <typename TInputImage, typename TOutputImage, typename TInterpolatorPrecisionType>
+template <typename TInputImage,
+          typename TOutputImage,
+          typename TInterpolatorPrecisionType,
+          typename TTransformPrecisionType>
 void
-GPUResampleImageFilter<TInputImage, TOutputImage, TInterpolatorPrecisionType>::SetBSplineTransformCoefficientsToGPU(
-  const std::size_t transformIndex)
+GPUResampleImageFilter<TInputImage, TOutputImage, TInterpolatorPrecisionType, TTransformPrecisionType>::
+  SetBSplineTransformCoefficientsToGPU(const std::size_t transformIndex)
 {
   itkDebugMacro(<< "GPUResampleImageFilter::SetBSplineTransformCoefficientsToGPU(" << transformIndex << ") called");
 
@@ -858,11 +890,14 @@ GPUResampleImageFilter<TInputImage, TOutputImage, TInterpolatorPrecisionType>::S
  * ***************** SetArgumentsForPostKernelManager ***********************
  */
 
-template <typename TInputImage, typename TOutputImage, typename TInterpolatorPrecisionType>
+template <typename TInputImage,
+          typename TOutputImage,
+          typename TInterpolatorPrecisionType,
+          typename TTransformPrecisionType>
 void
-GPUResampleImageFilter<TInputImage, TOutputImage, TInterpolatorPrecisionType>::SetArgumentsForPostKernelManager(
-  const typename GPUInputImage::Pointer &  input,
-  const typename GPUOutputImage::Pointer & output)
+GPUResampleImageFilter<TInputImage, TOutputImage, TInterpolatorPrecisionType, TTransformPrecisionType>::
+  SetArgumentsForPostKernelManager(const typename GPUInputImage::Pointer &  input,
+                                   const typename GPUOutputImage::Pointer & output)
 {
   itkDebugMacro(<< "GPUResampleImageFilter::SetArgumentsForPostKernelManager(" << input->GetNameOfClass() << ", "
                 << output->GetNameOfClass() << ") called");
@@ -935,10 +970,13 @@ GPUResampleImageFilter<TInputImage, TOutputImage, TInterpolatorPrecisionType>::S
  * ***************** GetTransformType ***********************
  */
 
-template <typename TInputImage, typename TOutputImage, typename TInterpolatorPrecisionType>
+template <typename TInputImage,
+          typename TOutputImage,
+          typename TInterpolatorPrecisionType,
+          typename TTransformPrecisionType>
 auto
-GPUResampleImageFilter<TInputImage, TOutputImage, TInterpolatorPrecisionType>::GetTransformType(
-  const int & transformIndex) const -> const GPUTransformTypeEnum
+GPUResampleImageFilter<TInputImage, TOutputImage, TInterpolatorPrecisionType, TTransformPrecisionType>::
+  GetTransformType(const int & transformIndex) const -> const GPUTransformTypeEnum
 {
   if (this->m_TransformIsCombo)
   {
@@ -990,9 +1028,12 @@ GPUResampleImageFilter<TInputImage, TOutputImage, TInterpolatorPrecisionType>::G
  * ***************** HasTransform ***********************
  */
 
-template <typename TInputImage, typename TOutputImage, typename TInterpolatorPrecisionType>
+template <typename TInputImage,
+          typename TOutputImage,
+          typename TInterpolatorPrecisionType,
+          typename TTransformPrecisionType>
 bool
-GPUResampleImageFilter<TInputImage, TOutputImage, TInterpolatorPrecisionType>::HasTransform(
+GPUResampleImageFilter<TInputImage, TOutputImage, TInterpolatorPrecisionType, TTransformPrecisionType>::HasTransform(
   const GPUTransformTypeEnum type) const
 {
   if (this->m_FilterLoopGPUKernelHandle.empty())
@@ -1014,10 +1055,13 @@ GPUResampleImageFilter<TInputImage, TOutputImage, TInterpolatorPrecisionType>::H
  * ***************** GetTransformHandle ***********************
  */
 
-template <typename TInputImage, typename TOutputImage, typename TInterpolatorPrecisionType>
+template <typename TInputImage,
+          typename TOutputImage,
+          typename TInterpolatorPrecisionType,
+          typename TTransformPrecisionType>
 int
-GPUResampleImageFilter<TInputImage, TOutputImage, TInterpolatorPrecisionType>::GetTransformHandle(
-  const GPUTransformTypeEnum type) const
+GPUResampleImageFilter<TInputImage, TOutputImage, TInterpolatorPrecisionType, TTransformPrecisionType>::
+  GetTransformHandle(const GPUTransformTypeEnum type) const
 {
   if (this->m_FilterLoopGPUKernelHandle.empty())
   {
@@ -1038,11 +1082,13 @@ GPUResampleImageFilter<TInputImage, TOutputImage, TInterpolatorPrecisionType>::G
  * ***************** GetKernelIdFromTransformId ***********************
  */
 
-template <typename TInputImage, typename TOutputImage, typename TInterpolatorPrecisionType>
+template <typename TInputImage,
+          typename TOutputImage,
+          typename TInterpolatorPrecisionType,
+          typename TTransformPrecisionType>
 bool
-GPUResampleImageFilter<TInputImage, TOutputImage, TInterpolatorPrecisionType>::GetKernelIdFromTransformId(
-  const std::size_t & transformIndex,
-  std::size_t &       kernelId) const
+GPUResampleImageFilter<TInputImage, TOutputImage, TInterpolatorPrecisionType, TTransformPrecisionType>::
+  GetKernelIdFromTransformId(const std::size_t & transformIndex, std::size_t & kernelId) const
 {
   if (this->m_TransformIsCombo)
   {
@@ -1102,10 +1148,13 @@ GPUResampleImageFilter<TInputImage, TOutputImage, TInterpolatorPrecisionType>::G
  * ***************** GetGPUBSplineBaseTransform ***********************
  */
 
-template <typename TInputImage, typename TOutputImage, typename TInterpolatorPrecisionType>
+template <typename TInputImage,
+          typename TOutputImage,
+          typename TInterpolatorPrecisionType,
+          typename TTransformPrecisionType>
 auto
-GPUResampleImageFilter<TInputImage, TOutputImage, TInterpolatorPrecisionType>::GetGPUBSplineBaseTransform(
-  const std::size_t transformIndex) -> GPUBSplineBaseTransformType *
+GPUResampleImageFilter<TInputImage, TOutputImage, TInterpolatorPrecisionType, TTransformPrecisionType>::
+  GetGPUBSplineBaseTransform(const std::size_t transformIndex) -> GPUBSplineBaseTransformType *
 {
   GPUBSplineBaseTransformType * GPUBSplineTransformBase = nullptr;
 
@@ -1135,10 +1184,14 @@ GPUResampleImageFilter<TInputImage, TOutputImage, TInterpolatorPrecisionType>::G
  * ***************** PrintSelf ***********************
  */
 
-template <typename TInputImage, typename TOutputImage, typename TInterpolatorPrecisionType>
+template <typename TInputImage,
+          typename TOutputImage,
+          typename TInterpolatorPrecisionType,
+          typename TTransformPrecisionType>
 void
-GPUResampleImageFilter<TInputImage, TOutputImage, TInterpolatorPrecisionType>::PrintSelf(std::ostream & os,
-                                                                                         Indent         indent) const
+GPUResampleImageFilter<TInputImage, TOutputImage, TInterpolatorPrecisionType, TTransformPrecisionType>::PrintSelf(
+  std::ostream & os,
+  Indent         indent) const
 {
   CPUSuperclass::PrintSelf(os, indent);
   GPUSuperclass::PrintSelf(os, indent);

--- a/Common/OpenCL/ITKimprovements/itkGPUImage.h
+++ b/Common/OpenCL/ITKimprovements/itkGPUImage.h
@@ -96,6 +96,17 @@ public:
 
   using NeighborhoodAccessorFunctorType = NeighborhoodAccessorFunctor<Self>;
 
+  /** Override Rebind and RebindImageType of itk::Image class */
+  template <typename UPixelType, unsigned int VUImageDimension = VImageDimension>
+  struct Rebind
+  {
+    using Type = itk::GPUImage<UPixelType, VUImageDimension>;
+  };
+
+  template <typename UPixelType, unsigned int VUImageDimension = VImageDimension>
+  using RebindImageType = itk::GPUImage<UPixelType, VUImageDimension>;
+
+
   /** Allocate CPU and GPU memory space */
   void
   Allocate(bool initialize = false) override;

--- a/Components/FixedImagePyramids/OpenCLFixedGenericPyramid/elxOpenCLFixedGenericPyramid.hxx
+++ b/Components/FixedImagePyramids/OpenCLFixedGenericPyramid/elxOpenCLFixedGenericPyramid.hxx
@@ -196,8 +196,12 @@ OpenCLFixedGenericPyramid<TElastix>::GenerateData()
 
   if (computedUsingOpenCL)
   {
-    // Graft output
-    this->GraftOutput(this->m_GPUPyramid->GetOutput());
+    // Graft outputs
+    const auto numberOfLevels = this->GetNumberOfLevels();
+    for (unsigned int i = 0; i < numberOfLevels; i++)
+    {
+      this->GraftNthOutput(i, this->m_GPUPyramid->GetOutput(i));
+    }
 
     // Report OpenCL device to the log
     this->ReportToLog();

--- a/Components/MovingImagePyramids/OpenCLMovingGenericPyramid/elxOpenCLMovingGenericPyramid.hxx
+++ b/Components/MovingImagePyramids/OpenCLMovingGenericPyramid/elxOpenCLMovingGenericPyramid.hxx
@@ -196,8 +196,12 @@ OpenCLMovingGenericPyramid<TElastix>::GenerateData()
 
   if (computedUsingOpenCL)
   {
-    // Graft output
-    this->GraftOutput(this->m_GPUPyramid->GetOutput());
+    // Graft outputs
+    const auto numberOfLevels = this->GetNumberOfLevels();
+    for (unsigned int i = 0; i < numberOfLevels; i++)
+    {
+      this->GraftNthOutput(i, this->m_GPUPyramid->GetOutput(i));
+    }
 
     // Report OpenCL device to the log
     this->ReportToLog();

--- a/Testing/itkGPUFactoriesTest.cxx
+++ b/Testing/itkGPUFactoriesTest.cxx
@@ -197,7 +197,7 @@ TestGPUFilterFactories()
 
   // Print all elastix registered factories
   PrintAllRegisteredFactories();
-  if (!IsRegistered(1, 64))
+  if (!IsRegistered(1, 32))
   {
     return false;
   }

--- a/Testing/itkGPUGenericMultiResolutionPyramidImageFilterTest.cxx
+++ b/Testing/itkGPUGenericMultiResolutionPyramidImageFilterTest.cxx
@@ -88,7 +88,8 @@ main(int argc, char * argv[])
   using OutputImageType = itk::Image<OutputPixelType, Dimension>;
 
   // CPU Typedefs
-  using FilterType = itk::GenericMultiResolutionPyramidImageFilter<InputImageType, OutputImageType>;
+  using PrecisionType = float;
+  using FilterType = itk::GenericMultiResolutionPyramidImageFilter<InputImageType, OutputImageType, PrecisionType>;
   using ReaderType = itk::ImageFileReader<InputImageType>;
 
   // Reader


### PR DESCRIPTION
This PR provides the cosmetic changes needed for PR https://github.com/SuperElastix/elastix/pull/243 together with a small addition. Hence, full credits should be given to @squll1peter for writing up the original PR and resolving the CL_OUT_OF_RESOURCES issue discussed in PR https://github.com/SuperElastix/elastix/pull/243 and issue https://github.com/SuperElastix/elastix/issues/70!  Two different bugs are actually solved. In short summary:

1. The CL_OUT_OF_RESOURCES error. This bug was created because `itk::SmoothingRecursiveGaussianImageFilter` was overriding (here: https://github.com/InsightSoftwareConsortium/ITK/blob/3c6de8f009aadfab8f801070237cb699f5c895cb/Modules/Filtering/Smoothing/include/itkSmoothingRecursiveGaussianImageFilter.h#L80-L87) the internal pixel type of `RecursiveGaussianImageFilter` member objects using the templated struct `Rebind`. However, `Rebind` was only implemented for `itk::Image` and not `itk::GPUImage`, making the latter call the implementation of the former and leading to mixing of the two types. The solution here was to create the equivalent `Rebind` for `itk::GPUImage`

2. A crash was appearing during the start of the second registration resolution because only the first output of the pyramid member object was communicated/grafted to the FixedGenericPyramid / MovingGenericPyramid objects. A simple for-loop to graft all outputs was added as solution.

-------------------------------------------------------------------------------------
In addition to the above bug-fixing changes, the class signature of itkGPUResampleImageFilter was updated to match the one of itkResampleImageFilter where an extra templated parameter was added (`TTransformPrecisionType`). The `itkGPUResampleImageFilterFactory` was updated accordingly.
 
An important note: Several of the related tests were passing successfully before this changes, where clearly they shouldn't. So, some work needs to be done there to make them effective.  

A second note is that memory allocation enhancement, provided in the original PR, is not implemented here, but it should be looked into the future.