### PR TITLE
COMP: error C2039: 'm_ShowProgress': is not a member of OpenCLResampler

### DIFF
--- a/Components/Resamplers/OpenCLResampler/elxOpenCLResampler.hxx
+++ b/Components/Resamplers/OpenCLResampler/elxOpenCLResampler.hxx
@@ -70,7 +70,6 @@ elastix::OpenCLResampler<TElastix>::OpenCLResampler()
   }
 
   this->m_UseOpenCL = true;
-  this->m_ShowProgress = false;
 
 } // end Constructor
 


### PR DESCRIPTION
Fixed an OpenCL compile error, saying:

> Components\Resamplers\OpenCLResampler\elxOpenCLResampler.hxx(73,9): error C2039: 'm_ShowProgress': is not a member of 'elastix::Open
CLResampler<ElastixType>'

Reported by Konstantinos Ntatsis (@ntatsisk).

Error was introduced with commit e39de3ab5c80ec947ccd68e243b27c6f098632e2 "STYLE: Remove `ResamplerBase::m_ShowProgress` (which was always true)"