### PR TITLE
Remove xout from "itk*.*" files in elastix/Common

### DIFF
--- a/Common/CostFunctions/itkAdvancedImageToImageMetric.hxx
+++ b/Common/CostFunctions/itkAdvancedImageToImageMetric.hxx
@@ -27,8 +27,6 @@
 #  include <omp.h>
 #endif
 
-#include "itkTimeProbe.h"
-
 namespace itk
 {
 
@@ -193,9 +191,6 @@ AdvancedImageToImageMetric<TFixedImage, TMovingImage>::InitializeLimiters()
       itkExceptionMacro(<< "No fixed image limiter has been set!");
     }
 
-    itk::TimeProbe timer;
-    timer.Start();
-
     using ComputeFixedImageExtremaFilterType = typename itk::ComputeImageExtremaFilter<FixedImageType>;
     typename ComputeFixedImageExtremaFilterType::Pointer computeFixedImageExtrema =
       ComputeFixedImageExtremaFilterType::New();
@@ -218,9 +213,6 @@ AdvancedImageToImageMetric<TFixedImage, TMovingImage>::InitializeLimiters()
     }
 
     computeFixedImageExtrema->Update();
-    timer.Stop();
-    elxout << "  Computing the fixed image extrema took " << static_cast<long>(timer.GetMean() * 1000) << " ms."
-           << std::endl;
 
     this->m_FixedImageTrueMax = computeFixedImageExtrema->GetMaximum();
     this->m_FixedImageTrueMin = computeFixedImageExtrema->GetMinimum();
@@ -248,9 +240,6 @@ AdvancedImageToImageMetric<TFixedImage, TMovingImage>::InitializeLimiters()
       itkExceptionMacro(<< "No moving image limiter has been set!");
     }
 
-    itk::TimeProbe timer;
-    timer.Start();
-
     using ComputeMovingImageExtremaFilterType = typename itk::ComputeImageExtremaFilter<MovingImageType>;
     typename ComputeMovingImageExtremaFilterType::Pointer computeMovingImageExtrema =
       ComputeMovingImageExtremaFilterType::New();
@@ -271,10 +260,6 @@ AdvancedImageToImageMetric<TFixedImage, TMovingImage>::InitializeLimiters()
       }
     }
     computeMovingImageExtrema->Update();
-
-    timer.Stop();
-    elxout << "  Computing the moving image extrema took " << static_cast<long>(timer.GetMean() * 1000) << " ms."
-           << std::endl;
 
     this->m_MovingImageTrueMax = computeMovingImageExtrema->GetMaximum();
     this->m_MovingImageTrueMin = computeMovingImageExtrema->GetMinimum();

--- a/Common/itkComputePreconditionerUsingDisplacementDistribution.hxx
+++ b/Common/itkComputePreconditionerUsingDisplacementDistribution.hxx
@@ -317,11 +317,6 @@ ComputePreconditionerUsingDisplacementDistribution<TFixedImage, TTransform>::Com
       ++counter_tmp;
     }
 
-#if 0
-    //elxout << sigma << " ";
-    elxout << std::scientific << "The preconditioner before interpolation: [ "
-      << preconditioner[i] << " " << "]" << std::endl << std::fixed;
-#endif
   } // end loop over localStepSize vector
 
   if (counter_tmp > 0)
@@ -555,13 +550,6 @@ ComputePreconditionerUsingDisplacementDistribution<TFixedImage, TTransform>::Com
   /** Constrained the condition number into a given range, here we first try kappa = 2. */
   double conditionNumber = maxEigenvalue / minEigenvalue;
 
-#if 1
-  elxout << std::scientific << "The max eigen value is: [ " << maxEigenvalue << " ]\n"
-         << "The min eigen value is: [ " << minEigenvalue << " ]\n"
-         << "The condition number before constraints is: [ " << conditionNumber << " ]" << std::endl
-         << std::fixed;
-#endif
-
   if (transformIsBSpline && conditionNumber > this->m_ConditionNumber)
   {
     minEigenvalue = maxEigenvalue / this->m_ConditionNumber;
@@ -664,10 +652,6 @@ ComputePreconditionerUsingDisplacementDistribution<TFixedImage, TTransform>::Com
     }
   }
 
-#if 0
-  elxout << std::scientific << "The max eigen value is: [ " << maxEigenvalue << " " << "]\n" << "The min eigen value is: [ " << minEigenvalue << " " << "]" << std::endl;
-#endif
-
   /** Condition number check. */
   double conditionNumber = maxEigenvalue / minEigenvalue;
 
@@ -683,9 +667,6 @@ ComputePreconditionerUsingDisplacementDistribution<TFixedImage, TTransform>::Com
     }
   }
 
-#if 0
-  elxout << std::scientific << "The condition number after constraints is: [ " << maxEigenvalue / minEigenvalue << " " << "]" << std::endl << std::fixed;
-#endif
 } // end ComputeJacobiTypePreconditioner()
 
 


### PR DESCRIPTION
During today's internal weekly elastix sprint, we agreed that the "itk*.*" files in elastix/Common should not use the elastix specific logging system (neither the old xout system, nor the new one that is under development). @mstaring @stefanklein 