### PR TITLE
Chain insertions (`<<`) to the same "xout" stream in Configuration and Optimizers

### DIFF
--- a/Common/itkComputePreconditionerUsingDisplacementDistribution.hxx
+++ b/Common/itkComputePreconditionerUsingDisplacementDistribution.hxx
@@ -318,9 +318,9 @@ ComputePreconditionerUsingDisplacementDistribution<TFixedImage, TTransform>::Com
     }
 
 #if 0
-    elxout << std::scientific << "The preconditioner before interpolation: [ ";
     //elxout << sigma << " ";
-    elxout << preconditioner[i] << " " << "]" << std::endl << std::fixed;
+    elxout << std::scientific << "The preconditioner before interpolation: [ "
+      << preconditioner[i] << " " << "]" << std::endl << std::fixed;
 #endif
   } // end loop over localStepSize vector
 

--- a/Components/Optimizers/AdaGrad/elxAdaGrad.hxx
+++ b/Components/Optimizers/AdaGrad/elxAdaGrad.hxx
@@ -382,9 +382,10 @@ AdaGrad<TElastix>::AfterRegistration()
 {
   /** Print the best metric value. */
   double bestValue = this->GetValue();
-  elxout << '\n' << "Final metric value  = " << bestValue << std::endl;
+  elxout << '\n'
+         << "Final metric value  = " << bestValue << std::endl
 
-  elxout << "Settings of " << this->elxGetClassName() << " for all resolutions:" << std::endl;
+         << "Settings of " << this->elxGetClassName() << " for all resolutions:" << std::endl;
   this->PrintSettingsVector(this->m_SettingsVector);
 
 } // end AfterRegistration()
@@ -896,44 +897,44 @@ AdaGrad<TElastix>::PrintSettingsVector(const SettingsVectorType & settings) cons
   {
     elxout << settings[i].a << " ";
   }
-  elxout << ")\n";
+  elxout << ")\n"
 
-  elxout << "( SP_A ";
+         << "( SP_A ";
   for (unsigned int i = 0; i < nrofres; ++i)
   {
     elxout << settings[i].A << " ";
   }
-  elxout << ")\n";
+  elxout << ")\n"
 
-  elxout << "( SP_alpha ";
+         << "( SP_alpha ";
   for (unsigned int i = 0; i < nrofres; ++i)
   {
     elxout << settings[i].alpha << " ";
   }
-  elxout << ")\n";
+  elxout << ")\n"
 
-  elxout << "( SigmoidMax ";
+         << "( SigmoidMax ";
   for (unsigned int i = 0; i < nrofres; ++i)
   {
     elxout << settings[i].fmax << " ";
   }
-  elxout << ")\n";
+  elxout << ")\n"
 
-  elxout << "( SigmoidMin ";
+         << "( SigmoidMin ";
   for (unsigned int i = 0; i < nrofres; ++i)
   {
     elxout << settings[i].fmin << " ";
   }
-  elxout << ")\n";
+  elxout << ")\n"
 
-  elxout << "( SigmoidScale ";
+         << "( SigmoidScale ";
   for (unsigned int i = 0; i < nrofres; ++i)
   {
     elxout << settings[i].omega << " ";
   }
-  elxout << ")\n";
+  elxout << ")\n"
 
-  elxout << std::endl;
+         << std::endl;
 
 } // end PrintSettingsVector()
 

--- a/Components/Optimizers/AdaGrad/elxAdaGrad.hxx
+++ b/Components/Optimizers/AdaGrad/elxAdaGrad.hxx
@@ -383,7 +383,7 @@ AdaGrad<TElastix>::AfterRegistration()
   /** Print the best metric value. */
   double bestValue = this->GetValue();
   elxout << '\n'
-         << "Final metric value  = " << bestValue << std::endl
+         << "Final metric value  = " << bestValue << '\n'
 
          << "Settings of " << this->elxGetClassName() << " for all resolutions:" << std::endl;
   this->PrintSettingsVector(this->m_SettingsVector);

--- a/Components/Optimizers/AdaptiveStochasticGradientDescent/elxAdaptiveStochasticGradientDescent.hxx
+++ b/Components/Optimizers/AdaptiveStochasticGradientDescent/elxAdaptiveStochasticGradientDescent.hxx
@@ -360,9 +360,10 @@ AdaptiveStochasticGradientDescent<TElastix>::AfterRegistration()
 {
   /** Print the best metric value. */
   double bestValue = this->GetValue();
-  elxout << '\n' << "Final metric value  = " << bestValue << std::endl;
+  elxout << '\n'
+         << "Final metric value  = " << bestValue << std::endl
 
-  elxout << "Settings of " << this->elxGetClassName() << " for all resolutions:" << std::endl;
+         << "Settings of " << this->elxGetClassName() << " for all resolutions:" << std::endl;
   this->PrintSettingsVector(this->m_SettingsVector);
 
 } // end AfterRegistration()
@@ -965,44 +966,44 @@ AdaptiveStochasticGradientDescent<TElastix>::PrintSettingsVector(const SettingsV
   {
     elxout << settings[i].a << " ";
   }
-  elxout << ")\n";
+  elxout << ")\n"
 
-  elxout << "( SP_A ";
+         << "( SP_A ";
   for (unsigned int i = 0; i < nrofres; ++i)
   {
     elxout << settings[i].A << " ";
   }
-  elxout << ")\n";
+  elxout << ")\n"
 
-  elxout << "( SP_alpha ";
+         << "( SP_alpha ";
   for (unsigned int i = 0; i < nrofres; ++i)
   {
     elxout << settings[i].alpha << " ";
   }
-  elxout << ")\n";
+  elxout << ")\n"
 
-  elxout << "( SigmoidMax ";
+         << "( SigmoidMax ";
   for (unsigned int i = 0; i < nrofres; ++i)
   {
     elxout << settings[i].fmax << " ";
   }
-  elxout << ")\n";
+  elxout << ")\n"
 
-  elxout << "( SigmoidMin ";
+         << "( SigmoidMin ";
   for (unsigned int i = 0; i < nrofres; ++i)
   {
     elxout << settings[i].fmin << " ";
   }
-  elxout << ")\n";
+  elxout << ")\n"
 
-  elxout << "( SigmoidScale ";
+         << "( SigmoidScale ";
   for (unsigned int i = 0; i < nrofres; ++i)
   {
     elxout << settings[i].omega << " ";
   }
-  elxout << ")\n";
+  elxout << ")\n"
 
-  elxout << std::endl;
+         << std::endl;
 
 } // end PrintSettingsVector()
 

--- a/Components/Optimizers/AdaptiveStochasticGradientDescent/elxAdaptiveStochasticGradientDescent.hxx
+++ b/Components/Optimizers/AdaptiveStochasticGradientDescent/elxAdaptiveStochasticGradientDescent.hxx
@@ -361,7 +361,7 @@ AdaptiveStochasticGradientDescent<TElastix>::AfterRegistration()
   /** Print the best metric value. */
   double bestValue = this->GetValue();
   elxout << '\n'
-         << "Final metric value  = " << bestValue << std::endl
+         << "Final metric value  = " << bestValue << '\n'
 
          << "Settings of " << this->elxGetClassName() << " for all resolutions:" << std::endl;
   this->PrintSettingsVector(this->m_SettingsVector);

--- a/Components/Optimizers/AdaptiveStochasticLBFGS/elxAdaptiveStochasticLBFGS.hxx
+++ b/Components/Optimizers/AdaptiveStochasticLBFGS/elxAdaptiveStochasticLBFGS.hxx
@@ -446,7 +446,7 @@ AdaptiveStochasticLBFGS<TElastix>::AfterRegistration()
 
   double bestValue = this->GetValue();
   elxout << '\n'
-         << "Final metric value  = " << bestValue << std::endl
+         << "Final metric value  = " << bestValue << '\n'
 
          << "Settings of " << this->elxGetClassName() << " for all resolutions:" << std::endl;
   this->PrintSettingsVector(this->m_SettingsVector);

--- a/Components/Optimizers/AdaptiveStochasticLBFGS/elxAdaptiveStochasticLBFGS.hxx
+++ b/Components/Optimizers/AdaptiveStochasticLBFGS/elxAdaptiveStochasticLBFGS.hxx
@@ -445,9 +445,10 @@ AdaptiveStochasticLBFGS<TElastix>::AfterRegistration()
   /** Print the best metric value. */
 
   double bestValue = this->GetValue();
-  elxout << '\n' << "Final metric value  = " << bestValue << std::endl;
+  elxout << '\n'
+         << "Final metric value  = " << bestValue << std::endl
 
-  elxout << "Settings of " << this->elxGetClassName() << " for all resolutions:" << std::endl;
+         << "Settings of " << this->elxGetClassName() << " for all resolutions:" << std::endl;
   this->PrintSettingsVector(this->m_SettingsVector);
 
 } // end AfterRegistration()
@@ -1435,44 +1436,44 @@ AdaptiveStochasticLBFGS<TElastix>::PrintSettingsVector(const SettingsVectorType 
   {
     elxout << settings[i].a << " ";
   }
-  elxout << ")\n";
+  elxout << ")\n"
 
-  elxout << "( SP_A ";
+         << "( SP_A ";
   for (unsigned int i = 0; i < nrofres; ++i)
   {
     elxout << settings[i].A << " ";
   }
-  elxout << ")\n";
+  elxout << ")\n"
 
-  elxout << "( SP_alpha ";
+         << "( SP_alpha ";
   for (unsigned int i = 0; i < nrofres; ++i)
   {
     elxout << settings[i].alpha << " ";
   }
-  elxout << ")\n";
+  elxout << ")\n"
 
-  elxout << "( SigmoidMax ";
+         << "( SigmoidMax ";
   for (unsigned int i = 0; i < nrofres; ++i)
   {
     elxout << settings[i].fmax << " ";
   }
-  elxout << ")\n";
+  elxout << ")\n"
 
-  elxout << "( SigmoidMin ";
+         << "( SigmoidMin ";
   for (unsigned int i = 0; i < nrofres; ++i)
   {
     elxout << settings[i].fmin << " ";
   }
-  elxout << ")\n";
+  elxout << ")\n"
 
-  elxout << "( SigmoidScale ";
+         << "( SigmoidScale ";
   for (unsigned int i = 0; i < nrofres; ++i)
   {
     elxout << settings[i].omega << " ";
   }
-  elxout << ")\n";
+  elxout << ")\n"
 
-  elxout << std::endl;
+         << std::endl;
 
 } // end PrintSettingsVector()
 

--- a/Components/Optimizers/AdaptiveStochasticVarianceReducedGradient/elxAdaptiveStochasticVarianceReducedGradient.hxx
+++ b/Components/Optimizers/AdaptiveStochasticVarianceReducedGradient/elxAdaptiveStochasticVarianceReducedGradient.hxx
@@ -386,7 +386,7 @@ AdaptiveStochasticVarianceReducedGradient<TElastix>::AfterRegistration()
 
   double bestValue = this->GetValue();
   elxout << '\n'
-         << "Final metric value  = " << bestValue << std::endl
+         << "Final metric value  = " << bestValue << '\n'
 
          << "Settings of " << this->elxGetClassName() << " for all resolutions:" << std::endl;
   this->PrintSettingsVector(this->m_SettingsVector);

--- a/Components/Optimizers/AdaptiveStochasticVarianceReducedGradient/elxAdaptiveStochasticVarianceReducedGradient.hxx
+++ b/Components/Optimizers/AdaptiveStochasticVarianceReducedGradient/elxAdaptiveStochasticVarianceReducedGradient.hxx
@@ -385,9 +385,10 @@ AdaptiveStochasticVarianceReducedGradient<TElastix>::AfterRegistration()
   /** Print the best metric value. */
 
   double bestValue = this->GetValue();
-  elxout << '\n' << "Final metric value  = " << bestValue << std::endl;
+  elxout << '\n'
+         << "Final metric value  = " << bestValue << std::endl
 
-  elxout << "Settings of " << this->elxGetClassName() << " for all resolutions:" << std::endl;
+         << "Settings of " << this->elxGetClassName() << " for all resolutions:" << std::endl;
   this->PrintSettingsVector(this->m_SettingsVector);
 
 } // end AfterRegistration()
@@ -1231,44 +1232,44 @@ AdaptiveStochasticVarianceReducedGradient<TElastix>::PrintSettingsVector(const S
   {
     elxout << settings[i].a << " ";
   }
-  elxout << ")\n";
+  elxout << ")\n"
 
-  elxout << "( SP_A ";
+         << "( SP_A ";
   for (unsigned int i = 0; i < nrofres; ++i)
   {
     elxout << settings[i].A << " ";
   }
-  elxout << ")\n";
+  elxout << ")\n"
 
-  elxout << "( SP_alpha ";
+         << "( SP_alpha ";
   for (unsigned int i = 0; i < nrofres; ++i)
   {
     elxout << settings[i].alpha << " ";
   }
-  elxout << ")\n";
+  elxout << ")\n"
 
-  elxout << "( SigmoidMax ";
+         << "( SigmoidMax ";
   for (unsigned int i = 0; i < nrofres; ++i)
   {
     elxout << settings[i].fmax << " ";
   }
-  elxout << ")\n";
+  elxout << ")\n"
 
-  elxout << "( SigmoidMin ";
+         << "( SigmoidMin ";
   for (unsigned int i = 0; i < nrofres; ++i)
   {
     elxout << settings[i].fmin << " ";
   }
-  elxout << ")\n";
+  elxout << ")\n"
 
-  elxout << "( SigmoidScale ";
+         << "( SigmoidScale ";
   for (unsigned int i = 0; i < nrofres; ++i)
   {
     elxout << settings[i].omega << " ";
   }
-  elxout << ")\n";
+  elxout << ")\n"
 
-  elxout << std::endl;
+         << std::endl;
 
 } // end PrintSettingsVector()
 

--- a/Components/Optimizers/FullSearch/elxFullSearchOptimizer.hxx
+++ b/Components/Optimizers/FullSearch/elxFullSearchOptimizer.hxx
@@ -264,7 +264,7 @@ FullSearch<TElastix>::AfterEachResolution()
   {
     elxout << bestIndex[dim] << " ";
   }
-  elxout << "]" << std::endl
+  elxout << "]" << '\n'
 
          << "The corresponding parameter values: [ ";
   for (unsigned int dim = 0; dim < nrOfSSDims; ++dim)

--- a/Components/Optimizers/FullSearch/elxFullSearchOptimizer.hxx
+++ b/Components/Optimizers/FullSearch/elxFullSearchOptimizer.hxx
@@ -264,7 +264,7 @@ FullSearch<TElastix>::AfterEachResolution()
   {
     elxout << bestIndex[dim] << " ";
   }
-  elxout << "]" << '\n'
+  elxout << "]\n"
 
          << "The corresponding parameter values: [ ";
   for (unsigned int dim = 0; dim < nrOfSSDims; ++dim)

--- a/Components/Optimizers/FullSearch/elxFullSearchOptimizer.hxx
+++ b/Components/Optimizers/FullSearch/elxFullSearchOptimizer.hxx
@@ -264,9 +264,9 @@ FullSearch<TElastix>::AfterEachResolution()
   {
     elxout << bestIndex[dim] << " ";
   }
-  elxout << "]" << std::endl;
+  elxout << "]" << std::endl
 
-  elxout << "The corresponding parameter values: [ ";
+         << "The corresponding parameter values: [ ";
   for (unsigned int dim = 0; dim < nrOfSSDims; ++dim)
   {
     elxout << bestPoint[dim] << " ";

--- a/Components/Optimizers/PreconditionedGradientDescent/elxPreconditionedGradientDescent.hxx
+++ b/Components/Optimizers/PreconditionedGradientDescent/elxPreconditionedGradientDescent.hxx
@@ -279,9 +279,10 @@ PreconditionedGradientDescent<TElastix>::AfterRegistration()
 {
   /** Print the best metric value */
   double bestValue = this->GetValue();
-  elxout << '\n' << "Final metric value  = " << bestValue << std::endl;
+  elxout << '\n'
+         << "Final metric value  = " << bestValue << std::endl
 
-  elxout << "Settings of " << this->elxGetClassName() << " for all resolutions:" << std::endl;
+         << "Settings of " << this->elxGetClassName() << " for all resolutions:" << std::endl;
   this->PrintSettingsVector(this->m_SettingsVector);
 
 } // end AfterRegistration()
@@ -712,44 +713,44 @@ PreconditionedGradientDescent<TElastix>::PrintSettingsVector(const SettingsVecto
   {
     elxout << settings[i].a << " ";
   }
-  elxout << ")\n";
+  elxout << ")\n"
 
-  elxout << "( SP_A ";
+         << "( SP_A ";
   for (unsigned int i = 0; i < nrofres; ++i)
   {
     elxout << settings[i].A << " ";
   }
-  elxout << ")\n";
+  elxout << ")\n"
 
-  elxout << "( SP_alpha ";
+         << "( SP_alpha ";
   for (unsigned int i = 0; i < nrofres; ++i)
   {
     elxout << settings[i].alpha << " ";
   }
-  elxout << ")\n";
+  elxout << ")\n"
 
-  elxout << "( SigmoidMax ";
+         << "( SigmoidMax ";
   for (unsigned int i = 0; i < nrofres; ++i)
   {
     elxout << settings[i].fmax << " ";
   }
-  elxout << ")\n";
+  elxout << ")\n"
 
-  elxout << "( SigmoidMin ";
+         << "( SigmoidMin ";
   for (unsigned int i = 0; i < nrofres; ++i)
   {
     elxout << settings[i].fmin << " ";
   }
-  elxout << ")\n";
+  elxout << ")\n"
 
-  elxout << "( SigmoidScale ";
+         << "( SigmoidScale ";
   for (unsigned int i = 0; i < nrofres; ++i)
   {
     elxout << settings[i].omega << " ";
   }
-  elxout << ")\n";
+  elxout << ")\n"
 
-  elxout << std::endl;
+         << std::endl;
 
 } // end PrintSettingsVector()
 

--- a/Components/Optimizers/PreconditionedGradientDescent/elxPreconditionedGradientDescent.hxx
+++ b/Components/Optimizers/PreconditionedGradientDescent/elxPreconditionedGradientDescent.hxx
@@ -280,7 +280,7 @@ PreconditionedGradientDescent<TElastix>::AfterRegistration()
   /** Print the best metric value */
   double bestValue = this->GetValue();
   elxout << '\n'
-         << "Final metric value  = " << bestValue << std::endl
+         << "Final metric value  = " << bestValue << '\n'
 
          << "Settings of " << this->elxGetClassName() << " for all resolutions:" << std::endl;
   this->PrintSettingsVector(this->m_SettingsVector);

--- a/Components/Optimizers/PreconditionedStochasticGradientDescent/elxPreconditionedStochasticGradientDescent.hxx
+++ b/Components/Optimizers/PreconditionedStochasticGradientDescent/elxPreconditionedStochasticGradientDescent.hxx
@@ -390,7 +390,7 @@ PreconditionedStochasticGradientDescent<TElastix>::AfterRegistration()
   /** Print the best metric value. */
   double bestValue = this->GetValue();
   elxout << '\n'
-         << "Final metric value  = " << bestValue << std::endl
+         << "Final metric value  = " << bestValue << '\n'
 
          << "Settings of " << this->elxGetClassName() << " for all resolutions:" << std::endl;
   this->PrintSettingsVector(this->m_SettingsVector);

--- a/Components/Optimizers/PreconditionedStochasticGradientDescent/elxPreconditionedStochasticGradientDescent.hxx
+++ b/Components/Optimizers/PreconditionedStochasticGradientDescent/elxPreconditionedStochasticGradientDescent.hxx
@@ -389,9 +389,10 @@ PreconditionedStochasticGradientDescent<TElastix>::AfterRegistration()
 {
   /** Print the best metric value. */
   double bestValue = this->GetValue();
-  elxout << '\n' << "Final metric value  = " << bestValue << std::endl;
+  elxout << '\n'
+         << "Final metric value  = " << bestValue << std::endl
 
-  elxout << "Settings of " << this->elxGetClassName() << " for all resolutions:" << std::endl;
+         << "Settings of " << this->elxGetClassName() << " for all resolutions:" << std::endl;
   this->PrintSettingsVector(this->m_SettingsVector);
 
 } // end AfterRegistration()
@@ -916,44 +917,44 @@ PreconditionedStochasticGradientDescent<TElastix>::PrintSettingsVector(const Set
   {
     elxout << settings[i].a << " ";
   }
-  elxout << ")\n";
+  elxout << ")\n"
 
-  elxout << "( SP_A ";
+         << "( SP_A ";
   for (unsigned int i = 0; i < nrofres; ++i)
   {
     elxout << settings[i].A << " ";
   }
-  elxout << ")\n";
+  elxout << ")\n"
 
-  elxout << "( SP_alpha ";
+         << "( SP_alpha ";
   for (unsigned int i = 0; i < nrofres; ++i)
   {
     elxout << settings[i].alpha << " ";
   }
-  elxout << ")\n";
+  elxout << ")\n"
 
-  elxout << "( SigmoidMax ";
+         << "( SigmoidMax ";
   for (unsigned int i = 0; i < nrofres; ++i)
   {
     elxout << settings[i].fmax << " ";
   }
-  elxout << ")\n";
+  elxout << ")\n"
 
-  elxout << "( SigmoidMin ";
+         << "( SigmoidMin ";
   for (unsigned int i = 0; i < nrofres; ++i)
   {
     elxout << settings[i].fmin << " ";
   }
-  elxout << ")\n";
+  elxout << ")\n"
 
-  elxout << "( SigmoidScale ";
+         << "( SigmoidScale ";
   for (unsigned int i = 0; i < nrofres; ++i)
   {
     elxout << settings[i].omega << " ";
   }
-  elxout << ")\n";
+  elxout << ")\n"
 
-  elxout << std::endl;
+         << std::endl;
 
 } // end PrintSettingsVector()
 

--- a/Core/Configuration/elxConfiguration.cxx
+++ b/Core/Configuration/elxConfiguration.cxx
@@ -89,17 +89,11 @@ Configuration::PrintParameterFile() const
   /** Read what's in the parameter file. */
   std::string params = this->m_ParameterFileParser->ReturnParameterFileAsString();
 
-  /** Separate clearly in log-file. */
+  /** Separate clearly in log-file, before and after writing the parameter file. */
   xl::xout["logonly"] << '\n'
                       << "=============== start of ParameterFile: " << this->GetParameterFileName()
-                      << " ===============" << std::endl;
-
-  /** Write the parameter file. */
-  xl::xout["logonly"] << params;
-  // std::cerr << params;
-
-  /** Separate clearly in log-file. */
-  xl::xout["logonly"] << '\n'
+                      << " ===============\n"
+                      << params << '\n'
                       << "=============== end of ParameterFile: " << this->GetParameterFileName()
                       << " ===============\n"
                       << std::endl;


### PR DESCRIPTION
Follow-up to pull request #786 Chain consecutive insertions (`<<`) to the same "xout" stream, replace `std::endl` by `\n`