### PR TITLE
Find previous configuration without interpreting "InitialTransformParametersFileName" as index value

### DIFF
--- a/Core/ComponentBaseClasses/elxTransformBase.hxx
+++ b/Core/ComponentBaseClasses/elxTransformBase.hxx
@@ -358,39 +358,20 @@ TransformBase<TElastix>::ReadFromFile()
   }
   else
   {
-    // The value of "InitialTransformParametersFileName" is either an index
-    // (size_t) into the vector of configuration objects, or the file name of
-    // a transform parameters file. If it is an index, call
-    // ReadInitialTransformFromConfiguration, otherwise call ReadInitialTransformFromFile.
-
-    /** Get initial transform index number. */
-    std::istringstream to_size_t(fileName);
-    size_t             index;
-    to_size_t >> index;
-
-    if (to_size_t.eof() && !to_size_t.fail())
+    /** Check if the initial transform of this transform parameter file
+     * is not the same as this transform parameter file. Otherwise,
+     * we will have an infinite loop.
+     */
+    std::string fullFileName1 = itksys::SystemTools::CollapseFullPath(fileName);
+    std::string fullFileName2 = itksys::SystemTools::CollapseFullPath(configuration.GetParameterFileName());
+    if (fullFileName1 == fullFileName2)
     {
-      /** We can safely read the initial transform. */
-      // Retrieve configuration object from internally stored vector of configuration objects.
-      this->ReadInitialTransformFromConfiguration(this->GetElastix()->GetConfiguration(index));
+      itkExceptionMacro(<< "ERROR: The InitialTransformParametersFileName is identical to the current "
+                           "TransformParameters filename! An infinite loop is not allowed.");
     }
-    else
-    {
-      /** Check if the initial transform of this transform parameter file
-       * is not the same as this transform parameter file. Otherwise,
-       * we will have an infinite loop.
-       */
-      std::string fullFileName1 = itksys::SystemTools::CollapseFullPath(fileName);
-      std::string fullFileName2 = itksys::SystemTools::CollapseFullPath(configuration.GetParameterFileName());
-      if (fullFileName1 == fullFileName2)
-      {
-        itkExceptionMacro(<< "ERROR: The InitialTransformParametersFileName is identical to the current "
-                             "TransformParameters filename! An infinite loop is not allowed.");
-      }
 
-      /** We can safely read the initial transform. */
-      this->ReadInitialTransformFromFile(fileName.c_str());
-    }
+    /** We can safely read the initial transform. */
+    this->ReadInitialTransformFromFile(fileName.c_str());
   }
 
   /** Task 3 - Read from the configuration file how to combine the

--- a/Core/ComponentBaseClasses/elxTransformBase.hxx
+++ b/Core/ComponentBaseClasses/elxTransformBase.hxx
@@ -336,8 +336,27 @@ TransformBase<TElastix>::ReadFromFile()
   std::string fileName = "NoInitialTransform";
   configuration.ReadParameter(fileName, "InitialTransformParametersFileName", 0);
 
+  const ElastixBase & elastixBase = Deref(Superclass::GetElastix());
+
   /** Call the function ReadInitialTransformFromFile. */
-  if (fileName != "NoInitialTransform")
+  if (fileName == "NoInitialTransform")
+  {
+    const auto numberOfConfigurations = elastixBase.GetNumberOfConfigurations();
+
+    if ((numberOfConfigurations > 1) && (&configuration != elastixBase.GetConfiguration(0)))
+    {
+      for (size_t index{ 1 }; index < numberOfConfigurations; ++index)
+      {
+        if (elastixBase.GetConfiguration(index) == &configuration)
+        {
+          // Use the previous configuration (at position index - 1) for the initial transform.
+          this->ReadInitialTransformFromConfiguration(elastixBase.GetConfiguration(index - 1));
+          break;
+        }
+      }
+    }
+  }
+  else
   {
     // The value of "InitialTransformParametersFileName" is either an index
     // (size_t) into the vector of configuration objects, or the file name of

--- a/Core/Kernel/elxElastixBase.cxx
+++ b/Core/Kernel/elxElastixBase.cxx
@@ -497,4 +497,15 @@ ElastixBase::GetConfiguration(const size_t index) const
 }
 
 
+/**
+ * ************** GetNumberOfConfigurations *********************
+ */
+
+size_t
+ElastixBase::GetNumberOfConfigurations() const
+{
+  return m_Configurations.size();
+}
+
+
 } // end namespace elastix

--- a/Core/Kernel/elxElastixBase.h
+++ b/Core/Kernel/elxElastixBase.h
@@ -357,6 +357,10 @@ public:
   Configuration::ConstPointer
   GetConfiguration(const size_t index) const;
 
+  /** Returns the number of configurations in the vector of configurations. */
+  size_t
+  GetNumberOfConfigurations() const;
+
   IterationInfo &
   GetIterationInfo()
   {

--- a/Core/Main/elastixlib.cxx
+++ b/Core/Main/elastixlib.cxx
@@ -309,13 +309,6 @@ ELASTIX::RegisterImages(ImagePointer                          fixedImage,
     /** Get the transformation parameter map. */
     this->m_TransformParametersList.push_back(elastixMain->GetTransformParametersMap());
 
-    /** Set initial transform to an index number instead of a parameter filename. */
-    if (i > 0)
-    {
-      std::ostringstream toString;
-      toString << (i - 1);
-      this->m_TransformParametersList[i]["InitialTransformParametersFileName"][0] = toString.str();
-    }
   } // end loop over registrations
 
   elx::log::info("-------------------------------------------------------------------------\n");

--- a/Core/Main/itkElastixRegistrationMethod.hxx
+++ b/Core/Main/itkElastixRegistrationMethod.hxx
@@ -254,11 +254,6 @@ ElastixRegistrationMethod<TFixedImage, TMovingImage>::GenerateData()
     fixedImageOriginalDirection = elastixMain->GetOriginalFixedImageDirectionFlat();
 
     transformParameterMapVector.push_back(elastixMain->GetTransformParametersMap());
-    if (i > 0)
-    {
-      transformParameterMapVector[i]["InitialTransformParametersFileName"] =
-        ParameterValueVectorType(1, std::to_string(i - 1));
-    }
 
     // TODO: Fix elastix corrupting default pixel value parameter
     transformParameterMapVector.back()["DefaultPixelValue"] = parameterMap["DefaultPixelValue"];

--- a/Core/Main/itkTransformixFilter.hxx
+++ b/Core/Main/itkTransformixFilter.hxx
@@ -244,11 +244,6 @@ TransformixFilter<TMovingImage>::GenerateData()
     transformParameterMap["MovingImageDimension"] = ParameterValueVectorType(1, std::to_string(movingImageDimension));
     transformParameterMap["ResultImagePixelType"] =
       ParameterValueVectorType(1, elx::PixelTypeToString<typename TMovingImage::PixelType>());
-
-    if (i > 0)
-    {
-      transformParameterMap["InitialTransformParametersFileName"] = ParameterValueVectorType(1, std::to_string(i - 1));
-    }
   }
 
   // Run transformix


### PR DESCRIPTION
Abandoned the hack that was introduced by commit f9a51b81bfb7d631b75c9ceba1c4638787f72158 (Coert Metz, @coertmetz, June 13, 2013), which said:

> Instead of a filename, the initial transform parameters are referenced to with an index and transform parameters of all registration steps are stored in a vector of configuration objects. It is still a kind of hack, but given the current elastix architecture at least a practical one.

Instead, simply assumed that the configurations are stored in the vector in the order of which they should be applied.   (Which was always the case anyway.)

Aims to make the meaning of "InitialTransformParametersFileName" straightforward and unambiguous, and make it easier for end-users to create a sequence of transformation parameter maps in memory, as input to the elastix or transformix library interface.  