### PR TITLE
ENH: Upgrade elastix from C++14 to C++17

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -2,7 +2,7 @@
 cmake_minimum_required(VERSION 3.16.3)
 
 project(elastix)
-set(CMAKE_CXX_STANDARD 14)
+set(CMAKE_CXX_STANDARD 17)
 
 if(BUILD_SHARED_LIBS)
   message(FATAL_ERROR "Elastix does not support BUILD_SHARED_LIBS")

--- a/dox/externalproject/CMakeLists.txt
+++ b/dox/externalproject/CMakeLists.txt
@@ -23,7 +23,7 @@ include(${ELASTIX_CONFIG_TARGETS_FILE})
 # Build a small example executable.
 add_executable(elastix_translation_example ElastixTranslationExample.cxx)
 
-set_property(TARGET elastix_translation_example PROPERTY CXX_STANDARD 14)
+set_property(TARGET elastix_translation_example PROPERTY CXX_STANDARD 17)
 
 target_include_directories(elastix_translation_example
   PRIVATE ${ELASTIX_INCLUDE_DIRS} ${ITK_INCLUDE_DIRS})


### PR DESCRIPTION
Following ITK pull request https://github.com/InsightSoftwareConsortium/ITK/pull/3969 commit https://github.com/InsightSoftwareConsortium/ITK/commit/513507e4c70172d5431563f89dc77c6bae1ad5b1 "ENH: Upgrade ITK from C++14 to C++17"

Follow-up to pull request https://github.com/SuperElastix/elastix/pull/513 commit d98d9c0eeb2e826e7733541ebd4edeac3fa86ec1 "ENH: Upgrade elastix from C++11 to C++14".