### PR TITLE
ENH: Convert the input images to the user-specified internal pixel type

### DIFF
--- a/Core/Main/elxForEachSupportedImageType.h
+++ b/Core/Main/elxForEachSupportedImageType.h
@@ -46,6 +46,24 @@ ForEachSupportedImageType(const TFunction & func)
   ForEachSupportedImageType(func, std::make_index_sequence<elx::NrOfSupportedImageTypes>());
 }
 
+template <typename TFunction, std::size_t... VIndexSequence>
+bool
+ForEachSupportedImageTypeUntilTrue(const TFunction & func, const std::index_sequence<VIndexSequence...> &)
+{
+  // Expand the sequence by a fold expression of the form (func(n) || func(n - 1) || ... || func(1)).
+  return (func(elx::ElastixTypedef<VIndexSequence + 1>{}) || ...);
+}
+
+
+/** Runs a function `func(ElastixTypedef<VIndex>{})`, for each supported image type from "elxSupportedImageTypes.h",
+ * until the function returns true. */
+template <typename TFunction>
+bool
+ForEachSupportedImageTypeUntilTrue(const TFunction & func)
+{
+  return ForEachSupportedImageTypeUntilTrue(func, std::make_index_sequence<elx::NrOfSupportedImageTypes>());
+}
+
 } // namespace elastix
 
 

--- a/Core/Main/elxLibUtilities.cxx
+++ b/Core/Main/elxLibUtilities.cxx
@@ -28,7 +28,6 @@ LibUtilities::SetParameterValueAndWarnOnOverride(ParameterMapType &  parameterMa
                                                  const std::string & parameterName,
                                                  const std::string & parameterValue)
 {
-
   if (const auto found = parameterMap.find(parameterName); found == parameterMap.end())
   {
     parameterMap[parameterName] = { parameterValue };
@@ -43,5 +42,23 @@ LibUtilities::SetParameterValueAndWarnOnOverride(ParameterMapType &  parameterMa
     }
   }
 }
+
+
+std::string
+LibUtilities::RetrievePixelTypeParameterValue(const ParameterMapType & parameterMap, const std::string & parameterName)
+{
+  if (const auto found = parameterMap.find(parameterName); found != parameterMap.end())
+  {
+    if (const auto & second = found->second; !second.empty())
+    {
+      if (const auto & front = second.front(); !front.empty())
+      {
+        return front;
+      }
+    }
+  }
+  return "float";
+}
+
 
 } // namespace elastix

--- a/Core/Main/elxLibUtilities.h
+++ b/Core/Main/elxLibUtilities.h
@@ -18,8 +18,15 @@
 #ifndef elxLibUtilities_h
 #define elxLibUtilities_h
 
+#include "elxForEachSupportedImageType.h"
+
+#include <itkCastImageFilter.h>
+#include <itkDataObject.h>
+#include <itkSmartPointer.h>
+
 #include <map>
 #include <string>
+#include <type_traits> // For is_same_v.
 #include <vector>
 
 
@@ -34,6 +41,58 @@ void
 SetParameterValueAndWarnOnOverride(ParameterMapType &  parameterMap,
                                    const std::string & parameterName,
                                    const std::string & parameterValue);
+
+
+/** Retrieves the PixelType string value of the specified parameter. Returns "float" by default. */
+std::string
+RetrievePixelTypeParameterValue(const ParameterMapType & parameterMap, const std::string & parameterName);
+
+template <typename TInputImage>
+itk::SmartPointer<itk::DataObject>
+CastToInternalPixelType(itk::SmartPointer<TInputImage> inputImage, const std::string & internalPixelTypeString)
+{
+  if (inputImage == nullptr)
+  {
+    itkGenericExceptionMacro("The specified input image should not be null!");
+  }
+
+  itk::SmartPointer<itk::DataObject> outputImage;
+
+  elx::ForEachSupportedImageTypeUntilTrue([inputImage, &outputImage, &internalPixelTypeString](const auto elxTypedef) {
+    using ElxTypedef = decltype(elxTypedef);
+
+    if constexpr (TInputImage::ImageDimension == ElxTypedef::MovingDimension)
+    {
+      using InternalImageType = typename ElxTypedef::MovingImageType;
+
+      if (internalPixelTypeString == ElxTypedef::MovingPixelTypeString)
+      {
+        if constexpr (std::is_same_v<TInputImage, InternalImageType>)
+        {
+          outputImage = inputImage;
+        }
+        else
+        {
+          const auto castFilter = itk::CastImageFilter<TInputImage, InternalImageType>::New();
+          castFilter->SetInput(inputImage);
+          castFilter->Update();
+          outputImage = castFilter->GetOutput();
+        }
+        return true;
+      }
+    }
+    return false;
+  });
+
+  if (outputImage == nullptr)
+  {
+    itkGenericExceptionMacro("Failed to cast to the specified internal pixel type \""
+                             << internalPixelTypeString
+                             << "\". It may need to be added to the CMake variable ELASTIX_IMAGE_"
+                             << TInputImage::ImageDimension << "D_PIXELTYPES.");
+  }
+  return outputImage;
+}
 
 } // namespace elastix::LibUtilities
 

--- a/Core/Main/itkElastixRegistrationMethod.h
+++ b/Core/Main/itkElastixRegistrationMethod.h
@@ -307,6 +307,23 @@ private:
   void
   RemoveInputsOfType(const DataObjectIdentifierType & inputName);
 
+
+  /** Retrieves either the fixed or the moving input images. */
+  template <typename TImage>
+  std::vector<TImage *>
+  GetInputImages(const char * const inputTypeString)
+  {
+    std::vector<TImage *> images;
+    for (const auto & inputName : this->GetInputNames())
+    {
+      if (this->IsInputOfType(inputTypeString, inputName))
+      {
+        images.push_back(itkDynamicCastInDebugMode<TImage *>(this->ProcessObject::GetInput(inputName)));
+      }
+    }
+    return images;
+  }
+
   /** Private using-declaration, just to avoid GCC compilation warnings: '...' was hidden [-Woverloaded-virtual] */
   using Superclass::SetInput;
 


### PR DESCRIPTION
Both ElastixRegistrationMethod and TransformixFilter now convert their input images to the internal pixel type, specified by elastix/transformix parameters, "FixedInternalImagePixelType" and "MovingInternalImagePixelType" (which are "float" by default).

The conversion is performed internally by `itk::CastImageFilter`. It is only performed when the pixel type of an input image is actually different from the specified internal pixel type.

The converted images are cached in memory, to avoid repeating the very same (potentially expensive) image conversion multiple times.

GoogleTest unit tests are included.

Related to issue #322 "TransformixFilter does not process non-float pixel type images"