### PR TITLE
BUG: Avoid crash when m_Elastix->GetFixedImage() returns nullptr

### DIFF
--- a/Core/ComponentBaseClasses/elxResamplerBase.hxx
+++ b/Core/ComponentBaseClasses/elxResamplerBase.hxx
@@ -47,15 +47,15 @@ ResamplerBase<TElastix>::BeforeRegistrationBase()
    * \todo make it a cast to the fixed image type
    */
   using FixedImageType = typename ElastixType::FixedImageType;
-  FixedImageType * fixedImage = this->m_Elastix->GetFixedImage();
+  FixedImageType & fixedImage = Deref(this->m_Elastix->GetFixedImage());
   ITKBaseType &    resampleImageFilter = this->GetSelf();
 
   /** Set the region info to the same values as in the fixedImage. */
-  resampleImageFilter.SetSize(fixedImage->GetLargestPossibleRegion().GetSize());
-  resampleImageFilter.SetOutputStartIndex(fixedImage->GetLargestPossibleRegion().GetIndex());
-  resampleImageFilter.SetOutputOrigin(fixedImage->GetOrigin());
-  resampleImageFilter.SetOutputSpacing(fixedImage->GetSpacing());
-  resampleImageFilter.SetOutputDirection(fixedImage->GetDirection());
+  resampleImageFilter.SetSize(fixedImage.GetLargestPossibleRegion().GetSize());
+  resampleImageFilter.SetOutputStartIndex(fixedImage.GetLargestPossibleRegion().GetIndex());
+  resampleImageFilter.SetOutputOrigin(fixedImage.GetOrigin());
+  resampleImageFilter.SetOutputSpacing(fixedImage.GetSpacing());
+  resampleImageFilter.SetOutputDirection(fixedImage.GetDirection());
 
   const Configuration & configuration = Deref(Superclass::GetConfiguration());
 


### PR DESCRIPTION
Instead of using the pointer returned by `GetFixedImage()` directly, pass it to `elx::Deref(ptr)`, which throws an exception if it is null. Avoids a common case of undefined behavior, when the actual pixel type of the user specified fixed image was not included with the appropriate  `ELASTIX_IMAGE_nD_PIXELTYPES` CMake parameter. Allows finding out about the mistake in a more gentle way.

Triggered by discussion "Elastix5.1.0 C++ project failure at elastix translation example", started by  @Kunyadav at https://github.com/SuperElastix/elastix/discussions/867
