### PR TITLE
STYLE: Add in-class `{}` default member initializers to "itk*.h" files

### DIFF
--- a/Common/CostFunctions/itkAdvancedImageToImageMetric.h
+++ b/Common/CostFunctions/itkAdvancedImageToImageMetric.h
@@ -417,7 +417,7 @@ protected:
   /** Variables for multi-threading. */
   bool m_UseMetricSingleThreaded{ true };
   bool m_UseMultiThread{ false };
-  bool m_UseOpenMP;
+  bool m_UseOpenMP{};
 
   /** Helper structs that multi-threads the computation of
    * the metric derivative using ITK threads.
@@ -430,7 +430,7 @@ protected:
     DerivativeValueType * st_DerivativePointer;
     DerivativeValueType   st_NormalizationFactor;
   };
-  mutable MultiThreaderParameterType m_ThreaderMetricParameters;
+  mutable MultiThreaderParameterType m_ThreaderMetricParameters{};
 
   /** Most metrics will perform multi-threading by letting
    * each thread compute a part of the value and derivative.

--- a/Common/CostFunctions/itkExponentialLimiterFunction.h
+++ b/Common/CostFunctions/itkExponentialLimiterFunction.h
@@ -85,10 +85,10 @@ protected:
   virtual void
   ComputeLimiterSettings();
 
-  double m_UTminUB;
-  double m_UTminUBinv;
-  double m_LTminLB;
-  double m_LTminLBinv;
+  double m_UTminUB{};
+  double m_UTminUBinv{};
+  double m_LTminLB{};
+  double m_LTminLBinv{};
 };
 
 } // end namespace itk

--- a/Common/CostFunctions/itkImageToImageMetricWithFeatures.h
+++ b/Common/CostFunctions/itkImageToImageMetricWithFeatures.h
@@ -238,15 +238,15 @@ protected:
   using typename Superclass::MovingImageContinuousIndexType;
 
   /** Member variables. */
-  unsigned int                        m_NumberOfFixedFeatureImages;
-  unsigned int                        m_NumberOfMovingFeatureImages;
-  FixedFeatureImageVectorType         m_FixedFeatureImages;
-  MovingFeatureImageVectorType        m_MovingFeatureImages;
-  FixedFeatureInterpolatorVectorType  m_FixedFeatureInterpolators;
-  MovingFeatureInterpolatorVectorType m_MovingFeatureInterpolators;
+  unsigned int                        m_NumberOfFixedFeatureImages{};
+  unsigned int                        m_NumberOfMovingFeatureImages{};
+  FixedFeatureImageVectorType         m_FixedFeatureImages{};
+  MovingFeatureImageVectorType        m_MovingFeatureImages{};
+  FixedFeatureInterpolatorVectorType  m_FixedFeatureInterpolators{};
+  MovingFeatureInterpolatorVectorType m_MovingFeatureInterpolators{};
 
-  std::vector<bool>                    m_FeatureInterpolatorsIsBSpline;
-  BSplineFeatureInterpolatorVectorType m_MovingFeatureBSplineInterpolators;
+  std::vector<bool>                    m_FeatureInterpolatorsIsBSpline{};
+  BSplineFeatureInterpolatorVectorType m_MovingFeatureBSplineInterpolators{};
 
   /** Initialize variables for image derivative computation; this
    * method is called by Initialize.

--- a/Common/CostFunctions/itkLimiterFunctionBase.h
+++ b/Common/CostFunctions/itkLimiterFunctionBase.h
@@ -115,10 +115,10 @@ protected:
 
   ~LimiterFunctionBase() override = default;
 
-  OutputType m_UpperBound;
-  OutputType m_LowerBound;
-  InputType  m_UpperThreshold;
-  InputType  m_LowerThreshold;
+  OutputType m_UpperBound{};
+  OutputType m_LowerBound{};
+  InputType  m_UpperThreshold{};
+  InputType  m_LowerThreshold{};
 };
 
 } // end namespace itk

--- a/Common/CostFunctions/itkMultiInputImageToImageMetricBase.h
+++ b/Common/CostFunctions/itkMultiInputImageToImageMetricBase.h
@@ -387,16 +387,16 @@ protected:
   IsInsideMovingMask(const MovingImagePointType & mappedPoint) const override;
 
   /** Protected member variables. */
-  FixedImageVectorType             m_FixedImageVector;
-  FixedImageMaskVectorType         m_FixedImageMaskVector;
-  FixedImageRegionVectorType       m_FixedImageRegionVector;
-  MovingImageVectorType            m_MovingImageVector;
-  MovingImageMaskVectorType        m_MovingImageMaskVector;
-  InterpolatorVectorType           m_InterpolatorVector;
-  FixedImageInterpolatorVectorType m_FixedImageInterpolatorVector;
+  FixedImageVectorType             m_FixedImageVector{};
+  FixedImageMaskVectorType         m_FixedImageMaskVector{};
+  FixedImageRegionVectorType       m_FixedImageRegionVector{};
+  MovingImageVectorType            m_MovingImageVector{};
+  MovingImageMaskVectorType        m_MovingImageMaskVector{};
+  InterpolatorVectorType           m_InterpolatorVector{};
+  FixedImageInterpolatorVectorType m_FixedImageInterpolatorVector{};
 
   bool                          m_InterpolatorsAreBSpline{ false };
-  BSplineInterpolatorVectorType m_BSplineInterpolatorVector;
+  BSplineInterpolatorVectorType m_BSplineInterpolatorVector{};
 
 private:
   /// Avoids accidentally calling `this->FastEvaluateMovingImageValueAndDerivative(mappedPoint, ..., threadId)`, when
@@ -407,7 +407,7 @@ private:
   FastEvaluateMovingImageValueAndDerivative(...) const = delete;
 
   /** Private member variables. */
-  FixedImageRegionType m_DummyFixedImageRegion;
+  FixedImageRegionType m_DummyFixedImageRegion{};
 
   unsigned int m_NumberOfFixedImages{ 0 };
   unsigned int m_NumberOfFixedImageMasks{ 0 };

--- a/Common/CostFunctions/itkParzenWindowHistogramImageToImageMetric.h
+++ b/Common/CostFunctions/itkParzenWindowHistogramImageToImageMetric.h
@@ -269,33 +269,33 @@ protected:
   /** Protected variables **************************** */
 
   /** Variables for Alpha (the normalization factor of the histogram). */
-  mutable double         m_Alpha;
-  mutable DerivativeType m_PerturbedAlphaRight;
-  mutable DerivativeType m_PerturbedAlphaLeft;
+  mutable double         m_Alpha{};
+  mutable DerivativeType m_PerturbedAlphaRight{};
+  mutable DerivativeType m_PerturbedAlphaLeft{};
 
   /** Variables for the pdfs (actually: histograms). */
-  mutable MarginalPDFType       m_FixedImageMarginalPDF;
-  mutable MarginalPDFType       m_MovingImageMarginalPDF;
-  JointPDFPointer               m_JointPDF;
-  JointPDFDerivativesPointer    m_JointPDFDerivatives;
-  JointPDFDerivativesPointer    m_IncrementalJointPDFRight;
-  JointPDFDerivativesPointer    m_IncrementalJointPDFLeft;
-  IncrementalMarginalPDFPointer m_FixedIncrementalMarginalPDFRight;
-  IncrementalMarginalPDFPointer m_MovingIncrementalMarginalPDFRight;
-  IncrementalMarginalPDFPointer m_FixedIncrementalMarginalPDFLeft;
-  IncrementalMarginalPDFPointer m_MovingIncrementalMarginalPDFLeft;
-  mutable JointPDFRegionType    m_JointPDFWindow; // no need for mutable anymore?
-  double                        m_MovingImageNormalizedMin;
-  double                        m_FixedImageNormalizedMin;
-  double                        m_FixedImageBinSize;
-  double                        m_MovingImageBinSize;
-  double                        m_FixedParzenTermToIndexOffset;
-  double                        m_MovingParzenTermToIndexOffset;
+  mutable MarginalPDFType       m_FixedImageMarginalPDF{};
+  mutable MarginalPDFType       m_MovingImageMarginalPDF{};
+  JointPDFPointer               m_JointPDF{};
+  JointPDFDerivativesPointer    m_JointPDFDerivatives{};
+  JointPDFDerivativesPointer    m_IncrementalJointPDFRight{};
+  JointPDFDerivativesPointer    m_IncrementalJointPDFLeft{};
+  IncrementalMarginalPDFPointer m_FixedIncrementalMarginalPDFRight{};
+  IncrementalMarginalPDFPointer m_MovingIncrementalMarginalPDFRight{};
+  IncrementalMarginalPDFPointer m_FixedIncrementalMarginalPDFLeft{};
+  IncrementalMarginalPDFPointer m_MovingIncrementalMarginalPDFLeft{};
+  mutable JointPDFRegionType    m_JointPDFWindow{}; // no need for mutable anymore?
+  double                        m_MovingImageNormalizedMin{};
+  double                        m_FixedImageNormalizedMin{};
+  double                        m_FixedImageBinSize{};
+  double                        m_MovingImageBinSize{};
+  double                        m_FixedParzenTermToIndexOffset{};
+  double                        m_MovingParzenTermToIndexOffset{};
 
   /** Kernels for computing Parzen histograms and derivatives. */
-  KernelFunctionPointer m_FixedKernel;
-  KernelFunctionPointer m_MovingKernel;
-  KernelFunctionPointer m_DerivativeMovingKernel;
+  KernelFunctionPointer m_FixedKernel{};
+  KernelFunctionPointer m_MovingKernel{};
+  KernelFunctionPointer m_DerivativeMovingKernel{};
 
   /** Initialize threading related parameters. */
   void
@@ -474,7 +474,7 @@ protected:
 
 private:
   /** Threading related parameters. */
-  mutable std::vector<JointPDFPointer> m_ThreaderJointPDFs;
+  mutable std::vector<JointPDFPointer> m_ThreaderJointPDFs{};
 
   /** Helper structs that multi-threads the computation of
    * the metric derivative using ITK threads.
@@ -483,7 +483,7 @@ private:
   {
     Self * m_Metric;
   };
-  ParzenWindowHistogramMultiThreaderParameterType m_ParzenWindowHistogramThreaderParameters;
+  ParzenWindowHistogramMultiThreaderParameterType m_ParzenWindowHistogramThreaderParameters{};
 
   struct ParzenWindowHistogramGetValueAndDerivativePerThreadStruct
   {
@@ -500,14 +500,14 @@ private:
     m_ParzenWindowHistogramGetValueAndDerivativePerThreadVariables;
 
   /** Variables that can/should be accessed by their Set/Get functions. */
-  unsigned long m_NumberOfFixedHistogramBins;
-  unsigned long m_NumberOfMovingHistogramBins;
-  unsigned int  m_FixedKernelBSplineOrder;
-  unsigned int  m_MovingKernelBSplineOrder;
-  bool          m_UseDerivative;
-  bool          m_UseExplicitPDFDerivatives;
-  bool          m_UseFiniteDifferenceDerivative;
-  double        m_FiniteDifferencePerturbation;
+  unsigned long m_NumberOfFixedHistogramBins{};
+  unsigned long m_NumberOfMovingHistogramBins{};
+  unsigned int  m_FixedKernelBSplineOrder{};
+  unsigned int  m_MovingKernelBSplineOrder{};
+  bool          m_UseDerivative{};
+  bool          m_UseExplicitPDFDerivatives{};
+  bool          m_UseFiniteDifferenceDerivative{};
+  double        m_FiniteDifferencePerturbation{};
 };
 
 } // end namespace itk

--- a/Common/CostFunctions/itkScaledSingleValuedCostFunction.h
+++ b/Common/CostFunctions/itkScaledSingleValuedCostFunction.h
@@ -144,11 +144,11 @@ protected:
 
 private:
   /** Member variables. */
-  ScalesType                      m_Scales;
-  ScalesType                      m_SquaredScales;
-  SingleValuedCostFunctionPointer m_UnscaledCostFunction;
-  bool                            m_UseScales;
-  bool                            m_NegateCostFunction;
+  ScalesType                      m_Scales{};
+  ScalesType                      m_SquaredScales{};
+  SingleValuedCostFunctionPointer m_UnscaledCostFunction{};
+  bool                            m_UseScales{};
+  bool                            m_NegateCostFunction{};
 };
 
 } // end namespace itk

--- a/Common/ImageSamplers/itkImageRandomSamplerBase.h
+++ b/Common/ImageSamplers/itkImageRandomSamplerBase.h
@@ -83,7 +83,7 @@ protected:
   PrintSelf(std::ostream & os, Indent indent) const override;
 
   /** Member variable used when threading. */
-  std::vector<double> m_RandomNumberList;
+  std::vector<double> m_RandomNumberList{};
 };
 
 } // end namespace itk

--- a/Common/ImageSamplers/itkImageSamplerBase.h
+++ b/Common/ImageSamplers/itkImageSamplerBase.h
@@ -223,7 +223,7 @@ protected:
 
   /***/
   unsigned long                            m_NumberOfSamples{ 0 };
-  std::vector<ImageSampleContainerPointer> m_ThreaderSampleContainer;
+  std::vector<ImageSampleContainerPointer> m_ThreaderSampleContainer{};
 
   // tmp?
   bool m_UseMultiThread{ false };
@@ -231,14 +231,14 @@ protected:
 private:
   /** Member variables. */
   MaskConstPointer           m_Mask{ nullptr };
-  MaskVectorType             m_MaskVector;
+  MaskVectorType             m_MaskVector{};
   unsigned int               m_NumberOfMasks{ 0 };
-  InputImageRegionType       m_InputImageRegion;
-  InputImageRegionVectorType m_InputImageRegionVector;
+  InputImageRegionType       m_InputImageRegion{};
+  InputImageRegionVectorType m_InputImageRegionVector{};
   unsigned int               m_NumberOfInputImageRegions{ 0 };
 
-  InputImageRegionType m_CroppedInputImageRegion;
-  InputImageRegionType m_DummyInputImageRegion;
+  InputImageRegionType m_CroppedInputImageRegion{};
+  InputImageRegionType m_DummyInputImageRegion{};
 };
 
 } // end namespace itk

--- a/Common/ImageSamplers/itkVectorContainerSource.h
+++ b/Common/ImageSamplers/itkVectorContainerSource.h
@@ -83,8 +83,8 @@ protected:
 
 private:
   /** Member variables. */
-  int m_GenerateDataRegion;
-  int m_GenerateDataNumberOfRegions;
+  int m_GenerateDataRegion{};
+  int m_GenerateDataNumberOfRegions{};
 };
 
 } // end namespace itk

--- a/Common/LineSearchOptimizers/itkLineSearchOptimizer.h
+++ b/Common/LineSearchOptimizers/itkLineSearchOptimizer.h
@@ -127,7 +127,7 @@ protected:
   void
   PrintSelf(std::ostream & os, Indent indent) const override;
 
-  double m_CurrentStepLength;
+  double m_CurrentStepLength{};
 
   /** Set the current step length AND the current position, where
    * the current position is computed as:
@@ -142,11 +142,11 @@ protected:
   DirectionalDerivative(const DerivativeType & derivative) const;
 
 private:
-  ParametersType m_LineSearchDirection;
+  ParametersType m_LineSearchDirection{};
 
-  double m_MinimumStepLength;
-  double m_MaximumStepLength;
-  double m_InitialStepLengthEstimate;
+  double m_MinimumStepLength{};
+  double m_MaximumStepLength{};
+  double m_InitialStepLengthEstimate{};
 };
 
 } // end namespace itk

--- a/Common/LineSearchOptimizers/itkMoreThuenteLineSearchOptimizer.h
+++ b/Common/LineSearchOptimizers/itkMoreThuenteLineSearchOptimizer.h
@@ -181,13 +181,13 @@ protected:
   void
   PrintSelf(std::ostream & os, Indent indent) const override;
 
-  unsigned long     m_CurrentIteration;
-  bool              m_InitialDerivativeProvided;
-  bool              m_InitialValueProvided;
-  StopConditionType m_StopCondition;
-  bool              m_Stop;
-  bool              m_SufficientDecreaseConditionSatisfied;
-  bool              m_CurvatureConditionSatisfied;
+  unsigned long     m_CurrentIteration{};
+  bool              m_InitialDerivativeProvided{};
+  bool              m_InitialValueProvided{};
+  StopConditionType m_StopCondition{};
+  bool              m_Stop{};
+  bool              m_SufficientDecreaseConditionSatisfied{};
+  bool              m_CurvatureConditionSatisfied{};
 
   /** Load the initial value and derivative into m_f and m_g. */
   virtual void
@@ -248,36 +248,36 @@ protected:
                   const double stpmin,
                   const double stpmax) const;
 
-  double m_step;
-  double m_stepx;
-  double m_stepy;
-  double m_stepmin;
-  double m_stepmax;
+  double m_step{};
+  double m_stepx{};
+  double m_stepy{};
+  double m_stepmin{};
+  double m_stepmax{};
 
-  MeasureType m_f; // CurrentValue
-  MeasureType m_fx;
-  MeasureType m_fy;
-  MeasureType m_finit;
+  MeasureType m_f{}; // CurrentValue
+  MeasureType m_fx{};
+  MeasureType m_fy{};
+  MeasureType m_finit{};
 
-  DerivativeType m_g;  // CurrentDerivative
-  double         m_dg; // CurrentDirectionalDerivative
-  double         m_dginit;
-  double         m_dgx;
-  double         m_dgy;
-  double         m_dgtest;
+  DerivativeType m_g{};  // CurrentDerivative
+  double         m_dg{}; // CurrentDirectionalDerivative
+  double         m_dginit{};
+  double         m_dgx{};
+  double         m_dgy{};
+  double         m_dgtest{};
 
-  double m_width;
-  double m_width1;
+  double m_width{};
+  double m_width1{};
 
-  bool m_brackt;
-  bool m_stage1;
-  bool m_SafeGuardedStepFailed;
+  bool m_brackt{};
+  bool m_stage1{};
+  bool m_SafeGuardedStepFailed{};
 
 private:
-  unsigned long m_MaximumNumberOfIterations;
-  double        m_ValueTolerance;
-  double        m_GradientTolerance;
-  double        m_IntervalTolerance;
+  unsigned long m_MaximumNumberOfIterations{};
+  double        m_ValueTolerance{};
+  double        m_GradientTolerance{};
+  double        m_IntervalTolerance{};
 };
 
 } // end namespace itk

--- a/Common/MevisDicomTiff/itkMevisDicomTiffImageIO.h
+++ b/Common/MevisDicomTiff/itkMevisDicomTiffImageIO.h
@@ -166,28 +166,28 @@ private:
   FindElement(const gdcm::DataSet ds, const gdcm::Tag tag, gdcm::DataElement & de, const bool breadthfirstsearch);
 
   // the following may include the pathname
-  std::string m_DcmFileName;
-  std::string m_TiffFileName;
+  std::string m_DcmFileName{};
+  std::string m_TiffFileName{};
 
-  TIFF *         m_TIFFImage;
-  unsigned int   m_TIFFDimension;
-  bool           m_IsOpen;
-  unsigned short m_Compression;
-  unsigned int   m_BitsPerSample;
-  unsigned int   m_Width;
-  unsigned int   m_Length;
-  unsigned int   m_Depth;
-  bool           m_IsTiled;
-  unsigned int   m_TileWidth;
-  unsigned int   m_TileLength;
-  unsigned int   m_TileDepth;
-  unsigned short m_NumberOfTiles;
+  TIFF *         m_TIFFImage{};
+  unsigned int   m_TIFFDimension{};
+  bool           m_IsOpen{};
+  unsigned short m_Compression{};
+  unsigned int   m_BitsPerSample{};
+  unsigned int   m_Width{};
+  unsigned int   m_Length{};
+  unsigned int   m_Depth{};
+  bool           m_IsTiled{};
+  unsigned int   m_TileWidth{};
+  unsigned int   m_TileLength{};
+  unsigned int   m_TileDepth{};
+  unsigned short m_NumberOfTiles{};
 
-  double m_RescaleSlope;
-  double m_RescaleIntercept;
-  double m_GantryTilt;
-  double m_EstimatedMinimum;
-  double m_EstimatedMaximum;
+  double m_RescaleSlope{};
+  double m_RescaleIntercept{};
+  double m_GantryTilt{};
+  double m_EstimatedMinimum{};
+  double m_EstimatedMaximum{};
 };
 
 } // end namespace itk

--- a/Common/OpenCL/Filters/itkGPUAdvancedCombinationTransformCopier.h
+++ b/Common/OpenCL/Filters/itkGPUAdvancedCombinationTransformCopier.h
@@ -245,10 +245,10 @@ private:
                             TransformSpaceDimensionToType<3>);
 
 private:
-  CPUComboTransformConstPointer m_InputTransform;
-  GPUComboTransformPointer      m_Output;
-  ModifiedTimeType              m_InternalTransformTime;
-  bool                          m_ExplicitMode;
+  CPUComboTransformConstPointer m_InputTransform{};
+  GPUComboTransformPointer      m_Output{};
+  ModifiedTimeType              m_InternalTransformTime{};
+  bool                          m_ExplicitMode{};
 };
 
 } // end namespace itk

--- a/Common/OpenCL/Filters/itkGPUBSplineBaseTransform.h
+++ b/Common/OpenCL/Filters/itkGPUBSplineBaseTransform.h
@@ -95,18 +95,18 @@ protected:
   bool
   GetSourceCode(std::string & source) const override;
 
-  GPUCoefficientImageArray     m_GPUBSplineTransformCoefficientImages;
-  GPUCoefficientImageBaseArray m_GPUBSplineTransformCoefficientImagesBase;
+  GPUCoefficientImageArray     m_GPUBSplineTransformCoefficientImages{};
+  GPUCoefficientImageBaseArray m_GPUBSplineTransformCoefficientImagesBase{};
 
 private:
   GPUBSplineBaseTransform(const Self & other) = delete;
   const Self &
   operator=(const Self &) = delete;
 
-  std::vector<std::string> m_Sources;
+  std::vector<std::string> m_Sources{};
 
   // User specified spline order (3rd or cubic is the default)
-  unsigned int m_SplineOrder;
+  unsigned int m_SplineOrder{};
 };
 
 } // end namespace itk

--- a/Common/OpenCL/Filters/itkGPUBSplineDecompositionImageFilter.h
+++ b/Common/OpenCL/Filters/itkGPUBSplineDecompositionImageFilter.h
@@ -83,8 +83,8 @@ protected:
   GPUGenerateData();
 
 private:
-  std::size_t m_FilterGPUKernelHandle;
-  std::size_t m_DeviceLocalMemorySize;
+  std::size_t m_FilterGPUKernelHandle{};
+  std::size_t m_DeviceLocalMemorySize{};
 };
 
 } // end namespace itk

--- a/Common/OpenCL/Filters/itkGPUBSplineInterpolateImageFunction.h
+++ b/Common/OpenCL/Filters/itkGPUBSplineInterpolateImageFunction.h
@@ -101,10 +101,10 @@ protected:
   GetSourceCode(std::string & source) const override;
 
 private:
-  GPUCoefficientImagePointer m_GPUCoefficients;
-  GPUDataManagerPointer      m_GPUCoefficientsImageBase;
+  GPUCoefficientImagePointer m_GPUCoefficients{};
+  GPUDataManagerPointer      m_GPUCoefficientsImageBase{};
 
-  std::vector<std::string> m_Sources;
+  std::vector<std::string> m_Sources{};
 };
 
 } // end namespace itk

--- a/Common/OpenCL/Filters/itkGPUCompositeTransformCopier.h
+++ b/Common/OpenCL/Filters/itkGPUCompositeTransformCopier.h
@@ -138,11 +138,11 @@ protected:
   PrintSelf(std::ostream & os, Indent indent) const override;
 
 private:
-  CPUCompositeTransformConstPointer m_InputTransform;
-  GPUCompositeTransformPointer      m_Output;
-  ModifiedTimeType                  m_InternalTransformTime;
-  bool                              m_ExplicitMode;
-  GPUTransformCopierPointer         m_TransformCopier;
+  CPUCompositeTransformConstPointer m_InputTransform{};
+  GPUCompositeTransformPointer      m_Output{};
+  ModifiedTimeType                  m_InternalTransformTime{};
+  bool                              m_ExplicitMode{};
+  GPUTransformCopierPointer         m_TransformCopier{};
 };
 
 } // end namespace itk

--- a/Common/OpenCL/Filters/itkGPUIdentityTransform.h
+++ b/Common/OpenCL/Filters/itkGPUIdentityTransform.h
@@ -84,7 +84,7 @@ private:
   const Self &
   operator=(const Self &) = delete;
 
-  std::vector<std::string> m_Sources;
+  std::vector<std::string> m_Sources{};
 };
 
 } // end namespace itk

--- a/Common/OpenCL/Filters/itkGPUInterpolatorBase.h
+++ b/Common/OpenCL/Filters/itkGPUInterpolatorBase.h
@@ -56,7 +56,7 @@ protected:
   GPUInterpolatorBase();
   virtual ~GPUInterpolatorBase() = default;
 
-  GPUDataManager::Pointer m_ParametersDataManager;
+  GPUDataManager::Pointer m_ParametersDataManager{};
 };
 
 } // end namespace itk

--- a/Common/OpenCL/Filters/itkGPUInterpolatorCopier.h
+++ b/Common/OpenCL/Filters/itkGPUInterpolatorCopier.h
@@ -134,11 +134,11 @@ protected:
   PrintSelf(std::ostream & os, Indent indent) const override;
 
 private:
-  CPUInterpolatorConstPointer    m_InputInterpolator;
-  GPUInterpolatorPointer         m_Output;
-  GPUExplicitInterpolatorPointer m_ExplicitOutput;
-  ModifiedTimeType               m_InternalTransformTime;
-  bool                           m_ExplicitMode;
+  CPUInterpolatorConstPointer    m_InputInterpolator{};
+  GPUInterpolatorPointer         m_Output{};
+  GPUExplicitInterpolatorPointer m_ExplicitOutput{};
+  ModifiedTimeType               m_InternalTransformTime{};
+  bool                           m_ExplicitMode{};
 };
 
 } // end namespace itk

--- a/Common/OpenCL/Filters/itkGPULinearInterpolateImageFunction.h
+++ b/Common/OpenCL/Filters/itkGPULinearInterpolateImageFunction.h
@@ -72,7 +72,7 @@ protected:
   GetSourceCode(std::string & source) const override;
 
 private:
-  std::vector<std::string> m_Sources;
+  std::vector<std::string> m_Sources{};
 };
 
 } // end namespace itk

--- a/Common/OpenCL/Filters/itkGPUMatrixOffsetTransformBase.h
+++ b/Common/OpenCL/Filters/itkGPUMatrixOffsetTransformBase.h
@@ -97,7 +97,7 @@ private:
   const Self &
   operator=(const Self &) = delete;
 
-  std::vector<std::string> m_Sources;
+  std::vector<std::string> m_Sources{};
 };
 
 } // end namespace itk

--- a/Common/OpenCL/Filters/itkGPUNearestNeighborInterpolateImageFunction.h
+++ b/Common/OpenCL/Filters/itkGPUNearestNeighborInterpolateImageFunction.h
@@ -74,7 +74,7 @@ protected:
   GetSourceCode(std::string & source) const override;
 
 private:
-  std::vector<std::string> m_Sources;
+  std::vector<std::string> m_Sources{};
 };
 
 } // end namespace itk

--- a/Common/OpenCL/Filters/itkGPURecursiveGaussianImageFilter.h
+++ b/Common/OpenCL/Filters/itkGPURecursiveGaussianImageFilter.h
@@ -85,8 +85,8 @@ protected:
   GPUGenerateData() override;
 
 private:
-  std::size_t m_FilterGPUKernelHandle;
-  std::size_t m_DeviceLocalMemorySize;
+  std::size_t m_FilterGPUKernelHandle{};
+  std::size_t m_DeviceLocalMemorySize{};
 };
 
 } // end namespace itk

--- a/Common/OpenCL/Filters/itkGPUResampleImageFilter.h
+++ b/Common/OpenCL/Filters/itkGPUResampleImageFilter.h
@@ -185,14 +185,14 @@ protected:
   GetGPUBSplineBaseTransform(const std::size_t transformIndex);
 
 private:
-  GPUInterpolatorBase * m_InterpolatorBase;
-  GPUTransformBase *    m_TransformBase;
+  GPUInterpolatorBase * m_InterpolatorBase{};
+  GPUTransformBase *    m_TransformBase{};
 
-  GPUDataManagerPointer m_InputGPUImageBase;
-  GPUDataManagerPointer m_OutputGPUImageBase;
-  GPUDataManagerPointer m_FilterParameters;
-  GPUDataManagerPointer m_DeformationFieldBuffer;
-  unsigned int          m_RequestedNumberOfSplits;
+  GPUDataManagerPointer m_InputGPUImageBase{};
+  GPUDataManagerPointer m_OutputGPUImageBase{};
+  GPUDataManagerPointer m_FilterParameters{};
+  GPUDataManagerPointer m_DeformationFieldBuffer{};
+  unsigned int          m_RequestedNumberOfSplits{};
 
   using TransformHandle = std::pair<int, bool>;
   using TransformsHandle = std::map<GPUTransformTypeEnum, TransformHandle>;
@@ -215,26 +215,26 @@ private:
 
   };
 
-  std::vector< TransformKernelHelper > m_SupportedTransformKernels;
+  std::vector< TransformKernelHelper > m_SupportedTransformKernels{};
 #endif
 
-  std::vector<std::string> m_Sources;
-  std::size_t              m_SourceIndex;
+  std::vector<std::string> m_Sources{};
+  std::size_t              m_SourceIndex{};
 
-  std::size_t m_InterpolatorSourceLoadedIndex;
-  std::size_t m_TransformSourceLoadedIndex;
+  std::size_t m_InterpolatorSourceLoadedIndex{};
+  std::size_t m_TransformSourceLoadedIndex{};
 
-  bool m_InterpolatorIsBSpline;
-  bool m_TransformIsCombo;
+  bool m_InterpolatorIsBSpline{};
+  bool m_TransformIsCombo{};
 
-  std::size_t      m_FilterPreGPUKernelHandle;
-  TransformsHandle m_FilterLoopGPUKernelHandle;
-  std::size_t      m_FilterPostGPUKernelHandle;
+  std::size_t      m_FilterPreGPUKernelHandle{};
+  TransformsHandle m_FilterLoopGPUKernelHandle{};
+  std::size_t      m_FilterPostGPUKernelHandle{};
 
   // GPU kernel managers
-  GPUKernelManagerPointer m_PreKernelManager;
-  GPUKernelManagerPointer m_LoopKernelManager;
-  GPUKernelManagerPointer m_PostKernelManager;
+  GPUKernelManagerPointer m_PreKernelManager{};
+  GPUKernelManagerPointer m_LoopKernelManager{};
+  GPUKernelManagerPointer m_PostKernelManager{};
 };
 
 } // end namespace itk

--- a/Common/OpenCL/Filters/itkGPUShrinkImageFilter.h
+++ b/Common/OpenCL/Filters/itkGPUShrinkImageFilter.h
@@ -90,8 +90,8 @@ protected:
   GPUGenerateData() override;
 
 private:
-  std::size_t m_FilterGPUKernelHandle;
-  std::size_t m_DeviceLocalMemorySize;
+  std::size_t m_FilterGPUKernelHandle{};
+  std::size_t m_DeviceLocalMemorySize{};
 };
 
 } // end namespace itk

--- a/Common/OpenCL/Filters/itkGPUTransformBase.h
+++ b/Common/OpenCL/Filters/itkGPUTransformBase.h
@@ -96,7 +96,7 @@ protected:
   GPUTransformBase();
   virtual ~GPUTransformBase() = default;
 
-  GPUDataManager::Pointer m_ParametersDataManager;
+  GPUDataManager::Pointer m_ParametersDataManager{};
 
 private:
   GPUTransformBase(const Self & other) = delete;

--- a/Common/OpenCL/Filters/itkGPUTransformCopier.h
+++ b/Common/OpenCL/Filters/itkGPUTransformCopier.h
@@ -223,10 +223,10 @@ private:
                             TransformSpaceDimensionToType<3>);
 
 private:
-  CPUTransformConstPointer m_InputTransform;
-  GPUTransformPointer      m_Output;
-  ModifiedTimeType         m_InternalTransformTime;
-  bool                     m_ExplicitMode;
+  CPUTransformConstPointer m_InputTransform{};
+  GPUTransformPointer      m_Output{};
+  ModifiedTimeType         m_InternalTransformTime{};
+  bool                     m_ExplicitMode{};
 };
 
 } // end namespace itk

--- a/Common/OpenCL/Filters/itkGPUTranslationTransformBase.h
+++ b/Common/OpenCL/Filters/itkGPUTranslationTransformBase.h
@@ -87,7 +87,7 @@ private:
   const Self &
   operator=(const Self &) = delete;
 
-  std::vector<std::string> m_Sources;
+  std::vector<std::string> m_Sources{};
 };
 
 } // end namespace itk

--- a/Common/OpenCL/ITKimprovements/itkGPUDataManager.h
+++ b/Common/OpenCL/ITKimprovements/itkGPUDataManager.h
@@ -180,27 +180,27 @@ protected:
   PrintSelf(std::ostream & os, Indent indent) const override;
 
 protected:
-  unsigned int m_BufferSize; // # of bytes
+  unsigned int m_BufferSize{}; // # of bytes
 
-  OpenCLContext * m_Context;
+  OpenCLContext * m_Context{};
 
   /** buffer type */
-  cl_mem_flags m_MemFlags;
+  cl_mem_flags m_MemFlags{};
 
   /** buffer pointers */
-  cl_mem m_GPUBuffer;
-  void * m_CPUBuffer;
+  cl_mem m_GPUBuffer{};
+  void * m_CPUBuffer{};
 
   /** checks if buffer needs to be updated */
-  bool m_IsGPUBufferDirty;
-  bool m_IsCPUBufferDirty;
+  bool m_IsGPUBufferDirty{};
+  bool m_IsCPUBufferDirty{};
 
   /** extra safety flags */
-  bool m_CPUBufferLock;
-  bool m_GPUBufferLock;
+  bool m_CPUBufferLock{};
+  bool m_GPUBufferLock{};
 
   /** Mutex lock to prevent r/w hazard for multithreaded code */
-  std::mutex m_Mutex;
+  std::mutex m_Mutex{};
 };
 
 } // namespace itk

--- a/Common/OpenCL/ITKimprovements/itkGPUImage.h
+++ b/Common/OpenCL/ITKimprovements/itkGPUImage.h
@@ -267,9 +267,9 @@ protected:
   PrintSelf(std::ostream & os, Indent indent) const override;
 
 private:
-  bool m_Graft;
+  bool m_Graft{};
 
-  typename GPUImageDataManager<GPUImage>::Pointer m_DataManager;
+  typename GPUImageDataManager<GPUImage>::Pointer m_DataManager{};
 };
 
 //------------------------------------------------------------------------------

--- a/Common/OpenCL/ITKimprovements/itkGPUImageDataManager.h
+++ b/Common/OpenCL/ITKimprovements/itkGPUImageDataManager.h
@@ -100,7 +100,7 @@ protected:
   ~GPUImageDataManager() override = default;
 
 private:
-  typename ImageType::Pointer m_Image;
+  typename ImageType::Pointer m_Image{};
 };
 
 } // namespace itk

--- a/Common/OpenCL/ITKimprovements/itkGPUImageToImageFilter.h
+++ b/Common/OpenCL/ITKimprovements/itkGPUImageToImageFilter.h
@@ -125,10 +125,10 @@ protected:
   {}
 
   // GPU kernel manager
-  typename OpenCLKernelManager::Pointer m_GPUKernelManager;
+  typename OpenCLKernelManager::Pointer m_GPUKernelManager{};
 
 private:
-  bool m_GPUEnabled;
+  bool m_GPUEnabled{};
 };
 
 } // end namespace itk

--- a/Common/OpenCL/ITKimprovements/itkGPUUnaryFunctorImageFilter.h
+++ b/Common/OpenCL/ITKimprovements/itkGPUUnaryFunctorImageFilter.h
@@ -135,10 +135,10 @@ protected:
 
   /** GPU kernel handle is defined here instead of in the child class
    * because GPUGenerateData() in this base class is used. */
-  int m_UnaryFunctorImageFilterGPUKernelHandle;
+  int m_UnaryFunctorImageFilterGPUKernelHandle{};
 
 private:
-  FunctorType m_Functor;
+  FunctorType m_Functor{};
 };
 
 } // end of namespace itk

--- a/Common/OpenCL/ITKimprovements/itkOpenCLKernelManager.h
+++ b/Common/OpenCL/ITKimprovements/itkOpenCLKernelManager.h
@@ -161,7 +161,7 @@ protected:
   ResetArguments(const std::size_t kernelIdx);
 
 private:
-  OpenCLContext * m_Context;
+  OpenCLContext * m_Context{};
 
   struct KernelArgumentList
   {
@@ -169,8 +169,8 @@ private:
     GPUDataManager::Pointer m_GPUDataManager;
   };
 
-  std::vector<OpenCLKernel>                    m_Kernels;
-  std::vector<std::vector<KernelArgumentList>> m_KernelArgumentReady;
+  std::vector<OpenCLKernel>                    m_Kernels{};
+  std::vector<std::vector<KernelArgumentList>> m_KernelArgumentReady{};
 };
 
 } // end namespace itk

--- a/Common/OpenCL/ITKimprovements/itkOpenCLLogger.h
+++ b/Common/OpenCL/ITKimprovements/itkOpenCLLogger.h
@@ -95,12 +95,12 @@ protected:
 private:
   static Pointer m_Instance;
 
-  std::string m_FileName;
-  std::string m_OutputDirectory;
+  std::string m_FileName{};
+  std::string m_OutputDirectory{};
 
-  itk::StdStreamLogOutput::Pointer m_Stream;
-  std::ostream *                   m_FileStream;
-  bool                             m_Created;
+  itk::StdStreamLogOutput::Pointer m_Stream{};
+  std::ostream *                   m_FileStream{};
+  bool                             m_Created{};
 };
 
 } // end namespace itk

--- a/Common/ParameterFileParser/itkParameterFileParser.h
+++ b/Common/ParameterFileParser/itkParameterFileParser.h
@@ -129,8 +129,8 @@ protected:
 
 private:
   /** Member variables. */
-  std::string      m_ParameterFileName;
-  ParameterMapType m_ParameterMap;
+  std::string      m_ParameterFileName{};
+  ParameterMapType m_ParameterMap{};
 };
 
 } // end of namespace itk

--- a/Common/ParameterFileParser/itkParameterMapInterface.h
+++ b/Common/ParameterFileParser/itkParameterMapInterface.h
@@ -418,7 +418,7 @@ protected:
 
 private:
   /** Member variable to store the parameters. */
-  ParameterMapType m_ParameterMap;
+  ParameterMapType m_ParameterMap{};
 
   bool m_PrintErrorMessages{ true };
 };

--- a/Common/Transforms/itkAdvancedBSplineDeformableTransform.h
+++ b/Common/Transforms/itkAdvancedBSplineDeformableTransform.h
@@ -310,9 +310,9 @@ protected:
    * For each direction we create a different weights function for thread-
    * safety.
    */
-  WeightsFunctionPointer                                       m_WeightsFunction;
-  std::vector<DerivativeWeightsFunctionPointer>                m_DerivativeWeightsFunctions;
-  std::vector<std::vector<SODerivativeWeightsFunctionPointer>> m_SODerivativeWeightsFunctions;
+  WeightsFunctionPointer                                       m_WeightsFunction{};
+  std::vector<DerivativeWeightsFunctionPointer>                m_DerivativeWeightsFunctions{};
+  std::vector<std::vector<SODerivativeWeightsFunctionPointer>> m_SODerivativeWeightsFunctions{};
 
 private:
   friend class MultiBSplineDeformableTransformWithNormal<ScalarType, Self::SpaceDimension, VSplineOrder>;

--- a/Common/Transforms/itkAdvancedBSplineDeformableTransformBase.h
+++ b/Common/Transforms/itkAdvancedBSplineDeformableTransformBase.h
@@ -359,13 +359,13 @@ protected:
   InsideValidRegion(const ContinuousIndexType & index) const;
 
 private:
-  const unsigned m_SplineOrder;
+  const unsigned m_SplineOrder{};
 
 protected:
   /** Array of images representing the B-spline coefficients
    *  in each dimension.
    */
-  ImagePointer m_CoefficientImages[NDimensions];
+  ImagePointer m_CoefficientImages[NDimensions]{};
 
   /** Variables defining the coefficient grid extend. */
   RegionType     m_GridRegion{};
@@ -374,42 +374,42 @@ protected:
   OriginType     m_GridOrigin{};
   GridOffsetType m_GridOffsetTable{};
 
-  DirectionType                                     m_PointToIndexMatrix;
-  SpatialJacobianType                               m_PointToIndexMatrix2;
-  DirectionType                                     m_PointToIndexMatrixTransposed;
-  SpatialJacobianType                               m_PointToIndexMatrixTransposed2;
-  FixedArray<ScalarType, NDimensions>               m_PointToIndexMatrixDiagonal;
-  FixedArray<ScalarType, NDimensions * NDimensions> m_PointToIndexMatrixDiagonalProducts;
-  DirectionType                                     m_IndexToPoint;
-  bool                                              m_PointToIndexMatrixIsDiagonal;
+  DirectionType                                     m_PointToIndexMatrix{};
+  SpatialJacobianType                               m_PointToIndexMatrix2{};
+  DirectionType                                     m_PointToIndexMatrixTransposed{};
+  SpatialJacobianType                               m_PointToIndexMatrixTransposed2{};
+  FixedArray<ScalarType, NDimensions>               m_PointToIndexMatrixDiagonal{};
+  FixedArray<ScalarType, NDimensions * NDimensions> m_PointToIndexMatrixDiagonalProducts{};
+  DirectionType                                     m_IndexToPoint{};
+  bool                                              m_PointToIndexMatrixIsDiagonal{};
 
-  RegionType m_ValidRegion;
+  RegionType m_ValidRegion{};
 
   /** Variables defining the interpolation support region. */
-  unsigned long       m_Offset;
-  SizeType            m_SupportSize;
-  ContinuousIndexType m_ValidRegionBegin;
-  ContinuousIndexType m_ValidRegionEnd;
+  unsigned long       m_Offset{};
+  SizeType            m_SupportSize{};
+  ContinuousIndexType m_ValidRegionBegin{};
+  ContinuousIndexType m_ValidRegionEnd{};
 
   /** Keep a pointer to the input parameters. */
-  const ParametersType * m_InputParametersPointer;
+  const ParametersType * m_InputParametersPointer{};
 
   /** Jacobian as SpaceDimension number of images. */
   using JacobianPixelType = typename JacobianType::ValueType;
   using JacobianImageType = Image<JacobianPixelType, Self::SpaceDimension>;
 
-  typename JacobianImageType::Pointer m_JacobianImage[NDimensions];
+  typename JacobianImageType::Pointer m_JacobianImage[NDimensions]{};
 
   /** Keep track of last support region used in computing the Jacobian
    * for fast resetting of Jacobian to zero.
    */
-  mutable IndexType m_LastJacobianIndex;
+  mutable IndexType m_LastJacobianIndex{};
 
   /** Array holding images wrapped from the flat parameters. */
-  ImagePointer m_WrappedImage[NDimensions];
+  ImagePointer m_WrappedImage[NDimensions]{};
 
   /** Internal parameters buffer. */
-  ParametersType m_InternalParametersBuffer;
+  ParametersType m_InternalParametersBuffer{};
 
   void
   UpdateGridOffsetTable();

--- a/Common/Transforms/itkAdvancedEuler3DTransform.h
+++ b/Common/Transforms/itkAdvancedEuler3DTransform.h
@@ -158,10 +158,10 @@ protected:
   PrecomputeJacobianOfSpatialJacobian();
 
 private:
-  ScalarType m_AngleX;
-  ScalarType m_AngleY;
-  ScalarType m_AngleZ;
-  bool       m_ComputeZYX;
+  ScalarType m_AngleX{};
+  ScalarType m_AngleY{};
+  ScalarType m_AngleZ{};
+  bool       m_ComputeZYX{};
 };
 
 // class AdvancedEuler3DTransform

--- a/Common/Transforms/itkAdvancedIdentityTransform.h
+++ b/Common/Transforms/itkAdvancedIdentityTransform.h
@@ -327,12 +327,12 @@ protected:
   ~AdvancedIdentityTransform() override = default;
 
 private:
-  JacobianType                  m_LocalJacobian;
-  SpatialJacobianType           m_SpatialJacobian;
-  SpatialHessianType            m_SpatialHessian;
-  NonZeroJacobianIndicesType    m_NonZeroJacobianIndices;
-  JacobianOfSpatialJacobianType m_JacobianOfSpatialJacobian;
-  JacobianOfSpatialHessianType  m_JacobianOfSpatialHessian;
+  JacobianType                  m_LocalJacobian{};
+  SpatialJacobianType           m_SpatialJacobian{};
+  SpatialHessianType            m_SpatialHessian{};
+  NonZeroJacobianIndicesType    m_NonZeroJacobianIndices{};
+  JacobianOfSpatialJacobianType m_JacobianOfSpatialJacobian{};
+  JacobianOfSpatialHessianType  m_JacobianOfSpatialHessian{};
 };
 
 } // end namespace itk

--- a/Common/Transforms/itkAdvancedImageMomentsCalculator.h
+++ b/Common/Transforms/itkAdvancedImageMomentsCalculator.h
@@ -308,30 +308,30 @@ private:
   void
   operator=(const Self &);
 
-  ThreaderType::Pointer m_Threader;
+  ThreaderType::Pointer m_Threader{};
 
-  mutable MultiThreaderParameterType m_ThreaderParameters;
+  mutable MultiThreaderParameterType m_ThreaderParameters{};
 
-  mutable std::vector<AlignedComputePerThreadStruct> m_ComputePerThreadVariables;
-  bool                                               m_UseMultiThread;
-  SizeValueType                                      m_NumberOfPixelsCounted;
+  mutable std::vector<AlignedComputePerThreadStruct> m_ComputePerThreadVariables{};
+  bool                                               m_UseMultiThread{};
+  SizeValueType                                      m_NumberOfPixelsCounted{};
 
-  SizeValueType               m_NumberOfSamplesForCenteredTransformInitialization;
-  InputPixelType              m_LowerThresholdForCenterGravity;
-  bool                        m_CenterOfGravityUsesLowerThreshold;
-  ImageSampleContainerPointer m_SampleContainer;
+  SizeValueType               m_NumberOfSamplesForCenteredTransformInitialization{};
+  InputPixelType              m_LowerThresholdForCenterGravity{};
+  bool                        m_CenterOfGravityUsesLowerThreshold{};
+  ImageSampleContainerPointer m_SampleContainer{};
 
-  bool       m_Valid; // Have moments been computed yet?
-  ScalarType m_M0;    // Zeroth moment
-  VectorType m_M1;    // First moments about origin
-  MatrixType m_M2;    // Second moments about origin
-  VectorType m_Cg;    // Center of gravity (physical units)
-  MatrixType m_Cm;    // Second central moments (physical)
-  VectorType m_Pm;    // Principal moments (physical)
-  MatrixType m_Pa;    // Principal axes (physical)
+  bool       m_Valid{}; // Have moments been computed yet?
+  ScalarType m_M0{};    // Zeroth moment
+  VectorType m_M1{};    // First moments about origin
+  MatrixType m_M2{};    // Second moments about origin
+  VectorType m_Cg{};    // Center of gravity (physical units)
+  MatrixType m_Cm{};    // Second central moments (physical)
+  VectorType m_Pm{};    // Principal moments (physical)
+  MatrixType m_Pa{};    // Principal axes (physical)
 
-  ImageConstPointer         m_Image;
-  SpatialObjectConstPointer m_SpatialObjectMask;
+  ImageConstPointer         m_Image{};
+  SpatialObjectConstPointer m_SpatialObjectMask{};
 
 }; // class AdvancedImageMomentsCalculator
 } // end namespace itk

--- a/Common/Transforms/itkAdvancedMatrixOffsetTransformBase.h
+++ b/Common/Transforms/itkAdvancedMatrixOffsetTransformBase.h
@@ -426,10 +426,10 @@ protected:
   /** (spatial) Jacobians and Hessians can mostly be precomputed by this transform.
    * Store them in these member variables.
    * SpatialJacobian is simply m_Matrix */
-  NonZeroJacobianIndicesType    m_NonZeroJacobianIndices;
-  SpatialHessianType            m_SpatialHessian;
-  JacobianOfSpatialJacobianType m_JacobianOfSpatialJacobian;
-  JacobianOfSpatialHessianType  m_JacobianOfSpatialHessian;
+  NonZeroJacobianIndicesType    m_NonZeroJacobianIndices{};
+  SpatialHessianType            m_SpatialHessian{};
+  JacobianOfSpatialJacobianType m_JacobianOfSpatialJacobian{};
+  JacobianOfSpatialHessianType  m_JacobianOfSpatialHessian{};
 
 private:
   AdvancedMatrixOffsetTransformBase(const Self & other);
@@ -454,8 +454,8 @@ private:
   OutputVectorType m_Translation{};
 
   /** To avoid recomputation of the inverse if not needed. */
-  TimeStamp         m_MatrixMTime;
-  mutable TimeStamp m_InverseMatrixMTime;
+  TimeStamp         m_MatrixMTime{};
+  mutable TimeStamp m_InverseMatrixMTime{};
 };
 
 } // namespace itk

--- a/Common/Transforms/itkAdvancedRigid2DTransform.h
+++ b/Common/Transforms/itkAdvancedRigid2DTransform.h
@@ -225,7 +225,7 @@ protected:
   PrecomputeJacobianOfSpatialJacobian();
 
 private:
-  TScalarType m_Angle;
+  TScalarType m_Angle{};
 };
 
 

--- a/Common/Transforms/itkAdvancedSimilarity2DTransform.h
+++ b/Common/Transforms/itkAdvancedSimilarity2DTransform.h
@@ -228,7 +228,7 @@ protected:
   PrecomputeJacobianOfSpatialJacobian() override;
 
 private:
-  ScaleType m_Scale;
+  ScaleType m_Scale{};
 };
 
 // class AdvancedSimilarity2DTransform

--- a/Common/Transforms/itkAdvancedSimilarity3DTransform.h
+++ b/Common/Transforms/itkAdvancedSimilarity3DTransform.h
@@ -166,7 +166,7 @@ protected:
   PrecomputeJacobianOfSpatialJacobian();
 
 private:
-  ScaleType m_Scale;
+  ScaleType m_Scale{};
 };
 
 // class AdvancedSimilarity3DTransform

--- a/Common/Transforms/itkAdvancedVersorTransform.h
+++ b/Common/Transforms/itkAdvancedVersorTransform.h
@@ -186,7 +186,7 @@ private:
   operator=(const Self &); // Not implemented
 
   /** Versor containing the rotation */
-  VersorType m_Versor;
+  VersorType m_Versor{};
 };
 
 // class AdvancedVersorTransform

--- a/Common/Transforms/itkBSplineInterpolationDerivativeWeightFunction.h
+++ b/Common/Transforms/itkBSplineInterpolationDerivativeWeightFunction.h
@@ -104,7 +104,7 @@ protected:
 
 private:
   /** Member variables. */
-  unsigned int m_DerivativeDirection;
+  unsigned int m_DerivativeDirection{};
 };
 
 } // end namespace itk

--- a/Common/Transforms/itkBSplineInterpolationSecondOrderDerivativeWeightFunction.h
+++ b/Common/Transforms/itkBSplineInterpolationSecondOrderDerivativeWeightFunction.h
@@ -106,8 +106,8 @@ protected:
   PrintSelf(std::ostream & os, Indent indent) const override;
 
 private:
-  vnl_vector_fixed<double, 2> m_DerivativeDirections;
-  bool                        m_EqualDerivativeDirections;
+  vnl_vector_fixed<double, 2> m_DerivativeDirections{};
+  bool                        m_EqualDerivativeDirections{};
 };
 
 } // end namespace itk

--- a/Common/Transforms/itkBSplineInterpolationWeightFunctionBase.h
+++ b/Common/Transforms/itkBSplineInterpolationWeightFunctionBase.h
@@ -140,9 +140,9 @@ protected:
   PrintSelf(std::ostream & os, Indent indent) const override;
 
   /** Member variables. */
-  unsigned long m_NumberOfWeights;
-  SizeType      m_SupportSize;
-  TableType     m_OffsetToIndexTable;
+  unsigned long m_NumberOfWeights{};
+  SizeType      m_SupportSize{};
+  TableType     m_OffsetToIndexTable{};
 
 private:
   /** Function to initialize the support region. */

--- a/Common/Transforms/itkGridScheduleComputer.h
+++ b/Common/Transforms/itkGridScheduleComputer.h
@@ -150,12 +150,12 @@ protected:
   ~GridScheduleComputer() override = default;
 
   /** Declare member variables, needed for B-spline grid. */
-  VectorSpacingType           m_GridSpacings;
-  VectorOriginType            m_GridOrigins;
-  VectorDirectionType         m_GridDirections;
-  VectorRegionType            m_GridRegions;
-  TransformConstPointer       m_InitialTransform;
-  VectorGridSpacingFactorType m_GridSpacingFactors;
+  VectorSpacingType           m_GridSpacings{};
+  VectorOriginType            m_GridOrigins{};
+  VectorDirectionType         m_GridDirections{};
+  VectorRegionType            m_GridRegions{};
+  TransformConstPointer       m_InitialTransform{};
+  VectorGridSpacingFactorType m_GridSpacingFactors{};
 
   /** PrintSelf. */
   void
@@ -173,19 +173,19 @@ protected:
 
 private:
   /** Declare member variables, needed in functions. */
-  OriginType    m_ImageOrigin;
-  SpacingType   m_ImageSpacing;
-  RegionType    m_ImageRegion;
-  DirectionType m_ImageDirection;
-  unsigned int  m_BSplineOrder;
-  unsigned int  m_NumberOfLevels;
-  SpacingType   m_FinalGridSpacing;
+  OriginType    m_ImageOrigin{};
+  SpacingType   m_ImageSpacing{};
+  RegionType    m_ImageRegion{};
+  DirectionType m_ImageDirection{};
+  unsigned int  m_BSplineOrder{};
+  unsigned int  m_NumberOfLevels{};
+  SpacingType   m_FinalGridSpacing{};
 
   /** Clamp the upsampling factor. */
   itkSetClampMacro(UpsamplingFactor, float, 1.0, NumericTraits<float>::max());
 
   /** Declare member variables, needed internally. */
-  float m_UpsamplingFactor;
+  float m_UpsamplingFactor{};
 };
 
 } // end namespace itk

--- a/Common/Transforms/itkRecursiveBSplineTransform.h
+++ b/Common/Transforms/itkRecursiveBSplineTransform.h
@@ -193,7 +193,7 @@ private:
   using RecursiveBSplineWeightFunctionType =
     itk::RecursiveBSplineInterpolationWeightFunction<TScalarType, NDimensions, VSplineOrder>;
 
-  elastix::DefaultConstruct<RecursiveBSplineWeightFunctionType> m_RecursiveBSplineWeightFunction;
+  elastix::DefaultConstruct<RecursiveBSplineWeightFunctionType> m_RecursiveBSplineWeightFunction{};
 };
 
 } // end namespace itk

--- a/Common/Transforms/itkStackTransform.h
+++ b/Common/Transforms/itkStackTransform.h
@@ -381,7 +381,7 @@ private:
 
 
   // Transform container
-  std::vector<SubTransformPointer> m_SubTransformContainer;
+  std::vector<SubTransformPointer> m_SubTransformContainer{};
 
   // Stack spacing and origin of last dimension
   TScalarType m_StackSpacing{ 1.0 };

--- a/Common/Transforms/itkUpsampleBSplineParametersFilter.h
+++ b/Common/Transforms/itkUpsampleBSplineParametersFilter.h
@@ -115,15 +115,15 @@ protected:
 
 private:
   /** Private member variables. */
-  OriginType    m_CurrentGridOrigin;
-  SpacingType   m_CurrentGridSpacing;
-  DirectionType m_CurrentGridDirection;
-  RegionType    m_CurrentGridRegion;
-  OriginType    m_RequiredGridOrigin;
-  SpacingType   m_RequiredGridSpacing;
-  DirectionType m_RequiredGridDirection;
-  RegionType    m_RequiredGridRegion;
-  unsigned int  m_BSplineOrder;
+  OriginType    m_CurrentGridOrigin{};
+  SpacingType   m_CurrentGridSpacing{};
+  DirectionType m_CurrentGridDirection{};
+  RegionType    m_CurrentGridRegion{};
+  OriginType    m_RequiredGridOrigin{};
+  SpacingType   m_RequiredGridSpacing{};
+  DirectionType m_RequiredGridDirection{};
+  RegionType    m_RequiredGridRegion{};
+  unsigned int  m_BSplineOrder{};
 };
 
 } // end namespace itk

--- a/Common/itkAdvancedRayCastInterpolateImageFunction.h
+++ b/Common/itkAdvancedRayCastInterpolateImageFunction.h
@@ -201,7 +201,7 @@ protected:
   PrintSelf(std::ostream & os, Indent indent) const override;
 
   /// Transformation used to calculate the new focal point position
-  TransformPointer m_Transform;
+  TransformPointer m_Transform{};
 
   /// The focal point or position of the ray source
   InputPointType m_FocalPoint{};
@@ -210,7 +210,7 @@ protected:
   double m_Threshold{ 0.0 };
 
   /// Pointer to the interpolator
-  InterpolatorPointer m_Interpolator;
+  InterpolatorPointer m_Interpolator{};
 
 private:
   SizeType

--- a/Common/itkComputeDisplacementDistribution.h
+++ b/Common/itkComputeDisplacementDistribution.h
@@ -142,15 +142,15 @@ protected:
   using ThreaderType = itk::PlatformMultiThreader;
   using ThreadInfoType = ThreaderType::WorkUnitInfo;
 
-  typename FixedImageType::ConstPointer   m_FixedImage;
-  FixedImageRegionType                    m_FixedImageRegion;
-  FixedImageMaskConstPointer              m_FixedImageMask;
-  TransformPointer                        m_Transform;
-  ScaledSingleValuedCostFunction::Pointer m_CostFunction;
-  SizeValueType                           m_NumberOfJacobianMeasurements;
-  DerivativeType                          m_ExactGradient;
-  SizeValueType                           m_NumberOfParameters;
-  ThreaderType::Pointer                   m_Threader;
+  typename FixedImageType::ConstPointer   m_FixedImage{};
+  FixedImageRegionType                    m_FixedImageRegion{};
+  FixedImageMaskConstPointer              m_FixedImageMask{};
+  TransformPointer                        m_Transform{};
+  ScaledSingleValuedCostFunction::Pointer m_CostFunction{};
+  SizeValueType                           m_NumberOfJacobianMeasurements{};
+  DerivativeType                          m_ExactGradient{};
+  SizeValueType                           m_NumberOfParameters{};
+  ThreaderType::Pointer                   m_Threader{};
 
   using FixedImageIndexType = typename FixedImageType::IndexType;
   using FixedImagePointType = typename FixedImageType::PointType;
@@ -216,13 +216,13 @@ protected:
   itkAlignedTypedef(ITK_CACHE_LINE_ALIGNMENT, PaddedComputePerThreadStruct, AlignedComputePerThreadStruct);
 
 private:
-  mutable MultiThreaderParameterType m_ThreaderParameters;
+  mutable MultiThreaderParameterType m_ThreaderParameters{};
 
-  mutable std::vector<AlignedComputePerThreadStruct> m_ComputePerThreadVariables;
+  mutable std::vector<AlignedComputePerThreadStruct> m_ComputePerThreadVariables{};
 
-  SizeValueType               m_NumberOfPixelsCounted;
-  bool                        m_UseMultiThread;
-  ImageSampleContainerPointer m_SampleContainer;
+  SizeValueType               m_NumberOfPixelsCounted{};
+  bool                        m_UseMultiThread{};
+  ImageSampleContainerPointer m_SampleContainer{};
 };
 
 } // end namespace itk

--- a/Common/itkComputeImageExtremaFilter.h
+++ b/Common/itkComputeImageExtremaFilter.h
@@ -112,9 +112,9 @@ protected:
   ThreadedGenerateDataImageMask(const RegionType &);
   virtual void
                                SameGeometry();
-  RegionType                   m_ImageRegion;
-  ImageMaskConstPointer        m_ImageMask;
-  ImageSpatialMaskConstPointer m_ImageSpatialMask;
+  RegionType                   m_ImageRegion{};
+  ImageMaskConstPointer        m_ImageMask{};
+  ImageSpatialMaskConstPointer m_ImageSpatialMask{};
   bool                         m_UseMask{ false };
   bool                         m_SameGeometry{ false };
 
@@ -129,7 +129,7 @@ private:
   PixelType                      m_ThreadMin{ 1 };
   PixelType                      m_ThreadMax{ 1 };
 
-  std::mutex m_Mutex;
+  std::mutex m_Mutex{};
 }; // end of class
 } // end namespace itk
 

--- a/Common/itkComputeJacobianTerms.h
+++ b/Common/itkComputeJacobianTerms.h
@@ -111,10 +111,10 @@ protected:
   ~ComputeJacobianTerms() override = default;
 
   typename FixedImageType::ConstPointer m_FixedImage{ nullptr };
-  FixedImageRegionType                  m_FixedImageRegion;
+  FixedImageRegionType                  m_FixedImageRegion{};
   FixedImageMaskConstPointer            m_FixedImageMask{ nullptr };
   TransformPointer                      m_Transform{ nullptr };
-  ScalesType                            m_Scales;
+  ScalesType                            m_Scales{};
   bool                                  m_UseScales{ false };
 
   unsigned int  m_MaxBandCovSize{ 0 };

--- a/Common/itkComputePreconditionerUsingDisplacementDistribution.h
+++ b/Common/itkComputePreconditionerUsingDisplacementDistribution.h
@@ -138,9 +138,9 @@ protected:
   using typename Superclass::CoordinateRepresentationType;
   using typename Superclass::NumberOfParametersType;
 
-  double m_MaximumStepLength;
-  double m_RegularizationKappa;
-  double m_ConditionNumber;
+  double m_MaximumStepLength{};
+  double m_RegularizationKappa{};
+  double m_ConditionNumber{};
 };
 
 } // end namespace itk

--- a/Common/itkErodeMaskImageFilter.h
+++ b/Common/itkErodeMaskImageFilter.h
@@ -135,9 +135,9 @@ protected:
   GenerateData() override;
 
 private:
-  bool         m_IsMovingMask;
-  unsigned int m_ResolutionLevel;
-  ScheduleType m_Schedule;
+  bool         m_IsMovingMask{};
+  unsigned int m_ResolutionLevel{};
+  ScheduleType m_Schedule{};
 };
 
 } // end namespace itk

--- a/Common/itkGenericMultiResolutionPyramidImageFilter.h
+++ b/Common/itkGenericMultiResolutionPyramidImageFilter.h
@@ -270,10 +270,10 @@ protected:
   void
   ReleaseOutputs();
 
-  SmoothingScheduleType m_SmoothingSchedule;
-  unsigned int          m_CurrentLevel;
-  bool                  m_ComputeOnlyForCurrentLevel;
-  bool                  m_SmoothingScheduleDefined;
+  SmoothingScheduleType m_SmoothingSchedule{};
+  unsigned int          m_CurrentLevel{};
+  bool                  m_ComputeOnlyForCurrentLevel{};
+  bool                  m_SmoothingScheduleDefined{};
 
 private:
   /** Typedef for smoother. Smooth always happens first, then only from

--- a/Common/itkMultiOrderBSplineDecompositionImageFilter.h
+++ b/Common/itkMultiOrderBSplineDecompositionImageFilter.h
@@ -153,14 +153,15 @@ protected:
   EnlargeOutputRequestedRegion(DataObject * output) override;
 
   /** These are needed by the smoothing spline routine. */
-  std::vector<CoeffType>         m_Scratch;    // temp storage for processing of Coefficients
-  typename TInputImage::SizeType m_DataLength; // Image size
+  std::vector<CoeffType>         m_Scratch{};    // temp storage for processing of Coefficients
+  typename TInputImage::SizeType m_DataLength{}; // Image size
 
-  unsigned int m_SplineOrder[ImageDimension]; // User specified spline order per dimension (3rd or cubic is the default)
-  double       m_SplinePoles[3];              // Poles calculated for a given spline order
-  int          m_NumberOfPoles;               // number of poles
-  double       m_Tolerance;                   // Tolerance used for determining initial causal coefficient
-  unsigned int m_IteratorDirection;           // Direction for iterator incrementing
+  unsigned int
+               m_SplineOrder[ImageDimension]{}; // User specified spline order per dimension (3rd or cubic is the default)
+  double       m_SplinePoles[3]{};              // Poles calculated for a given spline order
+  int          m_NumberOfPoles{};               // number of poles
+  double       m_Tolerance{};                   // Tolerance used for determining initial causal coefficient
+  unsigned int m_IteratorDirection{};           // Direction for iterator incrementing
 
 private:
   /** Determines the poles for dimension given the Spline Order. */

--- a/Common/itkMultiResolutionImageRegistrationMethod2.h
+++ b/Common/itkMultiResolutionImageRegistrationMethod2.h
@@ -277,29 +277,29 @@ protected:
    * itk::MultiResolutionImageRegistrationMethod these member variables
    * are made protected, so they can be accessed by children classes.
    */
-  ParametersType m_LastTransformParameters;
-  bool           m_Stop;
+  ParametersType m_LastTransformParameters{};
+  bool           m_Stop{};
 
 private:
   /** Member variables. */
-  MetricPointer          m_Metric;
-  OptimizerType::Pointer m_Optimizer;
-  TransformPointer       m_Transform;
-  InterpolatorPointer    m_Interpolator;
+  MetricPointer          m_Metric{};
+  OptimizerType::Pointer m_Optimizer{};
+  TransformPointer       m_Transform{};
+  InterpolatorPointer    m_Interpolator{};
 
-  ParametersType m_InitialTransformParameters;
-  ParametersType m_InitialTransformParametersOfNextLevel;
+  ParametersType m_InitialTransformParameters{};
+  ParametersType m_InitialTransformParametersOfNextLevel{};
 
-  MovingImageConstPointer   m_MovingImage;
-  FixedImageConstPointer    m_FixedImage;
-  MovingImagePyramidPointer m_MovingImagePyramid;
-  FixedImagePyramidPointer  m_FixedImagePyramid;
+  MovingImageConstPointer   m_MovingImage{};
+  FixedImageConstPointer    m_FixedImage{};
+  MovingImagePyramidPointer m_MovingImagePyramid{};
+  FixedImagePyramidPointer  m_FixedImagePyramid{};
 
-  FixedImageRegionType        m_FixedImageRegion;
-  FixedImageRegionPyramidType m_FixedImageRegionPyramid;
+  FixedImageRegionType        m_FixedImageRegion{};
+  FixedImageRegionPyramidType m_FixedImageRegionPyramid{};
 
-  unsigned long m_NumberOfLevels;
-  unsigned long m_CurrentLevel;
+  unsigned long m_NumberOfLevels{};
+  unsigned long m_CurrentLevel{};
 };
 
 } // end namespace itk

--- a/Common/itkParabolicErodeDilateImageFilter.h
+++ b/Common/itkParabolicErodeDilateImageFilter.h
@@ -153,14 +153,14 @@ protected:
   void
   EnlargeOutputRequestedRegion(DataObject * output) override;
 
-  bool m_UseImageSpacing;
+  bool m_UseImageSpacing{};
 
 private:
-  RadiusType                      m_Scale;
-  typename TInputImage::PixelType m_Extreme;
+  RadiusType                      m_Scale{};
+  typename TInputImage::PixelType m_Extreme{};
 
-  int m_MagnitudeSign;
-  int m_CurrentDimension;
+  int m_MagnitudeSign{};
+  int m_CurrentDimension{};
 };
 
 } // end namespace itk

--- a/Common/itkRecursiveBSplineInterpolationWeightFunction.h
+++ b/Common/itkRecursiveBSplineInterpolationWeightFunction.h
@@ -117,9 +117,9 @@ private:
   Evaluate(const ContinuousIndexType & index, WeightsType & weights, IndexType & startIndex) const override;
 
   /** Private members; We unfortunatly cannot use those of the superclass. */
-  unsigned int m_NumberOfWeights;
-  unsigned int m_NumberOfIndices;
-  SizeType     m_SupportSize;
+  unsigned int m_NumberOfWeights{};
+  unsigned int m_NumberOfIndices{};
+  SizeType     m_SupportSize{};
 
   /** Interpolation kernel type. */
   using KernelType = BSplineKernelFunction2<VSplineOrder>;

--- a/Common/itkReducedDimensionBSplineInterpolateImageFunction.h
+++ b/Common/itkReducedDimensionBSplineInterpolateImageFunction.h
@@ -188,10 +188,10 @@ protected:
   PrintSelf(std::ostream & os, Indent indent) const override;
 
   // These are needed by the smoothing spline routine.
-  typename TImageType::SizeType m_DataLength;  // Image size
-  unsigned int                  m_SplineOrder; // User specified spline order (3rd or cubic is the default)
+  typename TImageType::SizeType m_DataLength{};  // Image size
+  unsigned int                  m_SplineOrder{}; // User specified spline order (3rd or cubic is the default)
 
-  typename CoefficientImageType::ConstPointer m_Coefficients; // Spline coefficients
+  typename CoefficientImageType::ConstPointer m_Coefficients{}; // Spline coefficients
 
 private:
   SizeType
@@ -230,13 +230,13 @@ private:
   void
   ApplyMirrorBoundaryConditions(vnl_matrix<long> & evaluateIndex, unsigned int splineOrder) const;
 
-  std::vector<IndexType> m_PointsToIndex; // Preallocation of interpolation neighborhood indicies
+  std::vector<IndexType> m_PointsToIndex{}; // Preallocation of interpolation neighborhood indicies
 
-  CoefficientFilterPointer m_CoefficientFilter;
+  CoefficientFilterPointer m_CoefficientFilter{};
 
   // flag to take or not the image direction into account when computing the
   // derivatives.
-  bool m_UseImageDirection;
+  bool m_UseImageDirection{};
 };
 
 } // namespace itk

--- a/Common/itkScaledSingleValuedNonLinearOptimizer.h
+++ b/Common/itkScaledSingleValuedNonLinearOptimizer.h
@@ -142,8 +142,8 @@ protected:
   PrintSelf(std::ostream & os, Indent indent) const override;
 
   /** Member variables. */
-  ParametersType            m_ScaledCurrentPosition;
-  ScaledCostFunctionPointer m_ScaledCostFunction;
+  ParametersType            m_ScaledCurrentPosition{};
+  ScaledCostFunctionPointer m_ScaledCostFunction{};
 
   /** Set m_ScaledCurrentPosition. */
   virtual void
@@ -187,8 +187,8 @@ private:
    * GetCurrentPosition is called. This method needs a member variable,
    * because the GetCurrentPosition return something by reference.
    */
-  mutable ParametersType m_UnscaledCurrentPosition;
-  bool                   m_Maximize;
+  mutable ParametersType m_UnscaledCurrentPosition{};
+  bool                   m_Maximize{};
 };
 
 } // end namespace itk

--- a/Common/itkTransformixInputPointFileReader.h
+++ b/Common/itkTransformixInputPointFileReader.h
@@ -101,7 +101,7 @@ private:
   unsigned long m_NumberOfPoints{ 0 };
   bool          m_PointsAreIndices{ false };
 
-  std::ifstream m_Reader;
+  std::ifstream m_Reader{};
 };
 
 } // end namespace itk

--- a/Components/Metrics/AdvancedKappaStatistic/itkAdvancedKappaStatisticImageToImageMetric.h
+++ b/Components/Metrics/AdvancedKappaStatistic/itkAdvancedKappaStatisticImageToImageMetric.h
@@ -225,10 +225,10 @@ protected:
   AccumulateDerivativesThreaderCallback(void * arg);
 
 private:
-  bool     m_UseForegroundValue;
-  RealType m_ForegroundValue;
-  RealType m_Epsilon;
-  bool     m_Complement;
+  bool     m_UseForegroundValue{};
+  RealType m_ForegroundValue{};
+  RealType m_Epsilon{};
+  bool     m_Complement{};
 
   /** Threading related parameters. */
 
@@ -258,7 +258,8 @@ private:
   itkAlignedTypedef(ITK_CACHE_LINE_ALIGNMENT,
                     PaddedKappaGetValueAndDerivativePerThreadStruct,
                     AlignedKappaGetValueAndDerivativePerThreadStruct);
-  mutable std::vector<AlignedKappaGetValueAndDerivativePerThreadStruct> m_KappaGetValueAndDerivativePerThreadVariables;
+  mutable std::vector<AlignedKappaGetValueAndDerivativePerThreadStruct>
+    m_KappaGetValueAndDerivativePerThreadVariables{};
 };
 
 } // end namespace itk

--- a/Components/Metrics/AdvancedMattesMutualInformation/itkParzenWindowMutualInformationImageToImageMetric.h
+++ b/Components/Metrics/AdvancedMattesMutualInformation/itkParzenWindowMutualInformationImageToImageMetric.h
@@ -236,7 +236,7 @@ protected:
   {
     Self * m_Metric;
   };
-  ParzenWindowMutualInformationMultiThreaderParameterType m_ParzenWindowMutualInformationThreaderParameters;
+  ParzenWindowMutualInformationMultiThreaderParameterType m_ParzenWindowMutualInformationThreaderParameters{};
 
   /** Multi-threaded versions of the ComputePDF function. */
   void
@@ -258,10 +258,10 @@ private:
   /** Helper array for storing the values of the JointPDF ratios. */
   using PRatioType = double;
   using PRatioArrayType = Array2D<PRatioType>;
-  mutable PRatioArrayType m_PRatioArray;
+  mutable PRatioArrayType m_PRatioArray{};
 
   /** Setting */
-  bool m_UseJacobianPreconditioning;
+  bool m_UseJacobianPreconditioning{};
 
   /** Helper function to compute the derivative for the low memory variant. */
   void

--- a/Components/Metrics/AdvancedMeanSquares/itkAdvancedMeanSquaresImageToImageMetric.h
+++ b/Components/Metrics/AdvancedMeanSquares/itkAdvancedMeanSquaresImageToImageMetric.h
@@ -217,7 +217,7 @@ protected:
     NearestNeighborInterpolateImageFunction<FixedImageType, CoordinateRepresentationType>;
   using SelfHessianSamplerType = ImageGridSampler<FixedImageType>;
 
-  double m_NormalizationFactor;
+  double m_NormalizationFactor{};
 
   /** Compute a pixel's contribution to the measure and derivatives;
    * Called by GetValueAndDerivative(). */
@@ -253,10 +253,10 @@ protected:
   AfterThreadedGetValueAndDerivative(MeasureType & value, DerivativeType & derivative) const override;
 
 private:
-  bool         m_UseNormalization;
-  double       m_SelfHessianSmoothingSigma;
-  double       m_SelfHessianNoiseRange;
-  unsigned int m_NumberOfSamplesForSelfHessian;
+  bool         m_UseNormalization{};
+  double       m_SelfHessianSmoothingSigma{};
+  double       m_SelfHessianNoiseRange{};
+  unsigned int m_NumberOfSamplesForSelfHessian{};
 };
 
 } // end namespace itk

--- a/Components/Metrics/AdvancedNormalizedCorrelation/itkAdvancedNormalizedCorrelationImageToImageMetric.h
+++ b/Components/Metrics/AdvancedNormalizedCorrelation/itkAdvancedNormalizedCorrelationImageToImageMetric.h
@@ -238,7 +238,7 @@ protected:
   AccumulateDerivativesThreaderCallback(void * arg);
 
 private:
-  mutable bool m_SubtractMean;
+  mutable bool m_SubtractMean{};
 
   using AccumulateType = typename NumericTraits<MeasureType>::AccumulateType;
 

--- a/Components/Metrics/BendingEnergyPenalty/itkTransformBendingEnergyPenaltyTerm.h
+++ b/Components/Metrics/BendingEnergyPenalty/itkTransformBendingEnergyPenaltyTerm.h
@@ -180,7 +180,7 @@ protected:
   ~TransformBendingEnergyPenaltyTerm() override = default;
 
 private:
-  unsigned int m_NumberOfSamplesForSelfHessian;
+  unsigned int m_NumberOfSamplesForSelfHessian{};
 };
 
 } // end namespace itk

--- a/Components/Metrics/DistancePreservingRigidityPenalty/itkDistancePreservingRigidityPenaltyTerm.h
+++ b/Components/Metrics/DistancePreservingRigidityPenalty/itkDistancePreservingRigidityPenaltyTerm.h
@@ -213,16 +213,16 @@ protected:
 
 private:
   /** Member variables. */
-  BSplineTransformPointer m_BSplineTransform;
+  BSplineTransformPointer m_BSplineTransform{};
 
-  mutable MeasureType m_RigidityPenaltyTermValue;
+  mutable MeasureType m_RigidityPenaltyTermValue{};
 
-  BSplineKnotImagePointer m_BSplineKnotImage;
-  PenaltyGridImagePointer m_PenaltyGridImage;
-  SegmentedImagePointer   m_SegmentedImage;
-  SegmentedImagePointer   m_SampledSegmentedImage;
+  BSplineKnotImagePointer m_BSplineKnotImage{};
+  PenaltyGridImagePointer m_PenaltyGridImage{};
+  SegmentedImagePointer   m_SegmentedImage{};
+  SegmentedImagePointer   m_SampledSegmentedImage{};
 
-  unsigned int m_NumberOfRigidGrids;
+  unsigned int m_NumberOfRigidGrids{};
 };
 
 // end class DistancePreservingRigidityPenaltyTerm

--- a/Components/Metrics/GradientDifference/itkGradientDifferenceImageToImageMetric2.h
+++ b/Components/Metrics/GradientDifference/itkGradientDifferenceImageToImageMetric2.h
@@ -188,40 +188,40 @@ protected:
 
 private:
   /** The variance of the moving image gradients. */
-  mutable MovedGradientPixelType m_Variance[FixedImageDimension];
+  mutable MovedGradientPixelType m_Variance[FixedImageDimension]{};
 
   /** The range of the moving image gradients. */
-  mutable MovedGradientPixelType m_MinMovedGradient[MovedImageDimension];
-  mutable MovedGradientPixelType m_MaxMovedGradient[MovedImageDimension];
+  mutable MovedGradientPixelType m_MinMovedGradient[MovedImageDimension]{};
+  mutable MovedGradientPixelType m_MaxMovedGradient[MovedImageDimension]{};
 
   /** The range of the fixed image gradients. */
-  mutable FixedGradientPixelType m_MinFixedGradient[FixedImageDimension];
-  mutable FixedGradientPixelType m_MaxFixedGradient[FixedImageDimension];
+  mutable FixedGradientPixelType m_MinFixedGradient[FixedImageDimension]{};
+  mutable FixedGradientPixelType m_MaxFixedGradient[FixedImageDimension]{};
 
   /** The filter for transforming the moving image. */
-  typename TransformMovingImageFilterType::Pointer m_TransformMovingImageFilter;
+  typename TransformMovingImageFilterType::Pointer m_TransformMovingImageFilter{};
 
   /** The Sobel gradients of the fixed image */
-  CastFixedImageFilterPointer m_CastFixedImageFilter;
+  CastFixedImageFilterPointer m_CastFixedImageFilter{};
 
-  SobelOperator<FixedGradientPixelType, Self::FixedImageDimension> m_FixedSobelOperators[FixedImageDimension];
+  SobelOperator<FixedGradientPixelType, Self::FixedImageDimension> m_FixedSobelOperators[FixedImageDimension]{};
 
-  typename FixedSobelFilter::Pointer m_FixedSobelFilters[Self::FixedImageDimension];
+  typename FixedSobelFilter::Pointer m_FixedSobelFilters[Self::FixedImageDimension]{};
 
-  ZeroFluxNeumannBoundaryCondition<MovedGradientImageType> m_MovedBoundCond;
-  ZeroFluxNeumannBoundaryCondition<FixedGradientImageType> m_FixedBoundCond;
+  ZeroFluxNeumannBoundaryCondition<MovedGradientImageType> m_MovedBoundCond{};
+  ZeroFluxNeumannBoundaryCondition<FixedGradientImageType> m_FixedBoundCond{};
 
   /** The Sobel gradients of the moving image */
-  CastMovedImageFilterPointer m_CastMovedImageFilter;
+  CastMovedImageFilterPointer m_CastMovedImageFilter{};
 
-  SobelOperator<MovedGradientPixelType, Self::MovedImageDimension> m_MovedSobelOperators[MovedImageDimension];
+  SobelOperator<MovedGradientPixelType, Self::MovedImageDimension> m_MovedSobelOperators[MovedImageDimension]{};
 
-  typename MovedSobelFilter::Pointer m_MovedSobelFilters[Self::MovedImageDimension];
+  typename MovedSobelFilter::Pointer m_MovedSobelFilters[Self::MovedImageDimension]{};
 
-  ScalesType                  m_Scales;
-  double                      m_DerivativeDelta;
-  double                      m_Rescalingfactor;
-  CombinationTransformPointer m_CombinationTransform;
+  ScalesType                  m_Scales{};
+  double                      m_DerivativeDelta{};
+  double                      m_Rescalingfactor{};
+  CombinationTransformPointer m_CombinationTransform{};
 };
 
 } // end namespace itk

--- a/Components/Metrics/KNNGraphAlphaMutualInformation/KNN/itkANNBruteForceTree.h
+++ b/Components/Metrics/KNNGraphAlphaMutualInformation/KNN/itkANNBruteForceTree.h
@@ -83,7 +83,7 @@ protected:
   ~ANNBruteForceTree() override;
 
   /** Member variables. */
-  ANNBruteForceTreeType * m_ANNTree;
+  ANNBruteForceTreeType * m_ANNTree{};
 };
 
 } // end namespace itk

--- a/Components/Metrics/KNNGraphAlphaMutualInformation/KNN/itkANNFixedRadiusTreeSearch.h
+++ b/Components/Metrics/KNNGraphAlphaMutualInformation/KNN/itkANNFixedRadiusTreeSearch.h
@@ -86,8 +86,8 @@ protected:
   ~ANNFixedRadiusTreeSearch() override = default;
 
   /** Member variables. */
-  double m_ErrorBound;
-  double m_SquaredRadius;
+  double m_ErrorBound{};
+  double m_SquaredRadius{};
 };
 
 } // end namespace itk

--- a/Components/Metrics/KNNGraphAlphaMutualInformation/KNN/itkANNPriorityTreeSearch.h
+++ b/Components/Metrics/KNNGraphAlphaMutualInformation/KNN/itkANNPriorityTreeSearch.h
@@ -85,8 +85,8 @@ protected:
   ~ANNPriorityTreeSearch() override = default;
 
   /** Member variables. */
-  double          m_ErrorBound;
-  ANNkDTreeType * m_BinaryTreeAskDTree;
+  double          m_ErrorBound{};
+  ANNkDTreeType * m_BinaryTreeAskDTree{};
 };
 
 } // end namespace itk

--- a/Components/Metrics/KNNGraphAlphaMutualInformation/KNN/itkANNStandardTreeSearch.h
+++ b/Components/Metrics/KNNGraphAlphaMutualInformation/KNN/itkANNStandardTreeSearch.h
@@ -78,7 +78,7 @@ protected:
   ~ANNStandardTreeSearch() override = default;
 
   /** Member variables. */
-  double m_ErrorBound;
+  double m_ErrorBound{};
 };
 
 } // end namespace itk

--- a/Components/Metrics/KNNGraphAlphaMutualInformation/KNN/itkANNbdTree.h
+++ b/Components/Metrics/KNNGraphAlphaMutualInformation/KNN/itkANNbdTree.h
@@ -87,7 +87,7 @@ protected:
   PrintSelf(std::ostream & os, Indent indent) const override;
 
   /** Member variables. */
-  ShrinkingRuleType m_ShrinkingRule;
+  ShrinkingRuleType m_ShrinkingRule{};
 };
 
 } // end namespace itk

--- a/Components/Metrics/KNNGraphAlphaMutualInformation/KNN/itkANNkDTree.h
+++ b/Components/Metrics/KNNGraphAlphaMutualInformation/KNN/itkANNkDTree.h
@@ -105,9 +105,9 @@ protected:
   PrintSelf(std::ostream & os, Indent indent) const override;
 
   /** Member variables. */
-  ANNkDTreeType *   m_ANNTree;
-  SplittingRuleType m_SplittingRule;
-  BucketSizeType    m_BucketSize;
+  ANNkDTreeType *   m_ANNTree{};
+  SplittingRuleType m_SplittingRule{};
+  BucketSizeType    m_BucketSize{};
 };
 
 } // end namespace itk

--- a/Components/Metrics/KNNGraphAlphaMutualInformation/KNN/itkBinaryANNTreeSearchBase.h
+++ b/Components/Metrics/KNNGraphAlphaMutualInformation/KNN/itkBinaryANNTreeSearchBase.h
@@ -78,7 +78,7 @@ protected:
   ~BinaryANNTreeSearchBase() override = default;
 
   /** Member variables. */
-  typename BinaryANNTreeType::Pointer m_BinaryTreeAsITKANNType;
+  typename BinaryANNTreeType::Pointer m_BinaryTreeAsITKANNType{};
 };
 
 } // end namespace itk

--- a/Components/Metrics/KNNGraphAlphaMutualInformation/KNN/itkBinaryTreeBase.h
+++ b/Components/Metrics/KNNGraphAlphaMutualInformation/KNN/itkBinaryTreeBase.h
@@ -88,7 +88,7 @@ protected:
 
 private:
   /** Store the samples. */
-  typename SampleType::Pointer m_Sample;
+  typename SampleType::Pointer m_Sample{};
 };
 
 } // end namespace itk

--- a/Components/Metrics/KNNGraphAlphaMutualInformation/KNN/itkBinaryTreeSearchBase.h
+++ b/Components/Metrics/KNNGraphAlphaMutualInformation/KNN/itkBinaryTreeSearchBase.h
@@ -78,9 +78,9 @@ protected:
   ~BinaryTreeSearchBase() override = default;
 
   /** Member variables. */
-  BinaryTreePointer m_BinaryTree;
-  unsigned int      m_KNearestNeighbors;
-  unsigned int      m_DataDimension;
+  BinaryTreePointer m_BinaryTree{};
+  unsigned int      m_KNearestNeighbors{};
+  unsigned int      m_DataDimension{};
 };
 
 } // end namespace itk

--- a/Components/Metrics/KNNGraphAlphaMutualInformation/KNN/itkListSampleCArray.h
+++ b/Components/Metrics/KNNGraphAlphaMutualInformation/KNN/itkListSampleCArray.h
@@ -140,12 +140,12 @@ protected:
 
 private:
   /** The internal storage of the data in a C array. */
-  InternalDataContainerType m_InternalContainer;
-  InstanceIdentifier        m_InternalContainerSize;
-  InstanceIdentifier        m_ActualSize;
+  InternalDataContainerType m_InternalContainer{};
+  InstanceIdentifier        m_InternalContainerSize{};
+  InstanceIdentifier        m_ActualSize{};
 
   /** Dummy needed for GetMeasurementVector(). */
-  mutable MeasurementVectorType m_TemporaryMeasurementVector;
+  mutable MeasurementVectorType m_TemporaryMeasurementVector{};
 
   /** Function to allocate the memory of the data container. */
   void

--- a/Components/Metrics/KNNGraphAlphaMutualInformation/itkKNNGraphAlphaMutualInformationImageToImageMetric.h
+++ b/Components/Metrics/KNNGraphAlphaMutualInformation/itkKNNGraphAlphaMutualInformationImageToImageMetric.h
@@ -266,16 +266,16 @@ protected:
   PrintSelf(std::ostream & os, Indent indent) const override;
 
   /** Member variables. */
-  BinaryKNNTreePointer m_BinaryKNNTreeFixed;
-  BinaryKNNTreePointer m_BinaryKNNTreeMoving;
-  BinaryKNNTreePointer m_BinaryKNNTreeJoint;
+  BinaryKNNTreePointer m_BinaryKNNTreeFixed{};
+  BinaryKNNTreePointer m_BinaryKNNTreeMoving{};
+  BinaryKNNTreePointer m_BinaryKNNTreeJoint{};
 
-  BinaryKNNTreeSearchPointer m_BinaryKNNTreeSearcherFixed;
-  BinaryKNNTreeSearchPointer m_BinaryKNNTreeSearcherMoving;
-  BinaryKNNTreeSearchPointer m_BinaryKNNTreeSearcherJoint;
+  BinaryKNNTreeSearchPointer m_BinaryKNNTreeSearcherFixed{};
+  BinaryKNNTreeSearchPointer m_BinaryKNNTreeSearcherMoving{};
+  BinaryKNNTreeSearchPointer m_BinaryKNNTreeSearcherJoint{};
 
-  double m_Alpha;
-  double m_AvoidDivisionBy;
+  double m_Alpha{};
+  double m_AvoidDivisionBy{};
 
 private:
   /** Typedef's for the computation of the derivative. */

--- a/Components/Metrics/MissingStructurePenalty/itkMissingStructurePenalty.h
+++ b/Components/Metrics/MissingStructurePenalty/itkMissingStructurePenalty.h
@@ -164,10 +164,10 @@ protected:
   // void PrintSelf(std::ostream& os, Indent indent) const;
 
   /** Member variables. */
-  FixedMeshConstPointer m_FixedMesh;
+  FixedMeshConstPointer m_FixedMesh{};
 
-  mutable FixedMeshContainerConstPointer m_FixedMeshContainer;
-  mutable MappedMeshContainerPointer     m_MappedMeshContainer;
+  mutable FixedMeshContainerConstPointer m_FixedMeshContainer{};
+  mutable MappedMeshContainerPointer     m_MappedMeshContainer{};
 
 private:
   void

--- a/Components/Metrics/NormalizedGradientCorrelation/itkNormalizedGradientCorrelationImageToImageMetric.h
+++ b/Components/Metrics/NormalizedGradientCorrelation/itkNormalizedGradientCorrelationImageToImageMetric.h
@@ -173,34 +173,34 @@ protected:
   using MovedSobelFilter = NeighborhoodOperatorImageFilter<MovedGradientImageType, MovedGradientImageType>;
 
 private:
-  ScalesType                  m_Scales;
-  double                      m_DerivativeDelta;
-  CombinationTransformPointer m_CombinationTransform;
+  ScalesType                  m_Scales{};
+  double                      m_DerivativeDelta{};
+  CombinationTransformPointer m_CombinationTransform{};
 
   /** The mean of the moving image gradients. */
-  mutable MovedGradientPixelType m_MeanMovedGradient[MovedImageDimension];
+  mutable MovedGradientPixelType m_MeanMovedGradient[MovedImageDimension]{};
 
   /** The mean of the fixed image gradients. */
-  mutable FixedGradientPixelType m_MeanFixedGradient[FixedImageDimension];
+  mutable FixedGradientPixelType m_MeanFixedGradient[FixedImageDimension]{};
 
   /** The filter for transforming the moving images. */
-  TransformMovingImageFilterPointer m_TransformMovingImageFilter;
+  TransformMovingImageFilterPointer m_TransformMovingImageFilter{};
 
   /** The Sobel gradients of the fixed image */
-  CastFixedImageFilterPointer m_CastFixedImageFilter;
+  CastFixedImageFilterPointer m_CastFixedImageFilter{};
 
-  SobelOperator<FixedGradientPixelType, Self::FixedImageDimension> m_FixedSobelOperators[FixedImageDimension];
+  SobelOperator<FixedGradientPixelType, Self::FixedImageDimension> m_FixedSobelOperators[FixedImageDimension]{};
 
-  typename FixedSobelFilter::Pointer m_FixedSobelFilters[Self::FixedImageDimension];
+  typename FixedSobelFilter::Pointer m_FixedSobelFilters[Self::FixedImageDimension]{};
 
-  ZeroFluxNeumannBoundaryCondition<MovedGradientImageType> m_MovedBoundCond;
-  ZeroFluxNeumannBoundaryCondition<FixedGradientImageType> m_FixedBoundCond;
+  ZeroFluxNeumannBoundaryCondition<MovedGradientImageType> m_MovedBoundCond{};
+  ZeroFluxNeumannBoundaryCondition<FixedGradientImageType> m_FixedBoundCond{};
 
   /** The Sobel gradients of the moving image */
-  CastMovedImageFilterPointer                                      m_CastMovedImageFilter;
-  SobelOperator<MovedGradientPixelType, Self::MovedImageDimension> m_MovedSobelOperators[MovedImageDimension];
+  CastMovedImageFilterPointer                                      m_CastMovedImageFilter{};
+  SobelOperator<MovedGradientPixelType, Self::MovedImageDimension> m_MovedSobelOperators[MovedImageDimension]{};
 
-  typename MovedSobelFilter::Pointer m_MovedSobelFilters[Self::MovedImageDimension];
+  typename MovedSobelFilter::Pointer m_MovedSobelFilters[Self::MovedImageDimension]{};
 };
 
 } // end namespace itk

--- a/Components/Metrics/PCAMetric/itkPCAMetric.h
+++ b/Components/Metrics/PCAMetric/itkPCAMetric.h
@@ -164,16 +164,16 @@ protected:
                                         const MovingImageDerivativeType & movingImageDerivative,
                                         DerivativeType &                  imageJacobian) const;
 
-  mutable vnl_vector<double> m_firstEigenVector;
-  mutable vnl_vector<double> m_secondEigenVector;
-  mutable vnl_vector<double> m_thirdEigenVector;
-  mutable vnl_vector<double> m_fourthEigenVector;
-  mutable vnl_vector<double> m_fifthEigenVector;
-  mutable vnl_vector<double> m_sixthEigenVector;
-  mutable vnl_vector<double> m_seventhEigenVector;
-  mutable vnl_vector<double> m_eigenValues;
-  mutable vnl_vector<double> m_normdCdmu;
-  mutable int                m_NumberOfSamples;
+  mutable vnl_vector<double> m_firstEigenVector{};
+  mutable vnl_vector<double> m_secondEigenVector{};
+  mutable vnl_vector<double> m_thirdEigenVector{};
+  mutable vnl_vector<double> m_fourthEigenVector{};
+  mutable vnl_vector<double> m_fifthEigenVector{};
+  mutable vnl_vector<double> m_sixthEigenVector{};
+  mutable vnl_vector<double> m_seventhEigenVector{};
+  mutable vnl_vector<double> m_eigenValues{};
+  mutable vnl_vector<double> m_normdCdmu{};
+  mutable int                m_NumberOfSamples{};
 
 private:
   /** Sample n random numbers from 0..m and add them to the vector. */
@@ -181,28 +181,28 @@ private:
   SampleRandom(const int n, const int m, std::vector<int> & numbers) const;
 
   /** Variables to control random sampling in last dimension. */
-  bool         m_SampleLastDimensionRandomly;
-  unsigned int m_NumSamplesLastDimension;
-  unsigned int m_NumAdditionalSamplesFixed;
-  unsigned int m_ReducedDimensionIndex;
+  bool         m_SampleLastDimensionRandomly{};
+  unsigned int m_NumSamplesLastDimension{};
+  unsigned int m_NumAdditionalSamplesFixed{};
+  unsigned int m_ReducedDimensionIndex{};
 
-  bool m_DeNoise;
+  bool m_DeNoise{};
 
-  double m_VarNoise;
+  double m_VarNoise{};
 
   /** Bool to determine if we want to subtract the mean derivate from the derivative elements. */
-  bool m_SubtractMean;
+  bool m_SubtractMean{};
 
   /** GridSize of B-spline transform. */
-  FixedImageSizeType m_GridSize;
+  FixedImageSizeType m_GridSize{};
 
   /** Bool to indicate if the transform used is a stacktransform. Set by elx files. */
-  bool m_TransformIsStackTransform;
+  bool m_TransformIsStackTransform{};
 
   /** Integer to indicate how many eigenvalues you want to use in the metric */
-  unsigned int m_NumEigenValues;
+  unsigned int m_NumEigenValues{};
 
-  bool m_UseDerivativeOfMean;
+  bool m_UseDerivativeOfMean{};
 };
 
 } // end namespace itk

--- a/Components/Metrics/PCAMetric/itkPCAMetric_F_multithreaded.h
+++ b/Components/Metrics/PCAMetric/itkPCAMetric_F_multithreaded.h
@@ -204,7 +204,7 @@ private:
     Self * m_Metric;
   };
 
-  PCAMetricMultiThreaderParameterType m_PCAMetricThreaderParameters;
+  PCAMetricMultiThreaderParameterType m_PCAMetricThreaderParameters{};
 
   struct PCAMetricGetSamplesPerThreadStruct
   {
@@ -220,16 +220,16 @@ private:
                     PaddedPCAMetricGetSamplesPerThreadStruct,
                     AlignedPCAMetricGetSamplesPerThreadStruct);
 
-  mutable std::vector<AlignedPCAMetricGetSamplesPerThreadStruct> m_PCAMetricGetSamplesPerThreadVariables;
+  mutable std::vector<AlignedPCAMetricGetSamplesPerThreadStruct> m_PCAMetricGetSamplesPerThreadVariables{};
 
-  unsigned int m_G;
-  unsigned int m_LastDimIndex;
+  unsigned int m_G{};
+  unsigned int m_LastDimIndex{};
 
   /** Bool to determine if we want to subtract the mean derivate from the derivative elements. */
   bool m_SubtractMean{ false };
 
   /** GridSize of B-spline transform. */
-  FixedImageSizeType m_GridSize;
+  FixedImageSizeType m_GridSize{};
 
   /** Bool to indicate if the transform used is a stacktransform. Set by elx files. */
   bool m_TransformIsStackTransform{ false };
@@ -238,12 +238,12 @@ private:
   unsigned int m_NumEigenValues{ 6 };
 
   /** Matrices, needed for derivative calculation */
-  mutable std::vector<unsigned int> m_PixelStartIndex;
-  mutable MatrixType                m_Atmm;
-  mutable DerivativeMatrixType      m_vSAtmm;
-  mutable DerivativeMatrixType      m_CSv;
-  mutable DerivativeMatrixType      m_Sv;
-  mutable DerivativeMatrixType      m_vdSdmu_part1;
+  mutable std::vector<unsigned int> m_PixelStartIndex{};
+  mutable MatrixType                m_Atmm{};
+  mutable DerivativeMatrixType      m_vSAtmm{};
+  mutable DerivativeMatrixType      m_CSv{};
+  mutable DerivativeMatrixType      m_Sv{};
+  mutable DerivativeMatrixType      m_vdSdmu_part1{};
 };
 
 } // end namespace itk

--- a/Components/Metrics/PCAMetric2/itkPCAMetric2.h
+++ b/Components/Metrics/PCAMetric2/itkPCAMetric2.h
@@ -159,14 +159,14 @@ private:
   SampleRandom(const int n, const int m, std::vector<int> & numbers) const;
 
   /** Variables to control random sampling in last dimension. */
-  unsigned int m_NumAdditionalSamplesFixed;
-  unsigned int m_ReducedDimensionIndex;
+  unsigned int m_NumAdditionalSamplesFixed{};
+  unsigned int m_ReducedDimensionIndex{};
 
   /** Bool to determine if we want to subtract the mean derivate from the derivative elements. */
   bool m_SubtractMean{ false };
 
   /** GridSize of B-spline transform. */
-  FixedImageSizeType m_GridSize;
+  FixedImageSizeType m_GridSize{};
 
   /** Bool to indicate if the transform used is a stacktransform. Set by elx files. */
   bool m_TransformIsStackTransform{ false };

--- a/Components/Metrics/PatternIntensity/itkPatternIntensityImageToImageMetric.h
+++ b/Components/Metrics/PatternIntensity/itkPatternIntensityImageToImageMetric.h
@@ -177,19 +177,19 @@ protected:
   ComputePIDiff(const TransformParametersType & parameters, float scalingfactor) const;
 
 private:
-  TransformMovingImageFilterPointer  m_TransformMovingImageFilter;
-  DifferenceImageFilterPointer       m_DifferenceImageFilter;
-  RescaleIntensityImageFilterPointer m_RescaleImageFilter;
-  MultiplyImageFilterPointer         m_MultiplyImageFilter;
-  double                             m_NoiseConstant;
-  unsigned int                       m_NeighborhoodRadius;
-  double                             m_DerivativeDelta;
-  double                             m_NormalizationFactor;
-  double                             m_Rescalingfactor;
-  bool                               m_OptimizeNormalizationFactor;
-  ScalesType                         m_Scales;
-  MeasureType                        m_FixedMeasure;
-  CombinationTransformPointer        m_CombinationTransform;
+  TransformMovingImageFilterPointer  m_TransformMovingImageFilter{};
+  DifferenceImageFilterPointer       m_DifferenceImageFilter{};
+  RescaleIntensityImageFilterPointer m_RescaleImageFilter{};
+  MultiplyImageFilterPointer         m_MultiplyImageFilter{};
+  double                             m_NoiseConstant{};
+  unsigned int                       m_NeighborhoodRadius{};
+  double                             m_DerivativeDelta{};
+  double                             m_NormalizationFactor{};
+  double                             m_Rescalingfactor{};
+  bool                               m_OptimizeNormalizationFactor{};
+  ScalesType                         m_Scales{};
+  MeasureType                        m_FixedMeasure{};
+  CombinationTransformPointer        m_CombinationTransform{};
 };
 
 } // end namespace itk

--- a/Components/Metrics/PolydataDummyPenalty/itkPolydataDummyPenalty.h
+++ b/Components/Metrics/PolydataDummyPenalty/itkPolydataDummyPenalty.h
@@ -182,8 +182,8 @@ protected:
   PrintSelf(std::ostream & os, Indent indent) const override;
 
   /** Member variables. */
-  mutable FixedMeshContainerConstPointer m_FixedMeshContainer;
-  mutable MappedMeshContainerPointer     m_MappedMeshContainer;
+  mutable FixedMeshContainerConstPointer m_FixedMeshContainer{};
+  mutable MappedMeshContainerPointer     m_MappedMeshContainer{};
 };
 
 } // end namespace itk

--- a/Components/Metrics/RigidityPenalty/itkTransformRigidityPenaltyTerm.h
+++ b/Components/Metrics/RigidityPenalty/itkTransformRigidityPenaltyTerm.h
@@ -319,39 +319,39 @@ private:
   FilterSeparable(const CoefficientImageType *, const std::vector<NeighborhoodType> & Operators) const;
 
   /** Member variables. */
-  BSplineTransformPointer m_BSplineTransform;
-  ScalarType              m_LinearityConditionWeight;
-  ScalarType              m_OrthonormalityConditionWeight;
-  ScalarType              m_PropernessConditionWeight;
+  BSplineTransformPointer m_BSplineTransform{};
+  ScalarType              m_LinearityConditionWeight{};
+  ScalarType              m_OrthonormalityConditionWeight{};
+  ScalarType              m_PropernessConditionWeight{};
 
-  mutable MeasureType m_RigidityPenaltyTermValue;
-  mutable MeasureType m_LinearityConditionValue;
-  mutable MeasureType m_OrthonormalityConditionValue;
-  mutable MeasureType m_PropernessConditionValue;
-  mutable MeasureType m_LinearityConditionGradientMagnitude;
-  mutable MeasureType m_OrthonormalityConditionGradientMagnitude;
-  mutable MeasureType m_PropernessConditionGradientMagnitude;
+  mutable MeasureType m_RigidityPenaltyTermValue{};
+  mutable MeasureType m_LinearityConditionValue{};
+  mutable MeasureType m_OrthonormalityConditionValue{};
+  mutable MeasureType m_PropernessConditionValue{};
+  mutable MeasureType m_LinearityConditionGradientMagnitude{};
+  mutable MeasureType m_OrthonormalityConditionGradientMagnitude{};
+  mutable MeasureType m_PropernessConditionGradientMagnitude{};
 
-  bool m_UseLinearityCondition;
-  bool m_UseOrthonormalityCondition;
-  bool m_UsePropernessCondition;
-  bool m_CalculateLinearityCondition;
-  bool m_CalculateOrthonormalityCondition;
-  bool m_CalculatePropernessCondition;
+  bool m_UseLinearityCondition{};
+  bool m_UseOrthonormalityCondition{};
+  bool m_UsePropernessCondition{};
+  bool m_CalculateLinearityCondition{};
+  bool m_CalculateOrthonormalityCondition{};
+  bool m_CalculatePropernessCondition{};
 
   /** Rigidity image variables. */
-  CoordinateRepresentationType     m_DilationRadiusMultiplier;
-  bool                             m_DilateRigidityImages;
-  mutable bool                     m_RigidityCoefficientImageIsFilled;
-  RigidityImagePointer             m_FixedRigidityImage;
-  RigidityImagePointer             m_MovingRigidityImage;
-  RigidityImagePointer             m_RigidityCoefficientImage;
-  std::vector<DilateFilterPointer> m_FixedRigidityImageDilation;
-  std::vector<DilateFilterPointer> m_MovingRigidityImageDilation;
-  RigidityImagePointer             m_FixedRigidityImageDilated;
-  RigidityImagePointer             m_MovingRigidityImageDilated;
-  bool                             m_UseFixedRigidityImage;
-  bool                             m_UseMovingRigidityImage;
+  CoordinateRepresentationType     m_DilationRadiusMultiplier{};
+  bool                             m_DilateRigidityImages{};
+  mutable bool                     m_RigidityCoefficientImageIsFilled{};
+  RigidityImagePointer             m_FixedRigidityImage{};
+  RigidityImagePointer             m_MovingRigidityImage{};
+  RigidityImagePointer             m_RigidityCoefficientImage{};
+  std::vector<DilateFilterPointer> m_FixedRigidityImageDilation{};
+  std::vector<DilateFilterPointer> m_MovingRigidityImageDilation{};
+  RigidityImagePointer             m_FixedRigidityImageDilated{};
+  RigidityImagePointer             m_MovingRigidityImageDilated{};
+  bool                             m_UseFixedRigidityImage{};
+  bool                             m_UseMovingRigidityImage{};
 };
 
 } // end namespace itk

--- a/Components/Metrics/StatisticalShapePenalty/itkStatisticalShapePointPenalty.h
+++ b/Components/Metrics/StatisticalShapePenalty/itkStatisticalShapePointPenalty.h
@@ -219,40 +219,40 @@ private:
   void
   CalculateCutOffDerivative(typename DerivativeType::element_type & derivativeElement, const MeasureType & value) const;
 
-  const VnlVectorType * m_MeanVector;
-  const VnlMatrixType * m_CovarianceMatrix;
-  const VnlMatrixType * m_EigenVectors;
-  const VnlVectorType * m_EigenValues;
+  const VnlVectorType * m_MeanVector{};
+  const VnlMatrixType * m_CovarianceMatrix{};
+  const VnlMatrixType * m_EigenVectors{};
+  const VnlVectorType * m_EigenValues{};
 
-  VnlMatrixType * m_InverseCovarianceMatrix;
+  VnlMatrixType * m_InverseCovarianceMatrix{};
 
-  double m_CentroidXVariance;
-  double m_CentroidXStd;
-  double m_CentroidYVariance;
-  double m_CentroidYStd;
-  double m_CentroidZVariance;
-  double m_CentroidZStd;
-  double m_SizeVariance;
-  double m_SizeStd;
+  double m_CentroidXVariance{};
+  double m_CentroidXStd{};
+  double m_CentroidYVariance{};
+  double m_CentroidYStd{};
+  double m_CentroidZVariance{};
+  double m_CentroidZStd{};
+  double m_SizeVariance{};
+  double m_SizeStd{};
 
-  bool m_ShrinkageIntensityNeedsUpdate;
-  bool m_BaseVarianceNeedsUpdate;
-  bool m_VariancesNeedsUpdate;
+  bool m_ShrinkageIntensityNeedsUpdate{};
+  bool m_BaseVarianceNeedsUpdate{};
+  bool m_VariancesNeedsUpdate{};
 
-  VnlVectorType * m_EigenValuesRegularized;
+  VnlVectorType * m_EigenValuesRegularized{};
 
-  mutable ProposalDerivativeType * m_ProposalDerivative;
-  unsigned int                     m_ProposalLength;
-  bool                             m_NormalizedShapeModel;
-  int                              m_ShapeModelCalculation;
-  double                           m_ShrinkageIntensity;
-  double                           m_BaseVariance;
-  double                           m_BaseStd;
-  mutable VnlVectorType            m_ProposalVector;
-  mutable VnlVectorType            m_MeanValues;
+  mutable ProposalDerivativeType * m_ProposalDerivative{};
+  unsigned int                     m_ProposalLength{};
+  bool                             m_NormalizedShapeModel{};
+  int                              m_ShapeModelCalculation{};
+  double                           m_ShrinkageIntensity{};
+  double                           m_BaseVariance{};
+  double                           m_BaseStd{};
+  mutable VnlVectorType            m_ProposalVector{};
+  mutable VnlVectorType            m_MeanValues{};
 
-  double m_CutOffValue;
-  double m_CutOffSharpness;
+  double m_CutOffValue{};
+  double m_CutOffSharpness{};
 };
 
 } // end namespace itk

--- a/Components/Metrics/SumOfPairwiseCorrelationsMetric/itkSumOfPairwiseCorrelationCoefficientsMetric.h
+++ b/Components/Metrics/SumOfPairwiseCorrelationsMetric/itkSumOfPairwiseCorrelationCoefficientsMetric.h
@@ -159,14 +159,14 @@ private:
   SampleRandom(const int n, const int m, std::vector<int> & numbers) const;
 
   /** Variables to control random sampling in last dimension. */
-  unsigned int m_NumAdditionalSamplesFixed;
-  unsigned int m_ReducedDimensionIndex;
+  unsigned int m_NumAdditionalSamplesFixed{};
+  unsigned int m_ReducedDimensionIndex{};
 
   /** Bool to determine if we want to subtract the mean derivate from the derivative elements. */
   bool m_SubtractMean{ true };
 
   /** GridSize of B-spline transform. */
-  FixedImageSizeType m_GridSize;
+  FixedImageSizeType m_GridSize{};
 
   /** Bool to indicate if the transform used is a stacktransform. Set by elx files. */
   bool m_TransformIsStackTransform{ true };

--- a/Components/Metrics/SumSquaredTissueVolumeDifferenceMetric/itkSumSquaredTissueVolumeDifferenceImageToImageMetric.h
+++ b/Components/Metrics/SumSquaredTissueVolumeDifferenceMetric/itkSumSquaredTissueVolumeDifferenceImageToImageMetric.h
@@ -242,10 +242,10 @@ protected:
 
 private:
   /** Intensity value to use for air.  Default is -1000 */
-  RealType m_AirValue;
+  RealType m_AirValue{};
 
   /** Intensity value to use for tissue.  Default is 55 */
-  RealType m_TissueValue;
+  RealType m_TissueValue{};
 
 }; // end class SumSquaredTissueVolumeDifferenceImageToImageMetric
 

--- a/Components/Metrics/VarianceOverLastDimension/itkVarianceOverLastDimensionImageMetric.h
+++ b/Components/Metrics/VarianceOverLastDimension/itkVarianceOverLastDimensionImageMetric.h
@@ -187,17 +187,17 @@ private:
   /** Variables to control random sampling in last dimension. */
   bool         m_SampleLastDimensionRandomly{ false };
   unsigned int m_NumSamplesLastDimension{ 10 };
-  unsigned int m_NumAdditionalSamplesFixed;
-  unsigned int m_ReducedDimensionIndex;
+  unsigned int m_NumAdditionalSamplesFixed{};
+  unsigned int m_ReducedDimensionIndex{};
 
   /** Bool to determine if we want to subtract the mean derivate from the derivative elements. */
   bool m_SubtractMean{ false };
 
   /** Initial variance in last dimension, used as normalization factor. */
-  float m_InitialVariance;
+  float m_InitialVariance{};
 
   /** GridSize of B-spline transform. */
-  FixedImageSizeType m_GridSize;
+  FixedImageSizeType m_GridSize{};
 
   /** Bool to indicate if the transform used is a stacktransform. Set by elx files. */
   bool m_TransformIsStackTransform{ false };

--- a/Components/Optimizers/AdaGrad/itkAdaptiveStepsizeOptimizer.h
+++ b/Components/Optimizers/AdaGrad/itkAdaptiveStepsizeOptimizer.h
@@ -132,9 +132,9 @@ protected:
   UpdateCurrentTime() override;
 
   /** The PreviousGradient, necessary for the CruzAcceleration */
-  DerivativeType m_PreviousSearchDirection;
-  ParametersType m_PreconditionVector;
-  std::string    m_StepSizeStrategy;
+  DerivativeType m_PreviousSearchDirection{};
+  ParametersType m_PreconditionVector{};
+  std::string    m_StepSizeStrategy{};
 
 private:
   /** Settings */

--- a/Components/Optimizers/AdaptiveStochasticGradientDescent/itkAdaptiveStochasticGradientDescentOptimizer.h
+++ b/Components/Optimizers/AdaptiveStochasticGradientDescent/itkAdaptiveStochasticGradientDescentOptimizer.h
@@ -131,7 +131,7 @@ protected:
   UpdateCurrentTime() override;
 
   /** The PreviousGradient, necessary for the CruzAcceleration */
-  DerivativeType m_PreviousGradient;
+  DerivativeType m_PreviousGradient{};
 
 private:
   /** Settings */

--- a/Components/Optimizers/AdaptiveStochasticLBFGS/itkAdaptiveStochasticLBFGSOptimizer.h
+++ b/Components/Optimizers/AdaptiveStochasticLBFGS/itkAdaptiveStochasticLBFGSOptimizer.h
@@ -134,11 +134,11 @@ protected:
   // m_previousGradient m_PrePreviousGradient are not used, where should I put them?
   // DerivativeType m_previousGradient;
   // DerivativeType m_PrePreviousGradient;
-  unsigned long m_UpdateFrequenceL;
-  bool          m_UseSearchDirForAdaptiveStepSize;
+  unsigned long m_UpdateFrequenceL{};
+  bool          m_UseSearchDirForAdaptiveStepSize{};
   bool          m_UseAdaptiveStepSizes{ true };
   double        m_SearchLengthScale{ 10 };
-  std::string   m_StepSizeStrategy;
+  std::string   m_StepSizeStrategy{};
 
 private:
   /** Settings */

--- a/Components/Optimizers/AdaptiveStochasticVarianceReducedGradient/itkAdaptiveStochasticVarianceReducedGradientOptimizer.h
+++ b/Components/Optimizers/AdaptiveStochasticVarianceReducedGradient/itkAdaptiveStochasticVarianceReducedGradientOptimizer.h
@@ -129,7 +129,7 @@ protected:
   UpdateCurrentTime() override;
 
   /** The PreviousGradient, necessary for the CruzAcceleration */
-  DerivativeType m_PreviousGradient;
+  DerivativeType m_PreviousGradient{};
 
 private:
   /** Settings */

--- a/Components/Optimizers/AdaptiveStochasticVarianceReducedGradient/itkStandardStochasticVarianceReducedGradientDescentOptimizer.h
+++ b/Components/Optimizers/AdaptiveStochasticVarianceReducedGradient/itkStandardStochasticVarianceReducedGradientDescentOptimizer.h
@@ -151,12 +151,12 @@ protected:
   double m_CurrentTime{ 0.0 };
 
   /** Constant step size or others, different value of k. */
-  bool m_UseConstantStep;
+  bool m_UseConstantStep{};
 
 private:
   /**Parameters, as described by Spall.*/
   double m_Param_a{ 1.0 };
-  double m_Param_beta;
+  double m_Param_beta{};
   double m_Param_A{ 1.0 };
   double m_Param_alpha{ 0.602 };
 

--- a/Components/Optimizers/AdaptiveStochasticVarianceReducedGradient/itkStochasticVarianceReducedGradientDescentOptimizer.h
+++ b/Components/Optimizers/AdaptiveStochasticVarianceReducedGradient/itkStochasticVarianceReducedGradientDescentOptimizer.h
@@ -182,23 +182,23 @@ protected:
 
   // made protected so subclass can access
   double         m_Value{ 0.0 };
-  DerivativeType m_Gradient;
-  ParametersType m_SearchDir;
-  ParametersType m_PreviousSearchDir;
+  DerivativeType m_Gradient{};
+  ParametersType m_SearchDir{};
+  ParametersType m_PreviousSearchDir{};
   // ParametersType                m_PrePreviousSearchDir;
-  ParametersType    m_MeanSearchDir;
+  ParametersType    m_MeanSearchDir{};
   double            m_LearningRate{ 1.0 };
   StopConditionType m_StopCondition{ MaximumNumberOfIterations };
-  DerivativeType    m_PreviousGradient;
+  DerivativeType    m_PreviousGradient{};
   // DerivativeType                m_PrePreviousGradient;
-  ParametersType        m_PreviousPosition;
+  ParametersType        m_PreviousPosition{};
   ThreaderType::Pointer m_Threader{ ThreaderType::New() };
 
   bool          m_Stop{ false };
   unsigned long m_NumberOfIterations{ 100 };
-  unsigned long m_NumberOfInnerIterations;
+  unsigned long m_NumberOfInnerIterations{};
   unsigned long m_CurrentIteration{ 0 };
-  unsigned long m_CurrentInnerIteration;
+  unsigned long m_CurrentInnerIteration{};
   unsigned long m_LBFGSMemory{ 0 };
 
 private:

--- a/Components/Optimizers/CMAEvolutionStrategy/itkCMAEvolutionStrategyOptimizer.h
+++ b/Components/Optimizers/CMAEvolutionStrategy/itkCMAEvolutionStrategyOptimizer.h
@@ -275,7 +275,7 @@ protected:
   /** \f$chiN  = E( \|N(0,I)\|\f$ */
   double m_ExpectationNormNormalDistribution{ 0.0 };
   /** array of \f$w_i\f$ */
-  RecombinationWeightsType m_RecombinationWeights;
+  RecombinationWeightsType m_RecombinationWeights{};
   /** Length of the MeasureHistory deque */
   unsigned long m_HistoryLength{ 0 };
 
@@ -291,29 +291,29 @@ protected:
   bool m_Heaviside{ false };
 
   /** \f$d_i = x_i - m\f$ */
-  ParameterContainerType m_SearchDirs;
+  ParameterContainerType m_SearchDirs{};
   /** realisations of \f$N(0,I)\f$ */
-  ParameterContainerType m_NormalizedSearchDirs;
+  ParameterContainerType m_NormalizedSearchDirs{};
   /** cost function values for each \f$x_i = m + d_i\f$ */
-  MeasureContainerType m_CostFunctionValues;
+  MeasureContainerType m_CostFunctionValues{};
   /** \f$m(g+1) - m(g)\f$ */
-  ParametersType m_CurrentScaledStep;
+  ParametersType m_CurrentScaledStep{};
   /** \f$1/\sigma * D^{-1} * B' * m_CurrentScaledStep, needed for p_{\sigma}\f$ */
-  ParametersType m_CurrentNormalizedStep;
+  ParametersType m_CurrentNormalizedStep{};
   /** \f$p_c\f$ */
-  ParametersType m_EvolutionPath;
+  ParametersType m_EvolutionPath{};
   /** \f$p_\sigma\f$ */
-  ParametersType m_ConjugateEvolutionPath;
+  ParametersType m_ConjugateEvolutionPath{};
 
   /** History of best measure values */
-  MeasureHistoryType m_MeasureHistory;
+  MeasureHistoryType m_MeasureHistory{};
 
   /** C: covariance matrix */
-  CovarianceMatrixType m_C;
+  CovarianceMatrixType m_C{};
   /** B: eigen vector matrix */
-  CovarianceMatrixType m_B;
+  CovarianceMatrixType m_B{};
   /** D: sqrt(eigen values) */
-  EigenValueMatrixType m_D;
+  EigenValueMatrixType m_D{};
 
   /** Constructor */
   CMAEvolutionStrategyOptimizer();

--- a/Components/Optimizers/ConjugateGradient/itkGenericConjugateGradientOptimizer.h
+++ b/Components/Optimizers/ConjugateGradient/itkGenericConjugateGradientOptimizer.h
@@ -144,7 +144,7 @@ protected:
   void
   PrintSelf(std::ostream & os, Indent indent) const override;
 
-  DerivativeType    m_CurrentGradient;
+  DerivativeType    m_CurrentGradient{};
   MeasureType       m_CurrentValue{ 0.0 };
   unsigned long     m_CurrentIteration{ 0 };
   StopConditionType m_StopCondition{ Unknown };
@@ -166,11 +166,11 @@ protected:
   bool m_PreviousGradientAndSearchDirValid{ false };
 
   /** The name of the BetaDefinition */
-  BetaDefinitionType m_BetaDefinition;
+  BetaDefinitionType m_BetaDefinition{};
 
   /** A mapping that links the names of the BetaDefinitions to functions that
    * compute \f$\beta\f$. */
-  BetaDefinitionMapType m_BetaDefinitionMap;
+  BetaDefinitionMapType m_BetaDefinitionMap{};
 
   /** Function to add a new beta definition. The first argument should be a name
    * via which a user can select this \f$\beta\f$ definition. The second argument is a

--- a/Components/Optimizers/FiniteDifferenceGradientDescent/itkFiniteDifferenceGradientDescentOptimizer.h
+++ b/Components/Optimizers/FiniteDifferenceGradientDescent/itkFiniteDifferenceGradientDescentOptimizer.h
@@ -146,7 +146,7 @@ protected:
   PrintSelf(std::ostream & os, Indent indent) const override;
 
   // made protected so subclass can access
-  DerivativeType m_Gradient;
+  DerivativeType m_Gradient{};
   double         m_LearningRate{ 0.0 };
   double         m_GradientMagnitude{ 0.0 };
 

--- a/Components/Optimizers/FullSearch/itkFullSearchOptimizer.h
+++ b/Components/Optimizers/FullSearch/itkFullSearchOptimizer.h
@@ -229,11 +229,11 @@ protected:
   StopConditionType m_StopCondition{ FullRangeSearched };
 
   SearchSpacePointer   m_SearchSpace{ nullptr };
-  SearchSpacePointType m_CurrentPointInSearchSpace;
-  SearchSpaceIndexType m_CurrentIndexInSearchSpace;
-  SearchSpacePointType m_BestPointInSearchSpace;
-  SearchSpaceIndexType m_BestIndexInSearchSpace;
-  SearchSpaceSizeType  m_SearchSpaceSize;
+  SearchSpacePointType m_CurrentPointInSearchSpace{};
+  SearchSpaceIndexType m_CurrentIndexInSearchSpace{};
+  SearchSpacePointType m_BestPointInSearchSpace{};
+  SearchSpaceIndexType m_BestIndexInSearchSpace{};
+  SearchSpaceSizeType  m_SearchSpaceSize{};
   unsigned int         m_NumberOfSearchSpaceDimensions{ 0 };
 
   unsigned long m_LastSearchSpaceChanges{ 0 };

--- a/Components/Optimizers/PreconditionedGradientDescent/itkAdaptiveStochasticPreconditionedGradientDescentOptimizer.h
+++ b/Components/Optimizers/PreconditionedGradientDescent/itkAdaptiveStochasticPreconditionedGradientDescentOptimizer.h
@@ -143,7 +143,7 @@ protected:
   UpdateCurrentTime();
 
   /** The Previous search direction = P g, necessary for the CruzAcceleration */
-  DerivativeType m_PreviousSearchDirection;
+  DerivativeType m_PreviousSearchDirection{};
 
 private:
   /** Settings */

--- a/Components/Optimizers/PreconditionedGradientDescent/itkPreconditionedGradientDescentOptimizer.h
+++ b/Components/Optimizers/PreconditionedGradientDescent/itkPreconditionedGradientDescentOptimizer.h
@@ -202,15 +202,15 @@ protected:
   using cholmod_l = int CInt; // change to UF_long if using;
 
   // made protected so subclass can access
-  DerivativeType    m_Gradient;
+  DerivativeType    m_Gradient{};
   double            m_LearningRate{ 1.0 };
   StopConditionType m_StopCondition{ MaximumNumberOfIterations };
-  DerivativeType    m_SearchDirection;
+  DerivativeType    m_SearchDirection{};
   double            m_LargestEigenValue{ 1.0 };
   double            m_ConditionNumber{ 1.0 };
   double            m_Sparsity{ 1.0 };
 
-  cholmod_common * m_CholmodCommon;
+  cholmod_common * m_CholmodCommon{};
   cholmod_factor * m_CholmodFactor{ nullptr };
   cholmod_sparse * m_CholmodGradient{ nullptr };
 

--- a/Components/Optimizers/PreconditionedStochasticGradientDescent/itkPreconditionedASGDOptimizer.h
+++ b/Components/Optimizers/PreconditionedStochasticGradientDescent/itkPreconditionedASGDOptimizer.h
@@ -131,9 +131,9 @@ protected:
   UpdateCurrentTime() override;
 
   /** The PreviousGradient, necessary for the CruzAcceleration */
-  DerivativeType m_PreviousSearchDirection;
-  ParametersType m_PreconditionVector;
-  std::string    m_StepSizeStrategy;
+  DerivativeType m_PreviousSearchDirection{};
+  ParametersType m_PreconditionVector{};
+  std::string    m_StepSizeStrategy{};
 
 private:
   /** Settings */

--- a/Components/Optimizers/QuasiNewtonLBFGS/itkQuasiNewtonLBFGSOptimizer.h
+++ b/Components/Optimizers/QuasiNewtonLBFGS/itkQuasiNewtonLBFGSOptimizer.h
@@ -142,7 +142,7 @@ protected:
   PrintSelf(std::ostream & os, Indent indent) const override
   {}
 
-  DerivativeType    m_CurrentGradient;
+  DerivativeType    m_CurrentGradient{};
   MeasureType       m_CurrentValue{ 0.0 };
   unsigned long     m_CurrentIteration{ 0 };
   StopConditionType m_StopCondition{ Unknown };
@@ -152,9 +152,9 @@ protected:
   /** Is true when the LineSearchOptimizer has been started. */
   bool m_InLineSearch{ false };
 
-  RhoType m_Rho;
-  SType   m_S;
-  YType   m_Y;
+  RhoType m_Rho{};
+  SType   m_S{};
+  YType   m_Y{};
 
   unsigned int m_Point{ 0 };
   unsigned int m_PreviousPoint{ 0 };

--- a/Components/Optimizers/RSGDEachParameterApart/itkRSGDEachParameterApartBaseOptimizer.h
+++ b/Components/Optimizers/RSGDEachParameterApart/itkRSGDEachParameterApartBaseOptimizer.h
@@ -156,8 +156,8 @@ protected:
 
 
 private:
-  DerivativeType m_Gradient;
-  DerivativeType m_PreviousGradient;
+  DerivativeType m_Gradient{};
+  DerivativeType m_PreviousGradient{};
 
   bool        m_Stop{ false };
   bool        m_Maximize{ false };
@@ -167,7 +167,7 @@ private:
   double      m_MinimumStepLength{ 1e-3 };
 
   /** All current step lengths */
-  DerivativeType m_CurrentStepLengths;
+  DerivativeType m_CurrentStepLengths{};
   /** The average current step length */
   double m_CurrentStepLength{ 0 };
 

--- a/Components/Optimizers/StandardGradientDescent/itkGradientDescentOptimizer2.h
+++ b/Components/Optimizers/StandardGradientDescent/itkGradientDescentOptimizer2.h
@@ -146,8 +146,8 @@ protected:
   PrintSelf(std::ostream & os, Indent indent) const override;
 
   // made protected so subclass can access
-  DerivativeType    m_Gradient;
-  DerivativeType    m_SearchDirection;
+  DerivativeType    m_Gradient{};
+  DerivativeType    m_SearchDirection{};
   StopConditionType m_StopCondition{ MaximumNumberOfIterations };
 
 private:
@@ -157,7 +157,7 @@ private:
   unsigned long m_NumberOfIterations{ 100 };
   unsigned long m_CurrentIteration{ 0 };
 
-  bool m_UseOpenMP;
+  bool m_UseOpenMP{};
 };
 
 } // end namespace itk

--- a/Components/Optimizers/StandardStochasticGradientDescent/itkStandardStochasticGradientDescentOptimizer.h
+++ b/Components/Optimizers/StandardStochasticGradientDescent/itkStandardStochasticGradientDescentOptimizer.h
@@ -157,12 +157,12 @@ protected:
   double m_CurrentTime{ 0.0 };
 
   /** Constant step size or others, different value of k. */
-  bool m_UseConstantStep;
+  bool m_UseConstantStep{};
 
 private:
   /**Parameters, as described by Spall.*/
   double m_Param_a{ 1.0 };
-  double m_Param_beta;
+  double m_Param_beta{};
   double m_Param_A{ 1.0 };
   double m_Param_alpha{ 0.602 };
 

--- a/Components/Optimizers/StandardStochasticGradientDescent/itkStochasticGradientDescentOptimizer.h
+++ b/Components/Optimizers/StandardStochasticGradientDescent/itkStochasticGradientDescentOptimizer.h
@@ -183,23 +183,23 @@ protected:
 
   // made protected so subclass can access
   double                m_Value{ 0.0 };
-  DerivativeType        m_Gradient;
-  ParametersType        m_SearchDir;
-  ParametersType        m_PreviousSearchDir;
-  ParametersType        m_PrePreviousSearchDir;
-  ParametersType        m_MeanSearchDir;
+  DerivativeType        m_Gradient{};
+  ParametersType        m_SearchDir{};
+  ParametersType        m_PreviousSearchDir{};
+  ParametersType        m_PrePreviousSearchDir{};
+  ParametersType        m_MeanSearchDir{};
   double                m_LearningRate{ 1.0 };
   StopConditionType     m_StopCondition{ MaximumNumberOfIterations };
-  DerivativeType        m_PreviousGradient;
-  DerivativeType        m_PrePreviousGradient;
-  ParametersType        m_PreviousPosition;
+  DerivativeType        m_PreviousGradient{};
+  DerivativeType        m_PrePreviousGradient{};
+  ParametersType        m_PreviousPosition{};
   ThreaderType::Pointer m_Threader{ ThreaderType::New() };
 
   bool          m_Stop{ false };
   unsigned long m_NumberOfIterations{ 100 };
-  unsigned long m_NumberOfInnerIterations;
+  unsigned long m_NumberOfInnerIterations{};
   unsigned long m_CurrentIteration{ 0 };
-  unsigned long m_CurrentInnerIteration;
+  unsigned long m_CurrentInnerIteration{};
   unsigned long m_LBFGSMemory{ 0 };
 
 private:

--- a/Components/Registrations/MultiMetricMultiResolutionRegistration/itkCombinationImageToImageMetric.h
+++ b/Components/Registrations/MultiMetricMultiResolutionRegistration/itkCombinationImageToImageMetric.h
@@ -446,20 +446,20 @@ protected:
   PrintSelf(std::ostream & os, Indent indent) const override;
 
   /** Store the metrics and the corresponding weights. */
-  unsigned int                                 m_NumberOfMetrics;
-  std::vector<SingleValuedCostFunctionPointer> m_Metrics;
-  std::vector<double>                          m_MetricWeights;
-  std::vector<double>                          m_MetricRelativeWeights;
-  bool                                         m_UseRelativeWeights;
-  std::vector<bool>                            m_UseMetric;
-  mutable std::vector<MeasureType>             m_MetricValues;
-  mutable std::vector<DerivativeType>          m_MetricDerivatives;
-  mutable std::vector<double>                  m_MetricDerivativesMagnitude;
-  mutable std::vector<double>                  m_MetricComputationTime;
+  unsigned int                                 m_NumberOfMetrics{};
+  std::vector<SingleValuedCostFunctionPointer> m_Metrics{};
+  std::vector<double>                          m_MetricWeights{};
+  std::vector<double>                          m_MetricRelativeWeights{};
+  bool                                         m_UseRelativeWeights{};
+  std::vector<bool>                            m_UseMetric{};
+  mutable std::vector<MeasureType>             m_MetricValues{};
+  mutable std::vector<DerivativeType>          m_MetricDerivatives{};
+  mutable std::vector<double>                  m_MetricDerivativesMagnitude{};
+  mutable std::vector<double>                  m_MetricComputationTime{};
 
   /** Dummy image region and derivatives. */
-  FixedImageRegionType m_NullFixedImageRegion;
-  DerivativeType       m_NullDerivative;
+  FixedImageRegionType m_NullFixedImageRegion{};
+  DerivativeType       m_NullDerivative{};
 
 private:
   /** Initialize some multi-threading related parameters.

--- a/Components/Registrations/MultiMetricMultiResolutionRegistration/itkMultiMetricMultiResolutionImageRegistrationMethod.h
+++ b/Components/Registrations/MultiMetricMultiResolutionRegistration/itkMultiMetricMultiResolutionImageRegistrationMethod.h
@@ -317,25 +317,25 @@ protected:
   CheckOnInitialize();
 
   /** Variables already defined in the superclass, but as private...  */
-  bool           m_Stop;
-  ParametersType m_LastTransformParameters;
+  bool           m_Stop{};
+  ParametersType m_LastTransformParameters{};
 
   /** A shortcut to m_Metric of type CombinationMetricPointer. */
-  CombinationMetricPointer m_CombinationMetric;
+  CombinationMetricPointer m_CombinationMetric{};
 
   /** Containers for the pointers supplied by the user. */
-  std::vector<FixedImageConstPointer>    m_FixedImages;
-  std::vector<MovingImageConstPointer>   m_MovingImages;
-  std::vector<FixedImageRegionType>      m_FixedImageRegions;
-  std::vector<FixedImagePyramidPointer>  m_FixedImagePyramids;
-  std::vector<MovingImagePyramidPointer> m_MovingImagePyramids;
-  std::vector<InterpolatorPointer>       m_Interpolators;
+  std::vector<FixedImageConstPointer>    m_FixedImages{};
+  std::vector<MovingImageConstPointer>   m_MovingImages{};
+  std::vector<FixedImageRegionType>      m_FixedImageRegions{};
+  std::vector<FixedImagePyramidPointer>  m_FixedImagePyramids{};
+  std::vector<MovingImagePyramidPointer> m_MovingImagePyramids{};
+  std::vector<InterpolatorPointer>       m_Interpolators{};
 
   /** This vector is filled by the PrepareAllPyramids function. */
-  std::vector<FixedImageRegionPyramidType> m_FixedImageRegionPyramids;
+  std::vector<FixedImageRegionPyramidType> m_FixedImageRegionPyramids{};
 
   /** Dummy image region. */
-  FixedImageRegionType m_NullFixedImageRegion;
+  FixedImageRegionType m_NullFixedImageRegion{};
 };
 
 } // end namespace itk

--- a/Components/Registrations/MultiResolutionRegistrationWithFeatures/itkMultiInputMultiResolutionImageRegistrationMethodBase.h
+++ b/Components/Registrations/MultiResolutionRegistrationWithFeatures/itkMultiInputMultiResolutionImageRegistrationMethodBase.h
@@ -301,22 +301,22 @@ protected:
   CheckOnInitialize();
 
   /** Containers for the pointers supplied by the user */
-  FixedImageVectorType             m_FixedImages;
-  MovingImageVectorType            m_MovingImages;
-  FixedImageRegionVectorType       m_FixedImageRegions;
-  FixedImagePyramidVectorType      m_FixedImagePyramids;
-  MovingImagePyramidVectorType     m_MovingImagePyramids;
-  InterpolatorVectorType           m_Interpolators;
-  FixedImageInterpolatorVectorType m_FixedImageInterpolators;
+  FixedImageVectorType             m_FixedImages{};
+  MovingImageVectorType            m_MovingImages{};
+  FixedImageRegionVectorType       m_FixedImageRegions{};
+  FixedImagePyramidVectorType      m_FixedImagePyramids{};
+  MovingImagePyramidVectorType     m_MovingImagePyramids{};
+  InterpolatorVectorType           m_Interpolators{};
+  FixedImageInterpolatorVectorType m_FixedImageInterpolators{};
 
   /** This vector is filled by the PreparePyramids function. */
-  FixedImageRegionPyramidVectorType m_FixedImageRegionPyramids;
+  FixedImageRegionPyramidVectorType m_FixedImageRegionPyramids{};
 
   /** Dummy image region */
-  FixedImageRegionType m_NullFixedImageRegion;
+  FixedImageRegionType m_NullFixedImageRegion{};
 
 private:
-  MultiInputMetricPointer m_MultiInputMetric;
+  MultiInputMetricPointer m_MultiInputMetric{};
 };
 
 } // end namespace itk

--- a/Components/Transforms/AdvancedAffineTransform/itkCenteredTransformInitializer2.h
+++ b/Components/Transforms/AdvancedAffineTransform/itkCenteredTransformInitializer2.h
@@ -210,24 +210,24 @@ protected:
   itkGetModifiableObjectMacro(Transform, TransformType);
 
   /** Settings for MomentsCalculator. */
-  SizeValueType  m_NumberOfSamplesForCenteredTransformInitialization;
-  InputPixelType m_LowerThresholdForCenterGravity;
-  bool           m_CenterOfGravityUsesLowerThreshold;
+  SizeValueType  m_NumberOfSamplesForCenteredTransformInitialization{};
+  InputPixelType m_LowerThresholdForCenterGravity{};
+  bool           m_CenterOfGravityUsesLowerThreshold{};
 
 private:
-  TransformPointer m_Transform;
+  TransformPointer m_Transform{};
 
-  FixedImagePointer      m_FixedImage;
-  MovingImagePointer     m_MovingImage;
-  FixedImageMaskPointer  m_FixedImageMask;
-  MovingImageMaskPointer m_MovingImageMask;
+  FixedImagePointer      m_FixedImage{};
+  MovingImagePointer     m_MovingImage{};
+  FixedImageMaskPointer  m_FixedImageMask{};
+  MovingImageMaskPointer m_MovingImageMask{};
 
-  bool m_UseMoments;
-  bool m_UseOrigins;
-  bool m_UseTop;
+  bool m_UseMoments{};
+  bool m_UseOrigins{};
+  bool m_UseTop{};
 
-  FixedImageCalculatorPointer  m_FixedCalculator;
-  MovingImageCalculatorPointer m_MovingCalculator;
+  FixedImageCalculatorPointer  m_FixedCalculator{};
+  MovingImageCalculatorPointer m_MovingCalculator{};
 };
 
 } // namespace itk

--- a/Components/Transforms/AffineDTITransform/itkAffineDTI2DTransform.h
+++ b/Components/Transforms/AffineDTITransform/itkAffineDTI2DTransform.h
@@ -157,9 +157,9 @@ protected:
   PrecomputeJacobianOfSpatialJacobian();
 
 private:
-  ScalarArrayType m_Angle;
-  ScalarArrayType m_Shear;
-  ScalarArrayType m_Scale;
+  ScalarArrayType m_Angle{};
+  ScalarArrayType m_Shear{};
+  ScalarArrayType m_Scale{};
 };
 
 } // namespace itk

--- a/Components/Transforms/AffineDTITransform/itkAffineDTI3DTransform.h
+++ b/Components/Transforms/AffineDTITransform/itkAffineDTI3DTransform.h
@@ -170,9 +170,9 @@ protected:
   PrecomputeJacobianOfSpatialJacobian();
 
 private:
-  ScalarArrayType m_Angle;
-  ScalarArrayType m_Shear;
-  ScalarArrayType m_Scale;
+  ScalarArrayType m_Angle{};
+  ScalarArrayType m_Shear{};
+  ScalarArrayType m_Scale{};
 };
 
 } // namespace itk

--- a/Components/Transforms/AffineLogTransform/itkAffineLogTransform.h
+++ b/Components/Transforms/AffineLogTransform/itkAffineLogTransform.h
@@ -109,7 +109,7 @@ protected:
   PrecomputeJacobianOfSpatialJacobian();
 
 private:
-  MatrixType m_MatrixLogDomain;
+  MatrixType m_MatrixLogDomain{};
 };
 
 } // namespace itk

--- a/Components/Transforms/BSplineDeformableTransformWithDiffusion/itkDeformationFieldRegulizer.h
+++ b/Components/Transforms/BSplineDeformableTransformWithDiffusion/itkDeformationFieldRegulizer.h
@@ -119,13 +119,13 @@ protected:
 
 private:
   /** Declaration of members. */
-  IntermediaryDFTransformPointer m_IntermediaryDeformationFieldTransform;
-  bool                           m_Initialized;
+  IntermediaryDFTransformPointer m_IntermediaryDeformationFieldTransform{};
+  bool                           m_Initialized{};
 
   /** Declarations of region things. */
-  RegionType  m_DeformationFieldRegion;
-  OriginType  m_DeformationFieldOrigin;
-  SpacingType m_DeformationFieldSpacing;
+  RegionType  m_DeformationFieldRegion{};
+  OriginType  m_DeformationFieldOrigin{};
+  SpacingType m_DeformationFieldSpacing{};
 };
 
 } // end namespace itk

--- a/Components/Transforms/BSplineDeformableTransformWithDiffusion/itkDeformationVectorFieldTransform.h
+++ b/Components/Transforms/BSplineDeformableTransformWithDiffusion/itkDeformationVectorFieldTransform.h
@@ -117,7 +117,7 @@ protected:
 
 private:
   /** Member variables. */
-  CoefficientImagePointer m_Images[SpaceDimension];
+  CoefficientImagePointer m_Images[SpaceDimension]{};
 };
 
 } // end namespace itk

--- a/Components/Transforms/BSplineDeformableTransformWithDiffusion/itkVectorMeanDiffusionImageFilter.h
+++ b/Components/Transforms/BSplineDeformableTransformWithDiffusion/itkVectorMeanDiffusionImageFilter.h
@@ -141,14 +141,14 @@ protected:
 
 private:
   /** Declare member variables. */
-  InputSizeType m_Radius;
-  unsigned int  m_NumberOfIterations;
+  InputSizeType m_Radius{};
+  unsigned int  m_NumberOfIterations{};
 
   /** Declare member images. */
-  GrayValueImagePointer m_GrayValueImage;
-  DoubleImagePointer    m_Cx;
+  GrayValueImagePointer m_GrayValueImage{};
+  DoubleImagePointer    m_Cx{};
 
-  RescaleImageFilterPointer m_RescaleFilter;
+  RescaleImageFilterPointer m_RescaleFilter{};
 
   /** For calculating a feature image from the input m_GrayValueImage. */
   void

--- a/Components/Transforms/DeformationFieldTransform/itkDeformationFieldInterpolatingTransform.h
+++ b/Components/Transforms/DeformationFieldTransform/itkDeformationFieldInterpolatingTransform.h
@@ -254,9 +254,9 @@ protected:
   void
   PrintSelf(std::ostream & os, Indent indent) const override;
 
-  DeformationFieldPointer             m_DeformationField;
-  DeformationFieldPointer             m_ZeroDeformationField;
-  DeformationFieldInterpolatorPointer m_DeformationFieldInterpolator;
+  DeformationFieldPointer             m_DeformationField{};
+  DeformationFieldPointer             m_ZeroDeformationField{};
+  DeformationFieldInterpolatorPointer m_DeformationFieldInterpolator{};
 };
 
 } // namespace itk

--- a/Components/Transforms/MultiBSplineTransformWithNormal/itkMultiBSplineDeformableTransformWithNormal.h
+++ b/Components/Transforms/MultiBSplineTransformWithNormal/itkMultiBSplineDeformableTransformWithNormal.h
@@ -475,7 +475,7 @@ protected:
   // bool m_SplineOrderOdd;
 
   /** Keep a pointer to the input parameters. */
-  const ParametersType * m_InputParametersPointer;
+  const ParametersType * m_InputParametersPointer{};
 
   /** Jacobian as SpaceDimension number of images. */
   /*
@@ -483,7 +483,7 @@ protected:
   using JacobianImageType = Image< JacobianPixelType,
     itkGetStaticConstMacro( SpaceDimension ) >;
 
-  typename JacobianImageType::Pointer m_JacobianImage[ NDimensions ];
+  typename JacobianImageType::Pointer m_JacobianImage[ NDimensions ]{};
   */
 
   /** Keep track of last support region used in computing the Jacobian
@@ -495,18 +495,18 @@ protected:
   // ImagePointer    m_WrappedImage[ NDimensions ];
 
   /** Internal parameters buffer. */
-  ParametersType m_InternalParametersBuffer;
+  ParametersType m_InternalParametersBuffer{};
 
   using TransformType = AdvancedBSplineDeformableTransform<TScalarType, Self::SpaceDimension, VSplineOrder>;
 
-  unsigned char                                m_NbLabels;
-  ImageLabelPointer                            m_Labels;
-  ImageLabelInterpolatorPointer                m_LabelsInterpolator;
-  ImageVectorPointer                           m_LabelsNormals;
-  std::vector<typename TransformType::Pointer> m_Trans;
-  std::vector<ParametersType>                  m_Para;
-  mutable int                                  m_LastJacobian;
-  ImageBasePointer                             m_LocalBases;
+  unsigned char                                m_NbLabels{};
+  ImageLabelPointer                            m_Labels{};
+  ImageLabelInterpolatorPointer                m_LabelsInterpolator{};
+  ImageVectorPointer                           m_LabelsNormals{};
+  std::vector<typename TransformType::Pointer> m_Trans{};
+  std::vector<ParametersType>                  m_Para{};
+  mutable int                                  m_LastJacobian{};
+  ImageBasePointer                             m_LocalBases{};
 
 private:
   void

--- a/Components/Transforms/SplineKernelTransform/itkElasticBodyReciprocalSplineKernelTransform2.h
+++ b/Components/Transforms/SplineKernelTransform/itkElasticBodyReciprocalSplineKernelTransform2.h
@@ -150,7 +150,7 @@ protected:
   ComputeG(const InputVectorType & x, GMatrixType & GMatrix) const override;
 
   /** alpha, Poisson's ratio */
-  TScalarType m_Alpha;
+  TScalarType m_Alpha{};
 };
 
 } // namespace itk

--- a/Components/Transforms/SplineKernelTransform/itkElasticBodySplineKernelTransform2.h
+++ b/Components/Transforms/SplineKernelTransform/itkElasticBodySplineKernelTransform2.h
@@ -151,7 +151,7 @@ protected:
   /** alpha,  Alpha is related to Poisson's Ratio \f$\nu\f$ as
    * \f$\alpha = 12 ( 1 - \nu ) - 1\f$
    */
-  TScalarType m_Alpha;
+  TScalarType m_Alpha{};
 };
 
 } // namespace itk

--- a/Components/Transforms/SplineKernelTransform/itkKernelTransform2.h
+++ b/Components/Transforms/SplineKernelTransform/itkKernelTransform2.h
@@ -395,10 +395,10 @@ public:
   using ColumnMatrixType = vnl_matrix_fixed<TScalarType, NDimensions, 1>;
 
   /** The list of source landmarks, denoted 'p'. */
-  PointSetPointer m_SourceLandmarks;
+  PointSetPointer m_SourceLandmarks{};
 
   /** The list of target landmarks, denoted 'q'. */
-  PointSetPointer m_TargetLandmarks;
+  PointSetPointer m_TargetLandmarks{};
 
 protected:
   /** Compute G(x)
@@ -455,43 +455,43 @@ protected:
   ReorganizeW();
 
   /** Stiffness parameter. */
-  double m_Stiffness;
+  double m_Stiffness{};
 
   /** The list of displacements.
    * d[i] = q[i] - p[i];
    */
-  VectorSetPointer m_Displacements;
+  VectorSetPointer m_Displacements{};
 
   /** The L matrix. */
-  LMatrixType m_LMatrix;
+  LMatrixType m_LMatrix{};
 
   /** The inverse of L, which we also cache. */
-  LMatrixType m_LMatrixInverse;
+  LMatrixType m_LMatrixInverse{};
 
   /** The K matrix. */
-  KMatrixType m_KMatrix;
+  KMatrixType m_KMatrix{};
 
   /** The P matrix. */
-  PMatrixType m_PMatrix;
+  PMatrixType m_PMatrix{};
 
   /** The Y matrix. */
-  YMatrixType m_YMatrix;
+  YMatrixType m_YMatrix{};
 
   /** The W matrix. */
-  WMatrixType m_WMatrix;
+  WMatrixType m_WMatrix{};
 
   /** The Deformation matrix.
    * This is an auxiliary matrix that will hold the Deformation (non-affine)
    * part of the transform. Those are the coefficients that will multiply the
    * Kernel function.
    */
-  DMatrixType m_DMatrix;
+  DMatrixType m_DMatrix{};
 
   /** Rotational/Shearing part of the Affine component of the Transformation. */
-  AMatrixType m_AMatrix;
+  AMatrixType m_AMatrix{};
 
   /** Translational part of the Affine component of the Transformation. */
-  BMatrixType m_BVector;
+  BMatrixType m_BVector{};
 
   /** The G matrix.
    * It used to be mutable because m_GMatrix was made an ivar only to avoid
@@ -501,13 +501,13 @@ protected:
   // GMatrixType m_GMatrix;
 
   /** Has the W matrix been computed? */
-  bool m_WMatrixComputed;
+  bool m_WMatrixComputed{};
   /** Has the L matrix been computed? */
-  bool m_LMatrixComputed;
+  bool m_LMatrixComputed{};
   /** Has the L inverse matrix been computed? */
-  bool m_LInverseComputed;
+  bool m_LInverseComputed{};
   /** Has the L matrix decomposition been computed? */
-  bool m_LMatrixDecompositionComputed;
+  bool m_LMatrixDecompositionComputed{};
 
   /** Decompositions, needed for the L matrix.
    * These decompositions are cached for performance reasons during registration.
@@ -518,25 +518,25 @@ protected:
   using SVDDecompositionType = vnl_svd<ScalarType>;
   using QRDecompositionType = vnl_qr<ScalarType>;
 
-  SVDDecompositionType * m_LMatrixDecompositionSVD;
-  QRDecompositionType *  m_LMatrixDecompositionQR;
+  SVDDecompositionType * m_LMatrixDecompositionSVD{};
+  QRDecompositionType *  m_LMatrixDecompositionQR{};
 
   /** Identity matrix. */
-  IMatrixType m_I;
+  IMatrixType m_I{};
 
   /** Precomputed nonzero Jacobian indices (simply all params) */
-  NonZeroJacobianIndicesType m_NonZeroJacobianIndices;
+  NonZeroJacobianIndicesType m_NonZeroJacobianIndices{};
 
   /** The Jacobian can be computed much faster for some of the
    * derived kerbel transforms, most notably the TPS.
    */
-  bool m_FastComputationPossible;
+  bool m_FastComputationPossible{};
 
 private:
-  TScalarType m_PoissonRatio;
+  TScalarType m_PoissonRatio{};
 
   /** Using SVD or QR decomposition. */
-  std::string m_MatrixInversionMethod;
+  std::string m_MatrixInversionMethod{};
 };
 
 } // end namespace itk

--- a/Components/Transforms/TranslationTransform/itkTranslationTransformInitializer.h
+++ b/Components/Transforms/TranslationTransform/itkTranslationTransformInitializer.h
@@ -151,15 +151,15 @@ protected:
   PrintSelf(std::ostream & os, Indent indent) const override;
 
 private:
-  TransformPointer   m_Transform;
-  FixedImagePointer  m_FixedImage;
-  MovingImagePointer m_MovingImage;
-  FixedMaskPointer   m_FixedMask;
-  MovingMaskPointer  m_MovingMask;
-  bool               m_UseMoments;
+  TransformPointer   m_Transform{};
+  FixedImagePointer  m_FixedImage{};
+  MovingImagePointer m_MovingImage{};
+  FixedMaskPointer   m_FixedMask{};
+  MovingMaskPointer  m_MovingMask{};
+  bool               m_UseMoments{};
 
-  FixedImageCalculatorPointer  m_FixedCalculator;
-  MovingImageCalculatorPointer m_MovingCalculator;
+  FixedImageCalculatorPointer  m_FixedCalculator{};
+  MovingImageCalculatorPointer m_MovingCalculator{};
 };
 
 } // namespace itk

--- a/Components/Transforms/WeightedCombinationTransform/itkWeightedCombinationTransform.h
+++ b/Components/Transforms/WeightedCombinationTransform/itkWeightedCombinationTransform.h
@@ -241,14 +241,14 @@ protected:
   WeightedCombinationTransform();
   ~WeightedCombinationTransform() override = default;
 
-  TransformContainerType m_TransformContainer;
-  double                 m_SumOfWeights;
+  TransformContainerType m_TransformContainer{};
+  double                 m_SumOfWeights{};
 
   /** Precomputed nonzero Jacobian indices (simply all params) */
-  NonZeroJacobianIndicesType m_NonZeroJacobianIndices;
+  NonZeroJacobianIndicesType m_NonZeroJacobianIndices{};
 
 private:
-  bool m_NormalizeWeights;
+  bool m_NormalizeWeights{};
 };
 
 } // end namespace itk

--- a/Core/Main/itkTransformixFilter.h
+++ b/Core/Main/itkTransformixFilter.h
@@ -297,7 +297,7 @@ private:
   typename MeshType::ConstPointer m_InputMesh{ nullptr };
   typename MeshType::Pointer      m_OutputMesh{ nullptr };
 
-  TransformBase::ConstPointer m_Transform;
+  TransformBase::ConstPointer m_Transform{};
 
   SmartPointer<TransformType> m_CombinationTransform;
 };

--- a/Testing/itkCommandLineArgumentParser.h
+++ b/Testing/itkCommandLineArgumentParser.h
@@ -266,20 +266,20 @@ protected:
   StringCast(const std::string & parameterValue, std::string & casted) const;
 
   /** A vector of strings to store the command line arguments. */
-  std::vector<std::string> m_Argv;
+  std::vector<std::string> m_Argv{};
 
   /** A map to store the arguments and their indices. The arguments are stored
    * INCLUDING the leading dash. I.e. an example pair is ("-test", 2)
    */
-  ArgumentMapType m_ArgumentMap;
+  ArgumentMapType m_ArgumentMap{};
 
   /** The list of required arguments. They are stored with an accompanying help text string. */
-  std::vector<std::pair<std::string, std::string>> m_RequiredArguments;
+  std::vector<std::pair<std::string, std::string>> m_RequiredArguments{};
 
   /** A list of arguments with the condition that exactly one in each set must exist. */
-  std::vector<std::pair<std::vector<std::string>, std::string>> m_RequiredExactlyOneArguments;
+  std::vector<std::pair<std::vector<std::string>, std::string>> m_RequiredExactlyOneArguments{};
 
-  std::string m_ProgramHelpText;
+  std::string m_ProgramHelpText{};
 };
 
 // end class CommandLineArgumentParser


### PR DESCRIPTION
Ran "AddEmptyDefaultMemberInitializers" from pull request https://github.com/InsightSoftwareConsortium/ITK/pull/3935 ("ENH: Add C++ script to add in-class `{}` member initializers to ITK") on the elastix source tree.