### PR TITLE
BUG: Only use InitialTransformParameterObject during first registration

### DIFF
--- a/Core/Main/itkElastixRegistrationMethod.hxx
+++ b/Core/Main/itkElastixRegistrationMethod.hxx
@@ -232,7 +232,7 @@ ElastixRegistrationMethod<TFixedImage, TMovingImage>::GenerateData()
     unsigned int isError = 0;
     try
     {
-      isError = m_InitialTransformParameterObject
+      isError = ((i == 0) && m_InitialTransformParameterObject)
                   ? elastixMain->RunWithInitialTransformParameterMaps(
                       argumentMap, parameterMap, m_InitialTransformParameterObject->GetParameterMap())
                   : elastixMain->Run(argumentMap, parameterMap);


### PR DESCRIPTION
When `ElastixRegistrationMethod::GenerateData()` does a sequence of multiple registrations, only the first one should use the parameter maps from the InitialTransformParameterObject. _Right?_  😃 

Follow-up to pull request https://github.com/SuperElastix/elastix/pull/856 commit 48c64583c8514eac7fa9ad46848be9d100ac80c9 "Add `SetInitialTransformParameterObject` to `ElastixRegistrationMethod`"