### PR TITLE
STYLE: Use C++17 `_v` variable templates from `std` library type traits

### DIFF
--- a/Common/GTesting/elxConversionGTest.cxx
+++ b/Common/GTesting/elxConversionGTest.cxx
@@ -246,7 +246,7 @@ template <typename TSignedInteger>
 void
 Expect_negative_parameter_value_can_not_be_read_as_unsigned()
 {
-  static_assert(std::is_signed<TSignedInteger>::value, "Must be a signed integer type!");
+  static_assert(std::is_signed_v<TSignedInteger>, "Must be a signed integer type!");
 
   for (TSignedInteger integer : { std::numeric_limits<TSignedInteger>::min(), TSignedInteger{ -1 } })
   {
@@ -268,8 +268,7 @@ template <typename TFloatingPoint>
 void
 Expect_lossless_round_trip_of_floating_point_parameter_values()
 {
-  static_assert(std::is_floating_point<TFloatingPoint>::value,
-                "This function is only meant to test floating point types!");
+  static_assert(std::is_floating_point_v<TFloatingPoint>, "This function is only meant to test floating point types!");
 
   using NumericLimits = std::numeric_limits<TFloatingPoint>;
 

--- a/Common/GTesting/elxTransformIOGTest.cxx
+++ b/Common/GTesting/elxTransformIOGTest.cxx
@@ -104,9 +104,9 @@ struct WithDimension
       using ItkCompositeTransformType = itk::CompositeTransform<double, NDimension>;
 
       static_assert(
-        std::is_base_of<itk::Transform<double, NDimension, NDimension>, TExpectedCorrespondingItkTransform>::value,
+        std::is_base_of_v<itk::Transform<double, NDimension, NDimension>, TExpectedCorrespondingItkTransform>,
         "TExpectedCorrespondingItkTransform should be derived from the expected `itk::Transform` specialization!");
-      static_assert(!std::is_base_of<ItkCompositeTransformType, TExpectedCorrespondingItkTransform>::value,
+      static_assert(!std::is_base_of_v<ItkCompositeTransformType, TExpectedCorrespondingItkTransform>,
                     "TExpectedCorrespondingItkTransform should not be derived from `itk::CompositeTransform`!");
 
       const auto elxTransform = CheckNew<ElastixTransformType>();
@@ -117,9 +117,8 @@ struct WithDimension
 
       const auto compositeTransform = elx::TransformIO::ConvertToItkCompositeTransform(*elxTransform);
       ASSERT_NE(compositeTransform, nullptr);
-      static_assert(
-        std::is_same<const itk::SmartPointer<ItkCompositeTransformType>, decltype(compositeTransform)>::value,
-        "`ConvertToItkCompositeTransform` should have the expected `SmartPointer` return type!");
+      static_assert(std::is_same_v<const itk::SmartPointer<ItkCompositeTransformType>, decltype(compositeTransform)>,
+                    "`ConvertToItkCompositeTransform` should have the expected `SmartPointer` return type!");
 
       const auto & transformQueue = compositeTransform->GetTransformQueue();
       ASSERT_EQ(transformQueue.size(), 1);
@@ -593,7 +592,7 @@ Expect_elx_TransformPoint_yields_same_point_as_ITK(const TITKTransform & itkTran
                                          2.0,
                                          NumericLimits::max() };
 
-  constexpr auto numberOfTestInputValues = std::extent<decltype(testInputValues)>::value;
+  constexpr auto numberOfTestInputValues = std::extent_v<decltype(testInputValues)>;
 
   // Use the test input values as coordinates.
   for (const auto index : itk::ZeroBasedIndexRange<Dimension>(itk::Size<Dimension>::Filled(numberOfTestInputValues)))
@@ -606,7 +605,7 @@ Expect_elx_TransformPoint_yields_same_point_as_ITK(const TITKTransform & itkTran
     const auto expectedOutputPoint = itkTransform.TransformPoint(inputPoint);
     const auto actualOutputPoint = elxTransform->TransformPoint(inputPoint);
 
-    static_assert(std::is_same<decltype(actualOutputPoint), decltype(expectedOutputPoint)>::value,
+    static_assert(std::is_same_v<decltype(actualOutputPoint), decltype(expectedOutputPoint)>,
                   "elxTransform->TransformPoint must have the expected return type!");
 
     if (expectedOutputPoint != inputPoint)

--- a/Common/OpenCL/ITKimprovements/itkOpenCLKernel.h
+++ b/Common/OpenCL/ITKimprovements/itkOpenCLKernel.h
@@ -307,7 +307,7 @@ public:
   /*
   template< typename T,
   typename = typename std::enable_if<
-    std::is_scalar< T >::value || std::is_union< T >::value >::type >
+    std::is_scalar_v< T > || std::is_union_v< T > >::type >
   cl_int SetArg( const cl_uint index, const T value )
   {
     return clSetKernelArg( this->m_KernelId, index,

--- a/Components/elxGenericPyramidHelper.h
+++ b/Components/elxGenericPyramidHelper.h
@@ -43,8 +43,8 @@ public:
   {
     using ElastixType = typename TPyramid::ElastixType;
 
-    constexpr bool isFixed = std::is_same<TPyramid, FixedGenericPyramid<ElastixType>>::value;
-    constexpr bool isMoving = std::is_same<TPyramid, MovingGenericPyramid<ElastixType>>::value;
+    constexpr bool isFixed = std::is_same_v<TPyramid, FixedGenericPyramid<ElastixType>>;
+    constexpr bool isMoving = std::is_same_v<TPyramid, MovingGenericPyramid<ElastixType>>;
 
     static_assert(isMoving != isFixed, "TPyramid must be either FixedGenericPyramid or MovingGenericPyramid!");
 

--- a/Core/Install/elxConversion.cxx
+++ b/Core/Install/elxConversion.cxx
@@ -66,8 +66,7 @@ template <typename TFloatingPoint>
 bool
 StringToFloatingPointValue(const std::string & str, TFloatingPoint & value)
 {
-  static_assert(std::is_floating_point<TFloatingPoint>::value,
-                "This function template only supports floating point types.");
+  static_assert(std::is_floating_point_v<TFloatingPoint>, "This function template only supports floating point types.");
 
   using NumericLimits = std::numeric_limits<TFloatingPoint>;
 

--- a/Core/Install/elxConversion.h
+++ b/Core/Install/elxConversion.h
@@ -89,8 +89,8 @@ public:
   static std::string
   ToString(const TInteger integerValue)
   {
-    static_assert(std::is_integral<TInteger>::value, "An integer type expected!");
-    static_assert(!std::is_same<TInteger, bool>::value, "No bool expected!");
+    static_assert(std::is_integral_v<TInteger>, "An integer type expected!");
+    static_assert(!std::is_same_v<TInteger, bool>, "No bool expected!");
     return std::to_string(integerValue);
   }
 
@@ -171,13 +171,13 @@ public:
   StringToValue(const std::string & str, T & value)
   {
     // Conversion to bool is supported by another StringToValue overload.
-    static_assert(!std::is_same<T, bool>::value, "This StringToValue<T> overload does not support bool!");
+    static_assert(!std::is_same_v<T, bool>, "This StringToValue<T> overload does not support bool!");
 
     // 8-bits (signed/unsigned) char types are supported by other StringToValue
     // overloads.
     static_assert(sizeof(T) > 1, "This StringToValue<T> overload does not support (signed/unsigned) char!");
 
-    if (std::is_unsigned<T>::value && (!str.empty()) && (str.front() == '-'))
+    if (std::is_unsigned_v<T> && (!str.empty()) && (str.front() == '-'))
     {
       // An unsigned value should not start with a minus sign!
       return false;

--- a/Core/Main/GTesting/elxCoreMainGTestUtilities.h
+++ b/Core/Main/GTesting/elxCoreMainGTestUtilities.h
@@ -90,7 +90,7 @@ template <typename TRawPointer>
 decltype(auto)
 DerefRawPointer(const TRawPointer ptr)
 {
-  static_assert(std::is_pointer<TRawPointer>::value, "For smart pointers, use DerefSmartPointer instead!");
+  static_assert(std::is_pointer_v<TRawPointer>, "For smart pointers, use DerefSmartPointer instead!");
 
   if (ptr == nullptr)
   {
@@ -104,7 +104,7 @@ template <typename TSmartPointer>
 decltype(auto)
 DerefSmartPointer(const TSmartPointer & ptr)
 {
-  static_assert(!std::is_pointer<TSmartPointer>::value, "For raw pointers, use DerefRawPointer instead!");
+  static_assert(!std::is_pointer_v<TSmartPointer>, "For raw pointers, use DerefRawPointer instead!");
 
   if (ptr == nullptr)
   {

--- a/Testing/itkCompareCompositeTransformsTest.cxx
+++ b/Testing/itkCompareCompositeTransformsTest.cxx
@@ -39,7 +39,7 @@ template <typename TDerivedTransform>
 bool
 IsDerivedTransformOfType(const itk::SmartPointer<itk::Transform<ScalarType, Dimension, Dimension>> & ptr)
 {
-  static_assert(std::is_base_of<itk::Transform<ScalarType, Dimension, Dimension>, TDerivedTransform>::value,
+  static_assert(std::is_base_of_v<itk::Transform<ScalarType, Dimension, Dimension>, TDerivedTransform>,
                 "TDerivedTransform must be derived from itk::Transform!");
   return dynamic_cast<const TDerivedTransform *>(ptr.GetPointer()) != nullptr;
 }


### PR DESCRIPTION
Following ITK pull request https://github.com/InsightSoftwareConsortium/ITK/pull/3987 commit https://github.com/InsightSoftwareConsortium/ITK/commit/1a914b71bd0e15a4ec687631924c2026b78726fb (merged to the ITK master branch on April 4, 2023).