### PR TITLE
ElastixRegistrationMethod transform objects

### DIFF
--- a/Core/Kernel/elxElastixBase.h
+++ b/Core/Kernel/elxElastixBase.h
@@ -303,7 +303,7 @@ public:
 
   /** Empty ApplyTransform()-function to be overridden. */
   virtual int
-  ApplyTransform() = 0;
+  ApplyTransform(bool doReadTransform) = 0;
 
   /** Function that is called at the very beginning of ElastixTemplate::Run().
    * It checks the command line input arguments.

--- a/Core/Kernel/elxElastixTemplate.h
+++ b/Core/Kernel/elxElastixTemplate.h
@@ -217,7 +217,7 @@ public:
   Run() override;
 
   int
-  ApplyTransform() override;
+  ApplyTransform(bool doReadTransform) override;
 
   /** The Callback functions. */
   int

--- a/Core/Kernel/elxElastixTemplate.hxx
+++ b/Core/Kernel/elxElastixTemplate.hxx
@@ -255,7 +255,7 @@ ElastixTemplate<TFixedImage, TMovingImage>::Run()
 
 template <class TFixedImage, class TMovingImage>
 int
-ElastixTemplate<TFixedImage, TMovingImage>::ApplyTransform()
+ElastixTemplate<TFixedImage, TMovingImage>::ApplyTransform(const bool doReadTransform)
 {
   /** Timer. */
   itk::TimeProbe timer;
@@ -307,7 +307,11 @@ ElastixTemplate<TFixedImage, TMovingImage>::ApplyTransform()
   auto & elxTransformBase = *(this->GetElxTransformBase());
 
   elxResamplerBase.ReadFromFile();
-  elxTransformBase.ReadFromFile();
+
+  if (doReadTransform)
+  {
+    elxTransformBase.ReadFromFile();
+  }
 
   /** Tell the user. */
   timer.Stop();

--- a/Core/Kernel/elxTransformixMain.h
+++ b/Core/Kernel/elxTransformixMain.h
@@ -19,6 +19,7 @@
 #define elxTransformixMain_h
 
 #include "elxElastixMain.h"
+#include <itkTransformBase.h>
 
 namespace elastix
 {
@@ -90,8 +91,8 @@ public:
   Run(const ArgumentMapType & argmap, const ParameterMapType & inputMap) override;
 
   /** Run version for using transformix as library. */
-  virtual int
-  Run(const ArgumentMapType & argmap, const std::vector<ParameterMapType> & inputMaps);
+  int
+  Run(const ArgumentMapType & argmap, const std::vector<ParameterMapType> & inputMaps, itk::TransformBase * = nullptr);
 
   /** Get and Set input- and outputImage. */
   virtual void
@@ -106,6 +107,11 @@ protected:
    */
   int
   InitDBIndex() override;
+
+private:
+  /** Does Run with an optionally specified Transform. */
+  int
+  RunWithTransform(itk::TransformBase *);
 };
 
 } // end namespace elastix

--- a/Core/Main/GTesting/itkElastixRegistrationMethodGTest.cxx
+++ b/Core/Main/GTesting/itkElastixRegistrationMethodGTest.cxx
@@ -558,6 +558,36 @@ GTEST_TEST(itkElastixRegistrationMethod, InitialTransformParameterFileLinkToTran
 }
 
 
+GTEST_TEST(itkElastixRegistrationMethod, GetNumberOfTransforms)
+{
+  constexpr auto ImageDimension = 2U;
+  using ImageType = itk::Image<float, ImageDimension>;
+  const auto image =
+    CreateImageFilledWithSequenceOfNaturalNumbers<ImageType::PixelType>(itk::Size<ImageDimension>{ 5, 6 });
+
+  DefaultConstructibleElastixRegistrationMethod<ImageType, ImageType> registration;
+
+  registration.SetFixedImage(image);
+  registration.SetMovingImage(image);
+
+  for (const bool useInitialTransform : { false, true })
+  {
+    registration.SetInitialTransformParameterFileName(
+      useInitialTransform ? (GetDataDirectoryPath() + "/Translation(1,-2)/TransformParameters.txt") : "");
+
+    registration.SetParameterObject(CreateParameterObject({ // Parameters in alphabetic order:
+                                                            { "AutomaticTransformInitialization", "false" },
+                                                            { "ImageSampler", "Full" },
+                                                            { "MaximumNumberOfIterations", "0" },
+                                                            { "Metric", "AdvancedNormalizedCorrelation" },
+                                                            { "Optimizer", "AdaptiveStochasticGradientDescent" },
+                                                            { "Transform", "BSplineTransform" } }));
+    registration.Update();
+    EXPECT_EQ(registration.GetNumberOfTransforms(), useInitialTransform ? 2 : 1);
+  }
+}
+
+
 GTEST_TEST(itkElastixRegistrationMethod, WriteCompositeTransform)
 {
   constexpr auto ImageDimension = 2U;

--- a/Core/Main/GTesting/itkElastixRegistrationMethodGTest.cxx
+++ b/Core/Main/GTesting/itkElastixRegistrationMethodGTest.cxx
@@ -558,6 +558,64 @@ GTEST_TEST(itkElastixRegistrationMethod, InitialTransformParameterFileLinkToTran
 }
 
 
+GTEST_TEST(itkElastixRegistrationMethod, GetCombinationTransform)
+{
+  constexpr auto ImageDimension = 2U;
+  using ImageType = itk::Image<float, ImageDimension>;
+  const auto image =
+    CreateImageFilledWithSequenceOfNaturalNumbers<ImageType::PixelType>(itk::Size<ImageDimension>{ 5, 6 });
+
+  struct NameAndItkTransform
+  {
+    const char *                                                    name;
+    itk::Transform<double, ImageDimension, ImageDimension>::Pointer itkTransform;
+  };
+
+  DefaultConstructibleElastixRegistrationMethod<ImageType, ImageType> registration;
+  registration.SetFixedImage(image);
+  registration.SetMovingImage(image);
+
+  const std::string rootOutputDirectoryPath = GetCurrentBinaryDirectoryPath() + '/' + GetNameOfTest(*this);
+  itk::FileTools::CreateDirectory(rootOutputDirectoryPath);
+
+  for (const bool useInitialTransform : { false, true })
+  {
+    registration.SetInitialTransformParameterFileName(
+      useInitialTransform ? (GetDataDirectoryPath() + "/Translation(1,-2)/TransformParameters.txt") : "");
+
+    const std::string outputSubdirectoryPath =
+      rootOutputDirectoryPath + "/" + (useInitialTransform ? "InitialTranslation(1,-2)" : "NoInitialTransform");
+    itk::FileTools::CreateDirectory(outputSubdirectoryPath);
+
+    for (const auto nameAndItkTransform :
+         { NameAndItkTransform{ "AffineTransform", itk::AffineTransform<double, ImageDimension>::New() },
+           NameAndItkTransform{ "BSplineTransform", itk::BSplineTransform<double, ImageDimension>::New() },
+           NameAndItkTransform{ "EulerTransform", itk::Euler2DTransform<>::New() },
+           NameAndItkTransform{ "RecursiveBSplineTransform", itk::BSplineTransform<double, ImageDimension>::New() },
+           NameAndItkTransform{ "SimilarityTransform", itk::Similarity2DTransform<>::New() },
+           NameAndItkTransform{ "TranslationTransform", itk::TranslationTransform<double, ImageDimension>::New() } })
+    {
+      const auto & expectedItkTransform = *(nameAndItkTransform.itkTransform);
+      const auto   expectedNumberOfFixedParameters = expectedItkTransform.GetFixedParameters().size();
+
+      registration.SetParameterObject(CreateParameterObject({ // Parameters in alphabetic order:
+                                                              { "AutomaticTransformInitialization", "false" },
+                                                              { "ImageSampler", "Full" },
+                                                              { "MaximumNumberOfIterations", "0" },
+                                                              { "Metric", "AdvancedNormalizedCorrelation" },
+                                                              { "Optimizer", "AdaptiveStochasticGradientDescent" },
+                                                              { "Transform", nameAndItkTransform.name } }));
+      registration.Update();
+
+      using CompositeTransformType = itk::CompositeTransform<double, ImageDimension>;
+      const auto combinationTransform = registration.GetCombinationTransform();
+
+      EXPECT_NE(combinationTransform, nullptr);
+    }
+  }
+}
+
+
 GTEST_TEST(itkElastixRegistrationMethod, GetNumberOfTransforms)
 {
   constexpr auto ImageDimension = 2U;

--- a/Core/Main/GTesting/itkElastixRegistrationMethodGTest.cxx
+++ b/Core/Main/GTesting/itkElastixRegistrationMethodGTest.cxx
@@ -588,6 +588,43 @@ GTEST_TEST(itkElastixRegistrationMethod, GetNumberOfTransforms)
 }
 
 
+GTEST_TEST(itkElastixRegistrationMethod, GetNthTransform)
+{
+  constexpr auto ImageDimension = 2U;
+  using ImageType = itk::Image<float, ImageDimension>;
+  const auto image =
+    CreateImageFilledWithSequenceOfNaturalNumbers<ImageType::PixelType>(itk::Size<ImageDimension>{ 5, 6 });
+
+  DefaultConstructibleElastixRegistrationMethod<ImageType, ImageType> registration;
+
+  registration.SetFixedImage(image);
+  registration.SetMovingImage(image);
+
+  for (const bool useInitialTransform : { false, true })
+  {
+    registration.SetInitialTransformParameterFileName(
+      useInitialTransform ? (GetDataDirectoryPath() + "/Translation(1,-2)/TransformParameters.txt") : "");
+
+    const std::string nameOfLastTransform = "BSplineTransform";
+    registration.SetParameterObject(CreateParameterObject({ // Parameters in alphabetic order:
+                                                            { "AutomaticTransformInitialization", "false" },
+                                                            { "ImageSampler", "Full" },
+                                                            { "MaximumNumberOfIterations", "0" },
+                                                            { "Metric", "AdvancedNormalizedCorrelation" },
+                                                            { "Optimizer", "AdaptiveStochasticGradientDescent" },
+                                                            { "Transform", nameOfLastTransform } }));
+    registration.Update();
+
+    const unsigned int numberOfTransforms{ useInitialTransform ? 2U : 1U };
+
+    for (unsigned int n{ 0 }; n < numberOfTransforms; ++n)
+    {
+      EXPECT_NE(registration.GetNthTransform(n), nullptr);
+    }
+  }
+}
+
+
 GTEST_TEST(itkElastixRegistrationMethod, WriteCompositeTransform)
 {
   constexpr auto ImageDimension = 2U;

--- a/Core/Main/itkElastixRegistrationMethod.h
+++ b/Core/Main/itkElastixRegistrationMethod.h
@@ -38,6 +38,8 @@
 #include "itkImageSource.h"
 
 #include "elxElastixMain.h"
+#include "elxElastixTemplate.h"
+#include "elxTransformBase.h"
 #include "elxParameterObject.h"
 
 /**
@@ -282,6 +284,8 @@ private:
 
   /** Private using-declaration, just to avoid GCC compilation warnings: '...' was hidden [-Woverloaded-virtual] */
   using Superclass::SetInput;
+
+  using ElastixTransformBaseType = elx::TransformBase<elx::ElastixTemplate<TFixedImage, TMovingImage>>;
 
   SmartPointer<const elx::ElastixMain> m_ElastixMain{ nullptr };
 

--- a/Core/Main/itkElastixRegistrationMethod.h
+++ b/Core/Main/itkElastixRegistrationMethod.h
@@ -262,6 +262,10 @@ public:
   SmartPointer<Transform<double, FixedImageDimension, MovingImageDimension>>
   GetNthTransform(const unsigned int n) const;
 
+  /** Returns the combination transformation, produced during the last Update(). */
+  SmartPointer<Transform<double, FixedImageDimension, MovingImageDimension>>
+  GetCombinationTransform() const;
+
   /** Converts the specified elastix Transform object to the corresponding ITK Transform object. Returns null if there
    * is no corresponding ITK Transform type. */
   static SmartPointer<Transform<double, FixedImageDimension, MovingImageDimension>>

--- a/Core/Main/itkElastixRegistrationMethod.h
+++ b/Core/Main/itkElastixRegistrationMethod.h
@@ -254,6 +254,10 @@ public:
   itkSetMacro(NumberOfThreads, int);
   itkGetConstMacro(NumberOfThreads, int);
 
+  /** Returns the number of transformations, produced during the last Update(). */
+  unsigned int
+  GetNumberOfTransforms() const;
+
 protected:
   ElastixRegistrationMethod();
 

--- a/Core/Main/itkElastixRegistrationMethod.h
+++ b/Core/Main/itkElastixRegistrationMethod.h
@@ -262,6 +262,11 @@ public:
   SmartPointer<Transform<double, FixedImageDimension, MovingImageDimension>>
   GetNthTransform(const unsigned int n) const;
 
+  /** Converts the specified elastix Transform object to the corresponding ITK Transform object. Returns null if there
+   * is no corresponding ITK Transform type. */
+  static SmartPointer<Transform<double, FixedImageDimension, MovingImageDimension>>
+  ConvertToItkTransform(const Transform<double, FixedImageDimension, MovingImageDimension> &);
+
 protected:
   ElastixRegistrationMethod();
 

--- a/Core/Main/itkElastixRegistrationMethod.h
+++ b/Core/Main/itkElastixRegistrationMethod.h
@@ -98,6 +98,7 @@ public:
 
   using FixedMaskType = Image<unsigned char, FixedImageDimension>;
   using MovingMaskType = Image<unsigned char, MovingImageDimension>;
+  using TransformType = Transform<double, FixedImageDimension, MovingImageDimension>;
 
   using FixedImageType = TFixedImage;
   using MovingImageType = TMovingImage;
@@ -259,17 +260,17 @@ public:
   GetNumberOfTransforms() const;
 
   /** Returns the nth transformation, produced during the last Update(). */
-  SmartPointer<Transform<double, FixedImageDimension, MovingImageDimension>>
+  SmartPointer<TransformType>
   GetNthTransform(const unsigned int n) const;
 
   /** Returns the combination transformation, produced during the last Update(). */
-  SmartPointer<Transform<double, FixedImageDimension, MovingImageDimension>>
+  SmartPointer<TransformType>
   GetCombinationTransform() const;
 
   /** Converts the specified elastix Transform object to the corresponding ITK Transform object. Returns null if there
    * is no corresponding ITK Transform type. */
-  static SmartPointer<Transform<double, FixedImageDimension, MovingImageDimension>>
-  ConvertToItkTransform(const Transform<double, FixedImageDimension, MovingImageDimension> &);
+  static SmartPointer<TransformType>
+  ConvertToItkTransform(const TransformType &);
 
 protected:
   ElastixRegistrationMethod();

--- a/Core/Main/itkElastixRegistrationMethod.h
+++ b/Core/Main/itkElastixRegistrationMethod.h
@@ -258,6 +258,10 @@ public:
   unsigned int
   GetNumberOfTransforms() const;
 
+  /** Returns the nth transformation, produced during the last Update(). */
+  SmartPointer<Transform<double, FixedImageDimension, MovingImageDimension>>
+  GetNthTransform(const unsigned int n) const;
+
 protected:
   ElastixRegistrationMethod();
 

--- a/Core/Main/itkElastixRegistrationMethod.hxx
+++ b/Core/Main/itkElastixRegistrationMethod.hxx
@@ -828,6 +828,26 @@ ElastixRegistrationMethod<TFixedImage, TMovingImage>::GetNthTransform(const unsi
   return elxTransformBase->GetAsITKBaseType()->GetNthTransform(n);
 }
 
+
+template <typename TFixedImage, typename TMovingImage>
+auto
+ElastixRegistrationMethod<TFixedImage, TMovingImage>::ConvertToItkTransform(
+  const Transform<double, FixedImageDimension, MovingImageDimension> & elxTransform)
+  -> SmartPointer<Transform<double, FixedImageDimension, MovingImageDimension>>
+{
+  const auto * const combinationTransform =
+    dynamic_cast<const itk::AdvancedCombinationTransform<double, FixedImageDimension> *>(&elxTransform);
+
+  const auto itkTransform = combinationTransform
+                              ? elx::TransformIO::ConvertToCompositionOfItkTransforms(*combinationTransform)
+                              : elx::TransformIO::ConvertToSingleItkTransform(elxTransform);
+  if (itkTransform)
+  {
+    return itkTransform;
+  }
+  itkGenericExceptionMacro("Failed to convert transform object " << elxTransform);
+}
+
 } // namespace itk
 
 #endif

--- a/Core/Main/itkElastixRegistrationMethod.hxx
+++ b/Core/Main/itkElastixRegistrationMethod.hxx
@@ -831,6 +831,28 @@ ElastixRegistrationMethod<TFixedImage, TMovingImage>::GetNthTransform(const unsi
 
 template <typename TFixedImage, typename TMovingImage>
 auto
+ElastixRegistrationMethod<TFixedImage, TMovingImage>::GetCombinationTransform() const
+  -> SmartPointer<Transform<double, FixedImageDimension, MovingImageDimension>>
+{
+  const auto * const transformContainer = m_ElastixMain->GetElastixBase().GetTransformContainer();
+
+  if ((transformContainer == nullptr) || transformContainer->empty())
+  {
+    return nullptr;
+  }
+
+  auto * const elxTransformBase = dynamic_cast<ElastixTransformBaseType *>(transformContainer->front().GetPointer());
+
+  if (elxTransformBase == nullptr)
+  {
+    return nullptr;
+  }
+  return elxTransformBase->GetAsITKBaseType();
+}
+
+
+template <typename TFixedImage, typename TMovingImage>
+auto
 ElastixRegistrationMethod<TFixedImage, TMovingImage>::ConvertToItkTransform(
   const Transform<double, FixedImageDimension, MovingImageDimension> & elxTransform)
   -> SmartPointer<Transform<double, FixedImageDimension, MovingImageDimension>>

--- a/Core/Main/itkElastixRegistrationMethod.hxx
+++ b/Core/Main/itkElastixRegistrationMethod.hxx
@@ -806,6 +806,28 @@ ElastixRegistrationMethod<TFixedImage, TMovingImage>::GetNumberOfTransforms() co
 }
 
 
+template <typename TFixedImage, typename TMovingImage>
+auto
+ElastixRegistrationMethod<TFixedImage, TMovingImage>::GetNthTransform(const unsigned int n) const
+  -> SmartPointer<Transform<double, FixedImageDimension, MovingImageDimension>>
+{
+  const auto * const transformContainer = m_ElastixMain->GetElastixBase().GetTransformContainer();
+
+  if ((transformContainer == nullptr) || transformContainer->empty())
+  {
+    return nullptr;
+  }
+
+  const auto * const elxTransformBase =
+    dynamic_cast<ElastixTransformBaseType *>(transformContainer->front().GetPointer());
+
+  if (elxTransformBase == nullptr)
+  {
+    return nullptr;
+  }
+  return elxTransformBase->GetAsITKBaseType()->GetNthTransform(n);
+}
+
 } // namespace itk
 
 #endif

--- a/Core/Main/itkElastixRegistrationMethod.hxx
+++ b/Core/Main/itkElastixRegistrationMethod.hxx
@@ -809,7 +809,7 @@ ElastixRegistrationMethod<TFixedImage, TMovingImage>::GetNumberOfTransforms() co
 template <typename TFixedImage, typename TMovingImage>
 auto
 ElastixRegistrationMethod<TFixedImage, TMovingImage>::GetNthTransform(const unsigned int n) const
-  -> SmartPointer<Transform<double, FixedImageDimension, MovingImageDimension>>
+  -> SmartPointer<TransformType>
 {
   const auto * const transformContainer = m_ElastixMain->GetElastixBase().GetTransformContainer();
 
@@ -831,8 +831,7 @@ ElastixRegistrationMethod<TFixedImage, TMovingImage>::GetNthTransform(const unsi
 
 template <typename TFixedImage, typename TMovingImage>
 auto
-ElastixRegistrationMethod<TFixedImage, TMovingImage>::GetCombinationTransform() const
-  -> SmartPointer<Transform<double, FixedImageDimension, MovingImageDimension>>
+ElastixRegistrationMethod<TFixedImage, TMovingImage>::GetCombinationTransform() const -> SmartPointer<TransformType>
 {
   const auto * const transformContainer = m_ElastixMain->GetElastixBase().GetTransformContainer();
 
@@ -853,9 +852,8 @@ ElastixRegistrationMethod<TFixedImage, TMovingImage>::GetCombinationTransform() 
 
 template <typename TFixedImage, typename TMovingImage>
 auto
-ElastixRegistrationMethod<TFixedImage, TMovingImage>::ConvertToItkTransform(
-  const Transform<double, FixedImageDimension, MovingImageDimension> & elxTransform)
-  -> SmartPointer<Transform<double, FixedImageDimension, MovingImageDimension>>
+ElastixRegistrationMethod<TFixedImage, TMovingImage>::ConvertToItkTransform(const TransformType & elxTransform)
+  -> SmartPointer<TransformType>
 {
   const auto * const combinationTransform =
     dynamic_cast<const itk::AdvancedCombinationTransform<double, FixedImageDimension> *>(&elxTransform);

--- a/Core/Main/itkElastixRegistrationMethod.hxx
+++ b/Core/Main/itkElastixRegistrationMethod.hxx
@@ -788,6 +788,24 @@ ElastixRegistrationMethod<TFixedImage, TMovingImage>::RemoveInputsOfType(const D
 }
 
 
+template <typename TFixedImage, typename TMovingImage>
+unsigned int
+ElastixRegistrationMethod<TFixedImage, TMovingImage>::GetNumberOfTransforms() const
+{
+  const auto * const transformContainer = m_ElastixMain->GetElastixBase().GetTransformContainer();
+
+  if ((transformContainer == nullptr) || transformContainer->empty())
+  {
+    return 0;
+  }
+
+  const auto * const elxTransformBase =
+    dynamic_cast<ElastixTransformBaseType *>(transformContainer->front().GetPointer());
+
+  return (elxTransformBase == nullptr) ? 0 : elxTransformBase->GetAsITKBaseType()->GetNumberOfTransforms();
+}
+
+
 } // namespace itk
 
 #endif

--- a/Core/Main/itkTransformixFilter.h
+++ b/Core/Main/itkTransformixFilter.h
@@ -103,6 +103,8 @@ public:
 
   using MeshType = Mesh<OutputImagePixelType, MovingImageDimension>;
 
+  using TransformType = Transform<double, MovingImageDimension, MovingImageDimension>;
+
   /** Typedefs for images of determinants of spatial Jacobian matrices, and images of spatial Jacobian matrices */
   using SpatialJacobianDeterminantImageType = itk::Image<float, MovingImageDimension>;
   using SpatialJacobianMatrixImageType =
@@ -225,6 +227,8 @@ public:
    * transform object, with additional information from the specified transform parameter object. */
   itkSetConstObjectMacro(Transform, TransformBase);
 
+  itkSetObjectMacro(CombinationTransform, TransformType);
+
   /** Computes the spatial Jacobian determinant for each pixel, and returns an image of the computed values.
   \note Before calling this member function, Update() must be called. */
   SmartPointer<SpatialJacobianDeterminantImageType>
@@ -288,6 +292,8 @@ private:
   typename MeshType::Pointer      m_OutputMesh{ nullptr };
 
   TransformBase::ConstPointer m_Transform;
+
+  SmartPointer<TransformType> m_CombinationTransform;
 };
 
 } // namespace itk

--- a/Core/Main/itkTransformixFilter.hxx
+++ b/Core/Main/itkTransformixFilter.hxx
@@ -265,7 +265,7 @@ TransformixFilter<TMovingImage>::GenerateData()
   unsigned int isError = 0;
   try
   {
-    isError = transformixMain->Run(argumentMap, transformParameterMapVector);
+    isError = transformixMain->Run(argumentMap, transformParameterMapVector, m_CombinationTransform);
 
     if (m_InputMesh)
     {


### PR DESCRIPTION
Added public functions to retrieve the transformation(s) produced by elastix through the `itk::ElastixRegistrationMethod` interface:

 - ElastixRegistrationMethod::GetCombinationTransform()
 - TransformixFilter::SetCombinationTransform(transform)
 -  ~~ElastixRegistrationMethod::GetCompositeTransform()~~
 - ElastixRegistrationMethod::GetNumberOfTransforms()
 - ElastixRegistrationMethod::GetNthTransform(n)
 - ElastixRegistrationMethod::ConvertToItkTransform(transform)
 
The transform return by `ConvertToItkTransform(transform)` is a standard ITK transform. Note that this function may throw an exception, if there is no corresponding ITK transform for the actual elastix transform.

The transforms returned by `GetCombinationTransform()` and `GetNthTransform(n)` are specific to elastix. However, the elastix combination transform may be used as argument to `TransformixFilter.SetCombinationTransform(transform)`, and the _nth_ transform may be used as argument to `ConvertToItkTransform(transform)`..


