### PR TITLE
BUG: Do not try to load targets file when embedded

### DIFF
--- a/ElastixConfig.cmake.in
+++ b/ElastixConfig.cmake.in
@@ -28,7 +28,8 @@ endif()
 
 # Import ELASTIX targets.
 set( ELASTIX_CONFIG_TARGETS_FILE "${_ELASTIXConfig_DIR}/ElastixTargets.cmake")
-if(NOT ELASTIX_TARGETS_IMPORTED)
+list( GET ELASTIX_LIBRARIES 0 _first_library)
+if(NOT ELASTIX_TARGETS_IMPORTED AND NOT TARGET ${_first_library})
   set(ELASTIX_TARGETS_IMPORTED 1)
   include("${ELASTIX_CONFIG_TARGETS_FILE}")
 endif()


### PR DESCRIPTION
When elastix is embedded with add_subdirectory in cases like CMake FetchContent, the targets will be created, and we should not try to use the target exports file.