### PR TITLE
Set NumberOfResolutions = 3 by default, throw exception if NumberOfResolutions is 0

### DIFF
--- a/Components/Registrations/MultiMetricMultiResolutionRegistration/elxMultiMetricMultiResolutionRegistration.hxx
+++ b/Components/Registrations/MultiMetricMultiResolutionRegistration/elxMultiMetricMultiResolutionRegistration.hxx
@@ -49,6 +49,11 @@ MultiMetricMultiResolutionRegistration<TElastix>::BeforeRegistration()
   /** Set the number of resolutions.*/
   unsigned int numberOfResolutions = 3;
   this->m_Configuration->ReadParameter(numberOfResolutions, "NumberOfResolutions", 0);
+  if (numberOfResolutions == 0)
+  {
+    itkExceptionMacro("The NumberOfResolutions parameter must have a non-zero value!");
+  }
+
   this->SetNumberOfLevels(numberOfResolutions);
 
   /** Set the FixedImageRegions to the buffered regions. */

--- a/Components/Registrations/MultiResolutionRegistration/elxMultiResolutionRegistration.hxx
+++ b/Components/Registrations/MultiResolutionRegistration/elxMultiResolutionRegistration.hxx
@@ -54,6 +54,11 @@ MultiResolutionRegistration<TElastix>::BeforeRegistration()
   /** Set the number of resolutions. */
   unsigned int numberOfResolutions = 3;
   this->m_Configuration->ReadParameter(numberOfResolutions, "NumberOfResolutions", 0);
+  if (numberOfResolutions == 0)
+  {
+    itkExceptionMacro("The NumberOfResolutions parameter must have a non-zero value!");
+  }
+
   this->SetNumberOfLevels(numberOfResolutions);
 
   /** Set the FixedImageRegion. */

--- a/Components/Registrations/MultiResolutionRegistrationWithFeatures/elxMultiResolutionRegistrationWithFeatures.hxx
+++ b/Components/Registrations/MultiResolutionRegistrationWithFeatures/elxMultiResolutionRegistrationWithFeatures.hxx
@@ -38,6 +38,10 @@ MultiResolutionRegistrationWithFeatures<TElastix>::BeforeRegistration()
   /** Set the number of resolutions. */
   unsigned int numberOfResolutions = 3;
   this->m_Configuration->ReadParameter(numberOfResolutions, "NumberOfResolutions", 0);
+  if (numberOfResolutions == 0)
+  {
+    itkExceptionMacro("The NumberOfResolutions parameter must have a non-zero value!");
+  }
   this->SetNumberOfLevels(numberOfResolutions);
 
   /** Set the FixedImageRegions to the buffered regions. */

--- a/Components/elxGenericPyramidHelper.h
+++ b/Components/elxGenericPyramidHelper.h
@@ -65,7 +65,7 @@ public:
     configuration.ReadParameter(numberOfResolutions, "NumberOfResolutions", 0, true);
     if (numberOfResolutions == 0)
     {
-      numberOfResolutions = 1;
+      itkGenericExceptionMacro("The NumberOfResolutions parameter must have a non-zero value!");
     }
 
     /** Create a default schedule. Set the numberOfLevels first. */

--- a/Core/ComponentBaseClasses/elxFixedImagePyramidBase.hxx
+++ b/Core/ComponentBaseClasses/elxFixedImagePyramidBase.hxx
@@ -103,7 +103,7 @@ FixedImagePyramidBase<TElastix>::SetFixedSchedule()
   configuration.ReadParameter(numberOfResolutions, "NumberOfResolutions", 0, true);
   if (numberOfResolutions == 0)
   {
-    numberOfResolutions = 1;
+    itkExceptionMacro("The NumberOfResolutions parameter must have a non-zero value!");
   }
 
   /** Create a default schedule. Set the numberOfLevels first. */

--- a/Core/ComponentBaseClasses/elxMovingImagePyramidBase.hxx
+++ b/Core/ComponentBaseClasses/elxMovingImagePyramidBase.hxx
@@ -100,7 +100,7 @@ MovingImagePyramidBase<TElastix>::SetMovingSchedule()
   const Configuration & configuration = Deref(Superclass::GetConfiguration());
 
   /** Read numberOfResolutions. */
-  unsigned int numberOfResolutions = 0;
+  unsigned int numberOfResolutions = 3;
   configuration.ReadParameter(numberOfResolutions, "NumberOfResolutions", 0, true);
   if (numberOfResolutions == 0)
   {

--- a/Core/ComponentBaseClasses/elxMovingImagePyramidBase.hxx
+++ b/Core/ComponentBaseClasses/elxMovingImagePyramidBase.hxx
@@ -104,9 +104,8 @@ MovingImagePyramidBase<TElastix>::SetMovingSchedule()
   configuration.ReadParameter(numberOfResolutions, "NumberOfResolutions", 0, true);
   if (numberOfResolutions == 0)
   {
-    log::error("ERROR: NumberOfResolutions not specified!");
+    itkExceptionMacro("The NumberOfResolutions parameter must have a non-zero value!");
   }
-  /** \todo quit program? Actually this check should be in the ::BeforeAll() method. */
 
   /** Create a default schedule. Set the numberOfLevels first. */
   this->GetAsITKBaseType()->SetNumberOfLevels(numberOfResolutions);


### PR DESCRIPTION
Following commit f84ac0d1094ebdb13e456b1b8cf1f6f9bfcd0a38 "ENH: First checkin of a generic pyramid...", February 2, 2012.

Addressed issue https://github.com/SuperElastix/elastix/issues/858 MovingImagePyramidBase, FixedImagePyramidBase have different defaults for "NumberOfResolutions"