### PR TITLE
ENH: Only write parameter file to log file when level = `info` (default)

### DIFF
--- a/Core/Configuration/elxConfiguration.cxx
+++ b/Core/Configuration/elxConfiguration.cxx
@@ -90,12 +90,12 @@ Configuration::PrintParameterFile() const
   std::string params = this->m_ParameterFileParser->ReturnParameterFileAsString();
 
   /** Separate clearly in log-file, before and after writing the parameter file. */
-  log::to_log_file(std::ostringstream{} << '\n'
-                                        << "=============== start of ParameterFile: " << this->GetParameterFileName()
-                                        << " ===============\n"
-                                        << params << '\n'
-                                        << "=============== end of ParameterFile: " << this->GetParameterFileName()
-                                        << " ===============\n");
+  log::info_to_log_file(std::ostringstream{} << '\n'
+                                             << "=============== start of ParameterFile: "
+                                             << this->GetParameterFileName() << " ===============\n"
+                                             << params << '\n'
+                                             << "=============== end of ParameterFile: " << this->GetParameterFileName()
+                                             << " ===============\n");
 
 } // end PrintParameterFile()
 

--- a/Core/Kernel/elxElastixTemplate.hxx
+++ b/Core/Kernel/elxElastixTemplate.hxx
@@ -770,7 +770,7 @@ ElastixTemplate<TFixedImage, TMovingImage>::CreateTransformParameterFile(const s
   /** Separate clearly in log-file. */
   if (toLog)
   {
-    log::to_log_file("\n=============== start of TransformParameterFile ===============");
+    log::info_to_log_file("\n=============== start of TransformParameterFile ===============");
   }
 
   /** Create transformationParameterInfo. */
@@ -799,8 +799,8 @@ ElastixTemplate<TFixedImage, TMovingImage>::CreateTransformParameterFile(const s
   /** Separate clearly in log-file. */
   if (toLog)
   {
-    log::to_log_file(transformationParameterInfo.str());
-    log::to_log_file("=============== end of TransformParameterFile ===============");
+    log::info_to_log_file(transformationParameterInfo.str());
+    log::info_to_log_file("=============== end of TransformParameterFile ===============");
   }
 
 } // end CreateTransformParameterFile()

--- a/Core/Kernel/elxlog.cxx
+++ b/Core/Kernel/elxlog.cxx
@@ -165,12 +165,18 @@ setup_implementation(const std::string & log_filename,
   auto & data = get_log_data();
 
   // From here, the code is exception free, so all sinks will be set properly.
-  data.get_log_file_logger().sinks() = std::move(log_file_sink);
+  const auto spdlog_level = to_spdlog_level_enum(log_level);
+
+  auto & log_file_logger = data.get_log_file_logger();
+
+  log_file_logger.sinks() = std::move(log_file_sink);
+  log_file_logger.set_level(spdlog_level);
+
   data.get_stdout_logger().sinks() = std::move(stdout_sink);
 
   auto & multi_logger = data.get_multi_logger();
 
-  multi_logger.set_level(to_spdlog_level_enum(log_level));
+  multi_logger.set_level(spdlog_level);
   multi_logger.sinks() = std::move(all_sinks);
 }
 
@@ -249,15 +255,15 @@ log::error(const std::ostream & stream)
 }
 
 void
-log::to_log_file(const std::string & message)
+log::info_to_log_file(const std::string & message)
 {
   get_log_data().get_log_file_logger().info(message);
 }
 
 void
-log::to_log_file(const std::ostream & stream)
+log::info_to_log_file(const std::ostream & stream)
 {
-  log::to_log_file(get_string_from_stream(stream));
+  log::info_to_log_file(get_string_from_stream(stream));
 }
 
 void

--- a/Core/Kernel/elxlog.h
+++ b/Core/Kernel/elxlog.h
@@ -85,10 +85,10 @@ public:
   ///@{
   /** Passes the message only to the log file, not to stdout. */
   static void
-  to_log_file(const std::string & message);
+  info_to_log_file(const std::string & message);
 
   static void
-  to_log_file(const std::ostream & stream);
+  info_to_log_file(const std::ostream & stream);
   ///@}
 
   ///@{


### PR DESCRIPTION
Replaced `log::to_log_file` with `log::info_to_log_file`, which _only_ writes to file when the log level is `info` (which is the default).

ElastixTemplate::CreateTransformParameterFile and Configuration::PrintParameterFile() no longer write to file when the log level is `warning`, `error`, or `off`.