### PR TITLE
ENH: Add `InitialTransformParameterMap` to ElastixRegistrationMethod

### DIFF
--- a/Core/ComponentBaseClasses/elxTransformBase.hxx
+++ b/Core/ComponentBaseClasses/elxTransformBase.hxx
@@ -192,6 +192,17 @@ TransformBase<TElastix>::BeforeRegistrationBase()
         itkExceptionMacro(<< "ERROR: the file " << fileName << " does not exist!");
       }
     }
+    else
+    {
+      const auto & initialTransformParameterMap = this->m_Configuration->GetInitialTransformParameterMap();
+
+      if (!initialTransformParameterMap.empty())
+      {
+        const auto initialTransformConfiguration = Configuration::New();
+        initialTransformConfiguration->Initialize({}, initialTransformParameterMap);
+        this->ReadInitialTransformFromConfiguration(initialTransformConfiguration);
+      }
+    }
   }
 
 } // end BeforeRegistrationBase()

--- a/Core/Configuration/elxConfiguration.h
+++ b/Core/Configuration/elxConfiguration.h
@@ -71,6 +71,8 @@ public:
   using CommandLineArgumentMapType = std::map<std::string, std::string>;
   using CommandLineEntryType = CommandLineArgumentMapType::value_type;
 
+  using ParameterMapType = itk::ParameterFileParser::ParameterMapType;
+
   /** Get and Set CommandLine arguments into the argument map. */
   std::string
   GetCommandLineArgument(const std::string & key) const;
@@ -108,6 +110,18 @@ public:
   /** Get and Set the total number of elastix levels. */
   itkSetMacro(TotalNumberOfElastixLevels, unsigned int);
   itkGetConstMacro(TotalNumberOfElastixLevels, unsigned int);
+
+  void
+  SetInitialTransformParameterMap(const ParameterMapType & parameterMap)
+  {
+    m_InitialTransformParameterMap = parameterMap;
+  }
+
+  ParameterMapType
+  GetInitialTransformParameterMap() const
+  {
+    return m_InitialTransformParameterMap;
+  }
 
   /***/
   bool
@@ -312,6 +326,7 @@ protected:
 
 private:
   CommandLineArgumentMapType                m_CommandLineArgumentMap{};
+  ParameterMapType                          m_InitialTransformParameterMap{};
   std::string                               m_ParameterFileName{};
   const itk::ParameterFileParser::Pointer   m_ParameterFileParser{ itk::ParameterFileParser::New() };
   const itk::ParameterMapInterface::Pointer m_ParameterMapInterface{ itk::ParameterMapInterface::New() };

--- a/Core/Kernel/elxElastixMain.h
+++ b/Core/Kernel/elxElastixMain.h
@@ -19,6 +19,7 @@
 #define elxElastixMain_h
 
 #include "elxMainBase.h"
+#include "elxDeref.h"
 
 
 namespace elastix
@@ -112,6 +113,21 @@ public:
   itkSetObjectMacro(InitialTransform, itk::Object);
   itkGetModifiableObjectMacro(InitialTransform, itk::Object);
 
+  void
+  SetInitialTransformParameterMap(const ParameterMapType & parameterMap)
+  {
+    Configuration & configuration = Deref(Superclass::GetConfiguration());
+    configuration.SetInitialTransformParameterMap(parameterMap);
+  }
+
+  ParameterMapType
+  GetInitialTransformParameterMap() const
+  {
+    const Configuration * const configuration = Superclass::GetConfiguration();
+    return configuration ? configuration->GetInitialTransformParameterMap() : ParameterMapType{};
+  }
+
+
   /** Set/Get the original fixed image direction as a flat array
    * (d11 d21 d31 d21 d22 etc ) */
   virtual void
@@ -163,6 +179,8 @@ protected:
 
   /** The initial transform. */
   ObjectPointer m_InitialTransform{ nullptr };
+
+  ParameterMapType m_InitialTransformParameterMap{};
 
   /** Transformation parameters map containing parameters that is the
    *  result of registration.

--- a/Core/Main/GTesting/itkElastixRegistrationMethodGTest.cxx
+++ b/Core/Main/GTesting/itkElastixRegistrationMethodGTest.cxx
@@ -582,6 +582,60 @@ GTEST_TEST(itkElastixRegistrationMethod, InitialTransformParameterFile)
 }
 
 
+GTEST_TEST(itkElastixRegistrationMethod, InitialTransformParameterMap)
+{
+  using PixelType = float;
+  constexpr auto ImageDimension = 2U;
+  using ImageType = itk::Image<PixelType, ImageDimension>;
+  using SizeType = itk::Size<ImageDimension>;
+  using IndexType = itk::Index<ImageDimension>;
+  using OffsetType = itk::Offset<ImageDimension>;
+
+  const OffsetType initialTranslation{ { 1, -2 } };
+  const auto       regionSize = SizeType::Filled(2);
+  const SizeType   imageSize{ { 5, 6 } };
+  const IndexType  fixedImageRegionIndex{ { 1, 3 } };
+
+  const auto fixedImage = CreateImage<PixelType>(imageSize);
+  FillImageRegion(*fixedImage, fixedImageRegionIndex, regionSize);
+
+  const auto movingImage = CreateImage<PixelType>(imageSize);
+
+  DefaultConstructibleElastixRegistrationMethod<ImageType, ImageType> registration;
+
+  registration.SetFixedImage(fixedImage);
+  registration.SetInitialTransformParameterMap({ { "NumberOfParameters", { "2" } },
+                                                 { "Transform", { "TranslationTransform" } },
+                                                 { "TransformParameters", { "1", "-2" } } });
+
+  registration.SetParameterObject(CreateParameterObject({ // Parameters in alphabetic order:
+                                                          { "ImageSampler", "Full" },
+                                                          { "MaximumNumberOfIterations", "2" },
+                                                          { "Metric", "AdvancedNormalizedCorrelation" },
+                                                          { "Optimizer", "AdaptiveStochasticGradientDescent" },
+                                                          { "Transform", "TranslationTransform" } }));
+
+  const auto toOffset = [](const IndexType & index) { return index - IndexType(); };
+
+  for (const auto index :
+       itk::ImageRegionIndexRange<ImageDimension>(itk::ImageRegion<ImageDimension>({ 0, -2 }, { 2, 3 })))
+  {
+    movingImage->FillBuffer(0);
+    FillImageRegion(*movingImage, fixedImageRegionIndex + toOffset(index), regionSize);
+    registration.SetMovingImage(movingImage);
+    registration.Update();
+
+    const auto transformParameters = GetTransformParametersFromFilter(registration);
+    ASSERT_EQ(transformParameters.size(), ImageDimension);
+
+    for (unsigned i{}; i < ImageDimension; ++i)
+    {
+      EXPECT_EQ(std::round(transformParameters[i]), index[i] - initialTranslation[i]);
+    }
+  }
+}
+
+
 GTEST_TEST(itkElastixRegistrationMethod, InitialTransformParameterFileLinkToTransformFile)
 {
   using PixelType = float;

--- a/Core/Main/itkElastixRegistrationMethod.h
+++ b/Core/Main/itkElastixRegistrationMethod.h
@@ -201,6 +201,18 @@ public:
     this->SetInitialTransformParameterFileName("");
   }
 
+  void
+  SetInitialTransformParameterMap(const ParameterMapType & parameterMap)
+  {
+    m_InitialTransformParameterMap = parameterMap;
+  }
+
+  ParameterMapType
+  GetInitialTransformParameterMap() const
+  {
+    return m_InitialTransformParameterMap;
+  }
+
   /** Set/Get/Remove fixed point set filename. */
   itkSetMacro(FixedPointSetFileName, std::string);
   itkGetConstMacro(FixedPointSetFileName, std::string);
@@ -311,9 +323,10 @@ private:
 
   SmartPointer<const elx::ElastixMain> m_ElastixMain{ nullptr };
 
-  std::string m_InitialTransformParameterFileName{};
-  std::string m_FixedPointSetFileName{};
-  std::string m_MovingPointSetFileName{};
+  std::string      m_InitialTransformParameterFileName{};
+  ParameterMapType m_InitialTransformParameterMap{};
+  std::string      m_FixedPointSetFileName{};
+  std::string      m_MovingPointSetFileName{};
 
   std::string m_OutputDirectory{};
   std::string m_LogFileName{};

--- a/Core/Main/itkElastixRegistrationMethod.hxx
+++ b/Core/Main/itkElastixRegistrationMethod.hxx
@@ -232,6 +232,7 @@ ElastixRegistrationMethod<TFixedImage, TMovingImage>::GenerateData()
     unsigned int isError = 0;
     try
     {
+      elastixMain->SetInitialTransformParameterMap(m_InitialTransformParameterMap);
       isError = elastixMain->Run(argumentMap, parameterMap);
     }
     catch (const itk::ExceptionObject & e)


### PR DESCRIPTION
Adds the ability to specify the initial transform of a registration by a parameter map, for example:

    registration.SetInitialTransformParameterMap({ { "NumberOfParameters", { "2" } },
                                                   { "Transform", { "TranslationTransform" } },
                                                   { "TransformParameters", { "1", "-2" } } });