### PR TITLE
Deduce internal pixel types from template parameters of interface

### DIFF
--- a/Core/CMakeLists.txt
+++ b/Core/CMakeLists.txt
@@ -199,6 +199,8 @@ target_link_libraries(elastix_exe ${ELASTIX_TARGET_LINK_LIBRARIES})
 # The library type (STATIC or SHARED) is determined by the parameter
 # BUILD_SHARED_LIBS.
 add_library(elastix_lib
+  Main/elxLibUtilities.cxx
+  Main/elxLibUtilities.h
   Main/elxParameterObject.cxx
   Main/elxParameterObject.h
   Main/elastixlib.cxx
@@ -234,6 +236,8 @@ target_link_libraries(transformix_exe ${ELASTIX_TARGET_LINK_LIBRARIES})
 # The library type (STATIC or SHARED) is determined by the parameter
 # BUILD_SHARED_LIBS.
 add_library(transformix_lib
+  Main/elxLibUtilities.cxx
+  Main/elxLibUtilities.h
   Main/elxParameterObject.cxx
   Main/elxParameterObject.h
   Main/transformixlib.cxx

--- a/Core/Main/elxLibUtilities.cxx
+++ b/Core/Main/elxLibUtilities.cxx
@@ -1,0 +1,47 @@
+/*=========================================================================
+ *
+ *  Copyright UMC Utrecht and contributors
+ *
+ *  Licensed under the Apache License, Version 2.0 (the "License");
+ *  you may not use this file except in compliance with the License.
+ *  You may obtain a copy of the License at
+ *
+ *        http://www.apache.org/licenses/LICENSE-2.0.txt
+ *
+ *  Unless required by applicable law or agreed to in writing, software
+ *  distributed under the License is distributed on an "AS IS" BASIS,
+ *  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *  See the License for the specific language governing permissions and
+ *  limitations under the License.
+ *
+ *=========================================================================*/
+
+// Its own header file:
+#include "elxLibUtilities.h"
+
+#include "elxlog.h"
+
+namespace elastix
+{
+void
+LibUtilities::SetParameterValueAndWarnOnOverride(ParameterMapType &  parameterMap,
+                                                 const std::string & parameterName,
+                                                 const std::string & parameterValue)
+{
+
+  if (const auto found = parameterMap.find(parameterName); found == parameterMap.end())
+  {
+    parameterMap[parameterName] = { parameterValue };
+  }
+  else
+  {
+    if (found->second.size() != 1 || found->second.front() != parameterValue)
+    {
+      found->second = { parameterValue };
+      log::warn("WARNING: The values of parameter \"" + parameterName +
+                "\" are automatically overridden!\n  The value \"" + parameterValue + "\" is used instead.");
+    }
+  }
+}
+
+} // namespace elastix

--- a/Core/Main/elxLibUtilities.h
+++ b/Core/Main/elxLibUtilities.h
@@ -1,0 +1,40 @@
+/*=========================================================================
+ *
+ *  Copyright UMC Utrecht and contributors
+ *
+ *  Licensed under the Apache License, Version 2.0 (the "License");
+ *  you may not use this file except in compliance with the License.
+ *  You may obtain a copy of the License at
+ *
+ *        http://www.apache.org/licenses/LICENSE-2.0.txt
+ *
+ *  Unless required by applicable law or agreed to in writing, software
+ *  distributed under the License is distributed on an "AS IS" BASIS,
+ *  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *  See the License for the specific language governing permissions and
+ *  limitations under the License.
+ *
+ *=========================================================================*/
+#ifndef elxLibUtilities_h
+#define elxLibUtilities_h
+
+#include <map>
+#include <string>
+#include <vector>
+
+
+namespace elastix::LibUtilities
+{
+using ParameterValuesType = std::vector<std::string>;
+using ParameterMapType = std::map<std::string, ParameterValuesType>;
+
+
+/** Sets the specified parameter value. Warns when it overrides existing parameter values. */
+void
+SetParameterValueAndWarnOnOverride(ParameterMapType &  parameterMap,
+                                   const std::string & parameterName,
+                                   const std::string & parameterValue);
+
+} // namespace elastix::LibUtilities
+
+#endif

--- a/Core/Main/itkElastixRegistrationMethod.hxx
+++ b/Core/Main/itkElastixRegistrationMethod.hxx
@@ -193,22 +193,25 @@ ElastixRegistrationMethod<TFixedImage, TMovingImage>::GenerateData()
                                  m_EnableOutput && m_LogToConsole,
                                  static_cast<elastix::log::level>(m_LogLevel));
 
+  const auto fixedImageDimensionString = std::to_string(fixedImageDimension);
+  const auto fixedImagePixelTypeString = elx::PixelTypeToString<typename TFixedImage::PixelType>();
+  const auto movingImageDimensionString = std::to_string(movingImageDimension);
+
   // Run the (possibly multiple) registration(s)
   for (unsigned int i = 0; i < parameterMapVector.size(); ++i)
   {
     auto & parameterMap = parameterMapVector[i];
 
     // Set image dimension from input images (overrides user settings)
-    parameterMap["FixedImageDimension"] = ParameterValueVectorType(1, std::to_string(fixedImageDimension));
-    parameterMap["MovingImageDimension"] = ParameterValueVectorType(1, std::to_string(movingImageDimension));
-    parameterMap["ResultImagePixelType"] =
-      ParameterValueVectorType(1, elx::PixelTypeToString<typename TFixedImage::PixelType>());
+    parameterMap["FixedImageDimension"] = { fixedImageDimensionString };
+    parameterMap["MovingImageDimension"] = { movingImageDimensionString };
+    parameterMap["ResultImagePixelType"] = { fixedImagePixelTypeString };
 
     // Initial transform parameter files are handled via arguments and enclosing loop, not
     // InitialTransformParametersFileName
     if (parameterMap.find("InitialTransformParametersFileName") != parameterMap.end())
     {
-      parameterMap["InitialTransformParametersFileName"] = ParameterValueVectorType(1, "NoInitialTransform");
+      parameterMap["InitialTransformParametersFileName"] = { "NoInitialTransform" };
     }
 
     // Create new instance of ElastixMain

--- a/Core/Main/itkElastixRegistrationMethod.hxx
+++ b/Core/Main/itkElastixRegistrationMethod.hxx
@@ -38,6 +38,8 @@
 #include "elxPixelTypeToString.h"
 #include "itkElastixRegistrationMethod.h"
 
+#include "elxLibUtilities.h"
+
 #include <algorithm> // For find.
 #include <memory>    // For unique_ptr.
 
@@ -75,6 +77,8 @@ template <typename TFixedImage, typename TMovingImage>
 void
 ElastixRegistrationMethod<TFixedImage, TMovingImage>::GenerateData()
 {
+  using elx::LibUtilities::SetParameterValueAndWarnOnOverride;
+
   // Force compiler to instantiate the image dimensions, otherwise we may get
   //   Undefined symbols for architecture x86_64:
   //     "elx::ElastixRegistrationMethod<itk::Image<float, 2u> >::FixedImageDimension"
@@ -204,18 +208,15 @@ ElastixRegistrationMethod<TFixedImage, TMovingImage>::GenerateData()
     auto & parameterMap = parameterMapVector[i];
 
     // Set image dimension and pixel type from input images (overrides user settings)
-    parameterMap["FixedImageDimension"] = { fixedImageDimensionString };
-    parameterMap["FixedInternalImagePixelType"] = { fixedImagePixelTypeString };
-    parameterMap["MovingImageDimension"] = { movingImageDimensionString };
-    parameterMap["MovingInternalImagePixelType"] = { movingImagePixelTypeString };
-    parameterMap["ResultImagePixelType"] = { fixedImagePixelTypeString };
+    SetParameterValueAndWarnOnOverride(parameterMap, "FixedImageDimension", fixedImageDimensionString);
+    SetParameterValueAndWarnOnOverride(parameterMap, "FixedInternalImagePixelType", fixedImagePixelTypeString);
+    SetParameterValueAndWarnOnOverride(parameterMap, "MovingImageDimension", movingImageDimensionString);
+    SetParameterValueAndWarnOnOverride(parameterMap, "MovingInternalImagePixelType", movingImagePixelTypeString);
+    SetParameterValueAndWarnOnOverride(parameterMap, "ResultImagePixelType", fixedImagePixelTypeString);
 
     // Initial transform parameter files are handled via arguments and enclosing loop, not
     // InitialTransformParametersFileName
-    if (parameterMap.find("InitialTransformParametersFileName") != parameterMap.end())
-    {
-      parameterMap["InitialTransformParametersFileName"] = { "NoInitialTransform" };
-    }
+    SetParameterValueAndWarnOnOverride(parameterMap, "InitialTransformParametersFileName", "NoInitialTransform");
 
     // Create new instance of ElastixMain
     const auto elastixMain = elx::ElastixMain::New();

--- a/Core/Main/itkElastixRegistrationMethod.hxx
+++ b/Core/Main/itkElastixRegistrationMethod.hxx
@@ -196,15 +196,18 @@ ElastixRegistrationMethod<TFixedImage, TMovingImage>::GenerateData()
   const auto fixedImageDimensionString = std::to_string(fixedImageDimension);
   const auto fixedImagePixelTypeString = elx::PixelTypeToString<typename TFixedImage::PixelType>();
   const auto movingImageDimensionString = std::to_string(movingImageDimension);
+  const auto movingImagePixelTypeString = elx::PixelTypeToString<typename TMovingImage::PixelType>();
 
   // Run the (possibly multiple) registration(s)
   for (unsigned int i = 0; i < parameterMapVector.size(); ++i)
   {
     auto & parameterMap = parameterMapVector[i];
 
-    // Set image dimension from input images (overrides user settings)
+    // Set image dimension and pixel type from input images (overrides user settings)
     parameterMap["FixedImageDimension"] = { fixedImageDimensionString };
+    parameterMap["FixedInternalImagePixelType"] = { fixedImagePixelTypeString };
     parameterMap["MovingImageDimension"] = { movingImageDimensionString };
+    parameterMap["MovingInternalImagePixelType"] = { movingImagePixelTypeString };
     parameterMap["ResultImagePixelType"] = { fixedImagePixelTypeString };
 
     // Initial transform parameter files are handled via arguments and enclosing loop, not

--- a/Core/Main/itkTransformixFilter.hxx
+++ b/Core/Main/itkTransformixFilter.hxx
@@ -36,6 +36,8 @@
 #define itkTransformixFilter_hxx
 
 #include "itkTransformixFilter.h"
+
+#include "elxLibUtilities.h"
 #include "elxPixelTypeToString.h"
 #include "elxTransformBase.h"
 #include "elxTransformIO.h"
@@ -62,6 +64,8 @@ template <typename TMovingImage>
 void
 TransformixFilter<TMovingImage>::GenerateData()
 {
+  using elx::LibUtilities::SetParameterValueAndWarnOnOverride;
+
   // Force compiler to instantiate the image dimension, otherwise we may get
   //   Undefined symbols for architecture x86_64:
   //     "elastix::TransformixFilter<itk::Image<float, 2u> >::MovingImageDimension"
@@ -184,9 +188,12 @@ TransformixFilter<TMovingImage>::GenerateData()
 
       transformParameterMap["ITKTransformFixedParameters"] = convertToParameterValues(transform.GetFixedParameters());
       transformParameterMap["ITKTransformParameters"] = convertToParameterValues(transform.GetParameters());
-      transformParameterMap["ITKTransformType"] = { transform.GetTransformTypeAsString() };
-      transformParameterMap["Transform"] = { elx::TransformIO::ConvertITKNameOfClassToElastixClassName(
-        transform.GetNameOfClass()) };
+      SetParameterValueAndWarnOnOverride(
+        transformParameterMap, "ITKTransformType", transform.GetTransformTypeAsString());
+      SetParameterValueAndWarnOnOverride(
+        transformParameterMap,
+        "Transform",
+        elx::TransformIO::ConvertITKNameOfClassToElastixClassName(transform.GetNameOfClass()));
     };
     const auto compositeTransform =
       dynamic_cast<const CompositeTransform<double, MovingImageDimension> *>(&*m_Transform);
@@ -243,11 +250,13 @@ TransformixFilter<TMovingImage>::GenerateData()
   {
     auto & transformParameterMap = transformParameterMapVector[i];
 
-    transformParameterMap["FixedImageDimension"] = { movingImageDimensionString };
-    transformParameterMap["FixedInternalImagePixelType"] = { movingImagePixelTypeString };
-    transformParameterMap["MovingImageDimension"] = { movingImageDimensionString };
-    transformParameterMap["MovingInternalImagePixelType"] = { movingImagePixelTypeString };
-    transformParameterMap["ResultImagePixelType"] = { movingImagePixelTypeString };
+    SetParameterValueAndWarnOnOverride(transformParameterMap, "FixedImageDimension", movingImageDimensionString);
+    SetParameterValueAndWarnOnOverride(
+      transformParameterMap, "FixedInternalImagePixelType", movingImagePixelTypeString);
+    SetParameterValueAndWarnOnOverride(transformParameterMap, "MovingImageDimension", movingImageDimensionString);
+    SetParameterValueAndWarnOnOverride(
+      transformParameterMap, "MovingInternalImagePixelType", movingImagePixelTypeString);
+    SetParameterValueAndWarnOnOverride(transformParameterMap, "ResultImagePixelType", movingImagePixelTypeString);
   }
 
   // Run transformix

--- a/Core/Main/itkTransformixFilter.hxx
+++ b/Core/Main/itkTransformixFilter.hxx
@@ -244,7 +244,9 @@ TransformixFilter<TMovingImage>::GenerateData()
     auto & transformParameterMap = transformParameterMapVector[i];
 
     transformParameterMap["FixedImageDimension"] = { movingImageDimensionString };
+    transformParameterMap["FixedInternalImagePixelType"] = { movingImagePixelTypeString };
     transformParameterMap["MovingImageDimension"] = { movingImageDimensionString };
+    transformParameterMap["MovingInternalImagePixelType"] = { movingImagePixelTypeString };
     transformParameterMap["ResultImagePixelType"] = { movingImagePixelTypeString };
   }
 

--- a/Core/Main/itkTransformixFilter.hxx
+++ b/Core/Main/itkTransformixFilter.hxx
@@ -235,15 +235,17 @@ TransformixFilter<TMovingImage>::GenerateData()
     }
   }
 
+  const auto movingImageDimensionString = std::to_string(movingImageDimension);
+  const auto movingImagePixelTypeString = elx::PixelTypeToString<typename TMovingImage::PixelType>();
+
   // Set pixel types from input image, override user settings
   for (unsigned int i = 0; i < transformParameterMapVector.size(); ++i)
   {
     auto & transformParameterMap = transformParameterMapVector[i];
 
-    transformParameterMap["FixedImageDimension"] = ParameterValueVectorType(1, std::to_string(movingImageDimension));
-    transformParameterMap["MovingImageDimension"] = ParameterValueVectorType(1, std::to_string(movingImageDimension));
-    transformParameterMap["ResultImagePixelType"] =
-      ParameterValueVectorType(1, elx::PixelTypeToString<typename TMovingImage::PixelType>());
+    transformParameterMap["FixedImageDimension"] = { movingImageDimensionString };
+    transformParameterMap["MovingImageDimension"] = { movingImageDimensionString };
+    transformParameterMap["ResultImagePixelType"] = { movingImagePixelTypeString };
   }
 
   // Run transformix


### PR DESCRIPTION
Basically reverting commit faf20af8f0c950038031571709794edef54a5dfe "ENH: Allow ElastixFilter and TransformixFilter users to manually specify internal pixel types. Previously these was automatically deduced from instantiated template parameters" by Kasper Marstal (@kaspermarstal), September 4, 2016.

Discussed "in person" with Marius Staring, this afternoon. With the current design, the internal pixel types _must be_ the same as the pixel types of the `ElastixRegistrationMethod<TFixedImage, TMovingImage>` and the `TransformixFilter<TMovingImage>` template arguments anyway. 

Also the subject of this discussion:
- https://github.com/SuperElastix/elastix/discussions/872
