### PR TITLE
STYLE: Add local variables for "number of parameters" to `if` statements

### DIFF
--- a/Common/Transforms/itkAdvancedBSplineDeformableTransformBase.hxx
+++ b/Common/Transforms/itkAdvancedBSplineDeformableTransformBase.hxx
@@ -260,9 +260,9 @@ AdvancedBSplineDeformableTransformBase<TScalarType, NDimensions>::SetParameters(
 
   // check if the number of parameters match the
   // expected number of parameters
-  if (parameters.Size() != this->GetNumberOfParameters())
+  if (const auto numberOfParameters = parameters.size(); numberOfParameters != this->GetNumberOfParameters())
   {
-    itkExceptionMacro(<< "Mismatched between parameters size " << parameters.size() << " and region size "
+    itkExceptionMacro(<< "Mismatched between parameters size " << numberOfParameters << " and region size "
                       << this->m_GridRegion.GetNumberOfPixels());
   }
 
@@ -303,9 +303,10 @@ AdvancedBSplineDeformableTransformBase<TScalarType, NDimensions>::SetFixedParame
       parameters[3 * NDimensions + (di * NDimensions + di)] = 1;
     }
   }
-  else if (passedParameters.Size() != NumberOfFixedParameters)
+  else if (const auto numberOfPassedParameters = passedParameters.size();
+           numberOfPassedParameters != NumberOfFixedParameters)
   {
-    itkExceptionMacro(<< "Mismatched between parameters size " << passedParameters.size()
+    itkExceptionMacro(<< "Mismatched between parameters size " << numberOfPassedParameters
                       << " and number of fixed parameters " << NumberOfFixedParameters);
   }
   else
@@ -398,9 +399,9 @@ AdvancedBSplineDeformableTransformBase<TScalarType, NDimensions>::SetParametersB
 {
   // check if the number of parameters match the
   // expected number of parameters
-  if (parameters.Size() != this->GetNumberOfParameters())
+  if (const auto numberOfParameters = parameters.size(); numberOfParameters != this->GetNumberOfParameters())
   {
-    itkExceptionMacro(<< "Mismatched between parameters size " << parameters.size() << " and region size "
+    itkExceptionMacro(<< "Mismatched between parameters size " << numberOfParameters << " and region size "
                       << this->m_GridRegion.GetNumberOfPixels());
   }
 

--- a/Common/itkMultiResolutionImageRegistrationMethod2.hxx
+++ b/Common/itkMultiResolutionImageRegistrationMethod2.hxx
@@ -162,11 +162,11 @@ MultiResolutionImageRegistrationMethod2<TFixedImage, TMovingImage>::PreparePyram
 
   this->m_InitialTransformParametersOfNextLevel = this->m_InitialTransformParameters;
 
-  if (this->m_InitialTransformParametersOfNextLevel.Size() != this->m_Transform->GetNumberOfParameters())
+  if (const auto numberOfInitialTransformParameters = this->m_InitialTransformParameters.size();
+      numberOfInitialTransformParameters != this->m_Transform->GetNumberOfParameters())
   {
-    itkExceptionMacro(<< "Size mismatch between initial parameters ("
-                      << this->m_InitialTransformParametersOfNextLevel.Size() << ") and transform ("
-                      << this->m_Transform->GetNumberOfParameters() << ")");
+    itkExceptionMacro(<< "Size mismatch between initial parameters (" << numberOfInitialTransformParameters
+                      << ") and transform (" << this->m_Transform->GetNumberOfParameters() << ")");
   }
 
   // Sanity checks

--- a/Components/Transforms/MultiBSplineTransformWithNormal/itkMultiBSplineDeformableTransformWithNormal.hxx
+++ b/Components/Transforms/MultiBSplineTransformWithNormal/itkMultiBSplineDeformableTransformWithNormal.hxx
@@ -523,9 +523,9 @@ MultiBSplineDeformableTransformWithNormal<TScalarType, NDimensions, VSplineOrder
 {
   // check if the number of parameters match the
   // expected number of parameters
-  if (parameters.Size() != this->GetNumberOfParameters())
+  if (const auto numberOfParameters = parameters.size(); numberOfParameters != this->GetNumberOfParameters())
   {
-    itkExceptionMacro(<< "Mismatched between parameters size " << parameters.size() << " and region size "
+    itkExceptionMacro(<< "Mismatched between parameters size " << numberOfParameters << " and region size "
                       << this->GetNumberOfParameters());
   }
 
@@ -562,9 +562,9 @@ MultiBSplineDeformableTransformWithNormal<TScalarType, NDimensions, VSplineOrder
 {
   // check if the number of parameters match the
   // expected number of parameters
-  if (parameters.Size() != this->GetNumberOfParameters())
+  if (const auto numberOfParameters = parameters.size(); numberOfParameters != this->GetNumberOfParameters())
   {
-    itkExceptionMacro(<< "Mismatched between parameters size " << parameters.size() << " and region size "
+    itkExceptionMacro(<< "Mismatched between parameters size " << numberOfParameters << " and region size "
                       << this->GetNumberOfParameters());
   }
 


### PR DESCRIPTION
Avoided redundant `size()` or `Size()` calls.