### PR TITLE
STYLE: Move PrintSettingsVector and Settings types to `OptimizerBase`

### DIFF
--- a/Components/Optimizers/AdaGrad/elxAdaGrad.h
+++ b/Components/Optimizers/AdaGrad/elxAdaGrad.h
@@ -305,11 +305,8 @@ protected:
   using TransformType = typename itkRegistrationType::TransformType;
   using JacobianType = typename TransformType::JacobianType;
   using JacobianValueType = typename JacobianType::ValueType;
-  struct SettingsType
-  {
-    double a, A, alpha, fmax, fmin, omega;
-  };
-  using SettingsVectorType = typename std::vector<SettingsType>;
+  using typename Superclass2::SettingsType;
+  using typename Superclass2::SettingsVectorType;
   using OutputImageType = typename ElastixType::FixedImageType;
 
   using PreconditionerEstimationType =
@@ -375,10 +372,6 @@ protected:
   double m_GlobalStepSize;
   double m_RegularizationKappa;
   double m_ConditionNumber;
-
-  /** Print the contents of the settings vector to elxout. */
-  virtual void
-  PrintSettingsVector(const SettingsVectorType & settings) const;
 
   /** Select different method to estimate some reasonable values for the parameters
    * SP_a, SP_alpha (=1), SigmoidMin, SigmoidMax (=1), and

--- a/Components/Optimizers/AdaGrad/elxAdaGrad.hxx
+++ b/Components/Optimizers/AdaGrad/elxAdaGrad.hxx
@@ -367,7 +367,7 @@ AdaGrad<TElastix>::AfterEachResolution()
   SettingsVectorType tempSettingsVector;
   tempSettingsVector.push_back(settings);
   elxout << "Settings of " << this->elxGetClassName() << " in resolution " << level << ":" << std::endl;
-  this->PrintSettingsVector(tempSettingsVector);
+  Superclass2::PrintSettingsVector(tempSettingsVector);
 
 } // end AfterEachResolution()
 
@@ -386,7 +386,7 @@ AdaGrad<TElastix>::AfterRegistration()
          << "Final metric value  = " << bestValue << '\n'
 
          << "Settings of " << this->elxGetClassName() << " for all resolutions:" << std::endl;
-  this->PrintSettingsVector(this->m_SettingsVector);
+  Superclass2::PrintSettingsVector(this->m_SettingsVector);
 
 } // end AfterRegistration()
 
@@ -879,64 +879,6 @@ AdaGrad<TElastix>::SampleGradients(const ParametersType & mu0, double perturbati
   }
 
 } // end SampleGradients()
-
-
-/**
- * **************** PrintSettingsVector **********************
- */
-
-template <class TElastix>
-void
-AdaGrad<TElastix>::PrintSettingsVector(const SettingsVectorType & settings) const
-{
-  const unsigned long nrofres = settings.size();
-
-  /** Print to log file */
-  elxout << "( SP_a ";
-  for (unsigned int i = 0; i < nrofres; ++i)
-  {
-    elxout << settings[i].a << " ";
-  }
-  elxout << ")\n"
-
-         << "( SP_A ";
-  for (unsigned int i = 0; i < nrofres; ++i)
-  {
-    elxout << settings[i].A << " ";
-  }
-  elxout << ")\n"
-
-         << "( SP_alpha ";
-  for (unsigned int i = 0; i < nrofres; ++i)
-  {
-    elxout << settings[i].alpha << " ";
-  }
-  elxout << ")\n"
-
-         << "( SigmoidMax ";
-  for (unsigned int i = 0; i < nrofres; ++i)
-  {
-    elxout << settings[i].fmax << " ";
-  }
-  elxout << ")\n"
-
-         << "( SigmoidMin ";
-  for (unsigned int i = 0; i < nrofres; ++i)
-  {
-    elxout << settings[i].fmin << " ";
-  }
-  elxout << ")\n"
-
-         << "( SigmoidScale ";
-  for (unsigned int i = 0; i < nrofres; ++i)
-  {
-    elxout << settings[i].omega << " ";
-  }
-  elxout << ")\n"
-
-         << std::endl;
-
-} // end PrintSettingsVector()
 
 
 /**

--- a/Components/Optimizers/AdaptiveStochasticGradientDescent/elxAdaptiveStochasticGradientDescent.h
+++ b/Components/Optimizers/AdaptiveStochasticGradientDescent/elxAdaptiveStochasticGradientDescent.h
@@ -300,12 +300,8 @@ protected:
   using JacobianType = typename TransformType::JacobianType;
   using ComputeJacobianTermsType = itk::ComputeJacobianTerms<FixedImageType, TransformType>;
   using JacobianValueType = typename JacobianType::ValueType;
-  struct SettingsType
-  {
-    double a, A, alpha, fmax, fmin, omega;
-  };
-  using SettingsVectorType = typename std::vector<SettingsType>;
-
+  using typename Superclass2::SettingsType;
+  using typename Superclass2::SettingsVectorType;
   using ComputeDisplacementDistributionType = itk::ComputeDisplacementDistribution<FixedImageType, TransformType>;
 
   /** Samplers: */
@@ -354,10 +350,6 @@ protected:
   RandomGeneratorPointer m_RandomGenerator;
 
   double m_SigmoidScaleFactor;
-
-  /** Print the contents of the settings vector to elxout. */
-  virtual void
-  PrintSettingsVector(const SettingsVectorType & settings) const;
 
   /** Select different method to estimate some reasonable values for the parameters
    * SP_a, SP_alpha (=1), SigmoidMin, SigmoidMax (=1), and

--- a/Components/Optimizers/AdaptiveStochasticGradientDescent/elxAdaptiveStochasticGradientDescent.hxx
+++ b/Components/Optimizers/AdaptiveStochasticGradientDescent/elxAdaptiveStochasticGradientDescent.hxx
@@ -345,7 +345,7 @@ AdaptiveStochasticGradientDescent<TElastix>::AfterEachResolution()
   SettingsVectorType tempSettingsVector;
   tempSettingsVector.push_back(settings);
   elxout << "Settings of " << this->elxGetClassName() << " in resolution " << level << ":" << std::endl;
-  this->PrintSettingsVector(tempSettingsVector);
+  Superclass2::PrintSettingsVector(tempSettingsVector);
 
 } // end AfterEachResolution()
 
@@ -364,7 +364,7 @@ AdaptiveStochasticGradientDescent<TElastix>::AfterRegistration()
          << "Final metric value  = " << bestValue << '\n'
 
          << "Settings of " << this->elxGetClassName() << " for all resolutions:" << std::endl;
-  this->PrintSettingsVector(this->m_SettingsVector);
+  Superclass2::PrintSettingsVector(this->m_SettingsVector);
 
 } // end AfterRegistration()
 
@@ -948,64 +948,6 @@ AdaptiveStochasticGradientDescent<TElastix>::SampleGradients(const ParametersTyp
   }
 
 } // end SampleGradients()
-
-
-/**
- * **************** PrintSettingsVector **********************
- */
-
-template <class TElastix>
-void
-AdaptiveStochasticGradientDescent<TElastix>::PrintSettingsVector(const SettingsVectorType & settings) const
-{
-  const unsigned long nrofres = settings.size();
-
-  /** Print to log file */
-  elxout << "( SP_a ";
-  for (unsigned int i = 0; i < nrofres; ++i)
-  {
-    elxout << settings[i].a << " ";
-  }
-  elxout << ")\n"
-
-         << "( SP_A ";
-  for (unsigned int i = 0; i < nrofres; ++i)
-  {
-    elxout << settings[i].A << " ";
-  }
-  elxout << ")\n"
-
-         << "( SP_alpha ";
-  for (unsigned int i = 0; i < nrofres; ++i)
-  {
-    elxout << settings[i].alpha << " ";
-  }
-  elxout << ")\n"
-
-         << "( SigmoidMax ";
-  for (unsigned int i = 0; i < nrofres; ++i)
-  {
-    elxout << settings[i].fmax << " ";
-  }
-  elxout << ")\n"
-
-         << "( SigmoidMin ";
-  for (unsigned int i = 0; i < nrofres; ++i)
-  {
-    elxout << settings[i].fmin << " ";
-  }
-  elxout << ")\n"
-
-         << "( SigmoidScale ";
-  for (unsigned int i = 0; i < nrofres; ++i)
-  {
-    elxout << settings[i].omega << " ";
-  }
-  elxout << ")\n"
-
-         << std::endl;
-
-} // end PrintSettingsVector()
 
 
 /**

--- a/Components/Optimizers/AdaptiveStochasticLBFGS/elxAdaptiveStochasticLBFGS.h
+++ b/Components/Optimizers/AdaptiveStochasticLBFGS/elxAdaptiveStochasticLBFGS.h
@@ -243,12 +243,8 @@ protected:
   using JacobianType = typename TransformType::JacobianType;
   using ComputeJacobianTermsType = itk::ComputeJacobianTerms<FixedImageType, TransformType>;
   using JacobianValueType = typename JacobianType::ValueType;
-  struct SettingsType
-  {
-    double a, A, alpha, fmax, fmin, omega;
-  };
-  using SettingsVectorType = typename std::vector<SettingsType>;
-
+  using typename Superclass2::SettingsType;
+  using typename Superclass2::SettingsVectorType;
   using ComputeDisplacementDistributionType = itk::ComputeDisplacementDistribution<FixedImageType, TransformType>;
 
   /** Samplers: */
@@ -310,10 +306,6 @@ protected:
   typename RandomGeneratorType::Pointer m_RandomGenerator;
 
   double m_SigmoidScaleFactor;
-
-  /** Print the contents of the settings vector to elxout. */
-  virtual void
-  PrintSettingsVector(const SettingsVectorType & settings) const;
 
   /** Select different method to estimate some reasonable values for the parameters
    * SP_a, SP_alpha (=1), SigmoidMin, SigmoidMax (=1), and

--- a/Components/Optimizers/AdaptiveStochasticLBFGS/elxAdaptiveStochasticLBFGS.hxx
+++ b/Components/Optimizers/AdaptiveStochasticLBFGS/elxAdaptiveStochasticLBFGS.hxx
@@ -429,7 +429,7 @@ AdaptiveStochasticLBFGS<TElastix>::AfterEachResolution()
   SettingsVectorType tempSettingsVector;
   tempSettingsVector.push_back(settings);
   elxout << "Settings of " << this->elxGetClassName() << " in resolution " << level << ":" << std::endl;
-  this->PrintSettingsVector(tempSettingsVector);
+  Superclass2::PrintSettingsVector(tempSettingsVector);
 
 } // end AfterEachResolution()
 
@@ -449,7 +449,7 @@ AdaptiveStochasticLBFGS<TElastix>::AfterRegistration()
          << "Final metric value  = " << bestValue << '\n'
 
          << "Settings of " << this->elxGetClassName() << " for all resolutions:" << std::endl;
-  this->PrintSettingsVector(this->m_SettingsVector);
+  Superclass2::PrintSettingsVector(this->m_SettingsVector);
 
 } // end AfterRegistration()
 
@@ -1418,64 +1418,6 @@ AdaptiveStochasticLBFGS<TElastix>::SampleGradients(const ParametersType & mu0,
   }
 
 } // end SampleGradients()
-
-
-/**
- * **************** PrintSettingsVector **********************
- */
-
-template <class TElastix>
-void
-AdaptiveStochasticLBFGS<TElastix>::PrintSettingsVector(const SettingsVectorType & settings) const
-{
-  const unsigned long nrofres = settings.size();
-
-  /** Print to log file */
-  elxout << "( SP_a ";
-  for (unsigned int i = 0; i < nrofres; ++i)
-  {
-    elxout << settings[i].a << " ";
-  }
-  elxout << ")\n"
-
-         << "( SP_A ";
-  for (unsigned int i = 0; i < nrofres; ++i)
-  {
-    elxout << settings[i].A << " ";
-  }
-  elxout << ")\n"
-
-         << "( SP_alpha ";
-  for (unsigned int i = 0; i < nrofres; ++i)
-  {
-    elxout << settings[i].alpha << " ";
-  }
-  elxout << ")\n"
-
-         << "( SigmoidMax ";
-  for (unsigned int i = 0; i < nrofres; ++i)
-  {
-    elxout << settings[i].fmax << " ";
-  }
-  elxout << ")\n"
-
-         << "( SigmoidMin ";
-  for (unsigned int i = 0; i < nrofres; ++i)
-  {
-    elxout << settings[i].fmin << " ";
-  }
-  elxout << ")\n"
-
-         << "( SigmoidScale ";
-  for (unsigned int i = 0; i < nrofres; ++i)
-  {
-    elxout << settings[i].omega << " ";
-  }
-  elxout << ")\n"
-
-         << std::endl;
-
-} // end PrintSettingsVector()
 
 
 /**

--- a/Components/Optimizers/AdaptiveStochasticVarianceReducedGradient/elxAdaptiveStochasticVarianceReducedGradient.h
+++ b/Components/Optimizers/AdaptiveStochasticVarianceReducedGradient/elxAdaptiveStochasticVarianceReducedGradient.h
@@ -318,12 +318,8 @@ protected:
   using JacobianType = typename TransformType::JacobianType;
   using ComputeJacobianTermsType = itk::ComputeJacobianTerms<FixedImageType, TransformType>;
   using JacobianValueType = typename JacobianType::ValueType;
-  struct SettingsType
-  {
-    double a, A, alpha, fmax, fmin, omega;
-  };
-  using SettingsVectorType = typename std::vector<SettingsType>;
-
+  using typename Superclass2::SettingsType;
+  using typename Superclass2::SettingsVectorType;
   using ComputeDisplacementDistributionType = itk::ComputeDisplacementDistribution<FixedImageType, TransformType>;
 
   /** Samplers: */
@@ -379,10 +375,6 @@ protected:
   typename RandomGeneratorType::Pointer m_RandomGenerator;
 
   double m_SigmoidScaleFactor;
-
-  /** Print the contents of the settings vector to elxout. */
-  virtual void
-  PrintSettingsVector(const SettingsVectorType & settings) const;
 
   /** Select different method to estimate some reasonable values for the parameters
    * SP_a, SP_alpha (=1), SigmoidMin, SigmoidMax (=1), and

--- a/Components/Optimizers/AdaptiveStochasticVarianceReducedGradient/elxAdaptiveStochasticVarianceReducedGradient.hxx
+++ b/Components/Optimizers/AdaptiveStochasticVarianceReducedGradient/elxAdaptiveStochasticVarianceReducedGradient.hxx
@@ -369,7 +369,7 @@ AdaptiveStochasticVarianceReducedGradient<TElastix>::AfterEachResolution()
   SettingsVectorType tempSettingsVector;
   tempSettingsVector.push_back(settings);
   elxout << "Settings of " << this->elxGetClassName() << " in resolution " << level << ":" << std::endl;
-  this->PrintSettingsVector(tempSettingsVector);
+  Superclass2::PrintSettingsVector(tempSettingsVector);
 
 } // end AfterEachResolution()
 
@@ -389,7 +389,7 @@ AdaptiveStochasticVarianceReducedGradient<TElastix>::AfterRegistration()
          << "Final metric value  = " << bestValue << '\n'
 
          << "Settings of " << this->elxGetClassName() << " for all resolutions:" << std::endl;
-  this->PrintSettingsVector(this->m_SettingsVector);
+  Superclass2::PrintSettingsVector(this->m_SettingsVector);
 
 } // end AfterRegistration()
 
@@ -1214,64 +1214,6 @@ AdaptiveStochasticVarianceReducedGradient<TElastix>::SampleGradients(const Param
   }
 
 } // end SampleGradients()
-
-
-/**
- * **************** PrintSettingsVector **********************
- */
-
-template <class TElastix>
-void
-AdaptiveStochasticVarianceReducedGradient<TElastix>::PrintSettingsVector(const SettingsVectorType & settings) const
-{
-  const unsigned long nrofres = settings.size();
-
-  /** Print to log file */
-  elxout << "( SP_a ";
-  for (unsigned int i = 0; i < nrofres; ++i)
-  {
-    elxout << settings[i].a << " ";
-  }
-  elxout << ")\n"
-
-         << "( SP_A ";
-  for (unsigned int i = 0; i < nrofres; ++i)
-  {
-    elxout << settings[i].A << " ";
-  }
-  elxout << ")\n"
-
-         << "( SP_alpha ";
-  for (unsigned int i = 0; i < nrofres; ++i)
-  {
-    elxout << settings[i].alpha << " ";
-  }
-  elxout << ")\n"
-
-         << "( SigmoidMax ";
-  for (unsigned int i = 0; i < nrofres; ++i)
-  {
-    elxout << settings[i].fmax << " ";
-  }
-  elxout << ")\n"
-
-         << "( SigmoidMin ";
-  for (unsigned int i = 0; i < nrofres; ++i)
-  {
-    elxout << settings[i].fmin << " ";
-  }
-  elxout << ")\n"
-
-         << "( SigmoidScale ";
-  for (unsigned int i = 0; i < nrofres; ++i)
-  {
-    elxout << settings[i].omega << " ";
-  }
-  elxout << ")\n"
-
-         << std::endl;
-
-} // end PrintSettingsVector()
 
 
 /**

--- a/Components/Optimizers/PreconditionedGradientDescent/elxPreconditionedGradientDescent.h
+++ b/Components/Optimizers/PreconditionedGradientDescent/elxPreconditionedGradientDescent.h
@@ -174,11 +174,8 @@ public:
   ResumeOptimization();
 
 protected:
-  struct SettingsType
-  {
-    double a, A, alpha, fmax, fmin, omega;
-  };
-  using SettingsVectorType = typename std::vector<SettingsType>;
+  using typename Superclass2::SettingsType;
+  using typename Superclass2::SettingsVectorType;
 
   /** Other protected typedefs */
   using RandomGeneratorType = itk::Statistics::MersenneTwisterRandomVariateGenerator;
@@ -214,10 +211,6 @@ protected:
   /** Get the SelfHessian from the metric and submit as Precondition matrix */
   virtual void
   SetSelfHessian();
-
-  /** Print the contents of the settings vector to elxout. */
-  virtual void
-  PrintSettingsVector(const SettingsVectorType & settings) const;
 
   /** Estimates some reasonable values for the parameters
    * SP_a, SP_alpha (=1), SigmoidMin, SigmoidMax (=1), and SigmoidScale.

--- a/Components/Optimizers/PreconditionedGradientDescent/elxPreconditionedGradientDescent.hxx
+++ b/Components/Optimizers/PreconditionedGradientDescent/elxPreconditionedGradientDescent.hxx
@@ -264,7 +264,7 @@ PreconditionedGradientDescent<TElastix>::AfterEachResolution()
   SettingsVectorType tempSettingsVector;
   tempSettingsVector.push_back(settings);
   elxout << "Settings of " << this->elxGetClassName() << " in resolution " << level << ":" << std::endl;
-  this->PrintSettingsVector(tempSettingsVector);
+  Superclass2::PrintSettingsVector(tempSettingsVector);
 
 } // end AfterEachResolution()
 
@@ -283,7 +283,7 @@ PreconditionedGradientDescent<TElastix>::AfterRegistration()
          << "Final metric value  = " << bestValue << '\n'
 
          << "Settings of " << this->elxGetClassName() << " for all resolutions:" << std::endl;
-  this->PrintSettingsVector(this->m_SettingsVector);
+  Superclass2::PrintSettingsVector(this->m_SettingsVector);
 
 } // end AfterRegistration()
 
@@ -695,64 +695,6 @@ PreconditionedGradientDescent<TElastix>::SampleGradients(const ParametersType & 
   }
 
 } // end SampleGradients()
-
-
-/**
- * **************** PrintSettingsVector **********************
- */
-
-template <class TElastix>
-void
-PreconditionedGradientDescent<TElastix>::PrintSettingsVector(const SettingsVectorType & settings) const
-{
-  const unsigned long nrofres = settings.size();
-
-  /** Print to log file */
-  elxout << "( SP_a ";
-  for (unsigned int i = 0; i < nrofres; ++i)
-  {
-    elxout << settings[i].a << " ";
-  }
-  elxout << ")\n"
-
-         << "( SP_A ";
-  for (unsigned int i = 0; i < nrofres; ++i)
-  {
-    elxout << settings[i].A << " ";
-  }
-  elxout << ")\n"
-
-         << "( SP_alpha ";
-  for (unsigned int i = 0; i < nrofres; ++i)
-  {
-    elxout << settings[i].alpha << " ";
-  }
-  elxout << ")\n"
-
-         << "( SigmoidMax ";
-  for (unsigned int i = 0; i < nrofres; ++i)
-  {
-    elxout << settings[i].fmax << " ";
-  }
-  elxout << ")\n"
-
-         << "( SigmoidMin ";
-  for (unsigned int i = 0; i < nrofres; ++i)
-  {
-    elxout << settings[i].fmin << " ";
-  }
-  elxout << ")\n"
-
-         << "( SigmoidScale ";
-  for (unsigned int i = 0; i < nrofres; ++i)
-  {
-    elxout << settings[i].omega << " ";
-  }
-  elxout << ")\n"
-
-         << std::endl;
-
-} // end PrintSettingsVector()
 
 
 /**

--- a/Components/Optimizers/PreconditionedStochasticGradientDescent/elxPreconditionedStochasticGradientDescent.h
+++ b/Components/Optimizers/PreconditionedStochasticGradientDescent/elxPreconditionedStochasticGradientDescent.h
@@ -293,11 +293,8 @@ protected:
   using TransformType = typename itkRegistrationType::TransformType;
   using JacobianType = typename TransformType::JacobianType;
   using JacobianValueType = typename JacobianType::ValueType;
-  struct SettingsType
-  {
-    double a, A, alpha, fmax, fmin, omega;
-  };
-  using SettingsVectorType = typename std::vector<SettingsType>;
+  using typename Superclass2::SettingsType;
+  using typename Superclass2::SettingsVectorType;
   using OutputImageType = typename ElastixType::FixedImageType;
 
   using PreconditionerEstimationType =
@@ -362,10 +359,6 @@ protected:
   double m_GlobalStepSize;
   double m_RegularizationKappa;
   double m_ConditionNumber;
-
-  /** Print the contents of the settings vector to elxout. */
-  virtual void
-  PrintSettingsVector(const SettingsVectorType & settings) const;
 
   /** Select different method to estimate some reasonable values for the parameters
    * SP_a, SP_alpha (=1), SigmoidMin, SigmoidMax (=1), and

--- a/Components/Optimizers/PreconditionedStochasticGradientDescent/elxPreconditionedStochasticGradientDescent.hxx
+++ b/Components/Optimizers/PreconditionedStochasticGradientDescent/elxPreconditionedStochasticGradientDescent.hxx
@@ -374,7 +374,7 @@ PreconditionedStochasticGradientDescent<TElastix>::AfterEachResolution()
   SettingsVectorType tempSettingsVector;
   tempSettingsVector.push_back(settings);
   elxout << "Settings of " << this->elxGetClassName() << " in resolution " << level << ":" << std::endl;
-  this->PrintSettingsVector(tempSettingsVector);
+  Superclass2::PrintSettingsVector(tempSettingsVector);
 
 } // end AfterEachResolution()
 
@@ -393,7 +393,7 @@ PreconditionedStochasticGradientDescent<TElastix>::AfterRegistration()
          << "Final metric value  = " << bestValue << '\n'
 
          << "Settings of " << this->elxGetClassName() << " for all resolutions:" << std::endl;
-  this->PrintSettingsVector(this->m_SettingsVector);
+  Superclass2::PrintSettingsVector(this->m_SettingsVector);
 
 } // end AfterRegistration()
 
@@ -899,64 +899,6 @@ PreconditionedStochasticGradientDescent<TElastix>::SampleGradients(const Paramet
   }
 
 } // end SampleGradients()
-
-
-/**
- * **************** PrintSettingsVector **********************
- */
-
-template <class TElastix>
-void
-PreconditionedStochasticGradientDescent<TElastix>::PrintSettingsVector(const SettingsVectorType & settings) const
-{
-  const unsigned long nrofres = settings.size();
-
-  /** Print to log file */
-  elxout << "( SP_a ";
-  for (unsigned int i = 0; i < nrofres; ++i)
-  {
-    elxout << settings[i].a << " ";
-  }
-  elxout << ")\n"
-
-         << "( SP_A ";
-  for (unsigned int i = 0; i < nrofres; ++i)
-  {
-    elxout << settings[i].A << " ";
-  }
-  elxout << ")\n"
-
-         << "( SP_alpha ";
-  for (unsigned int i = 0; i < nrofres; ++i)
-  {
-    elxout << settings[i].alpha << " ";
-  }
-  elxout << ")\n"
-
-         << "( SigmoidMax ";
-  for (unsigned int i = 0; i < nrofres; ++i)
-  {
-    elxout << settings[i].fmax << " ";
-  }
-  elxout << ")\n"
-
-         << "( SigmoidMin ";
-  for (unsigned int i = 0; i < nrofres; ++i)
-  {
-    elxout << settings[i].fmin << " ";
-  }
-  elxout << ")\n"
-
-         << "( SigmoidScale ";
-  for (unsigned int i = 0; i < nrofres; ++i)
-  {
-    elxout << settings[i].omega << " ";
-  }
-  elxout << ")\n"
-
-         << std::endl;
-
-} // end PrintSettingsVector()
 
 
 /**

--- a/Core/ComponentBaseClasses/elxOptimizerBase.h
+++ b/Core/ComponentBaseClasses/elxOptimizerBase.h
@@ -126,6 +126,16 @@ protected:
   virtual bool
   GetNewSamplesEveryIteration() const;
 
+  struct SettingsType
+  {
+    double a, A, alpha, fmax, fmin, omega;
+  };
+  using SettingsVectorType = typename std::vector<SettingsType>;
+
+  /** Print the contents of the settings vector to elxout. */
+  static void
+  PrintSettingsVector(const SettingsVectorType & settings);
+
 private:
   elxDeclarePureVirtualGetSelfMacro(ITKBaseType);
 

--- a/Core/ComponentBaseClasses/elxOptimizerBase.hxx
+++ b/Core/ComponentBaseClasses/elxOptimizerBase.hxx
@@ -127,6 +127,64 @@ OptimizerBase<TElastix>::GetNewSamplesEveryIteration() const
 
 
 /**
+ * **************** PrintSettingsVector **********************
+ */
+
+template <class TElastix>
+void
+OptimizerBase<TElastix>::PrintSettingsVector(const SettingsVectorType & settings)
+{
+  const unsigned long nrofres = settings.size();
+
+  /** Print to log file */
+  elxout << "( SP_a ";
+  for (unsigned int i = 0; i < nrofres; ++i)
+  {
+    elxout << settings[i].a << " ";
+  }
+  elxout << ")\n"
+
+         << "( SP_A ";
+  for (unsigned int i = 0; i < nrofres; ++i)
+  {
+    elxout << settings[i].A << " ";
+  }
+  elxout << ")\n"
+
+         << "( SP_alpha ";
+  for (unsigned int i = 0; i < nrofres; ++i)
+  {
+    elxout << settings[i].alpha << " ";
+  }
+  elxout << ")\n"
+
+         << "( SigmoidMax ";
+  for (unsigned int i = 0; i < nrofres; ++i)
+  {
+    elxout << settings[i].fmax << " ";
+  }
+  elxout << ")\n"
+
+         << "( SigmoidMin ";
+  for (unsigned int i = 0; i < nrofres; ++i)
+  {
+    elxout << settings[i].fmin << " ";
+  }
+  elxout << ")\n"
+
+         << "( SigmoidScale ";
+  for (unsigned int i = 0; i < nrofres; ++i)
+  {
+    elxout << settings[i].omega << " ";
+  }
+  elxout << ")\n"
+
+         << std::endl;
+
+} // end PrintSettingsVector()
+
+
+/**
  * ****************** SetSinusScales ********************
  */
 


### PR DESCRIPTION
Removed the duplicated `PrintSettingsVector` implementations from six optimizers:

    AdaGrad
    AdaptiveStochasticGradientDescent
    AdaptiveStochasticLBFGS
    AdaptiveStochasticVarianceReducedGradient
    PreconditionedGradientDescent
    PreconditionedStochasticGradientDescent