### PR TITLE
COMP: Fix OpenCL elxElastixMain.cxx compilation errors

### DIFF
--- a/Core/Kernel/elxElastixMain.cxx
+++ b/Core/Kernel/elxElastixMain.cxx
@@ -18,6 +18,11 @@
 
 #include "elxElastixMain.h"
 
+#ifdef ELASTIX_USE_OPENCL
+#  include "itkOpenCLContext.h"
+#  include "itkOpenCLSetup.h"
+#endif
+
 namespace elastix
 {
 


### PR DESCRIPTION
Fixed the errors that occur when ELASTIX_USE_OPENCL is enabled, saying:

> elxElastixMain.cxx(84,10): error C2039: 'CreateOpenCLContext': is not a member of 'itk'
...
> elxElastixMain.cxx(95,26): error C3861: 'CreateOpenCLLogger': identifier not found

These errors were introduced with pull request https://github.com/SuperElastix/elastix/pull/806 commit c2a5de712dd14ade6f36cc45b443e8f7113b501d "STYLE: Add `MainBase`, a base class of ElastixMain and TransformixMain", and reported by Konstantinos Ntatsis (@ntatsisk).