### PR TITLE
STYLE: Rename "Configurations" from Kernel to "TransformConfigurations"

### DIFF
--- a/Core/ComponentBaseClasses/elxTransformBase.hxx
+++ b/Core/ComponentBaseClasses/elxTransformBase.hxx
@@ -341,16 +341,16 @@ TransformBase<TElastix>::ReadFromFile()
   /** Call the function ReadInitialTransformFromFile. */
   if (fileName == "NoInitialTransform")
   {
-    const auto numberOfConfigurations = elastixBase.GetNumberOfConfigurations();
+    const auto numberOfConfigurations = elastixBase.GetNumberOfTransformConfigurations();
 
-    if ((numberOfConfigurations > 1) && (&configuration != elastixBase.GetConfiguration(0)))
+    if ((numberOfConfigurations > 1) && (&configuration != elastixBase.GetTransformConfiguration(0)))
     {
       for (size_t index{ 1 }; index < numberOfConfigurations; ++index)
       {
-        if (elastixBase.GetConfiguration(index) == &configuration)
+        if (elastixBase.GetTransformConfiguration(index) == &configuration)
         {
           // Use the previous configuration (at position index - 1) for the initial transform.
-          this->ReadInitialTransformFromConfiguration(elastixBase.GetConfiguration(index - 1));
+          this->ReadInitialTransformFromConfiguration(elastixBase.GetTransformConfiguration(index - 1));
           break;
         }
       }

--- a/Core/Kernel/elxElastixBase.cxx
+++ b/Core/Kernel/elxElastixBase.cxx
@@ -476,13 +476,13 @@ ElastixBase::GetTransformParametersMap() const
 
 
 /**
- * ************** SetConfigurations *********************
+ * ************** SetTransformConfigurations *********************
  */
 
 void
-ElastixBase::SetConfigurations(const std::vector<Configuration::ConstPointer> & configurations)
+ElastixBase::SetTransformConfigurations(const std::vector<Configuration::ConstPointer> & configurations)
 {
-  m_Configurations = configurations;
+  m_TransformConfigurations = configurations;
 }
 
 
@@ -491,20 +491,20 @@ ElastixBase::SetConfigurations(const std::vector<Configuration::ConstPointer> & 
  */
 
 Configuration::ConstPointer
-ElastixBase::GetConfiguration(const size_t index) const
+ElastixBase::GetTransformConfiguration(const size_t index) const
 {
-  return m_Configurations[index];
+  return m_TransformConfigurations[index];
 }
 
 
 /**
- * ************** GetNumberOfConfigurations *********************
+ * ************** GetNumberOfTransformConfigurations *********************
  */
 
 size_t
-ElastixBase::GetNumberOfConfigurations() const
+ElastixBase::GetNumberOfTransformConfigurations() const
 {
-  return m_Configurations.size();
+  return m_TransformConfigurations.size();
 }
 
 

--- a/Core/Kernel/elxElastixBase.h
+++ b/Core/Kernel/elxElastixBase.h
@@ -350,15 +350,15 @@ public:
 
   /** Set configuration vector. Library only. */
   void
-  SetConfigurations(const std::vector<Configuration::ConstPointer> & configurations);
+  SetTransformConfigurations(const std::vector<Configuration::ConstPointer> & configurations);
 
-  /** Return configuration from vector of configurations. Library only. */
+  /** Return configuration from vector of transformation configurations. Library only. */
   Configuration::ConstPointer
-  GetConfiguration(const size_t index) const;
+  GetTransformConfiguration(const size_t index) const;
 
-  /** Returns the number of configurations in the vector of configurations. */
+  /** Returns the number of configurations in the vector of transformation configurations. */
   size_t
-  GetNumberOfConfigurations() const;
+  GetNumberOfTransformConfigurations() const;
 
   IterationInfo &
   GetIterationInfo()
@@ -481,7 +481,7 @@ private:
   Configuration::Pointer m_Configuration{ nullptr };
 
   /** A vector of configuration objects, needed when transformix is used as library. */
-  std::vector<Configuration::ConstPointer> m_Configurations;
+  std::vector<Configuration::ConstPointer> m_TransformConfigurations;
 
   IterationInfo m_IterationInfo;
 

--- a/Core/Kernel/elxMainBase.cxx
+++ b/Core/Kernel/elxMainBase.cxx
@@ -132,8 +132,8 @@ MainBase::EnterCommandLineArgumentsWithTransformParameterMaps(
   const std::vector<ParameterMapType> & transformParameterMaps)
 {
   const auto numberOfTransformParameterMaps = transformParameterMaps.size();
-  m_Configurations.clear();
-  m_Configurations.resize(numberOfTransformParameterMaps);
+  m_TransformConfigurations.clear();
+  m_TransformConfigurations.resize(numberOfTransformParameterMaps);
 
   for (size_t i = 0; i < numberOfTransformParameterMaps; ++i)
   {
@@ -142,7 +142,7 @@ MainBase::EnterCommandLineArgumentsWithTransformParameterMaps(
      */
     const auto configuration = Configuration::New();
     int        dummy = configuration->Initialize(argmap, transformParameterMaps[i]);
-    m_Configurations[i] = configuration;
+    m_TransformConfigurations[i] = configuration;
     if (dummy)
     {
       log::error(std::ostringstream{} << "ERROR: Something went wrong during initialization of configuration object "

--- a/Core/Kernel/elxMainBase.h
+++ b/Core/Kernel/elxMainBase.h
@@ -189,7 +189,7 @@ protected:
   ObjectPointer m_Elastix{ nullptr };
 
   /** A vector of configuration objects, needed when transformix is used as library. */
-  std::vector<Configuration::ConstPointer> m_Configurations{};
+  std::vector<Configuration::ConstPointer> m_TransformConfigurations{};
 
   /** Description of the ImageTypes. */
   PixelTypeDescriptionType m_FixedImagePixelType{};

--- a/Core/Kernel/elxTransformixMain.cxx
+++ b/Core/Kernel/elxTransformixMain.cxx
@@ -115,7 +115,7 @@ TransformixMain::RunWithTransform(itk::TransformBase * const transform)
 
   /** Set some information in the ElastixBase. */
   elastixBase.SetConfiguration(MainBase::GetConfiguration());
-  elastixBase.SetConfigurations(this->m_Configurations);
+  elastixBase.SetTransformConfigurations(this->m_TransformConfigurations);
   elastixBase.SetDBIndex(this->m_DBIndex);
 
   /** Populate the component containers. No default is specified for the Transform. */


### PR DESCRIPTION
Renamed ElastixBase and MainBase member variables `m_Configurations` to `m_TransformConfigurations`. Also renamed ElastixBase member function `GetConfiguration(size_t)`  to `GetTransformConfiguration(size_t)`.

Aims to clarify that these particular configurations represent transformations (rather than arbitrary sets of registration parameters).