### PR TITLE
STYLE: No longer link to "rt", because clock_gettime() is no longer used

### DIFF
--- a/Common/CMakeLists.txt
+++ b/Common/CMakeLists.txt
@@ -214,14 +214,7 @@ endif()
 #---------------------------------------------------------------------
 # Link against other libraries.
 
-if(UNIX AND NOT APPLE)
-  target_link_libraries(elxCommon
-    ${ITK_LIBRARIES}
-    rt # Needed for elxTimer, clock_gettime()
-  )
-else()
-  target_link_libraries(elxCommon
-    ${ITK_LIBRARIES}
-  )
-endif()
+target_link_libraries(elxCommon
+  ${ITK_LIBRARIES}
+)
 


### PR DESCRIPTION
`clock_gettime()` was only used by the `Timer` class: commit 2a25d6c6504c5e6aad71ecfa5ddd9978f281db08, 16 February 2011. This `Timer` class was removed by commit e058d54e7fc8cc2101b7c03793408e84c85c3b53, 6 May 2014.