### PR TITLE
Restore MSVC warning level (`/W3`) and fix the warnings

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -75,6 +75,10 @@ include(elastixVersion)
 # Function for exporting targets
 include(elastixExportTarget)
 
+if (MSVC)
+  add_compile_options(/W3)
+endif()
+
 #---------------------------------------------------------------------
 # Find OpenCL.
 if(ELASTIX_USE_OPENCL)

--- a/Components/Optimizers/AdaGrad/elxAdaGrad.hxx
+++ b/Components/Optimizers/AdaGrad/elxAdaGrad.hxx
@@ -956,7 +956,7 @@ AdaGrad<TElastix>::GetScaledDerivativeWithExceptionHandling(const ParametersType
   {
     this->GetScaledValueAndDerivative(parameters, dummyvalue, derivative);
   }
-  catch (itk::ExceptionObject & err)
+  catch (const itk::ExceptionObject &)
   {
     this->m_StopCondition = MetricError;
     this->StopOptimization();

--- a/Components/Optimizers/AdaptiveStochasticLBFGS/elxAdaptiveStochasticLBFGS.hxx
+++ b/Components/Optimizers/AdaptiveStochasticLBFGS/elxAdaptiveStochasticLBFGS.hxx
@@ -1491,7 +1491,7 @@ AdaptiveStochasticLBFGS<TElastix>::GetScaledDerivativeWithExceptionHandling(cons
   {
     this->GetScaledValueAndDerivative(parameters, dummyvalue, derivative);
   }
-  catch (itk::ExceptionObject & err)
+  catch (const itk::ExceptionObject &)
   {
     this->m_StopCondition = MetricError;
     this->StopOptimization();

--- a/Components/Optimizers/AdaptiveStochasticVarianceReducedGradient/elxAdaptiveStochasticVarianceReducedGradient.hxx
+++ b/Components/Optimizers/AdaptiveStochasticVarianceReducedGradient/elxAdaptiveStochasticVarianceReducedGradient.hxx
@@ -1288,7 +1288,7 @@ AdaptiveStochasticVarianceReducedGradient<TElastix>::GetScaledDerivativeWithExce
   {
     this->GetScaledValueAndDerivative(parameters, dummyvalue, derivative);
   }
-  catch (itk::ExceptionObject & err)
+  catch (const itk::ExceptionObject &)
   {
     this->m_StopCondition = MetricError;
     this->StopOptimization();

--- a/Components/Optimizers/FullSearch/itkFullSearchOptimizer.cxx
+++ b/Components/Optimizers/FullSearch/itkFullSearchOptimizer.cxx
@@ -88,7 +88,7 @@ FullSearchOptimizer::ResumeOptimization()
     {
       m_Value = m_CostFunction->GetValue(this->GetCurrentPosition());
     }
-    catch (ExceptionObject & err)
+    catch (const ExceptionObject &)
     {
       // An exception has occurred.
       // Terminate immediately.

--- a/Components/Optimizers/QuasiNewtonLBFGS/itkQuasiNewtonLBFGSOptimizer.cxx
+++ b/Components/Optimizers/QuasiNewtonLBFGS/itkQuasiNewtonLBFGSOptimizer.cxx
@@ -359,7 +359,7 @@ QuasiNewtonLBFGSOptimizer::LineSearch(const ParametersType searchDir,
   {
     LSO->GetCurrentValueAndDerivative(f, g);
   }
-  catch (ExceptionObject & err)
+  catch (const ExceptionObject &)
   {
     this->m_StopCondition = MetricError;
     this->StopOptimization();

--- a/Components/Optimizers/RSGDEachParameterApart/itkRSGDEachParameterApartBaseOptimizer.cxx
+++ b/Components/Optimizers/RSGDEachParameterApart/itkRSGDEachParameterApartBaseOptimizer.cxx
@@ -95,7 +95,7 @@ RSGDEachParameterApartBaseOptimizer::ResumeOptimization()
     {
       m_CostFunction->GetValueAndDerivative(this->GetCurrentPosition(), m_Value, m_Gradient);
     }
-    catch (ExceptionObject & err)
+    catch (const ExceptionObject &)
     {
       m_StopCondition = MetricError;
       this->StopOptimization();


### PR DESCRIPTION
CMake no longer adds /W3 automatically, by default (from CMake 3.15), so the Visual C++ warning level has dropped unintentionally from /W3 to /W1 with pull request #631 commit a349180014ee0824a2e9a9763803bc25d5fb63d7, "ENH: Upgrade cmake_minimum_required from 3.10.2 to 3.16.3, following ITK", 26 March 2022.

See also:

"MSVC warning flags are not in CMAKE_<LANG>_FLAGS by default"
https://cmake.org/cmake/help/latest/policy/CMP0092.html

"MSVC: Do not add /W3 to CMAKE_<LANG>_FLAGS by default"
https://gitlab.kitware.com/cmake/cmake/-/merge_requests/3250
