### PR TITLE
COMP: Exclude Doxygen related files from Azure Pipelines CI

### DIFF
--- a/Testing/CI/Azure/ci.yml
+++ b/Testing/CI/Azure/ci.yml
@@ -9,12 +9,18 @@ variables:
 trigger:
   paths:
     exclude:
-    - CODE_OF_CONDUCT.md
-    - CONTRIBUTING.md
-    - GOVERNANCE.md
-    - README.md
+    - '*.md'
     - LICENSE
     - .github/workflows/*
+    - dox/doxygen/*
+    - tools/*
+pr:
+  paths:
+    exclude:
+    - '*.md'
+    - LICENSE
+    - .github/workflows/*
+    - dox/doxygen/*
     - tools/*
 
 jobs:


### PR DESCRIPTION
Further extended the exclusion of specific files from the Azure Pipelines CI runs. Those files were not tested by the CI anyway.

Inspired by ITK pull request https://github.com/InsightSoftwareConsortium/ITK/pull/3930 commit https://github.com/InsightSoftwareConsortium/ITK/commit/eb5ca2585a62e5031d137a46194dd944600e758b "COMP: Exclude Utilities/Maintenance and documentation files from AZP CI"