### PR TITLE
ENH: Add TransformixFilter SpatialJacobian, DeterminantOfSpatialJacobian

### DIFF
--- a/Core/Kernel/elxElastixTemplate.hxx
+++ b/Core/Kernel/elxElastixTemplate.hxx
@@ -332,7 +332,7 @@ ElastixTemplate<TFixedImage, TMovingImage>::ApplyTransform()
   timer.Stop();
   elxout << "  Transforming points done, it took " << Conversion::SecondsToDHMS(timer.GetMean(), 2) << std::endl;
 
-  /** Call ComputeDeterminantOfSpatialJacobian.
+  /** Call ComputeSpatialJacobianDeterminantImage.
    * Actually we could loop over all transforms.
    * But for now, there seems to be no use yet for that.
    */
@@ -341,7 +341,7 @@ ElastixTemplate<TFixedImage, TMovingImage>::ApplyTransform()
   elxout << "Compute determinant of spatial Jacobian ..." << std::endl;
   try
   {
-    elxTransformBase.ComputeDeterminantOfSpatialJacobian();
+    elxTransformBase.ComputeAndWriteSpatialJacobianDeterminantImage();
   }
   catch (const itk::ExceptionObject & excp)
   {
@@ -352,7 +352,7 @@ ElastixTemplate<TFixedImage, TMovingImage>::ApplyTransform()
   elxout << "  Computing determinant of spatial Jacobian done, it took "
          << Conversion::SecondsToDHMS(timer.GetMean(), 2) << std::endl;
 
-  /** Call ComputeSpatialJacobian.
+  /** Call ComputeAndWriteSpatialJacobianMatrixImage.
    * Actually we could loop over all transforms.
    * But for now, there seems to be no use yet for that.
    */
@@ -361,7 +361,7 @@ ElastixTemplate<TFixedImage, TMovingImage>::ApplyTransform()
   elxout << "Compute spatial Jacobian (full matrix) ..." << std::endl;
   try
   {
-    elxTransformBase.ComputeSpatialJacobian();
+    elxTransformBase.ComputeAndWriteSpatialJacobianMatrixImage();
   }
   catch (const itk::ExceptionObject & excp)
   {

--- a/Core/Main/itkTransformixFilter.h
+++ b/Core/Main/itkTransformixFilter.h
@@ -39,6 +39,8 @@
 #include "itkMesh.h"
 #include "itkTransformBase.h"
 
+#include "elxElastixTemplate.h"
+#include "elxTransformBase.h"
 #include "elxTransformixMain.h"
 #include "elxParameterObject.h"
 
@@ -100,6 +102,11 @@ public:
   itkStaticConstMacro(MovingImageDimension, unsigned int, TMovingImage::ImageDimension);
 
   using MeshType = Mesh<OutputImagePixelType, MovingImageDimension>;
+
+  /** Typedefs for images of determinants of spatial Jacobian matrices, and images of spatial Jacobian matrices */
+  using SpatialJacobianDeterminantImageType = itk::Image<float, MovingImageDimension>;
+  using SpatialJacobianMatrixImageType =
+    itk::Image<itk::Matrix<float, MovingImageDimension, MovingImageDimension>, MovingImageDimension>;
 
   /** Set/Get/Add moving image. */
   virtual void
@@ -218,6 +225,16 @@ public:
    * transform object, with additional information from the specified transform parameter object. */
   itkSetConstObjectMacro(Transform, TransformBase);
 
+  /** Computes the spatial Jacobian determinant for each pixel, and returns an image of the computed values.
+  \note Before calling this member function, Update() must be called. */
+  SmartPointer<SpatialJacobianDeterminantImageType>
+  ComputeSpatialJacobianDeterminantImage() const;
+
+  /** Computes the spatial Jacobian matrix for each pixel, and returns an image of the computed matrices.
+  \note Before calling this member function, Update() must be called. */
+  SmartPointer<SpatialJacobianMatrixImageType>
+  ComputeSpatialJacobianMatrixImage() const;
+
 protected:
   TransformixFilter();
 
@@ -247,6 +264,13 @@ private:
    *  from ProcessObject and TransformixFilter.
    */
   using ProcessObject::RemoveInput;
+
+  using ElastixTransformBaseType = elx::TransformBase<elx::ElastixTemplate<TMovingImage, TMovingImage>>;
+
+  const ElastixTransformBaseType *
+  GetFirstElastixTransformBase() const;
+
+  SmartPointer<const elx::TransformixMain> m_TransformixMain{ nullptr };
 
   std::string m_FixedPointSetFileName{};
   bool        m_ComputeSpatialJacobian{ false };


### PR DESCRIPTION
This commit adds two `itk::TransformixFilter` member functions, `ComputeSpatialJacobianDeterminantImage()` and `ComputeSpatialJacobianMatrixImage()`, both producing an `itk::Image`.

It has replaced the old `elx::TransformBase` member functions ComputeDeterminantOfSpatialJacobian() and ComputeSpatialJacobian() by `ComputeAndWriteSpatialJacobianDeterminantImage()` and `ComputeAndWriteSpatialJacobianMatrixImage()`, respectively. And it has added `elx::TransformBase` member functions `ComputeSpatialJacobianDeterminantImage()` and `ComputeSpatialJacobianMatrixImage()`, which just produce the image, but do not write the result to disk.