### PR TITLE
ENH: Add GetParameterMaps and SetParameterMaps to ParameterObject

### DIFF
--- a/Core/Main/elxParameterObject.cxx
+++ b/Core/Main/elxParameterObject.cxx
@@ -66,6 +66,21 @@ ParameterObject::SetParameterMap(const ParameterMapVectorType & parameterMaps)
 
 
 /**
+ * ********************* SetParameterMaps *********************
+ */
+
+void
+ParameterObject::SetParameterMaps(const ParameterMapVectorType & parameterMaps)
+{
+  if (m_ParameterMaps != parameterMaps)
+  {
+    m_ParameterMaps = parameterMaps;
+    this->Modified();
+  }
+}
+
+
+/**
  * ********************* AddParameterMap *********************
  */
 

--- a/Core/Main/elxParameterObject.h
+++ b/Core/Main/elxParameterObject.h
@@ -60,12 +60,20 @@ public:
   void
   SetParameterMap(const ParameterMapVectorType & parameterMaps);
   void
+  SetParameterMaps(const ParameterMapVectorType & parameterMaps);
+  void
   AddParameterMap(const ParameterMapType & parameterMap);
   const ParameterMapType &
   GetParameterMap(const unsigned int index) const;
 
   const ParameterMapVectorType &
   GetParameterMap() const
+  {
+    return m_ParameterMaps;
+  }
+
+  const ParameterMapVectorType &
+  GetParameterMaps() const
   {
     return m_ParameterMaps;
   }


### PR DESCRIPTION
Equivalent to `GetParameterMaps()` and `SetParameterMap(const ParameterMapVectorType &)`.

It appears more readable in these cases, to use the plural form "maps", rather than "map". Moreover, `SetParameterMaps` may be easier to use because it is not overloading.