### PR TITLE
BUG: Fix OpenCL resampler for GPUMatrixOffset transforms + tests

### DIFF
--- a/Common/OpenCL/Filters/itkGPUMatrixOffsetTransformBase.hxx
+++ b/Common/OpenCL/Filters/itkGPUMatrixOffsetTransformBase.hxx
@@ -27,21 +27,18 @@ namespace ITKGPUMatrixOffsetTransformBase
 typedef struct
 {
   cl_float matrix;
-  cl_float inverse_matrix;
   cl_float offset;
 } GPUMatrixOffsetTransformBase1D;
 
 typedef struct
 {
   cl_float4 matrix;
-  cl_float4 inverse_matrix;
   cl_float2 offset;
 } GPUMatrixOffsetTransformBase2D;
 
 typedef struct
 {
-  cl_float16 matrix;         // OpenCL does not have float9
-  cl_float16 inverse_matrix; // OpenCL does not have float9
+  cl_float16 matrix; // OpenCL does not have float9
   cl_float3  offset;
 } GPUMatrixOffsetTransformBase3D;
 

--- a/Testing/CMakeLists.txt
+++ b/Testing/CMakeLists.txt
@@ -554,7 +554,7 @@ if(ELASTIX_USE_OPENCL)
          ${TestOutputDir}/3DCT_lung_baseline_resample_nearest_affine_GPU.mha
     -i   NearestNeighbor
     -t   Affine
-    -rmse 2.8)
+    -rmse 0.2)
 
   elx_add_opencl_test(GPUResampleImageFilterTest "-LinearAffine" "OpenCL" ""
     -in  ${TestDataDir}/3DCT_lung_baseline.mha
@@ -562,7 +562,7 @@ if(ELASTIX_USE_OPENCL)
          ${TestOutputDir}/3DCT_lung_baseline_resample_linear_affine_GPU.mha
     -i   Linear
     -t   Affine
-    -rmse 1.0)
+    -rmse 0.05)
 
   elx_add_opencl_test(GPUResampleImageFilterTest "-BSplineAffine" "OpenCL" ""
     -in  ${TestDataDir}/3DCT_lung_baseline.mha
@@ -570,7 +570,7 @@ if(ELASTIX_USE_OPENCL)
          ${TestOutputDir}/3DCT_lung_baseline_resample_bspline_affine_GPU.mha
     -i   BSpline
     -t   Affine
-    -rmse 1.0)
+    -rmse 0.1)
 
   # Translation transform tests
   elx_add_opencl_test(GPUResampleImageFilterTest "-NearestTranslation" "OpenCL" ""
@@ -587,7 +587,7 @@ if(ELASTIX_USE_OPENCL)
          ${TestOutputDir}/3DCT_lung_baseline_resample_linear_translation_GPU.mha
     -i   Linear
     -t   Translation
-    -rmse 0.1)
+    -rmse 0.05)
 
   elx_add_opencl_test(GPUResampleImageFilterTest "-BSplineTranslation" "OpenCL" ""
     -in  ${TestDataDir}/3DCT_lung_baseline.mha
@@ -595,7 +595,7 @@ if(ELASTIX_USE_OPENCL)
          ${TestOutputDir}/3DCT_lung_baseline_resample_bspline_translation_GPU.mha
     -i   BSpline
     -t   Translation
-    -rmse 0.11)
+    -rmse 0.05)
 
   # BSpline transform tests
   elx_add_opencl_test(GPUResampleImageFilterTest "-NearestBSpline" "OpenCL" ""
@@ -605,7 +605,7 @@ if(ELASTIX_USE_OPENCL)
     -i   NearestNeighbor
     -t   BSpline
     -p   ${elastix_SOURCE_DIR}/Testing/parameters_AdvancedBSplineDeformableTransformTest.txt
-    -rmse 0.5)
+    -rmse 0.05)
 
   elx_add_opencl_test(GPUResampleImageFilterTest "-LinearBSpline" "OpenCL" ""
     -in  ${TestDataDir}/3DCT_lung_baseline.mha
@@ -623,7 +623,7 @@ if(ELASTIX_USE_OPENCL)
     -i   BSpline
     -t   BSpline
     -p   ${elastix_SOURCE_DIR}/Testing/parameters_AdvancedBSplineDeformableTransformTest.txt
-    -rmse 0.04)
+    -rmse 0.05)
 
   # Euler transform tests
   elx_add_opencl_test(GPUResampleImageFilterTest "-NearestEuler" "OpenCL" ""
@@ -640,7 +640,7 @@ if(ELASTIX_USE_OPENCL)
          ${TestOutputDir}/3DCT_lung_baseline_resample_linear_euler_GPU.mha
     -i   Linear
     -t   Euler
-    -rmse 0.1)
+    -rmse 0.03)
 
   elx_add_opencl_test(GPUResampleImageFilterTest "-BSplineEuler" "OpenCL" ""
     -in  ${TestDataDir}/3DCT_lung_baseline.mha
@@ -648,7 +648,7 @@ if(ELASTIX_USE_OPENCL)
          ${TestOutputDir}/3DCT_lung_baseline_resample_bspline_euler_GPU.mha
     -i   BSpline
     -t   Euler
-    -rmse 0.11)
+    -rmse 0.05)
 
   # Similarity transform tests
   elx_add_opencl_test(GPUResampleImageFilterTest "-NearestSimilarity" "OpenCL" ""
@@ -665,7 +665,7 @@ if(ELASTIX_USE_OPENCL)
          ${TestOutputDir}/3DCT_lung_baseline_resample_linear_similarity_GPU.mha
     -i   Linear
     -t   Similarity
-    -rmse 0.1)
+    -rmse 0.03)
 
   elx_add_opencl_test(GPUResampleImageFilterTest "-BSplineSimilarity" "OpenCL" ""
     -in  ${TestDataDir}/3DCT_lung_baseline.mha
@@ -673,7 +673,7 @@ if(ELASTIX_USE_OPENCL)
          ${TestOutputDir}/3DCT_lung_baseline_resample_bspline_similarity_GPU.mha
     -i   BSpline
     -t   Similarity
-    -rmse 0.1)
+    -rmse 0.05)
 
   elx_add_opencl_test(GPUResampleImageFilterTest "-NearestComboAffine" "OpenCL" ""
      -in  ${TestDataDir}/3DCT_lung_baseline.mha
@@ -681,7 +681,7 @@ if(ELASTIX_USE_OPENCL)
           ${TestOutputDir}/3DCT_lung_baseline_resample_combo_nearest_affine_GPU.mha
      -i   NearestNeighbor
      -t   Affine
-     -c -rmse 2.8)
+     -c -rmse 2.0)
 
    elx_add_opencl_test(GPUResampleImageFilterTest "-NearestComboBSpline" "OpenCL" ""
      -in  ${TestDataDir}/3DCT_lung_baseline.mha
@@ -699,7 +699,7 @@ if(ELASTIX_USE_OPENCL)
      -i   NearestNeighbor
      -t   Affine BSpline
      -p   ${elastix_SOURCE_DIR}/Testing/parameters_AdvancedBSplineDeformableTransformTest.txt
-     -c -rmse 0.3)
+     -c -rmse 0.2)
 
 endif()
 

--- a/Testing/itkGPUBSplineDecompositionImageFilterTest.cxx
+++ b/Testing/itkGPUBSplineDecompositionImageFilterTest.cxx
@@ -21,6 +21,8 @@
 #include "itkGPUImageFactory.h"
 #include "itkGPUBSplineDecompositionImageFilterFactory.h"
 
+#include "itkOpenCLContextScopeGuard.h"
+
 // ITK include files
 #include "itkImageFileReader.h"
 #include "itkImageFileWriter.h"
@@ -54,6 +56,7 @@ main(int argc, char * argv[])
   {
     return EXIT_FAILURE;
   }
+  const itk::OpenCLContextScopeGuard openCLContextScopeGuard{};
 
   /** Get the command line arguments. */
   std::string        inputFileName = argv[1];
@@ -100,7 +103,6 @@ main(int argc, char * argv[])
     catch (itk::ExceptionObject & e)
     {
       std::cerr << "ERROR: " << e << std::endl;
-      itk::ReleaseContext();
       return EXIT_FAILURE;
     }
     cpuFilter->Modified();
@@ -121,7 +123,6 @@ main(int argc, char * argv[])
   catch (itk::ExceptionObject & e)
   {
     std::cerr << "ERROR: " << e << std::endl;
-    itk::ReleaseContext();
     return EXIT_FAILURE;
   }
 
@@ -144,7 +145,6 @@ main(int argc, char * argv[])
   catch (itk::ExceptionObject & e)
   {
     std::cerr << "ERROR: " << e << std::endl;
-    itk::ReleaseContext();
     return EXIT_FAILURE;
   }
   gpuFilter->SetSplineOrder(splineOrder);
@@ -169,7 +169,6 @@ main(int argc, char * argv[])
     catch (itk::ExceptionObject & e)
     {
       std::cerr << "ERROR: " << e << std::endl;
-      itk::ReleaseContext();
       return EXIT_FAILURE;
     }
     gpuFilter->Modified();
@@ -190,7 +189,6 @@ main(int argc, char * argv[])
   catch (itk::ExceptionObject & e)
   {
     std::cerr << "ERROR: " << e << std::endl;
-    itk::ReleaseContext();
     return EXIT_FAILURE;
   }
 
@@ -204,11 +202,9 @@ main(int argc, char * argv[])
   if (RMSerror > epsilon)
   {
     std::cerr << "ERROR: RMSE between CPU and GPU result larger than expected" << std::endl;
-    itk::ReleaseContext();
     return EXIT_FAILURE;
   }
 
   // End program.
-  itk::ReleaseContext();
   return EXIT_SUCCESS;
 } // end main()

--- a/Testing/itkGPUCastImageFilterTest.cxx
+++ b/Testing/itkGPUCastImageFilterTest.cxx
@@ -21,6 +21,8 @@
 #include "itkGPUImageFactory.h"
 #include "itkGPUCastImageFilterFactory.h"
 
+#include "itkOpenCLContextScopeGuard.h"
+
 // ITK include files
 #include "itkImageFileReader.h"
 #include "itkImageFileWriter.h"
@@ -53,6 +55,7 @@ main(int argc, char * argv[])
   {
     return EXIT_FAILURE;
   }
+  const itk::OpenCLContextScopeGuard openCLContextScopeGuard{};
 
   /** Get the command line arguments. */
   std::string        inputFileName = argv[1];
@@ -99,7 +102,6 @@ main(int argc, char * argv[])
     catch (itk::ExceptionObject & e)
     {
       std::cerr << "ERROR: " << e << std::endl;
-      itk::ReleaseContext();
       return EXIT_FAILURE;
     }
 
@@ -124,7 +126,6 @@ main(int argc, char * argv[])
   catch (itk::ExceptionObject & e)
   {
     std::cerr << "ERROR: " << e << std::endl;
-    itk::ReleaseContext();
     return EXIT_FAILURE;
   }
 
@@ -147,7 +148,6 @@ main(int argc, char * argv[])
   catch (itk::ExceptionObject & e)
   {
     std::cerr << "ERROR: " << e << std::endl;
-    itk::ReleaseContext();
     return EXIT_FAILURE;
   }
 
@@ -171,7 +171,6 @@ main(int argc, char * argv[])
     catch (itk::ExceptionObject & e)
     {
       std::cerr << "ERROR: " << e << std::endl;
-      itk::ReleaseContext();
       return EXIT_FAILURE;
     }
     // Modify the filter, only not the last iteration
@@ -195,7 +194,6 @@ main(int argc, char * argv[])
   catch (itk::ExceptionObject & e)
   {
     std::cerr << "ERROR: " << e << std::endl;
-    itk::ReleaseContext();
     return EXIT_FAILURE;
   }
 
@@ -209,11 +207,9 @@ main(int argc, char * argv[])
   if (RMSerror > epsilon)
   {
     std::cerr << "ERROR: RMSE between CPU and GPU result larger than expected" << std::endl;
-    itk::ReleaseContext();
     return EXIT_FAILURE;
   }
 
   // End program.
-  itk::ReleaseContext();
   return EXIT_SUCCESS;
 } // end main()

--- a/Testing/itkGPUFactoriesTest.cxx
+++ b/Testing/itkGPUFactoriesTest.cxx
@@ -27,6 +27,8 @@
 #include "itkGPUResampleImageFilterFactory.h"
 #include "itkGPUShrinkImageFilterFactory.h"
 
+#include "itkOpenCLContextScopeGuard.h"
+
 // Interpolate includes
 #include "itkGPULinearInterpolateImageFunctionFactory.h"
 #include "itkGPUNearestNeighborInterpolateImageFunctionFactory.h"
@@ -517,6 +519,7 @@ main()
   {
     return EXIT_FAILURE;
   }
+  const itk::OpenCLContextScopeGuard openCLContextScopeGuard{};
 
   // ITK creates some factories unregister them
   itk::ObjectFactoryBase::UnRegisterAllFactories();

--- a/Testing/itkGPURecursiveGaussianImageFilterTest.cxx
+++ b/Testing/itkGPURecursiveGaussianImageFilterTest.cxx
@@ -20,6 +20,8 @@
 // GPU include files
 #include "itkGPURecursiveGaussianImageFilter.h"
 
+#include "itkOpenCLContextScopeGuard.h"
+
 // ITK include files
 #include "itkImageFileReader.h"
 #include "itkImageFileWriter.h"
@@ -65,6 +67,7 @@ main(int argc, char * argv[])
   {
     return EXIT_FAILURE;
   }
+  const itk::OpenCLContextScopeGuard openCLContextScopeGuard{};
 
   // Some hard-coded testing options
   const std::string  inputFileName = argv[1];
@@ -87,7 +90,6 @@ main(int argc, char * argv[])
   catch (itk::ExceptionObject & excp)
   {
     std::cerr << "ERROR: " << excp << std::endl;
-    itk::ReleaseContext();
     return EXIT_FAILURE;
   }
 
@@ -126,7 +128,6 @@ main(int argc, char * argv[])
   catch (itk::ExceptionObject & e)
   {
     std::cerr << "ERROR: " << e << std::endl;
-    itk::ReleaseContext();
     return EXIT_FAILURE;
   }
 
@@ -142,7 +143,6 @@ main(int argc, char * argv[])
   catch (itk::ExceptionObject & e)
   {
     std::cerr << "ERROR: " << e << std::endl;
-    itk::ReleaseContext();
     return EXIT_FAILURE;
   }
 
@@ -168,7 +168,6 @@ main(int argc, char * argv[])
   catch (itk::ExceptionObject & e)
   {
     std::cerr << "ERROR: " << e << std::endl;
-    itk::ReleaseContext();
     return EXIT_FAILURE;
   }
 
@@ -182,7 +181,6 @@ main(int argc, char * argv[])
   if (RMSerror > epsilon)
   {
     std::cerr << "ERROR: RMSE between CPU and GPU result larger than expected" << std::endl;
-    itk::ReleaseContext();
     return EXIT_FAILURE;
   }
 
@@ -226,12 +224,10 @@ main(int argc, char * argv[])
     if (RMSerror > epsilon)
     {
       std::cerr << "ERROR: RMSE between CPU and GPU result larger than expected" << std::endl;
-      itk::ReleaseContext();
       return EXIT_FAILURE;
     }
   }
 
   // End program.
-  itk::ReleaseContext();
   return EXIT_SUCCESS;
 } // end main()

--- a/Testing/itkGPUResampleImageFilterTest.cxx
+++ b/Testing/itkGPUResampleImageFilterTest.cxx
@@ -20,6 +20,8 @@
 // GPU include files
 #include "itkGPUResampleImageFilter.h"
 
+#include "itkOpenCLContextScopeGuard.h"
+
 // GPU copiers
 #include "itkGPUTransformCopier.h"
 #include "itkGPUAdvancedCombinationTransformCopier.h"
@@ -609,6 +611,7 @@ main(int argc, char * argv[])
   {
     return EXIT_FAILURE;
   }
+  const itk::OpenCLContextScopeGuard openCLContextScopeGuard{};
 
   // Check for the device 'double' support
   itk::OpenCLContext::Pointer context = itk::OpenCLContext::GetInstance();
@@ -616,7 +619,6 @@ main(int argc, char * argv[])
   {
     std::cerr << "Your OpenCL device: " << context->GetDefaultDevice().GetName()
               << ", does not support 'double' computations. Consider updating it." << std::endl;
-    itk::ReleaseContext();
     return EXIT_FAILURE;
   }
 
@@ -633,12 +635,10 @@ main(int argc, char * argv[])
 
   if (validateArguments == itk::CommandLineArgumentParser::FAILED)
   {
-    itk::ReleaseContext();
     return EXIT_FAILURE;
   }
   else if (validateArguments == itk::CommandLineArgumentParser::HELPREQUESTED)
   {
-    itk::ReleaseContext();
     return EXIT_SUCCESS;
   }
 
@@ -660,7 +660,6 @@ main(int argc, char * argv[])
   if (interpolator != "NearestNeighbor" && interpolator != "Linear" && interpolator != "BSpline")
   {
     std::cerr << "ERROR: interpolator \"-i\" should be one of {NearestNeighbor, Linear, BSpline}." << std::endl;
-    itk::ReleaseContext();
     return EXIT_FAILURE;
   }
 
@@ -674,7 +673,6 @@ main(int argc, char * argv[])
   if (transforms.size() > 1 && !useComboTransform)
   {
     std::cerr << "ERROR: for multiple transforms option \"-c\" should provided." << std::endl;
-    itk::ReleaseContext();
     return EXIT_FAILURE;
   }
 
@@ -688,7 +686,6 @@ main(int argc, char * argv[])
       std::cerr << "ERROR: transforms \"-t\" should be one of {Affine, Translation, BSpline, Euler, Similarity} or "
                    "combination of them."
                 << std::endl;
-      itk::ReleaseContext();
       return EXIT_FAILURE;
     }
   }
@@ -703,7 +700,6 @@ main(int argc, char * argv[])
       if (!retp)
       {
         std::cerr << "ERROR: You should specify parameters file \"-p\" for the B-spline transform." << std::endl;
-        itk::ReleaseContext();
         return EXIT_FAILURE;
       }
       // Faster B-spline tests
@@ -794,7 +790,6 @@ main(int argc, char * argv[])
   catch (itk::ExceptionObject & e)
   {
     std::cerr << "ERROR: Caught ITK exception during cpuReader->Update(): " << e << std::endl;
-    itk::ReleaseContext();
     return EXIT_FAILURE;
   }
 
@@ -952,7 +947,6 @@ main(int argc, char * argv[])
     catch (itk::ExceptionObject & e)
     {
       std::cerr << "ERROR: Caught ITK exception during cpuFilter->Update(): " << e << std::endl;
-      itk::ReleaseContext();
       return EXIT_FAILURE;
     }
 
@@ -978,7 +972,6 @@ main(int argc, char * argv[])
   catch (itk::ExceptionObject & e)
   {
     std::cerr << "ERROR: Caught ITK exception during cpuWriter->Update(): " << e << std::endl;
-    itk::ReleaseContext();
     return EXIT_FAILURE;
   }
 
@@ -1027,7 +1020,6 @@ main(int argc, char * argv[])
   catch (itk::ExceptionObject & e)
   {
     std::cerr << "Caught ITK exception during gpuFilter::New(): " << e << std::endl;
-    itk::ReleaseContext();
     return EXIT_FAILURE;
   }
 
@@ -1051,7 +1043,6 @@ main(int argc, char * argv[])
   catch (itk::ExceptionObject & e)
   {
     std::cerr << "ERROR: Caught ITK exception during cpuReader->Update(): " << e << std::endl;
-    itk::ReleaseContext();
     return EXIT_FAILURE;
   }
 
@@ -1081,7 +1072,6 @@ main(int argc, char * argv[])
       else
       {
         std::cerr << "ERROR: Unable to retrieve CPU AdvancedCombinationTransform." << std::endl;
-        itk::ReleaseContext();
         return EXIT_FAILURE;
       }
     }
@@ -1089,7 +1079,6 @@ main(int argc, char * argv[])
   catch (itk::ExceptionObject & e)
   {
     std::cerr << "ERROR: Caught ITK exception during copy transforms: " << e << std::endl;
-    itk::ReleaseContext();
     return EXIT_FAILURE;
   }
 
@@ -1114,7 +1103,6 @@ main(int argc, char * argv[])
     catch (itk::ExceptionObject & e)
     {
       std::cerr << "ERROR: " << e << std::endl;
-      itk::ReleaseContext();
       return EXIT_FAILURE;
     }
 
@@ -1125,7 +1113,6 @@ main(int argc, char * argv[])
     catch (itk::ExceptionObject & e)
     {
       std::cerr << "ERROR: " << e << std::endl;
-      itk::ReleaseContext();
       return EXIT_FAILURE;
     }
     // Modify the filter, only not the last iteration
@@ -1150,7 +1137,6 @@ main(int argc, char * argv[])
   catch (itk::ExceptionObject & e)
   {
     std::cerr << "ERROR: " << e << std::endl;
-    itk::ReleaseContext();
     return EXIT_FAILURE;
   }
 
@@ -1165,11 +1151,9 @@ main(int argc, char * argv[])
   {
     std::cerr << "ERROR: the RMSE between the CPU and GPU results is " << RMSerror
               << ", which is larger than the expected " << rmseError << std::endl;
-    itk::ReleaseContext();
     return EXIT_FAILURE;
   }
 
   // End program.
-  itk::ReleaseContext();
   return EXIT_SUCCESS;
 }

--- a/Testing/itkGPUResampleImageFilterTest.cxx
+++ b/Testing/itkGPUResampleImageFilterTest.cxx
@@ -61,6 +61,7 @@
 
 // Other include files
 #include <iomanip> // setprecision, etc.
+#include <random>  // For mt19937.
 #include <sstream>
 
 //------------------------------------------------------------------------------
@@ -798,6 +799,7 @@ main(int argc, char * argv[])
 
   using RandomNumberGeneratorType = itk::Statistics::MersenneTwisterRandomVariateGenerator;
   RandomNumberGeneratorType::Pointer randomNum = RandomNumberGeneratorType::GetInstance();
+  randomNum->SetSeed(std::mt19937::default_seed);
 
   InputImageType::ConstPointer        inputImage = cpuReader->GetOutput();
   const InputImageType::SpacingType   inputSpacing = inputImage->GetSpacing();

--- a/Testing/itkGPUShrinkImageFilterTest.cxx
+++ b/Testing/itkGPUShrinkImageFilterTest.cxx
@@ -21,6 +21,8 @@
 #include "itkGPUImageFactory.h"
 #include "itkGPUShrinkImageFilterFactory.h"
 
+#include "itkOpenCLContextScopeGuard.h"
+
 // ITK include files
 #include "itkImageFileReader.h"
 #include "itkImageFileWriter.h"
@@ -53,6 +55,7 @@ main(int argc, char * argv[])
   {
     return EXIT_FAILURE;
   }
+  const itk::OpenCLContextScopeGuard openCLContextScopeGuard{};
 
   /** Get the command line arguments. */
   const std::string  inputFileName = argv[1];
@@ -99,7 +102,6 @@ main(int argc, char * argv[])
     catch (itk::ExceptionObject & e)
     {
       std::cerr << "ERROR: " << e << std::endl;
-      itk::ReleaseContext();
       return EXIT_FAILURE;
     }
 
@@ -125,7 +127,6 @@ main(int argc, char * argv[])
   catch (itk::ExceptionObject & e)
   {
     std::cerr << "ERROR: " << e << std::endl;
-    itk::ReleaseContext();
     return EXIT_FAILURE;
   }
 
@@ -148,7 +149,6 @@ main(int argc, char * argv[])
   catch (itk::ExceptionObject & e)
   {
     std::cerr << "ERROR: " << e << std::endl;
-    itk::ReleaseContext();
     return EXIT_FAILURE;
   }
   gpuFilter->SetShrinkFactors(shrinkFactor);
@@ -180,7 +180,6 @@ main(int argc, char * argv[])
     catch (itk::ExceptionObject & e)
     {
       std::cerr << "ERROR: " << e << std::endl;
-      itk::ReleaseContext();
       return EXIT_FAILURE;
     }
     // Modify the filter, only not the last iteration
@@ -205,7 +204,6 @@ main(int argc, char * argv[])
   catch (itk::ExceptionObject & e)
   {
     std::cerr << "ERROR: " << e << std::endl;
-    itk::ReleaseContext();
     return EXIT_FAILURE;
   }
 
@@ -219,11 +217,9 @@ main(int argc, char * argv[])
   if (RMSerror > epsilon)
   {
     std::cerr << "ERROR: RMSE between CPU and GPU result larger than expected" << std::endl;
-    itk::ReleaseContext();
     return EXIT_FAILURE;
   }
 
   // End program.
-  itk::ReleaseContext();
   return EXIT_SUCCESS;
 } // end main()

--- a/Testing/itkGPUSmoothingRecursiveGaussianImageFilterTest.cxx
+++ b/Testing/itkGPUSmoothingRecursiveGaussianImageFilterTest.cxx
@@ -22,6 +22,8 @@
 #include "itkGPURecursiveGaussianImageFilterFactory.h"
 #include "itkGPUCastImageFilterFactory.h" // used internally in smoothing filter
 
+#include "itkOpenCLContextScopeGuard.h"
+
 // ITK include files
 #include "itkSmoothingRecursiveGaussianImageFilter.h"
 #include "itkImageFileReader.h"
@@ -56,6 +58,7 @@ main(int argc, char * argv[])
   {
     return EXIT_FAILURE;
   }
+  const itk::OpenCLContextScopeGuard openCLContextScopeGuard{};
 
   /** Get the command line arguments. */
   const std::string  inputFileName = argv[1];
@@ -108,7 +111,6 @@ main(int argc, char * argv[])
     catch (itk::ExceptionObject & e)
     {
       std::cerr << "ERROR: " << e << std::endl;
-      itk::ReleaseContext();
       return EXIT_FAILURE;
     }
     filter->Modified();
@@ -128,7 +130,6 @@ main(int argc, char * argv[])
   catch (itk::ExceptionObject & e)
   {
     std::cerr << "ERROR: " << e << std::endl;
-    itk::ReleaseContext();
     return EXIT_FAILURE;
   }
 
@@ -158,7 +159,6 @@ main(int argc, char * argv[])
   catch (itk::ExceptionObject & e)
   {
     std::cerr << "ERROR: " << e << std::endl;
-    itk::ReleaseContext();
     return EXIT_FAILURE;
   }
   gpuFilter->SetSigmaArray(sigmaArray);
@@ -190,7 +190,6 @@ main(int argc, char * argv[])
     catch (itk::ExceptionObject & e)
     {
       std::cerr << "ERROR: " << e << std::endl;
-      itk::ReleaseContext();
       return EXIT_FAILURE;
     }
     gpuFilter->Modified();
@@ -211,7 +210,6 @@ main(int argc, char * argv[])
   catch (itk::ExceptionObject & e)
   {
     std::cerr << "ERROR: " << e << std::endl;
-    itk::ReleaseContext();
     return EXIT_FAILURE;
   }
 
@@ -225,11 +223,9 @@ main(int argc, char * argv[])
   if (RMSerror > epsilon)
   {
     std::cerr << "ERROR: RMSE between CPU and GPU result larger than expected" << std::endl;
-    itk::ReleaseContext();
     return EXIT_FAILURE;
   }
 
   // End program.
-  itk::ReleaseContext();
   return EXIT_SUCCESS;
 } // end main()

--- a/Testing/itkOpenCLBufferTest.cxx
+++ b/Testing/itkOpenCLBufferTest.cxx
@@ -109,10 +109,8 @@ main()
   catch (itk::ExceptionObject & e)
   {
     std::cerr << "Caught ITK exception: " << e << std::endl;
-    itk::ReleaseContext();
     return EXIT_FAILURE;
   }
 
-  itk::ReleaseContext();
   return EXIT_SUCCESS;
 }

--- a/Testing/itkOpenCLContextTest.cxx
+++ b/Testing/itkOpenCLContextTest.cxx
@@ -25,7 +25,6 @@ main()
 
   if (contextNull->IsCreated())
   {
-    itk::ReleaseContext();
     return EXIT_FAILURE;
   }
 
@@ -34,7 +33,6 @@ main()
   // Check the pointers, they should be the same
   if (contextNull.GetPointer() != context.GetPointer())
   {
-    itk::ReleaseContext();
     return EXIT_FAILURE;
   }
 
@@ -46,7 +44,6 @@ main()
 
   if (!context->IsCreated())
   {
-    itk::ReleaseContext();
     return EXIT_FAILURE;
   }
 
@@ -57,6 +54,5 @@ main()
   }
 
   // Release and exit
-  itk::ReleaseContext();
   return EXIT_SUCCESS;
 }

--- a/Testing/itkOpenCLEventTest.cxx
+++ b/Testing/itkOpenCLEventTest.cxx
@@ -18,6 +18,8 @@
 #include "itkTestHelper.h"
 #include "itkOpenCLEventTest.h"
 
+#include "itkOpenCLContextScopeGuard.h"
+
 int
 main()
 {
@@ -33,9 +35,9 @@ main()
     // Create and check OpenCL context
     if (!itk::CreateContext())
     {
-      itk::ReleaseContext();
       return EXIT_FAILURE;
     }
+    const itk::OpenCLContextScopeGuard openCLContextScopeGuard{};
 
     itk::OpenCLContext::Pointer context = itk::OpenCLContext::GetInstance();
 
@@ -43,14 +45,12 @@ main()
 #ifdef OPENCL_PROFILING
     if (!context->GetDefaultCommandQueue().IsProfilingEnabled())
     {
-      itk::ReleaseContext();
       return EXIT_FAILURE;
     }
 #else
     itk::OpenCLCommandQueue queue = context->CreateCommandQueue(CL_QUEUE_PROFILING_ENABLE);
     if (!queue.IsProfilingEnabled())
     {
-      itk::ReleaseContext();
       return EXIT_FAILURE;
     }
     context->SetCommandQueue(queue);
@@ -90,25 +90,21 @@ main()
     // Check the event execution times
     if (event.GetFinishTime() == 0)
     {
-      itk::ReleaseContext();
       return EXIT_FAILURE;
     }
 
     if (event.GetSubmitTime() <= event.GetQueueTime())
     {
-      itk::ReleaseContext();
       return EXIT_FAILURE;
     }
 
     if (event.GetRunTime() <= event.GetSubmitTime())
     {
-      itk::ReleaseContext();
       return EXIT_FAILURE;
     }
 
     if (event.GetFinishTime() <= event.GetRunTime())
     {
-      itk::ReleaseContext();
       return EXIT_FAILURE;
     }
 
@@ -117,10 +113,8 @@ main()
   catch (itk::ExceptionObject & e)
   {
     std::cerr << "Caught ITK exception: " << e << std::endl;
-    itk::ReleaseContext();
     return EXIT_FAILURE;
   }
 
-  itk::ReleaseContext();
   return EXIT_SUCCESS;
 }

--- a/Testing/itkOpenCLImageTest.cxx
+++ b/Testing/itkOpenCLImageTest.cxx
@@ -39,7 +39,6 @@ main()
     if (!context->IsCreated())
     {
       std::cerr << "OpenCL-enabled device is not present." << std::endl;
-      itk::ReleaseContext();
       return EXIT_FAILURE;
     }
 
@@ -111,10 +110,8 @@ main()
   catch (itk::ExceptionObject & e)
   {
     std::cerr << "Caught ITK exception: " << e << std::endl;
-    itk::ReleaseContext();
     return EXIT_FAILURE;
   }
 
-  itk::ReleaseContext();
   return EXIT_SUCCESS;
 }

--- a/Testing/itkOpenCLKernelManagerTest.cxx
+++ b/Testing/itkOpenCLKernelManagerTest.cxx
@@ -25,17 +25,14 @@ main()
   context->Create(itk::OpenCLContext::DevelopmentSingleMaximumFlopsDevice);
   if (!context->IsCreated())
   {
-    itk::ReleaseContext();
     return EXIT_FAILURE;
   }
 
   itk::OpenCLKernelManager::Pointer kernelManager = itk::OpenCLKernelManager::New();
   if (kernelManager.IsNull())
   {
-    itk::ReleaseContext();
     return EXIT_FAILURE;
   }
 
-  itk::ReleaseContext();
   return EXIT_SUCCESS;
 }

--- a/Testing/itkOpenCLKernelToImageBridgeTest.cxx
+++ b/Testing/itkOpenCLKernelToImageBridgeTest.cxx
@@ -91,10 +91,8 @@ main()
   catch (itk::ExceptionObject & e)
   {
     std::cerr << "Caught ITK exception: " << e << std::endl;
-    itk::ReleaseContext();
     return EXIT_FAILURE;
   }
 
-  itk::ReleaseContext();
   return EXIT_SUCCESS;
 }

--- a/Testing/itkOpenCLSamplerTest.cxx
+++ b/Testing/itkOpenCLSamplerTest.cxx
@@ -40,17 +40,14 @@ main()
 
     if (sampler.IsNull())
     {
-      itk::ReleaseContext();
       return EXIT_FAILURE;
     }
   }
   catch (itk::ExceptionObject & e)
   {
     std::cerr << "Caught ITK exception: " << e << std::endl;
-    itk::ReleaseContext();
     return EXIT_FAILURE;
   }
 
-  itk::ReleaseContext();
   return EXIT_SUCCESS;
 }

--- a/Testing/itkOpenCLSimpleTest.cxx
+++ b/Testing/itkOpenCLSimpleTest.cxx
@@ -70,10 +70,8 @@ main()
   catch (itk::ExceptionObject & e)
   {
     std::cerr << "Caught ITK exception: " << e << std::endl;
-    itk::ReleaseContext();
     return EXIT_FAILURE;
   }
 
-  itk::ReleaseContext();
   return EXIT_SUCCESS;
 }

--- a/Testing/itkOpenCLSizeTest.cxx
+++ b/Testing/itkOpenCLSizeTest.cxx
@@ -44,10 +44,8 @@ main()
   catch (itk::ExceptionObject & e)
   {
     std::cerr << "Caught ITK exception: " << e << std::endl;
-    itk::ReleaseContext();
     return EXIT_FAILURE;
   }
 
-  itk::ReleaseContext();
   return EXIT_SUCCESS;
 }

--- a/Testing/itkOpenCLVectorTest.cxx
+++ b/Testing/itkOpenCLVectorTest.cxx
@@ -167,10 +167,8 @@ main(int argc, char * argv[])
   catch (itk::ExceptionObject & e)
   {
     std::cerr << "Caught ITK exception: " << e << std::endl;
-    itk::ReleaseContext();
     return EXIT_FAILURE;
   }
 
-  itk::ReleaseContext();
   return EXIT_SUCCESS;
 }


### PR DESCRIPTION
The tests for any GPUMatrixOffset transform (Affine, Euler and Similarity) were failing since the final output from the GPU was an empty image - it did not cause any code crash, but high RMSE between CPU and GPU instead. I think that the error was introduced by commit https://github.com/SuperElastix/elastix/commit/b556886c26c0a9301d81325e6dbb9d4365c68a76, when fixing issue https://github.com/SuperElastix/elastix/issues/647. The `inverse_matrix` data member of the structs `GPUMatrixOffsetTransformBase1D/2D/3D` were the only ones not removed, effectively passing unitialized memory to the GPU. This PR fixes that. In addition, it adds a random seed as in commit https://github.com/SuperElastix/elastix/commit/bb0b4fb9177ca3987d394769988b2af765fec6e7, and removes the calls to `ReleaseContext()` as in commit https://github.com/SuperElastix/elastix/commit/278a27b0feacbc9d7f65386c356a958c5517182b.

Overall, together with PR https://github.com/SuperElastix/elastix/pull/734 (already merged), the existing issues https://github.com/SuperElastix/elastix/issues/70, https://github.com/SuperElastix/elastix/issues/107, https://github.com/SuperElastix/elastix/issues/218, and maybe https://github.com/SuperElastix/elastix/issues/226, all related to running OpenCL in Elastix, should be fixed. All tests pass for me now! :) 

@N-Dekker, could you please review it? 
@dpshamonin, could you run your extensive benchmarks based on this PR?