### PR TITLE
Deprecate ParameterObject member functions Get/SetParameterMap in favor of Get/SetParameterMaps

### DIFF
--- a/Core/Main/GTesting/elxCoreMainGTestUtilities.h
+++ b/Core/Main/GTesting/elxCoreMainGTestUtilities.h
@@ -255,7 +255,7 @@ std::vector<double>
 GetTransformParametersFromFilter(TFilter & filter)
 {
   const auto   transformParameterObject = filter.GetTransformParameterObject();
-  const auto & transformParameterMaps = DerefRawPointer(transformParameterObject).GetParameterMap();
+  const auto & transformParameterMaps = DerefRawPointer(transformParameterObject).GetParameterMaps();
   return GetTransformParametersFromMaps(transformParameterMaps);
 }
 

--- a/Core/Main/GTesting/itkElastixRegistrationMethodGTest.cxx
+++ b/Core/Main/GTesting/itkElastixRegistrationMethodGTest.cxx
@@ -691,7 +691,7 @@ GTEST_TEST(itkElastixRegistrationMethod, SetInitialTransformParameterObject)
         registration.Update();
 
         const auto & transformParameterMaps =
-          DerefRawPointer(registration.GetTransformParameterObject()).GetParameterMap();
+          DerefRawPointer(registration.GetTransformParameterObject()).GetParameterMaps();
 
         ASSERT_EQ(transformParameterMaps.size(), numberOfParameterMaps);
 
@@ -766,7 +766,7 @@ GTEST_TEST(itkElastixRegistrationMethod, InitialTransformParameterFileLinkToTran
         registration.Update();
         const elx::ParameterObject & transformParameterObject =
           DerefRawPointer(registration.GetTransformParameterObject());
-        const auto & transformParameterMaps = transformParameterObject.GetParameterMap();
+        const auto & transformParameterMaps = transformParameterObject.GetParameterMaps();
         EXPECT_EQ(transformParameterMaps.size(), 1);
         return Front(transformParameterMaps);
       };

--- a/Core/Main/GTesting/itkTransformixFilterGTest.cxx
+++ b/Core/Main/GTesting/itkTransformixFilterGTest.cxx
@@ -1130,7 +1130,7 @@ GTEST_TEST(itkTransformixFilter, UpdateThrowsExceptionOnZeroParameterMaps)
                                      { "Size", ConvertToParameterValues(imageSize) },
                                      { "Spacing", ParameterValuesType(ImageDimension, "1") } } };
 
-    transformParameterObject.SetParameterMap(parameterMaps);
+    transformParameterObject.SetParameterMaps(parameterMaps);
 
     elx::DefaultConstruct<itk::TransformixFilter<ImageType>> transformixFilter{};
     transformixFilter.SetMovingImage(&image);
@@ -1227,7 +1227,7 @@ GTEST_TEST(itkTransformixFilter, SetCompositeTransformOfTranslationAndScale)
   for (size_t numberOfParameterMaps{ 1 }; numberOfParameterMaps <= 3; ++numberOfParameterMaps)
   {
     elx::DefaultConstruct<elx::ParameterObject> transformParameterObject{};
-    transformParameterObject.SetParameterMap(ParameterMapVectorType(numberOfParameterMaps, transformParameterMap));
+    transformParameterObject.SetParameterMaps(ParameterMapVectorType(numberOfParameterMaps, transformParameterMap));
 
     elx::DefaultConstruct<itk::TransformixFilter<ImageType>> transformixFilter{};
     transformixFilter.SetMovingImage(inputImage);

--- a/Core/Main/elxParameterObject.cxx
+++ b/Core/Main/elxParameterObject.cxx
@@ -36,7 +36,7 @@ void
 ParameterObject::SetParameterMap(const ParameterMapType & parameterMap)
 {
   ParameterMapVectorType parameterMapVector = ParameterMapVectorType(1, parameterMap);
-  this->SetParameterMap(parameterMapVector);
+  this->SetParameterMaps(parameterMapVector);
 }
 
 /**
@@ -198,7 +198,7 @@ ParameterObject::RemoveParameter(const ParameterKeyType & key)
 void
 ParameterObject::ReadParameterFile(const ParameterFileNameType & parameterFileName)
 {
-  this->SetParameterMap(ParameterMapVectorType{ itk::ParameterFileParser::ReadParameterMap(parameterFileName) });
+  this->SetParameterMaps({ itk::ParameterFileParser::ReadParameterMap(parameterFileName) });
 }
 
 

--- a/Core/Main/elxParameterObject.h
+++ b/Core/Main/elxParameterObject.h
@@ -57,16 +57,19 @@ public:
   SetParameterMap(const ParameterMapType & parameterMap);
   void
   SetParameterMap(const unsigned int index, const ParameterMapType & parameterMap);
-  void
+
+  [[deprecated("Instead of calling this overload, please call SetParameterMaps")]] void
   SetParameterMap(const ParameterMapVectorType & parameterMaps);
+
   void
   SetParameterMaps(const ParameterMapVectorType & parameterMaps);
+
   void
   AddParameterMap(const ParameterMapType & parameterMap);
   const ParameterMapType &
   GetParameterMap(const unsigned int index) const;
 
-  const ParameterMapVectorType &
+  [[deprecated("Instead of calling this member function, please call GetParameterMaps")]] const ParameterMapVectorType &
   GetParameterMap() const
   {
     return m_ParameterMaps;

--- a/Core/Main/itkElastixRegistrationMethod.hxx
+++ b/Core/Main/itkElastixRegistrationMethod.hxx
@@ -131,7 +131,7 @@ ElastixRegistrationMethod<TFixedImage, TMovingImage>::GenerateData()
   // Set ParameterMap
   ParameterObjectPointer parameterObject =
     itkDynamicCastInDebugMode<elx::ParameterObject *>(this->ProcessObject::GetInput("ParameterObject"));
-  ParameterMapVectorType parameterMapVector = parameterObject->GetParameterMap();
+  ParameterMapVectorType parameterMapVector = parameterObject->GetParameterMaps();
 
   if (parameterMapVector.empty())
   {
@@ -234,7 +234,7 @@ ElastixRegistrationMethod<TFixedImage, TMovingImage>::GenerateData()
     {
       isError = ((i == 0) && m_InitialTransformParameterObject)
                   ? elastixMain->RunWithInitialTransformParameterMaps(
-                      argumentMap, parameterMap, m_InitialTransformParameterObject->GetParameterMap())
+                      argumentMap, parameterMap, m_InitialTransformParameterObject->GetParameterMaps())
                   : elastixMain->Run(argumentMap, parameterMap);
     }
     catch (const itk::ExceptionObject & e)
@@ -285,7 +285,7 @@ ElastixRegistrationMethod<TFixedImage, TMovingImage>::GenerateData()
 
   // Save parameter map
   elx::ParameterObject::Pointer transformParameterObject = elx::ParameterObject::New();
-  transformParameterObject->SetParameterMap(transformParameterMapVector);
+  transformParameterObject->SetParameterMaps(transformParameterMapVector);
   this->SetNthOutput(1, transformParameterObject);
 }
 

--- a/Core/Main/itkTransformixFilter.hxx
+++ b/Core/Main/itkTransformixFilter.hxx
@@ -160,7 +160,7 @@ TransformixFilter<TMovingImage>::GenerateData()
 
   // Get ParameterMap
   ParameterObjectPointer transformParameterObject = this->GetTransformParameterObject();
-  ParameterMapVectorType transformParameterMapVector = transformParameterObject->GetParameterMap();
+  ParameterMapVectorType transformParameterMapVector = transformParameterObject->GetParameterMaps();
 
   // Assert user did not set empty parameter map
   if (transformParameterMapVector.empty())

--- a/dox/externalproject/ElastixTranslationExample.cxx
+++ b/dox/externalproject/ElastixTranslationExample.cxx
@@ -91,7 +91,7 @@ main()
     const auto * const transformParameterObject = filter->GetTransformParameterObject();
     assert(transformParameterObject != nullptr);
 
-    const auto & transformParameterMaps = transformParameterObject->GetParameterMap();
+    const auto & transformParameterMaps = transformParameterObject->GetParameterMaps();
     assert(!transformParameterMaps.empty());
 
     const auto & transformParameterMap = transformParameterMaps.front();


### PR DESCRIPTION
For your information @kaspermarstal  😃 