### PR TITLE
STYLE: C++17 does define constexpr static data members inside the class

### DIFF
--- a/Core/Main/itkElastixRegistrationMethod.hxx
+++ b/Core/Main/itkElastixRegistrationMethod.hxx
@@ -81,13 +81,6 @@ ElastixRegistrationMethod<TFixedImage, TMovingImage>::GenerateData()
   using elx::LibUtilities::RetrievePixelTypeParameterValue;
   using elx::LibUtilities::SetParameterValueAndWarnOnOverride;
 
-  // Force compiler to instantiate the image dimensions, otherwise we may get
-  //   Undefined symbols for architecture x86_64:
-  //     "elx::ElastixRegistrationMethod<itk::Image<float, 2u> >::FixedImageDimension"
-  // on some platforms.
-  const unsigned int fixedImageDimension = FixedImageDimension;
-  const unsigned int movingImageDimension = MovingImageDimension;
-
   DataObjectContainerPointer fixedMaskContainer = nullptr;
   DataObjectContainerPointer movingMaskContainer = nullptr;
   DataObjectContainerPointer resultImageContainer = nullptr;
@@ -184,9 +177,9 @@ ElastixRegistrationMethod<TFixedImage, TMovingImage>::GenerateData()
                                  m_EnableOutput && m_LogToConsole,
                                  static_cast<elastix::log::level>(m_LogLevel));
 
-  const auto fixedImageDimensionString = std::to_string(fixedImageDimension);
+  const auto fixedImageDimensionString = std::to_string(FixedImageDimension);
   const auto fixedImagePixelTypeString = elx::PixelTypeToString<typename TFixedImage::PixelType>();
-  const auto movingImageDimensionString = std::to_string(movingImageDimension);
+  const auto movingImageDimensionString = std::to_string(MovingImageDimension);
 
   const std::vector<TFixedImage *>  fixedInputImages = GetInputImages<TFixedImage>("FixedImage");
   const std::vector<TMovingImage *> movingInputImages = GetInputImages<TMovingImage>("MovingImage");

--- a/Core/Main/itkTransformixFilter.hxx
+++ b/Core/Main/itkTransformixFilter.hxx
@@ -68,12 +68,6 @@ TransformixFilter<TImage>::GenerateData()
   using elx::LibUtilities::RetrievePixelTypeParameterValue;
   using elx::LibUtilities::SetParameterValueAndWarnOnOverride;
 
-  // Force compiler to instantiate the image dimension, otherwise we may get
-  //   Undefined symbols for architecture x86_64:
-  //     "elastix::TransformixFilter<itk::Image<float, 2u> >::MovingImageDimension"
-  // on some platforms.
-  const unsigned int movingImageDimension = MovingImageDimension;
-
   if (this->IsEmpty(this->GetMovingImage()) && m_FixedPointSetFileName.empty() && !m_ComputeSpatialJacobian &&
       !m_ComputeDeterminantOfSpatialJacobian && !m_ComputeDeformationField)
   {
@@ -246,7 +240,7 @@ TransformixFilter<TImage>::GenerateData()
     }
   }
 
-  const auto movingImageDimensionString = std::to_string(movingImageDimension);
+  const auto movingImageDimensionString = std::to_string(MovingImageDimension);
   const auto movingImagePixelTypeString = elx::PixelTypeToString<typename TImage::PixelType>();
 
   // Set pixel types from input image, override user settings


### PR DESCRIPTION
Dropped pre-C++17 workarounds against "undefined symbols" build errors, when using constexpr static data members.