### PR TITLE
Show progress percentage only when requested by user

### DIFF
--- a/Components/Optimizers/AdaGrad/elxAdaGrad.hxx
+++ b/Components/Optimizers/AdaGrad/elxAdaGrad.hxx
@@ -780,9 +780,9 @@ AdaGrad<TElastix>::SampleGradients(const ParametersType & mu0, double perturbati
   } // end if NewSamplesEveryIteration.
 
   /** Prepare for progress printing. */
-  const auto progressObserver = BaseComponent::IsElastixLibrary()
-                                  ? nullptr
-                                  : ProgressCommand::CreateAndSetUpdateFrequency(this->m_NumberOfGradientMeasurements);
+  const auto progressObserver = log::is_progress_percentage_shown()
+                                  ? ProgressCommand::CreateAndSetUpdateFrequency(this->m_NumberOfGradientMeasurements)
+                                  : nullptr;
   log::info("  Sampling gradients ...");
 
   /** Initialize some variables for storing gradients and their magnitudes. */

--- a/Components/Optimizers/AdaptiveStochasticGradientDescent/elxAdaptiveStochasticGradientDescent.hxx
+++ b/Components/Optimizers/AdaptiveStochasticGradientDescent/elxAdaptiveStochasticGradientDescent.hxx
@@ -853,9 +853,9 @@ AdaptiveStochasticGradientDescent<TElastix>::SampleGradients(const ParametersTyp
   } // end if NewSamplesEveryIteration.
 
   /** Prepare for progress printing. */
-  const auto progressObserver = BaseComponent::IsElastixLibrary()
-                                  ? nullptr
-                                  : ProgressCommand::CreateAndSetUpdateFrequency(this->m_NumberOfGradientMeasurements);
+  const auto progressObserver = log::is_progress_percentage_shown()
+                                  ? ProgressCommand::CreateAndSetUpdateFrequency(this->m_NumberOfGradientMeasurements)
+                                  : nullptr;
   log::info("  Sampling gradients ...");
 
   /** Initialize some variables for storing gradients and their magnitudes. */

--- a/Components/Optimizers/AdaptiveStochasticLBFGS/elxAdaptiveStochasticLBFGS.hxx
+++ b/Components/Optimizers/AdaptiveStochasticLBFGS/elxAdaptiveStochasticLBFGS.hxx
@@ -1326,9 +1326,9 @@ AdaptiveStochasticLBFGS<TElastix>::SampleGradients(const ParametersType & mu0,
   }   // end if NewSamplesEveryIteration.
 
   /** Prepare for progress printing. */
-  const auto progressObserver = BaseComponent::IsElastixLibrary()
-                                  ? nullptr
-                                  : ProgressCommand::CreateAndSetUpdateFrequency(this->m_NumberOfGradientMeasurements);
+  const auto progressObserver = log::is_progress_percentage_shown()
+                                  ? ProgressCommand::CreateAndSetUpdateFrequency(this->m_NumberOfGradientMeasurements)
+                                  : nullptr;
   // elxout << "  Sampling gradients ..." << std::endl;
 
   /** Initialize some variables for storing gradients and their magnitudes. */

--- a/Components/Optimizers/AdaptiveStochasticVarianceReducedGradient/elxAdaptiveStochasticVarianceReducedGradient.hxx
+++ b/Components/Optimizers/AdaptiveStochasticVarianceReducedGradient/elxAdaptiveStochasticVarianceReducedGradient.hxx
@@ -1121,9 +1121,9 @@ AdaptiveStochasticVarianceReducedGradient<TElastix>::SampleGradients(const Param
   }   // end if NewSamplesEveryIteration.
 
   /** Prepare for progress printing. */
-  const auto progressObserver = BaseComponent::IsElastixLibrary()
-                                  ? nullptr
-                                  : ProgressCommand::CreateAndSetUpdateFrequency(this->m_NumberOfGradientMeasurements);
+  const auto progressObserver = log::is_progress_percentage_shown()
+                                  ? ProgressCommand::CreateAndSetUpdateFrequency(this->m_NumberOfGradientMeasurements)
+                                  : nullptr;
   log::info("  Sampling gradients ...");
 
   /** Initialize some variables for storing gradients and their magnitudes. */

--- a/Components/Optimizers/PreconditionedStochasticGradientDescent/elxPreconditionedStochasticGradientDescent.hxx
+++ b/Components/Optimizers/PreconditionedStochasticGradientDescent/elxPreconditionedStochasticGradientDescent.hxx
@@ -792,9 +792,9 @@ PreconditionedStochasticGradientDescent<TElastix>::SampleGradients(const Paramet
   } // end if NewSamplesEveryIteration.
 
   /** Prepare for progress printing. */
-  const auto progressObserver = BaseComponent::IsElastixLibrary()
-                                  ? nullptr
-                                  : ProgressCommand::CreateAndSetUpdateFrequency(this->m_NumberOfGradientMeasurements);
+  const auto progressObserver = log::is_progress_percentage_shown()
+                                  ? ProgressCommand::CreateAndSetUpdateFrequency(this->m_NumberOfGradientMeasurements)
+                                  : nullptr;
   log::info("  Sampling gradients ...");
 
   /** Initialize some variables for storing gradients and their magnitudes. */

--- a/Core/ComponentBaseClasses/elxResamplerBase.hxx
+++ b/Core/ComponentBaseClasses/elxResamplerBase.hxx
@@ -298,9 +298,9 @@ ResamplerBase<TElastix>::ResampleAndWriteResultImage(const char * filename, cons
   resampleImageFilter.Modified();
 
   /** Add a progress observer to the resampler. */
-  const auto progressObserver = (!showProgress || BaseComponent::IsElastixLibrary())
-                                  ? nullptr
-                                  : ProgressCommand::CreateAndConnect(resampleImageFilter);
+  const auto progressObserver = (showProgress && log::is_progress_percentage_shown())
+                                  ? ProgressCommand::CreateAndConnect(resampleImageFilter)
+                                  : nullptr;
 
   /** Do the resampling. */
   try
@@ -417,7 +417,7 @@ ResamplerBase<TElastix>::CreateItkResultImage()
   resampleImageFilter.Modified();
 
   const auto progressObserver =
-    BaseComponent::IsElastixLibrary() ? nullptr : ProgressCommand::CreateAndConnect(*(this->GetAsITKBaseType()));
+    log::is_progress_percentage_shown() ? ProgressCommand::CreateAndConnect(*(this->GetAsITKBaseType())) : nullptr;
 
   /** Do the resampling. */
   try

--- a/Core/ComponentBaseClasses/elxTransformBase.hxx
+++ b/Core/ComponentBaseClasses/elxTransformBase.hxx
@@ -972,7 +972,7 @@ TransformBase<TElastix>::GenerateDeformationFieldImage() const -> typename Defor
 
   /** Track the progress of the generation of the deformation field. */
   const auto progressObserver =
-    BaseComponent::IsElastixLibrary() ? nullptr : ProgressCommand::CreateAndConnect(*defGenerator);
+    log::is_progress_percentage_shown() ? ProgressCommand::CreateAndConnect(*defGenerator) : nullptr;
 
   try
   {
@@ -1092,7 +1092,7 @@ TransformBase<TElastix>::ComputeAndWriteSpatialJacobianDeterminantImage() const
 
   /** Track the progress of the generation of the deformation field. */
   const auto progressObserver =
-    BaseComponent::IsElastixLibrary() ? nullptr : ProgressCommand::CreateAndConnect(*jacGenerator);
+    log::is_progress_percentage_shown() ? ProgressCommand::CreateAndConnect(*jacGenerator) : nullptr;
   /** Create a name for the deformation field file. */
   std::string resultImageFormat = "mhd";
   this->m_Configuration->ReadParameter(resultImageFormat, "ResultImageFormat", 0, false);
@@ -1144,7 +1144,7 @@ TransformBase<TElastix>::ComputeAndWriteSpatialJacobianMatrixImage() const
   const auto infoChanger = CreateChangeInformationImageFilter(jacGenerator->GetOutput());
 
   const auto progressObserver =
-    BaseComponent::IsElastixLibrary() ? nullptr : ProgressCommand::CreateAndConnect(*jacGenerator);
+    log::is_progress_percentage_shown() ? ProgressCommand::CreateAndConnect(*jacGenerator) : nullptr;
   /** Create a name for the deformation field file. */
   std::string resultImageFormat = "mhd";
   this->m_Configuration->ReadParameter(resultImageFormat, "ResultImageFormat", 0, false);

--- a/Core/Kernel/elxlog.cxx
+++ b/Core/Kernel/elxlog.cxx
@@ -60,6 +60,19 @@ public:
   reset()
   {
     m_loggers = {};
+    m_show_progress_percentage = false;
+  }
+
+  void
+  set_show_progress_percentage(const bool new_value)
+  {
+    m_show_progress_percentage = new_value;
+  }
+
+  bool
+  is_progress_percentage_shown() const
+  {
+    return m_show_progress_percentage;
   }
 
 private:
@@ -71,6 +84,7 @@ private:
   };
 
   loggers m_loggers;
+  bool    m_show_progress_percentage{ false };
 };
 
 
@@ -131,7 +145,8 @@ void
 setup_implementation(const std::string & log_filename,
                      const bool          do_log_to_file,
                      const bool          do_log_to_stdout,
-                     const log::level    log_level)
+                     const log::level    log_level,
+                     const bool          show_progress_percentage)
 {
   std::vector<spdlog::sink_ptr> log_file_sink;
   std::vector<spdlog::sink_ptr> stdout_sink;
@@ -176,6 +191,8 @@ setup_implementation(const std::string & log_filename,
 
   multi_logger.set_level(spdlog_level);
   multi_logger.sinks() = std::move(multi_logger_sinks);
+
+  data.set_show_progress_percentage(show_progress_percentage);
 }
 
 template <spdlog::level::level_enum spdlog_level>
@@ -209,11 +226,12 @@ bool
 log::setup(const std::string & log_filename,
            const bool          do_log_to_file,
            const bool          do_log_to_stdout,
-           const log::level    log_level)
+           const log::level    log_level,
+           const bool          show_progress_percentage)
 {
   try
   {
-    setup_implementation(log_filename, do_log_to_file, do_log_to_stdout, log_level);
+    setup_implementation(log_filename, do_log_to_file, do_log_to_stdout, log_level, show_progress_percentage);
     return true;
   }
   catch (const std::exception &)
@@ -228,9 +246,10 @@ log::guard::guard() = default;
 log::guard::guard(const std::string & log_filename,
                   const bool          do_log_to_file,
                   const bool          do_log_to_stdout,
-                  const log::level    log_level)
+                  const log::level    log_level,
+                  const bool          show_progress_percentage)
 {
-  setup_implementation(log_filename, do_log_to_file, do_log_to_stdout, log_level);
+  setup_implementation(log_filename, do_log_to_file, do_log_to_stdout, log_level, show_progress_percentage);
 }
 
 log::guard::~guard()
@@ -308,6 +327,12 @@ void
 log::to_stdout(const std::ostream & stream)
 {
   log::to_stdout(get_string_from_stream(stream));
+}
+
+bool
+log::is_progress_percentage_shown()
+{
+  return get_log_data().is_progress_percentage_shown();
 }
 
 } // end namespace elastix

--- a/Core/Kernel/elxlog.h
+++ b/Core/Kernel/elxlog.h
@@ -43,7 +43,8 @@ public:
   setup(const std::string & log_filename,
         const bool          do_log_to_file,
         const bool          do_log_to_stdout,
-        const level         log_level = {});
+        const level         log_level = {},
+        const bool          show_progress_percentage = false);
 
   /** Does setup and reset the logging system, according to the C++ "RAII" principle) */
   class guard
@@ -56,7 +57,8 @@ public:
     guard(const std::string & log_filename,
           const bool          do_log_to_file,
           const bool          do_log_to_stdout,
-          const level         log_level);
+          const level         log_level,
+          const bool          show_progress_percentage = false);
 
     /** Does reset the logging system. */
     ~guard();
@@ -99,6 +101,9 @@ public:
   static void
   to_stdout(const std::ostream & stream);
   ///@}
+
+  static bool
+  is_progress_percentage_shown();
 };
 
 } // end namespace elastix

--- a/Core/Kernel/elxlog.h
+++ b/Core/Kernel/elxlog.h
@@ -58,7 +58,7 @@ public:
           const bool          do_log_to_file,
           const bool          do_log_to_stdout,
           const level         log_level,
-          const bool          show_progress_percentage = false);
+          const bool          show_progress_percentage);
 
     /** Does reset the logging system. */
     ~guard();

--- a/Core/Main/elastix.cxx
+++ b/Core/Main/elastix.cxx
@@ -65,6 +65,7 @@ constexpr const char * elastixHelpText =
   "  -mp       point set for moving image\n"
   "  -t0       parameter file for initial transform\n"
   "  -loglevel set the log level to \"off\", \"error\", \"warning\", or \"info\" (default),\n"
+  "  -progress set progress percentage indication \"on\" or \"off\" (default),\n"
   "  -priority set the process priority to high, abovenormal, normal (default),\n"
   "            belownormal, or idle (Windows only option)\n"
   "  -threads  set the maximum number of threads of elastix\n\n"
@@ -137,6 +138,7 @@ main(int argc, char ** argv)
     std::queue<std::string> parameterFileList;
     std::string             outFolder;
     auto                    level = elx::log::level::info;
+    bool                    showProgressPercentage = false;
 
     /** Put command line parameters into parameterFileList. */
     for (unsigned int i = 1; static_cast<long>(i) < (argc - 1); i += 2)
@@ -167,21 +169,31 @@ main(int argc, char ** argv)
         }
         else
         {
-          if (key == "-out")
+          if (key == "-progress")
           {
-            /** Make sure that last character of the output folder equals a '/' or '\'. */
-            const char last = value.back();
-            if (last != '/' && last != '\\')
+            if (value == "on")
             {
-              value.append("/");
+              showProgressPercentage = true;
             }
-            value = elx::Conversion::ToNativePathNameSeparators(value);
+          }
+          else
+          {
 
-            /** Save this information. */
-            outFolder = value;
+            if (key == "-out")
+            {
+              /** Make sure that last character of the output folder equals a '/' or '\'. */
+              const char last = value.back();
+              if (last != '/' && last != '\\')
+              {
+                value.append("/");
+              }
+              value = elx::Conversion::ToNativePathNameSeparators(value);
 
-          } // end if key == "-out"
+              /** Save this information. */
+              outFolder = value;
 
+            } // end if key == "-out"
+          }
           /** Attempt to save the arguments in the ArgumentMap. */
           if (argMap.count(key) == 0)
           {
@@ -224,7 +236,7 @@ main(int argc, char ** argv)
       {
         /** Setup the log system. */
         const std::string logFileName = outFolder + "elastix.log";
-        const int         returndummy2 = elx::log::setup(logFileName, true, true, level) ? 0 : 1;
+        const int returndummy2 = elx::log::setup(logFileName, true, true, level, showProgressPercentage) ? 0 : 1;
 
         if (returndummy2 != 0)
         {

--- a/Core/Main/itkElastixRegistrationMethod.h
+++ b/Core/Main/itkElastixRegistrationMethod.h
@@ -256,6 +256,10 @@ public:
   itkSetMacro(LogLevel, ElastixLogLevel);
   itkGetConstMacro(LogLevel, ElastixLogLevel);
 
+  itkSetMacro(ShowProgressPercentage, bool);
+  itkGetConstReferenceMacro(ShowProgressPercentage, bool);
+  itkBooleanMacro(ShowProgressPercentage);
+
   itkSetMacro(NumberOfThreads, int);
   itkGetConstMacro(NumberOfThreads, int);
 
@@ -323,6 +327,7 @@ private:
   bool m_LogToFile{ false };
 
   ElastixLogLevel m_LogLevel{};
+  bool            m_ShowProgressPercentage{ false };
 
   int m_NumberOfThreads{ 0 };
 

--- a/Core/Main/itkElastixRegistrationMethod.hxx
+++ b/Core/Main/itkElastixRegistrationMethod.hxx
@@ -191,7 +191,8 @@ ElastixRegistrationMethod<TFixedImage, TMovingImage>::GenerateData()
   const elx::log::guard logGuard(logFileName,
                                  m_EnableOutput && m_LogToFile,
                                  m_EnableOutput && m_LogToConsole,
-                                 static_cast<elastix::log::level>(m_LogLevel));
+                                 static_cast<elastix::log::level>(m_LogLevel),
+                                 m_ShowProgressPercentage);
 
   // Run the (possibly multiple) registration(s)
   for (unsigned int i = 0; i < parameterMapVector.size(); ++i)

--- a/Core/Main/itkTransformixFilter.h
+++ b/Core/Main/itkTransformixFilter.h
@@ -216,6 +216,10 @@ public:
   itkSetMacro(LogLevel, ElastixLogLevel);
   itkGetConstMacro(LogLevel, ElastixLogLevel);
 
+  itkSetMacro(ShowProgressPercentage, bool);
+  itkGetConstReferenceMacro(ShowProgressPercentage, bool);
+  itkBooleanMacro(ShowProgressPercentage);
+
   /** Sets an (optional) input mesh. An Update() will transform its points, and store them in the output mesh.  */
   itkSetConstObjectMacro(InputMesh, MeshType);
 
@@ -293,6 +297,7 @@ private:
   bool m_LogToFile{ false };
 
   ElastixLogLevel m_LogLevel{};
+  bool            m_ShowProgressPercentage{ false };
 
   typename MeshType::ConstPointer m_InputMesh{ nullptr };
   typename MeshType::Pointer      m_OutputMesh{ nullptr };

--- a/Core/Main/itkTransformixFilter.hxx
+++ b/Core/Main/itkTransformixFilter.hxx
@@ -143,7 +143,8 @@ TransformixFilter<TMovingImage>::GenerateData()
   const elx::log::guard logGuard(logFileName,
                                  m_EnableOutput && m_LogToFile,
                                  m_EnableOutput && m_LogToConsole,
-                                 static_cast<elastix::log::level>(m_LogLevel));
+                                 static_cast<elastix::log::level>(m_LogLevel),
+                                 m_ShowProgressPercentage);
 
   // Instantiate transformix
   const auto transformixMain = elx::TransformixMain::New();

--- a/Core/Main/transformix.cxx
+++ b/Core/Main/transformix.cxx
@@ -59,6 +59,7 @@ constexpr const char * transformixHelpText =
   "  -jacmat   use \"-jacmat all\" to generate an image with the spatial Jacobian\n"
   "            matrix at each voxel\n"
   "  -loglevel set the log level to \"off\", \"error\", \"warning\", or \"info\" (default),\n"
+  "  -progress set progress percentage indication \"on\" or \"off\" (default),\n"
   "  -priority set the process priority to high, abovenormal, normal (default),\n"
   "            belownormal, or idle (Windows only option)\n"
   "  -threads  set the maximum number of threads of transformix\n"
@@ -134,6 +135,7 @@ main(int argc, char ** argv)
     std::string     outFolder = "";
     std::string     logFileName = "";
     auto            level = elx::log::level::info;
+    bool            showProgressPercentage = false;
 
     /** Put command line parameters into parameterFileList. */
     for (unsigned int i = 1; static_cast<long>(i) < argc - 1; i += 2)
@@ -151,21 +153,31 @@ main(int argc, char ** argv)
       }
       else
       {
-        if (key == "-out")
+        if (key == "-progress")
         {
-          /** Make sure that last character of the output folder equals a '/' or '\'. */
-          const char last = value.back();
-          if (last != '/' && last != '\\')
+          if (value == "on")
           {
-            value.append("/");
+            showProgressPercentage = true;
           }
-          value = elx::Conversion::ToNativePathNameSeparators(value);
+        }
+        else
+        {
+          if (key == "-out")
+          {
+            /** Make sure that last character of the output folder equals a '/' or '\'. */
+            const char last = value.back();
+            if (last != '/' && last != '\\')
+            {
+              value.append("/");
+            }
+            value = elx::Conversion::ToNativePathNameSeparators(value);
 
-          /** Save this information. */
-          outFolderPresent = true;
-          outFolder = value;
+            /** Save this information. */
+            outFolderPresent = true;
+            outFolder = value;
 
-        } // end if key == "-out"
+          } // end if key == "-out"
+        }
       }
       /** Attempt to save the arguments in the ArgumentMap. */
       if (argMap.count(key) == 0)
@@ -217,7 +229,7 @@ main(int argc, char ** argv)
       {
         /** Setup the log system. */
         logFileName = argMap["-out"] + "transformix.log";
-        int returndummy2 = elx::log::setup(logFileName, true, true, level) ? 0 : 1;
+        int returndummy2 = elx::log::setup(logFileName, true, true, level, showProgressPercentage) ? 0 : 1;
         if (returndummy2)
         {
           std::cerr << "ERROR while setting up the log system." << std::endl;

--- a/Core/elxProgressCommand.cxx
+++ b/Core/elxProgressCommand.cxx
@@ -36,14 +36,6 @@ ProgressCommand::ProgressCommand()
   m_NumberOfVoxels = 0;
   m_NumberOfUpdates = 0;
 
-  /** Check if the output of the stream is a console. */
-  m_StreamOutputIsConsole = false;
-  int currentPos = std::cout.tellp();
-  if (currentPos == -1)
-  {
-    m_StreamOutputIsConsole = true;
-  }
-
 } // end Constructor()
 
 
@@ -101,12 +93,9 @@ ProgressCommand::ConnectObserver(itk::ProcessObject * filter)
   this->DisconnectObserver(m_ObservedProcessObject);
 
   /** Connect to the new filter. */
-  if (m_StreamOutputIsConsole)
-  {
-    m_Tag = filter->AddObserver(itk::ProgressEvent(), this);
-    m_TagIsSet = true;
-    m_ObservedProcessObject = filter;
-  }
+  m_Tag = filter->AddObserver(itk::ProgressEvent(), this);
+  m_TagIsSet = true;
+  m_ObservedProcessObject = filter;
 
 } // end ConnectObserver()
 
@@ -118,14 +107,11 @@ ProgressCommand::ConnectObserver(itk::ProcessObject * filter)
 void
 ProgressCommand::DisconnectObserver(itk::ProcessObject * filter)
 {
-  if (m_StreamOutputIsConsole)
+  if (m_TagIsSet)
   {
-    if (m_TagIsSet)
-    {
-      filter->RemoveObserver(m_Tag);
-      m_TagIsSet = false;
-      m_ObservedProcessObject = nullptr;
-    }
+    filter->RemoveObserver(m_Tag);
+    m_TagIsSet = false;
+    m_ObservedProcessObject = nullptr;
   }
 
 } // end DisconnectObserver()
@@ -203,13 +189,10 @@ ProgressCommand::PrintProgress(const float progress) const
 void
 ProgressCommand::UpdateAndPrintProgress(const unsigned long currentVoxelNumber) const
 {
-  if (m_StreamOutputIsConsole)
+  const unsigned long frac = static_cast<unsigned long>(m_NumberOfVoxels / m_NumberOfUpdates);
+  if (currentVoxelNumber % frac == 0)
   {
-    const unsigned long frac = static_cast<unsigned long>(m_NumberOfVoxels / m_NumberOfUpdates);
-    if (currentVoxelNumber % frac == 0)
-    {
-      this->PrintProgress(static_cast<float>(currentVoxelNumber) / static_cast<float>(m_NumberOfVoxels));
-    }
+    this->PrintProgress(static_cast<float>(currentVoxelNumber) / static_cast<float>(m_NumberOfVoxels));
   }
 
 } // end PrintProgress()

--- a/Core/elxProgressCommand.h
+++ b/Core/elxProgressCommand.h
@@ -145,9 +145,6 @@ public:
   itkSetStringMacro(EndString);
   itkGetStringMacro(EndString);
 
-  /** Get a boolean indicating if the output is a console. */
-  itkGetConstReferenceMacro(StreamOutputIsConsole, bool);
-
   static Pointer
   CreateAndSetUpdateFrequency(unsigned long numberOfVoxels);
 
@@ -167,7 +164,6 @@ private:
   std::string m_EndString;
 
   /** Member variables to keep track of what is set. */
-  bool                 m_StreamOutputIsConsole;
   unsigned long        m_Tag;
   bool                 m_TagIsSet;
   ProcessObjectPointer m_ObservedProcessObject;


### PR DESCRIPTION
Until now, during a time consuming process, the progress percentage was shown _only_ by elastix/transformix executables, not by the library. Moreover, it was then _only_ shown if `std::cout.tellp()` would return -1. The return value of `std::cout.tellp()` appears platform dependent, and it does not really tell if showing the progress percentage is desirable. For details, see issue #756 "Executable progress indication appears suppressed on Windows".

This pull request proposes to add an extra `bool` flag to our `elx::log` class which specifies whether the user wants to see a progress percentage.

It extends the executable interface with an option `-progress on`, and it adds `ShowProgressPercentageOn`/`Off` member functions to the ITKElastix/library interface. By default, the progress percentage is _not_ shown (which was the behavior on Windows until now anyway).