### PR TITLE
Add InitialTransformParameterObject maps to registration result

### DIFF
--- a/Core/Main/itkElastixRegistrationMethod.hxx
+++ b/Core/Main/itkElastixRegistrationMethod.hxx
@@ -92,8 +92,10 @@ ElastixRegistrationMethod<TFixedImage, TMovingImage>::GenerateData()
   DataObjectContainerPointer movingMaskContainer = nullptr;
   DataObjectContainerPointer resultImageContainer = nullptr;
   ElastixMainObjectPointer   transform = nullptr;
-  ParameterMapVectorType     transformParameterMapVector;
-  FlatDirectionCosinesType   fixedImageOriginalDirection;
+  ParameterMapVectorType     transformParameterMapVector = m_InitialTransformParameterObject
+                                                         ? m_InitialTransformParameterObject->GetParameterMaps()
+                                                         : ParameterMapVectorType{};
+  FlatDirectionCosinesType fixedImageOriginalDirection;
 
   // Split inputs into separate containers
   for (const auto & inputName : this->GetInputNames())


### PR DESCRIPTION
Added the maps from the InitialTransformParameterObject of an ElastixRegistrationMethod to the output TransformParameterObject (at the begin, before the maps added during registration).

Ensures that the initial transform is included, when the result from `registration.GetTransformParameterObject()` is passed to `transformix.SetTransformParameterObject`.