### PR TITLE
Suppress "WARNING: The parameter..." logging when level is `error` (errors only)

### DIFF
--- a/Common/ParameterFileParser/itkParameterMapInterface.cxx
+++ b/Common/ParameterFileParser/itkParameterMapInterface.cxx
@@ -74,7 +74,7 @@ bool
 ParameterMapInterface::ReadParameter(bool &              parameterValue,
                                      const std::string & parameterName,
                                      const unsigned int  entry_nr,
-                                     const bool          printThisErrorMessage,
+                                     const bool          produceWarningMessage,
                                      std::string &       warningMessage) const
 {
   /** Translate the default boolean to string. */
@@ -90,7 +90,7 @@ ParameterMapInterface::ReadParameter(bool &              parameterValue,
 
   /** Read the boolean as a string. */
   bool dummy =
-    this->ReadParameter(parameterValueString, parameterName, entry_nr, printThisErrorMessage, warningMessage);
+    this->ReadParameter(parameterValueString, parameterName, entry_nr, produceWarningMessage, warningMessage);
 
   /** Translate the read-in string to boolean. */
   parameterValue = false;
@@ -118,7 +118,7 @@ ParameterMapInterface::ReadParameter(std::vector<std::string> & parameterValues,
                                      const std::string &        parameterName,
                                      const unsigned int         entry_nr_start,
                                      const unsigned int         entry_nr_end,
-                                     const bool                 printThisErrorMessage,
+                                     const bool                 produceWarningMessage,
                                      std::string &              warningMessage) const
 {
   /** Reset the warning message. */
@@ -130,7 +130,7 @@ ParameterMapInterface::ReadParameter(std::vector<std::string> & parameterValues,
   /** Check if the requested parameter exists. */
   if (numberOfEntries == 0)
   {
-    if (printThisErrorMessage && this->m_PrintErrorMessages)
+    if (produceWarningMessage && this->m_PrintErrorMessages)
     {
       std::ostringstream outputStringStream;
       outputStringStream << "WARNING: The parameter \"" << parameterName << "\", requested between entry numbers "

--- a/Common/ParameterFileParser/itkParameterMapInterface.cxx
+++ b/Common/ParameterFileParser/itkParameterMapInterface.cxx
@@ -75,7 +75,7 @@ ParameterMapInterface::ReadParameter(bool &              parameterValue,
                                      const std::string & parameterName,
                                      const unsigned int  entry_nr,
                                      const bool          printThisErrorMessage,
-                                     std::string &       errorMessage) const
+                                     std::string &       warningMessage) const
 {
   /** Translate the default boolean to string. */
   std::string parameterValueString;
@@ -89,7 +89,8 @@ ParameterMapInterface::ReadParameter(bool &              parameterValue,
   }
 
   /** Read the boolean as a string. */
-  bool dummy = this->ReadParameter(parameterValueString, parameterName, entry_nr, printThisErrorMessage, errorMessage);
+  bool dummy =
+    this->ReadParameter(parameterValueString, parameterName, entry_nr, printThisErrorMessage, warningMessage);
 
   /** Translate the read-in string to boolean. */
   parameterValue = false;
@@ -118,10 +119,10 @@ ParameterMapInterface::ReadParameter(std::vector<std::string> & parameterValues,
                                      const unsigned int         entry_nr_start,
                                      const unsigned int         entry_nr_end,
                                      const bool                 printThisErrorMessage,
-                                     std::string &              errorMessage) const
+                                     std::string &              warningMessage) const
 {
-  /** Reset the error message. */
-  errorMessage = "";
+  /** Reset the warning message. */
+  warningMessage = "";
 
   /** Get the number of entries. */
   std::size_t numberOfEntries = this->CountNumberOfParameterEntries(parameterName);
@@ -135,7 +136,7 @@ ParameterMapInterface::ReadParameter(std::vector<std::string> & parameterValues,
       outputStringStream << "WARNING: The parameter \"" << parameterName << "\", requested between entry numbers "
                          << entry_nr_start << " and " << entry_nr_end << ", does not exist at all.\n"
                          << "  The default values are used instead.";
-      errorMessage = outputStringStream.str();
+      warningMessage = outputStringStream.str();
     }
     return false;
   }

--- a/Common/ParameterFileParser/itkParameterMapInterface.h
+++ b/Common/ParameterFileParser/itkParameterMapInterface.h
@@ -138,7 +138,7 @@ public:
   ReadParameter(T &                 parameterValue,
                 const std::string & parameterName,
                 const unsigned int  entry_nr,
-                const bool          printThisErrorMessage,
+                const bool          produceWarningMessage,
                 std::string &       warningMessage) const
   {
     /** Reset the warning message. */
@@ -150,7 +150,7 @@ public:
     /** Check if the requested parameter exists. */
     if (numberOfEntries == 0)
     {
-      if (printThisErrorMessage && this->m_PrintErrorMessages)
+      if (produceWarningMessage && this->m_PrintErrorMessages)
       {
         std::ostringstream outputStringStream;
         outputStringStream << "WARNING: The parameter \"" << parameterName << "\", requested at entry number "
@@ -168,7 +168,7 @@ public:
     /** Check if it exists at the requested entry number. */
     if (entry_nr >= numberOfEntries)
     {
-      if (printThisErrorMessage && this->m_PrintErrorMessages)
+      if (produceWarningMessage && this->m_PrintErrorMessages)
       {
         std::ostringstream outputStringStream;
         outputStringStream << "WARNING: The parameter \"" << parameterName << "\" does not exist at entry number "
@@ -200,11 +200,11 @@ public:
   ReadParameter(bool &              parameterValue,
                 const std::string & parameterName,
                 const unsigned int  entry_nr,
-                const bool          printThisErrorMessage,
+                const bool          produceWarningMessage,
                 std::string &       warningMessage) const;
 
   /** A shorter version of ReadParameter() that does not require the boolean
-   * printThisErrorMessage. Instead the default value true is used.
+   * produceWarningMessage. Instead the default value true is used.
    */
   template <class T>
   bool
@@ -229,7 +229,7 @@ public:
                 const std::string & prefix,
                 const unsigned int  entry_nr,
                 const int           default_entry_nr,
-                const bool          printThisErrorMessage,
+                const bool          produceWarningMessage,
                 std::string &       warningMessage) const
   {
     std::string fullname = prefix + parameterName;
@@ -256,7 +256,7 @@ public:
     /** If we haven't found anything, give a warning that the default value
      * provided by the caller is used.
      */
-    if (!found && printThisErrorMessage && this->m_PrintErrorMessages)
+    if (!found && produceWarningMessage && this->m_PrintErrorMessages)
     {
       return this->ReadParameter(parameterValue, parameterName, entry_nr, true, warningMessage);
     }
@@ -266,7 +266,7 @@ public:
 
 
   /** A shorter version of the extended ReadParameter() that does not require
-   * the boolean printThisErrorMessage. Instead the default value true is used.
+   * the boolean produceWarningMessage. Instead the default value true is used.
    */
   template <class T>
   bool
@@ -288,7 +288,7 @@ public:
                 const std::string & parameterName,
                 const unsigned int  entry_nr_start,
                 const unsigned int  entry_nr_end,
-                const bool          printThisErrorMessage,
+                const bool          produceWarningMessage,
                 std::string &       warningMessage) const
   {
     /** Reset the warning message. */
@@ -300,7 +300,7 @@ public:
     /** Check if the requested parameter exists. */
     if (numberOfEntries == 0)
     {
-      if (printThisErrorMessage && this->m_PrintErrorMessages)
+      if (produceWarningMessage && this->m_PrintErrorMessages)
       {
         std::ostringstream outputStringStream;
         outputStringStream << "WARNING: The parameter \"" << parameterName << "\", requested between entry numbers "
@@ -365,7 +365,7 @@ public:
                 const std::string &        parameterName,
                 const unsigned int         entry_nr_start,
                 const unsigned int         entry_nr_end,
-                const bool                 printThisErrorMessage,
+                const bool                 produceWarningMessage,
                 std::string &              warningMessage) const;
 
 

--- a/Common/ParameterFileParser/itkParameterMapInterface.h
+++ b/Common/ParameterFileParser/itkParameterMapInterface.h
@@ -64,9 +64,9 @@ namespace itk
  * unsigned long parameterValue = 3;
  * unsigned int index = 2;
  * bool printWarning = true;
- * std::string errorMessage = "";
+ * std::string warningMessage = "";
  * bool success = p_interface->ReadParameter( parameterValue,
- *   "ParameterName", index, printWarning, errorMessage );
+ *   "ParameterName", index, printWarning, warningMessage );
  *
  *
  * Note that some of the templated functions are defined in the header to
@@ -139,10 +139,10 @@ public:
                 const std::string & parameterName,
                 const unsigned int  entry_nr,
                 const bool          printThisErrorMessage,
-                std::string &       errorMessage) const
+                std::string &       warningMessage) const
   {
-    /** Reset the error message. */
-    errorMessage = "";
+    /** Reset the warning message. */
+    warningMessage = "";
 
     /** Get the number of entries. */
     std::size_t numberOfEntries = this->CountNumberOfParameterEntries(parameterName);
@@ -156,7 +156,7 @@ public:
         outputStringStream << "WARNING: The parameter \"" << parameterName << "\", requested at entry number "
                            << entry_nr << ", does not exist at all.\n"
                            << "  The default value \"" << parameterValue << "\" is used instead.";
-        errorMessage = outputStringStream.str();
+        warningMessage = outputStringStream.str();
       }
 
       return false;
@@ -173,7 +173,7 @@ public:
         std::ostringstream outputStringStream;
         outputStringStream << "WARNING: The parameter \"" << parameterName << "\" does not exist at entry number "
                            << entry_nr << ".\n  The default value \"" << parameterValue << "\" is used instead.";
-        errorMessage = outputStringStream.str();
+        warningMessage = outputStringStream.str();
       }
       return false;
     }
@@ -201,7 +201,7 @@ public:
                 const std::string & parameterName,
                 const unsigned int  entry_nr,
                 const bool          printThisErrorMessage,
-                std::string &       errorMessage) const;
+                std::string &       warningMessage) const;
 
   /** A shorter version of ReadParameter() that does not require the boolean
    * printThisErrorMessage. Instead the default value true is used.
@@ -211,9 +211,9 @@ public:
   ReadParameter(T &                 parameterValue,
                 const std::string & parameterName,
                 const unsigned int  entry_nr,
-                std::string &       errorMessage) const
+                std::string &       warningMessage) const
   {
-    return this->ReadParameter(parameterValue, parameterName, entry_nr, true, errorMessage);
+    return this->ReadParameter(parameterValue, parameterName, entry_nr, true, warningMessage);
   }
 
 
@@ -230,7 +230,7 @@ public:
                 const unsigned int  entry_nr,
                 const int           default_entry_nr,
                 const bool          printThisErrorMessage,
-                std::string &       errorMessage) const
+                std::string &       warningMessage) const
   {
     std::string fullname = prefix + parameterName;
     bool        found = false;
@@ -258,7 +258,7 @@ public:
      */
     if (!found && printThisErrorMessage && this->m_PrintErrorMessages)
     {
-      return this->ReadParameter(parameterValue, parameterName, entry_nr, true, errorMessage);
+      return this->ReadParameter(parameterValue, parameterName, entry_nr, true, warningMessage);
     }
 
     return found;
@@ -275,9 +275,9 @@ public:
                 const std::string & prefix,
                 const unsigned int  entry_nr,
                 const unsigned int  default_entry_nr,
-                std::string &       errorMessage) const
+                std::string &       warningMessage) const
   {
-    return this->ReadParameter(parameterValue, parameterName, prefix, entry_nr, default_entry_nr, true, errorMessage);
+    return this->ReadParameter(parameterValue, parameterName, prefix, entry_nr, default_entry_nr, true, warningMessage);
   }
 
 
@@ -289,10 +289,10 @@ public:
                 const unsigned int  entry_nr_start,
                 const unsigned int  entry_nr_end,
                 const bool          printThisErrorMessage,
-                std::string &       errorMessage) const
+                std::string &       warningMessage) const
   {
-    /** Reset the error message. */
-    errorMessage = "";
+    /** Reset the warning message. */
+    warningMessage = "";
 
     /** Get the number of entries. */
     std::size_t numberOfEntries = this->CountNumberOfParameterEntries(parameterName);
@@ -306,7 +306,7 @@ public:
         outputStringStream << "WARNING: The parameter \"" << parameterName << "\", requested between entry numbers "
                            << entry_nr_start << " and " << entry_nr_end << ", does not exist at all.\n"
                            << "  The default values are used instead.";
-        errorMessage = outputStringStream.str();
+        warningMessage = outputStringStream.str();
       }
       return false;
     }
@@ -366,7 +366,7 @@ public:
                 const unsigned int         entry_nr_start,
                 const unsigned int         entry_nr_end,
                 const bool                 printThisErrorMessage,
-                std::string &              errorMessage) const;
+                std::string &              warningMessage) const;
 
 
   /** Returns the values of the specified parameter. */

--- a/Core/Configuration/elxConfiguration.h
+++ b/Core/Configuration/elxConfiguration.h
@@ -150,11 +150,11 @@ public:
   ReadParameter(T &                 parameterValue,
                 const std::string & parameterName,
                 const unsigned int  entry_nr,
-                const bool          printThisErrorMessage) const
+                const bool          produceWarningMessage) const
   {
     std::string warningMessage = "";
     bool        found = this->m_ParameterMapInterface->ReadParameter(
-      parameterValue, parameterName, entry_nr, printThisErrorMessage, warningMessage);
+      parameterValue, parameterName, entry_nr, produceWarningMessage, warningMessage);
     if (!warningMessage.empty())
     {
       log::warn(warningMessage);
@@ -188,11 +188,11 @@ public:
                 const std::string & prefix,
                 const unsigned int  entry_nr,
                 const int           default_entry_nr,
-                const bool          printThisErrorMessage) const
+                const bool          produceWarningMessage) const
   {
     std::string warningMessage = "";
     bool        found = this->m_ParameterMapInterface->ReadParameter(
-      parameterValue, parameterName, prefix, entry_nr, default_entry_nr, printThisErrorMessage, warningMessage);
+      parameterValue, parameterName, prefix, entry_nr, default_entry_nr, produceWarningMessage, warningMessage);
     if (!warningMessage.empty())
     {
       log::warn(warningMessage);
@@ -258,10 +258,10 @@ public:
   RetrieveParameterValue(const T &           defaultParameterValue,
                          const std::string & parameterName,
                          const unsigned int  entry_nr,
-                         const bool          printThisErrorMessage) const
+                         const bool          produceWarningMessage) const
   {
     auto parameterValue = defaultParameterValue;
-    (void)Self::ReadParameter<T>(parameterValue, parameterName, entry_nr, printThisErrorMessage);
+    (void)Self::ReadParameter<T>(parameterValue, parameterName, entry_nr, produceWarningMessage);
     return parameterValue;
   }
 
@@ -272,9 +272,9 @@ public:
   RetrieveParameterStringValue(const std::string & defaultParameterValue,
                                const std::string & parameterName,
                                const unsigned int  entry_nr,
-                               const bool          printThisErrorMessage) const
+                               const bool          produceWarningMessage) const
   {
-    return Self::RetrieveParameterValue(defaultParameterValue, parameterName, entry_nr, printThisErrorMessage);
+    return Self::RetrieveParameterValue(defaultParameterValue, parameterName, entry_nr, produceWarningMessage);
   }
 
 
@@ -285,11 +285,11 @@ public:
                 const std::string & parameterName,
                 const unsigned int  entry_nr_start,
                 const unsigned int  entry_nr_end,
-                const bool          printThisErrorMessage) const
+                const bool          produceWarningMessage) const
   {
     std::string warningMessage = "";
     bool        found = this->m_ParameterMapInterface->ReadParameter(
-      parameterValues, parameterName, entry_nr_start, entry_nr_end, printThisErrorMessage, warningMessage);
+      parameterValues, parameterName, entry_nr_start, entry_nr_end, produceWarningMessage, warningMessage);
     if (!warningMessage.empty())
     {
       log::warn(warningMessage);

--- a/Core/Configuration/elxConfiguration.h
+++ b/Core/Configuration/elxConfiguration.h
@@ -152,12 +152,12 @@ public:
                 const unsigned int  entry_nr,
                 const bool          printThisErrorMessage) const
   {
-    std::string errorMessage = "";
+    std::string warningMessage = "";
     bool        found = this->m_ParameterMapInterface->ReadParameter(
-      parameterValue, parameterName, entry_nr, printThisErrorMessage, errorMessage);
-    if (!errorMessage.empty())
+      parameterValue, parameterName, entry_nr, printThisErrorMessage, warningMessage);
+    if (!warningMessage.empty())
     {
-      log::error(errorMessage);
+      log::warn(warningMessage);
     }
 
     return found;
@@ -169,11 +169,11 @@ public:
   bool
   ReadParameter(T & parameterValue, const std::string & parameterName, const unsigned int entry_nr) const
   {
-    std::string errorMessage = "";
-    bool found = this->m_ParameterMapInterface->ReadParameter(parameterValue, parameterName, entry_nr, errorMessage);
-    if (!errorMessage.empty())
+    std::string warningMessage = "";
+    bool found = this->m_ParameterMapInterface->ReadParameter(parameterValue, parameterName, entry_nr, warningMessage);
+    if (!warningMessage.empty())
     {
-      log::error(errorMessage);
+      log::warn(warningMessage);
     }
 
     return found;
@@ -190,12 +190,12 @@ public:
                 const int           default_entry_nr,
                 const bool          printThisErrorMessage) const
   {
-    std::string errorMessage = "";
+    std::string warningMessage = "";
     bool        found = this->m_ParameterMapInterface->ReadParameter(
-      parameterValue, parameterName, prefix, entry_nr, default_entry_nr, printThisErrorMessage, errorMessage);
-    if (!errorMessage.empty())
+      parameterValue, parameterName, prefix, entry_nr, default_entry_nr, printThisErrorMessage, warningMessage);
+    if (!warningMessage.empty())
     {
-      log::error(errorMessage);
+      log::warn(warningMessage);
     }
 
     return found;
@@ -211,12 +211,12 @@ public:
                 const unsigned int  entry_nr,
                 const int           default_entry_nr) const
   {
-    std::string errorMessage = "";
+    std::string warningMessage = "";
     bool        found = this->m_ParameterMapInterface->ReadParameter(
-      parameterValue, parameterName, prefix, entry_nr, default_entry_nr, errorMessage);
-    if (!errorMessage.empty())
+      parameterValue, parameterName, prefix, entry_nr, default_entry_nr, warningMessage);
+    if (!warningMessage.empty())
     {
-      log::error(errorMessage);
+      log::warn(warningMessage);
     }
 
     return found;
@@ -287,12 +287,12 @@ public:
                 const unsigned int  entry_nr_end,
                 const bool          printThisErrorMessage) const
   {
-    std::string errorMessage = "";
+    std::string warningMessage = "";
     bool        found = this->m_ParameterMapInterface->ReadParameter(
-      parameterValues, parameterName, entry_nr_start, entry_nr_end, printThisErrorMessage, errorMessage);
-    if (!errorMessage.empty())
+      parameterValues, parameterName, entry_nr_start, entry_nr_end, printThisErrorMessage, warningMessage);
+    if (!warningMessage.empty())
     {
-      log::error(errorMessage);
+      log::warn(warningMessage);
     }
 
     return found;


### PR DESCRIPTION
@stefanklein FYI We agreed at today's sprint that those typical "WARNING: The parameter..." messages from `ParameterMapInterface` should be suppressed when the user specifies that only error messages should be displayed (command-line option `-loglevel error`).