### PR TITLE
PERF: Simplify TransformPoint member functions of BSpline Transform class templates

### DIFF
--- a/Common/Transforms/itkRecursiveBSplineTransform.hxx
+++ b/Common/Transforms/itkRecursiveBSplineTransform.hxx
@@ -34,17 +34,11 @@ auto
 RecursiveBSplineTransform<TScalar, NDimensions, VSplineOrder>::TransformPoint(const InputPointType & point) const
   -> OutputPointType
 {
-  /** Initialize output point. */
-  OutputPointType outputPoint;
-
-  /** Allocate weights on the stack: */
-
   /** Check if the coefficient image has been set. */
   if (!this->m_CoefficientImages[0])
   {
     itkWarningMacro(<< "B-spline coefficients have not been set");
-    outputPoint = point;
-    return outputPoint;
+    return point;
   }
 
   /** Convert to continuous index. */
@@ -52,11 +46,9 @@ RecursiveBSplineTransform<TScalar, NDimensions, VSplineOrder>::TransformPoint(co
 
   // NOTE: if the support region does not lie totally within the grid
   // we assume zero displacement and return the input point
-  bool inside = this->InsideValidRegion(cindex);
-  if (!inside)
+  if (!this->InsideValidRegion(cindex))
   {
-    outputPoint = point;
-    return outputPoint;
+    return point;
   }
 
   // Compute interpolation weighs and store them in weights1D
@@ -80,6 +72,8 @@ RecursiveBSplineTransform<TScalar, NDimensions, VSplineOrder>::TransformPoint(co
   /** Call the recursive TransformPoint function. */
   ScalarType displacement[SpaceDimension];
   ImplementationType::TransformPoint(displacement, mu, bsplineOffsetTable, weights1D.data());
+
+  OutputPointType outputPoint;
 
   // The output point is the start point + displacement.
   for (unsigned int j = 0; j < SpaceDimension; ++j)


### PR DESCRIPTION
Removed unnecessary local variables, `numberOfWeights`, `indicesArray`, `indices`, `transformedPoint`, `outputPoint`, and `basePointer` from both `AdvancedBSplineDeformableTransform` and `CyclicBSplineDeformableTransform`.

A small but significant improvement of the runtime performance (more than 6%) was observed, from ~3.0 sec. (before this commit) down to ~2.8 sec. (with this commit), when calling `AdvancedBSplineDeformableTransform::TransformPoint` 10'000'000 times.

Also did some code clean-up  within `RecursiveBSplineTransform::TransformPoint`

Follow-up to pull request #582 "Code cleanup BSpline Transforms from Common/Transforms" (January 17, 2022)

@ntatsisk Can you see if this obvious code clean-up makes the regular (non-recursive) BSpline Transform any faster?