### PR TITLE
STYLE: Add elx::ComponentInstaller, simplify elxInstallMacro(_classname)

### DIFF
--- a/Core/CMakeLists.txt
+++ b/Core/CMakeLists.txt
@@ -32,6 +32,7 @@ set(InstallFilesForExecutables
 set(InstallFilesForComponents
   Install/elxComponentDatabase.cxx
   Install/elxComponentDatabase.h
+  Install/elxComponentInstaller.h
   Install/elxConversion.cxx
   Install/elxConversion.h
   Install/elxBaseComponent.cxx

--- a/Core/Install/elxComponentInstaller.h
+++ b/Core/Install/elxComponentInstaller.h
@@ -1,0 +1,63 @@
+/*=========================================================================
+ *
+ *  Copyright UMC Utrecht and contributors
+ *
+ *  Licensed under the Apache License, Version 2.0 (the "License");
+ *  you may not use this file except in compliance with the License.
+ *  You may obtain a copy of the License at
+ *
+ *        http://www.apache.org/licenses/LICENSE-2.0.txt
+ *
+ *  Unless required by applicable law or agreed to in writing, software
+ *  distributed under the License is distributed on an "AS IS" BASIS,
+ *  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *  See the License for the specific language governing permissions and
+ *  limitations under the License.
+ *
+ *=========================================================================*/
+
+#ifndef elxComponentInstaller_h
+#define elxComponentInstaller_h
+
+#include "elxInstallFunctions.h"
+#include "elxPrepareImageTypeSupport.h" // For ElastixTypedef.
+#include "elxSupportedImageTypes.h"     // For NrOfSupportedImageTypes.
+
+namespace elastix
+{
+/** Installs the component specified by its first argument. Note that `TComponent` is a "template template parameter".
+ * It has a `TElastix` as template parameter, for example `elastix::TranslationTransformElastix` or
+ * `elastix::FixedSmoothingPyramid`. */
+template <template <class TElastix> class TComponent, unsigned VIndex = 1>
+class ComponentInstaller
+{
+public:
+  static int
+  DO(ComponentDatabase * cdb)
+  {
+    using ElastixType = typename ElastixTypedef<VIndex>::ElastixType;
+    const auto name = TComponent<ElastixType>::elxGetClassNameStatic();
+    const int  dummy = InstallFunctions<TComponent<ElastixType>>::InstallComponent(name, VIndex, cdb);
+    if (ElastixTypedef<VIndex + 1>::IsDefined)
+    {
+      return ComponentInstaller<TComponent, VIndex + 1>::DO(cdb);
+    }
+    return dummy;
+  }
+};
+
+
+template <template <class TElastix> class TComponent>
+class ComponentInstaller<TComponent, NrOfSupportedImageTypes + 1>
+{
+public:
+  static int
+  DO(ComponentDatabase * /** cdb */)
+  {
+    return 0;
+  }
+};
+
+} // namespace elastix
+
+#endif

--- a/Core/Install/elxIncludes.h
+++ b/Core/Install/elxIncludes.h
@@ -38,6 +38,7 @@
 #include "elxMacro.h"
 #include "elxElastixTemplate.h"
 #include "elxSupportedImageTypes.h"
+#include "elxComponentInstaller.h"
 
 /** Writing to screen and logfiles etc. */
 #include "elxlog.h"

--- a/Core/Install/elxMacro.h
+++ b/Core/Install/elxMacro.h
@@ -88,45 +88,16 @@
  * not less.
  *
  * Details: a function "int _classname##InstallComponent( _cdb )" is defined.
- * In this function a template is defined, _classname\#\#_install<VIndex>.
+ * In this function a ComponentInstaller template is instantiated.
  * It contains the ElastixTypedef<VIndex>, and recursive function DO(cdb).
  * DO installs the component for all defined ElastixTypedefs (so for all
  * supported image types).
  *
  */
 #define elxInstallMacro(_classname)                                                                                    \
-  template <unsigned VIndex>                                                                                           \
-  class ITK_TEMPLATE_EXPORT _classname##_install                                                                       \
-  {                                                                                                                    \
-  public:                                                                                                              \
-    static int                                                                                                         \
-    DO(::elastix::ComponentDatabase * cdb)                                                                             \
-    {                                                                                                                  \
-      using ElastixType = typename ::elastix::ElastixTypedef<VIndex>::ElastixType;                                     \
-      const auto name = ::elastix::_classname<ElastixType>::elxGetClassNameStatic();                                   \
-      const int  dummy =                                                                                               \
-        ::elastix::InstallFunctions<::elastix::_classname<ElastixType>>::InstallComponent(name, VIndex, cdb);          \
-      if (::elastix::ElastixTypedef<VIndex + 1>::IsDefined)                                                            \
-      {                                                                                                                \
-        return _classname##_install<VIndex + 1>::DO(cdb);                                                              \
-      }                                                                                                                \
-      return dummy;                                                                                                    \
-    }                                                                                                                  \
-  };                                                                                                                   \
-  template <>                                                                                                          \
-  class _classname##_install<::elastix::NrOfSupportedImageTypes + 1>                                                   \
-  {                                                                                                                    \
-  public:                                                                                                              \
-    static int                                                                                                         \
-    DO(::elastix::ComponentDatabase * /** cdb */)                                                                      \
-    {                                                                                                                  \
-      return 0;                                                                                                        \
-    }                                                                                                                  \
-  };                                                                                                                   \
   extern "C" int _classname##InstallComponent(::elastix::ComponentDatabase * _cdb)                                     \
   {                                                                                                                    \
-    int _InstallDummy##_classname = _classname##_install<1>::DO(_cdb);                                                 \
-    return _InstallDummy##_classname;                                                                                  \
+    return ::elastix::ComponentInstaller<::elastix::_classname>::DO(_cdb);                                             \
   } // ignore semicolon
 
 


### PR DESCRIPTION
Moved most of the code from the definition of `elxInstallMacro(_classname)` from "elxMacro.h" to a new file "elxComponentInstaller.h", and a new class template, `elx::ComponentInstaller`.

Aims to improve code readability and ease further maintenance.