### PR TITLE
PERF: Fill `jsj` (JacobianOfSpatialJacobian) in-place and remove `jsj1`

### DIFF
--- a/Common/Transforms/itkAdvancedCombinationTransform.hxx
+++ b/Common/Transforms/itkAdvancedCombinationTransform.hxx
@@ -1034,16 +1034,15 @@ AdvancedCombinationTransform<TScalarType, NDimensions>::GetJacobianOfSpatialJaco
   JacobianOfSpatialJacobianType & jsj,
   NonZeroJacobianIndicesType &    nonZeroJacobianIndices) const
 {
-  SpatialJacobianType           sj0;
-  JacobianOfSpatialJacobianType jsj1;
+  SpatialJacobianType sj0;
   m_InitialTransform->GetSpatialJacobian(inputPoint, sj0);
   m_CurrentTransform->GetJacobianOfSpatialJacobian(
-    m_InitialTransform->TransformPoint(inputPoint), jsj1, nonZeroJacobianIndices);
+    m_InitialTransform->TransformPoint(inputPoint), jsj, nonZeroJacobianIndices);
 
   jsj.resize(nonZeroJacobianIndices.size());
-  for (unsigned int mu = 0; mu < nonZeroJacobianIndices.size(); ++mu)
+  for (auto & matrix : jsj)
   {
-    jsj[mu] = jsj1[mu] * sj0;
+    matrix *= sj0;
   }
 
 } // end GetJacobianOfSpatialJacobianUseComposition()
@@ -1061,17 +1060,16 @@ AdvancedCombinationTransform<TScalarType, NDimensions>::GetJacobianOfSpatialJaco
   JacobianOfSpatialJacobianType & jsj,
   NonZeroJacobianIndicesType &    nonZeroJacobianIndices) const
 {
-  SpatialJacobianType           sj0, sj1;
-  JacobianOfSpatialJacobianType jsj1;
+  SpatialJacobianType sj0, sj1;
   m_InitialTransform->GetSpatialJacobian(inputPoint, sj0);
   m_CurrentTransform->GetJacobianOfSpatialJacobian(
-    m_InitialTransform->TransformPoint(inputPoint), sj1, jsj1, nonZeroJacobianIndices);
+    m_InitialTransform->TransformPoint(inputPoint), sj1, jsj, nonZeroJacobianIndices);
 
   sj = sj1 * sj0;
   jsj.resize(nonZeroJacobianIndices.size());
-  for (unsigned int mu = 0; mu < nonZeroJacobianIndices.size(); ++mu)
+  for (auto & matrix : jsj)
   {
-    jsj[mu] = jsj1[mu] * sj0;
+    matrix *= sj0;
   }
 
 } // end GetJacobianOfSpatialJacobianUseComposition()


### PR DESCRIPTION
Used modern C++ range-based `for` loops to iterate over the matrices of `jsj`, in both `GetJacobianOfSpatialJacobianUseComposition` overloads. Reduced dynamic memory usage by removing `jsj1` in those two cases.

Follow-up to pull request https://github.com/SuperElastix/elastix/pull/890 commit b9ea3a8e65a3e015a5a0f06acfb5bd22fad8dacc

---

This commit appears to make the registration part of [itkElastixRegistrationMethodTest](https://github.com/InsightSoftwareConsortium/ITKElastix/blob/a7150930fb27f0d2c56bbb466db12431eb180850/test/itkElastixRegistrationMethodTest.cxx) ~5% faster, going from ~33 seconds to 32-31 seconds on my PC. Timeouts of itkElastixRegistrationMethodTest at the CI of ITKElastix are a showstopper right now.

Update: I just tested the very same registration with elastix 5.1.0 (released last January) as well and it's ~34 seconds, so slightly _slower_ than the current revision from main. Which is cool 😃 