### PR TITLE
PERF: OpenCL resampler speedup when using BSplineInterpolator

### DIFF
--- a/Common/OpenCL/Filters/itkGPUInterpolatorCopier.hxx
+++ b/Common/OpenCL/Filters/itkGPUInterpolatorCopier.hxx
@@ -72,8 +72,7 @@ GPUInterpolatorCopier<TTypeList, NDimensions, TInterpolator, TOutputCoordRep>::U
 
     // Try Nearest
     using NearestNeighborInterpolatorType = NearestNeighborInterpolateImageFunction<CPUInputImageType, CPUCoordRepType>;
-    const typename NearestNeighborInterpolatorType::ConstPointer nearest =
-      dynamic_cast<const NearestNeighborInterpolatorType *>(m_InputInterpolator.GetPointer());
+    const auto nearest = dynamic_cast<const NearestNeighborInterpolatorType *>(m_InputInterpolator.GetPointer());
 
     if (nearest)
     {
@@ -96,8 +95,7 @@ GPUInterpolatorCopier<TTypeList, NDimensions, TInterpolator, TOutputCoordRep>::U
 
     // Try Linear
     using LinearInterpolatorType = LinearInterpolateImageFunction<CPUInputImageType, CPUCoordRepType>;
-    const typename LinearInterpolatorType::ConstPointer linear =
-      dynamic_cast<const LinearInterpolatorType *>(m_InputInterpolator.GetPointer());
+    const auto linear = dynamic_cast<const LinearInterpolatorType *>(m_InputInterpolator.GetPointer());
 
     if (linear)
     {
@@ -117,14 +115,11 @@ GPUInterpolatorCopier<TTypeList, NDimensions, TInterpolator, TOutputCoordRep>::U
     }
 
     // Try BSpline
-    using BSplineInterpolatorType =
-      BSplineInterpolateImageFunction<CPUInputImageType, CPUCoordRepType, double>;
-    const typename BSplineInterpolatorType::ConstPointer bspline =
-      dynamic_cast<const BSplineInterpolatorType *>(m_InputInterpolator.GetPointer());
+    using BSplineInterpolatorType = BSplineInterpolateImageFunction<CPUInputImageType, CPUCoordRepType, double>;
+    const auto bspline = dynamic_cast<const BSplineInterpolatorType *>(m_InputInterpolator.GetPointer());
 
     using BSplineInterpolatorFloatType = BSplineInterpolateImageFunction<CPUInputImageType, CPUCoordRepType, float>;
-    const typename BSplineInterpolatorFloatType::ConstPointer bsplineFloat =
-      dynamic_cast<const BSplineInterpolatorFloatType *>(m_InputInterpolator.GetPointer());
+    const auto bsplineFloat = dynamic_cast<const BSplineInterpolatorFloatType *>(m_InputInterpolator.GetPointer());
 
     if (bspline || bsplineFloat)
     {
@@ -136,14 +131,12 @@ GPUInterpolatorCopier<TTypeList, NDimensions, TInterpolator, TOutputCoordRep>::U
         // using m_Coefficients as ITK images inside the implementation,
         // and also BSplineDecompositionImageFilter for the calculations
         using GPUImageFactoryType = itk::GPUImageFactory2<TTypeList, NDimensions>;
-        using GPUImageFactoryPointer = typename GPUImageFactoryType::Pointer;
-        GPUImageFactoryPointer imageFactory = GPUImageFactoryType::New();
+        auto imageFactory = GPUImageFactoryType::New();
         itk::ObjectFactoryBase::RegisterFactory(imageFactory);
 
-        using GPUBSplineDecompositionImageFilterFactoryType = itk::GPUBSplineDecompositionImageFilterFactory2<TTypeList, TTypeList, NDimensions>;
-        using GPUBSplineDecompositionImageFilterFactoryTypePointer = typename GPUBSplineDecompositionImageFilterFactoryType::Pointer;
-        GPUBSplineDecompositionImageFilterFactoryTypePointer decompositionFactory =
-          GPUBSplineDecompositionImageFilterFactoryType::New();
+        using GPUBSplineDecompositionImageFilterFactoryType =
+          itk::GPUBSplineDecompositionImageFilterFactory2<TTypeList, TTypeList, NDimensions>;
+        auto decompositionFactory = GPUBSplineDecompositionImageFilterFactoryType::New();
         itk::ObjectFactoryBase::RegisterFactory(decompositionFactory);
 
         // Create GPU BSpline interpolator in explicit mode

--- a/Common/OpenCL/Filters/itkGPUInterpolatorCopier.hxx
+++ b/Common/OpenCL/Filters/itkGPUInterpolatorCopier.hxx
@@ -118,12 +118,18 @@ GPUInterpolatorCopier<TTypeList, NDimensions, TInterpolator, TOutputCoordRep>::U
 
     // Try BSpline
     using BSplineInterpolatorType =
-      BSplineInterpolateImageFunction<CPUInputImageType, CPUCoordRepType, CPUCoordRepType>;
+      BSplineInterpolateImageFunction<CPUInputImageType, CPUCoordRepType, double>;
     const typename BSplineInterpolatorType::ConstPointer bspline =
       dynamic_cast<const BSplineInterpolatorType *>(m_InputInterpolator.GetPointer());
 
-    if (bspline)
+    using BSplineInterpolatorFloatType = BSplineInterpolateImageFunction<CPUInputImageType, CPUCoordRepType, float>;
+    const typename BSplineInterpolatorFloatType::ConstPointer bsplineFloat =
+      dynamic_cast<const BSplineInterpolatorFloatType *>(m_InputInterpolator.GetPointer());
+
+    if (bspline || bsplineFloat)
     {
+      const auto splineOrder = bspline ? bspline->GetSplineOrder() : bsplineFloat->GetSplineOrder();
+
       if (this->m_ExplicitMode)
       {
         // Register image factory because BSplineInterpolateImageFunction
@@ -144,7 +150,7 @@ GPUInterpolatorCopier<TTypeList, NDimensions, TInterpolator, TOutputCoordRep>::U
         using GPUBSplineInterpolatorType =
           GPUBSplineInterpolateImageFunction<GPUInputImageType, GPUCoordRepType, GPUCoordRepType>;
         auto bsplineInterpolator = GPUBSplineInterpolatorType::New();
-        bsplineInterpolator->SetSplineOrder(bspline->GetSplineOrder());
+        bsplineInterpolator->SetSplineOrder(splineOrder);
 
         // UnRegister factories
         itk::ObjectFactoryBase::UnRegisterFactory(imageFactory);
@@ -158,7 +164,7 @@ GPUInterpolatorCopier<TTypeList, NDimensions, TInterpolator, TOutputCoordRep>::U
         using GPUBSplineInterpolatorType =
           BSplineInterpolateImageFunction<CPUInputImageType, GPUCoordRepType, GPUCoordRepType>;
         auto bsplineInterpolator = GPUBSplineInterpolatorType::New();
-        bsplineInterpolator->SetSplineOrder(bspline->GetSplineOrder());
+        bsplineInterpolator->SetSplineOrder(splineOrder);
         this->m_Output = bsplineInterpolator;
       }
       return;

--- a/Components/Resamplers/OpenCLResampler/elxOpenCLResampler.hxx
+++ b/Components/Resamplers/OpenCLResampler/elxOpenCLResampler.hxx
@@ -105,12 +105,16 @@ template <class TElastix>
 void
 OpenCLResampler<TElastix>::SetInterpolator(InterpolatorType * _arg)
 {
-  Superclass1::SetInterpolator(_arg);
-
   if (this->m_ContextCreated && this->m_GPUResamplerCreated)
   {
     // Set input for the interpolate copier
     this->m_InterpolatorCopier->SetInputInterpolator(_arg);
+  }
+  else
+  {
+    // Change the default LinearInterpolator only when the OpenCL
+    // is not properly setup
+    Superclass1::SetInterpolator(_arg);
   }
 } // end SetInterpolator()
 


### PR DESCRIPTION
While doing some benchmarks for issue: https://github.com/SuperElastix/elastix/issues/226, I noticed that when `BSplineInterpolator` is being used then `Transformix` runs faster in the CPU than the GPU. The order of the `itk::ProcessObject`s that is called is the following:

```
######################################### CPU TRANSFORMIX #########################################
class itk::ImageFileReader<class itk::Image<float,3>,class itk::DefaultConvertPixelTraits<float> >
class itk::TransformixFilter<class itk::Image<float,3> >
class itk::BSplineDecompositionImageFilter<class itk::Image<float,3>,class itk::Image<double,3> >
class elastix::MyStandardResampler<class elastix::ElastixTemplate<class itk::Image<float,3>,class itk::Image<float,3> > >
class itk::ChangeInformationImageFilter<class itk::Image<float,3> >
class itk::CastImageFilter<class itk::Image<float,3>,class itk::Image<float,3> >

######################################### GPU TRANSFORMIX #########################################
class itk::TransformixFilter<class itk::Image<float,3> >
class itk::BSplineDecompositionImageFilter<class itk::Image<float,3>,class itk::Image<double,3> >
class elastix::OpenCLResampler<class elastix::ElastixTemplate<class itk::Image<float,3>,class itk::Image<float,3> > >
class itk::BSplineDecompositionImageFilter<class itk::GPUImage<float,3>,class itk::Image<float,3> >
class itk::GPUResampleImageFilter<class itk::GPUImage<float,3>,class itk::GPUImage<float,3>,float,float>
class itk::ChangeInformationImageFilter<class itk::Image<float,3> >
class itk::CastImageFilter<class itk::Image<float,3>,class itk::Image<float,3> >
```

For GPU Transformix, there are two calls to  `itk::BSplineDecompositionImageFilter` which runs in CPU. The first is completely redundant, while the second should take place in the GPU. After the changes of this PR, the call stack is the following:

```
######################################### GPU TRANSFORMIX #########################################
class itk::TransformixFilter<class itk::Image<float,3> >
class elastix::OpenCLResampler<class elastix::ElastixTemplate<class itk::Image<float,3>,class itk::Image<float,3> > >
class itk::GPUBSplineDecompositionImageFilter<class itk::GPUImage<float,3>,class itk::Image<float,3> >
class itk::GPUCastImageFilter<class itk::GPUImage<float,3>,class itk::GPUImage<float,3> >
class itk::GPUResampleImageFilter<class itk::GPUImage<float,3>,class itk::GPUImage<float,3>,float,float>
class itk::ChangeInformationImageFilter<class itk::Image<float,3> >
class itk::CastImageFilter<class itk::Image<float,3>,class itk::Image<float,3> >
```
Just as indication for `n=1`, the run-times for a specific case that I tried (more to come):
```
CPU: 5.82052 sec
GPU-before: 11.1926 sec
GPU-updated: 0.828516 sec

```