### PR TITLE
Support "ShowProgressPercentage" parameter (false by default)

### DIFF
--- a/Components/Optimizers/AdaptiveStochasticGradientDescent/elxAdaptiveStochasticGradientDescent.hxx
+++ b/Components/Optimizers/AdaptiveStochasticGradientDescent/elxAdaptiveStochasticGradientDescent.hxx
@@ -852,10 +852,13 @@ AdaptiveStochasticGradientDescent<TElastix>::SampleGradients(const ParametersTyp
 
   } // end if NewSamplesEveryIteration.
 
+  const Configuration & configuration = Deref(Superclass2::GetConfiguration());
+
   /** Prepare for progress printing. */
-  const auto progressObserver = BaseComponent::IsElastixLibrary()
-                                  ? nullptr
-                                  : ProgressCommand::CreateAndSetUpdateFrequency(this->m_NumberOfGradientMeasurements);
+  const bool showProgressPercentage = configuration.RetrieveParameterValue(false, "ShowProgressPercentage", 0, false);
+  const auto progressObserver = showProgressPercentage
+                                  ? ProgressCommand::CreateAndSetUpdateFrequency(this->m_NumberOfGradientMeasurements)
+                                  : nullptr;
   log::info("  Sampling gradients ...");
 
   /** Initialize some variables for storing gradients and their magnitudes. */

--- a/Components/Optimizers/PreconditionedStochasticGradientDescent/elxPreconditionedStochasticGradientDescent.hxx
+++ b/Components/Optimizers/PreconditionedStochasticGradientDescent/elxPreconditionedStochasticGradientDescent.hxx
@@ -791,10 +791,13 @@ PreconditionedStochasticGradientDescent<TElastix>::SampleGradients(const Paramet
 
   } // end if NewSamplesEveryIteration.
 
+  const Configuration & configuration = Deref(Superclass2::GetConfiguration());
+
   /** Prepare for progress printing. */
-  const auto progressObserver = BaseComponent::IsElastixLibrary()
-                                  ? nullptr
-                                  : ProgressCommand::CreateAndSetUpdateFrequency(this->m_NumberOfGradientMeasurements);
+  const bool showProgressPercentage = configuration.RetrieveParameterValue(false, "ShowProgressPercentage", 0, false);
+  const auto progressObserver = showProgressPercentage
+                                  ? ProgressCommand::CreateAndSetUpdateFrequency(this->m_NumberOfGradientMeasurements)
+                                  : nullptr;
   log::info("  Sampling gradients ...");
 
   /** Initialize some variables for storing gradients and their magnitudes. */

--- a/Core/ComponentBaseClasses/elxResamplerBase.hxx
+++ b/Core/ComponentBaseClasses/elxResamplerBase.hxx
@@ -302,10 +302,12 @@ ResamplerBase<TElastix>::ResampleAndWriteResultImage(const char * filename, cons
   /** Make sure the resampler is updated. */
   resampleImageFilter.Modified();
 
+  const Configuration & configuration = Deref(Superclass::GetConfiguration());
+
   /** Add a progress observer to the resampler. */
-  const auto progressObserver = (!showProgress || BaseComponent::IsElastixLibrary())
-                                  ? nullptr
-                                  : ProgressCommand::CreateAndConnect(resampleImageFilter);
+  const bool showProgressPercentage = configuration.RetrieveParameterValue(false, "ShowProgressPercentage", 0, false);
+  const auto progressObserver =
+    (showProgress && showProgressPercentage) ? ProgressCommand::CreateAndConnect(resampleImageFilter) : nullptr;
 
   /** Do the resampling. */
   try
@@ -423,8 +425,11 @@ ResamplerBase<TElastix>::CreateItkResultImage()
   /** Make sure the resampler is updated. */
   resampleImageFilter.Modified();
 
+  const Configuration & configuration = Deref(Superclass::GetConfiguration());
+
+  const bool showProgressPercentage = configuration.RetrieveParameterValue(false, "ShowProgressPercentage", 0, false);
   const auto progressObserver =
-    BaseComponent::IsElastixLibrary() ? nullptr : ProgressCommand::CreateAndConnect(*(this->GetAsITKBaseType()));
+    showProgressPercentage ? ProgressCommand::CreateAndConnect(*(this->GetAsITKBaseType())) : nullptr;
 
   /** Do the resampling. */
   try
@@ -454,8 +459,6 @@ ResamplerBase<TElastix>::CreateItkResultImage()
   {
     resampleImageFilter.SetTransform(testptr->GetTransform());
   }
-
-  const Configuration & configuration = Deref(Superclass::GetConfiguration());
 
   /** Read output pixeltype from parameter the file. */
   std::string resultImagePixelType = "short";

--- a/Core/ComponentBaseClasses/elxTransformBase.hxx
+++ b/Core/ComponentBaseClasses/elxTransformBase.hxx
@@ -985,9 +985,11 @@ TransformBase<TElastix>::GenerateDeformationFieldImage() const -> typename Defor
   infoChanger->SetChangeDirection(retdc & !this->GetElastix()->GetUseDirectionCosines());
   infoChanger->SetInput(defGenerator->GetOutput());
 
+  const Configuration & configuration = Deref(Superclass::GetConfiguration());
+
   /** Track the progress of the generation of the deformation field. */
-  const auto progressObserver =
-    BaseComponent::IsElastixLibrary() ? nullptr : ProgressCommand::CreateAndConnect(*defGenerator);
+  const bool showProgressPercentage = configuration.RetrieveParameterValue(false, "ShowProgressPercentage", 0, false);
+  const auto progressObserver = showProgressPercentage ? ProgressCommand::CreateAndConnect(*defGenerator) : nullptr;
 
   try
   {
@@ -1110,8 +1112,8 @@ TransformBase<TElastix>::ComputeAndWriteSpatialJacobianDeterminantImage() const
   const auto infoChanger = CreateChangeInformationImageFilter(jacGenerator->GetOutput());
 
   /** Track the progress of the generation of the deformation field. */
-  const auto progressObserver =
-    BaseComponent::IsElastixLibrary() ? nullptr : ProgressCommand::CreateAndConnect(*jacGenerator);
+  const bool showProgressPercentage = configuration.RetrieveParameterValue(false, "ShowProgressPercentage", 0, false);
+  const auto progressObserver = showProgressPercentage ? ProgressCommand::CreateAndConnect(*jacGenerator) : nullptr;
   /** Create a name for the deformation field file. */
   std::string resultImageFormat = "mhd";
   configuration.ReadParameter(resultImageFormat, "ResultImageFormat", 0, false);
@@ -1164,8 +1166,8 @@ TransformBase<TElastix>::ComputeAndWriteSpatialJacobianMatrixImage() const
 
   const auto infoChanger = CreateChangeInformationImageFilter(jacGenerator->GetOutput());
 
-  const auto progressObserver =
-    BaseComponent::IsElastixLibrary() ? nullptr : ProgressCommand::CreateAndConnect(*jacGenerator);
+  const bool showProgressPercentage = configuration.RetrieveParameterValue(false, "ShowProgressPercentage", 0, false);
+  const auto progressObserver = showProgressPercentage ? ProgressCommand::CreateAndConnect(*jacGenerator) : nullptr;
   /** Create a name for the deformation field file. */
   std::string resultImageFormat = "mhd";
   configuration.ReadParameter(resultImageFormat, "ResultImageFormat", 0, false);

--- a/Core/elxProgressCommand.cxx
+++ b/Core/elxProgressCommand.cxx
@@ -36,14 +36,6 @@ ProgressCommand::ProgressCommand()
   m_NumberOfVoxels = 0;
   m_NumberOfUpdates = 0;
 
-  /** Check if the output of the stream is a console. */
-  m_StreamOutputIsConsole = false;
-  int currentPos = std::cout.tellp();
-  if (currentPos == -1)
-  {
-    m_StreamOutputIsConsole = true;
-  }
-
 } // end Constructor()
 
 
@@ -101,12 +93,9 @@ ProgressCommand::ConnectObserver(itk::ProcessObject * filter)
   this->DisconnectObserver(m_ObservedProcessObject);
 
   /** Connect to the new filter. */
-  if (m_StreamOutputIsConsole)
-  {
-    m_Tag = filter->AddObserver(itk::ProgressEvent(), this);
-    m_TagIsSet = true;
-    m_ObservedProcessObject = filter;
-  }
+  m_Tag = filter->AddObserver(itk::ProgressEvent(), this);
+  m_TagIsSet = true;
+  m_ObservedProcessObject = filter;
 
 } // end ConnectObserver()
 
@@ -118,14 +107,11 @@ ProgressCommand::ConnectObserver(itk::ProcessObject * filter)
 void
 ProgressCommand::DisconnectObserver(itk::ProcessObject * filter)
 {
-  if (m_StreamOutputIsConsole)
+  if (m_TagIsSet)
   {
-    if (m_TagIsSet)
-    {
-      filter->RemoveObserver(m_Tag);
-      m_TagIsSet = false;
-      m_ObservedProcessObject = nullptr;
-    }
+    filter->RemoveObserver(m_Tag);
+    m_TagIsSet = false;
+    m_ObservedProcessObject = nullptr;
   }
 
 } // end DisconnectObserver()
@@ -203,13 +189,10 @@ ProgressCommand::PrintProgress(const float progress) const
 void
 ProgressCommand::UpdateAndPrintProgress(const unsigned long currentVoxelNumber) const
 {
-  if (m_StreamOutputIsConsole)
+  const unsigned long frac = static_cast<unsigned long>(m_NumberOfVoxels / m_NumberOfUpdates);
+  if (currentVoxelNumber % frac == 0)
   {
-    const unsigned long frac = static_cast<unsigned long>(m_NumberOfVoxels / m_NumberOfUpdates);
-    if (currentVoxelNumber % frac == 0)
-    {
-      this->PrintProgress(static_cast<float>(currentVoxelNumber) / static_cast<float>(m_NumberOfVoxels));
-    }
+    this->PrintProgress(static_cast<float>(currentVoxelNumber) / static_cast<float>(m_NumberOfVoxels));
   }
 
 } // end PrintProgress()

--- a/Core/elxProgressCommand.h
+++ b/Core/elxProgressCommand.h
@@ -145,9 +145,6 @@ public:
   itkSetStringMacro(EndString);
   itkGetStringMacro(EndString);
 
-  /** Get a boolean indicating if the output is a console. */
-  itkGetConstReferenceMacro(StreamOutputIsConsole, bool);
-
   static Pointer
   CreateAndSetUpdateFrequency(unsigned long numberOfVoxels);
 
@@ -167,7 +164,6 @@ private:
   std::string m_EndString;
 
   /** Member variables to keep track of what is set. */
-  bool                 m_StreamOutputIsConsole;
   unsigned long        m_Tag;
   bool                 m_TagIsSet;
   ProcessObjectPointer m_ObservedProcessObject;


### PR DESCRIPTION
Allows enabling showing progress percentages at the console (standard output), by adding the following elastix parameter:

    (ShowProgressPercentage "true")

As I discussed last week with Marius Staring (@mstaring).

This pull request aims to supersede PR #826 "Show progress percentage only when requested by user" (which would instead add an extra command-line option `-progress on`, and `ShowProgressPercentageOn`/`Off` member functions.) It also addresses issue #756 "Executable progress indication appears suppressed on Windows".