### PR TITLE
STYLE: Add `const` to declarations of configurations

### DIFF
--- a/Core/ComponentBaseClasses/elxTransformBase.h
+++ b/Core/ComponentBaseClasses/elxTransformBase.h
@@ -368,7 +368,7 @@ private:
   /** Function to read the initial transform parameters from the specified configuration object.
    */
   void
-  ReadInitialTransformFromConfiguration(const Configuration::Pointer);
+  ReadInitialTransformFromConfiguration(const Configuration::ConstPointer);
 
   /** Execute stuff before everything else:
    * \li Check the appearance of an initial transform.

--- a/Core/ComponentBaseClasses/elxTransformBase.hxx
+++ b/Core/ComponentBaseClasses/elxTransformBase.hxx
@@ -423,7 +423,7 @@ TransformBase<TElastix>::ReadInitialTransformFromFile(const char * transformPara
 template <class TElastix>
 void
 TransformBase<TElastix>::ReadInitialTransformFromConfiguration(
-  const Configuration::Pointer configurationInitialTransform)
+  const Configuration::ConstPointer configurationInitialTransform)
 {
   /** Read the InitialTransform name. */
   ComponentDescriptionType initialTransformName = "AffineTransform";

--- a/Core/Install/elxBaseComponentSE.h
+++ b/Core/Install/elxBaseComponentSE.h
@@ -119,7 +119,7 @@ public:
 
   /** Set the configuration. Added for transformix. */
   void
-  SetConfiguration(Configuration * _arg);
+  SetConfiguration(const Configuration * _arg);
 
   /** Get a pointer to the Registration component.
    * This is a convenience function, since the registration
@@ -137,9 +137,9 @@ protected:
   BaseComponentSE() = default;
   ~BaseComponentSE() override = default;
 
-  itk::WeakPointer<TElastix> m_Elastix{};
-  ConfigurationPointer       m_Configuration{};
-  RegistrationType *         m_Registration{};
+  itk::WeakPointer<TElastix>  m_Elastix{};
+  Configuration::ConstPointer m_Configuration{};
+  RegistrationType *          m_Registration{};
 
 private:
   virtual const itk::Object &

--- a/Core/Install/elxBaseComponentSE.hxx
+++ b/Core/Install/elxBaseComponentSE.hxx
@@ -57,7 +57,7 @@ BaseComponentSE<TElastix>::SetElastix(TElastix * const _arg)
 
 template <class TElastix>
 void
-BaseComponentSE<TElastix>::SetConfiguration(Configuration * const _arg)
+BaseComponentSE<TElastix>::SetConfiguration(const Configuration * const _arg)
 {
   /** If this->m_Configuration is not set, then set it.*/
   if (this->m_Configuration != _arg)

--- a/Core/Kernel/elxElastixBase.cxx
+++ b/Core/Kernel/elxElastixBase.cxx
@@ -480,7 +480,7 @@ ElastixBase::GetTransformParametersMap() const
  */
 
 void
-ElastixBase::SetConfigurations(const std::vector<ConfigurationPointer> & configurations)
+ElastixBase::SetConfigurations(const std::vector<Configuration::ConstPointer> & configurations)
 {
   m_Configurations = configurations;
 }
@@ -490,7 +490,7 @@ ElastixBase::SetConfigurations(const std::vector<ConfigurationPointer> & configu
  * ************** GetConfiguration *********************
  */
 
-ElastixBase::ConfigurationPointer
+Configuration::ConstPointer
 ElastixBase::GetConfiguration(const size_t index) const
 {
   return m_Configurations[index];

--- a/Core/Kernel/elxElastixBase.h
+++ b/Core/Kernel/elxElastixBase.h
@@ -351,10 +351,10 @@ public:
 
   /** Set configuration vector. Library only. */
   void
-  SetConfigurations(const std::vector<ConfigurationPointer> & configurations);
+  SetConfigurations(const std::vector<Configuration::ConstPointer> & configurations);
 
   /** Return configuration from vector of configurations. Library only. */
-  ConfigurationPointer
+  Configuration::ConstPointer
   GetConfiguration(const size_t index) const;
 
   IterationInfo &
@@ -478,7 +478,7 @@ private:
   ConfigurationPointer m_Configuration{ nullptr };
 
   /** A vector of configuration objects, needed when transformix is used as library. */
-  std::vector<ConfigurationPointer> m_Configurations;
+  std::vector<Configuration::ConstPointer> m_Configurations;
 
   IterationInfo m_IterationInfo;
 

--- a/Core/Kernel/elxMainBase.cxx
+++ b/Core/Kernel/elxMainBase.cxx
@@ -129,25 +129,31 @@ MainBase::EnterCommandLineArguments(const ArgumentMapType & argmap, const Parame
 void
 MainBase::EnterCommandLineArguments(const ArgumentMapType & argmap, const std::vector<ParameterMapType> & inputMaps)
 {
+  const auto numberOfInputMaps = inputMaps.size();
   m_Configurations.clear();
-  m_Configurations.resize(inputMaps.size());
+  m_Configurations.resize(numberOfInputMaps);
 
-  for (size_t i = 0; i < inputMaps.size(); ++i)
+  for (size_t i = 0; i < numberOfInputMaps; ++i)
   {
     /** Initialize the configuration object with the
      * command line parameters entered by the user.
      */
-    m_Configurations[i] = Configuration::New();
-    int dummy = m_Configurations[i]->Initialize(argmap, inputMaps[i]);
+    const auto configuration = Configuration::New();
+    int        dummy = configuration->Initialize(argmap, inputMaps[i]);
+    m_Configurations[i] = configuration;
     if (dummy)
     {
       log::error(std::ostringstream{} << "ERROR: Something went wrong during initialization of configuration object "
                                       << i << ".");
     }
+
+    if ((i + 1) == numberOfInputMaps)
+    {
+      /** Copy last configuration object to m_Configuration. */
+      m_Configuration = configuration;
+    }
   }
 
-  /** Copy last configuration object to m_Configuration. */
-  m_Configuration = m_Configurations[inputMaps.size() - 1];
 } // end EnterCommandLineArguments()
 
 

--- a/Core/Kernel/elxMainBase.h
+++ b/Core/Kernel/elxMainBase.h
@@ -189,7 +189,7 @@ protected:
   ObjectPointer m_Elastix{ nullptr };
 
   /** A vector of configuration objects, needed when transformix is used as library. */
-  std::vector<ConfigurationPointer> m_Configurations{};
+  std::vector<Configuration::ConstPointer> m_Configurations{};
 
   /** Description of the ImageTypes. */
   PixelTypeDescriptionType m_FixedImagePixelType{};


### PR DESCRIPTION
Declared the m_Configurations members of ElastixBase and MainBase as vector of `ConstPointer`s. Declared `BaseComponentSE::m_Configuration` as a `ConstPointer`.

Note that the m_Configuration members of ElastixBase and MainBase are unaffected by this commit. ElastixBase still has non-const member function calls like `m_Configuration->SetCommandLineArgument("-out", ...)`, while MainBase still calls `m_Configuration->Initialize`, and its derived class ElastixMain does function calls like `configuration.SetElastixLevel(level)`.

`MainBase::EnterCommandLineArguments(const ArgumentMapType &, const std::vector<ParameterMapType> &)` needed some small refactoring for this to compile.