### PR TITLE
STYLE: Remove redundant SetOutputDirection(GetIdentity()) calls

### DIFF
--- a/Components/Metrics/DistancePreservingRigidityPenalty/elxDistancePreservingRigidityPenaltyTerm.hxx
+++ b/Components/Metrics/DistancePreservingRigidityPenalty/elxDistancePreservingRigidityPenaltyTerm.hxx
@@ -48,7 +48,6 @@ DistancePreservingRigidityPenalty<TElastix>::BeforeRegistration()
 
   /** Possibly overrule the direction cosines. */
   ChangeInfoFilterPointer infoChanger = ChangeInfoFilterType::New();
-  infoChanger->SetOutputDirection(DirectionType::GetIdentity());
   infoChanger->SetChangeDirection(!this->GetElastix()->GetUseDirectionCosines());
 
   /** Do the reading. */

--- a/Components/Metrics/RigidityPenalty/elxTransformRigidityPenaltyTerm.hxx
+++ b/Components/Metrics/RigidityPenalty/elxTransformRigidityPenaltyTerm.hxx
@@ -51,7 +51,6 @@ TransformRigidityPenalty<TElastix>::BeforeRegistration()
 
     /** Possibly overrule the direction cosines. */
     ChangeInfoFilterPointer infoChanger = ChangeInfoFilterType::New();
-    infoChanger->SetOutputDirection(DirectionType::GetIdentity());
     infoChanger->SetChangeDirection(!this->GetElastix()->GetUseDirectionCosines());
 
     /** Do the reading. */
@@ -92,7 +91,6 @@ TransformRigidityPenalty<TElastix>::BeforeRegistration()
 
     /** Possibly overrule the direction cosines. */
     ChangeInfoFilterPointer infoChanger = ChangeInfoFilterType::New();
-    infoChanger->SetOutputDirection(DirectionType::GetIdentity());
     infoChanger->SetChangeDirection(!this->GetElastix()->GetUseDirectionCosines());
 
     /** Do the reading. */

--- a/Components/Transforms/DeformationFieldTransform/elxDeformationFieldTransform.hxx
+++ b/Components/Transforms/DeformationFieldTransform/elxDeformationFieldTransform.hxx
@@ -79,7 +79,6 @@ DeformationFieldTransform<TElastix>::ReadFromFile()
 
   /** Possibly overrule the direction cosines. */
   ChangeInfoFilterPointer infoChanger = ChangeInfoFilterType::New();
-  infoChanger->SetOutputDirection(DirectionType::GetIdentity());
   infoChanger->SetChangeDirection(!this->GetElastix()->GetUseDirectionCosines());
 
   try

--- a/Core/Kernel/elxElastixBase.h
+++ b/Core/Kernel/elxElastixBase.h
@@ -453,7 +453,6 @@ protected:
       for (const auto & fileName : *fileNameContainer)
       {
         const auto infoChanger = itk::ChangeInformationImageFilter<TImage>::New();
-        infoChanger->SetOutputDirection(DirectionType::GetIdentity());
         infoChanger->SetChangeDirection(!useDirectionCosines);
 
         /** Do the reading. */


### PR DESCRIPTION
The `OutputDirection` of an `itk::ChangeInformationImageFilter` is already the identity matrix by default. It was already the identity matrix by default with ITK commit e974315f3ebec0c35db4d717cfca59ba95c37c9f "ENH: now supports changing direction." by Bill Lorensen, April 18, 2005: https://github.com/InsightSoftwareConsortium/ITK/blob/e974315f3ebec0c35db4d717cfca59ba95c37c9f/Code/BasicFilters/itkChangeInformationImageFilter.txx#L46