### PR TITLE
STYLE: Remove unnecessary `inline` keywords from "itk*.h" files

### DIFF
--- a/Common/CostFunctions/itkAdvancedImageToImageMetric.h
+++ b/Common/CostFunctions/itkAdvancedImageToImageMetric.h
@@ -375,12 +375,12 @@ protected:
   /** Multi-threaded metric computation. */
 
   /** Multi-threaded version of GetValue(). */
-  virtual inline void
+  virtual void
   ThreadedGetValue(ThreadIdType threadID)
   {}
 
   /** Finalize multi-threaded metric computation. */
-  virtual inline void
+  virtual void
   AfterThreadedGetValue(MeasureType & value) const
   {}
 
@@ -393,12 +393,12 @@ protected:
   LaunchGetValueThreaderCallback() const;
 
   /** Multi-threaded version of GetValueAndDerivative(). */
-  virtual inline void
+  virtual void
   ThreadedGetValueAndDerivative(ThreadIdType threadID)
   {}
 
   /** Finalize multi-threaded metric computation. */
-  virtual inline void
+  virtual void
   AfterThreadedGetValueAndDerivative(MeasureType & value, DerivativeType & derivative) const
   {}
 

--- a/Common/CostFunctions/itkParzenWindowHistogramImageToImageMetric.h
+++ b/Common/CostFunctions/itkParzenWindowHistogramImageToImageMetric.h
@@ -302,11 +302,11 @@ protected:
   InitializeThreadingParameters() const override;
 
   /** Multi-threaded versions of the ComputePDF function. */
-  inline void
+  void
   ThreadedComputePDFs(ThreadIdType threadId);
 
   /** Single-threadedly accumulate results. */
-  inline void
+  void
   AfterThreadedComputePDFs() const;
 
   /** Helper function to launch the threads. */

--- a/Common/Transforms/itkAdvancedCombinationTransform.h
+++ b/Common/Transforms/itkAdvancedCombinationTransform.h
@@ -321,21 +321,21 @@ protected:
    */
 
   /** ADDITION: \f$T(x) = T_0(x) + T_1(x) - x\f$ */
-  inline OutputPointType
+  OutputPointType
   TransformPointUseAddition(const InputPointType & point) const;
 
   /** COMPOSITION: \f$T(x) = T_1( T_0(x) )\f$
    * \warning: assumes that input and output point type are the same.
    */
-  inline OutputPointType
+  OutputPointType
   TransformPointUseComposition(const InputPointType & point) const;
 
   /** CURRENT ONLY: \f$T(x) = T_1(x)\f$ */
-  inline OutputPointType
+  OutputPointType
   TransformPointNoInitialTransform(const InputPointType & point) const;
 
   /** NO CURRENT TRANSFORM SET: throw an exception. */
-  inline OutputPointType
+  OutputPointType
   TransformPointNoCurrentTransform(const InputPointType & point) const;
 
   /** ************************************************
@@ -343,21 +343,21 @@ protected:
    */
 
   /** ADDITION: \f$J(x) = J_1(x)\f$ */
-  inline void
+  void
   GetJacobianUseAddition(const InputPointType &, JacobianType &, NonZeroJacobianIndicesType &) const;
 
   /** COMPOSITION: \f$J(x) = J_1( T_0(x) )\f$
    * \warning: assumes that input and output point type are the same.
    */
-  inline void
+  void
   GetJacobianUseComposition(const InputPointType &, JacobianType &, NonZeroJacobianIndicesType &) const;
 
   /** CURRENT ONLY: \f$J(x) = J_1(x)\f$ */
-  inline void
+  void
   GetJacobianNoInitialTransform(const InputPointType &, JacobianType &, NonZeroJacobianIndicesType &) const;
 
   /** NO CURRENT TRANSFORM SET: throw an exception. */
-  inline void
+  void
   GetJacobianNoCurrentTransform(const InputPointType &, JacobianType &, NonZeroJacobianIndicesType &) const;
 
   /** ************************************************
@@ -365,7 +365,7 @@ protected:
    */
 
   /** ADDITION: \f$J(x) = J_1(x)\f$ */
-  inline void
+  void
   EvaluateJacobianWithImageGradientProductUseAddition(const InputPointType &,
                                                       const MovingImageGradientType &,
                                                       DerivativeType &,
@@ -374,21 +374,21 @@ protected:
   /** COMPOSITION: \f$J(x) = J_1( T_0(x) )\f$
    * \warning: assumes that input and output point type are the same.
    */
-  inline void
+  void
   EvaluateJacobianWithImageGradientProductUseComposition(const InputPointType &,
                                                          const MovingImageGradientType &,
                                                          DerivativeType &,
                                                          NonZeroJacobianIndicesType &) const;
 
   /** CURRENT ONLY: \f$J(x) = J_1(x)\f$ */
-  inline void
+  void
   EvaluateJacobianWithImageGradientProductNoInitialTransform(const InputPointType &,
                                                              const MovingImageGradientType &,
                                                              DerivativeType &,
                                                              NonZeroJacobianIndicesType &) const;
 
   /** NO CURRENT TRANSFORM SET: throw an exception. */
-  inline void
+  void
   EvaluateJacobianWithImageGradientProductNoCurrentTransform(const InputPointType &,
                                                              const MovingImageGradientType &,
                                                              DerivativeType &,
@@ -399,21 +399,21 @@ protected:
    */
 
   /** ADDITION: \f$J(x) = J_1(x)\f$ */
-  inline void
+  void
   GetSpatialJacobianUseAddition(const InputPointType & inputPoint, SpatialJacobianType & sj) const;
 
   /** COMPOSITION: \f$J(x) = J_1( T_0(x) )\f$
    * \warning: assumes that input and output point type are the same.
    */
-  inline void
+  void
   GetSpatialJacobianUseComposition(const InputPointType & inputPoint, SpatialJacobianType & sj) const;
 
   /** CURRENT ONLY: \f$J(x) = J_1(x)\f$ */
-  inline void
+  void
   GetSpatialJacobianNoInitialTransform(const InputPointType & inputPoint, SpatialJacobianType & sj) const;
 
   /** NO CURRENT TRANSFORM SET: throw an exception. */
-  inline void
+  void
   GetSpatialJacobianNoCurrentTransform(const InputPointType & inputPoint, SpatialJacobianType & sj) const;
 
   /** ************************************************
@@ -421,21 +421,21 @@ protected:
    */
 
   /** ADDITION: \f$J(x) = J_1(x)\f$ */
-  inline void
+  void
   GetSpatialHessianUseAddition(const InputPointType & inputPoint, SpatialHessianType & sh) const;
 
   /** COMPOSITION: \f$J(x) = J_1( T_0(x) )\f$
    * \warning: assumes that input and output point type are the same.
    */
-  inline void
+  void
   GetSpatialHessianUseComposition(const InputPointType & inputPoint, SpatialHessianType & sh) const;
 
   /** CURRENT ONLY: \f$J(x) = J_1(x)\f$ */
-  inline void
+  void
   GetSpatialHessianNoInitialTransform(const InputPointType & inputPoint, SpatialHessianType & sh) const;
 
   /** NO CURRENT TRANSFORM SET: throw an exception. */
-  inline void
+  void
   GetSpatialHessianNoCurrentTransform(const InputPointType & inputPoint, SpatialHessianType & sh) const;
 
   /** ************************************************
@@ -443,12 +443,12 @@ protected:
    */
 
   /** ADDITION: \f$J(x) = J_1(x)\f$ */
-  inline void
+  void
   GetJacobianOfSpatialJacobianUseAddition(const InputPointType &          inputPoint,
                                           JacobianOfSpatialJacobianType & jsj,
                                           NonZeroJacobianIndicesType &    nonZeroJacobianIndices) const;
 
-  inline void
+  void
   GetJacobianOfSpatialJacobianUseAddition(const InputPointType &          inputPoint,
                                           SpatialJacobianType &           sj,
                                           JacobianOfSpatialJacobianType & jsj,
@@ -457,36 +457,36 @@ protected:
   /** COMPOSITION: \f$J(x) = J_1( T_0(x) )\f$
    * \warning: assumes that input and output point type are the same.
    */
-  inline void
+  void
   GetJacobianOfSpatialJacobianUseComposition(const InputPointType &          inputPoint,
                                              JacobianOfSpatialJacobianType & jsj,
                                              NonZeroJacobianIndicesType &    nonZeroJacobianIndices) const;
 
-  inline void
+  void
   GetJacobianOfSpatialJacobianUseComposition(const InputPointType &          inputPoint,
                                              SpatialJacobianType &           sj,
                                              JacobianOfSpatialJacobianType & jsj,
                                              NonZeroJacobianIndicesType &    nonZeroJacobianIndices) const;
 
   /** CURRENT ONLY: \f$J(x) = J_1(x)\f$ */
-  inline void
+  void
   GetJacobianOfSpatialJacobianNoInitialTransform(const InputPointType &          inputPoint,
                                                  JacobianOfSpatialJacobianType & jsj,
                                                  NonZeroJacobianIndicesType &    nonZeroJacobianIndices) const;
 
-  inline void
+  void
   GetJacobianOfSpatialJacobianNoInitialTransform(const InputPointType &          inputPoint,
                                                  SpatialJacobianType &           sj,
                                                  JacobianOfSpatialJacobianType & jsj,
                                                  NonZeroJacobianIndicesType &    nonZeroJacobianIndices) const;
 
   /** NO CURRENT TRANSFORM SET: throw an exception. */
-  inline void
+  void
   GetJacobianOfSpatialJacobianNoCurrentTransform(const InputPointType &          inputPoint,
                                                  JacobianOfSpatialJacobianType & jsj,
                                                  NonZeroJacobianIndicesType &    nonZeroJacobianIndices) const;
 
-  inline void
+  void
   GetJacobianOfSpatialJacobianNoCurrentTransform(const InputPointType &          inputPoint,
                                                  SpatialJacobianType &           sj,
                                                  JacobianOfSpatialJacobianType & jsj,
@@ -497,12 +497,12 @@ protected:
    */
 
   /** ADDITION: \f$J(x) = J_1(x)\f$ */
-  inline void
+  void
   GetJacobianOfSpatialHessianUseAddition(const InputPointType &         inputPoint,
                                          JacobianOfSpatialHessianType & jsh,
                                          NonZeroJacobianIndicesType &   nonZeroJacobianIndices) const;
 
-  inline void
+  void
   GetJacobianOfSpatialHessianUseAddition(const InputPointType &         inputPoint,
                                          SpatialHessianType &           sh,
                                          JacobianOfSpatialHessianType & jsh,
@@ -511,36 +511,36 @@ protected:
   /** COMPOSITION: \f$J(x) = J_1( T_0(x) )\f$
    * \warning: assumes that input and output point type are the same.
    */
-  inline void
+  void
   GetJacobianOfSpatialHessianUseComposition(const InputPointType &         inputPoint,
                                             JacobianOfSpatialHessianType & jsh,
                                             NonZeroJacobianIndicesType &   nonZeroJacobianIndices) const;
 
-  inline void
+  void
   GetJacobianOfSpatialHessianUseComposition(const InputPointType &         inputPoint,
                                             SpatialHessianType &           sh,
                                             JacobianOfSpatialHessianType & jsh,
                                             NonZeroJacobianIndicesType &   nonZeroJacobianIndices) const;
 
   /** CURRENT ONLY: \f$J(x) = J_1(x)\f$ */
-  inline void
+  void
   GetJacobianOfSpatialHessianNoInitialTransform(const InputPointType &         inputPoint,
                                                 JacobianOfSpatialHessianType & jsh,
                                                 NonZeroJacobianIndicesType &   nonZeroJacobianIndices) const;
 
-  inline void
+  void
   GetJacobianOfSpatialHessianNoInitialTransform(const InputPointType &         inputPoint,
                                                 SpatialHessianType &           sh,
                                                 JacobianOfSpatialHessianType & jsh,
                                                 NonZeroJacobianIndicesType &   nonZeroJacobianIndices) const;
 
   /** NO CURRENT TRANSFORM SET: throw an exception. */
-  inline void
+  void
   GetJacobianOfSpatialHessianNoCurrentTransform(const InputPointType &         inputPoint,
                                                 JacobianOfSpatialHessianType & jsh,
                                                 NonZeroJacobianIndicesType &   nonZeroJacobianIndices) const;
 
-  inline void
+  void
   GetJacobianOfSpatialHessianNoCurrentTransform(const InputPointType &         inputPoint,
                                                 SpatialHessianType &           sh,
                                                 JacobianOfSpatialHessianType & jsh,

--- a/Common/Transforms/itkAdvancedImageMomentsCalculator.h
+++ b/Common/Transforms/itkAdvancedImageMomentsCalculator.h
@@ -269,7 +269,7 @@ protected:
   ComputeThreaderCallback(void * arg);
 
   /** The threaded implementation of Compute(). */
-  virtual inline void
+  virtual void
   ThreadedCompute(ThreadIdType threadID);
 
   /** Initialize some multi-threading related parameters. */

--- a/Common/Transforms/itkBSplineDerivativeKernelFunction2.h
+++ b/Common/Transforms/itkBSplineDerivativeKernelFunction2.h
@@ -94,7 +94,7 @@ public:
 
 
   /** Evaluate the function. */
-  inline double
+  double
   Evaluate(const double & u) const override
   {
     return Self::FastEvaluate(u);
@@ -102,7 +102,7 @@ public:
 
 
   /** Evaluate the function. */
-  inline void
+  void
   Evaluate(const double & u, double * weights) const override
   {
     return Self::FastEvaluate(u, weights);
@@ -131,7 +131,7 @@ private:
   // Derivative not defined.
 
   /** First order spline */
-  inline static double
+  static double
   Evaluate(const Dispatch<1> &, const double u)
   {
     const double absValue = std::abs(u);
@@ -151,7 +151,7 @@ private:
   }
 
 
-  inline static void
+  static void
   Evaluate(const Dispatch<1> &, const double u, double * weights)
   {
     // MS \todo: check
@@ -176,7 +176,7 @@ private:
 
 
   /** Second order spline. */
-  inline static double
+  static double
   Evaluate(const Dispatch<2> &, const double u)
   {
     double absValue = std::abs(u);
@@ -196,7 +196,7 @@ private:
   }
 
 
-  inline static void
+  static void
   Evaluate(const Dispatch<2> &, const double u, double * weights)
   {
     // MS \todo: check
@@ -207,7 +207,7 @@ private:
 
 
   /**  Third order spline. */
-  inline static double
+  static double
   Evaluate(const Dispatch<3> &, const double u)
   {
     const double absValue = std::abs(u);
@@ -246,7 +246,7 @@ private:
   }
 
 
-  inline static void
+  static void
   Evaluate(const Dispatch<3> &, const double u, double * weights)
   {
     const double absValue = std::abs(u);

--- a/Common/Transforms/itkBSplineKernelFunction2.h
+++ b/Common/Transforms/itkBSplineKernelFunction2.h
@@ -98,7 +98,7 @@ public:
 
 
   /** Evaluate the function at one point. */
-  inline double
+  double
   Evaluate(const double & u) const override
   {
     return Self::FastEvaluate(u);
@@ -108,7 +108,7 @@ public:
   /** Evaluate the function at the entire support. This is slightly faster,
    * since no if's are needed.
    */
-  inline void
+  void
   Evaluate(const double & u, double * weights) const override
   {
     Self::FastEvaluate(u, weights);
@@ -138,7 +138,7 @@ private:
    */
 
   /** Zeroth order spline. */
-  inline static double
+  static double
   Evaluate(const Dispatch<0> &, const double u)
   {
     const double absValue = std::abs(u);
@@ -159,7 +159,7 @@ private:
 
 
   /** First order spline */
-  inline static double
+  static double
   Evaluate(const Dispatch<1> &, const double u)
   {
     const double absValue = std::abs(u);
@@ -176,7 +176,7 @@ private:
 
 
   /** Second order spline. */
-  inline static double
+  static double
   Evaluate(const Dispatch<2> &, const double u)
   {
     const double absValue = std::abs(u);
@@ -197,7 +197,7 @@ private:
 
 
   /** Third order spline. */
-  inline static double
+  static double
   Evaluate(const Dispatch<3> &, const double u)
   {
     const double absValue = std::abs(u);
@@ -223,7 +223,7 @@ private:
    */
 
   /** Zeroth order spline. */
-  inline static void
+  static void
   Evaluate(const Dispatch<0> &, const double u, double * weights)
   {
     const double absValue = std::abs(u);
@@ -244,7 +244,7 @@ private:
 
 
   /** First order spline */
-  inline static void
+  static void
   Evaluate(const Dispatch<1> &, const double u, double * weights)
   {
     const double absValue = std::abs(u);
@@ -255,7 +255,7 @@ private:
 
 
   /** Second order spline. */
-  inline static void
+  static void
   Evaluate(const Dispatch<2> &, const double u, double * weights)
   {
     const double absValue = std::abs(u);
@@ -268,7 +268,7 @@ private:
 
 
   /**  Third order spline. */
-  inline static void
+  static void
   Evaluate(const Dispatch<3> &, const double u, double * weights)
   {
     const double absValue = std::abs(u);

--- a/Common/Transforms/itkBSplineSecondOrderDerivativeKernelFunction2.h
+++ b/Common/Transforms/itkBSplineSecondOrderDerivativeKernelFunction2.h
@@ -79,7 +79,7 @@ public:
 
 
   /** Evaluate the function. */
-  inline double
+  double
   Evaluate(const double & u) const override
   {
     return Self::FastEvaluate(u);
@@ -87,7 +87,7 @@ public:
 
 
   /** Evaluate the function. */
-  inline void
+  void
   Evaluate(const double u, double * weights) const
   {
     Self::FastEvaluate(u, weights);
@@ -121,7 +121,7 @@ private:
   // Second order derivative not defined.
 
   /** Second order spline. */
-  inline static double
+  static double
   Evaluate(const Dispatch<2> &, const double u)
   {
     double absValue = std::abs(u);
@@ -149,7 +149,7 @@ private:
   }
 
 
-  inline static void
+  static void
   Evaluate(const Dispatch<2> &, const double u, double * weights)
   {
     weights[0] = 1.0;
@@ -159,7 +159,7 @@ private:
 
 
   /**  Third order spline. */
-  inline static double
+  static double
   Evaluate(const Dispatch<3> &, const double u)
   {
     const double absValue = std::abs(u);
@@ -179,7 +179,7 @@ private:
   }
 
 
-  inline static void
+  static void
   Evaluate(const Dispatch<3> &, const double u, double * weights)
   {
     weights[0] = -u + 2.0;
@@ -190,14 +190,14 @@ private:
 
 
   /** Unimplemented spline order */
-  inline static double
+  static double
   Evaluate(const DispatchBase &, const double)
   {
     itkGenericExceptionMacro("Evaluate not implemented for spline order " << SplineOrder);
   }
 
 
-  inline static void
+  static void
   Evaluate(const DispatchBase &, const double, double *)
   {
     itkGenericExceptionMacro("Evaluate not implemented for spline order " << SplineOrder);

--- a/Common/Transforms/itkRecursiveBSplineTransformImplementation.h
+++ b/Common/Transforms/itkRecursiveBSplineTransformImplementation.h
@@ -57,7 +57,7 @@ public:
   itkStaticConstMacro(BSplineNumberOfIndices, unsigned int, RecursiveBSplineWeightFunctionType::NumberOfIndices);
 
   /** TransformPoint recursive implementation. */
-  static inline void
+  static void
   TransformPoint(TScalar * const               opp,
                  const TScalar * const * const mu,
                  const OffsetValueType * const gridOffsetTable,
@@ -91,7 +91,7 @@ public:
 
 
   /** GetJacobian recursive implementation. */
-  static inline void
+  static void
   GetJacobian(TScalar *& jacobians, const double * const weights1D, const double value)
   {
     for (unsigned int k = 0; k <= SplineOrder; ++k)
@@ -104,7 +104,7 @@ public:
 
 
   /** EvaluateJacobianWithImageGradientProduct recursive implementation. */
-  static inline void
+  static void
   EvaluateJacobianWithImageGradientProduct(TScalar *&                      imageJacobian,
                                            const InternalFloatType * const movingImageGradient,
                                            const double * const            weights1D,
@@ -121,7 +121,7 @@ public:
 
 
   /** ComputeNonZeroJacobianIndices recursive implementation. */
-  static inline void
+  static void
   ComputeNonZeroJacobianIndices(unsigned long *&              nzji,
                                 const unsigned long           parametersPerDim,
                                 unsigned long                 currentIndex,
@@ -143,7 +143,7 @@ public:
    * As an (almost) free by-product this function delivers the displacement,
    * i.e. the TransformPoint() function.
    */
-  static inline void
+  static void
   GetSpatialJacobian(InternalFloatType * const     sj,
                      const TScalar * const * const mu,
                      const OffsetValueType * const gridOffsetTable,
@@ -205,7 +205,7 @@ public:
    *
    * Note that we store only one of the symmetric halves of Hk.
    */
-  static inline void
+  static void
   GetSpatialHessian(InternalFloatType * const     sh,
                     const TScalar * const * const mu,
                     const OffsetValueType * const gridOffsetTable,
@@ -265,7 +265,7 @@ public:
   /** GetJacobianOfSpatialJacobian recursive implementation.
    * Multiplication with the direction cosines is performed in the end-case.
    */
-  static inline void
+  static void
   GetJacobianOfSpatialJacobian(InternalFloatType *&            jsj_out,
                                const double * const            weights1D,           // normal B-spline weights
                                const double * const            derivativeWeights1D, // 1st derivative of B-spline
@@ -301,7 +301,7 @@ public:
   /** GetJacobianOfSpatialHessian recursive implementation.
    * Multiplication with the direction cosines is performed in the end - case.
    */
-  static inline void
+  static void
   GetJacobianOfSpatialHessian(InternalFloatType *&            jsh_out,
                               const double * const            weights1D,           // normal B-spline weights
                               const double * const            derivativeWeights1D, // 1st derivative of B-spline
@@ -365,7 +365,7 @@ public:
   itkStaticConstMacro(BSplineNumberOfIndices, unsigned int, RecursiveBSplineWeightFunctionType::NumberOfIndices);
 
   /** TransformPoint recursive implementation. */
-  static inline void
+  static void
   TransformPoint(TScalar * const               opp,
                  const TScalar * const * const mu,
                  const OffsetValueType * const gridOffsetTable,
@@ -379,7 +379,7 @@ public:
 
 
   /** GetJacobian recursive implementation. */
-  static inline void
+  static void
   GetJacobian(TScalar *& jacobians, const double * const weights1D, const double value)
   {
     unsigned long offset = 0;
@@ -393,7 +393,7 @@ public:
 
 
   /** EvaluateJacobianWithImageGradientProduct recursive implementation. */
-  static inline void
+  static void
   EvaluateJacobianWithImageGradientProduct(TScalar *&                      imageJacobian,
                                            const InternalFloatType * const movingImageGradient,
                                            const double * const            weights1D,
@@ -408,7 +408,7 @@ public:
 
 
   /** ComputeNonZeroJacobianIndices recursive implementation. */
-  static inline void
+  static void
   ComputeNonZeroJacobianIndices(unsigned long *&              nzji,
                                 const unsigned long           parametersPerDim,
                                 const unsigned long           currentIndex,
@@ -423,7 +423,7 @@ public:
 
 
   /** GetSpatialJacobian recursive implementation. */
-  static inline void
+  static void
   GetSpatialJacobian(InternalFloatType * const     sj,
                      const TScalar * const * const mu,
                      const OffsetValueType * const gridOffsetTable,
@@ -438,7 +438,7 @@ public:
 
 
   /** GetSpatialHessian recursive implementation. */
-  static inline void
+  static void
   GetSpatialHessian(InternalFloatType * const     sh,
                     const TScalar * const * const mu,
                     const OffsetValueType * const gridOffsetTable,
@@ -454,7 +454,7 @@ public:
 
 
   /** GetJacobianOfSpatialJacobian recursive implementation. */
-  static inline void
+  static void
   GetJacobianOfSpatialJacobian(InternalFloatType *&            jsj_out,
                                const double * const            weights1D,           // normal B-spline weights
                                const double * const            derivativeWeights1D, // 1st derivative of B-spline
@@ -493,7 +493,7 @@ public:
 
 
   /** GetJacobianOfSpatialHessian recursive implementation. */
-  static inline void
+  static void
   GetJacobianOfSpatialHessian(InternalFloatType *&            jsh_out,
                               const double * const            weights1D,           // normal B-spline weights
                               const double * const            derivativeWeights1D, // 1st derivative of B-spline

--- a/Common/itkAdvancedLinearInterpolateImageFunction.h
+++ b/Common/itkAdvancedLinearInterpolateImageFunction.h
@@ -131,21 +131,21 @@ private:
   {};
 
   /** Method to compute both the value and the derivative. 2D specialization. */
-  inline void
+  void
   EvaluateValueAndDerivativeOptimized(const Dispatch<2> &,
                                       const ContinuousIndexType & x,
                                       OutputType &                value,
                                       CovariantVectorType &       deriv) const;
 
   /** Method to compute both the value and the derivative. 3D specialization. */
-  inline void
+  void
   EvaluateValueAndDerivativeOptimized(const Dispatch<3> &,
                                       const ContinuousIndexType & x,
                                       OutputType &                value,
                                       CovariantVectorType &       deriv) const;
 
   /** Method to compute both the value and the derivative. Generic. */
-  inline void
+  void
   EvaluateValueAndDerivativeOptimized(const DispatchBase &,
                                       const ContinuousIndexType & x,
                                       OutputType &                value,
@@ -156,7 +156,7 @@ private:
 
 
   /** Method to compute both the value and the derivative. Generic. */
-  inline void
+  void
   EvaluateValueAndDerivativeUnOptimized(const ContinuousIndexType & x,
                                         OutputType &                value,
                                         CovariantVectorType &       deriv) const

--- a/Common/itkAdvancedRayCastInterpolateImageFunction.h
+++ b/Common/itkAdvancedRayCastInterpolateImageFunction.h
@@ -168,7 +168,7 @@ public:
   /** Check if a point is inside the image buffer.
    * \warning For efficiency, no validity checking of
    * the input image pointer is done. */
-  inline bool
+  bool
   IsInsideBuffer(const PointType &) const override
   {
     return true;

--- a/Common/itkComputeDisplacementDistribution.h
+++ b/Common/itkComputeDisplacementDistribution.h
@@ -192,7 +192,7 @@ protected:
   ComputeThreaderCallback(void * arg);
 
   /** The threaded implementation of Compute(). */
-  virtual inline void
+  virtual void
   ThreadedCompute(ThreadIdType threadID);
 
   /** Initialize some multi-threading related parameters. */

--- a/Common/itkNDImageTemplate.h
+++ b/Common/itkNDImageTemplate.h
@@ -240,7 +240,7 @@ protected:
   class ITK_TEMPLATE_EXPORT ConvertToDynamicArray
   {
   public:
-    inline static TOut
+    static TOut
     DO(const TIn & in)
     {
       TOut out(VDimension);
@@ -257,7 +257,7 @@ protected:
   class ITK_TEMPLATE_EXPORT ConvertToStaticArray
   {
   public:
-    inline static TOut
+    static TOut
     DO(const TIn & in)
     {
       TOut out;

--- a/Components/Metrics/AdvancedKappaStatistic/itkAdvancedKappaStatisticImageToImageMetric.h
+++ b/Components/Metrics/AdvancedKappaStatistic/itkAdvancedKappaStatisticImageToImageMetric.h
@@ -213,11 +213,11 @@ protected:
   InitializeThreadingParameters() const override;
 
   /** Get value and derivatives for each thread. */
-  inline void
+  void
   ThreadedGetValueAndDerivative(ThreadIdType threadID) override;
 
   /** Gather the values and derivatives from all threads */
-  inline void
+  void
   AfterThreadedGetValueAndDerivative(MeasureType & value, DerivativeType & derivative) const override;
 
   /** AccumulateDerivatives threader callback function */

--- a/Components/Metrics/AdvancedMattesMutualInformation/itkParzenWindowMutualInformationImageToImageMetric.h
+++ b/Components/Metrics/AdvancedMattesMutualInformation/itkParzenWindowMutualInformationImageToImageMetric.h
@@ -239,11 +239,11 @@ protected:
   ParzenWindowMutualInformationMultiThreaderParameterType m_ParzenWindowMutualInformationThreaderParameters;
 
   /** Multi-threaded versions of the ComputePDF function. */
-  inline void
+  void
   ThreadedComputeDerivativeLowMemory(ThreadIdType threadId);
 
   /** Single-threadedly accumulate results. */
-  inline void
+  void
   AfterThreadedComputeDerivativeLowMemory(DerivativeType & derivative) const;
 
   /** Helper function to launch the threads. */

--- a/Components/Metrics/AdvancedMeanSquares/itkAdvancedMeanSquaresImageToImageMetric.h
+++ b/Components/Metrics/AdvancedMeanSquares/itkAdvancedMeanSquaresImageToImageMetric.h
@@ -237,19 +237,19 @@ protected:
                          HessianType &                      H) const;
 
   /** Get value for each thread. */
-  inline void
+  void
   ThreadedGetValue(ThreadIdType threadID) override;
 
   /** Gather the values from all threads. */
-  inline void
+  void
   AfterThreadedGetValue(MeasureType & value) const override;
 
   /** Get value and derivatives for each thread. */
-  inline void
+  void
   ThreadedGetValueAndDerivative(ThreadIdType threadID) override;
 
   /** Gather the values and derivatives from all threads. */
-  inline void
+  void
   AfterThreadedGetValueAndDerivative(MeasureType & value, DerivativeType & derivative) const override;
 
 private:

--- a/Components/Metrics/AdvancedNormalizedCorrelation/itkAdvancedNormalizedCorrelationImageToImageMetric.h
+++ b/Components/Metrics/AdvancedNormalizedCorrelation/itkAdvancedNormalizedCorrelationImageToImageMetric.h
@@ -226,11 +226,11 @@ protected:
   InitializeThreadingParameters() const override;
 
   /** Get value and derivatives for each thread. */
-  inline void
+  void
   ThreadedGetValueAndDerivative(ThreadIdType threadID) override;
 
   /** Gather the values and derivatives from all threads */
-  inline void
+  void
   AfterThreadedGetValueAndDerivative(MeasureType & value, DerivativeType & derivative) const override;
 
   /** AccumulateDerivatives threader callback function */

--- a/Components/Metrics/BendingEnergyPenalty/itkTransformBendingEnergyPenaltyTerm.h
+++ b/Components/Metrics/BendingEnergyPenalty/itkTransformBendingEnergyPenaltyTerm.h
@@ -145,11 +145,11 @@ public:
                         DerivativeType &       derivative) const override;
 
   /** Get value and derivatives for each thread. */
-  inline void
+  void
   ThreadedGetValueAndDerivative(ThreadIdType threadID) override;
 
   /** Gather the values and derivatives from all threads */
-  inline void
+  void
   AfterThreadedGetValueAndDerivative(MeasureType & value, DerivativeType & derivative) const override;
 
   /** Experimental feature: compute SelfHessian */

--- a/Components/Metrics/PCAMetric/itkPCAMetric_F_multithreaded.h
+++ b/Components/Metrics/PCAMetric/itkPCAMetric_F_multithreaded.h
@@ -167,17 +167,17 @@ protected:
                                         DerivativeType &                  imageJacobian) const override;
 
   /** Get value and derivatives for each thread. */
-  inline void
+  void
   ThreadedGetSamples(ThreadIdType threadID);
 
-  inline void
+  void
   ThreadedComputeDerivative(ThreadIdType threadID);
 
   /** Gather the values and derivatives from all threads */
-  inline void
+  void
   AfterThreadedGetSamples(MeasureType & value) const;
 
-  inline void
+  void
   AfterThreadedComputeDerivative(DerivativeType & derivative) const;
 
   /** Helper function to launch the threads. */

--- a/Components/Metrics/SumSquaredTissueVolumeDifferenceMetric/itkSumSquaredTissueVolumeDifferenceImageToImageMetric.h
+++ b/Components/Metrics/SumSquaredTissueVolumeDifferenceMetric/itkSumSquaredTissueVolumeDifferenceImageToImageMetric.h
@@ -225,19 +225,19 @@ protected:
     DerivativeType &                      jacobianOfSpatialJacobianDeterminant) const;
 
   /** Get value for each thread. */
-  inline void
+  void
   ThreadedGetValue(ThreadIdType threadID) override;
 
   /** Gather the values from all threads. */
-  inline void
+  void
   AfterThreadedGetValue(MeasureType & value) const override;
 
   /** Get value and derivatives for each thread. */
-  inline void
+  void
   ThreadedGetValueAndDerivative(ThreadIdType threadId) override;
 
   /** Gather the values and derivatives from all threads */
-  inline void
+  void
   AfterThreadedGetValueAndDerivative(MeasureType & measure, DerivativeType & derivative) const override;
 
 private:

--- a/Components/Transforms/MultiBSplineTransformWithNormal/itkMultiBSplineDeformableTransformWithNormal.hxx
+++ b/Components/Transforms/MultiBSplineTransformWithNormal/itkMultiBSplineDeformableTransformWithNormal.hxx
@@ -629,7 +629,7 @@ MultiBSplineDeformableTransformWithNormal<TScalarType, NDimensions, VSplineOrder
 #undef LOOP_ON_LABELS
 
 template <class TScalarType, unsigned int NDimensions, unsigned int VSplineOrder>
-inline void
+void
 MultiBSplineDeformableTransformWithNormal<TScalarType, NDimensions, VSplineOrder>::PointToLabel(
   const InputPointType & p,
   int &                  l) const


### PR DESCRIPTION
According to deft_code, answering "When should I write the keyword 'inline' for a function/method?", November 18, 2009:

> Generally, declaring templates `inline` is pointless, as they have the linkage semantics of `inline` already.

https://stackoverflow.com/questions/1759300/when-should-i-write-the-keyword-inline-for-a-function-method/1759575#1759575