### PR TITLE
BUG: ElastixRegistrationMethod shouldn't put "NoInitialTransform" in map

### DIFF
--- a/Core/Main/itkElastixRegistrationMethod.hxx
+++ b/Core/Main/itkElastixRegistrationMethod.hxx
@@ -222,10 +222,6 @@ ElastixRegistrationMethod<TFixedImage, TMovingImage>::GenerateData()
 
     SetParameterValueAndWarnOnOverride(parameterMap, "ResultImagePixelType", fixedImagePixelTypeString);
 
-    // Initial transform parameter files are handled via arguments and enclosing loop, not
-    // InitialTransformParametersFileName
-    SetParameterValueAndWarnOnOverride(parameterMap, "InitialTransformParametersFileName", "NoInitialTransform");
-
     // Create new instance of ElastixMain
     const auto elastixMain = elx::ElastixMain::New();
     m_ElastixMain = elastixMain;


### PR DESCRIPTION
ElastixRegistrationMethod should not set "NoInitialTransform" as parameter value of `InitialTransformParametersFileName`. The value "NoInitialTransform" might cause confusion, as the registration might still have an initial transform parameter file, specified by `SetInitialTransformParameterFileName`.

----

For the record, ElastixFilter (the predecessor of ElastixRegistrationMethod) started setting the value "NoInitialTransform" in the registration parameter map with pull request #50 commit 6a7f91641081d9b4a1d7f888695347bfdee93575,  "ENH: Explicitly ignore InitialTransformParametersFileName set via parameter maps in ElastixFilter", merged on March 20, 2018:

https://github.com/SuperElastix/elastix/blob/6a7f91641081d9b4a1d7f888695347bfdee93575/Core/Main/elxElastixFilter.hxx#L218-L222

FYI @kaspermarstal 