### PR TITLE
BUG: Add "ShowProgressPercentage" checks to `SampleGradients` Optimizers

### DIFF
--- a/Components/Optimizers/AdaGrad/elxAdaGrad.hxx
+++ b/Components/Optimizers/AdaGrad/elxAdaGrad.hxx
@@ -779,10 +779,13 @@ AdaGrad<TElastix>::SampleGradients(const ParametersType & mu0, double perturbati
 
   } // end if NewSamplesEveryIteration.
 
+  const Configuration & configuration = Deref(Superclass2::GetConfiguration());
+
   /** Prepare for progress printing. */
-  const auto progressObserver = BaseComponent::IsElastixLibrary()
-                                  ? nullptr
-                                  : ProgressCommand::CreateAndSetUpdateFrequency(this->m_NumberOfGradientMeasurements);
+  const bool showProgressPercentage = configuration.RetrieveParameterValue(false, "ShowProgressPercentage", 0, false);
+  const auto progressObserver = showProgressPercentage
+                                  ? ProgressCommand::CreateAndSetUpdateFrequency(this->m_NumberOfGradientMeasurements)
+                                  : nullptr;
   log::info("  Sampling gradients ...");
 
   /** Initialize some variables for storing gradients and their magnitudes. */

--- a/Components/Optimizers/AdaptiveStochasticLBFGS/elxAdaptiveStochasticLBFGS.hxx
+++ b/Components/Optimizers/AdaptiveStochasticLBFGS/elxAdaptiveStochasticLBFGS.hxx
@@ -1328,10 +1328,13 @@ AdaptiveStochasticLBFGS<TElastix>::SampleGradients(const ParametersType & mu0,
     } // end for loop over metrics
   }   // end if NewSamplesEveryIteration.
 
+  const Configuration & configuration = Deref(Superclass2::GetConfiguration());
+
   /** Prepare for progress printing. */
-  const auto progressObserver = BaseComponent::IsElastixLibrary()
-                                  ? nullptr
-                                  : ProgressCommand::CreateAndSetUpdateFrequency(this->m_NumberOfGradientMeasurements);
+  const bool showProgressPercentage = configuration.RetrieveParameterValue(false, "ShowProgressPercentage", 0, false);
+  const auto progressObserver = showProgressPercentage
+                                  ? ProgressCommand::CreateAndSetUpdateFrequency(this->m_NumberOfGradientMeasurements)
+                                  : nullptr;
   // elxout << "  Sampling gradients ..." << std::endl;
 
   /** Initialize some variables for storing gradients and their magnitudes. */

--- a/Components/Optimizers/AdaptiveStochasticVarianceReducedGradient/elxAdaptiveStochasticVarianceReducedGradient.hxx
+++ b/Components/Optimizers/AdaptiveStochasticVarianceReducedGradient/elxAdaptiveStochasticVarianceReducedGradient.hxx
@@ -1123,9 +1123,10 @@ AdaptiveStochasticVarianceReducedGradient<TElastix>::SampleGradients(const Param
   }   // end if NewSamplesEveryIteration.
 
   /** Prepare for progress printing. */
-  const auto progressObserver = BaseComponent::IsElastixLibrary()
-                                  ? nullptr
-                                  : ProgressCommand::CreateAndSetUpdateFrequency(this->m_NumberOfGradientMeasurements);
+  const bool showProgressPercentage = configuration.RetrieveParameterValue(false, "ShowProgressPercentage", 0, false);
+  const auto progressObserver = showProgressPercentage
+                                  ? ProgressCommand::CreateAndSetUpdateFrequency(this->m_NumberOfGradientMeasurements)
+                                  : nullptr;
   log::info("  Sampling gradients ...");
 
   /** Initialize some variables for storing gradients and their magnitudes. */


### PR DESCRIPTION
Added the missing "ShowProgressPercentage" parameter checks to `SampleGradients` member functions of Components/Optimizers.

Follow-up to pull request https://github.com/SuperElastix/elastix/pull/832 commit 05d2b40f23d5b1c1438521e505e349bb54fdf7e4 "ENH: Support "ShowProgressPercentage" parameter (`false` by default)"