### PR TITLE
Move the private member functions of ParameterFileParser to an unnamed namespace

### DIFF
--- a/Common/ParameterFileParser/itkParameterFileParser.cxx
+++ b/Common/ParameterFileParser/itkParameterFileParser.cxx
@@ -209,8 +209,7 @@ ParameterFileParser::CheckLine(const std::string & lineIn, std::string & lineOut
   /** 3. Check if line is between brackets. */
   if (!itksys::SystemTools::StringStartsWith(lineOut, "(") || !itksys::SystemTools::StringEndsWith(lineOut, ")"))
   {
-    const std::string hint = "Line is not between brackets: \"(...)\".";
-    ThrowException(lineIn, hint);
+    ThrowException(lineIn, "Line is not between brackets: \"(...)\".");
   }
 
   /** Remove brackets. */
@@ -221,8 +220,7 @@ ParameterFileParser::CheckLine(const std::string & lineIn, std::string & lineOut
   const bool                match4 = reTwoWords.find(lineOut);
   if (!match4)
   {
-    const std::string hint = "Line does not contain a parameter name and value.";
-    ThrowException(lineIn, hint);
+    ThrowException(lineIn, "Line does not contain a parameter name and value.");
   }
 
   /** At this point we know its at least a line containing a parameter.
@@ -275,15 +273,14 @@ ParameterFileParser::GetParameterFromLine(const std::string & fullLine, const st
   const bool                match = reInvalidCharacters1.find(parameterName);
   if (match)
   {
-    const std::string hint = "The parameter \"" + parameterName + "\" contains invalid characters (.,:;!@#$%^&-+|<>?).";
-    ThrowException(fullLine, hint);
+    ThrowException(fullLine,
+                   "The parameter \"" + parameterName + "\" contains invalid characters (.,:;!@#$%^&-+|<>?).");
   }
 
   /** 5) Insert this combination in the parameter map. */
   if (this->m_ParameterMap.count(parameterName))
   {
-    const std::string hint = "The parameter \"" + parameterName + "\" is specified more than once.";
-    ThrowException(fullLine, hint);
+    ThrowException(fullLine, "The parameter \"" + parameterName + "\" is specified more than once.");
   }
   else
   {
@@ -313,8 +310,7 @@ ParameterFileParser::SplitLine(const std::string &        fullLine,
   if (numQuotes % 2 == 1)
   {
     /** An invalid parameter line. */
-    const std::string hint = "This line has an odd number of quotes (\").";
-    ThrowException(fullLine, hint);
+    ThrowException(fullLine, "This line has an odd number of quotes (\").");
   }
 
   /** Loop over the line. */

--- a/Common/ParameterFileParser/itkParameterFileParser.cxx
+++ b/Common/ParameterFileParser/itkParameterFileParser.cxx
@@ -149,121 +149,12 @@ GetParameterFromLine(ParameterFileParser::ParameterMapType & parameterMap,
 } // end GetParameterFromLine()
 
 
-} // namespace
-
-/**
- * **************** Constructor ***************
- */
-
-ParameterFileParser::ParameterFileParser() = default;
-
-
-/**
- * **************** Destructor ***************
- */
-
-ParameterFileParser ::~ParameterFileParser() = default;
-
-
-/**
- * **************** GetParameterMap ***************
- */
-
-const ParameterFileParser::ParameterMapType &
-ParameterFileParser::GetParameterMap() const
-{
-  return this->m_ParameterMap;
-
-} // end GetParameterMap()
-
-
-/**
- * **************** ReadParameterFile ***************
- */
-
-void
-ParameterFileParser::ReadParameterFile()
-{
-  /** Perform some basic checks. */
-  this->BasicFileChecking();
-
-  /** Open the parameter file for reading. */
-  std::ifstream parameterFile(this->m_ParameterFileName);
-
-  /** Check if it opened. */
-  if (!parameterFile.is_open())
-  {
-    itkExceptionMacro(<< "ERROR: could not open " << this->m_ParameterFileName << " for reading.");
-  }
-
-  /** Clear the map. */
-  this->m_ParameterMap.clear();
-
-  /** Loop over the parameter file, line by line. */
-  std::string lineIn;
-  std::string lineOut;
-  while (parameterFile.good())
-  {
-    /** Extract a line. */
-    itksys::SystemTools::GetLineFromStream(parameterFile, lineIn);
-
-    /** Check this line. */
-    const bool validLine = this->CheckLine(lineIn, lineOut);
-
-    if (validLine)
-    {
-      /** Get the parameter name from this line and store it. */
-      GetParameterFromLine(m_ParameterMap, lineIn, lineOut);
-    }
-    // Otherwise, we simply ignore this line
-  }
-
-} // end ReadParameterFile()
-
-
-/**
- * **************** BasicFileChecking ***************
- */
-
-void
-ParameterFileParser::BasicFileChecking() const
-{
-  /** Check if the file name is given. */
-  if (this->m_ParameterFileName.empty())
-  {
-    itkExceptionMacro(<< "ERROR: FileName has not been set.");
-  }
-
-  /** Basic error checking: existence. */
-  const bool exists = itksys::SystemTools::FileExists(this->m_ParameterFileName);
-  if (!exists)
-  {
-    itkExceptionMacro(<< "ERROR: the file " << this->m_ParameterFileName << " does not exist.");
-  }
-
-  /** Basic error checking: file or directory. */
-  const bool isDir = itksys::SystemTools::FileIsDirectory(this->m_ParameterFileName);
-  if (isDir)
-  {
-    itkExceptionMacro(<< "ERROR: the file " << this->m_ParameterFileName << " is a directory.");
-  }
-
-  /** Check the extension. */
-  const std::string ext = itksys::SystemTools::GetFilenameLastExtension(this->m_ParameterFileName);
-  if (ext != ".txt")
-  {
-    itkExceptionMacro(<< "ERROR: the file " << this->m_ParameterFileName << " should be a text file (*.txt).");
-  }
-
-} // end BasicFileChecking()
-
-
-/**
- * **************** CheckLine ***************
- */
-
+// Checks a line.
+// - Returns  true if it is a valid line: containing a parameter.
+// - Returns false if it is a valid line: empty or comment.
+// - Throws an exception if it is not a valid line.
 bool
-ParameterFileParser::CheckLine(const std::string & lineIn, std::string & lineOut) const
+CheckLine(const std::string & lineIn, std::string & lineOut)
 {
   /** Preprocessing of lineIn:
    * 1) Replace tabs with spaces
@@ -340,8 +231,115 @@ ParameterFileParser::CheckLine(const std::string & lineIn, std::string & lineOut
    */
 
   return true;
+}
 
-} // end CheckLine()
+} // namespace
+
+/**
+ * **************** Constructor ***************
+ */
+
+ParameterFileParser::ParameterFileParser() = default;
+
+
+/**
+ * **************** Destructor ***************
+ */
+
+ParameterFileParser ::~ParameterFileParser() = default;
+
+
+/**
+ * **************** GetParameterMap ***************
+ */
+
+const ParameterFileParser::ParameterMapType &
+ParameterFileParser::GetParameterMap() const
+{
+  return this->m_ParameterMap;
+
+} // end GetParameterMap()
+
+
+/**
+ * **************** ReadParameterFile ***************
+ */
+
+void
+ParameterFileParser::ReadParameterFile()
+{
+  /** Perform some basic checks. */
+  this->BasicFileChecking();
+
+  /** Open the parameter file for reading. */
+  std::ifstream parameterFile(this->m_ParameterFileName);
+
+  /** Check if it opened. */
+  if (!parameterFile.is_open())
+  {
+    itkExceptionMacro(<< "ERROR: could not open " << this->m_ParameterFileName << " for reading.");
+  }
+
+  /** Clear the map. */
+  this->m_ParameterMap.clear();
+
+  /** Loop over the parameter file, line by line. */
+  std::string lineIn;
+  std::string lineOut;
+  while (parameterFile.good())
+  {
+    /** Extract a line. */
+    itksys::SystemTools::GetLineFromStream(parameterFile, lineIn);
+
+    /** Check this line. */
+    const bool validLine = CheckLine(lineIn, lineOut);
+
+    if (validLine)
+    {
+      /** Get the parameter name from this line and store it. */
+      GetParameterFromLine(m_ParameterMap, lineIn, lineOut);
+    }
+    // Otherwise, we simply ignore this line
+  }
+
+} // end ReadParameterFile()
+
+
+/**
+ * **************** BasicFileChecking ***************
+ */
+
+void
+ParameterFileParser::BasicFileChecking() const
+{
+  /** Check if the file name is given. */
+  if (this->m_ParameterFileName.empty())
+  {
+    itkExceptionMacro(<< "ERROR: FileName has not been set.");
+  }
+
+  /** Basic error checking: existence. */
+  const bool exists = itksys::SystemTools::FileExists(this->m_ParameterFileName);
+  if (!exists)
+  {
+    itkExceptionMacro(<< "ERROR: the file " << this->m_ParameterFileName << " does not exist.");
+  }
+
+  /** Basic error checking: file or directory. */
+  const bool isDir = itksys::SystemTools::FileIsDirectory(this->m_ParameterFileName);
+  if (isDir)
+  {
+    itkExceptionMacro(<< "ERROR: the file " << this->m_ParameterFileName << " is a directory.");
+  }
+
+  /** Check the extension. */
+  const std::string ext = itksys::SystemTools::GetFilenameLastExtension(this->m_ParameterFileName);
+  if (ext != ".txt")
+  {
+    itkExceptionMacro(<< "ERROR: the file " << this->m_ParameterFileName << " should be a text file (*.txt).");
+  }
+
+} // end BasicFileChecking()
 
 
 /**

--- a/Common/ParameterFileParser/itkParameterFileParser.cxx
+++ b/Common/ParameterFileParser/itkParameterFileParser.cxx
@@ -41,11 +41,10 @@ ThrowException(const std::string & line, const std::string & hint)
 
 
 // Splits a line in parameter name and values.
-void
-SplitLine(const std::string & fullLine, const std::string & line, std::vector<std::string> & splittedLine)
+std::vector<std::string>
+SplitLine(const std::string & fullLine, const std::string & line)
 {
-  splittedLine.clear();
-  splittedLine.resize(1);
+  std::vector<std::string> splittedLine(1);
 
   /** Count the number of quotes in the line. If it is an odd value, the
    * line contains an error; strings should start and end with a quote, so
@@ -91,6 +90,7 @@ SplitLine(const std::string & fullLine, const std::string & line, std::vector<st
       splittedLine[index].push_back(currentChar);
     }
   }
+  return splittedLine;
 
 } // end SplitLine()
 
@@ -305,8 +305,7 @@ ParameterFileParser::GetParameterFromLine(const std::string & fullLine, const st
    */
 
   /** 1) Split the line. */
-  std::vector<std::string> splittedLine;
-  SplitLine(fullLine, line, splittedLine);
+  std::vector<std::string> splittedLine = SplitLine(fullLine, line);
 
   /** 2) Get the parameter name. */
   std::string parameterName = splittedLine[0];

--- a/Common/ParameterFileParser/itkParameterFileParser.cxx
+++ b/Common/ParameterFileParser/itkParameterFileParser.cxx
@@ -27,6 +27,20 @@
 namespace itk
 {
 
+namespace
+{
+// Uniform way to throw exceptions when the parameter file appears to be invalid.
+void
+ThrowException(const std::string & line, const std::string & hint)
+{
+  itkGenericExceptionMacro("ERROR: the following line in your parameter file is invalid: \n\""
+                           << line + "\"\n"
+                           << hint << "\nPlease correct you parameter file!");
+
+} // end ThrowException()
+
+} // namespace
+
 /**
  * **************** Constructor ***************
  */
@@ -196,7 +210,7 @@ ParameterFileParser::CheckLine(const std::string & lineIn, std::string & lineOut
   if (!itksys::SystemTools::StringStartsWith(lineOut, "(") || !itksys::SystemTools::StringEndsWith(lineOut, ")"))
   {
     const std::string hint = "Line is not between brackets: \"(...)\".";
-    this->ThrowException(lineIn, hint);
+    ThrowException(lineIn, hint);
   }
 
   /** Remove brackets. */
@@ -208,7 +222,7 @@ ParameterFileParser::CheckLine(const std::string & lineIn, std::string & lineOut
   if (!match4)
   {
     const std::string hint = "Line does not contain a parameter name and value.";
-    this->ThrowException(lineIn, hint);
+    ThrowException(lineIn, hint);
   }
 
   /** At this point we know its at least a line containing a parameter.
@@ -262,14 +276,14 @@ ParameterFileParser::GetParameterFromLine(const std::string & fullLine, const st
   if (match)
   {
     const std::string hint = "The parameter \"" + parameterName + "\" contains invalid characters (.,:;!@#$%^&-+|<>?).";
-    this->ThrowException(fullLine, hint);
+    ThrowException(fullLine, hint);
   }
 
   /** 5) Insert this combination in the parameter map. */
   if (this->m_ParameterMap.count(parameterName))
   {
     const std::string hint = "The parameter \"" + parameterName + "\" is specified more than once.";
-    this->ThrowException(fullLine, hint);
+    ThrowException(fullLine, hint);
   }
   else
   {
@@ -300,7 +314,7 @@ ParameterFileParser::SplitLine(const std::string &        fullLine,
   {
     /** An invalid parameter line. */
     const std::string hint = "This line has an odd number of quotes (\").";
-    this->ThrowException(fullLine, hint);
+    ThrowException(fullLine, hint);
   }
 
   /** Loop over the line. */
@@ -338,20 +352,6 @@ ParameterFileParser::SplitLine(const std::string &        fullLine,
   }
 
 } // end SplitLine()
-
-
-/**
- * **************** ThrowException ***************
- */
-
-void
-ParameterFileParser::ThrowException(const std::string & line, const std::string & hint) const
-{
-  itkExceptionMacro("ERROR: the following line in your parameter file is invalid: \n\""
-                    << line + "\"\n"
-                    << hint << "\nPlease correct you parameter file!");
-
-} // end ThrowException()
 
 
 /**

--- a/Common/ParameterFileParser/itkParameterFileParser.cxx
+++ b/Common/ParameterFileParser/itkParameterFileParser.cxx
@@ -233,6 +233,44 @@ CheckLine(const std::string & lineIn, std::string & lineOut)
   return true;
 }
 
+
+// Performs the following checks:
+// - Is a filename is given
+// - Does the file exist
+// - Is a text file, i.e. does it end with .txt
+// If one of these conditions fail, an exception is thrown.
+void
+BasicFileChecking(const std::string & parameterFileName)
+{
+  /** Check if the file name is given. */
+  if (parameterFileName.empty())
+  {
+    itkGenericExceptionMacro("ERROR: FileName has not been set.");
+  }
+
+  /** Basic error checking: existence. */
+  const bool exists = itksys::SystemTools::FileExists(parameterFileName);
+  if (!exists)
+  {
+    itkGenericExceptionMacro("ERROR: the file " << parameterFileName << " does not exist.");
+  }
+
+  /** Basic error checking: file or directory. */
+  const bool isDir = itksys::SystemTools::FileIsDirectory(parameterFileName);
+  if (isDir)
+  {
+    itkGenericExceptionMacro("ERROR: the file " << parameterFileName << " is a directory.");
+  }
+
+  /** Check the extension. */
+  const std::string ext = itksys::SystemTools::GetFilenameLastExtension(parameterFileName);
+  if (ext != ".txt")
+  {
+    itkGenericExceptionMacro("ERROR: the file " << parameterFileName << " should be a text file (*.txt).");
+  }
+
+} // end BasicFileChecking()
+
 } // namespace
 
 /**
@@ -269,7 +307,7 @@ void
 ParameterFileParser::ReadParameterFile()
 {
   /** Perform some basic checks. */
-  this->BasicFileChecking();
+  BasicFileChecking(m_ParameterFileName);
 
   /** Open the parameter file for reading. */
   std::ifstream parameterFile(this->m_ParameterFileName);
@@ -306,43 +344,6 @@ ParameterFileParser::ReadParameterFile()
 
 
 /**
- * **************** BasicFileChecking ***************
- */
-
-void
-ParameterFileParser::BasicFileChecking() const
-{
-  /** Check if the file name is given. */
-  if (this->m_ParameterFileName.empty())
-  {
-    itkExceptionMacro(<< "ERROR: FileName has not been set.");
-  }
-
-  /** Basic error checking: existence. */
-  const bool exists = itksys::SystemTools::FileExists(this->m_ParameterFileName);
-  if (!exists)
-  {
-    itkExceptionMacro(<< "ERROR: the file " << this->m_ParameterFileName << " does not exist.");
-  }
-
-  /** Basic error checking: file or directory. */
-  const bool isDir = itksys::SystemTools::FileIsDirectory(this->m_ParameterFileName);
-  if (isDir)
-  {
-    itkExceptionMacro(<< "ERROR: the file " << this->m_ParameterFileName << " is a directory.");
-  }
-
-  /** Check the extension. */
-  const std::string ext = itksys::SystemTools::GetFilenameLastExtension(this->m_ParameterFileName);
-  if (ext != ".txt")
-  {
-    itkExceptionMacro(<< "ERROR: the file " << this->m_ParameterFileName << " should be a text file (*.txt).");
-  }
-
-} // end BasicFileChecking()
-
-
-/**
  * **************** ReturnParameterFileAsString ***************
  */
 
@@ -350,7 +351,7 @@ std::string
 ParameterFileParser::ReturnParameterFileAsString()
 {
   /** Perform some basic checks. */
-  this->BasicFileChecking();
+  BasicFileChecking(m_ParameterFileName);
 
   /** Open the parameter file for reading. */
   std::ifstream parameterFile(this->m_ParameterFileName);

--- a/Common/ParameterFileParser/itkParameterFileParser.cxx
+++ b/Common/ParameterFileParser/itkParameterFileParser.cxx
@@ -39,6 +39,61 @@ ThrowException(const std::string & line, const std::string & hint)
 
 } // end ThrowException()
 
+
+// Splits a line in parameter name and values.
+void
+SplitLine(const std::string & fullLine, const std::string & line, std::vector<std::string> & splittedLine)
+{
+  splittedLine.clear();
+  splittedLine.resize(1);
+
+  /** Count the number of quotes in the line. If it is an odd value, the
+   * line contains an error; strings should start and end with a quote, so
+   * the total number of quotes is even.
+   */
+  std::size_t numQuotes = itksys::SystemTools::CountChar(line.c_str(), '"');
+  if (numQuotes % 2 == 1)
+  {
+    /** An invalid parameter line. */
+    ThrowException(fullLine, "This line has an odd number of quotes (\").");
+  }
+
+  /** Loop over the line. */
+  unsigned int index = 0;
+  numQuotes = 0;
+  for (const char currentChar : line)
+  {
+    if (currentChar == '"')
+    {
+      /** Start a new element. */
+      splittedLine.push_back("");
+      ++index;
+      ++numQuotes;
+    }
+    else if (currentChar == ' ')
+    {
+      /** Only start a new element if it is not a quote, otherwise just add
+       * the space to the string.
+       */
+      if (numQuotes % 2 == 0)
+      {
+        splittedLine.push_back("");
+        ++index;
+      }
+      else
+      {
+        splittedLine[index].push_back(currentChar);
+      }
+    }
+    else
+    {
+      /** Add this character to the element. */
+      splittedLine[index].push_back(currentChar);
+    }
+  }
+
+} // end SplitLine()
+
 } // namespace
 
 /**
@@ -251,7 +306,7 @@ ParameterFileParser::GetParameterFromLine(const std::string & fullLine, const st
 
   /** 1) Split the line. */
   std::vector<std::string> splittedLine;
-  this->SplitLine(fullLine, line, splittedLine);
+  SplitLine(fullLine, line, splittedLine);
 
   /** 2) Get the parameter name. */
   std::string parameterName = splittedLine[0];
@@ -288,66 +343,6 @@ ParameterFileParser::GetParameterFromLine(const std::string & fullLine, const st
   }
 
 } // end GetParameterFromLine()
-
-
-/**
- * **************** SplitLine ***************
- */
-
-void
-ParameterFileParser::SplitLine(const std::string &        fullLine,
-                               const std::string &        line,
-                               std::vector<std::string> & splittedLine) const
-{
-  splittedLine.clear();
-  splittedLine.resize(1);
-
-  /** Count the number of quotes in the line. If it is an odd value, the
-   * line contains an error; strings should start and end with a quote, so
-   * the total number of quotes is even.
-   */
-  std::size_t numQuotes = itksys::SystemTools::CountChar(line.c_str(), '"');
-  if (numQuotes % 2 == 1)
-  {
-    /** An invalid parameter line. */
-    ThrowException(fullLine, "This line has an odd number of quotes (\").");
-  }
-
-  /** Loop over the line. */
-  unsigned int index = 0;
-  numQuotes = 0;
-  for (const char currentChar : line)
-  {
-    if (currentChar == '"')
-    {
-      /** Start a new element. */
-      splittedLine.push_back("");
-      ++index;
-      ++numQuotes;
-    }
-    else if (currentChar == ' ')
-    {
-      /** Only start a new element if it is not a quote, otherwise just add
-       * the space to the string.
-       */
-      if (numQuotes % 2 == 0)
-      {
-        splittedLine.push_back("");
-        ++index;
-      }
-      else
-      {
-        splittedLine[index].push_back(currentChar);
-      }
-    }
-    else
-    {
-      /** Add this character to the element. */
-      splittedLine[index].push_back(currentChar);
-    }
-  }
-
-} // end SplitLine()
 
 
 /**

--- a/Common/ParameterFileParser/itkParameterFileParser.cxx
+++ b/Common/ParameterFileParser/itkParameterFileParser.cxx
@@ -347,12 +347,9 @@ ParameterFileParser::SplitLine(const std::string &        fullLine,
 void
 ParameterFileParser::ThrowException(const std::string & line, const std::string & hint) const
 {
-  /** Construct an error message. */
-  const std::string errorMessage = "ERROR: the following line in your parameter file is invalid: \n\"" + line + "\"\n" +
-                                   hint + "\nPlease correct you parameter file!";
-
-  /** Throw exception. */
-  itkExceptionMacro(<< errorMessage);
+  itkExceptionMacro("ERROR: the following line in your parameter file is invalid: \n\""
+                    << line + "\"\n"
+                    << hint << "\nPlease correct you parameter file!");
 
 } // end ThrowException()
 

--- a/Common/ParameterFileParser/itkParameterFileParser.h
+++ b/Common/ParameterFileParser/itkParameterFileParser.h
@@ -132,14 +132,6 @@ private:
   void
   BasicFileChecking() const;
 
-  /** Checks a line.
-   * - Returns  true if it is a valid line: containing a parameter.
-   * - Returns false if it is a valid line: empty or comment.
-   * - Throws an exception if it is not a valid line.
-   */
-  bool
-  CheckLine(const std::string & line, std::string & lineOut) const;
-
   /** Member variables. */
   std::string      m_ParameterFileName;
   ParameterMapType m_ParameterMap;

--- a/Common/ParameterFileParser/itkParameterFileParser.h
+++ b/Common/ParameterFileParser/itkParameterFileParser.h
@@ -144,10 +144,6 @@ private:
   void
   GetParameterFromLine(const std::string & fullLine, const std::string & line);
 
-  /** Splits a line in parameter name and values. */
-  void
-  SplitLine(const std::string & fullLine, const std::string & line, std::vector<std::string> & splittedLine) const;
-
   /** Member variables. */
   std::string      m_ParameterFileName;
   ParameterMapType m_ParameterMap;

--- a/Common/ParameterFileParser/itkParameterFileParser.h
+++ b/Common/ParameterFileParser/itkParameterFileParser.h
@@ -148,12 +148,6 @@ private:
   void
   SplitLine(const std::string & fullLine, const std::string & line, std::vector<std::string> & splittedLine) const;
 
-  /** Uniform way to throw exceptions when the parameter file appears to be
-   * invalid.
-   */
-  void
-  ThrowException(const std::string & line, const std::string & hint) const;
-
   /** Member variables. */
   std::string      m_ParameterFileName;
   ParameterMapType m_ParameterMap;

--- a/Common/ParameterFileParser/itkParameterFileParser.h
+++ b/Common/ParameterFileParser/itkParameterFileParser.h
@@ -140,10 +140,6 @@ private:
   bool
   CheckLine(const std::string & line, std::string & lineOut) const;
 
-  /** Fills m_ParameterMap with valid entries. */
-  void
-  GetParameterFromLine(const std::string & fullLine, const std::string & line);
-
   /** Member variables. */
   std::string      m_ParameterFileName;
   ParameterMapType m_ParameterMap;

--- a/Common/ParameterFileParser/itkParameterFileParser.h
+++ b/Common/ParameterFileParser/itkParameterFileParser.h
@@ -123,15 +123,6 @@ protected:
   ~ParameterFileParser() override;
 
 private:
-  /** Performs the following checks:
-   * - Is a filename is given
-   * - Does the file exist
-   * - Is a text file, i.e. does it end with .txt
-   * If one of these conditions fail, an exception is thrown.
-   */
-  void
-  BasicFileChecking() const;
-
   /** Member variables. */
   std::string      m_ParameterFileName;
   ParameterMapType m_ParameterMap;


### PR DESCRIPTION
Following C++ Core Guidelines, September 23, 2022, _Use an unnamed (anonymous) namespace for all internal/non-exported entities_, https://isocpp.github.io/CppCoreGuidelines/CppCoreGuidelines#sf22-use-an-unnamed-anonymous-namespace-for-all-internalnon-exported-entities

Did a few more style improvements in itkParameterFileParser.cxx 