### PR TITLE
STYLE: Replace PrintArguments with MakeStringOfCommandLineArguments

### DIFF
--- a/Core/Main/elastix.cxx
+++ b/Core/Main/elastix.cxx
@@ -241,8 +241,9 @@ main(int argc, char ** argv)
     elxout << "elastix is started at " << GetCurrentDateAndTime() << ".\n" << std::endl;
 
     // Print where elastix was run, and print its version information.
-    elxout << "which elastix:   " << argv[0] << '\n' << elx::GetExtendedVersionInformation("elastix", "  ");
-    elx::PrintArguments(elxout, argv);
+    elxout << "which elastix:   " << argv[0] << '\n'
+           << elx::GetExtendedVersionInformation("elastix", "  ") << elx::MakeStringOfCommandLineArguments(argv)
+           << std::endl;
 
     itksys::SystemInformation info;
     info.RunCPUCheck();

--- a/Core/Main/elxMainExeUtilities.cxx
+++ b/Core/Main/elxMainExeUtilities.cxx
@@ -114,9 +114,11 @@ elastix::GetExtendedVersionInformation(const char * const executableName, const 
 }
 
 
-void
-elastix::PrintArguments(xoutlibrary::xoutbase & output, const char * const * const arguments)
+std::string
+elastix::MakeStringOfCommandLineArguments(const char * const * const arguments)
 {
+  std::ostringstream outputStringStream;
+
   if ((arguments == nullptr) || (*arguments == nullptr) || (*(arguments + 1) == nullptr))
   {
     assert(!"There should be at least two arguments!");
@@ -128,14 +130,15 @@ elastix::PrintArguments(xoutlibrary::xoutbase & output, const char * const * con
     };
 
     // Skip the first argument, as it is usually just the executable name.
-    output << "\nCommand-line arguments: \n  " << AddDoubleQuotesIfStringHasSpace(*(arguments + 1));
+    outputStringStream << "\nCommand-line arguments: \n  " << AddDoubleQuotesIfStringHasSpace(*(arguments + 1));
 
     auto argument = arguments + 2;
     while (*argument != nullptr)
     {
-      output << ' ' << AddDoubleQuotesIfStringHasSpace(*argument);
+      outputStringStream << ' ' << AddDoubleQuotesIfStringHasSpace(*argument);
       ++argument;
     }
-    output << '\n' << std::endl;
+    outputStringStream << '\n';
   }
+  return outputStringStream.str();
 }

--- a/Core/Main/elxMainExeUtilities.h
+++ b/Core/Main/elxMainExeUtilities.h
@@ -18,8 +18,6 @@
 #ifndef elxMainExeUtilities_h
 #define elxMainExeUtilities_h
 
-#include "xoutbase.h"
-
 #include <exception>
 #include <string>
 
@@ -34,9 +32,9 @@ ReportTerminatingException(const char * const executableName, const std::excepti
 std::string
 GetExtendedVersionInformation(const char * const executableName, const char * const indentation = "");
 
-/** Prints the command-line arguments to the specified output. */
-void
-PrintArguments(xoutlibrary::xoutbase & output, const char * const * const arguments);
+/** Makes a string of all command-line arguments. */
+std::string
+MakeStringOfCommandLineArguments(const char * const * const arguments);
 
 } // namespace elastix
 

--- a/Core/Main/transformix.cxx
+++ b/Core/Main/transformix.cxx
@@ -233,8 +233,9 @@ main(int argc, char ** argv)
     elxout << "transformix is started at " << GetCurrentDateAndTime() << ".\n" << std::endl;
 
     // Print where transformix was run, and print its version information.
-    elxout << "which transformix:   " << argv[0] << '\n' << elx::GetExtendedVersionInformation("transformix", "  ");
-    elx::PrintArguments(elxout, argv);
+    elxout << "which transformix:   " << argv[0] << '\n'
+           << elx::GetExtendedVersionInformation("transformix", "  ") << elx::MakeStringOfCommandLineArguments(argv)
+           << std::endl;
 
     itksys::SystemInformation info;
     info.RunCPUCheck();


### PR DESCRIPTION
Eases migration of the logging framework.