### PR TITLE
Test SetInitialTransformParameterObject  on a registration object of multiple parameter maps

### DIFF
--- a/Core/Main/GTesting/itkElastixRegistrationMethodGTest.cxx
+++ b/Core/Main/GTesting/itkElastixRegistrationMethodGTest.cxx
@@ -70,6 +70,14 @@ using DefaultConstructibleElastixRegistrationMethod =
 
 namespace
 {
+template <unsigned int VDimension>
+auto
+ConvertIndexToOffset(const itk::Index<VDimension> & index)
+{
+  return index - itk::Index<VDimension>{};
+};
+
+
 template <unsigned NDimension, unsigned NSplineOrder>
 void
 Test_WriteBSplineTransformToItkFileFormat(const std::string & rootOutputDirectoryPath)
@@ -561,13 +569,11 @@ GTEST_TEST(itkElastixRegistrationMethod, InitialTransformParameterFile)
                                                           { "Optimizer", "AdaptiveStochasticGradientDescent" },
                                                           { "Transform", "TranslationTransform" } }));
 
-  const auto toOffset = [](const IndexType & index) { return index - IndexType(); };
-
   for (const auto index :
        itk::ImageRegionIndexRange<ImageDimension>(itk::ImageRegion<ImageDimension>({ 0, -2 }, { 2, 3 })))
   {
     movingImage->FillBuffer(0);
-    FillImageRegion(*movingImage, fixedImageRegionIndex + toOffset(index), regionSize);
+    FillImageRegion(*movingImage, fixedImageRegionIndex + ConvertIndexToOffset(index), regionSize);
     registration.SetMovingImage(movingImage);
     registration.Update();
 
@@ -614,8 +620,6 @@ GTEST_TEST(itkElastixRegistrationMethod, SetInitialTransformParameterObject)
                                                           { "Optimizer", "AdaptiveStochasticGradientDescent" },
                                                           { "Transform", "TranslationTransform" } }));
 
-  const auto toOffset = [](const IndexType & index) { return index - IndexType(); };
-
   using ParameterMapVectorType = elx::ParameterObject::ParameterMapVectorType;
 
   // Test both one and two transform parameter maps.
@@ -635,7 +639,7 @@ GTEST_TEST(itkElastixRegistrationMethod, SetInitialTransformParameterObject)
          itk::ImageRegionIndexRange<ImageDimension>(itk::ImageRegion<ImageDimension>({ 0, -2 }, { 2, 3 })))
     {
       movingImage->FillBuffer(0);
-      FillImageRegion(*movingImage, fixedImageRegionIndex + toOffset(index), regionSize);
+      FillImageRegion(*movingImage, fixedImageRegionIndex + ConvertIndexToOffset(index), regionSize);
       registration.SetMovingImage(movingImage);
       registration.Update();
 
@@ -672,8 +676,6 @@ GTEST_TEST(itkElastixRegistrationMethod, InitialTransformParameterFileLinkToTran
 
   const auto movingImage = CreateImage<PixelType>(imageSize);
 
-  const auto toOffset = [](const IndexType & index) { return index - IndexType(); };
-
   const auto createRegistration = [fixedImage](const std::string & initialTransformParameterFileName) {
     const auto registration = CheckNew<RegistrationMethodType>();
     registration->SetFixedImage(fixedImage);
@@ -701,7 +703,7 @@ GTEST_TEST(itkElastixRegistrationMethod, InitialTransformParameterFileLinkToTran
          itk::ImageRegionIndexRange<ImageDimension>(itk::ImageRegion<ImageDimension>({ 0, -2 }, { 2, 3 })))
     {
       movingImage->FillBuffer(0);
-      FillImageRegion(*movingImage, fixedImageRegionIndex + toOffset(index), regionSize);
+      FillImageRegion(*movingImage, fixedImageRegionIndex + ConvertIndexToOffset(index), regionSize);
 
       const auto updateAndRetrieveTransformParameterMap = [movingImage](RegistrationMethodType & registration) {
         registration.SetMovingImage(movingImage);

--- a/Core/Main/GTesting/itkElastixRegistrationMethodGTest.cxx
+++ b/Core/Main/GTesting/itkElastixRegistrationMethodGTest.cxx
@@ -572,18 +572,14 @@ GTEST_TEST(itkElastixRegistrationMethod, InitialTransformParameterFile)
   for (const auto index :
        itk::ImageRegionIndexRange<ImageDimension>(itk::ImageRegion<ImageDimension>({ 0, -2 }, { 2, 3 })))
   {
+    const auto actualTranslation = ConvertIndexToOffset(index);
     movingImage->FillBuffer(0);
-    FillImageRegion(*movingImage, fixedImageRegionIndex + ConvertIndexToOffset(index), regionSize);
+    FillImageRegion(*movingImage, fixedImageRegionIndex + actualTranslation, regionSize);
     registration.SetMovingImage(movingImage);
     registration.Update();
 
     const auto transformParameters = GetTransformParametersFromFilter(registration);
-    ASSERT_EQ(transformParameters.size(), ImageDimension);
-
-    for (unsigned i{}; i < ImageDimension; ++i)
-    {
-      EXPECT_EQ(std::round(transformParameters[i]), index[i] - initialTranslation[i]);
-    }
+    EXPECT_EQ(initialTranslation + ConvertToOffset<ImageDimension>(transformParameters), actualTranslation);
   }
 }
 
@@ -638,18 +634,14 @@ GTEST_TEST(itkElastixRegistrationMethod, SetInitialTransformParameterObject)
     for (const auto index :
          itk::ImageRegionIndexRange<ImageDimension>(itk::ImageRegion<ImageDimension>({ 0, -2 }, { 2, 3 })))
     {
+      const auto actualTranslation = ConvertIndexToOffset(index);
       movingImage->FillBuffer(0);
-      FillImageRegion(*movingImage, fixedImageRegionIndex + ConvertIndexToOffset(index), regionSize);
+      FillImageRegion(*movingImage, fixedImageRegionIndex + actualTranslation, regionSize);
       registration.SetMovingImage(movingImage);
       registration.Update();
 
       const auto transformParameters = GetTransformParametersFromFilter(registration);
-      ASSERT_EQ(transformParameters.size(), ImageDimension);
-
-      for (unsigned i{}; i < ImageDimension; ++i)
-      {
-        EXPECT_EQ(std::round(transformParameters[i]), index[i] - initialTranslation[i]);
-      }
+      EXPECT_EQ(initialTranslation + ConvertToOffset<ImageDimension>(transformParameters), actualTranslation);
     }
   }
 }

--- a/Core/Main/GTesting/itkElastixRegistrationMethodGTest.cxx
+++ b/Core/Main/GTesting/itkElastixRegistrationMethodGTest.cxx
@@ -65,9 +65,8 @@ using elx::CoreMainGTestUtilities::GetNameOfTest;
 using elx::CoreMainGTestUtilities::GetTransformParametersFromFilter;
 
 
-template <typename TFixedImage, typename TMovingImage>
-using DefaultConstructibleElastixRegistrationMethod =
-  elx::DefaultConstruct<itk::ElastixRegistrationMethod<TFixedImage, TMovingImage>>;
+template <typename TImage>
+using ElastixRegistrationMethodType = itk::ElastixRegistrationMethod<TImage, TImage>;
 
 namespace
 {
@@ -98,7 +97,7 @@ Test_WriteBSplineTransformToItkFileFormat(const std::string & rootOutputDirector
   constexpr auto expectedNumberOfFixedParameters = NDimension * (NDimension + 3);
   ASSERT_EQ(defaultFixedParameters.size(), expectedNumberOfFixedParameters);
 
-  DefaultConstructibleElastixRegistrationMethod<ImageType, ImageType> registration;
+  elx::DefaultConstruct<ElastixRegistrationMethodType<ImageType>> registration{};
 
   registration.SetFixedImage(image);
   registration.SetMovingImage(image);
@@ -170,7 +169,7 @@ static_assert(static_cast<int>(itk::ElastixLogLevel::Info) == static_cast<int>(e
 GTEST_TEST(itkElastixRegistrationMethod, LogLevel)
 {
   using ImageType = itk::Image<float>;
-  elx::DefaultConstruct<itk::ElastixRegistrationMethod<ImageType, ImageType>> elastixRegistrationMethod;
+  elx::DefaultConstruct<ElastixRegistrationMethodType<ImageType>> elastixRegistrationMethod;
 
   ASSERT_EQ(elastixRegistrationMethod.GetLogLevel(), itk::ElastixLogLevel{});
 
@@ -191,7 +190,7 @@ GTEST_TEST(itkElastixRegistrationMethod, IsDefaultInitialized)
   using PixelType = float;
   using ImageType = itk::Image<PixelType, ImageDimension>;
 
-  const elx::DefaultConstruct<itk::ElastixRegistrationMethod<ImageType, ImageType>> elastixRegistrationMethod;
+  const elx::DefaultConstruct<ElastixRegistrationMethodType<ImageType>> elastixRegistrationMethod;
 
   EXPECT_EQ(elastixRegistrationMethod.GetInitialTransformParameterFileName(), std::string{});
   EXPECT_EQ(elastixRegistrationMethod.GetFixedPointSetFileName(), std::string{});
@@ -224,7 +223,7 @@ GTEST_TEST(itkElastixRegistrationMethod, Translation)
   const auto movingImage = CreateImage<PixelType>(imageSize);
   FillImageRegion(*movingImage, fixedImageRegionIndex + translationOffset, regionSize);
 
-  DefaultConstructibleElastixRegistrationMethod<ImageType, ImageType> registration;
+  elx::DefaultConstruct<ElastixRegistrationMethodType<ImageType>> registration{};
 
   registration.SetFixedImage(fixedImage);
   registration.SetMovingImage(movingImage);
@@ -264,7 +263,7 @@ GTEST_TEST(itkElastixRegistrationMethod, MaximumNumberOfIterationsZero)
   for (const auto optimizer :
        { "AdaptiveStochasticGradientDescent", "FiniteDifferenceGradientDescent", "StandardGradientDescent" })
   {
-    DefaultConstructibleElastixRegistrationMethod<ImageType, ImageType> registration;
+    elx::DefaultConstruct<ElastixRegistrationMethodType<ImageType>> registration{};
 
     registration.SetFixedImage(fixedImage);
     registration.SetMovingImage(movingImage);
@@ -308,7 +307,7 @@ GTEST_TEST(itkElastixRegistrationMethod, AutomaticTransformInitializationCenterO
 
   for (const bool automaticTransformInitialization : { false, true })
   {
-    DefaultConstructibleElastixRegistrationMethod<ImageType, ImageType> registration;
+    elx::DefaultConstruct<ElastixRegistrationMethodType<ImageType>> registration{};
 
     registration.SetFixedImage(fixedImage);
     registration.SetMovingImage(movingImage);
@@ -352,7 +351,7 @@ GTEST_TEST(itkElastixRegistrationMethod, WriteResultImage)
 
   for (const bool writeResultImage : { true, false })
   {
-    DefaultConstructibleElastixRegistrationMethod<ImageType, ImageType> registration;
+    elx::DefaultConstruct<ElastixRegistrationMethodType<ImageType>> registration{};
 
     registration.SetFixedImage(fixedImage);
     registration.SetMovingImage(movingImage);
@@ -427,7 +426,7 @@ GTEST_TEST(itkElastixRegistrationMethod, ResultImageName)
 
   for (const bool useCustomResultImageName : { true, false })
   {
-    DefaultConstructibleElastixRegistrationMethod<ImageType, ImageType> registration;
+    elx::DefaultConstruct<ElastixRegistrationMethodType<ImageType>> registration{};
 
     const std::string outputSubdirectoryPath = getOutputSubdirectoryPath(useCustomResultImageName);
     itk::FileTools::CreateDirectory(outputSubdirectoryPath);
@@ -498,7 +497,7 @@ GTEST_TEST(itkElastixRegistrationMethod, OutputHasSameOriginAsFixedImage)
     {
       movingImage->SetOrigin(movingImageOrigin);
 
-      DefaultConstructibleElastixRegistrationMethod<ImageType, ImageType> registration;
+      elx::DefaultConstruct<ElastixRegistrationMethodType<ImageType>> registration{};
 
       registration.SetFixedImage(fixedImage);
       registration.SetMovingImage(movingImage);
@@ -557,7 +556,7 @@ GTEST_TEST(itkElastixRegistrationMethod, InitialTransformParameterFile)
 
   const auto movingImage = CreateImage<PixelType>(imageSize);
 
-  DefaultConstructibleElastixRegistrationMethod<ImageType, ImageType> registration;
+  elx::DefaultConstruct<ElastixRegistrationMethodType<ImageType>> registration{};
 
   registration.SetFixedImage(fixedImage);
   registration.SetInitialTransformParameterFileName(GetDataDirectoryPath() +
@@ -604,9 +603,9 @@ GTEST_TEST(itkElastixRegistrationMethod, SetInitialTransformParameterObject)
 
   const auto movingImage = CreateImage<PixelType>(imageSize);
 
-  elx::DefaultConstruct<elx::ParameterObject>                         parameterObject{};
-  elx::DefaultConstruct<elx::ParameterObject>                         transformParameterObject{};
-  DefaultConstructibleElastixRegistrationMethod<ImageType, ImageType> registration;
+  elx::DefaultConstruct<elx::ParameterObject>                     parameterObject{};
+  elx::DefaultConstruct<elx::ParameterObject>                     transformParameterObject{};
+  elx::DefaultConstruct<ElastixRegistrationMethodType<ImageType>> registration{};
   registration.SetFixedImage(fixedImage);
   registration.SetInitialTransformParameterObject(&transformParameterObject);
   registration.SetParameterObject(&parameterObject);
@@ -678,7 +677,7 @@ GTEST_TEST(itkElastixRegistrationMethod, InitialTransformParameterFileLinkToTran
   using IndexType = itk::Index<ImageDimension>;
   using OffsetType = itk::Offset<ImageDimension>;
 
-  using RegistrationMethodType = itk::ElastixRegistrationMethod<ImageType, ImageType>;
+  using RegistrationMethodType = ElastixRegistrationMethodType<ImageType>;
 
   const OffsetType initialTranslation{ { 1, -2 } };
   const auto       regionSize = SizeType::Filled(2);
@@ -765,7 +764,7 @@ GTEST_TEST(itkElastixRegistrationMethod, GetCombinationTransform)
     itk::Transform<double, ImageDimension, ImageDimension>::Pointer itkTransform;
   };
 
-  DefaultConstructibleElastixRegistrationMethod<ImageType, ImageType> registration;
+  elx::DefaultConstruct<ElastixRegistrationMethodType<ImageType>> registration{};
   registration.SetFixedImage(image);
   registration.SetMovingImage(image);
 
@@ -817,7 +816,7 @@ GTEST_TEST(itkElastixRegistrationMethod, GetNumberOfTransforms)
   const auto image =
     CreateImageFilledWithSequenceOfNaturalNumbers<ImageType::PixelType>(itk::Size<ImageDimension>{ 5, 6 });
 
-  DefaultConstructibleElastixRegistrationMethod<ImageType, ImageType> registration;
+  elx::DefaultConstruct<ElastixRegistrationMethodType<ImageType>> registration{};
 
   registration.SetFixedImage(image);
   registration.SetMovingImage(image);
@@ -847,7 +846,7 @@ GTEST_TEST(itkElastixRegistrationMethod, GetNthTransform)
   const auto image =
     CreateImageFilledWithSequenceOfNaturalNumbers<ImageType::PixelType>(itk::Size<ImageDimension>{ 5, 6 });
 
-  DefaultConstructibleElastixRegistrationMethod<ImageType, ImageType> registration;
+  elx::DefaultConstruct<ElastixRegistrationMethodType<ImageType>> registration{};
 
   registration.SetFixedImage(image);
   registration.SetMovingImage(image);
@@ -884,7 +883,7 @@ GTEST_TEST(itkElastixRegistrationMethod, ConvertToItkTransform)
   const auto image =
     CreateImageFilledWithSequenceOfNaturalNumbers<ImageType::PixelType>(itk::Size<ImageDimension>{ 5, 6 });
 
-  DefaultConstructibleElastixRegistrationMethod<ImageType, ImageType> registration;
+  elx::DefaultConstruct<ElastixRegistrationMethodType<ImageType>> registration{};
 
   registration.SetFixedImage(image);
   registration.SetMovingImage(image);
@@ -909,7 +908,7 @@ GTEST_TEST(itkElastixRegistrationMethod, ConvertToItkTransform)
     for (unsigned int n{ 0 }; n < numberOfTransforms; ++n)
     {
       // TODO Check result
-      itk::ElastixRegistrationMethod<ImageType, ImageType>::ConvertToItkTransform(*registration.GetNthTransform(n));
+      ElastixRegistrationMethodType<ImageType>::ConvertToItkTransform(*registration.GetNthTransform(n));
     }
   }
 }
@@ -927,7 +926,7 @@ GTEST_TEST(itkElastixRegistrationMethod, WriteCompositeTransform)
     itk::Transform<double, ImageDimension, ImageDimension>::Pointer itkTransform;
   };
 
-  DefaultConstructibleElastixRegistrationMethod<ImageType, ImageType> registration;
+  elx::DefaultConstruct<ElastixRegistrationMethodType<ImageType>> registration{};
   registration.SetFixedImage(image);
   registration.SetMovingImage(image);
 
@@ -1057,7 +1056,7 @@ GTEST_TEST(itkElastixRegistrationMethod, EulerTranslation2D)
   const auto fixedImage = CreateImage<PixelType>(imageSize);
   setPixelsOfSquareRegion(*fixedImage, fixedImageRegionIndex);
 
-  DefaultConstructibleElastixRegistrationMethod<ImageType, ImageType> registration;
+  elx::DefaultConstruct<ElastixRegistrationMethodType<ImageType>> registration{};
   registration.SetFixedImage(fixedImage);
   registration.SetParameterObject(CreateParameterObject({ // Parameters in alphabetic order:
                                                           { "AutomaticTransformInitialization", "false" },
@@ -1141,7 +1140,7 @@ GTEST_TEST(itkElastixRegistrationMethod, EulerDiscRotation2D)
 
   const auto movingImage = CreateImage<PixelType>(imageSize);
 
-  DefaultConstructibleElastixRegistrationMethod<ImageType, ImageType> registration;
+  elx::DefaultConstruct<ElastixRegistrationMethodType<ImageType>> registration{};
 
   registration.SetFixedImage(fixedImage);
   registration.SetParameterObject(CreateParameterObject({ // Parameters in alphabetic order:


### PR DESCRIPTION
Triggered by 
- https://github.com/SuperElastix/elastix/pull/857

Also did some code cleanup of the GoogleTest of `itk::ElastixRegistrationMethodGTest`.