### PR TITLE
STYLE: Move `InitialTransform` from MainBase to ElastixMain

### DIFF
--- a/Core/Kernel/elxElastixMain.h
+++ b/Core/Kernel/elxElastixMain.h
@@ -105,6 +105,13 @@ public:
    */
   itkGetModifiableObjectMacro(FinalTransform, itk::Object);
 
+  /** Set/Get the initial transform
+   * the type is itk::Object, but the pointer should actually point
+   * to an itk::Transform type (or inherited from that one).
+   */
+  itkSetObjectMacro(InitialTransform, itk::Object);
+  itkGetModifiableObjectMacro(InitialTransform, itk::Object);
+
   /** Set/Get the original fixed image direction as a flat array
    * (d11 d21 d31 d21 d22 etc ) */
   virtual void
@@ -153,6 +160,9 @@ protected:
 
   /** A transform that is the result of registration. */
   ObjectPointer m_FinalTransform{ nullptr };
+
+  /** The initial transform. */
+  ObjectPointer m_InitialTransform{ nullptr };
 
   /** Transformation parameters map containing parameters that is the
    *  result of registration.

--- a/Core/Kernel/elxMainBase.h
+++ b/Core/Kernel/elxMainBase.h
@@ -126,13 +126,6 @@ public:
   ElastixBase &
   GetElastixBase() const;
 
-  /** Set/Get the initial transform
-   * the type is itk::Object, but the pointer should actually point
-   * to an itk::Transform type (or inherited from that one).
-   */
-  itkSetObjectMacro(InitialTransform, itk::Object);
-  itkGetModifiableObjectMacro(InitialTransform, itk::Object);
-
   /** Returns the Index that is used in elx::ComponentDatabase. */
   itkGetConstMacro(DBIndex, DBIndexType);
 
@@ -213,9 +206,6 @@ protected:
   DataObjectContainerPointer m_MovingImageContainer{ nullptr };
   DataObjectContainerPointer m_ResultImageContainer{ nullptr };
   DataObjectContainerPointer m_ResultDeformationFieldContainer{ nullptr };
-
-  /** The initial transform. */
-  ObjectPointer m_InitialTransform{ nullptr };
 
   /** InitDBIndex sets m_DBIndex by asking the ImageTypes
    * from the Configuration object and obtaining the corresponding

--- a/Core/Kernel/elxTransformixMain.cxx
+++ b/Core/Kernel/elxTransformixMain.cxx
@@ -148,11 +148,6 @@ TransformixMain::RunWithTransform(itk::TransformBase * const transform)
    */
   elastixBase.SetMovingImageContainer(this->GetModifiableMovingImageContainer());
 
-  /** Set the initial transform, if it happens to be there
-   * \todo: Does this make sense for transformix?
-   */
-  elastixBase.SetInitialTransform(this->GetModifiableInitialTransform());
-
   /** ApplyTransform! */
   try
   {


### PR DESCRIPTION
Made clearer that TransformixMain does not need to use the `InitialTransform` property of ElastixMain. `MainBase` is the common base class of TransformixMain and ElastixMain (from pull request https://github.com/SuperElastix/elastix/pull/806 commit c2a5de712dd14ade6f36cc45b443e8f7113b501d). So it appears preferable to move InitialTransform from MainBase to the elastix specific class ElastixMain.

Removed the `SetInitialTransform` call from TransformixMain, as it does not seem to make sense. Discussed with Marius (@mstaring) at our weekly internal elastix sprint.