### PR TITLE
STYLE: Remove initial `<<` insertion from `Macro(<< "`...`)` calls

### DIFF
--- a/Common/CostFunctions/itkAdvancedImageToImageMetric.hxx
+++ b/Common/CostFunctions/itkAdvancedImageToImageMetric.hxx
@@ -188,7 +188,7 @@ AdvancedImageToImageMetric<TFixedImage, TMovingImage>::InitializeLimiters()
   {
     if (this->GetFixedImageLimiter() == nullptr)
     {
-      itkExceptionMacro(<< "No fixed image limiter has been set!");
+      itkExceptionMacro("No fixed image limiter has been set!");
     }
 
     using ComputeFixedImageExtremaFilterType = typename itk::ComputeImageExtremaFilter<FixedImageType>;
@@ -237,7 +237,7 @@ AdvancedImageToImageMetric<TFixedImage, TMovingImage>::InitializeLimiters()
   {
     if (this->GetMovingImageLimiter() == nullptr)
     {
-      itkExceptionMacro(<< "No moving image limiter has been set!");
+      itkExceptionMacro("No moving image limiter has been set!");
     }
 
     using ComputeMovingImageExtremaFilterType = typename itk::ComputeImageExtremaFilter<MovingImageType>;
@@ -295,7 +295,7 @@ AdvancedImageToImageMetric<TFixedImage, TMovingImage>::InitializeImageSampler()
     /** Check if the ImageSampler is set. */
     if (!this->m_ImageSampler)
     {
-      itkExceptionMacro(<< "ImageSampler is not present");
+      itkExceptionMacro("ImageSampler is not present");
     }
 
     /** Initialize the Image Sampler. */
@@ -436,7 +436,7 @@ AdvancedImageToImageMetric<TFixedImage, TMovingImage>::CheckForAdvancedTransform
   {
     this->m_AdvancedTransform = nullptr;
     itkDebugMacro("Transform is not Advanced");
-    itkExceptionMacro(<< "The AdvancedImageToImageMetric requires an AdvancedTransform");
+    itkExceptionMacro("The AdvancedImageToImageMetric requires an AdvancedTransform");
   }
   else
   {

--- a/Common/CostFunctions/itkImageToImageMetricWithFeatures.hxx
+++ b/Common/CostFunctions/itkImageToImageMetricWithFeatures.hxx
@@ -54,12 +54,12 @@ ImageToImageMetricWithFeatures<TFixedImage, TMovingImage, TFixedFeatureImage, TM
     /** Check if all the fixed feature images are set. */
     if (!this->m_FixedFeatureImages[i])
     {
-      itkExceptionMacro(<< "ERROR: fixed feature image " << i << " is not set.");
+      itkExceptionMacro("ERROR: fixed feature image " << i << " is not set.");
     }
     /** Check if all the fixed feature interpolators are set. */
     if (!this->m_FixedFeatureInterpolators[i])
     {
-      itkExceptionMacro(<< "ERROR: fixed feature interpolator " << i << " is not set.");
+      itkExceptionMacro("ERROR: fixed feature interpolator " << i << " is not set.");
     }
     /** Connect the feature image to the interpolator. */
     this->m_FixedFeatureInterpolators[i]->SetInputImage(this->m_FixedFeatureImages[i]);
@@ -71,12 +71,12 @@ ImageToImageMetricWithFeatures<TFixedImage, TMovingImage, TFixedFeatureImage, TM
     /** Check if all the moving feature images are set. */
     if (!this->m_MovingFeatureImages[i])
     {
-      itkExceptionMacro(<< "ERROR: moving feature image " << i << " is not set.");
+      itkExceptionMacro("ERROR: moving feature image " << i << " is not set.");
     }
     /** Check if all the moving feature interpolators are set. */
     if (!this->m_MovingFeatureInterpolators[i])
     {
-      itkExceptionMacro(<< "ERROR: moving feature interpolator " << i << " is not set.");
+      itkExceptionMacro("ERROR: moving feature interpolator " << i << " is not set.");
     }
     /** Connect the feature image to the interpolator. */
     this->m_MovingFeatureInterpolators[i]->SetInputImage(this->m_MovingFeatureImages[i]);
@@ -316,12 +316,12 @@ ImageToImageMetricWithFeatures<TFixedImage, TMovingImage, TFixedFeatureImage, TM
     {
       this->m_FeatureInterpolatorsIsBSpline[i] = true;
       this->m_MovingFeatureBSplineInterpolators[i] = testPtr;
-      itkDebugMacro(<< "Interpolator " << i << " is B-spline.");
+      itkDebugMacro("Interpolator " << i << " is B-spline.");
     }
     else
     {
-      itkDebugMacro(<< "Interpolator " << i << " is NOT B-spline.");
-      itkExceptionMacro(<< "Interpolator " << i << " is NOT B-spline.");
+      itkDebugMacro("Interpolator " << i << " is NOT B-spline.");
+      itkExceptionMacro("Interpolator " << i << " is NOT B-spline.");
     }
   } // end for-loop
 

--- a/Common/CostFunctions/itkMultiInputImageToImageMetricBase.hxx
+++ b/Common/CostFunctions/itkMultiInputImageToImageMetricBase.hxx
@@ -178,13 +178,13 @@ MultiInputImageToImageMetricBase<TFixedImage, TMovingImage>::CheckForBSplineInte
     if (testPtr)
     {
       this->m_BSplineInterpolatorVector[i] = testPtr;
-      itkDebugMacro(<< "Interpolator " << i << " is B-spline.");
+      itkDebugMacro("Interpolator " << i << " is B-spline.");
     }
     else
     {
       this->m_InterpolatorsAreBSpline = false;
-      itkDebugMacro(<< "Interpolator " << i << " is NOT B-spline.");
-      itkExceptionMacro(<< "Interpolator " << i << " is NOT B-spline.");
+      itkDebugMacro("Interpolator " << i << " is NOT B-spline.");
+      itkExceptionMacro("Interpolator " << i << " is NOT B-spline.");
     }
   } // end for-loop
 
@@ -233,7 +233,7 @@ MultiInputImageToImageMetricBase<TFixedImage, TMovingImage>::InitializeImageSamp
     /** Check if the ImageSampler is set. */
     if (!this->m_ImageSampler)
     {
-      itkExceptionMacro(<< "ImageSampler is not present");
+      itkExceptionMacro("ImageSampler is not present");
     }
 
     /** Initialize the Image Sampler: set the fixed images. */

--- a/Common/CostFunctions/itkParzenWindowHistogramImageToImageMetric.hxx
+++ b/Common/CostFunctions/itkParzenWindowHistogramImageToImageMetric.hxx
@@ -356,8 +356,8 @@ ParzenWindowHistogramImageToImageMetric<TFixedImage, TMovingImage>::InitializeKe
       this->m_FixedKernel = BSplineKernelFunction2<3>::New();
       break;
     default:
-      itkExceptionMacro(<< "The following FixedKernelBSplineOrder is not implemented: "
-                        << this->m_FixedKernelBSplineOrder);
+      itkExceptionMacro(
+        "The following FixedKernelBSplineOrder is not implemented: " << this->m_FixedKernelBSplineOrder);
   } // end switch FixedKernelBSplineOrder
 
   switch (this->m_MovingKernelBSplineOrder)
@@ -384,8 +384,8 @@ ParzenWindowHistogramImageToImageMetric<TFixedImage, TMovingImage>::InitializeKe
       this->m_DerivativeMovingKernel = BSplineDerivativeKernelFunction2<3>::New();
       break;
     default:
-      itkExceptionMacro(<< "The following MovingKernelBSplineOrder is not implemented: "
-                        << this->m_MovingKernelBSplineOrder);
+      itkExceptionMacro(
+        "The following MovingKernelBSplineOrder is not implemented: " << this->m_MovingKernelBSplineOrder);
   } // end switch MovingKernelBSplineOrder
 
   /** The region of support of the Parzen window determines which bins

--- a/Common/CostFunctions/itkScaledSingleValuedCostFunction.cxx
+++ b/Common/CostFunctions/itkScaledSingleValuedCostFunction.cxx
@@ -48,7 +48,7 @@ ScaledSingleValuedCostFunction::GetValue(const ParametersType & parameters) cons
   const unsigned int numberOfParameters = this->GetNumberOfParameters();
   if (parameters.GetSize() != numberOfParameters)
   {
-    itkExceptionMacro(<< "Number of parameters is not like the unscaled cost function expects.");
+    itkExceptionMacro("Number of parameters is not like the unscaled cost function expects.");
   }
 
   MeasureType returnvalue = NumericTraits<MeasureType>::Zero;
@@ -86,7 +86,7 @@ ScaledSingleValuedCostFunction::GetDerivative(const ParametersType & parameters,
   const unsigned int numberOfParameters = this->GetNumberOfParameters();
   if (parameters.GetSize() != numberOfParameters)
   {
-    itkExceptionMacro(<< "Number of parameters is not like the unscaled cost function expects.");
+    itkExceptionMacro("Number of parameters is not like the unscaled cost function expects.");
   }
 
   if (this->m_UseScales)
@@ -130,7 +130,7 @@ ScaledSingleValuedCostFunction::GetValueAndDerivative(const ParametersType & par
   const unsigned int numberOfParameters = this->GetNumberOfParameters();
   if (parameters.GetSize() != numberOfParameters)
   {
-    itkExceptionMacro(<< "Number of parameters is not like the unscaled cost function expects.");
+    itkExceptionMacro("Number of parameters is not like the unscaled cost function expects.");
   }
 
   if (this->m_UseScales)
@@ -169,7 +169,7 @@ ScaledSingleValuedCostFunction::GetNumberOfParameters() const
 {
   if (this->m_UnscaledCostFunction.IsNull())
   {
-    itkExceptionMacro(<< "UnscaledCostFunction has not been set!");
+    itkExceptionMacro("UnscaledCostFunction has not been set!");
   }
   return this->m_UnscaledCostFunction->GetNumberOfParameters();
 
@@ -227,7 +227,7 @@ ScaledSingleValuedCostFunction::ConvertScaledToUnscaledParameters(ParametersType
     const ScalesType & scales = this->GetScales();
     if (scales.GetSize() != numberOfParameters)
     {
-      itkExceptionMacro(<< "Number of scales is not correct.");
+      itkExceptionMacro("Number of scales is not correct.");
     }
 
     for (unsigned int i = 0; i < numberOfParameters; ++i)
@@ -253,7 +253,7 @@ ScaledSingleValuedCostFunction::ConvertUnscaledToScaledParameters(ParametersType
     const ScalesType & scales = this->GetScales();
     if (scales.GetSize() != numberOfParameters)
     {
-      itkExceptionMacro(<< "Number of scales is not correct.");
+      itkExceptionMacro("Number of scales is not correct.");
     }
 
     for (unsigned int i = 0; i < numberOfParameters; ++i)

--- a/Common/CostFunctions/itkSingleValuedPointSetToPointSetMetric.hxx
+++ b/Common/CostFunctions/itkSingleValuedPointSetToPointSetMetric.hxx
@@ -49,7 +49,7 @@ SingleValuedPointSetToPointSetMetric<TFixedPointSet, TMovingPointSet>::SetTransf
 {
   if (!this->m_Transform)
   {
-    itkExceptionMacro(<< "Transform has not been assigned");
+    itkExceptionMacro("Transform has not been assigned");
   }
   this->m_Transform->SetParameters(parameters);
 
@@ -66,17 +66,17 @@ SingleValuedPointSetToPointSetMetric<TFixedPointSet, TMovingPointSet>::Initializ
 {
   if (!this->m_Transform)
   {
-    itkExceptionMacro(<< "Transform is not present");
+    itkExceptionMacro("Transform is not present");
   }
 
   if (!this->m_MovingPointSet)
   {
-    itkExceptionMacro(<< "MovingPointSet is not present");
+    itkExceptionMacro("MovingPointSet is not present");
   }
 
   if (!this->m_FixedPointSet)
   {
-    itkExceptionMacro(<< "FixedPointSet is not present");
+    itkExceptionMacro("FixedPointSet is not present");
   }
 
   // If the PointSet is provided by a source, update the source.

--- a/Common/ImageSamplers/itkImageFullSampler.hxx
+++ b/Common/ImageSamplers/itkImageFullSampler.hxx
@@ -72,7 +72,7 @@ ImageFullSampler<TInputImage>::GenerateData()
     }
     catch (...)
     {
-      itkExceptionMacro(<< "ERROR: failed to allocate memory for the sample container.");
+      itkExceptionMacro("ERROR: failed to allocate memory for the sample container.");
     }
 
     /** Simply loop over the image and store all samples in the container. */
@@ -164,7 +164,7 @@ ImageFullSampler<TInputImage>::ThreadedGenerateData(const InputImageRegionType &
     }
     catch (...)
     {
-      itkExceptionMacro(<< "ERROR: failed to allocate memory for the sample container.");
+      itkExceptionMacro("ERROR: failed to allocate memory for the sample container.");
     }
 
     /** Simply loop over the image and store all samples in the container. */

--- a/Common/ImageSamplers/itkImageGridSampler.hxx
+++ b/Common/ImageSamplers/itkImageGridSampler.hxx
@@ -219,7 +219,7 @@ ImageGridSampler<TInputImage>::SetNumberOfSamples(unsigned long nrofsamples)
   /** This function assumes that the input has been set. */
   if (!this->GetInput())
   {
-    itkExceptionMacro(<< "ERROR: only call the function SetNumberOfSamples() after the input has been set.");
+    itkExceptionMacro("ERROR: only call the function SetNumberOfSamples() after the input has been set.");
   }
 
   /** Compute an isotropic grid spacing (in voxels),

--- a/Common/ImageSamplers/itkImageRandomCoordinateSampler.hxx
+++ b/Common/ImageSamplers/itkImageRandomCoordinateSampler.hxx
@@ -195,7 +195,7 @@ ImageRandomCoordinateSampler<TInputImage>::ThreadedGenerateData(const InputImage
   typename MaskType::ConstPointer mask = this->GetMask();
   if (mask.IsNotNull())
   {
-    itkExceptionMacro(<< "ERROR: do not call this function when a mask is supplied.");
+    itkExceptionMacro("ERROR: do not call this function when a mask is supplied.");
   }
 
   /** Get handle to the input image. */

--- a/Common/ImageSamplers/itkImageRandomSampler.hxx
+++ b/Common/ImageSamplers/itkImageRandomSampler.hxx
@@ -139,7 +139,7 @@ ImageRandomSampler<TInputImage>::ThreadedGenerateData(const InputImageRegionType
   typename MaskType::ConstPointer mask = this->GetMask();
   if (mask.IsNotNull())
   {
-    itkExceptionMacro(<< "ERROR: do not call this function when a mask is supplied.");
+    itkExceptionMacro("ERROR: do not call this function when a mask is supplied.");
   }
 
   /** Get handle to the input image. */

--- a/Common/ImageSamplers/itkImageRandomSamplerSparseMask.hxx
+++ b/Common/ImageSamplers/itkImageRandomSamplerSparseMask.hxx
@@ -37,7 +37,7 @@ ImageRandomSamplerSparseMask<TInputImage>::GenerateData()
   /** Sanity check. */
   if (mask.IsNull())
   {
-    itkExceptionMacro(<< "ERROR: do not call this function when no mask is supplied.");
+    itkExceptionMacro("ERROR: do not call this function when no mask is supplied.");
   }
 
   /** Get handles to the input image and output sample container. */

--- a/Common/ImageSamplers/itkImageSamplerBase.hxx
+++ b/Common/ImageSamplers/itkImageSamplerBase.hxx
@@ -161,7 +161,7 @@ ImageSamplerBase<TInputImage>::GenerateInputRequestedRegion()
   /** Check if input image was set. */
   if (this->GetNumberOfInputs() == 0)
   {
-    itkExceptionMacro(<< "ERROR: Input image not set");
+    itkExceptionMacro("ERROR: Input image not set");
   }
 
   /** Get a pointer to the input image. */
@@ -356,7 +356,7 @@ ImageSamplerBase<TInputImage>::CropInputImageRegion()
      */
     if (!cropped)
     {
-      itkExceptionMacro(<< "ERROR: the bounding box of the mask lies entirely out of the InputImageRegion!");
+      itkExceptionMacro("ERROR: the bounding box of the mask lies entirely out of the InputImageRegion!");
     }
   }
 

--- a/Common/ImageSamplers/itkImageToVectorContainerFilter.hxx
+++ b/Common/ImageSamplers/itkImageToVectorContainerFilter.hxx
@@ -186,7 +186,7 @@ ImageToVectorContainerFilter<TInputImage, TOutputVectorContainer>::SplitRequeste
   splitRegion.SetIndex(splitIndex);
   splitRegion.SetSize(splitSize);
 
-  itkDebugMacro(<< "  Split Piece: " << splitRegion);
+  itkDebugMacro("  Split Piece: " << splitRegion);
 
   return maxThreadIdUsed + 1;
 

--- a/Common/ImageSamplers/itkMultiInputImageRandomCoordinateSampler.hxx
+++ b/Common/ImageSamplers/itkMultiInputImageRandomCoordinateSampler.hxx
@@ -148,7 +148,7 @@ MultiInputImageRandomCoordinateSampler<TInputImage>::GenerateSampleRegion(
   /** Check. */
   if (numberOfRegions != numberOfInputs && numberOfRegions != 1)
   {
-    itkExceptionMacro(<< "ERROR: The number of regions should be 1 or the number of inputs.");
+    itkExceptionMacro("ERROR: The number of regions should be 1 or the number of inputs.");
   }
 
   using DirectionType = typename InputImageType::DirectionType;
@@ -160,7 +160,7 @@ MultiInputImageRandomCoordinateSampler<TInputImage>::GenerateSampleRegion(
     DirectionType diri = this->GetInput(i)->GetDirection();
     if (diri != dir0)
     {
-      itkExceptionMacro(<< "ERROR: All input images should have the same direction cosines matrix.");
+      itkExceptionMacro("ERROR: All input images should have the same direction cosines matrix.");
     }
   }
 

--- a/Common/ImageSamplers/itkVectorContainerSource.hxx
+++ b/Common/ImageSamplers/itkVectorContainerSource.hxx
@@ -105,14 +105,14 @@ VectorContainerSource<TOutputVectorContainer>::GraftNthOutput(unsigned int idx, 
   /** Check idx. */
   if (idx >= this->GetNumberOfOutputs())
   {
-    itkExceptionMacro(<< "Requested to graft output " << idx << " but this filter only has "
-                      << this->GetNumberOfOutputs() << " Outputs.");
+    itkExceptionMacro("Requested to graft output " << idx << " but this filter only has " << this->GetNumberOfOutputs()
+                                                   << " Outputs.");
   }
 
   /** Check graft. */
   if (!graft)
   {
-    itkExceptionMacro(<< "Requested to graft output that is a NULL pointer");
+    itkExceptionMacro("Requested to graft output that is a NULL pointer");
   }
 
   /** Get a pointer to the output. */

--- a/Common/LineSearchOptimizers/itkMoreThuenteLineSearchOptimizer.cxx
+++ b/Common/LineSearchOptimizers/itkMoreThuenteLineSearchOptimizer.cxx
@@ -192,34 +192,34 @@ MoreThuenteLineSearchOptimizer::CheckSettings()
 {
   if (this->GetCostFunction() == nullptr)
   {
-    itkExceptionMacro(<< "CostFunction has not been set!");
+    itkExceptionMacro("CostFunction has not been set!");
   }
 
   const unsigned int numberOfParameters = this->GetCostFunction()->GetNumberOfParameters();
 
   if (this->GetInitialPosition().GetSize() != numberOfParameters)
   {
-    itkExceptionMacro(<< "InitialPosition has incorrect dimension!");
+    itkExceptionMacro("InitialPosition has incorrect dimension!");
   }
 
   if (this->GetLineSearchDirection().GetSize() != numberOfParameters)
   {
-    itkExceptionMacro(<< "LineSearchDirection has incorrect dimension!");
+    itkExceptionMacro("LineSearchDirection has incorrect dimension!");
   }
 
   if (this->GetMinimumStepLength() <= 0.0)
   {
-    itkExceptionMacro(<< "MinimumStepLength must be higher than zero!");
+    itkExceptionMacro("MinimumStepLength must be higher than zero!");
   }
 
   if (this->GetMinimumStepLength() > this->GetMaximumStepLength())
   {
-    itkExceptionMacro(<< "MinimumStepLength must be smaller than MaximumStepLength!");
+    itkExceptionMacro("MinimumStepLength must be smaller than MaximumStepLength!");
   }
 
   if (this->GetGradientTolerance() < this->GetValueTolerance())
   {
-    itkExceptionMacro(<< "GradientTolerance must be greater than ValueTolerance!");
+    itkExceptionMacro("GradientTolerance must be greater than ValueTolerance!");
   }
   return 0;
 

--- a/Common/MevisDicomTiff/itkMevisDicomTiffImageIO.cxx
+++ b/Common/MevisDicomTiff/itkMevisDicomTiffImageIO.cxx
@@ -175,7 +175,7 @@ MevisDicomTiffImageIO::FindElement(const gdcm::DataSet ds,
           }
           if (found)
           {
-            itkDebugMacro(<< "mevisIO: warning image orientation in dcm file is frame dependent!");
+            itkDebugMacro("mevisIO: warning image orientation in dcm file is frame dependent!");
           }
         }
       }
@@ -207,7 +207,7 @@ MevisDicomTiffImageIO::CanReadFile(const char * filename)
 
   if (basename.empty())
   {
-    itkExceptionMacro(<< "mevisIO:canreadfile(): no filename specified");
+    itkExceptionMacro("mevisIO:canreadfile(): no filename specified");
     return false;
   }
 
@@ -230,7 +230,7 @@ MevisDicomTiffImageIO::CanReadFile(const char * filename)
 
   if (!f.is_open() && !F.is_open())
   {
-    itkDebugMacro(<< "mevisIO:canreadfile(): cannot read (corresponding) dcm file");
+    itkDebugMacro("mevisIO:canreadfile(): cannot read (corresponding) dcm file");
     return false;
   }
   if (f.is_open())
@@ -258,7 +258,7 @@ MevisDicomTiffImageIO::CanReadFile(const char * filename)
 
   if (!t1.is_open() && !t2.is_open() && !t3.is_open() && !t4.is_open())
   {
-    itkDebugMacro(<< "mevisIO:canreadfile(): cannot read (corresponding) tif file");
+    itkDebugMacro("mevisIO:canreadfile(): cannot read (corresponding) tif file");
     return false;
   }
   if (t1.is_open())
@@ -287,7 +287,7 @@ MevisDicomTiffImageIO::CanReadFile(const char * filename)
   reader.SetFileName(m_DcmFileName.c_str());
   if (!reader.Read())
   {
-    itkDebugMacro(<< "mevisIO:canreadfile(): error opening dcm file " << m_DcmFileName);
+    itkDebugMacro("mevisIO:canreadfile(): error opening dcm file " << m_DcmFileName);
     return false;
   }
 
@@ -295,7 +295,7 @@ MevisDicomTiffImageIO::CanReadFile(const char * filename)
   m_TIFFImage = TIFFOpen(m_TiffFileName.c_str(), "rc"); // c is disable strip chopping
   if (m_TIFFImage == nullptr)
   {
-    itkDebugMacro(<< "mevisIO:canreadfile(): error opening tif file " << m_TiffFileName);
+    itkDebugMacro("mevisIO:canreadfile(): error opening tif file " << m_TiffFileName);
     return false;
   }
   else
@@ -303,12 +303,12 @@ MevisDicomTiffImageIO::CanReadFile(const char * filename)
     m_IsOpen = true;
     if (!TIFFGetField(m_TIFFImage, TIFFTAG_IMAGEWIDTH, &m_Width))
     {
-      itkDebugMacro(<< "mevisIO:canreadfile(): error getting IMAGEWIDTH ");
+      itkDebugMacro("mevisIO:canreadfile(): error getting IMAGEWIDTH ");
       return false;
     }
     if (!TIFFGetField(m_TIFFImage, TIFFTAG_IMAGELENGTH, &m_Length))
     {
-      itkDebugMacro(<< "mevisIO:canreadfile(): error getting IMAGELENGTH ");
+      itkDebugMacro("mevisIO:canreadfile(): error getting IMAGELENGTH ");
       return false;
     }
     if (!TIFFGetField(m_TIFFImage, TIFFTAG_IMAGEDEPTH, &m_Depth))
@@ -322,7 +322,7 @@ MevisDicomTiffImageIO::CanReadFile(const char * filename)
     }
     if (!TIFFGetField(m_TIFFImage, TIFFTAG_COMPRESSION, &m_Compression))
     {
-      itkDebugMacro(<< "mevisIO:canreadfile(): error getting COMPRESSION");
+      itkDebugMacro("mevisIO:canreadfile(): error getting COMPRESSION");
       // try resuming?
     }
 
@@ -333,12 +333,12 @@ MevisDicomTiffImageIO::CanReadFile(const char * filename)
 
       if (!TIFFGetField(m_TIFFImage, TIFFTAG_TILEWIDTH, &m_TileWidth))
       {
-        itkDebugMacro(<< "mevisIO:canreadfile(): error getting TILEWIDTH ");
+        itkDebugMacro("mevisIO:canreadfile(): error getting TILEWIDTH ");
         return false;
       }
       if (!TIFFGetField(m_TIFFImage, TIFFTAG_TILELENGTH, &m_TileLength))
       {
-        itkDebugMacro(<< "mevisIO:canreadfile(): error getting TILELength");
+        itkDebugMacro("mevisIO:canreadfile(): error getting TILELength");
         return false;
       }
       if (!TIFFGetField(m_TIFFImage, TIFFTAG_TILEDEPTH, &m_TileDepth))
@@ -427,7 +427,7 @@ MevisDicomTiffImageIO::ReadImageInformation()
   // sanity check
   if ((is2d && is3d) || (is3d && is4d) || (is2d && is4d))
   {
-    itkExceptionMacro(<< "mevisIO:readimageinformation(): error determining dimensionality from dcm file ");
+    itkExceptionMacro("mevisIO:readimageinformation(): error determining dimensionality from dcm file ");
   }
   if (is2d)
   {
@@ -443,7 +443,7 @@ MevisDicomTiffImageIO::ReadImageInformation()
     this->SetNumberOfDimensions(4);
     if (atnf.GetValue() % attp.GetValue() != 0)
     {
-      itkExceptionMacro(<< "mevisIO:readimageinformation(): error determining number of frames (== size z) in 4D file");
+      itkExceptionMacro("mevisIO:readimageinformation(): error determining number of frames (== size z) in 4D file");
     }
     m_Dimensions[2] = atnf.GetValue() / attp.GetValue();
     m_Dimensions[3] = attp.GetValue();
@@ -458,7 +458,7 @@ MevisDicomTiffImageIO::ReadImageInformation()
   }
   else
   {
-    itkExceptionMacro(<< "mevisIO:readimageinformation(): error reading dimensions-col from dcm-file");
+    itkExceptionMacro("mevisIO:readimageinformation(): error reading dimensions-col from dcm-file");
   }
 
   // dimensions - row
@@ -470,7 +470,7 @@ MevisDicomTiffImageIO::ReadImageInformation()
   }
   else
   {
-    itkExceptionMacro(<< "mevisIO:readimageinformation(): error reading dimensions-row from dcm-file");
+    itkExceptionMacro("mevisIO:readimageinformation(): error reading dimensions-row from dcm-file");
   }
 
   // pixel spacing (x,y)
@@ -483,7 +483,7 @@ MevisDicomTiffImageIO::ReadImageInformation()
   }
   else
   {
-    itkExceptionMacro(<< "mevisIO:readimageinformation(): error reading pixelspacing from dcm-file");
+    itkExceptionMacro("mevisIO:readimageinformation(): error reading pixelspacing from dcm-file");
   }
 
   // slice spacing (may be defined for 2d dicom files, if so
@@ -508,7 +508,7 @@ MevisDicomTiffImageIO::ReadImageInformation()
     if (is3d || is4d)
     {
       // throw an exception; this is dangerous.
-      itkExceptionMacro(<< "mevisIO:readimageinformation(): error reading slicespacing from dcm-file");
+      itkExceptionMacro("mevisIO:readimageinformation(): error reading slicespacing from dcm-file");
     }
   }
   // patient position (origin), always 3d vector in dcm file
@@ -534,7 +534,7 @@ MevisDicomTiffImageIO::ReadImageInformation()
   }
   else
   {
-    itkExceptionMacro(<< "mevisIO:readimageinformation(): error reading patient position (origin) from dcm-file");
+    itkExceptionMacro("mevisIO:readimageinformation(): error reading patient position (origin) from dcm-file");
   }
 
   // orientation (image orientation), always 3d vector
@@ -617,7 +617,7 @@ MevisDicomTiffImageIO::ReadImageInformation()
   else
   {
     // Throw an exception, to avoid headaches later
-    itkExceptionMacro(<< "mevisIO:readimageinformation(): error reading image orientation from dcm-file");
+    itkExceptionMacro("mevisIO:readimageinformation(): error reading image orientation from dcm-file");
   }
 
   // rescale
@@ -630,7 +630,7 @@ MevisDicomTiffImageIO::ReadImageInformation()
   else
   {
     // not necessary to throw an exception for this.
-    itkDebugMacro(<< "mevisIO:readimageinformation(): warning: intercept (0x0028,0x1052) not found in dcm header!");
+    itkDebugMacro("mevisIO:readimageinformation(): warning: intercept (0x0028,0x1052) not found in dcm header!");
     m_RescaleIntercept = 0.0; // default
   }
 
@@ -644,7 +644,7 @@ MevisDicomTiffImageIO::ReadImageInformation()
   else
   {
     // not necessary to throw an exception for this.
-    itkDebugMacro(<< "mevisIO:readimageinformation(): warning: slope (0x0028,0x1053) not found in dcm header!");
+    itkDebugMacro("mevisIO:readimageinformation(): warning: slope (0x0028,0x1053) not found in dcm header!");
     m_RescaleSlope = 1.0; // default
   }
   // gantry tilt
@@ -657,7 +657,7 @@ MevisDicomTiffImageIO::ReadImageInformation()
   else
   {
     // not necessary to throw an exception for this.
-    itkDebugMacro(<< "mevisIO: readimageinformation(): warning: gantry tilt (0x0018,0x1120) not found in dcm header!");
+    itkDebugMacro("mevisIO: readimageinformation(): warning: gantry tilt (0x0018,0x1120) not found in dcm header!");
     m_GantryTilt = 0.0; // default
   }
 
@@ -689,19 +689,19 @@ MevisDicomTiffImageIO::ReadImageInformation()
   // data type
   if (m_TIFFImage == nullptr)
   {
-    itkExceptionMacro(<< "mevisIO:readimageinformation: error opening file " << m_TiffFileName);
+    itkExceptionMacro("mevisIO:readimageinformation: error opening file " << m_TiffFileName);
   }
 
   // sanity checks, dim and sizes; NB: the value 3 below for the 4d case is not a typo! :)
   if ((is2d && m_TIFFDimension != 2) || (is3d && m_TIFFDimension != 3) || (is4d && m_TIFFDimension != 3))
   {
-    itkExceptionMacro(<< "mevisIO:readimageinformation: dcm/tiff dimensions do not correspond!");
+    itkExceptionMacro("mevisIO:readimageinformation: dcm/tiff dimensions do not correspond!");
   }
   if ((m_Width != m_Dimensions[0]) || (m_Length != m_Dimensions[1]) || (is3d && m_Depth != m_Dimensions[2]) ||
       (is4d && m_Depth != m_Dimensions[2] * m_Dimensions[3]))
 
   {
-    itkExceptionMacro(<< "mevisIO:readimageinformation: dcm/tiff sizes do not correspond!");
+    itkExceptionMacro("mevisIO:readimageinformation: dcm/tiff sizes do not correspond!");
   }
 
   // format 1 unsigned int
@@ -714,15 +714,15 @@ MevisDicomTiffImageIO::ReadImageInformation()
 
   if (!TIFFGetField(m_TIFFImage, TIFFTAG_SAMPLEFORMAT, &format))
   {
-    itkExceptionMacro(<< "mevisIO:readimageinformation: error getting SAMPLEFORMAT");
+    itkExceptionMacro("mevisIO:readimageinformation: error getting SAMPLEFORMAT");
   }
   if (!TIFFGetField(m_TIFFImage, TIFFTAG_SAMPLESPERPIXEL, &pixel))
   {
-    itkExceptionMacro(<< "mevisIO:readimageinformation: error getting SAMPLESPERPIXEL");
+    itkExceptionMacro("mevisIO:readimageinformation: error getting SAMPLESPERPIXEL");
   }
   if (!TIFFGetField(m_TIFFImage, TIFFTAG_BITSPERSAMPLE, &m_BitsPerSample))
   {
-    itkExceptionMacro(<< "mevisIO:readimageinformation: error getting BITSPERSAMPLE");
+    itkExceptionMacro("mevisIO:readimageinformation: error getting BITSPERSAMPLE");
   }
 
   // currently we only support grayscale
@@ -733,7 +733,7 @@ MevisDicomTiffImageIO::ReadImageInformation()
   }
   else
   {
-    itkExceptionMacro(<< "mevisIO:readimageinformation: currently only support grayscale");
+    itkExceptionMacro("mevisIO:readimageinformation: currently only support grayscale");
   }
 
   bool typeassign(false);
@@ -784,7 +784,7 @@ MevisDicomTiffImageIO::ReadImageInformation()
   }
   if (!typeassign)
   {
-    itkExceptionMacro(<< "mevisIO:readimageinformation: unsupported pixeltype ");
+    itkExceptionMacro("mevisIO:readimageinformation: unsupported pixeltype ");
   }
   // set compression
   // 1 none
@@ -823,13 +823,13 @@ MevisDicomTiffImageIO::Read(void * buffer)
   short int p;
   if (!TIFFGetField(m_TIFFImage, TIFFTAG_PLANARCONFIG, &p))
   {
-    itkExceptionMacro(<< "mevisIO:read(): error getting PLANARCONFIG");
+    itkExceptionMacro("mevisIO:read(): error getting PLANARCONFIG");
   }
   else
   {
     if (p != 1)
     {
-      itkExceptionMacro(<< "mevisIO:read(): non-contiguous data!");
+      itkExceptionMacro("mevisIO:read(): non-contiguous data!");
     }
   }
 
@@ -840,7 +840,7 @@ MevisDicomTiffImageIO::Read(void * buffer)
     // if the volume is multiple of tile.
     if (m_TIFFDimension == 3 && m_TileDepth != 1)
     {
-      itkExceptionMacro(<< "mevisIO:read(): unsupported tiledepth (should be one)! ");
+      itkExceptionMacro("mevisIO:read(): unsupported tiledepth (should be one)! ");
     }
 
     // buffer pointer is scanline based (one dimensional array)
@@ -873,7 +873,7 @@ MevisDicomTiffImageIO::Read(void * buffer)
           if (TIFFReadTile(m_TIFFImage, tilebuf, 0, 0, z0, 0) < 0)
           {
             _TIFFfree(tilebuf);
-            itkExceptionMacro(<< "mevisIO:read(): error reading tile (topleft)");
+            itkExceptionMacro("mevisIO:read(): error reading tile (topleft)");
           }
           else
           {
@@ -912,7 +912,7 @@ MevisDicomTiffImageIO::Read(void * buffer)
             if (TIFFReadTile(m_TIFFImage, tilebuf, 0, y0, z0, 0) < 0)
             {
               _TIFFfree(tilebuf);
-              itkExceptionMacro(<< "mevisIO:read(): error reading tile (top image)");
+              itkExceptionMacro("mevisIO:read(): error reading tile (top image)");
             }
             else
             {
@@ -939,7 +939,7 @@ MevisDicomTiffImageIO::Read(void * buffer)
             if (TIFFReadTile(m_TIFFImage, tilebuf, 0, y0, z0, 0) < 0)
             {
               _TIFFfree(tilebuf);
-              itkExceptionMacro(<< "mevisIO:read(): error reading tile (strip bottom)");
+              itkExceptionMacro("mevisIO:read(): error reading tile (strip bottom)");
             }
             else
             {
@@ -975,7 +975,7 @@ MevisDicomTiffImageIO::Read(void * buffer)
             if (TIFFReadTile(m_TIFFImage, tilebuf, x0, 0, z0, 0) < 0)
             {
               _TIFFfree(tilebuf);
-              itkExceptionMacro(<< "mevisIO:read(): error reading tile (top image)");
+              itkExceptionMacro("mevisIO:read(): error reading tile (top image)");
             }
             else
             {
@@ -1002,7 +1002,7 @@ MevisDicomTiffImageIO::Read(void * buffer)
             if (TIFFReadTile(m_TIFFImage, tilebuf, x0, 0, z0, 0) < 0)
             {
               _TIFFfree(tilebuf);
-              itkExceptionMacro(<< "mevisIO:read(): error reading tile (strip right)");
+              itkExceptionMacro("mevisIO:read(): error reading tile (strip right)");
             }
             else
             {
@@ -1053,7 +1053,7 @@ MevisDicomTiffImageIO::Read(void * buffer)
             if (TIFFReadTile(m_TIFFImage, tilebuf, x0, y0, z0, 0) < 0)
             {
               _TIFFfree(tilebuf);
-              itkExceptionMacro(<< "mevisIO:read(): error reading tile (topleft image)");
+              itkExceptionMacro("mevisIO:read(): error reading tile (topleft image)");
             }
             else
             {
@@ -1088,7 +1088,7 @@ MevisDicomTiffImageIO::Read(void * buffer)
             if (TIFFReadTile(m_TIFFImage, tilebuf, x0, y0, z0, 0) < 0)
             {
               _TIFFfree(tilebuf);
-              itkExceptionMacro(<< "mevisIO:read(): error reading tile (ydirection)");
+              itkExceptionMacro("mevisIO:read(): error reading tile (ydirection)");
             }
             else
             {
@@ -1117,7 +1117,7 @@ MevisDicomTiffImageIO::Read(void * buffer)
             if (TIFFReadTile(m_TIFFImage, tilebuf, x0, y0, z0, 0) < 0)
             {
               _TIFFfree(tilebuf);
-              itkExceptionMacro(<< "mevisIO:read(): error reading tile (x-direction)");
+              itkExceptionMacro("mevisIO:read(): error reading tile (x-direction)");
             }
             else
             {
@@ -1148,7 +1148,7 @@ MevisDicomTiffImageIO::Read(void * buffer)
           if (TIFFReadTile(m_TIFFImage, tilebuf, x0, y0, z0, 0) < 0)
           {
             _TIFFfree(tilebuf);
-            itkExceptionMacro(<< "mevisIO:read(): error reading tile (corner bottom)");
+            itkExceptionMacro("mevisIO:read(): error reading tile (corner bottom)");
           }
           else
           {
@@ -1169,7 +1169,7 @@ MevisDicomTiffImageIO::Read(void * buffer)
   else
   {
     // if not tiled then img is stripped
-    itkExceptionMacro(<< "mevisIO:read(): non-tiled dcm/tiff reading not (yet) implemented");
+    itkExceptionMacro("mevisIO:read(): non-tiled dcm/tiff reading not (yet) implemented");
   }
   return;
 }
@@ -1201,7 +1201,7 @@ MevisDicomTiffImageIO::CanWriteFile(const char * name)
   {
     // SK: throw an exception instead of writing to cerr. This is clearly
     // a situation that asks for an exception to be thrown.
-    itkExceptionMacro(<< "mevisIO:canwritefile(): no filename specified");
+    itkExceptionMacro("mevisIO:canwritefile(): no filename specified");
     return false;
   }
 
@@ -1252,13 +1252,13 @@ MevisDicomTiffImageIO ::Write(const void * buffer)
 {
   if (this->GetNumberOfDimensions() != 2 && this->GetNumberOfDimensions() != 3 && this->GetNumberOfDimensions() != 4)
   {
-    itkExceptionMacro(<< "mevisIO:write(): dcm/tiff writer only supports 2D/3D/4D");
+    itkExceptionMacro("mevisIO:write(): dcm/tiff writer only supports 2D/3D/4D");
   }
 
   std::ofstream dcmfile(m_DcmFileName.c_str(), std::ios::out | std::ios::binary);
   if (!dcmfile.is_open())
   {
-    itkExceptionMacro(<< "mevisIO:write(): error opening dcm file for writing " << m_DcmFileName);
+    itkExceptionMacro("mevisIO:write(): error opening dcm file for writing " << m_DcmFileName);
   }
   dcmfile.close();
 
@@ -1485,7 +1485,7 @@ MevisDicomTiffImageIO ::Write(const void * buffer)
       // number of components should be one
       if (this->GetNumberOfComponents() != 1)
       {
-        itkExceptionMacro(<< "mevisIO:write(): nr of Components should be 1 for SCALAR");
+        itkExceptionMacro("mevisIO:write(): nr of Components should be 1 for SCALAR");
       }
       gdcm::Attribute<0x0028, 0x0002> atsamples;
       atsamples.SetValue(1);
@@ -1561,7 +1561,7 @@ MevisDicomTiffImageIO ::Write(const void * buffer)
     break;
     default:
     {
-      itkExceptionMacro(<< "mevisIO:write(): error writing dcm-file unsupported component type");
+      itkExceptionMacro("mevisIO:write(): error writing dcm-file unsupported component type");
     }
   }
 
@@ -1670,7 +1670,7 @@ MevisDicomTiffImageIO ::Write(const void * buffer)
   }
   catch (gdcm::Exception & err)
   {
-    itkExceptionMacro(<< "mevisIO:write(): gdcm has thrown exception: " << err.GetDescription());
+    itkExceptionMacro("mevisIO:write(): gdcm has thrown exception: " << err.GetDescription());
   }
   if (!retwrite)
   {
@@ -1690,25 +1690,25 @@ MevisDicomTiffImageIO ::Write(const void * buffer)
   m_TIFFImage = TIFFOpen(m_TiffFileName.c_str(), "w");
   if (!m_TIFFImage)
   {
-    itkExceptionMacro(<< "mevisIO:write(): error opening tiff file for writing");
+    itkExceptionMacro("mevisIO:write(): error opening tiff file for writing");
   }
 
   // software comment
   if (!TIFFSetField(m_TIFFImage, TIFFTAG_SOFTWARE, c.c_str()))
   {
-    itkDebugMacro(<< "mevisIO:write(): error setting SOFTWARE");
+    itkDebugMacro("mevisIO:write(): error setting SOFTWARE");
   }
 
   // set sizes
   m_Width = m_Dimensions[0];
   if (!TIFFSetField(m_TIFFImage, TIFFTAG_IMAGEWIDTH, m_Width))
   {
-    itkExceptionMacro(<< "mevisIO:write(): error setting IMAGEWIDTH");
+    itkExceptionMacro("mevisIO:write(): error setting IMAGEWIDTH");
   }
   m_Length = m_Dimensions[1];
   if (!TIFFSetField(m_TIFFImage, TIFFTAG_IMAGELENGTH, m_Length))
   {
-    itkExceptionMacro(<< "mevisIO:write(): error setting IMAGELENGTH");
+    itkExceptionMacro("mevisIO:write(): error setting IMAGELENGTH");
   }
 
   // dimensions
@@ -1723,7 +1723,7 @@ MevisDicomTiffImageIO ::Write(const void * buffer)
     m_Depth = m_Dimensions[2];
     if (!TIFFSetField(m_TIFFImage, TIFFTAG_IMAGEDEPTH, m_Depth))
     {
-      itkExceptionMacro(<< "mevisIO:write(): error setting IMAGEDEPTH");
+      itkExceptionMacro("mevisIO:write(): error setting IMAGEDEPTH");
     }
   }
   if (m_NumberOfDimensions == 4)
@@ -1732,32 +1732,32 @@ MevisDicomTiffImageIO ::Write(const void * buffer)
     m_Depth = m_Dimensions[2] * m_Dimensions[3];
     if (!TIFFSetField(m_TIFFImage, TIFFTAG_IMAGEDEPTH, m_Depth))
     {
-      itkExceptionMacro(<< "mevisIO:write(): error setting IMAGEDEPTH");
+      itkExceptionMacro("mevisIO:write(): error setting IMAGEDEPTH");
     }
   }
   // photometric (default min-is-black)
   if (!TIFFSetField(m_TIFFImage, TIFFTAG_PHOTOMETRIC, PHOTOMETRIC_MINISBLACK))
   {
-    itkDebugMacro(<< "mevisIO:write(): error setting PHOTOMETRIC");
+    itkDebugMacro("mevisIO:write(): error setting PHOTOMETRIC");
   }
   // orientation (default row 0 top, col 0 lhs == 1)
   if (!TIFFSetField(m_TIFFImage, TIFFTAG_ORIENTATION, ORIENTATION_TOPLEFT))
   {
-    itkDebugMacro(<< "mevisIO:write(): error setting ORIENTATION");
+    itkDebugMacro("mevisIO:write(): error setting ORIENTATION");
   }
   // minimumn
   if (sign)
   {
     if (!TIFFSetField(m_TIFFImage, TIFFTAG_SMINSAMPLEVALUE, m_EstimatedMinimum))
     {
-      itkDebugMacro(<< "mevisIO:write(): error setting SMINSAMPLEVALUE");
+      itkDebugMacro("mevisIO:write(): error setting SMINSAMPLEVALUE");
     }
   }
   else
   {
     if (!TIFFSetField(m_TIFFImage, TIFFTAG_MINSAMPLEVALUE, static_cast<unsigned int>(m_EstimatedMinimum)))
     {
-      itkDebugMacro(<< "mevisIO:write(): error setting MINSAMPLEVALUE");
+      itkDebugMacro("mevisIO:write(): error setting MINSAMPLEVALUE");
     }
   }
   // maximum
@@ -1765,14 +1765,14 @@ MevisDicomTiffImageIO ::Write(const void * buffer)
   {
     if (!TIFFSetField(m_TIFFImage, TIFFTAG_SMAXSAMPLEVALUE, m_EstimatedMaximum))
     {
-      itkDebugMacro(<< "mevisIO:write(): error setting SMAXSAMPLEVALUE");
+      itkDebugMacro("mevisIO:write(): error setting SMAXSAMPLEVALUE");
     }
   }
   else
   {
     if (!TIFFSetField(m_TIFFImage, TIFFTAG_MAXSAMPLEVALUE, static_cast<unsigned int>(m_EstimatedMaximum)))
     {
-      itkDebugMacro(<< "mevisIO:write(): error setting MAXSAMPLEVALUE");
+      itkDebugMacro("mevisIO:write(): error setting MAXSAMPLEVALUE");
     }
   }
   // pixeltype
@@ -1783,16 +1783,16 @@ MevisDicomTiffImageIO ::Write(const void * buffer)
       // number of components should be one
       if (this->GetNumberOfComponents() != 1)
       {
-        itkExceptionMacro(<< "mevisIO:write(): nr of Components should be 1 for SCALAR");
+        itkExceptionMacro("mevisIO:write(): nr of Components should be 1 for SCALAR");
       }
       if (!TIFFSetField(m_TIFFImage, TIFFTAG_SAMPLESPERPIXEL, 1))
       {
-        itkExceptionMacro(<< "mevisIO:write(): error setting SAMPLESPERPIXEL");
+        itkExceptionMacro("mevisIO:write(): error setting SAMPLESPERPIXEL");
       }
     }
     break;
     default:
-      itkExceptionMacro(<< "mevisIO:write(): only SCALAR pixeltypes supported");
+      itkExceptionMacro("mevisIO:write(): only SCALAR pixeltypes supported");
   }
   // componenttype
   bool suc(false);
@@ -1847,11 +1847,11 @@ MevisDicomTiffImageIO ::Write(const void * buffer)
   }
   if (!suc)
   {
-    itkExceptionMacro(<< "mevisIO:write(): error setting SAMPLEFORMAT");
+    itkExceptionMacro("mevisIO:write(): error setting SAMPLEFORMAT");
   }
   if (!TIFFSetField(m_TIFFImage, TIFFTAG_BITSPERSAMPLE, m_BitsPerSample))
   {
-    itkExceptionMacro(<< "mevisIO:write(): error setting BITSPERSAMPLE ");
+    itkExceptionMacro("mevisIO:write(): error setting BITSPERSAMPLE ");
   }
 
   // compression, default always using lzw (overriding
@@ -1865,28 +1865,28 @@ MevisDicomTiffImageIO ::Write(const void * buffer)
   {
     if (!TIFFSetField(m_TIFFImage, TIFFTAG_COMPRESSION, 5))
     {
-      itkDebugMacro(<< "WARNING: mevisIO:write(): error setting COMPRESSION to LZW");
+      itkDebugMacro("WARNING: mevisIO:write(): error setting COMPRESSION to LZW");
     }
   }
   else
   {
     if (!TIFFSetField(m_TIFFImage, TIFFTAG_COMPRESSION, 1))
     {
-      itkDebugMacro(<< "WARNING: mevisIO:write(): error setting COMPRESSION to NONE");
+      itkDebugMacro("WARNING: mevisIO:write(): error setting COMPRESSION to NONE");
     }
   }
   // resolution (always assuming cm)
   if (!TIFFSetField(m_TIFFImage, TIFFTAG_RESOLUTIONUNIT, RESUNIT_CENTIMETER))
   {
-    itkExceptionMacro(<< "mevisIO:write(): error setting RESOLUTIONUNIT");
+    itkExceptionMacro("mevisIO:write(): error setting RESOLUTIONUNIT");
   }
   if (!TIFFSetField(m_TIFFImage, TIFFTAG_XRESOLUTION, static_cast<float>(10.0 / m_Spacing[0])))
   {
-    itkExceptionMacro(<< "mevisIO:write(): error setting XRESOLUTION");
+    itkExceptionMacro("mevisIO:write(): error setting XRESOLUTION");
   }
   if (!TIFFSetField(m_TIFFImage, TIFFTAG_YRESOLUTION, static_cast<float>(10.0 / m_Spacing[1])))
   {
-    itkExceptionMacro(<< "mevisIO:write(): error setting YRESOLUTION");
+    itkExceptionMacro("mevisIO:write(): error setting YRESOLUTION");
   }
 
   // setting tilespecs
@@ -1900,7 +1900,7 @@ MevisDicomTiffImageIO ::Write(const void * buffer)
     m_TileDepth = 1;
     if (!TIFFSetField(m_TIFFImage, TIFFTAG_TILEDEPTH, m_TileDepth))
     {
-      itkExceptionMacro(<< "mevisIO:write(): error setting TILEDEPTH");
+      itkExceptionMacro("mevisIO:write(): error setting TILEDEPTH");
     }
   }
 
@@ -1944,11 +1944,11 @@ MevisDicomTiffImageIO ::Write(const void * buffer)
 
   if (!TIFFSetField(m_TIFFImage, TIFFTAG_TILEWIDTH, m_TileWidth))
   {
-    itkExceptionMacro(<< "mevisIO:write(): error setting TILEWIDTH, m_TileWidth");
+    itkExceptionMacro("mevisIO:write(): error setting TILEWIDTH, m_TileWidth");
   }
   if (!TIFFSetField(m_TIFFImage, TIFFTAG_TILELENGTH, m_TileLength))
   {
-    itkExceptionMacro(<< "mevisIO:write(): error setting TILELENGTH, m_TileLength");
+    itkExceptionMacro("mevisIO:write(): error setting TILELENGTH, m_TileLength");
   }
 
   // now filling the image with buffer provided
@@ -1966,8 +1966,8 @@ MevisDicomTiffImageIO ::Write(const void * buffer)
     // now left open.
 
     TIFFClose(m_TIFFImage);
-    itkExceptionMacro(<< "mevisIO:write(): image x,y smaller than tilesize (16)! Consider different layout for tif (eg "
-                         "scanline layout)");
+    itkExceptionMacro("mevisIO:write(): image x,y smaller than tilesize (16)! Consider different layout for tif (eg "
+                      "scanline layout)");
   }
   else
   {
@@ -2007,7 +2007,7 @@ MevisDicomTiffImageIO ::Write(const void * buffer)
 
             _TIFFfree(tilebuf);
             TIFFClose(m_TIFFImage);
-            itkExceptionMacro(<< "mevisIO:write(): error writing tile.");
+            itkExceptionMacro("mevisIO:write(): error writing tile.");
           }
         }
       }
@@ -2040,7 +2040,7 @@ MevisDicomTiffImageIO ::Write(const void * buffer)
           {
             _TIFFfree(tilebuf);
             TIFFClose(m_TIFFImage);
-            itkExceptionMacro(<< "mevisIO:write(): error writing tile (ydirection)");
+            itkExceptionMacro("mevisIO:write(): error writing tile (ydirection)");
           }
         }
       }
@@ -2069,7 +2069,7 @@ MevisDicomTiffImageIO ::Write(const void * buffer)
           {
             _TIFFfree(tilebuf);
             TIFFClose(m_TIFFImage);
-            itkExceptionMacro(<< "mevisIO:write(): error writing tile (x-direction)");
+            itkExceptionMacro("mevisIO:write(): error writing tile (x-direction)");
           }
         }
       }
@@ -2100,7 +2100,7 @@ MevisDicomTiffImageIO ::Write(const void * buffer)
         {
           _TIFFfree(tilebuf);
           TIFFClose(m_TIFFImage);
-          itkExceptionMacro(<< "mevisIO:write(): error writing tile (corner bottom)");
+          itkExceptionMacro("mevisIO:write(): error writing tile (corner bottom)");
         }
       }
     } // end z

--- a/Common/OpenCL/Filters/itkGPUAdvancedCombinationTransformCopier.hxx
+++ b/Common/OpenCL/Filters/itkGPUAdvancedCombinationTransformCopier.hxx
@@ -73,7 +73,7 @@ GPUAdvancedCombinationTransformCopier<TTypeList,
 {
   if (!this->m_InputTransform)
   {
-    itkExceptionMacro(<< "ERROR: m_InputTransform not set");
+    itkExceptionMacro("ERROR: m_InputTransform not set");
   }
 
   // Update only if the input AdvancedCombinationTransform has been modified
@@ -106,8 +106,8 @@ GPUAdvancedCombinationTransformCopier<TTypeList,
     const bool copySucceeded = this->CopyToCurrentTransform(currentTransformCPU, currentTransformGPU);
     if (!copySucceeded)
     {
-      itkExceptionMacro(<< "ERROR: GPUAdvancedCombinationTransformCopier was unable to copy transform from: "
-                        << this->m_InputTransform);
+      itkExceptionMacro(
+        "ERROR: GPUAdvancedCombinationTransformCopier was unable to copy transform from: " << this->m_InputTransform);
     }
 
     // skip next step when last transform

--- a/Common/OpenCL/Filters/itkGPUBSplineDecompositionImageFilter.hxx
+++ b/Common/OpenCL/Filters/itkGPUBSplineDecompositionImageFilter.hxx
@@ -72,7 +72,7 @@ GPUBSplineDecompositionImageFilter<TInputImage, TOutputImage>::GPUBSplineDecompo
   }
   else
   {
-    itkExceptionMacro(<< "Kernel has not been loaded from:\n" << GPUSource);
+    itkExceptionMacro("Kernel has not been loaded from:\n" << GPUSource);
   }
 } // end Constructor()
 
@@ -85,7 +85,7 @@ template <typename TInputImage, typename TOutputImage>
 void
 GPUBSplineDecompositionImageFilter<TInputImage, TOutputImage>::GPUGenerateData()
 {
-  itkDebugMacro(<< "Calling GPUBSplineDecompositionImageFilter::GPUGenerateData()");
+  itkDebugMacro("Calling GPUBSplineDecompositionImageFilter::GPUGenerateData()");
 
   using GPUInputImage = typename GPUTraits<TInputImage>::Type;
   using GPUOutputImage = typename GPUTraits<TOutputImage>::Type;
@@ -96,11 +96,11 @@ GPUBSplineDecompositionImageFilter<TInputImage, TOutputImage>::GPUGenerateData()
   // Perform the safe check
   if (inPtr.IsNull())
   {
-    itkExceptionMacro(<< "The GPU InputImage is NULL. Filter unable to perform.");
+    itkExceptionMacro("The GPU InputImage is NULL. Filter unable to perform.");
   }
   if (otPtr.IsNull())
   {
-    itkExceptionMacro(<< "The GPU OutputImage is NULL. Filter unable to perform.");
+    itkExceptionMacro("The GPU OutputImage is NULL. Filter unable to perform.");
   }
 
   const typename GPUOutputImage::SizeType outSize = otPtr->GetLargestPossibleRegion().GetSize();
@@ -118,7 +118,7 @@ GPUBSplineDecompositionImageFilter<TInputImage, TOutputImage>::GPUGenerateData()
   // Check if GPU filter are able to perform for this image
   if (maxLength > this->m_DeviceLocalMemorySize)
   {
-    itkExceptionMacro(<< "GPUBSplineDecompositionImageFilter unable to perform.");
+    itkExceptionMacro("GPUBSplineDecompositionImageFilter unable to perform.");
   }
 
   // Cast here, see the same call in this->CopyImageToImage() of
@@ -239,7 +239,7 @@ GPUBSplineDecompositionImageFilter<TInputImage, TOutputImage>::GPUGenerateData()
 
   eventList.WaitForFinished();
 
-  itkDebugMacro(<< "GPUBSplineDecompositionImageFilter::GPUGenerateData() finished");
+  itkDebugMacro("GPUBSplineDecompositionImageFilter::GPUGenerateData() finished");
 } // end GPUGenerateData()
 
 

--- a/Common/OpenCL/Filters/itkGPUCastImageFilter.hxx
+++ b/Common/OpenCL/Filters/itkGPUCastImageFilter.hxx
@@ -52,7 +52,7 @@ GPUCastImageFilter<TInputImage, TOutputImage>::GPUCastImageFilter()
   }
   else
   {
-    itkExceptionMacro(<< "Kernel has not been loaded from string:\n" << GPUSource);
+    itkExceptionMacro("Kernel has not been loaded from string:\n" << GPUSource);
   }
 }
 
@@ -62,9 +62,9 @@ template <typename TInputImage, typename TOutputImage>
 void
 GPUCastImageFilter<TInputImage, TOutputImage>::GPUGenerateData()
 {
-  itkDebugMacro(<< "Calling GPUCastImageFilter::GPUGenerateData()");
+  itkDebugMacro("Calling GPUCastImageFilter::GPUGenerateData()");
   GPUSuperclass::GPUGenerateData();
-  itkDebugMacro(<< "GPUCastImageFilter::GPUGenerateData() finished");
+  itkDebugMacro("GPUCastImageFilter::GPUGenerateData() finished");
 }
 
 

--- a/Common/OpenCL/Filters/itkGPUCompositeTransformBase.hxx
+++ b/Common/OpenCL/Filters/itkGPUCompositeTransformBase.hxx
@@ -52,7 +52,7 @@ GPUCompositeTransformBase<TScalarType, NDimensions>::GetParametersDataManager(co
     }
     else
     {
-      itkExceptionMacro(<< "Could not get GPU transform base.");
+      itkExceptionMacro("Could not get GPU transform base.");
     }
   }
 }

--- a/Common/OpenCL/Filters/itkGPUCompositeTransformCopier.hxx
+++ b/Common/OpenCL/Filters/itkGPUCompositeTransformCopier.hxx
@@ -48,7 +48,7 @@ GPUCompositeTransformCopier<TTypeList, NDimensions, TCompositeTransform, TOutput
 {
   if (!this->m_InputTransform)
   {
-    itkExceptionMacro(<< "Input CompositeTransform has not been connected");
+    itkExceptionMacro("Input CompositeTransform has not been connected");
   }
 
   // Update only if the input AdvancedCombinationTransform has been modified

--- a/Common/OpenCL/Filters/itkGPUInterpolatorCopier.hxx
+++ b/Common/OpenCL/Filters/itkGPUInterpolatorCopier.hxx
@@ -55,7 +55,7 @@ GPUInterpolatorCopier<TTypeList, NDimensions, TInterpolator, TOutputCoordRep>::U
 {
   if (!this->m_InputInterpolator)
   {
-    itkExceptionMacro(<< "Input Interpolator has not been connected");
+    itkExceptionMacro("Input Interpolator has not been connected");
   }
 
   // Update only if the input AdvancedCombinationTransform has been modified
@@ -165,7 +165,7 @@ GPUInterpolatorCopier<TTypeList, NDimensions, TInterpolator, TOutputCoordRep>::U
 
     if (this->m_Output.IsNull())
     {
-      itkExceptionMacro(<< "GPUInterpolatorCopier was unable to copy interpolator from: " << this->m_InputInterpolator);
+      itkExceptionMacro("GPUInterpolatorCopier was unable to copy interpolator from: " << this->m_InputInterpolator);
     }
   }
 }

--- a/Common/OpenCL/Filters/itkGPURecursiveGaussianImageFilter.hxx
+++ b/Common/OpenCL/Filters/itkGPURecursiveGaussianImageFilter.hxx
@@ -67,7 +67,7 @@ GPURecursiveGaussianImageFilter<TInputImage, TOutputImage>::GPURecursiveGaussian
   }
   else
   {
-    itkExceptionMacro(<< "Kernel has not been loaded from:\n" << GPUSource);
+    itkExceptionMacro("Kernel has not been loaded from:\n" << GPUSource);
   }
 }
 
@@ -77,7 +77,7 @@ template <typename TInputImage, typename TOutputImage>
 void
 GPURecursiveGaussianImageFilter<TInputImage, TOutputImage>::GPUGenerateData()
 {
-  itkDebugMacro(<< "Calling GPURecursiveGaussianImageFilter::GPUGenerateData()");
+  itkDebugMacro("Calling GPURecursiveGaussianImageFilter::GPUGenerateData()");
 
   using GPUInputImage = typename GPUTraits<TInputImage>::Type;
   using GPUOutputImage = typename GPUTraits<TOutputImage>::Type;
@@ -88,11 +88,11 @@ GPURecursiveGaussianImageFilter<TInputImage, TOutputImage>::GPUGenerateData()
   // Perform the safe check
   if (inPtr.IsNull())
   {
-    itkExceptionMacro(<< "The GPU InputImage is NULL. Filter unable to perform.");
+    itkExceptionMacro("The GPU InputImage is NULL. Filter unable to perform.");
   }
   if (otPtr.IsNull())
   {
-    itkExceptionMacro(<< "The GPU OutputImage is NULL. Filter unable to perform.");
+    itkExceptionMacro("The GPU OutputImage is NULL. Filter unable to perform.");
   }
 
   const typename GPUOutputImage::SizeType outSize = otPtr->GetLargestPossibleRegion().GetSize();
@@ -102,7 +102,7 @@ GPURecursiveGaussianImageFilter<TInputImage, TOutputImage>::GPUGenerateData()
   // Check if GPU filter are able to perform for this image
   if (ln > this->m_DeviceLocalMemorySize)
   {
-    itkExceptionMacro(<< "GPURecursiveGaussianImageFilter unable to perform.");
+    itkExceptionMacro("GPURecursiveGaussianImageFilter unable to perform.");
   }
 
   int imgSize[TInputImage::ImageDimension];
@@ -229,7 +229,7 @@ GPURecursiveGaussianImageFilter<TInputImage, TOutputImage>::GPUGenerateData()
     break;
   }
 
-  itkDebugMacro(<< "GPURecursiveGaussianImageFilter::GPUGenerateData() finished");
+  itkDebugMacro("GPURecursiveGaussianImageFilter::GPUGenerateData() finished");
 }
 
 

--- a/Common/OpenCL/Filters/itkGPUResampleImageFilter.hxx
+++ b/Common/OpenCL/Filters/itkGPUResampleImageFilter.hxx
@@ -135,9 +135,7 @@ GPUResampleImageFilter<TInputImage, TOutputImage, TInterpolatorPrecisionType, TT
     this->m_PreKernelManager->BuildProgramFromSourceCode(resamplePreSource.str(), defines.str());
   if (program.IsNull())
   {
-    itkExceptionMacro(<< "Kernel has not been loaded from string:\n"
-                      << defines.str() << '\n'
-                      << resamplePreSource.str());
+    itkExceptionMacro("Kernel has not been loaded from string:\n" << defines.str() << '\n' << resamplePreSource.str());
   }
   this->m_FilterPreGPUKernelHandle = this->m_PreKernelManager->CreateKernel(program, "ResampleImageFilterPre");
 } // end Constructor
@@ -178,7 +176,7 @@ GPUResampleImageFilter<TInputImage, TOutputImage, TInterpolatorPrecisionType, TT
   std::string interpolatorSource;
   if (!interpolatorBase->GetSourceCode(interpolatorSource))
   {
-    itkExceptionMacro(<< "Unable to get interpolator source code.");
+    itkExceptionMacro("Unable to get interpolator source code.");
   }
 
   // Construct ResampleImageFilter Post code
@@ -201,7 +199,7 @@ GPUResampleImageFilter<TInputImage, TOutputImage, TInterpolatorPrecisionType, TT
     this->m_PostKernelManager->BuildProgramFromSourceCode(resamplePostSource.str(), defines);
   if (program.IsNull())
   {
-    itkExceptionMacro(<< "Kernel has not been loaded from string:\n" << defines << '\n' << resamplePostSource.str());
+    itkExceptionMacro("Kernel has not been loaded from string:\n" << defines << '\n' << resamplePostSource.str());
   }
 
   if (this->m_InterpolatorIsBSpline)
@@ -214,7 +212,7 @@ GPUResampleImageFilter<TInputImage, TOutputImage, TInterpolatorPrecisionType, TT
     this->m_FilterPostGPUKernelHandle = this->m_PostKernelManager->CreateKernel(program, "ResampleImageFilterPost");
   }
 
-  itkDebugMacro(<< "GPUResampleImageFilter::SetInterpolator() finished");
+  itkDebugMacro("GPUResampleImageFilter::SetInterpolator() finished");
 } // end SetInterpolator()
 
 
@@ -231,7 +229,7 @@ GPUResampleImageFilter<TInputImage, TOutputImage, TInterpolatorPrecisionType, TT
   ExtrapolatorType * _arg)
 {
   // CPUSuperclass::SetExtrapolator( _arg );
-  itkWarningMacro(<< "Setting Extrapolator for GPUResampleImageFilter not supported yet.");
+  itkWarningMacro("Setting Extrapolator for GPUResampleImageFilter not supported yet.");
 } // end SetExtrapolator()
 
 
@@ -300,7 +298,7 @@ GPUResampleImageFilter<TInputImage, TOutputImage, TInterpolatorPrecisionType, TT
   std::string transformSource;
   if (!transformBase->GetSourceCode(transformSource))
   {
-    itkExceptionMacro(<< "Unable to get transform source code.");
+    itkExceptionMacro("Unable to get transform source code.");
   }
 
   // Construct ResampleImageFilter Loop code
@@ -337,7 +335,7 @@ GPUResampleImageFilter<TInputImage, TOutputImage, TInterpolatorPrecisionType, TT
     this->m_LoopKernelManager->BuildProgramFromSourceCode(resampleLoopSource.str(), defines);
   if (program.IsNull())
   {
-    itkExceptionMacro(<< "Kernel has not been loaded from string:\n" << defines << '\n' << resampleLoopSource.str());
+    itkExceptionMacro("Kernel has not been loaded from string:\n" << defines << '\n' << resampleLoopSource.str());
   }
 
   // \todo: can we clean this up?
@@ -379,7 +377,7 @@ GPUResampleImageFilter<TInputImage, TOutputImage, TInterpolatorPrecisionType, TT
       this->m_LoopKernelManager->CreateKernel(program, "ResampleImageFilterLoop_BSplineTransform");
   }
 
-  itkDebugMacro(<< "GPUResampleImageFilter::SetTransform() finished");
+  itkDebugMacro("GPUResampleImageFilter::SetTransform() finished");
 } // end SetTransform()
 
 
@@ -395,7 +393,7 @@ void
 GPUResampleImageFilter<TInputImage, TOutputImage, TInterpolatorPrecisionType, TTransformPrecisionType>::
   GPUGenerateData()
 {
-  itkDebugMacro(<< "GPUResampleImageFilter::GPUGenerateData() called");
+  itkDebugMacro("GPUResampleImageFilter::GPUGenerateData() called");
 
   // Profiling
 #ifdef OPENCL_PROFILING
@@ -410,18 +408,18 @@ GPUResampleImageFilter<TInputImage, TOutputImage, TInterpolatorPrecisionType, TT
   // Perform safety checks
   if (inPtr.IsNull())
   {
-    itkExceptionMacro(<< "The GPU InputImage is NULL. Filter unable to perform.");
+    itkExceptionMacro("The GPU InputImage is NULL. Filter unable to perform.");
   }
   if (outPtr.IsNull())
   {
-    itkExceptionMacro(<< "The GPU OutputImage is NULL. Filter unable to perform.");
+    itkExceptionMacro("The GPU OutputImage is NULL. Filter unable to perform.");
   }
 
   // Get the largest possible output region.
   const OutputImageRegionType outputLargestRegion = outPtr->GetLargestPossibleRegion();
   if (outputLargestRegion.GetNumberOfPixels() == 0)
   {
-    itkExceptionMacro(<< "GPUResampleImageFilter has not been properly initialized. Filter unable to perform.");
+    itkExceptionMacro("GPUResampleImageFilter has not been properly initialized. Filter unable to perform.");
   }
 
   // Define filter parameters:
@@ -677,7 +675,7 @@ GPUResampleImageFilter<TInputImage, TOutputImage, TInterpolatorPrecisionType, TT
 
   eventList.WaitForFinished();
 
-  itkDebugMacro(<< "GPUResampleImageFilter::GPUGenerateData() finished");
+  itkDebugMacro("GPUResampleImageFilter::GPUGenerateData() finished");
 } // end GPUGenerateData()
 
 
@@ -693,7 +691,7 @@ void
 GPUResampleImageFilter<TInputImage, TOutputImage, TInterpolatorPrecisionType, TTransformPrecisionType>::
   SetArgumentsForPreKernelManager(const typename GPUOutputImage::Pointer & outputImage)
 {
-  itkDebugMacro(<< "GPUResampleImageFilter::SetArgumentsForPreKernelManager called");
+  itkDebugMacro("GPUResampleImageFilter::SetArgumentsForPreKernelManager called");
 
   // Get a handle to the pre kernel
   cl_uint        argidx = 0;
@@ -715,7 +713,7 @@ GPUResampleImageFilter<TInputImage, TOutputImage, TInterpolatorPrecisionType, TT
   OpenCLKernelToImageBridge<OutputImageType>::SetSize(
     preKernel, argidx++, outputImage->GetLargestPossibleRegion().GetSize());
 
-  itkDebugMacro(<< "GPUResampleImageFilter::SetArgumentsForPreKernelManager() finished");
+  itkDebugMacro("GPUResampleImageFilter::SetArgumentsForPreKernelManager() finished");
 } // end SetArgumentsForPreKernelManager()
 
 
@@ -732,8 +730,8 @@ GPUResampleImageFilter<TInputImage, TOutputImage, TInterpolatorPrecisionType, TT
   SetArgumentsForLoopKernelManager(const typename GPUInputImage::Pointer &  input,
                                    const typename GPUOutputImage::Pointer & output)
 {
-  itkDebugMacro(<< "GPUResampleImageFilter::SetArgumentsForLoopKernelManager(" << input->GetNameOfClass() << ", "
-                << output->GetNameOfClass() << ") called");
+  itkDebugMacro("GPUResampleImageFilter::SetArgumentsForLoopKernelManager(" << input->GetNameOfClass() << ", "
+                                                                            << output->GetNameOfClass() << ") called");
 
   // Loop over all supported transform types
   typename TransformsHandle::const_iterator it = this->m_FilterLoopGPUKernelHandle.begin();
@@ -762,7 +760,7 @@ GPUResampleImageFilter<TInputImage, TOutputImage, TInterpolatorPrecisionType, TT
       loopKernel, argidx++, output->GetLargestPossibleRegion().GetSize());
   }
 
-  itkDebugMacro(<< "GPUResampleImageFilter::SetArgumentsForLoopKernelManager() finished");
+  itkDebugMacro("GPUResampleImageFilter::SetArgumentsForLoopKernelManager() finished");
 } // end SetArgumentsForLoopKernelManager()
 
 
@@ -778,8 +776,7 @@ void
 GPUResampleImageFilter<TInputImage, TOutputImage, TInterpolatorPrecisionType, TTransformPrecisionType>::
   SetTransformParametersForLoopKernelManager(const std::size_t transformIndex)
 {
-  itkDebugMacro(<< "GPUResampleImageFilter::SetTransformArgumentsForLoopKernelManager(" << transformIndex
-                << ") called");
+  itkDebugMacro("GPUResampleImageFilter::SetTransformArgumentsForLoopKernelManager(" << transformIndex << ") called");
 
   const GPUTransformTypeEnum transformType = this->GetTransformType(transformIndex);
 
@@ -811,7 +808,7 @@ GPUResampleImageFilter<TInputImage, TOutputImage, TInterpolatorPrecisionType, TT
     this->SetBSplineTransformCoefficientsToGPU(transformIndex);
   }
 
-  itkDebugMacro(<< "GPUResampleImageFilter::SetTransformArgumentsForLoopKernelManager() finished");
+  itkDebugMacro("GPUResampleImageFilter::SetTransformArgumentsForLoopKernelManager() finished");
 } // end SetTransformArgumentsForLoopKernelManager()
 
 
@@ -827,7 +824,7 @@ void
 GPUResampleImageFilter<TInputImage, TOutputImage, TInterpolatorPrecisionType, TTransformPrecisionType>::
   SetBSplineTransformCoefficientsToGPU(const std::size_t transformIndex)
 {
-  itkDebugMacro(<< "GPUResampleImageFilter::SetBSplineTransformCoefficientsToGPU(" << transformIndex << ") called");
+  itkDebugMacro("GPUResampleImageFilter::SetBSplineTransformCoefficientsToGPU(" << transformIndex << ") called");
 
   // Typedefs
   using GPUBSplineTransformType = GPUBSplineBaseTransform<InterpolatorPrecisionType, InputImageDimension>;
@@ -879,7 +876,7 @@ GPUResampleImageFilter<TInputImage, TOutputImage, TInterpolatorPrecisionType, TT
                                                    false);
   }
 
-  itkDebugMacro(<< "GPUResampleImageFilter::SetBSplineTransformCoefficientsToGPU() finished");
+  itkDebugMacro("GPUResampleImageFilter::SetBSplineTransformCoefficientsToGPU() finished");
 } // end SetBSplineTransformCoefficientsToGPU()
 
 
@@ -896,8 +893,8 @@ GPUResampleImageFilter<TInputImage, TOutputImage, TInterpolatorPrecisionType, TT
   SetArgumentsForPostKernelManager(const typename GPUInputImage::Pointer &  input,
                                    const typename GPUOutputImage::Pointer & output)
 {
-  itkDebugMacro(<< "GPUResampleImageFilter::SetArgumentsForPostKernelManager(" << input->GetNameOfClass() << ", "
-                << output->GetNameOfClass() << ") called");
+  itkDebugMacro("GPUResampleImageFilter::SetArgumentsForPostKernelManager(" << input->GetNameOfClass() << ", "
+                                                                            << output->GetNameOfClass() << ") called");
 
   // Get a handle to the post kernel
   OpenCLKernel & postKernel = this->m_PostKernelManager->GetKernel(this->m_FilterPostGPUKernelHandle);
@@ -959,7 +956,7 @@ GPUResampleImageFilter<TInputImage, TOutputImage, TInterpolatorPrecisionType, TT
   this->m_PostKernelManager->SetKernelArgWithImage(
     this->m_FilterPostGPUKernelHandle, argidx++, this->m_InterpolatorBase->GetParametersDataManager());
 
-  itkDebugMacro(<< "GPUResampleImageFilter::SetArgumentsForPostKernelManager() finished");
+  itkDebugMacro("GPUResampleImageFilter::SetArgumentsForPostKernelManager() finished");
 } // end SetArgumentsForPostKernelManager()
 
 
@@ -1171,7 +1168,7 @@ GPUResampleImageFilter<TInputImage, TOutputImage, TInterpolatorPrecisionType, TT
 
   if (!GPUBSplineTransformBase)
   {
-    itkExceptionMacro(<< "Could not get coefficients from GPU BSpline transform.");
+    itkExceptionMacro("Could not get coefficients from GPU BSpline transform.");
   }
 
   return GPUBSplineTransformBase;

--- a/Common/OpenCL/Filters/itkGPUShrinkImageFilter.hxx
+++ b/Common/OpenCL/Filters/itkGPUShrinkImageFilter.hxx
@@ -53,7 +53,7 @@ GPUShrinkImageFilter<TInputImage, TOutputImage>::GPUShrinkImageFilter()
   }
   else
   {
-    itkExceptionMacro(<< "Kernel has not been loaded from:\n" << GPUSource);
+    itkExceptionMacro("Kernel has not been loaded from:\n" << GPUSource);
   }
 } // end Constructor()
 
@@ -66,7 +66,7 @@ template <typename TInputImage, typename TOutputImage>
 void
 GPUShrinkImageFilter<TInputImage, TOutputImage>::GPUGenerateData()
 {
-  itkDebugMacro(<< "Calling GPUShrinkImageFilter::GPUGenerateData()");
+  itkDebugMacro("Calling GPUShrinkImageFilter::GPUGenerateData()");
 
   using GPUInputImage = typename GPUTraits<TInputImage>::Type;
   using GPUOutputImage = typename GPUTraits<TOutputImage>::Type;
@@ -77,11 +77,11 @@ GPUShrinkImageFilter<TInputImage, TOutputImage>::GPUGenerateData()
   // Perform the safe check
   if (inPtr.IsNull())
   {
-    itkExceptionMacro(<< "The GPU InputImage is NULL. Filter unable to perform.");
+    itkExceptionMacro("The GPU InputImage is NULL. Filter unable to perform.");
   }
   if (otPtr.IsNull())
   {
-    itkExceptionMacro(<< "The GPU OutputImage is NULL. Filter unable to perform.");
+    itkExceptionMacro("The GPU OutputImage is NULL. Filter unable to perform.");
   }
 
   // Convert the factor for convenient multiplication
@@ -187,7 +187,7 @@ GPUShrinkImageFilter<TInputImage, TOutputImage>::GPUGenerateData()
 
   event.WaitForFinished();
 
-  itkDebugMacro(<< "GPUShrinkImageFilter::GPUGenerateData() finished");
+  itkDebugMacro("GPUShrinkImageFilter::GPUGenerateData() finished");
 } // end GPUGenerateData()
 
 

--- a/Common/OpenCL/Filters/itkGPUTransformCopier.hxx
+++ b/Common/OpenCL/Filters/itkGPUTransformCopier.hxx
@@ -61,7 +61,7 @@ GPUTransformCopier<TTypeList, NDimensions, TTransform, TOutputTransformPrecision
 {
   if (!this->m_InputTransform)
   {
-    itkExceptionMacro(<< "Input Transform has not been connected");
+    itkExceptionMacro("Input Transform has not been connected");
   }
 
   // Update only if the input AdvancedCombinationTransform has been modified
@@ -80,7 +80,7 @@ GPUTransformCopier<TTypeList, NDimensions, TTransform, TOutputTransformPrecision
     const bool copyResult = this->CopyTransform(this->m_InputTransform, this->m_Output);
     if (!copyResult || this->m_Output.IsNull())
     {
-      itkExceptionMacro(<< "GPUTransformCopier was unable to copy transform from: " << this->m_InputTransform);
+      itkExceptionMacro("GPUTransformCopier was unable to copy transform from: " << this->m_InputTransform);
     }
   }
 }

--- a/Common/OpenCL/ITKimprovements/itkGPUImage.hxx
+++ b/Common/OpenCL/ITKimprovements/itkGPUImage.hxx
@@ -306,8 +306,8 @@ GPUImage<TPixel, VImageDimension>::Graft(const DataObject * data)
     else
     {
       // pointer could not be cast back down
-      itkExceptionMacro(<< "itk::GPUImage::Graft() cannot cast " << typeid(data).name() << " to "
-                        << typeid(const GPUImageDataManagerType *).name());
+      itkExceptionMacro("itk::GPUImage::Graft() cannot cast " << typeid(data).name() << " to "
+                                                              << typeid(const GPUImageDataManagerType *).name());
     }
   }
 }

--- a/Common/OpenCL/ITKimprovements/itkGPUImageToImageFilter.hxx
+++ b/Common/OpenCL/ITKimprovements/itkGPUImageToImageFilter.hxx
@@ -116,7 +116,7 @@ GPUImageToImageFilter<TInputImage, TOutputImage, TParentImageFilter>::GraftOutpu
 {
   if (!graft)
   {
-    itkExceptionMacro(<< "Requested to graft output that is a NULL pointer");
+    itkExceptionMacro("Requested to graft output that is a NULL pointer");
   }
 
   using GPUOutputImage = typename itk::GPUTraits<TOutputImage>::Type;
@@ -138,8 +138,8 @@ GPUImageToImageFilter<TInputImage, TOutputImage, TParentImageFilter>::GraftOutpu
   else
   {
     // pointer could not be cast back down
-    itkExceptionMacro(<< "itk::GPUImageToImageFilter::GraftOutput() cannot cast " << typeid(graft).name() << " to "
-                      << typeid(GPUOutputImage *).name());
+    itkExceptionMacro("itk::GPUImageToImageFilter::GraftOutput() cannot cast " << typeid(graft).name() << " to "
+                                                                               << typeid(GPUOutputImage *).name());
   }
 }
 
@@ -152,7 +152,7 @@ GPUImageToImageFilter<TInputImage, TOutputImage, TParentImageFilter>::GraftOutpu
 {
   if (!graft)
   {
-    itkExceptionMacro(<< "Requested to graft output that is a NULL pointer");
+    itkExceptionMacro("Requested to graft output that is a NULL pointer");
   }
 
   using GPUOutputImage = typename itk::GPUTraits<TOutputImage>::Type;
@@ -174,8 +174,8 @@ GPUImageToImageFilter<TInputImage, TOutputImage, TParentImageFilter>::GraftOutpu
   else
   {
     // pointer could not be cast back down
-    itkExceptionMacro(<< "itk::GPUImageToImageFilter::GraftOutput() cannot cast " << typeid(graft).name() << " to "
-                      << typeid(GPUOutputImage *).name());
+    itkExceptionMacro("itk::GPUImageToImageFilter::GraftOutput() cannot cast " << typeid(graft).name() << " to "
+                                                                               << typeid(GPUOutputImage *).name());
   }
 }
 

--- a/Common/OpenCL/ITKimprovements/itkGPUUnaryFunctorImageFilter.hxx
+++ b/Common/OpenCL/ITKimprovements/itkGPUUnaryFunctorImageFilter.hxx
@@ -63,11 +63,11 @@ GPUUnaryFunctorImageFilter<TInputImage, TOutputImage, TFunction, TParentImageFil
   // Perform the safe check
   if (inPtr.IsNull())
   {
-    itkExceptionMacro(<< "The GPU InputImage is NULL. Filter unable to perform.");
+    itkExceptionMacro("The GPU InputImage is NULL. Filter unable to perform.");
   }
   if (otPtr.IsNull())
   {
-    itkExceptionMacro(<< "The GPU OutputImage is NULL. Filter unable to perform.");
+    itkExceptionMacro("The GPU OutputImage is NULL. Filter unable to perform.");
   }
 
   const typename GPUOutputImage::SizeType outSize = otPtr->GetLargestPossibleRegion().GetSize();

--- a/Common/OpenCL/ITKimprovements/itkOpenCLContext.cxx
+++ b/Common/OpenCL/ITKimprovements/itkOpenCLContext.cxx
@@ -186,7 +186,7 @@ OpenCLContext::Create(const OpenCLDevice::DeviceType type)
   d->is_created = (d->id != 0);
   if (!d->is_created)
   {
-    itkOpenCLWarningMacro(<< "OpenCLContext::Create(type:" << int(type) << "):" << this->GetErrorName(d->last_error));
+    itkOpenCLWarningMacro("OpenCLContext::Create(type:" << int(type) << "):" << this->GetErrorName(d->last_error));
   }
   else
   {
@@ -223,7 +223,7 @@ OpenCLContext::Create(const std::list<OpenCLDevice> & devices)
   d->is_created = (d->id != 0);
   if (!d->is_created)
   {
-    itkOpenCLWarningMacro(<< "OpenCLContext::Create:" << this->GetErrorName(d->last_error));
+    itkOpenCLWarningMacro("OpenCLContext::Create:" << this->GetErrorName(d->last_error));
   }
   else
   {
@@ -271,7 +271,7 @@ OpenCLContext::Create(const OpenCLContext::CreateMethod method)
         }
         else
         {
-          itkGenericExceptionMacro(<< "Unable to create OpenCLContext with method MultipleMaximumFlopsDevices.");
+          itkGenericExceptionMacro("Unable to create OpenCLContext with method MultipleMaximumFlopsDevices.");
         }
       }
     }
@@ -286,7 +286,7 @@ OpenCLContext::Create(const OpenCLContext::CreateMethod method)
 #  elif OPENCL_USE_INTEL_CPU
     device = OpenCLDevice::GetMaximumFlopsDeviceByVendor(OpenCLDevice::CPU, OpenCLPlatform::Intel);
 #  else
-    itkGenericExceptionMacro(<< "Unknown Intel OpenCL platform.");
+    itkGenericExceptionMacro("Unknown Intel OpenCL platform.");
 #  endif
 
     // NVidia platform
@@ -299,12 +299,12 @@ OpenCLContext::Create(const OpenCLContext::CreateMethod method)
 #  elif OPENCL_USE_AMD_CPU
     device = OpenCLDevice::GetMaximumFlopsDeviceByVendor(OpenCLDevice::CPU, OpenCLPlatform::AMD);
 #  else
-    itkGenericExceptionMacro(<< "Unknown AMD OpenCL platform.");
+    itkGenericExceptionMacro("Unknown AMD OpenCL platform.");
 #  endif
 
     // Unknown platform
 #else
-    itkGenericExceptionMacro(<< "Not supported OpenCL platform by OpenCLContext.");
+    itkGenericExceptionMacro("Not supported OpenCL platform by OpenCLContext.");
 #endif
 
     std::list<OpenCLDevice> devices;
@@ -321,7 +321,7 @@ OpenCLContext::Create(const OpenCLContext::CreateMethod method)
 #  elif OPENCL_USE_INTEL_CPU
     devices = OpenCLDevice::GetDevices(OpenCLDevice::CPU, OpenCLPlatform::Intel);
 #  else
-    itkGenericExceptionMacro(<< "Unknown Intel OpenCL platform.");
+    itkGenericExceptionMacro("Unknown Intel OpenCL platform.");
 #  endif
 
     // NVidia platform
@@ -334,12 +334,12 @@ OpenCLContext::Create(const OpenCLContext::CreateMethod method)
 #  elif OPENCL_USE_AMD_CPU
     devices = OpenCLDevice::GetDevices(OpenCLDevice::CPU, OpenCLPlatform::AMD);
 #  else
-    itkGenericExceptionMacro(<< "Unknown AMD OpenCL platform.");
+    itkGenericExceptionMacro("Unknown AMD OpenCL platform.");
 #  endif
 
     // Unknown platform
 #else
-    itkGenericExceptionMacro(<< "Not supported OpenCL platform by OpenCLContext.");
+    itkGenericExceptionMacro("Not supported OpenCL platform by OpenCLContext.");
 #endif
     this->CreateContext(devices, d);
   }
@@ -374,7 +374,7 @@ OpenCLContext::Create(const OpenCLContext::CreateMethod method)
         }
         else
         {
-          itkGenericExceptionMacro(<< "Unable to create OpenCLContext with method MultipleMaximumFlopsDevices.");
+          itkGenericExceptionMacro("Unable to create OpenCLContext with method MultipleMaximumFlopsDevices.");
         }
       }
     }
@@ -384,8 +384,7 @@ OpenCLContext::Create(const OpenCLContext::CreateMethod method)
   d->is_created = (d->id != 0);
   if (!d->is_created)
   {
-    itkOpenCLWarningMacro(<< "OpenCLContext::Create(method:" << int(method)
-                          << "):" << this->GetErrorName(d->last_error));
+    itkOpenCLWarningMacro("OpenCLContext::Create(method:" << int(method) << "):" << this->GetErrorName(d->last_error));
   }
   else
   {
@@ -412,8 +411,8 @@ OpenCLContext::Create(const OpenCLPlatform & platfrom, const OpenCLDevice::Devic
   d->is_created = (d->id != 0);
   if (!d->is_created)
   {
-    itkOpenCLWarningMacro(<< "OpenCLContext::Create(platfrom id:" << platfrom.GetPlatformId()
-                          << "):" << this->GetErrorName(d->last_error));
+    itkOpenCLWarningMacro("OpenCLContext::Create(platfrom id:" << platfrom.GetPlatformId()
+                                                               << "):" << this->GetErrorName(d->last_error));
   }
   else
   {
@@ -444,7 +443,7 @@ OpenCLContext::Create()
   platform = OpenCLPlatform::GetPlatform(OpenCLPlatform::Intel);
   this->CreateContext(platform, OpenCLDevice::CPU, d);
 #  else
-  itkGenericExceptionMacro(<< "Unknown Intel OpenCL platform.");
+  itkGenericExceptionMacro("Unknown Intel OpenCL platform.");
 #  endif
 
   // NVidia platform
@@ -460,19 +459,19 @@ OpenCLContext::Create()
   platform = OpenCLPlatform::GetPlatform(OpenCLPlatform::AMD);
   this->CreateContext(platform, OpenCLDevice::CPU, d);
 #  else
-  itkGenericExceptionMacro(<< "Unknown AMD OpenCL platform.");
+  itkGenericExceptionMacro("Unknown AMD OpenCL platform.");
 #  endif
 
   // Unknown platform
 #else
-  itkGenericExceptionMacro(<< "Not supported OpenCL platform by OpenCLContext.");
+  itkGenericExceptionMacro("Not supported OpenCL platform by OpenCLContext.");
 #endif
 
   // Check if OpenCL context has been created
   d->is_created = (d->id != 0);
   if (!d->is_created)
   {
-    itkOpenCLWarningMacro(<< "OpenCLContext::Create():" << this->GetErrorName(d->last_error));
+    itkOpenCLWarningMacro("OpenCLContext::Create():" << this->GetErrorName(d->last_error));
   }
   else
   {
@@ -799,7 +798,7 @@ OpenCLContext::GetDefaultCommandQueue()
 
     if (!queue)
     {
-      itkOpenCLWarningMacro(<< "OpenCLContext::GetDefaultCommandQueue:" << this->GetErrorName(d->last_error));
+      itkOpenCLWarningMacro("OpenCLContext::GetDefaultCommandQueue:" << this->GetErrorName(d->last_error));
       return OpenCLCommandQueue();
     }
     d->default_command_queue = OpenCLCommandQueue(this, queue);
@@ -958,7 +957,7 @@ OpenCLContext::CreateImageDevice(const OpenCLImageFormat &        format,
   cl_mem mem = nullptr;
   if (size.GetDimension() == 1)
   {
-    itkGenericExceptionMacro(<< "OpenCLContext::CreateImageDevice() not supported for 1D.");
+    itkGenericExceptionMacro("OpenCLContext::CreateImageDevice() not supported for 1D.");
   }
   else if (size.GetDimension() == 2)
   {
@@ -1014,7 +1013,7 @@ OpenCLContext::CreateImageHost(const OpenCLImageFormat &        format,
   cl_mem mem = nullptr;
   if (size.GetDimension() == 1)
   {
-    itkGenericExceptionMacro(<< "OpenCLContext::CreateImageHost() not supported for 1D.");
+    itkGenericExceptionMacro("OpenCLContext::CreateImageHost() not supported for 1D.");
   }
   else if (size.GetDimension() == 2)
   {
@@ -1062,7 +1061,7 @@ OpenCLContext::CreateImageCopy(const OpenCLImageFormat &        format,
   cl_mem mem = nullptr;
   if (size.GetDimension() == 1)
   {
-    itkGenericExceptionMacro(<< "OpenCLContext::CreateImageCopy() not supported for 1D.");
+    itkGenericExceptionMacro("OpenCLContext::CreateImageCopy() not supported for 1D.");
   }
   else if (size.GetDimension() == 2)
   {
@@ -1096,7 +1095,7 @@ OpenCLContext::CreateProgramFromSourceCode(const std::string & sourceCode,
 {
   if (sourceCode.empty())
   {
-    itkOpenCLWarningMacro(<< "The source code is empty for the OpenCL program.");
+    itkOpenCLWarningMacro("The source code is empty for the OpenCL program.");
     return OpenCLProgram();
   }
 
@@ -1126,7 +1125,7 @@ OpenCLContext::CreateProgramFromSourceCode(const std::string & sourceCode,
 
   if (oclSourceSize == 0)
   {
-    itkOpenCLWarningMacro(<< "Cannot build OpenCL brogram from empty source.");
+    itkOpenCLWarningMacro("Cannot build OpenCL brogram from empty source.");
     return OpenCLProgram();
   }
 
@@ -1140,13 +1139,13 @@ OpenCLContext::CreateProgramFromSourceCode(const std::string & sourceCode,
     std::ofstream debugfile(fileName.c_str());
     if (debugfile.is_open() == false)
     {
-      itkOpenCLWarningMacro(<< "Cannot create OpenCL debug source file: " << fileName);
+      itkOpenCLWarningMacro("Cannot create OpenCL debug source file: " << fileName);
       return OpenCLProgram();
     }
     debugfile << oclSource;
     debugfile.close();
 
-    itkOpenCLWarningMacro(<< "For Debugging your OpenCL kernel use:\n" << fileName);
+    itkOpenCLWarningMacro("For Debugging your OpenCL kernel use:\n" << fileName);
   }
 
   std::cout << "Creating OpenCL program from source." << std::endl;
@@ -1169,7 +1168,7 @@ OpenCLContext::CreateProgramFromSourceFile(const std::string & filename,
 {
   if (filename.empty())
   {
-    itkOpenCLWarningMacro(<< "The filename must be specified.");
+    itkOpenCLWarningMacro("The filename must be specified.");
     return OpenCLProgram();
   }
 
@@ -1177,7 +1176,7 @@ OpenCLContext::CreateProgramFromSourceFile(const std::string & filename,
   std::ifstream inputFile(filename.c_str(), std::ifstream::in | std::ifstream::binary);
   if (inputFile.is_open() == false)
   {
-    itkOpenCLWarningMacro(<< "Cannot open OpenCL source file: " << filename);
+    itkOpenCLWarningMacro("Cannot open OpenCL source file: " << filename);
     return OpenCLProgram();
   }
 
@@ -1205,7 +1204,7 @@ OpenCLContext::CreateProgramFromSourceFile(const std::string & filename,
 
   if (oclSourceSize == 0)
   {
-    itkOpenCLWarningMacro(<< "Cannot build OpenCL source file: " << filename << " is empty.");
+    itkOpenCLWarningMacro("Cannot build OpenCL source file: " << filename << " is empty.");
     return OpenCLProgram();
   }
 
@@ -1224,13 +1223,13 @@ OpenCLContext::CreateProgramFromSourceFile(const std::string & filename,
     std::ofstream debugfile(fileName.c_str());
     if (debugfile.is_open() == false)
     {
-      itkOpenCLWarningMacro(<< "Cannot create OpenCL debug source file: " << fileName);
+      itkOpenCLWarningMacro("Cannot create OpenCL debug source file: " << fileName);
       return OpenCLProgram();
     }
     debugfile << oclSource;
     debugfile.close();
 
-    itkOpenCLWarningMacro(<< "For Debugging your OpenCL kernel use:\n" << fileName << " , not original .cl file.");
+    itkOpenCLWarningMacro("For Debugging your OpenCL kernel use:\n" << fileName << " , not original .cl file.");
   }
 
   std::cout << "Creating OpenCL program from : " << fileName << std::endl;
@@ -1249,7 +1248,7 @@ OpenCLContext::CreateOpenCLProgram(const std::string & filename,
 {
   if (source.empty())
   {
-    itkOpenCLWarningMacro(<< "The source is empty for the OpenCL program in filename: '" << filename << "'");
+    itkOpenCLWarningMacro("The source is empty for the OpenCL program in filename: '" << filename << "'");
     return OpenCLProgram();
   }
 

--- a/Common/OpenCL/ITKimprovements/itkOpenCLKernelManager.cxx
+++ b/Common/OpenCL/ITKimprovements/itkOpenCLKernelManager.cxx
@@ -64,8 +64,8 @@ OpenCLKernelManager::CreateKernel(const OpenCLProgram & program, const std::stri
   // Check the program
   if (program.IsNull())
   {
-    itkOpenCLWarningMacro(<< "OpenCL kernel '" << name << "' has not been created.Provided program is null. Returned "
-                          << createResult);
+    itkOpenCLWarningMacro("OpenCL kernel '" << name << "' has not been created.Provided program is null. Returned "
+                                            << createResult);
     return createResult;
   }
 
@@ -73,7 +73,7 @@ OpenCLKernelManager::CreateKernel(const OpenCLProgram & program, const std::stri
   OpenCLKernel kernel = program.CreateKernel(name);
   if (kernel.IsNull())
   {
-    itkOpenCLWarningMacro(<< "Fail to create OpenCL kernel '" << name << "'. Returned " << createResult);
+    itkOpenCLWarningMacro("Fail to create OpenCL kernel '" << name << "'. Returned " << createResult);
     return createResult;
   }
 

--- a/Common/OpenCL/ITKimprovements/itkOpenCLKernelToImageBridge.hxx
+++ b/Common/OpenCL/ITKimprovements/itkOpenCLKernelToImageBridge.hxx
@@ -138,8 +138,8 @@ OpenCLKernelToImageBridge<TImage>::SetImageMetaData(OpenCLKernel &              
 
   if (imageMetaDataManager.IsNull())
   {
-    itkGenericExceptionMacro(<< "The data manager is NULL."
-                                "Unable to set ITK image meta data to the kernel.");
+    itkGenericExceptionMacro("The data manager is NULL."
+                             "Unable to set ITK image meta data to the kernel.");
   }
 
   // Set image base

--- a/Common/OpenCL/ITKimprovements/itkOpenCLLogger.cxx
+++ b/Common/OpenCL/ITKimprovements/itkOpenCLLogger.cxx
@@ -103,7 +103,7 @@ OpenCLLogger::Initialize()
   this->m_FileStream = new std::ofstream(logFileName.c_str(), std::ios::out);
   if (this->m_FileStream->fail())
   {
-    itkExceptionMacro(<< "Unable to open file: " << logFileName);
+    itkExceptionMacro("Unable to open file: " << logFileName);
     delete this->m_FileStream;
     this->m_FileStream = nullptr;
     this->m_Created = false;

--- a/Common/OpenCL/ITKimprovements/itkOpenCLMacro.h
+++ b/Common/OpenCL/ITKimprovements/itkOpenCLMacro.h
@@ -33,17 +33,17 @@
 
 //! This macro is used to print out debug message to the current message handler
 //! in instance methods
-//! itkOpenCLDebugMacro(<< "Debug message" << this->SomeVariable);
+//! itkOpenCLDebugMacro("Debug message" << this->SomeVariable);
 #define itkOpenCLDebugMacro(x) itkOpenCLDebugWithObjectMacro(this, x)
 
 //! This macro is used to print out warning message to the current message
 //! handler in instance methods
-//! itkOpenCLWarningMacro(<< "Warning message" << this->SomeVariable);
+//! itkOpenCLWarningMacro("Warning message" << this->SomeVariable);
 #define itkOpenCLWarningMacro(x) itkOpenCLWarningWithObjectMacro(this, x)
 
 //! This macro is used to print out error message to the current message handler
 //! in instance methods
-//! itkOpenCLErrorMacro(<< "Error message" << this->SomeVariable);
+//! itkOpenCLErrorMacro("Error message" << this->SomeVariable);
 #define itkOpenCLErrorMacro(x) itkOpenCLErrorWithObjectMacro(this, x)
 
 //! This macro is used to print out debug message to the current message handler

--- a/Common/OpenCL/itkGPUKernelManagerHelperFunctions.h
+++ b/Common/OpenCL/itkGPUKernelManagerHelperFunctions.h
@@ -143,13 +143,13 @@ SetKernelWithITKImage(OpenCLKernelManager::Pointer &      kernelManager,
   // Perform the safe check
   if (kernelManager.IsNull())
   {
-    itkGenericExceptionMacro(<< "The kernel manager is NULL.");
+    itkGenericExceptionMacro("The kernel manager is NULL.");
   }
 
   if (image.IsNull())
   {
-    itkGenericExceptionMacro(<< "The ITK image is NULL. "
-                                "Unable to set ITK image information to the kernel manager.");
+    itkGenericExceptionMacro("The ITK image is NULL. "
+                             "Unable to set ITK image information to the kernel manager.");
   }
 
   // Set ITK image to the kernelManager

--- a/Common/ParameterFileParser/itkParameterFileParser.cxx
+++ b/Common/ParameterFileParser/itkParameterFileParser.cxx
@@ -343,7 +343,7 @@ ParameterFileParser::ReadParameterFile()
   /** Check if it opened. */
   if (!parameterFile.is_open())
   {
-    itkExceptionMacro(<< "ERROR: could not open " << this->m_ParameterFileName << " for reading.");
+    itkExceptionMacro("ERROR: could not open " << this->m_ParameterFileName << " for reading.");
   }
 
   ReadParameterMapFromInputStream(m_ParameterMap, parameterFile);
@@ -367,7 +367,7 @@ ParameterFileParser::ReturnParameterFileAsString()
   /** Check if it opened. */
   if (!parameterFile.is_open())
   {
-    itkExceptionMacro(<< "ERROR: could not open " << this->m_ParameterFileName << " for reading.");
+    itkExceptionMacro("ERROR: could not open " << this->m_ParameterFileName << " for reading.");
   }
 
   /** Loop over the parameter file, line by line. */

--- a/Common/ParameterFileParser/itkParameterMapInterface.h
+++ b/Common/ParameterFileParser/itkParameterMapInterface.h
@@ -404,8 +404,9 @@ public:
       else
       {
         const auto entry_nr = &str - found->second.data();
-        itkExceptionMacro(<< "Failed to cast parameter \"" << parameterName << "\" entry number " << entry_nr
-                          << " value \"" << str << "\" to type \"" << typeid(T).name() << "\"!");
+        itkExceptionMacro("Failed to cast parameter \"" << parameterName << "\" entry number " << entry_nr
+                                                        << " value \"" << str << "\" to type \"" << typeid(T).name()
+                                                        << "\"!");
       }
     }
     return std::make_unique<std::vector<T>>(std::move(result));

--- a/Common/Transforms/itkAdvancedBSplineDeformableTransform.hxx
+++ b/Common/Transforms/itkAdvancedBSplineDeformableTransform.hxx
@@ -195,7 +195,7 @@ AdvancedBSplineDeformableTransform<TScalarType, NDimensions, VSplineOrder>::Tran
   /** Check if the coefficient image has been set. */
   if (!this->m_CoefficientImages[0])
   {
-    itkWarningMacro(<< "B-spline coefficients have not been set");
+    itkWarningMacro("B-spline coefficients have not been set");
     return point;
   }
 
@@ -302,7 +302,7 @@ AdvancedBSplineDeformableTransform<TScalarType, NDimensions, VSplineOrder>::GetJ
   /** Sanity check. */
   if (this->m_InputParametersPointer == nullptr)
   {
-    itkExceptionMacro(<< "Cannot compute Jacobian: parameters not set");
+    itkExceptionMacro("Cannot compute Jacobian: parameters not set");
   }
 
   /** Convert the physical point to a continuous index, which
@@ -645,7 +645,7 @@ AdvancedBSplineDeformableTransform<TScalarType, NDimensions, VSplineOrder>::GetJ
   // SetParameters or SetParametersByValue
   if (this->m_InputParametersPointer == nullptr)
   {
-    itkExceptionMacro(<< "Cannot compute Jacobian: parameters not set");
+    itkExceptionMacro("Cannot compute Jacobian: parameters not set");
   }
 
   jsj.resize(this->GetNumberOfNonZeroJacobianIndices());
@@ -739,7 +739,7 @@ AdvancedBSplineDeformableTransform<TScalarType, NDimensions, VSplineOrder>::GetJ
   // SetParameters or SetParametersByValue
   if (this->m_InputParametersPointer == nullptr)
   {
-    itkExceptionMacro(<< "Cannot compute Jacobian: parameters not set");
+    itkExceptionMacro("Cannot compute Jacobian: parameters not set");
   }
 
   jsj.resize(this->GetNumberOfNonZeroJacobianIndices());
@@ -889,7 +889,7 @@ AdvancedBSplineDeformableTransform<TScalarType, NDimensions, VSplineOrder>::GetJ
   // SetParameters or SetParametersByValue
   if (this->m_InputParametersPointer == nullptr)
   {
-    itkExceptionMacro(<< "Cannot compute Jacobian: parameters not set");
+    itkExceptionMacro("Cannot compute Jacobian: parameters not set");
   }
 
   jsh.resize(this->GetNumberOfNonZeroJacobianIndices());
@@ -1001,7 +1001,7 @@ AdvancedBSplineDeformableTransform<TScalarType, NDimensions, VSplineOrder>::GetJ
   // SetParameters or SetParametersByValue
   if (this->m_InputParametersPointer == nullptr)
   {
-    itkExceptionMacro(<< "Cannot compute Jacobian: parameters not set");
+    itkExceptionMacro("Cannot compute Jacobian: parameters not set");
   }
 
   jsh.resize(this->GetNumberOfNonZeroJacobianIndices());

--- a/Common/Transforms/itkAdvancedBSplineDeformableTransformBase.h
+++ b/Common/Transforms/itkAdvancedBSplineDeformableTransformBase.h
@@ -106,7 +106,7 @@ public:
         return TBSplineDeformableTransform<TScalarType, NDimensions, 3>::New();
       }
     }
-    itkGenericExceptionMacro(<< "ERROR: The provided spline order (" << splineOrder << ") is not supported.");
+    itkGenericExceptionMacro("ERROR: The provided spline order (" << splineOrder << ") is not supported.");
   }
 
 
@@ -263,7 +263,7 @@ public:
   OutputVectorType
   TransformVector(const InputVectorType &) const override
   {
-    itkExceptionMacro(<< "Method not applicable for deformable transform.");
+    itkExceptionMacro("Method not applicable for deformable transform.");
   }
 
 
@@ -273,7 +273,7 @@ public:
   OutputVnlVectorType
   TransformVector(const InputVnlVectorType &) const override
   {
-    itkExceptionMacro(<< "Method not applicable for deformable transform. ");
+    itkExceptionMacro("Method not applicable for deformable transform. ");
   }
 
 
@@ -283,7 +283,7 @@ public:
   OutputCovariantVectorType
   TransformCovariantVector(const InputCovariantVectorType &) const override
   {
-    itkExceptionMacro(<< "Method not applicable for deformable transform. ");
+    itkExceptionMacro("Method not applicable for deformable transform. ");
   }
 
 

--- a/Common/Transforms/itkAdvancedBSplineDeformableTransformBase.hxx
+++ b/Common/Transforms/itkAdvancedBSplineDeformableTransformBase.hxx
@@ -246,8 +246,8 @@ AdvancedBSplineDeformableTransformBase<TScalarType, NDimensions>::SetIdentity()
   }
   else
   {
-    itkExceptionMacro(<< "Input parameters for the spline haven't been set ! Set them using the SetParameters or "
-                         "SetCoefficientImage method first.");
+    itkExceptionMacro("Input parameters for the spline haven't been set ! Set them using the SetParameters or "
+                      "SetCoefficientImage method first.");
   }
 }
 
@@ -262,8 +262,8 @@ AdvancedBSplineDeformableTransformBase<TScalarType, NDimensions>::SetParameters(
   // expected number of parameters
   if (const auto numberOfParameters = parameters.size(); numberOfParameters != this->GetNumberOfParameters())
   {
-    itkExceptionMacro(<< "Mismatched between parameters size " << numberOfParameters << " and region size "
-                      << this->m_GridRegion.GetNumberOfPixels());
+    itkExceptionMacro("Mismatched between parameters size " << numberOfParameters << " and region size "
+                                                            << this->m_GridRegion.GetNumberOfPixels());
   }
 
   // Clean up buffered parameters
@@ -306,8 +306,8 @@ AdvancedBSplineDeformableTransformBase<TScalarType, NDimensions>::SetFixedParame
   else if (const auto numberOfPassedParameters = passedParameters.size();
            numberOfPassedParameters != NumberOfFixedParameters)
   {
-    itkExceptionMacro(<< "Mismatched between parameters size " << numberOfPassedParameters
-                      << " and number of fixed parameters " << NumberOfFixedParameters);
+    itkExceptionMacro("Mismatched between parameters size "
+                      << numberOfPassedParameters << " and number of fixed parameters " << NumberOfFixedParameters);
   }
   else
   {
@@ -401,8 +401,8 @@ AdvancedBSplineDeformableTransformBase<TScalarType, NDimensions>::SetParametersB
   // expected number of parameters
   if (const auto numberOfParameters = parameters.size(); numberOfParameters != this->GetNumberOfParameters())
   {
-    itkExceptionMacro(<< "Mismatched between parameters size " << numberOfParameters << " and region size "
-                      << this->m_GridRegion.GetNumberOfPixels());
+    itkExceptionMacro("Mismatched between parameters size " << numberOfParameters << " and region size "
+                                                            << this->m_GridRegion.GetNumberOfPixels());
   }
 
   // copy it
@@ -428,8 +428,8 @@ AdvancedBSplineDeformableTransformBase<TScalarType, NDimensions>::GetParameters(
    */
   if (nullptr == this->m_InputParametersPointer)
   {
-    itkExceptionMacro(<< "Cannot GetParameters() because m_InputParametersPointer is NULL. Perhaps "
-                         "SetCoefficientImages() has been called causing the NULL pointer.");
+    itkExceptionMacro("Cannot GetParameters() because m_InputParametersPointer is NULL. Perhaps "
+                      "SetCoefficientImages() has been called causing the NULL pointer.");
   }
 
   return (*this->m_InputParametersPointer);

--- a/Common/Transforms/itkAdvancedCombinationTransform.h
+++ b/Common/Transforms/itkAdvancedCombinationTransform.h
@@ -185,8 +185,8 @@ public:
   OutputCovariantVectorType
   TransformCovariantVector(const InputCovariantVectorType &) const override
   {
-    itkExceptionMacro(<< "TransformCovariantVector(const InputCovariantVectorType &) is not implemented for "
-                         "AdvancedCombinationTransform");
+    itkExceptionMacro("TransformCovariantVector(const InputCovariantVectorType &) is not implemented for "
+                      "AdvancedCombinationTransform");
   }
 
 

--- a/Common/Transforms/itkAdvancedCombinationTransform.hxx
+++ b/Common/Transforms/itkAdvancedCombinationTransform.hxx
@@ -110,8 +110,8 @@ AdvancedCombinationTransform<TScalarType, NDimensions>::GetNthTransform(SizeValu
   const SizeValueType numTransforms = GetNumberOfTransforms();
   if (n > numTransforms - 1)
   {
-    itkExceptionMacro(<< "The AdvancedCombinationTransform contains " << numTransforms
-                      << " transforms. Unable to retrieve Nth current transform with index " << n);
+    itkExceptionMacro("The AdvancedCombinationTransform contains "
+                      << numTransforms << " transforms. Unable to retrieve Nth current transform with index " << n);
   }
 
   TransformTypePointer               nthTransform;
@@ -357,7 +357,7 @@ AdvancedCombinationTransform<TScalarType, NDimensions>::GetInverse(Self * invers
      * the initial and the current transforms are defined.
      */
 
-    itkExceptionMacro(<< "ERROR: not implemented");
+    itkExceptionMacro("ERROR: not implemented");
 
     //     /** Try create the inverse of the initial transform. */
     //     InitialTransformPointer inverseT0 = InitialTransformType::New();

--- a/Common/Transforms/itkAdvancedEuler3DTransform.hxx
+++ b/Common/Transforms/itkAdvancedEuler3DTransform.hxx
@@ -54,7 +54,7 @@ template <class TScalarType>
 void
 AdvancedEuler3DTransform<TScalarType>::SetParameters(const ParametersType & parameters)
 {
-  itkDebugMacro(<< "Setting parameters " << parameters);
+  itkDebugMacro("Setting parameters " << parameters);
 
   // Set angles with parameters
   m_AngleX = parameters[0];
@@ -74,7 +74,7 @@ AdvancedEuler3DTransform<TScalarType>::SetParameters(const ParametersType & para
   // parameters and cannot know if the parameters have changed.
   this->Modified();
 
-  itkDebugMacro(<< "After setting parameters ");
+  itkDebugMacro("After setting parameters ");
 }
 
 

--- a/Common/Transforms/itkAdvancedImageMomentsCalculator.hxx
+++ b/Common/Transforms/itkAdvancedImageMomentsCalculator.hxx
@@ -424,7 +424,7 @@ AdvancedImageMomentsCalculator<TImage>::GetTotalMass() const -> ScalarType
 {
   if (!m_Valid)
   {
-    itkExceptionMacro(<< "GetTotalMass() invoked, but the moments have not been computed. Call Compute() first.");
+    itkExceptionMacro("GetTotalMass() invoked, but the moments have not been computed. Call Compute() first.");
   }
   return m_M0;
 }
@@ -437,7 +437,7 @@ AdvancedImageMomentsCalculator<TImage>::GetFirstMoments() const -> VectorType
 {
   if (!m_Valid)
   {
-    itkExceptionMacro(<< "GetFirstMoments() invoked, but the moments have not been computed. Call Compute() first.");
+    itkExceptionMacro("GetFirstMoments() invoked, but the moments have not been computed. Call Compute() first.");
   }
   return m_M1;
 }
@@ -450,7 +450,7 @@ AdvancedImageMomentsCalculator<TImage>::GetSecondMoments() const -> MatrixType
 {
   if (!m_Valid)
   {
-    itkExceptionMacro(<< "GetSecondMoments() invoked, but the moments have not been computed. Call Compute() first.");
+    itkExceptionMacro("GetSecondMoments() invoked, but the moments have not been computed. Call Compute() first.");
   }
   return m_M2;
 }
@@ -463,7 +463,7 @@ AdvancedImageMomentsCalculator<TImage>::GetCenterOfGravity() const -> VectorType
 {
   if (!m_Valid)
   {
-    itkExceptionMacro(<< "GetCenterOfGravity() invoked, but the moments have not been computed. Call Compute() first.");
+    itkExceptionMacro("GetCenterOfGravity() invoked, but the moments have not been computed. Call Compute() first.");
   }
   return m_Cg;
 }
@@ -476,7 +476,7 @@ AdvancedImageMomentsCalculator<TImage>::GetCentralMoments() const -> MatrixType
 {
   if (!m_Valid)
   {
-    itkExceptionMacro(<< "GetCentralMoments() invoked, but the moments have not been computed. Call Compute() first.");
+    itkExceptionMacro("GetCentralMoments() invoked, but the moments have not been computed. Call Compute() first.");
   }
   return m_Cm;
 }
@@ -503,7 +503,7 @@ AdvancedImageMomentsCalculator<TImage>::GetPrincipalAxes() const -> MatrixType
 {
   if (!m_Valid)
   {
-    itkExceptionMacro(<< "GetPrincipalAxes() invoked, but the moments have not been computed. Call Compute() first.");
+    itkExceptionMacro("GetPrincipalAxes() invoked, but the moments have not been computed. Call Compute() first.");
   }
   return m_Pa;
 }
@@ -590,8 +590,8 @@ AdvancedImageMomentsCalculator<TInputImage>::SampleImage(ImageSampleContainerPoi
 
   if (nrofsamples == 0)
   {
-    itkExceptionMacro(<< "No valid voxels (0/" << this->m_NumberOfSamplesForCenteredTransformInitialization
-                      << ") found to estimate the AutomaticTransformInitialization parameters.");
+    itkExceptionMacro("No valid voxels (0/" << this->m_NumberOfSamplesForCenteredTransformInitialization
+                                            << ") found to estimate the AutomaticTransformInitialization parameters.");
   }
 } // end SampleImage()
 

--- a/Common/Transforms/itkAdvancedMatrixOffsetTransformBase.hxx
+++ b/Common/Transforms/itkAdvancedMatrixOffsetTransformBase.hxx
@@ -309,7 +309,8 @@ AdvancedMatrixOffsetTransformBase<TScalarType, NInputDimensions, NOutputDimensio
 {
   if (parameters.Size() < (NOutputDimensions * NInputDimensions + NOutputDimensions))
   {
-    itkExceptionMacro(<< "Error setting parameters: parameters array size (" << parameters.Size()
+    itkExceptionMacro("Error setting parameters: parameters array size ("
+                      << parameters.Size()
                       << ") is less than expected  (NInputDimensions * NOutputDimensions + NOutputDimensions)  ("
                       << NInputDimensions << " * " << NOutputDimensions << " + " << NOutputDimensions << " = "
                       << NInputDimensions * NOutputDimensions + NOutputDimensions << ")");

--- a/Common/Transforms/itkAdvancedRigid2DTransform.hxx
+++ b/Common/Transforms/itkAdvancedRigid2DTransform.hxx
@@ -170,7 +170,7 @@ template <class TScalarType>
 void
 AdvancedRigid2DTransform<TScalarType>::SetParameters(const ParametersType & parameters)
 {
-  itkDebugMacro(<< "Setting parameters " << parameters);
+  itkDebugMacro("Setting parameters " << parameters);
 
   // Set angle
   this->SetVarAngle(parameters[0]);
@@ -191,7 +191,7 @@ AdvancedRigid2DTransform<TScalarType>::SetParameters(const ParametersType & para
   // parameters and cannot know if the parameters have changed.
   this->Modified();
 
-  itkDebugMacro(<< "After setting parameters ");
+  itkDebugMacro("After setting parameters ");
 }
 
 
@@ -200,7 +200,7 @@ template <class TScalarType>
 auto
 AdvancedRigid2DTransform<TScalarType>::GetParameters() const -> const ParametersType &
 {
-  itkDebugMacro(<< "Getting parameters ");
+  itkDebugMacro("Getting parameters ");
 
   // Get the angle
   this->m_Parameters[0] = m_Angle;
@@ -211,7 +211,7 @@ AdvancedRigid2DTransform<TScalarType>::GetParameters() const -> const Parameters
     this->m_Parameters[i + 1] = this->GetTranslation()[i];
   }
 
-  itkDebugMacro(<< "After getting parameters " << this->m_Parameters);
+  itkDebugMacro("After getting parameters " << this->m_Parameters);
 
   return this->m_Parameters;
 }

--- a/Common/Transforms/itkAdvancedRigid3DTransform.hxx
+++ b/Common/Transforms/itkAdvancedRigid3DTransform.hxx
@@ -83,7 +83,7 @@ AdvancedRigid3DTransform<TScalarType>::SetMatrix(const MatrixType & matrix)
   const double tolerance = 1e-10;
   if (!this->MatrixIsOrthogonal(matrix, tolerance))
   {
-    itkExceptionMacro(<< "Attempting to set a non-orthogonal rotation matrix");
+    itkExceptionMacro("Attempting to set a non-orthogonal rotation matrix");
   }
 
   this->Superclass::SetMatrix(matrix);
@@ -119,7 +119,7 @@ AdvancedRigid3DTransform<TScalarType>::SetParameters(const ParametersType & para
   const double tolerance = 1e-10;
   if (!this->MatrixIsOrthogonal(matrix, tolerance))
   {
-    itkExceptionMacro(<< "Attempting to set a non-orthogonal rotation matrix");
+    itkExceptionMacro("Attempting to set a non-orthogonal rotation matrix");
   }
 
   this->SetVarMatrix(matrix);

--- a/Common/Transforms/itkAdvancedSimilarity2DTransform.hxx
+++ b/Common/Transforms/itkAdvancedSimilarity2DTransform.hxx
@@ -54,7 +54,7 @@ template <class TScalarType>
 void
 AdvancedSimilarity2DTransform<TScalarType>::SetParameters(const ParametersType & parameters)
 {
-  itkDebugMacro(<< "Setting parameters " << parameters);
+  itkDebugMacro("Setting parameters " << parameters);
 
   // Set scale
   this->SetVarScale(parameters[0]);
@@ -77,7 +77,7 @@ AdvancedSimilarity2DTransform<TScalarType>::SetParameters(const ParametersType &
   // parameters and cannot know if the parameters have changed.
   this->Modified();
 
-  itkDebugMacro(<< "After setting parameters ");
+  itkDebugMacro("After setting parameters ");
 }
 
 
@@ -86,7 +86,7 @@ template <class TScalarType>
 auto
 AdvancedSimilarity2DTransform<TScalarType>::GetParameters() const -> const ParametersType &
 {
-  itkDebugMacro(<< "Getting parameters ");
+  itkDebugMacro("Getting parameters ");
 
   this->m_Parameters[0] = this->GetScale();
   this->m_Parameters[1] = this->GetAngle();
@@ -98,7 +98,7 @@ AdvancedSimilarity2DTransform<TScalarType>::GetParameters() const -> const Param
     this->m_Parameters[i + 2] = translation[i];
   }
 
-  itkDebugMacro(<< "After getting parameters " << this->m_Parameters);
+  itkDebugMacro("After getting parameters " << this->m_Parameters);
 
   return this->m_Parameters;
 }

--- a/Common/Transforms/itkAdvancedSimilarity3DTransform.hxx
+++ b/Common/Transforms/itkAdvancedSimilarity3DTransform.hxx
@@ -89,7 +89,7 @@ AdvancedSimilarity3DTransform<TScalarType>::SetMatrix(const MatrixType & matrix)
 
   if (det == 0.0)
   {
-    itkExceptionMacro(<< "Attempting to set a matrix with a zero determinant");
+    itkExceptionMacro("Attempting to set a matrix with a zero determinant");
   }
 
   //
@@ -105,7 +105,7 @@ AdvancedSimilarity3DTransform<TScalarType>::SetMatrix(const MatrixType & matrix)
   //
   if (s <= 0.0)
   {
-    itkExceptionMacro(<< "Attempting to set a matrix with a negative trace");
+    itkExceptionMacro("Attempting to set a matrix with a negative trace");
   }
 
   MatrixType testForOrthogonal = matrix;
@@ -114,7 +114,7 @@ AdvancedSimilarity3DTransform<TScalarType>::SetMatrix(const MatrixType & matrix)
   const double tolerance = 1e-10;
   if (!this->MatrixIsOrthogonal(testForOrthogonal, tolerance))
   {
-    itkExceptionMacro(<< "Attempting to set a non-orthogonal matrix (after removing scaling)");
+    itkExceptionMacro("Attempting to set a non-orthogonal matrix (after removing scaling)");
   }
 
   using Baseclass = AdvancedMatrixOffsetTransformBase<TScalarType, 3>;
@@ -129,7 +129,7 @@ void
 AdvancedSimilarity3DTransform<TScalarType>::SetParameters(const ParametersType & parameters)
 {
 
-  itkDebugMacro(<< "Setting parameters " << parameters);
+  itkDebugMacro("Setting parameters " << parameters);
 
   // Transfer the versor part
 
@@ -157,7 +157,7 @@ AdvancedSimilarity3DTransform<TScalarType>::SetParameters(const ParametersType &
   m_Scale = parameters[6]; // must be set before calling ComputeMatrix();
   this->ComputeMatrix();
 
-  itkDebugMacro(<< "Versor is now " << this->GetVersor());
+  itkDebugMacro("Versor is now " << this->GetVersor());
 
   // Transfer the translation part
   TranslationType newTranslation;
@@ -171,7 +171,7 @@ AdvancedSimilarity3DTransform<TScalarType>::SetParameters(const ParametersType &
   // parameters and cannot know if the parameters have changed.
   this->Modified();
 
-  itkDebugMacro(<< "After setting parameters ");
+  itkDebugMacro("After setting parameters ");
 }
 
 
@@ -189,7 +189,7 @@ template <class TScalarType>
 auto
 AdvancedSimilarity3DTransform<TScalarType>::GetParameters() const -> const ParametersType &
 {
-  itkDebugMacro(<< "Getting parameters ");
+  itkDebugMacro("Getting parameters ");
 
   this->m_Parameters[0] = this->GetVersor().GetX();
   this->m_Parameters[1] = this->GetVersor().GetY();
@@ -202,7 +202,7 @@ AdvancedSimilarity3DTransform<TScalarType>::GetParameters() const -> const Param
 
   this->m_Parameters[6] = this->GetScale();
 
-  itkDebugMacro(<< "After getting parameters " << this->m_Parameters);
+  itkDebugMacro("After getting parameters " << this->m_Parameters);
 
   return this->m_Parameters;
 }

--- a/Common/Transforms/itkAdvancedTransform.h
+++ b/Common/Transforms/itkAdvancedTransform.h
@@ -228,7 +228,7 @@ public:
   ComputeJacobianWithRespectToParameters(const InputPointType & itkNotUsed(p),
                                          JacobianType &         itkNotUsed(j)) const override
   {
-    itkExceptionMacro(<< "This ITK4 function is currently not used in elastix.");
+    itkExceptionMacro("This ITK4 function is currently not used in elastix.");
   }
 
 

--- a/Common/Transforms/itkAdvancedVersorRigid3DTransform.hxx
+++ b/Common/Transforms/itkAdvancedVersorRigid3DTransform.hxx
@@ -64,7 +64,7 @@ void
 AdvancedVersorRigid3DTransform<TScalarType>::SetParameters(const ParametersType & parameters)
 {
 
-  itkDebugMacro(<< "Setting parameters " << parameters);
+  itkDebugMacro("Setting parameters " << parameters);
 
   // Transfer the versor part
 
@@ -91,7 +91,7 @@ AdvancedVersorRigid3DTransform<TScalarType>::SetParameters(const ParametersType 
   this->SetVarVersor(newVersor);
   this->ComputeMatrix();
 
-  itkDebugMacro(<< "Versor is now " << this->GetVersor());
+  itkDebugMacro("Versor is now " << this->GetVersor());
 
   // Transfer the translation part
   TranslationType newTranslation;
@@ -105,7 +105,7 @@ AdvancedVersorRigid3DTransform<TScalarType>::SetParameters(const ParametersType 
   // parameters and cannot know if the parameters have changed.
   this->Modified();
 
-  itkDebugMacro(<< "After setting parameters ");
+  itkDebugMacro("After setting parameters ");
 }
 
 
@@ -122,7 +122,7 @@ template <class TScalarType>
 auto
 AdvancedVersorRigid3DTransform<TScalarType>::GetParameters() const -> const ParametersType &
 {
-  itkDebugMacro(<< "Getting parameters ");
+  itkDebugMacro("Getting parameters ");
 
   this->m_Parameters[0] = this->GetVersor().GetX();
   this->m_Parameters[1] = this->GetVersor().GetY();
@@ -133,7 +133,7 @@ AdvancedVersorRigid3DTransform<TScalarType>::GetParameters() const -> const Para
   this->m_Parameters[4] = this->GetTranslation()[1];
   this->m_Parameters[5] = this->GetTranslation()[2];
 
-  itkDebugMacro(<< "After getting parameters " << this->m_Parameters);
+  itkDebugMacro("After getting parameters " << this->m_Parameters);
 
   return this->m_Parameters;
 }

--- a/Common/Transforms/itkAdvancedVersorTransform.hxx
+++ b/Common/Transforms/itkAdvancedVersorTransform.hxx
@@ -71,7 +71,7 @@ template <class TScalarType>
 void
 AdvancedVersorTransform<TScalarType>::SetParameters(const ParametersType & parameters)
 {
-  itkDebugMacro(<< "Setting parameters " << parameters);
+  itkDebugMacro("Setting parameters " << parameters);
 
   // Transfer the versor part
   AxisType rightPart;
@@ -83,7 +83,7 @@ AdvancedVersorTransform<TScalarType>::SetParameters(const ParametersType & param
   // The versor will compute the scalar part.
   m_Versor.Set(rightPart);
 
-  itkDebugMacro(<< "Versor is now " << m_Versor);
+  itkDebugMacro("Versor is now " << m_Versor);
 
   this->ComputeMatrix();
 
@@ -91,7 +91,7 @@ AdvancedVersorTransform<TScalarType>::SetParameters(const ParametersType & param
   // parameters and cannot know if the parameters have changed.
   this->Modified();
 
-  itkDebugMacro(<< "After setting parameters ");
+  itkDebugMacro("After setting parameters ");
 }
 
 

--- a/Common/Transforms/itkCyclicBSplineDeformableTransform.hxx
+++ b/Common/Transforms/itkCyclicBSplineDeformableTransform.hxx
@@ -142,7 +142,7 @@ CyclicBSplineDeformableTransform<TScalarType, NDimensions, VSplineOrder>::Transf
   /** Check if the coefficient image has been set. */
   if (!this->m_CoefficientImages[0])
   {
-    itkWarningMacro(<< "B-spline coefficients have not been set");
+    itkWarningMacro("B-spline coefficients have not been set");
     return point;
   }
 
@@ -281,7 +281,7 @@ CyclicBSplineDeformableTransform<TScalarType, NDimensions, VSplineOrder>::GetSpa
   // SetParameters or SetParametersByValue
   if (this->m_InputParametersPointer == nullptr)
   {
-    itkExceptionMacro(<< "Cannot compute Jacobian: parameters not set");
+    itkExceptionMacro("Cannot compute Jacobian: parameters not set");
   }
 
   /** Convert the physical point to a continuous index, which

--- a/Common/Transforms/itkGridScheduleComputer.hxx
+++ b/Common/Transforms/itkGridScheduleComputer.hxx
@@ -334,8 +334,8 @@ GridScheduleComputer<TTransformScalarType, VImageDimension>::GetBSplineGrid(unsi
   /** Check level. */
   if (level > this->m_NumberOfLevels - 1)
   {
-    itkExceptionMacro(<< "ERROR: Requesting resolution level " << level << ", but only " << this->m_NumberOfLevels
-                      << " levels exist.");
+    itkExceptionMacro("ERROR: Requesting resolution level " << level << ", but only " << this->m_NumberOfLevels
+                                                            << " levels exist.");
   }
 
   /** Return values. */

--- a/Common/Transforms/itkRecursiveBSplineTransform.hxx
+++ b/Common/Transforms/itkRecursiveBSplineTransform.hxx
@@ -37,7 +37,7 @@ RecursiveBSplineTransform<TScalar, NDimensions, VSplineOrder>::TransformPoint(co
   /** Check if the coefficient image has been set. */
   if (!this->m_CoefficientImages[0])
   {
-    itkWarningMacro(<< "B-spline coefficients have not been set");
+    itkWarningMacro("B-spline coefficients have not been set");
     return point;
   }
 
@@ -382,7 +382,7 @@ RecursiveBSplineTransform<TScalar, NDimensions, VSplineOrder>::GetJacobianOfSpat
   // SetParameters or SetParametersByValue
   if (this->m_InputParametersPointer == nullptr)
   {
-    itkExceptionMacro(<< "Cannot compute Jacobian: parameters not set");
+    itkExceptionMacro("Cannot compute Jacobian: parameters not set");
   }
 
   jsj.resize(this->GetNumberOfNonZeroJacobianIndices());
@@ -465,7 +465,7 @@ RecursiveBSplineTransform<TScalar, NDimensions, VSplineOrder>::GetJacobianOfSpat
   // SetParameters or SetParametersByValue
   if (this->m_InputParametersPointer == nullptr)
   {
-    itkExceptionMacro(<< "Cannot compute Jacobian: parameters not set");
+    itkExceptionMacro("Cannot compute Jacobian: parameters not set");
   }
 
   jsh.resize(this->GetNumberOfNonZeroJacobianIndices());

--- a/Common/Transforms/itkStackTransform.h
+++ b/Common/Transforms/itkStackTransform.h
@@ -120,8 +120,8 @@ public:
     const auto numberOfFixedParameters = fixedParameters.size();
     if (numberOfFixedParameters < NumberOfGeneralFixedParametersOfStack)
     {
-      itkExceptionMacro(<< "The number of FixedParameters (" << numberOfFixedParameters << ") should be at least "
-                        << NumberOfGeneralFixedParametersOfStack);
+      itkExceptionMacro("The number of FixedParameters (" << numberOfFixedParameters << ") should be at least "
+                                                          << NumberOfGeneralFixedParametersOfStack);
     }
 
     if (Superclass::m_FixedParameters != fixedParameters)
@@ -257,8 +257,8 @@ protected:
     }
     else
     {
-      itkExceptionMacro(<< "The FixedParameters element (" << numberOfSubTransforms
-                        << ") should be a valid number (the number of subtransforms).");
+      itkExceptionMacro("The FixedParameters element (" << numberOfSubTransforms
+                                                        << ") should be a valid number (the number of subtransforms).");
     }
 
     for (auto & subTransform : m_SubTransformContainer)

--- a/Common/Transforms/itkStackTransform.hxx
+++ b/Common/Transforms/itkStackTransform.hxx
@@ -35,8 +35,8 @@ StackTransform<TScalarType, NInputDimensions, NOutputDimensions>::SetParameters(
   // Here we check if the number of parameters is #subtransforms * #parameters per subtransform.
   if (param.GetSize() != this->GetNumberOfParameters())
   {
-    itkExceptionMacro(<< "Number of parameters does not match the number of subtransforms * the number of parameters "
-                         "per subtransform.");
+    itkExceptionMacro("Number of parameters does not match the number of subtransforms * the number of parameters "
+                      "per subtransform.");
   }
 
   // Set separate subtransform parameters

--- a/Common/Transforms/itkTransformToDeterminantOfSpatialJacobianSource.hxx
+++ b/Common/Transforms/itkTransformToDeterminantOfSpatialJacobianSource.hxx
@@ -157,7 +157,7 @@ TransformToDeterminantOfSpatialJacobianSource<TOutputImage, TTransformPrecisionT
 {
   if (!image)
   {
-    itkExceptionMacro(<< "Cannot use a null image reference");
+    itkExceptionMacro("Cannot use a null image reference");
   }
 
   this->SetOutputOrigin(image->GetOrigin());
@@ -179,7 +179,7 @@ TransformToDeterminantOfSpatialJacobianSource<TOutputImage, TTransformPrecisionT
 {
   if (!this->m_Transform)
   {
-    itkExceptionMacro(<< "Transform not set");
+    itkExceptionMacro("Transform not set");
   }
 
   // Check whether we can use a fast path for resampling. Fast path

--- a/Common/Transforms/itkTransformToSpatialJacobianSource.hxx
+++ b/Common/Transforms/itkTransformToSpatialJacobianSource.hxx
@@ -146,7 +146,7 @@ TransformToSpatialJacobianSource<TOutputImage, TTransformPrecisionType>::SetOutp
 {
   if (!image)
   {
-    itkExceptionMacro(<< "Cannot use a null image reference");
+    itkExceptionMacro("Cannot use a null image reference");
   }
 
   this->SetOutputOrigin(image->GetOrigin());
@@ -168,7 +168,7 @@ TransformToSpatialJacobianSource<TOutputImage, TTransformPrecisionType>::BeforeT
 {
   if (!this->m_Transform)
   {
-    itkExceptionMacro(<< "Transform not set");
+    itkExceptionMacro("Transform not set");
   }
 
   // Check whether we can use a fast path for resampling. Fast path

--- a/Common/itkAdvancedLinearInterpolateImageFunction.h
+++ b/Common/itkAdvancedLinearInterpolateImageFunction.h
@@ -161,7 +161,7 @@ private:
                                         OutputType &                value,
                                         CovariantVectorType &       deriv) const
   {
-    itkExceptionMacro(<< "ERROR: EvaluateValueAndDerivativeAtContinuousIndex() is not implemented for this dimension ("
+    itkExceptionMacro("ERROR: EvaluateValueAndDerivativeAtContinuousIndex() is not implemented for this dimension ("
                       << ImageDimension << ").");
   }
 };

--- a/Common/itkComputeDisplacementDistribution.hxx
+++ b/Common/itkComputeDisplacementDistribution.hxx
@@ -618,8 +618,8 @@ ComputeDisplacementDistribution<TFixedImage, TTransform>::SampleFixedImageForJac
 
   if (nrofsamples == 0)
   {
-    itkExceptionMacro(<< "No valid voxels (0/" << this->m_NumberOfJacobianMeasurements
-                      << ") found to estimate the AdaptiveStochasticGradientDescent parameters.");
+    itkExceptionMacro("No valid voxels (0/" << this->m_NumberOfJacobianMeasurements
+                                            << ") found to estimate the AdaptiveStochasticGradientDescent parameters.");
   }
 } // end SampleFixedImageForJacobianTerms()
 

--- a/Common/itkComputeJacobianTerms.hxx
+++ b/Common/itkComputeJacobianTerms.hxx
@@ -529,8 +529,8 @@ ComputeJacobianTerms<TFixedImage, TTransform>::SampleFixedImageForJacobianTerms(
 
   if (nrofsamples == 0)
   {
-    itkExceptionMacro(<< "No valid voxels (0/" << this->m_NumberOfJacobianMeasurements
-                      << ") found to estimate the AdaptiveStochasticGradientDescent parameters.");
+    itkExceptionMacro("No valid voxels (0/" << this->m_NumberOfJacobianMeasurements
+                                            << ") found to estimate the AdaptiveStochasticGradientDescent parameters.");
   }
 
 } // end SampleFixedImageForJacobianTerms()

--- a/Common/itkComputePreconditionerUsingDisplacementDistribution.hxx
+++ b/Common/itkComputePreconditionerUsingDisplacementDistribution.hxx
@@ -59,7 +59,7 @@ ComputePreconditionerUsingDisplacementDistribution<TFixedImage, TTransform>::Com
                                                                                      double &               maxJJ,
                                                                                      std::string            methods)
 {
-  itkExceptionMacro(<< "ERROR: do not call");
+  itkExceptionMacro("ERROR: do not call");
 } // end Compute()
 
 
@@ -75,7 +75,7 @@ ComputePreconditionerUsingDisplacementDistribution<TFixedImage, TTransform>::Com
   double &               maxJJ,
   std::string            methods)
 {
-  itkExceptionMacro(<< "ERROR: do not call");
+  itkExceptionMacro("ERROR: do not call");
 } // end ComputeDistributionTermsUsingSearchDir()
 
 

--- a/Common/itkGenericMultiResolutionPyramidImageFilter.hxx
+++ b/Common/itkGenericMultiResolutionPyramidImageFilter.hxx
@@ -185,7 +185,7 @@ GenericMultiResolutionPyramidImageFilter<TInputImage, TOutputImage, TPrecisionTy
 
   if (schedule.rows() != this->m_NumberOfLevels || schedule.columns() != ImageDimension)
   {
-    itkDebugMacro(<< "Smoothing schedule has wrong dimensions");
+    itkDebugMacro("Smoothing schedule has wrong dimensions");
     return;
   }
 
@@ -648,7 +648,7 @@ GenericMultiResolutionPyramidImageFilter<TInputImage, TOutputImage, TPrecisionTy
 
     if (!image)
     {
-      itkExceptionMacro(<< "Input has not been set.");
+      itkExceptionMacro("Input has not been set.");
     }
     else
     {

--- a/Common/itkImageFileCastWriter.hxx
+++ b/Common/itkImageFileCastWriter.hxx
@@ -56,7 +56,7 @@ ImageFileCastWriter<TInputImage>::GenerateData()
 {
   const InputImageType * input = this->GetInput();
 
-  itkDebugMacro(<< "Writing file: " << this->GetFileName());
+  itkDebugMacro("Writing file: " << this->GetFileName());
 
   // Make sure that the image is the right type and no more than
   // four components.

--- a/Common/itkMeshFileReaderBase.hxx
+++ b/Common/itkMeshFileReaderBase.hxx
@@ -36,7 +36,7 @@ MeshFileReaderBase<TOutputMesh>::GenerateOutputInformation()
 {
   OutputMeshPointer output = this->GetOutput();
 
-  itkDebugMacro(<< "Reading file for GenerateOutputInformation(): " << m_FileName);
+  itkDebugMacro("Reading file for GenerateOutputInformation(): " << m_FileName);
 
   /** Check to see if we can read the file given the name or prefix */
   if (m_FileName.empty())

--- a/Common/itkMultiResolutionGaussianSmoothingPyramidImageFilter.hxx
+++ b/Common/itkMultiResolutionGaussianSmoothingPyramidImageFilter.hxx
@@ -56,7 +56,7 @@ MultiResolutionGaussianSmoothingPyramidImageFilter<TInputImage, TOutputImage>::S
 {
   if (schedule.rows() != this->m_NumberOfLevels || schedule.columns() != ImageDimension)
   {
-    itkDebugMacro(<< "Schedule has wrong dimensions");
+    itkDebugMacro("Schedule has wrong dimensions");
     return;
   }
 
@@ -223,7 +223,7 @@ MultiResolutionGaussianSmoothingPyramidImageFilter<TInputImage, TOutputImage>::G
 
   if (!inputPtr)
   {
-    itkExceptionMacro(<< "Input has not been set");
+    itkExceptionMacro("Input has not been set");
   }
 
   OutputImagePointer outputPtr;
@@ -267,7 +267,7 @@ MultiResolutionGaussianSmoothingPyramidImageFilter<TInputImage, TOutputImage>::G
   TOutputImage * ptr = static_cast<TOutputImage *>(refOutput);
   if (!ptr)
   {
-    itkExceptionMacro(<< "Could not cast refOutput to TOutputImage*.");
+    itkExceptionMacro("Could not cast refOutput to TOutputImage*.");
   }
 
   unsigned int ilevel;
@@ -338,7 +338,7 @@ MultiResolutionGaussianSmoothingPyramidImageFilter<TInputImage, TOutputImage>::G
 
   if (!image)
   {
-    itkExceptionMacro(<< "Input has not been set.");
+    itkExceptionMacro("Input has not been set.");
   }
 
   if (image)

--- a/Common/itkMultiResolutionImageRegistrationMethod2.hxx
+++ b/Common/itkMultiResolutionImageRegistrationMethod2.hxx
@@ -97,22 +97,22 @@ MultiResolutionImageRegistrationMethod2<TFixedImage, TMovingImage>::Initialize()
   // Sanity checks
   if (!this->m_Metric)
   {
-    itkExceptionMacro(<< "Metric is not present");
+    itkExceptionMacro("Metric is not present");
   }
 
   if (!this->m_Optimizer)
   {
-    itkExceptionMacro(<< "Optimizer is not present");
+    itkExceptionMacro("Optimizer is not present");
   }
 
   if (!this->m_Transform)
   {
-    itkExceptionMacro(<< "Transform is not present");
+    itkExceptionMacro("Transform is not present");
   }
 
   if (!this->m_Interpolator)
   {
-    itkExceptionMacro(<< "Interpolator is not present");
+    itkExceptionMacro("Interpolator is not present");
   }
 
   // Setup the metric
@@ -157,7 +157,7 @@ MultiResolutionImageRegistrationMethod2<TFixedImage, TMovingImage>::PreparePyram
 {
   if (!this->m_Transform)
   {
-    itkExceptionMacro(<< "Transform is not present");
+    itkExceptionMacro("Transform is not present");
   }
 
   this->m_InitialTransformParametersOfNextLevel = this->m_InitialTransformParameters;
@@ -165,29 +165,30 @@ MultiResolutionImageRegistrationMethod2<TFixedImage, TMovingImage>::PreparePyram
   if (const auto numberOfInitialTransformParameters = this->m_InitialTransformParameters.size();
       numberOfInitialTransformParameters != this->m_Transform->GetNumberOfParameters())
   {
-    itkExceptionMacro(<< "Size mismatch between initial parameters (" << numberOfInitialTransformParameters
-                      << ") and transform (" << this->m_Transform->GetNumberOfParameters() << ")");
+    itkExceptionMacro("Size mismatch between initial parameters ("
+                      << numberOfInitialTransformParameters << ") and transform ("
+                      << this->m_Transform->GetNumberOfParameters() << ")");
   }
 
   // Sanity checks
   if (!this->m_FixedImage)
   {
-    itkExceptionMacro(<< "FixedImage is not present");
+    itkExceptionMacro("FixedImage is not present");
   }
 
   if (!this->m_MovingImage)
   {
-    itkExceptionMacro(<< "MovingImage is not present");
+    itkExceptionMacro("MovingImage is not present");
   }
 
   if (!this->m_FixedImagePyramid)
   {
-    itkExceptionMacro(<< "Fixed image pyramid is not present");
+    itkExceptionMacro("Fixed image pyramid is not present");
   }
 
   if (!this->m_MovingImagePyramid)
   {
-    itkExceptionMacro(<< "Moving image pyramid is not present");
+    itkExceptionMacro("Moving image pyramid is not present");
   }
 
   // Setup the fixed image pyramid

--- a/Components/ImageSamplers/RandomCoordinate/elxRandomCoordinateSampler.hxx
+++ b/Components/ImageSamplers/RandomCoordinate/elxRandomCoordinateSampler.hxx
@@ -96,7 +96,7 @@ RandomCoordinateSampler<TElastix>::BeforeEachResolution()
     {
       if (sampleRegionSize[i] > (fixedImageSize[i] - 1) * fixedImageSpacing[i])
       {
-        itkExceptionMacro(<< "ERROR: in your parameter file you selected\n"
+        itkExceptionMacro("ERROR: in your parameter file you selected\n"
                           << "  SampleRegionSize[ " << i << " ] = " << sampleRegionSize[i]
                           << " mm,\n  while the fixed image size at dim = " << i << " is " << fixedImageSize[i]
                           << " voxels or " << fixedImageSize[i] * fixedImageSpacing[i] << " mm.\n"

--- a/Components/Interpolators/RayCastInterpolator/elxRayCastInterpolator.hxx
+++ b/Components/Interpolators/RayCastInterpolator/elxRayCastInterpolator.hxx
@@ -35,12 +35,12 @@ RayCastInterpolator<TElastix>::BeforeAll()
   // Check if 2D-3D
   if (this->m_Elastix->GetFixedImage()->GetImageDimension() != 3)
   {
-    itkExceptionMacro(<< "The RayCastInterpolator expects the fixed image to be 3D.");
+    itkExceptionMacro("The RayCastInterpolator expects the fixed image to be 3D.");
     return 1;
   }
   if (this->m_Elastix->GetMovingImage()->GetImageDimension() != 3)
   {
-    itkExceptionMacro(<< "The RayCastInterpolator expects the moving image to be 3D.");
+    itkExceptionMacro("The RayCastInterpolator expects the moving image to be 3D.");
     return 1;
   }
 

--- a/Components/Metrics/AdvancedNormalizedCorrelation/itkAdvancedNormalizedCorrelationImageToImageMetric.hxx
+++ b/Components/Metrics/AdvancedNormalizedCorrelation/itkAdvancedNormalizedCorrelationImageToImageMetric.hxx
@@ -304,7 +304,7 @@ AdvancedNormalizedCorrelationImageToImageMetric<TFixedImage, TMovingImage>::GetV
   MeasureType &                   value,
   DerivativeType &                derivative) const
 {
-  itkDebugMacro(<< "GetValueAndDerivative( " << parameters << " ) ");
+  itkDebugMacro("GetValueAndDerivative( " << parameters << " ) ");
 
   using DerivativeValueType = typename DerivativeType::ValueType;
 

--- a/Components/Metrics/CorrespondingPointsEuclideanDistanceMetric/elxCorrespondingPointsEuclideanDistanceMetric.hxx
+++ b/Components/Metrics/CorrespondingPointsEuclideanDistanceMetric/elxCorrespondingPointsEuclideanDistanceMetric.hxx
@@ -126,8 +126,8 @@ CorrespondingPointsEuclideanDistanceMetric<TElastix>::BeforeRegistration()
   /** Check. */
   if (nrOfFixedPoints != nrOfMovingPoints)
   {
-    itkExceptionMacro(<< "ERROR: the number of points in the fixed pointset (" << nrOfFixedPoints
-                      << ") does not match that of the moving pointset (" << nrOfMovingPoints
+    itkExceptionMacro("ERROR: the number of points in the fixed pointset ("
+                      << nrOfFixedPoints << ") does not match that of the moving pointset (" << nrOfMovingPoints
                       << "). The points do not correspond. ");
   }
 
@@ -163,7 +163,7 @@ CorrespondingPointsEuclideanDistanceMetric<TElastix>::ReadLandmarks(const std::s
   catch (const itk::ExceptionObject & err)
   {
     log::error(std::ostringstream{} << "  Error while opening " << landmarkFileName << '\n' << err);
-    itkExceptionMacro(<< "ERROR: unable to configure " << this->GetComponentLabel());
+    itkExceptionMacro("ERROR: unable to configure " << this->GetComponentLabel());
   }
 
   /** Some user-feedback. */

--- a/Components/Metrics/CorrespondingPointsEuclideanDistanceMetric/itkCorrespondingPointsEuclideanDistancePointMetric.hxx
+++ b/Components/Metrics/CorrespondingPointsEuclideanDistanceMetric/itkCorrespondingPointsEuclideanDistancePointMetric.hxx
@@ -45,13 +45,13 @@ CorrespondingPointsEuclideanDistancePointMetric<TFixedPointSet, TMovingPointSet>
   FixedPointSetConstPointer fixedPointSet = this->GetFixedPointSet();
   if (!fixedPointSet)
   {
-    itkExceptionMacro(<< "Fixed point set has not been assigned");
+    itkExceptionMacro("Fixed point set has not been assigned");
   }
 
   MovingPointSetConstPointer movingPointSet = this->GetMovingPointSet();
   if (!movingPointSet)
   {
-    itkExceptionMacro(<< "Moving point set has not been assigned");
+    itkExceptionMacro("Moving point set has not been assigned");
   }
 
   /** Initialize some variables. */
@@ -145,13 +145,13 @@ CorrespondingPointsEuclideanDistancePointMetric<TFixedPointSet, TMovingPointSet>
   FixedPointSetConstPointer fixedPointSet = this->GetFixedPointSet();
   if (!fixedPointSet)
   {
-    itkExceptionMacro(<< "Fixed point set has not been assigned");
+    itkExceptionMacro("Fixed point set has not been assigned");
   }
 
   MovingPointSetConstPointer movingPointSet = this->GetMovingPointSet();
   if (!movingPointSet)
   {
-    itkExceptionMacro(<< "Moving point set has not been assigned");
+    itkExceptionMacro("Moving point set has not been assigned");
   }
 
   /** Initialize some variables */

--- a/Components/Metrics/DistancePreservingRigidityPenalty/itkDistancePreservingRigidityPenaltyTerm.hxx
+++ b/Components/Metrics/DistancePreservingRigidityPenalty/itkDistancePreservingRigidityPenaltyTerm.hxx
@@ -72,7 +72,7 @@ DistancePreservingRigidityPenaltyTerm<TFixedImage, TScalarType>::Initialize()
   /** Set the B-spline transform to m_RigidityPenaltyTermMetric. */
   if (!transformIsBSpline)
   {
-    itkExceptionMacro(<< "ERROR: this metric expects a B-spline transform.");
+    itkExceptionMacro("ERROR: this metric expects a B-spline transform.");
   }
 
   /** Initialize BSplineKnotImage. */

--- a/Components/Metrics/GradientDifference/elxGradientDifferenceMetric.hxx
+++ b/Components/Metrics/GradientDifference/elxGradientDifferenceMetric.hxx
@@ -53,13 +53,13 @@ GradientDifferenceMetric<TElastix>::BeforeRegistration()
 
   if (this->m_Elastix->GetFixedImage()->GetImageDimension() != 3)
   {
-    itkExceptionMacro(<< "FixedImage must be 3D");
+    itkExceptionMacro("FixedImage must be 3D");
   }
   if (this->m_Elastix->GetFixedImage()->GetImageDimension() == 3)
   {
     if (this->m_Elastix->GetFixedImage()->GetLargestPossibleRegion().GetSize()[2] != 1)
     {
-      itkExceptionMacro(<< "Metric can only be used for 2D-3D registration. FixedImageSize[2] must be 1");
+      itkExceptionMacro("Metric can only be used for 2D-3D registration. FixedImageSize[2] must be 1");
     }
   }
 

--- a/Components/Metrics/GradientDifference/itkGradientDifferenceImageToImageMetric2.hxx
+++ b/Components/Metrics/GradientDifference/itkGradientDifferenceImageToImageMetric2.hxx
@@ -115,8 +115,8 @@ GradientDifferenceImageToImageMetric<TFixedImage, TMovingImage>::Initialize()
   }
   else
   {
-    itkExceptionMacro(<< "ERROR: the NormalizedGradientCorrelationImageToImageMetric is currently only suitable for "
-                         "2D-3D registration.\n"
+    itkExceptionMacro("ERROR: the NormalizedGradientCorrelationImageToImageMetric is currently only suitable for "
+                      "2D-3D registration.\n"
                       << "  Therefore it expects an interpolator of type RayCastInterpolator.");
   }
   this->m_TransformMovingImageFilter->SetInterpolator(this->m_Interpolator);

--- a/Components/Metrics/KNNGraphAlphaMutualInformation/KNN/itkANNPriorityTreeSearch.hxx
+++ b/Components/Metrics/KNNGraphAlphaMutualInformation/KNN/itkANNPriorityTreeSearch.hxx
@@ -68,7 +68,7 @@ ANNPriorityTreeSearch<TBinaryTree>::SetBinaryTree(BinaryTreeType * tree)
     }
     else
     {
-      itkExceptionMacro(<< "ERROR: Tree is not generated.");
+      itkExceptionMacro("ERROR: Tree is not generated.");
     }
   }
   else

--- a/Components/Metrics/KNNGraphAlphaMutualInformation/KNN/itkANNbdTree.hxx
+++ b/Components/Metrics/KNNGraphAlphaMutualInformation/KNN/itkANNbdTree.hxx
@@ -61,7 +61,7 @@ ANNbdTree<TListSample>::SetShrinkingRule(const std::string & rule)
   }
   else
   {
-    itkWarningMacro(<< "WARNING: No such shrinking rule.");
+    itkWarningMacro("WARNING: No such shrinking rule.");
   }
 
 } // end SetShrinkingRule()

--- a/Components/Metrics/KNNGraphAlphaMutualInformation/KNN/itkANNkDTree.hxx
+++ b/Components/Metrics/KNNGraphAlphaMutualInformation/KNN/itkANNkDTree.hxx
@@ -84,7 +84,7 @@ ANNkDTree<TListSample>::SetSplittingRule(const std::string & rule)
   }
   else
   {
-    itkWarningMacro(<< "WARNING: No such spliting rule.");
+    itkWarningMacro("WARNING: No such spliting rule.");
   }
 
 } // end SetSplittingRule()

--- a/Components/Metrics/KNNGraphAlphaMutualInformation/KNN/itkBinaryANNTreeSearchBase.hxx
+++ b/Components/Metrics/KNNGraphAlphaMutualInformation/KNN/itkBinaryANNTreeSearchBase.hxx
@@ -56,7 +56,7 @@ BinaryANNTreeSearchBase<TBinaryTree>::SetBinaryTree(BinaryTreeType * tree)
     }
     else
     {
-      itkExceptionMacro(<< "ERROR: The tree is not of type BinaryANNTreeBase.");
+      itkExceptionMacro("ERROR: The tree is not of type BinaryANNTreeBase.");
     }
   }
   else

--- a/Components/Metrics/KNNGraphAlphaMutualInformation/KNN/itkListSampleCArray.hxx
+++ b/Components/Metrics/KNNGraphAlphaMutualInformation/KNN/itkListSampleCArray.hxx
@@ -63,7 +63,7 @@ ListSampleCArray<TMeasurementVector, TInternalValue>::GetMeasurementVector(Insta
     mv = MeasurementVectorType(this->m_InternalContainer[id], this->GetMeasurementVectorSize(), false);
     return;
   }
-  itkExceptionMacro(<< "The requested index is larger than the container size.");
+  itkExceptionMacro("The requested index is larger than the container size.");
 
 } // end GetMeasurementVector()
 
@@ -83,7 +83,7 @@ ListSampleCArray<TMeasurementVector, TInternalValue>::GetMeasurementVector(Insta
       MeasurementVectorType(this->m_InternalContainer[id], this->GetMeasurementVectorSize(), false);
     return this->m_TemporaryMeasurementVector;
   }
-  itkExceptionMacro(<< "The requested index is larger than the container size.");
+  itkExceptionMacro("The requested index is larger than the container size.");
 
   /** dummy return; */
   return this->m_TemporaryMeasurementVector;

--- a/Components/Metrics/KNNGraphAlphaMutualInformation/elxKNNGraphAlphaMutualInformationMetric.hxx
+++ b/Components/Metrics/KNNGraphAlphaMutualInformation/elxKNNGraphAlphaMutualInformationMetric.hxx
@@ -164,7 +164,7 @@ KNNGraphAlphaMutualInformationMetric<TElastix>::BeforeEachResolution()
   }
   else
   {
-    itkExceptionMacro(<< "ERROR: there is no tree type \"" << treeType << "\" implemented.");
+    itkExceptionMacro("ERROR: there is no tree type \"" << treeType << "\" implemented.");
   }
 
   /** Get the parameters for the search tree. */
@@ -210,7 +210,7 @@ KNNGraphAlphaMutualInformationMetric<TElastix>::BeforeEachResolution()
   }
   else
   {
-    itkExceptionMacro(<< "ERROR: there is no tree searcher type \"" << treeSearchType << "\" implemented.");
+    itkExceptionMacro("ERROR: there is no tree searcher type \"" << treeSearchType << "\" implemented.");
   }
 
 } // end BeforeEachResolution()

--- a/Components/Metrics/KNNGraphAlphaMutualInformation/itkKNNGraphAlphaMutualInformationImageToImageMetric.hxx
+++ b/Components/Metrics/KNNGraphAlphaMutualInformation/itkKNNGraphAlphaMutualInformationImageToImageMetric.hxx
@@ -267,13 +267,13 @@ KNNGraphAlphaMutualInformationImageToImageMetric<TFixedImage, TMovingImage>::Ini
   /** Check if the kNN trees are set. We only need to check the fixed tree. */
   if (!this->m_BinaryKNNTreeFixed)
   {
-    itkExceptionMacro(<< "ERROR: The kNN tree is not set. ");
+    itkExceptionMacro("ERROR: The kNN tree is not set. ");
   }
 
   /** Check if the kNN tree searchers are set. We only need to check the fixed searcher. */
   if (!this->m_BinaryKNNTreeSearcherFixed)
   {
-    itkExceptionMacro(<< "ERROR: The kNN tree searcher is not set. ");
+    itkExceptionMacro("ERROR: The kNN tree searcher is not set. ");
   }
 
 } // end Initialize()

--- a/Components/Metrics/MissingStructurePenalty/itkMissingStructurePenalty.hxx
+++ b/Components/Metrics/MissingStructurePenalty/itkMissingStructurePenalty.hxx
@@ -48,12 +48,12 @@ MissingVolumeMeshPenalty<TFixedPointSet, TMovingPointSet>::Initialize()
 
   if (!this->m_Transform)
   {
-    itkExceptionMacro(<< "Transform is not present");
+    itkExceptionMacro("Transform is not present");
   }
 
   if (!this->m_FixedMeshContainer)
   {
-    itkExceptionMacro(<< "FixedMeshContainer is not present");
+    itkExceptionMacro("FixedMeshContainer is not present");
   }
 
   const FixedMeshContainerElementIdentifier numberOfMeshes = this->m_FixedMeshContainer->Size();
@@ -97,7 +97,7 @@ MissingVolumeMeshPenalty<TFixedPointSet, TMovingPointSet>::GetValue(const Transf
   FixedMeshContainerConstPointer fixedMeshContainer = this->GetFixedMeshContainer();
   if (!fixedMeshContainer)
   {
-    itkExceptionMacro(<< "FixedMeshContainer mesh has not been assigned");
+    itkExceptionMacro("FixedMeshContainer mesh has not been assigned");
   }
 
   /** Initialize some variables */
@@ -152,7 +152,7 @@ MissingVolumeMeshPenalty<TFixedPointSet, TMovingPointSet>::GetValueAndDerivative
   FixedMeshContainerConstPointer fixedMeshContainer = this->GetFixedMeshContainer();
   if (!fixedMeshContainer)
   {
-    itkExceptionMacro(<< "FixedMeshContainer mesh has not been assigned");
+    itkExceptionMacro("FixedMeshContainer mesh has not been assigned");
   }
 
   /** Initialize some variables */

--- a/Components/Metrics/NormalizedGradientCorrelation/elxNormalizedGradientCorrelationMetric.hxx
+++ b/Components/Metrics/NormalizedGradientCorrelation/elxNormalizedGradientCorrelationMetric.hxx
@@ -52,13 +52,13 @@ NormalizedGradientCorrelationMetric<TElastix>::BeforeRegistration()
 {
   if (this->m_Elastix->GetFixedImage()->GetImageDimension() != 3)
   {
-    itkExceptionMacro(<< "FixedImage must be 3D");
+    itkExceptionMacro("FixedImage must be 3D");
   }
   if (this->m_Elastix->GetFixedImage()->GetImageDimension() == 3)
   {
     if (this->m_Elastix->GetFixedImage()->GetLargestPossibleRegion().GetSize()[2] != 1)
     {
-      itkExceptionMacro(<< "Metric can only be used for 2D-3D registration. FixedImageSize[2] must be 1");
+      itkExceptionMacro("Metric can only be used for 2D-3D registration. FixedImageSize[2] must be 1");
     }
   }
 

--- a/Components/Metrics/NormalizedGradientCorrelation/itkNormalizedGradientCorrelationImageToImageMetric.hxx
+++ b/Components/Metrics/NormalizedGradientCorrelation/itkNormalizedGradientCorrelationImageToImageMetric.hxx
@@ -91,8 +91,8 @@ NormalizedGradientCorrelationImageToImageMetric<TFixedImage, TMovingImage>::Init
   }
   else
   {
-    itkExceptionMacro(<< "ERROR: the NormalizedGradientCorrelationImageToImageMetric is currently only suitable for "
-                         "2D-3D registration.\n"
+    itkExceptionMacro("ERROR: the NormalizedGradientCorrelationImageToImageMetric is currently only suitable for "
+                      "2D-3D registration.\n"
                       << "  Therefore it expects an interpolator of type RayCastInterpolator.");
   }
   this->m_TransformMovingImageFilter->SetInterpolator(this->m_Interpolator);
@@ -435,7 +435,7 @@ NormalizedGradientCorrelationImageToImageMetric<TFixedImage, TMovingImage>::SetT
 {
   if (!this->m_Transform)
   {
-    itkExceptionMacro(<< "Transform has not been assigned");
+    itkExceptionMacro("Transform has not been assigned");
   }
   this->m_Transform->SetParameters(parameters);
 

--- a/Components/Metrics/PatternIntensity/elxPatternIntensityMetric.hxx
+++ b/Components/Metrics/PatternIntensity/elxPatternIntensityMetric.hxx
@@ -52,13 +52,13 @@ PatternIntensityMetric<TElastix>::BeforeRegistration()
 {
   if (this->m_Elastix->GetFixedImage()->GetImageDimension() != 3)
   {
-    itkExceptionMacro(<< "FixedImage must be 3D");
+    itkExceptionMacro("FixedImage must be 3D");
   }
   if (this->m_Elastix->GetFixedImage()->GetImageDimension() == 3)
   {
     if (this->m_Elastix->GetFixedImage()->GetLargestPossibleRegion().GetSize()[2] != 1)
     {
-      itkExceptionMacro(<< "Metric can only be used for 2D-3D registration. FixedImageSize[2] must be 1");
+      itkExceptionMacro("Metric can only be used for 2D-3D registration. FixedImageSize[2] must be 1");
     }
   }
 

--- a/Components/Metrics/PatternIntensity/itkPatternIntensityImageToImageMetric.hxx
+++ b/Components/Metrics/PatternIntensity/itkPatternIntensityImageToImageMetric.hxx
@@ -72,8 +72,8 @@ PatternIntensityImageToImageMetric<TFixedImage, TMovingImage>::Initialize()
   }
   else
   {
-    itkExceptionMacro(<< "ERROR: the NormalizedGradientCorrelationImageToImageMetric is currently only suitable for "
-                         "2D-3D registration.\n"
+    itkExceptionMacro("ERROR: the NormalizedGradientCorrelationImageToImageMetric is currently only suitable for "
+                      "2D-3D registration.\n"
                       << "  Therefore it expects an interpolator of type RayCastInterpolator.");
   }
   this->m_TransformMovingImageFilter->SetInterpolator(this->m_Interpolator);

--- a/Components/Metrics/PolydataDummyPenalty/itkPolydataDummyPenalty.hxx
+++ b/Components/Metrics/PolydataDummyPenalty/itkPolydataDummyPenalty.hxx
@@ -47,12 +47,12 @@ MeshPenalty<TFixedPointSet, TMovingPointSet>::Initialize()
 
   if (!this->m_Transform)
   {
-    itkExceptionMacro(<< "Transform is not present");
+    itkExceptionMacro("Transform is not present");
   }
 
   if (!this->m_FixedMeshContainer)
   {
-    itkExceptionMacro(<< "FixedMeshContainer is not present");
+    itkExceptionMacro("FixedMeshContainer is not present");
   }
 
   const FixedMeshContainerElementIdentifier numberOfMeshes = this->m_FixedMeshContainer->Size();
@@ -110,7 +110,7 @@ MeshPenalty<TFixedPointSet, TMovingPointSet>::GetValue(const TransformParameters
   FixedMeshContainerConstPointer fixedMeshContainer = this->GetFixedMeshContainer();
   if (!fixedMeshContainer)
   {
-    itkExceptionMacro(<< "FixedMeshContainer mesh has not been assigned");
+    itkExceptionMacro("FixedMeshContainer mesh has not been assigned");
   }
 
   /** Initialize some variables */
@@ -168,7 +168,7 @@ MeshPenalty<TFixedPointSet, TMovingPointSet>::GetValueAndDerivative(const Transf
   FixedMeshContainerConstPointer fixedMeshContainer = this->GetFixedMeshContainer();
   if (!fixedMeshContainer)
   {
-    itkExceptionMacro(<< "FixedMeshContainer mesh has not been assigned");
+    itkExceptionMacro("FixedMeshContainer mesh has not been assigned");
   }
 
   /** Initialize some variables */

--- a/Components/Metrics/RigidityPenalty/itkTransformRigidityPenaltyTerm.hxx
+++ b/Components/Metrics/RigidityPenalty/itkTransformRigidityPenaltyTerm.hxx
@@ -135,7 +135,7 @@ TransformRigidityPenaltyTerm<TFixedImage, TScalarType>::Initialize()
   /** Set the B-spline transform to m_RigidityPenaltyTermMetric. */
   if (!transformIsBSpline)
   {
-    itkExceptionMacro(<< "ERROR: this metric expects a B-spline transform.");
+    itkExceptionMacro("ERROR: this metric expects a B-spline transform.");
   }
 
   /** Allocate the RigidityCoefficientImage, so that it matches the B-spline grid.
@@ -479,7 +479,7 @@ TransformRigidityPenaltyTerm<TFixedImage, TScalarType>::GetValue(const Parameter
   /** Sanity check. */
   if (ImageDimension != 2 && ImageDimension != 3)
   {
-    itkExceptionMacro(<< "ERROR: This filter is only implemented for dimension 2 and 3.");
+    itkExceptionMacro("ERROR: This filter is only implemented for dimension 2 and 3.");
   }
 
   /** Get a handle to the B-spline coefficient images. */
@@ -922,7 +922,7 @@ TransformRigidityPenaltyTerm<TFixedImage, TScalarType>::GetValueAndDerivative(co
   /** Sanity check. */
   if (ImageDimension != 2 && ImageDimension != 3)
   {
-    itkExceptionMacro(<< "ERROR: This filter is only implemented for dimension 2 and 3.");
+    itkExceptionMacro("ERROR: This filter is only implemented for dimension 2 and 3.");
   }
 
   /** Get a handle to the B-spline coefficient images. */
@@ -2150,7 +2150,7 @@ TransformRigidityPenaltyTerm<TFixedImage, TScalarType>::Create1DOperator(
   else
   {
     /** Throw an exception. */
-    itkExceptionMacro(<< "Can not create this type of operator.");
+    itkExceptionMacro("Can not create this type of operator.");
   }
 
 } // end Create1DOperator()
@@ -2317,7 +2317,7 @@ TransformRigidityPenaltyTerm<TFixedImage, TScalarType>::CreateNDOperator(
     if (ImageDimension == 2)
     {
       /** Not appropriate. Throw an exception. */
-      itkExceptionMacro(<< "This type of operator (FC) is not appropriate in 2D.");
+      itkExceptionMacro("This type of operator (FC) is not appropriate in 2D.");
     }
     else if (ImageDimension == 3)
     {
@@ -2458,7 +2458,7 @@ TransformRigidityPenaltyTerm<TFixedImage, TScalarType>::CreateNDOperator(
     if (ImageDimension == 2)
     {
       /** Not appropriate. Throw an exception. */
-      itkExceptionMacro(<< "This type of operator (FF) is not appropriate in 2D.");
+      itkExceptionMacro("This type of operator (FF) is not appropriate in 2D.");
     }
     else if (ImageDimension == 3)
     {
@@ -2550,7 +2550,7 @@ TransformRigidityPenaltyTerm<TFixedImage, TScalarType>::CreateNDOperator(
     if (ImageDimension == 2)
     {
       /** Not appropriate. Throw an exception. */
-      itkExceptionMacro(<< "This type of operator (FH) is not appropriate in 2D.");
+      itkExceptionMacro("This type of operator (FH) is not appropriate in 2D.");
     }
     else if (ImageDimension == 3)
     {
@@ -2592,7 +2592,7 @@ TransformRigidityPenaltyTerm<TFixedImage, TScalarType>::CreateNDOperator(
     if (ImageDimension == 2)
     {
       /** Not appropriate. Throw an exception. */
-      itkExceptionMacro(<< "This type of operator (FI) is not appropriate in 2D.");
+      itkExceptionMacro("This type of operator (FI) is not appropriate in 2D.");
     }
     else if (ImageDimension == 3)
     {
@@ -2632,7 +2632,7 @@ TransformRigidityPenaltyTerm<TFixedImage, TScalarType>::CreateNDOperator(
   else
   {
     /** Throw an exception. */
-    itkExceptionMacro(<< "Can not create this type of operator.");
+    itkExceptionMacro("Can not create this type of operator.");
   }
 
 } // end CreateNDOperator()

--- a/Components/Metrics/StatisticalShapePenalty/elxStatisticalShapePenalty.hxx
+++ b/Components/Metrics/StatisticalShapePenalty/elxStatisticalShapePenalty.hxx
@@ -95,7 +95,7 @@ StatisticalShapePenalty<TElastix>::BeforeRegistration()
   }
   else
   {
-    itkExceptionMacro(<< "Unable to open meanVector file: " << meanVectorName);
+    itkExceptionMacro("Unable to open meanVector file: " << meanVectorName);
   }
   this->SetMeanVector(meanVector);
 
@@ -104,9 +104,9 @@ StatisticalShapePenalty<TElastix>::BeforeRegistration()
   {
     if (nrOfFixedPoints * Self::FixedPointSetDimension != meanVector->size() - Self::FixedPointSetDimension - 1)
     {
-      itkExceptionMacro(<< "ERROR: the number of elements in the meanVector (" << meanVector->size()
-                        << ") does not match the number of points of the fixed pointset (" << nrOfFixedPoints
-                        << ") times the point dimensionality (" << Self::FixedPointSetDimension
+      itkExceptionMacro("ERROR: the number of elements in the meanVector ("
+                        << meanVector->size() << ") does not match the number of points of the fixed pointset ("
+                        << nrOfFixedPoints << ") times the point dimensionality (" << Self::FixedPointSetDimension
                         << ") plus a Centroid of dimension " << Self::FixedPointSetDimension << " plus a size element");
     }
   }
@@ -114,9 +114,10 @@ StatisticalShapePenalty<TElastix>::BeforeRegistration()
   {
     if (nrOfFixedPoints * Self::FixedPointSetDimension != meanVector->size())
     {
-      itkExceptionMacro(<< "ERROR: the number of elements in the meanVector (" << meanVector->size()
-                        << ") does not match the number of points of the fixed pointset (" << nrOfFixedPoints
-                        << ") times the point dimensionality (" << Self::FixedPointSetDimension << ")");
+      itkExceptionMacro("ERROR: the number of elements in the meanVector ("
+                        << meanVector->size() << ") does not match the number of points of the fixed pointset ("
+                        << nrOfFixedPoints << ") times the point dimensionality (" << Self::FixedPointSetDimension
+                        << ")");
     }
   }
 
@@ -135,7 +136,7 @@ StatisticalShapePenalty<TElastix>::BeforeRegistration()
   }
   else
   {
-    itkExceptionMacro(<< "Unable to open covarianceMatrix file: " << covarianceMatrixName);
+    itkExceptionMacro("Unable to open covarianceMatrix file: " << covarianceMatrixName);
   }
   this->SetCovarianceMatrix(covarianceMatrix);
 
@@ -293,7 +294,7 @@ StatisticalShapePenalty<TElastix>::ReadLandmarks(const std::string &            
   catch (const itk::ExceptionObject & err)
   {
     log::error(std::ostringstream{} << "  Error while opening " << landmarkFileName << '\n' << err);
-    itkExceptionMacro(<< "ERROR: unable to configure " << this->GetComponentLabel());
+    itkExceptionMacro("ERROR: unable to configure " << this->GetComponentLabel());
   }
 
   /** Some user-feedback. */

--- a/Components/Metrics/StatisticalShapePenalty/itkStatisticalShapePointPenalty.hxx
+++ b/Components/Metrics/StatisticalShapePenalty/itkStatisticalShapePointPenalty.hxx
@@ -180,7 +180,7 @@ StatisticalShapePointPenalty<TFixedPointSet, TMovingPointSet>::Initialize()
     {
       if (this->m_NormalizedShapeModel == true)
       {
-        itkExceptionMacro(<< "ShapeModelCalculation option 1 is only implemented for NormalizedShapeModel = false");
+        itkExceptionMacro("ShapeModelCalculation option 1 is only implemented for NormalizedShapeModel = false");
       }
 
       PCACovarianceType                pcaCovariance(*this->m_CovarianceMatrix);
@@ -244,7 +244,7 @@ StatisticalShapePointPenalty<TFixedPointSet, TMovingPointSet>::Initialize()
     {
       if (this->m_NormalizedShapeModel == false)
       {
-        itkExceptionMacro(<< "ShapeModelCalculation option 2 is only implemented for NormalizedShapeModel = true");
+        itkExceptionMacro("ShapeModelCalculation option 2 is only implemented for NormalizedShapeModel = true");
       }
 
       bool pcaNeedsUpdate = false;
@@ -350,7 +350,7 @@ StatisticalShapePointPenalty<TFixedPointSet, TMovingPointSet>::GetValue(
   FixedPointSetConstPointer fixedPointSet = this->GetFixedPointSet();
   if (!fixedPointSet)
   {
-    itkExceptionMacro(<< "Fixed point set has not been assigned");
+    itkExceptionMacro("Fixed point set has not been assigned");
   }
 
   /** Initialize some variables */
@@ -450,7 +450,7 @@ StatisticalShapePointPenalty<TFixedPointSet, TMovingPointSet>::GetValueAndDeriva
   FixedPointSetConstPointer fixedPointSet = this->GetFixedPointSet();
   if (!fixedPointSet)
   {
-    itkExceptionMacro(<< "Fixed point set has not been assigned");
+    itkExceptionMacro("Fixed point set has not been assigned");
   }
 
   /** Initialize some variables */

--- a/Components/Metrics/VarianceOverLastDimension/elxVarianceOverLastDimensionMetric.hxx
+++ b/Components/Metrics/VarianceOverLastDimension/elxVarianceOverLastDimensionMetric.hxx
@@ -68,7 +68,7 @@ VarianceOverLastDimensionMetric<TElastix>::BeforeRegistration()
 
   if (!dcValid)
   {
-    itkExceptionMacro(<< "\nERROR: the direction cosines matrix of the fixed image is invalid!\n\n"
+    itkExceptionMacro("\nERROR: the direction cosines matrix of the fixed image is invalid!\n\n"
                       << "  The VarianceOverLastDimensionMetric expects the last dimension to represent\n"
                       << "  time and therefore requires a direction cosines matrix of the form:\n"
                       << "       [ . . 0 ]\n"

--- a/Components/Optimizers/AdaGrad/elxAdaGrad.hxx
+++ b/Components/Optimizers/AdaGrad/elxAdaGrad.hxx
@@ -531,7 +531,7 @@ AdaGrad<TElastix>::AutomaticPreconditionerEstimation()
   MetricType * testPtr = dynamic_cast<MetricType *>(this->GetElastix()->GetElxMetricBase()->GetAsITKBaseType());
   if (!testPtr)
   {
-    itkExceptionMacro(<< "ERROR: VoxelWiseASGD expects the metric to be of type AdvancedImageToImageMetric!");
+    itkExceptionMacro("ERROR: VoxelWiseASGD expects the metric to be of type AdvancedImageToImageMetric!");
   }
 
   /** Getting pointers to the samplers. */

--- a/Components/Optimizers/AdaptiveStochasticLBFGS/elxAdaptiveStochasticLBFGS.hxx
+++ b/Components/Optimizers/AdaptiveStochasticLBFGS/elxAdaptiveStochasticLBFGS.hxx
@@ -934,7 +934,7 @@ AdaptiveStochasticLBFGS<TElastix>::AutomaticParameterEstimationOriginal()
   MetricType * testPtr = dynamic_cast<MetricType *>(this->GetElastix()->GetElxMetricBase()->GetAsITKBaseType());
   if (!testPtr)
   {
-    itkExceptionMacro(<< "ERROR: AdaptiveStochasticLBFGS expects the metric to be of type AdvancedImageToImageMetric!");
+    itkExceptionMacro("ERROR: AdaptiveStochasticLBFGS expects the metric to be of type AdvancedImageToImageMetric!");
   }
 
   /** Construct computeJacobianTerms to initialize the parameter estimation. */
@@ -1073,7 +1073,7 @@ AdaptiveStochasticLBFGS<TElastix>::AutomaticParameterEstimationUsingDisplacement
   MetricType * testPtr = dynamic_cast<MetricType *>(this->GetElastix()->GetElxMetricBase()->GetAsITKBaseType());
   if (!testPtr)
   {
-    itkExceptionMacro(<< "ERROR: AdaptiveStochasticLBFGS expects the metric to be of type AdvancedImageToImageMetric!");
+    itkExceptionMacro("ERROR: AdaptiveStochasticLBFGS expects the metric to be of type AdvancedImageToImageMetric!");
   }
 
   /** Construct computeJacobianTerms to initialize the parameter estimation. */
@@ -1185,7 +1185,7 @@ AdaptiveStochasticLBFGS<TElastix>::AutomaticLBFGSStepsizeEstimation()
   MetricType * testPtr = dynamic_cast<MetricType *>(this->GetElastix()->GetElxMetricBase()->GetAsITKBaseType());
   if (!testPtr)
   {
-    itkExceptionMacro(<< "ERROR: AdaptiveStochasticLBFGS expects the metric to be of type AdvancedImageToImageMetric!");
+    itkExceptionMacro("ERROR: AdaptiveStochasticLBFGS expects the metric to be of type AdvancedImageToImageMetric!");
   }
 
   /** Construct computeJacobianTerms to initialize the parameter estimation. */

--- a/Components/Optimizers/AdaptiveStochasticVarianceReducedGradient/elxAdaptiveStochasticVarianceReducedGradient.hxx
+++ b/Components/Optimizers/AdaptiveStochasticVarianceReducedGradient/elxAdaptiveStochasticVarianceReducedGradient.hxx
@@ -789,8 +789,8 @@ AdaptiveStochasticVarianceReducedGradient<TElastix>::AutomaticParameterEstimatio
   MetricType * testPtr = dynamic_cast<MetricType *>(this->GetElastix()->GetElxMetricBase()->GetAsITKBaseType());
   if (!testPtr)
   {
-    itkExceptionMacro(<< "ERROR: AdaptiveStochasticVarianceReducedGradient expects the metric to be of type "
-                         "AdvancedImageToImageMetric!");
+    itkExceptionMacro("ERROR: AdaptiveStochasticVarianceReducedGradient expects the metric to be of type "
+                      "AdvancedImageToImageMetric!");
   }
 
   /** Construct computeJacobianTerms to initialize the parameter estimation. */
@@ -929,8 +929,8 @@ AdaptiveStochasticVarianceReducedGradient<TElastix>::AutomaticParameterEstimatio
   MetricType * testPtr = dynamic_cast<MetricType *>(this->GetElastix()->GetElxMetricBase()->GetAsITKBaseType());
   if (!testPtr)
   {
-    itkExceptionMacro(<< "ERROR: AdaptiveStochasticVarianceReducedGradient expects the metric to be of type "
-                         "AdvancedImageToImageMetric!");
+    itkExceptionMacro("ERROR: AdaptiveStochasticVarianceReducedGradient expects the metric to be of type "
+                      "AdvancedImageToImageMetric!");
   }
 
   /** Construct computeJacobianTerms to initialize the parameter estimation. */

--- a/Components/Optimizers/CMAEvolutionStrategy/itkCMAEvolutionStrategyOptimizer.cxx
+++ b/Components/Optimizers/CMAEvolutionStrategy/itkCMAEvolutionStrategyOptimizer.cxx
@@ -292,7 +292,7 @@ CMAEvolutionStrategyOptimizer::InitializeConstants()
   this->m_EffectiveMu = 1.0 / this->m_RecombinationWeights.squared_magnitude();
   if (this->m_EffectiveMu >= lambdad)
   {
-    itkExceptionMacro(<< "The RecombinationWeights have unreasonable values!");
+    itkExceptionMacro("The RecombinationWeights have unreasonable values!");
   }
   /** alias: */
   const double mueff = this->m_EffectiveMu;
@@ -801,7 +801,7 @@ CMAEvolutionStrategyOptimizer::UpdateBD()
   returncode = eigenAnalysis.ComputeEigenValuesAndVectors(this->m_C, this->m_D, this->m_B);
   if (returncode != 0)
   {
-    itkExceptionMacro(<< "EigenAnalysis failed while computing eigenvalue nr: " << returncode);
+    itkExceptionMacro("EigenAnalysis failed while computing eigenvalue nr: " << returncode);
   }
 
   /** itk eigen analysis returns eigen vectors in rows... */

--- a/Components/Optimizers/ConjugateGradient/itkGenericConjugateGradientOptimizer.cxx
+++ b/Components/Optimizers/ConjugateGradient/itkGenericConjugateGradientOptimizer.cxx
@@ -281,7 +281,7 @@ GenericConjugateGradientOptimizer::LineSearch(const ParametersType searchDir,
   {
     this->m_StopCondition = LineSearchError;
     this->StopOptimization();
-    itkExceptionMacro(<< "No line search optimizer set");
+    itkExceptionMacro("No line search optimizer set");
   }
 
   LSO->SetCostFunction(this->m_ScaledCostFunction);
@@ -510,7 +510,7 @@ GenericConjugateGradientOptimizer::SetBetaDefinition(const BetaDefinitionType & 
   {
     if (this->m_BetaDefinitionMap.count(arg) != 1)
     {
-      itkExceptionMacro(<< "Undefined beta: " << arg);
+      itkExceptionMacro("Undefined beta: " << arg);
     }
     this->m_BetaDefinition = arg;
     this->Modified();

--- a/Components/Optimizers/FullSearch/elxFullSearchOptimizer.hxx
+++ b/Components/Optimizers/FullSearch/elxFullSearchOptimizer.hxx
@@ -178,7 +178,7 @@ FullSearch<TElastix>::BeforeEachResolution()
   }
   else
   {
-    itkExceptionMacro(<< "ERROR: elastix found an error in the search space definition, and is quiting.");
+    itkExceptionMacro("ERROR: elastix found an error in the search space definition, and is quiting.");
   }
 
 } // end BeforeEachResolution()

--- a/Components/Optimizers/PreconditionedGradientDescent/elxPreconditionedGradientDescent.hxx
+++ b/Components/Optimizers/PreconditionedGradientDescent/elxPreconditionedGradientDescent.hxx
@@ -381,8 +381,8 @@ PreconditionedGradientDescent<TElastix>::SetSelfHessian()
 
   if (metricWithSelfHessian == 0)
   {
-    itkExceptionMacro(<< "The PreconditionedGradientDescent optimizer can only be used with metrics that derive from "
-                         "the AdvancedImageToImage metric!");
+    itkExceptionMacro("The PreconditionedGradientDescent optimizer can only be used with metrics that derive from "
+                      "the AdvancedImageToImage metric!");
   }
 
   log::info("Computing SelfHessian.");

--- a/Components/Optimizers/QuasiNewtonLBFGS/itkQuasiNewtonLBFGSOptimizer.cxx
+++ b/Components/Optimizers/QuasiNewtonLBFGS/itkQuasiNewtonLBFGSOptimizer.cxx
@@ -330,7 +330,7 @@ QuasiNewtonLBFGSOptimizer::LineSearch(const ParametersType searchDir,
   {
     this->m_StopCondition = LineSearchError;
     this->StopOptimization();
-    itkExceptionMacro(<< "No line search optimizer set");
+    itkExceptionMacro("No line search optimizer set");
   }
 
   LSO->SetCostFunction(this->m_ScaledCostFunction);

--- a/Components/Optimizers/RSGDEachParameterApart/itkRSGDEachParameterApartBaseOptimizer.cxx
+++ b/Components/Optimizers/RSGDEachParameterApart/itkRSGDEachParameterApartBaseOptimizer.cxx
@@ -153,8 +153,9 @@ RSGDEachParameterApartBaseOptimizer::AdvanceOneStep()
   // Make sure the scales have been set properly
   if (scales.size() != spaceDimension)
   {
-    itkExceptionMacro(<< "The size of Scales is " << scales.size()
-                      << ", but the NumberOfParameters for the CostFunction is " << spaceDimension << ".");
+    itkExceptionMacro("The size of Scales is "
+                      << scales.size() << ", but the NumberOfParameters for the CostFunction is " << spaceDimension
+                      << ".");
   }
 
   for (unsigned int i = 0; i < spaceDimension; ++i)

--- a/Components/Optimizers/RSGDEachParameterApart/itkRSGDEachParameterApartOptimizer.cxx
+++ b/Components/Optimizers/RSGDEachParameterApart/itkRSGDEachParameterApartOptimizer.cxx
@@ -32,7 +32,7 @@ RSGDEachParameterApartOptimizer::StepAlongGradient(const DerivativeType & factor
                                                    const DerivativeType & transformedGradient)
 {
 
-  itkDebugMacro(<< "factor = " << factor << "  transformedGradient= " << transformedGradient);
+  itkDebugMacro("factor = " << factor << "  transformedGradient= " << transformedGradient);
 
   const unsigned int spaceDimension = m_CostFunction->GetNumberOfParameters();
 
@@ -45,7 +45,7 @@ RSGDEachParameterApartOptimizer::StepAlongGradient(const DerivativeType & factor
     newPosition[j] = currentPosition[j] + transformedGradient[j] * factor[j];
   }
 
-  itkDebugMacro(<< "new position = " << newPosition);
+  itkDebugMacro("new position = " << newPosition);
 
   this->SetCurrentPosition(newPosition);
 }

--- a/Components/Registrations/MultiMetricMultiResolutionRegistration/elxMultiMetricMultiResolutionRegistration.hxx
+++ b/Components/Registrations/MultiMetricMultiResolutionRegistration/elxMultiMetricMultiResolutionRegistration.hxx
@@ -329,8 +329,8 @@ MultiMetricMultiResolutionRegistration<TElastix>::SetComponents()
         if (this->GetElastix()->GetElxFixedImagePyramidBase(i))
         {
           log::error(std::ostringstream{} << "ERROR: An ImageSamper for metric " << i << " must be provided!");
-          itkExceptionMacro(<< "Not enough ImageSamplers provided!\nProvide an ImageSampler for metric " << i
-                            << ", like:\n  (ImageSampler \"Random\" ... \"Random\")");
+          itkExceptionMacro("Not enough ImageSamplers provided!\nProvide an ImageSampler for metric "
+                            << i << ", like:\n  (ImageSampler \"Random\" ... \"Random\")");
         }
 
         /** Try the zeroth image sampler for each metric. */
@@ -342,7 +342,7 @@ MultiMetricMultiResolutionRegistration<TElastix>::SetComponents()
         else
         {
           log::error("ERROR: No ImageSampler has been specified.");
-          itkExceptionMacro(<< "One of the metrics requires an ImageSampler, but it is not available!");
+          itkExceptionMacro("One of the metrics requires an ImageSampler, but it is not available!");
         }
       }
 

--- a/Components/Registrations/MultiMetricMultiResolutionRegistration/itkCombinationImageToImageMetric.hxx
+++ b/Components/Registrations/MultiMetricMultiResolutionRegistration/itkCombinationImageToImageMetric.hxx
@@ -576,7 +576,7 @@ CombinationImageToImageMetric<TFixedImage, TMovingImage>::Initialize()
   /** Check if at least one (image)metric is provided */
   if (this->GetNumberOfMetrics() == 0)
   {
-    itkExceptionMacro(<< "At least one metric should be set!");
+    itkExceptionMacro("At least one metric should be set!");
   }
 
   /** Call Initialize for all metrics. */
@@ -585,7 +585,7 @@ CombinationImageToImageMetric<TFixedImage, TMovingImage>::Initialize()
     SingleValuedCostFunctionType * costfunc = this->GetMetric(i);
     if (!costfunc)
     {
-      itkExceptionMacro(<< "Metric " << i << " has not been set!");
+      itkExceptionMacro("Metric " << i << " has not been set!");
     }
     ImageMetricType *    testPtr1 = dynamic_cast<ImageMetricType *>(this->GetMetric(i));
     PointSetMetricType * testPtr2 = dynamic_cast<PointSetMetricType *>(this->GetMetric(i));

--- a/Components/Registrations/MultiMetricMultiResolutionRegistration/itkMultiMetricMultiResolutionImageRegistrationMethod.hxx
+++ b/Components/Registrations/MultiMetricMultiResolutionRegistration/itkMultiMetricMultiResolutionImageRegistrationMethod.hxx
@@ -135,7 +135,7 @@ MultiMetricMultiResolutionImageRegistrationMethod<TFixedImage, TMovingImage>::Se
   }
   else
   {
-    itkExceptionMacro(<< "The metric must of type CombinationImageToImageMetric!");
+    itkExceptionMacro("The metric must of type CombinationImageToImageMetric!");
   }
 
 } // end SetMetric()
@@ -347,14 +347,14 @@ MultiMetricMultiResolutionImageRegistrationMethod<TFixedImage, TMovingImage>::Ge
   /** Check the transform and set the initial parameters. */
   if (this->GetTransform() == nullptr)
   {
-    itkExceptionMacro(<< "Transform is not present");
+    itkExceptionMacro("Transform is not present");
   }
 
   this->SetInitialTransformParametersOfNextLevel(this->GetInitialTransformParameters());
 
   if (this->GetInitialTransformParametersOfNextLevel().Size() != this->GetTransform()->GetNumberOfParameters())
   {
-    itkExceptionMacro(<< "Size mismatch between initial parameter and transform");
+    itkExceptionMacro("Size mismatch between initial parameter and transform");
   }
 
   /** Prepare the fixed and moving pyramids. */
@@ -500,19 +500,19 @@ MultiMetricMultiResolutionImageRegistrationMethod<TFixedImage, TMovingImage>::Ch
   /** Check if at least one of the following are provided. */
   if (this->GetFixedImage() == nullptr)
   {
-    itkExceptionMacro(<< "FixedImage is not present");
+    itkExceptionMacro("FixedImage is not present");
   }
   if (this->GetMovingImage() == nullptr)
   {
-    itkExceptionMacro(<< "MovingImage is not present");
+    itkExceptionMacro("MovingImage is not present");
   }
   if (this->GetFixedImagePyramid() == nullptr)
   {
-    itkExceptionMacro(<< "Fixed image pyramid is not present");
+    itkExceptionMacro("Fixed image pyramid is not present");
   }
   if (this->GetMovingImagePyramid() == nullptr)
   {
-    itkExceptionMacro(<< "Moving image pyramid is not present");
+    itkExceptionMacro("Moving image pyramid is not present");
   }
 
   /** Check if the number if fixed/moving pyramids >= nr of fixed/moving images,
@@ -520,15 +520,15 @@ MultiMetricMultiResolutionImageRegistrationMethod<TFixedImage, TMovingImage>::Ch
    */
   if (this->GetNumberOfFixedImagePyramids() < this->GetNumberOfFixedImages())
   {
-    itkExceptionMacro(<< "The number of fixed image pyramids should be >= the number of fixed images");
+    itkExceptionMacro("The number of fixed image pyramids should be >= the number of fixed images");
   }
   if (this->GetNumberOfMovingImagePyramids() < this->GetNumberOfMovingImages())
   {
-    itkExceptionMacro(<< "The number of moving image pyramids should be >= the number of moving images");
+    itkExceptionMacro("The number of moving image pyramids should be >= the number of moving images");
   }
   if (this->GetNumberOfFixedImageRegions() != this->GetNumberOfFixedImages())
   {
-    itkExceptionMacro(<< "The number of fixed image regions should equal the number of fixed images");
+    itkExceptionMacro("The number of fixed image regions should equal the number of fixed images");
   }
 
 } // end CheckPyramids()
@@ -545,60 +545,60 @@ MultiMetricMultiResolutionImageRegistrationMethod<TFixedImage, TMovingImage>::Ch
   /** Check if at least one of the following is present. */
   if (this->GetMetric() == nullptr)
   {
-    itkExceptionMacro(<< "Metric is not present");
+    itkExceptionMacro("Metric is not present");
   }
   if (this->GetOptimizer() == nullptr)
   {
-    itkExceptionMacro(<< "Optimizer is not present");
+    itkExceptionMacro("Optimizer is not present");
   }
   if (this->GetTransform() == nullptr)
   {
-    itkExceptionMacro(<< "Transform is not present");
+    itkExceptionMacro("Transform is not present");
   }
   if (this->GetInterpolator() == nullptr)
   {
-    itkExceptionMacro(<< "Interpolator is not present");
+    itkExceptionMacro("Interpolator is not present");
   }
 
   /** nrofmetrics >= nrofinterpolators >= nrofpyramids >= nofimages */
   unsigned int nrOfMetrics = this->GetCombinationMetric()->GetNumberOfMetrics();
   if (this->GetNumberOfInterpolators() > nrOfMetrics)
   {
-    itkExceptionMacro(<< "NumberOfInterpolators can not exceed the NumberOfMetrics in the CombinationMetric!");
+    itkExceptionMacro("NumberOfInterpolators can not exceed the NumberOfMetrics in the CombinationMetric!");
   }
   if (this->GetNumberOfFixedImagePyramids() > nrOfMetrics)
   {
-    itkExceptionMacro(<< "NumberOfFixedImagePyramids can not exceed the NumberOfMetrics in the CombinationMetric!");
+    itkExceptionMacro("NumberOfFixedImagePyramids can not exceed the NumberOfMetrics in the CombinationMetric!");
   }
   if (this->GetNumberOfMovingImagePyramids() > nrOfMetrics)
   {
-    itkExceptionMacro(<< "NumberOfMovingImagePyramids can not exceed the NumberOfMetrics in the CombinationMetric!");
+    itkExceptionMacro("NumberOfMovingImagePyramids can not exceed the NumberOfMetrics in the CombinationMetric!");
   }
   if (this->GetNumberOfMovingImagePyramids() > this->GetNumberOfInterpolators())
   {
-    itkExceptionMacro(<< "NumberOfMovingImagePyramids can not exceed the NumberOfInterpolators!");
+    itkExceptionMacro("NumberOfMovingImagePyramids can not exceed the NumberOfInterpolators!");
   }
 
   /** For all components: ==nrofmetrics of ==1. */
   if ((this->GetNumberOfInterpolators() != 1) && (this->GetNumberOfInterpolators() != nrOfMetrics))
   {
-    itkExceptionMacro(<< "The NumberOfInterpolators should equal 1 or equal the NumberOfMetrics");
+    itkExceptionMacro("The NumberOfInterpolators should equal 1 or equal the NumberOfMetrics");
   }
   if ((this->GetNumberOfFixedImagePyramids() != 1) && (this->GetNumberOfFixedImagePyramids() != nrOfMetrics))
   {
-    itkExceptionMacro(<< "The NumberOfFixedImagePyramids should equal 1 or equal the NumberOfMetrics");
+    itkExceptionMacro("The NumberOfFixedImagePyramids should equal 1 or equal the NumberOfMetrics");
   }
   if ((this->GetNumberOfMovingImagePyramids() != 1) && (this->GetNumberOfMovingImagePyramids() != nrOfMetrics))
   {
-    itkExceptionMacro(<< "The NumberOfMovingImagePyramids should equal 1 or equal the NumberOfMetrics");
+    itkExceptionMacro("The NumberOfMovingImagePyramids should equal 1 or equal the NumberOfMetrics");
   }
   if ((this->GetNumberOfFixedImages() != 1) && (this->GetNumberOfFixedImages() != nrOfMetrics))
   {
-    itkExceptionMacro(<< "The NumberOfFixedImages should equal 1 or equal the NumberOfMetrics");
+    itkExceptionMacro("The NumberOfFixedImages should equal 1 or equal the NumberOfMetrics");
   }
   if ((this->GetNumberOfMovingImages() != 1) && (this->GetNumberOfMovingImages() != nrOfMetrics))
   {
-    itkExceptionMacro(<< "The NumberOfMovingImages should equal 1 or equal the NumberOfMetrics");
+    itkExceptionMacro("The NumberOfMovingImages should equal 1 or equal the NumberOfMetrics");
   }
 
 } // end CheckOnInitialize()

--- a/Components/Registrations/MultiResolutionRegistration/elxMultiResolutionRegistration.hxx
+++ b/Components/Registrations/MultiResolutionRegistration/elxMultiResolutionRegistration.hxx
@@ -150,7 +150,7 @@ MultiResolutionRegistration<TElastix>::SetComponents()
     else
     {
       log::error("No ImageSampler has been specified.");
-      itkExceptionMacro(<< "The metric requires an ImageSampler, but it is not available!");
+      itkExceptionMacro("The metric requires an ImageSampler, but it is not available!");
     }
   }
 

--- a/Components/Registrations/MultiResolutionRegistrationWithFeatures/elxMultiResolutionRegistrationWithFeatures.hxx
+++ b/Components/Registrations/MultiResolutionRegistrationWithFeatures/elxMultiResolutionRegistrationWithFeatures.hxx
@@ -142,7 +142,7 @@ MultiResolutionRegistrationWithFeatures<TElastix>::GetAndSetComponents()
     else
     {
       log::error("No ImageSampler has been specified.");
-      itkExceptionMacro(<< "The metric requires an ImageSampler, but it is not available!");
+      itkExceptionMacro("The metric requires an ImageSampler, but it is not available!");
     }
   }
 

--- a/Components/Registrations/MultiResolutionRegistrationWithFeatures/itkMultiInputMultiResolutionImageRegistrationMethodBase.hxx
+++ b/Components/Registrations/MultiResolutionRegistrationWithFeatures/itkMultiInputMultiResolutionImageRegistrationMethodBase.hxx
@@ -230,7 +230,7 @@ MultiInputMultiResolutionImageRegistrationMethodBase<TFixedImage, TMovingImage>:
   }
   else
   {
-    itkExceptionMacro(<< "ERROR: This registration method expects a MultiInputImageToImageMetric");
+    itkExceptionMacro("ERROR: This registration method expects a MultiInputImageToImageMetric");
   }
 
 } // end SetMetric()
@@ -439,14 +439,14 @@ MultiInputMultiResolutionImageRegistrationMethodBase<TFixedImage, TMovingImage>:
   /** Check the transform and set the initial parameters. */
   if (this->GetTransform() == nullptr)
   {
-    itkExceptionMacro(<< "Transform is not present");
+    itkExceptionMacro("Transform is not present");
   }
 
   this->SetInitialTransformParametersOfNextLevel(this->GetInitialTransformParameters());
 
   if (this->GetInitialTransformParametersOfNextLevel().Size() != this->GetTransform()->GetNumberOfParameters())
   {
-    itkExceptionMacro(<< "Size mismatch between initial parameter and transform");
+    itkExceptionMacro("Size mismatch between initial parameter and transform");
   }
 
   /** Prepare the fixed and moving pyramids. */
@@ -592,19 +592,19 @@ MultiInputMultiResolutionImageRegistrationMethodBase<TFixedImage, TMovingImage>:
   /** Check if at least one of the following are provided. */
   if (this->GetFixedImage() == nullptr)
   {
-    itkExceptionMacro(<< "FixedImage is not present");
+    itkExceptionMacro("FixedImage is not present");
   }
   if (this->GetMovingImage() == nullptr)
   {
-    itkExceptionMacro(<< "MovingImage is not present");
+    itkExceptionMacro("MovingImage is not present");
   }
   if (this->GetFixedImagePyramid() == nullptr)
   {
-    itkExceptionMacro(<< "Fixed image pyramid is not present");
+    itkExceptionMacro("Fixed image pyramid is not present");
   }
   if (this->GetMovingImagePyramid() == nullptr)
   {
-    itkExceptionMacro(<< "Moving image pyramid is not present");
+    itkExceptionMacro("Moving image pyramid is not present");
   }
 
   /** Check if the number if fixed/moving pyramids >= nr of fixed/moving images,
@@ -612,15 +612,15 @@ MultiInputMultiResolutionImageRegistrationMethodBase<TFixedImage, TMovingImage>:
    */
   if (this->GetNumberOfFixedImagePyramids() < this->GetNumberOfFixedImages())
   {
-    itkExceptionMacro(<< "The number of fixed image pyramids should be >= the number of fixed images");
+    itkExceptionMacro("The number of fixed image pyramids should be >= the number of fixed images");
   }
   if (this->GetNumberOfMovingImagePyramids() < this->GetNumberOfMovingImages())
   {
-    itkExceptionMacro(<< "The number of moving image pyramids should be >= the number of moving images");
+    itkExceptionMacro("The number of moving image pyramids should be >= the number of moving images");
   }
   if (this->GetNumberOfFixedImageRegions() != this->GetNumberOfFixedImages())
   {
-    itkExceptionMacro(<< "The number of fixed image regions should equal the number of fixed image");
+    itkExceptionMacro("The number of fixed image regions should equal the number of fixed image");
   }
 
 } // end CheckPyramids()
@@ -637,25 +637,25 @@ MultiInputMultiResolutionImageRegistrationMethodBase<TFixedImage, TMovingImage>:
   /** check if at least one of the following is present. */
   if (this->GetMetric() == nullptr)
   {
-    itkExceptionMacro(<< "Metric is not present");
+    itkExceptionMacro("Metric is not present");
   }
   if (this->GetOptimizer() == nullptr)
   {
-    itkExceptionMacro(<< "Optimizer is not present");
+    itkExceptionMacro("Optimizer is not present");
   }
   if (this->GetTransform() == nullptr)
   {
-    itkExceptionMacro(<< "Transform is not present");
+    itkExceptionMacro("Transform is not present");
   }
   if (this->GetInterpolator() == nullptr)
   {
-    itkExceptionMacro(<< "Interpolator is not present");
+    itkExceptionMacro("Interpolator is not present");
   }
 
   /** nrofinterpolators >= nrofpyramids? */
   if (this->GetNumberOfMovingImagePyramids() > this->GetNumberOfInterpolators())
   {
-    itkExceptionMacro(<< "NumberOfMovingImagePyramids can not exceed the NumberOfInterpolators!");
+    itkExceptionMacro("NumberOfMovingImagePyramids can not exceed the NumberOfInterpolators!");
   }
 
 } // end CheckOnInitialize()

--- a/Components/Registrations/MultiResolutionRegistrationWithFeatures/itkMultiResolutionImageRegistrationMethodWithFeatures.hxx
+++ b/Components/Registrations/MultiResolutionRegistrationWithFeatures/itkMultiResolutionImageRegistrationMethodWithFeatures.hxx
@@ -37,19 +37,19 @@ MultiResolutionImageRegistrationMethodWithFeatures<TFixedImage, TMovingImage>::C
   /** Check if at least one of the following are provided. */
   if (this->GetFixedImage() == nullptr)
   {
-    itkExceptionMacro(<< "FixedImage is not present");
+    itkExceptionMacro("FixedImage is not present");
   }
   if (this->GetMovingImage() == nullptr)
   {
-    itkExceptionMacro(<< "MovingImage is not present");
+    itkExceptionMacro("MovingImage is not present");
   }
   if (this->GetFixedImagePyramid() == nullptr)
   {
-    itkExceptionMacro(<< "Fixed image pyramid is not present");
+    itkExceptionMacro("Fixed image pyramid is not present");
   }
   if (this->GetMovingImagePyramid() == nullptr)
   {
-    itkExceptionMacro(<< "Moving image pyramid is not present");
+    itkExceptionMacro("Moving image pyramid is not present");
   }
 
   /** Check if the number if fixed/moving pyramids == nr of fixed/moving images,
@@ -57,15 +57,15 @@ MultiResolutionImageRegistrationMethodWithFeatures<TFixedImage, TMovingImage>::C
    */
   if (this->GetNumberOfFixedImagePyramids() != this->GetNumberOfFixedImages())
   {
-    itkExceptionMacro(<< "The number of fixed image pyramids should equal the number of fixed images");
+    itkExceptionMacro("The number of fixed image pyramids should equal the number of fixed images");
   }
   if (this->GetNumberOfMovingImagePyramids() != this->GetNumberOfMovingImages())
   {
-    itkExceptionMacro(<< "The number of moving image pyramids should equal the number of moving images");
+    itkExceptionMacro("The number of moving image pyramids should equal the number of moving images");
   }
   if (this->GetNumberOfFixedImageRegions() != this->GetNumberOfFixedImages())
   {
-    itkExceptionMacro(<< "The number of fixed image regions should equal the number of fixed image");
+    itkExceptionMacro("The number of fixed image regions should equal the number of fixed image");
   }
 
 } // end CheckPyramids()

--- a/Components/ResampleInterpolators/RayCastResampleInterpolator/elxRayCastResampleInterpolator.hxx
+++ b/Components/ResampleInterpolators/RayCastResampleInterpolator/elxRayCastResampleInterpolator.hxx
@@ -101,12 +101,12 @@ RayCastResampleInterpolator<TElastix>::BeforeAll()
   // Check if 2D-3D
   if (this->m_Elastix->GetFixedImage()->GetImageDimension() != 3)
   {
-    itkExceptionMacro(<< "The RayCastInterpolator expects the fixed image to be 3D.");
+    itkExceptionMacro("The RayCastInterpolator expects the fixed image to be 3D.");
     return 1;
   }
   if (this->m_Elastix->GetMovingImage()->GetImageDimension() != 3)
   {
-    itkExceptionMacro(<< "The RayCastInterpolator expects the moving image to be 3D.");
+    itkExceptionMacro("The RayCastInterpolator expects the moving image to be 3D.");
     return 1;
   }
 

--- a/Components/Transforms/AdvancedAffineTransform/elxAdvancedAffineTransform.hxx
+++ b/Components/Transforms/AdvancedAffineTransform/elxAdvancedAffineTransform.hxx
@@ -108,7 +108,7 @@ AdvancedAffineTransformElastix<TElastix>::ReadFromFile()
     if (itkFixedParameterValues == nullptr)
     {
       log::error("ERROR: No center of rotation is specified in the transform parameter file");
-      itkExceptionMacro(<< "Transform parameter file is corrupt.")
+      itkExceptionMacro("Transform parameter file is corrupt.")
     }
   }
 
@@ -268,8 +268,8 @@ AdvancedAffineTransformElastix<TElastix>::InitializeTransform()
       if (SpaceDimension < 3)
       {
         /** Check if dimension is 3D or higher. **/
-        itkExceptionMacro(<< "ERROR: The GeometryTop intialization method does not make sense for 2D images. Use only "
-                             "for 3D or higher dimensional images.");
+        itkExceptionMacro("ERROR: The GeometryTop intialization method does not make sense for 2D images. Use only "
+                          "for 3D or higher dimensional images.");
       }
 
       transformInitializer->GeometryTopOn();
@@ -420,7 +420,7 @@ AdvancedAffineTransformElastix<TElastix>::SetScales()
        * An error is thrown, because using erroneous scales in the optimizer
        * can give unpredictable results.
        */
-      itkExceptionMacro(<< "ERROR: The Scales-option in the parameter-file has not been set properly.");
+      itkExceptionMacro("ERROR: The Scales-option in the parameter-file has not been set properly.");
     }
 
   } // end else: no automaticScalesEstimation

--- a/Components/Transforms/AdvancedBSplineTransform/elxAdvancedBSplineTransform.hxx
+++ b/Components/Transforms/AdvancedBSplineTransform/elxAdvancedBSplineTransform.hxx
@@ -203,8 +203,8 @@ AdvancedBSplineTransform<TElastix>::PreComputeGridInformation()
   /** Throw an exception if both methods are used. */
   if (count1 > 0 && count2 > 0)
   {
-    itkExceptionMacro(<< "ERROR: You can not specify both \"FinalGridSpacingInVoxels\""
-                         " and \"FinalGridSpacingInPhysicalUnits\" in the parameter file.");
+    itkExceptionMacro("ERROR: You can not specify both \"FinalGridSpacingInVoxels\""
+                      " and \"FinalGridSpacingInPhysicalUnits\" in the parameter file.");
   }
 
   /** Declare variables and set defaults. */
@@ -279,7 +279,7 @@ AdvancedBSplineTransform<TElastix>::PreComputeGridInformation()
     log::error(std::ostringstream{}
                << "ERROR: Invalid GridSpacingSchedule! The number of entries behind the GridSpacingSchedule "
                   "option should equal the numberOfResolutions, or the numberOfResolutions * ImageDimension.");
-    itkExceptionMacro(<< "ERROR: Invalid GridSpacingSchedule!");
+    itkExceptionMacro("ERROR: Invalid GridSpacingSchedule!");
   }
 
   /** Output a warning that the gridspacing may be adapted to fit the Cyclic
@@ -513,7 +513,7 @@ AdvancedBSplineTransform<TElastix>::SetOptimizerScales(const unsigned int edgeWi
       log::error(std::ostringstream{} << "ERROR: you specified a PassiveEdgeWidth of " << edgeWidth
                                       << ", while the total grid size in dimension " << i << " is only " << gridsize[i]
                                       << ".");
-      itkExceptionMacro(<< "ERROR: the PassiveEdgeWidth is too large!");
+      itkExceptionMacro("ERROR: the PassiveEdgeWidth is too large!");
     }
     insetgridindex[i] = gridindex[i] + edgeWidth;
   }

--- a/Components/Transforms/AffineDTITransform/elxAffineDTITransform.hxx
+++ b/Components/Transforms/AffineDTITransform/elxAffineDTITransform.hxx
@@ -46,7 +46,7 @@ AffineDTITransformElastix<TElastix>::BeforeRegistration()
 {
   if (SpaceDimension != 2 && SpaceDimension != 3)
   {
-    itkExceptionMacro(<< "AffineDTI transform only works for 2D or 3D images!");
+    itkExceptionMacro("AffineDTI transform only works for 2D or 3D images!");
   }
 
   /** Set center of rotation and initial translation. */
@@ -79,7 +79,7 @@ AffineDTITransformElastix<TElastix>::ReadFromFile()
   if (!pointRead)
   {
     log::error("ERROR: No center of rotation is specified in the transform parameter file");
-    itkExceptionMacro(<< "Transform parameter file is corrupt.")
+    itkExceptionMacro("Transform parameter file is corrupt.")
   }
 
   /** Set the center in this Transform. */
@@ -305,7 +305,7 @@ AffineDTITransformElastix<TElastix>::SetScales()
      * An error is thrown, because using erroneous scales in the optimizer
      * can give unpredictable results.
      */
-    itkExceptionMacro(<< "ERROR: The Scales-option in the parameter-file has not been set properly.");
+    itkExceptionMacro("ERROR: The Scales-option in the parameter-file has not been set properly.");
   }
 
   log::info(std::ostringstream{} << "Scales for transform parameters are: " << newscales);

--- a/Components/Transforms/AffineDTITransform/itkAffineDTI2DTransform.hxx
+++ b/Components/Transforms/AffineDTITransform/itkAffineDTI2DTransform.hxx
@@ -84,7 +84,7 @@ template <class TScalarType>
 void
 AffineDTI2DTransform<TScalarType>::SetParameters(const ParametersType & parameters)
 {
-  itkDebugMacro(<< "Setting parameters " << parameters);
+  itkDebugMacro("Setting parameters " << parameters);
 
   this->m_Angle[0] = parameters[0];
   this->m_Shear[0] = parameters[1];
@@ -104,7 +104,7 @@ AffineDTI2DTransform<TScalarType>::SetParameters(const ParametersType & paramete
   // parameters and cannot know if the parameters have changed.
   this->Modified();
 
-  itkDebugMacro(<< "After setting parameters ");
+  itkDebugMacro("After setting parameters ");
 }
 
 
@@ -143,7 +143,7 @@ void
 AffineDTI2DTransform<TScalarType>::ComputeMatrixParameters()
 {
   // let's hope we don't need it :)
-  itkExceptionMacro(<< "This function has not been implemented yet!");
+  itkExceptionMacro("This function has not been implemented yet!");
   this->ComputeMatrix();
 }
 

--- a/Components/Transforms/AffineDTITransform/itkAffineDTI3DTransform.hxx
+++ b/Components/Transforms/AffineDTITransform/itkAffineDTI3DTransform.hxx
@@ -99,7 +99,7 @@ template <class TScalarType>
 void
 AffineDTI3DTransform<TScalarType>::SetParameters(const ParametersType & parameters)
 {
-  itkDebugMacro(<< "Setting parameters " << parameters);
+  itkDebugMacro("Setting parameters " << parameters);
 
   this->m_Angle[0] = parameters[0];
   this->m_Angle[1] = parameters[1];
@@ -124,7 +124,7 @@ AffineDTI3DTransform<TScalarType>::SetParameters(const ParametersType & paramete
   // parameters and cannot know if the parameters have changed.
   this->Modified();
 
-  itkDebugMacro(<< "After setting parameters ");
+  itkDebugMacro("After setting parameters ");
 }
 
 
@@ -168,7 +168,7 @@ void
 AffineDTI3DTransform<TScalarType>::ComputeMatrixParameters()
 {
   // let's hope we don't need it :)
-  itkExceptionMacro(<< "This function has not been implemented yet!");
+  itkExceptionMacro("This function has not been implemented yet!");
   this->ComputeMatrix();
 }
 

--- a/Components/Transforms/AffineLogStackTransform/elxAffineLogStackTransform.hxx
+++ b/Components/Transforms/AffineLogStackTransform/elxAffineLogStackTransform.hxx
@@ -117,7 +117,7 @@ AffineLogStackTransform<TElastix>::ReadFromFile()
     if (!pointRead)
     {
       log::error("ERROR: No center of rotation is specified in the transform parameter file");
-      itkExceptionMacro(<< "Transform parameter file is corrupt.")
+      itkExceptionMacro("Transform parameter file is corrupt.")
     }
 
     this->InitializeAffineLogTransform();
@@ -388,7 +388,7 @@ AffineLogStackTransform<TElastix>::SetScales()
        * An error is thrown, because using erroneous scales in the optimizer
        * can give unpredictable results.
        */
-      itkExceptionMacro(<< "ERROR: The Scales-option in the parameter-file has not been set properly.");
+      itkExceptionMacro("ERROR: The Scales-option in the parameter-file has not been set properly.");
     }
 
   } // end else: no automaticScalesEstimation

--- a/Components/Transforms/AffineLogTransform/elxAffineLogTransform.hxx
+++ b/Components/Transforms/AffineLogTransform/elxAffineLogTransform.hxx
@@ -77,7 +77,7 @@ AffineLogTransformElastix<TElastix>::ReadFromFile()
   if (!pointRead)
   {
     log::error("ERROR: No center of rotation is specified in the transform parameter file");
-    itkExceptionMacro(<< "Transform parameter file is corrupt.");
+    itkExceptionMacro("Transform parameter file is corrupt.");
   }
 
   /** Set the center in this Transform. */
@@ -305,7 +305,7 @@ AffineLogTransformElastix<TElastix>::SetScales()
      * An error is thrown, because using erroneous scales in the optimizer
      * can give unpredictable results.
      */
-    itkExceptionMacro(<< "ERROR: The Scales-option in the parameter-file has not been set properly.");
+    itkExceptionMacro("ERROR: The Scales-option in the parameter-file has not been set properly.");
   }
 
   log::info(std::ostringstream{} << "Scales for transform parameters are: " << newscales);

--- a/Components/Transforms/AffineLogTransform/itkAffineLogTransform.hxx
+++ b/Components/Transforms/AffineLogTransform/itkAffineLogTransform.hxx
@@ -69,7 +69,7 @@ template <class TScalarType, unsigned int Dimension>
 void
 AffineLogTransform<TScalarType, Dimension>::SetParameters(const ParametersType & parameters)
 {
-  itkDebugMacro(<< "Setting parameters " << parameters);
+  itkDebugMacro("Setting parameters " << parameters);
   unsigned int k = 0; // Dummy loop index
 
   MatrixType exponentMatrix;
@@ -104,7 +104,7 @@ AffineLogTransform<TScalarType, Dimension>::SetParameters(const ParametersType &
   // parameters and cannot know if the parameters have changed.
 
   this->Modified();
-  itkDebugMacro(<< "After setting parameters ");
+  itkDebugMacro("After setting parameters ");
 }
 
 

--- a/Components/Transforms/BSplineDeformableTransformWithDiffusion/elxBSplineTransformWithDiffusion.hxx
+++ b/Components/Transforms/BSplineDeformableTransformWithDiffusion/elxBSplineTransformWithDiffusion.hxx
@@ -183,7 +183,7 @@ BSplineTransformWithDiffusion<TElastix>::BeforeRegistration()
     {
       log::error("ERROR: No MovingSegmentation filename specified.");
       /** Create and throw an exception. */
-      itkExceptionMacro(<< "ERROR: No MovingSegmentation filename specified.");
+      itkExceptionMacro("ERROR: No MovingSegmentation filename specified.");
     }
   }
 
@@ -207,7 +207,7 @@ BSplineTransformWithDiffusion<TElastix>::BeforeRegistration()
     {
       log::error("ERROR: No FixedSegmentation filename specified.");
       /** Create and throw an exception. */
-      itkExceptionMacro(<< "ERROR: No FixedSegmentation filename specified.");
+      itkExceptionMacro("ERROR: No FixedSegmentation filename specified.");
     }
   }
 
@@ -317,7 +317,7 @@ BSplineTransformWithDiffusion<TElastix>::BeforeRegistration()
                                     << "either a threshold or a segmentation, make a choice!");
 
     /** Create and throw an exception. */
-    itkExceptionMacro(<< "ERROR: Difficulty determining how to create the GrayValueImage. Check your parameter file.");
+    itkExceptionMacro("ERROR: Difficulty determining how to create the GrayValueImage. Check your parameter file.");
   }
 
   /** Set the interpolator. */

--- a/Components/Transforms/BSplineStackTransform/elxBSplineStackTransform.hxx
+++ b/Components/Transforms/BSplineStackTransform/elxBSplineStackTransform.hxx
@@ -242,8 +242,8 @@ BSplineStackTransform<TElastix>::PreComputeGridInformation()
   /** Throw an exception if both methods are used. */
   if (count1 > 0 && count2 > 0)
   {
-    itkExceptionMacro(<< "ERROR: You can not specify both \"FinalGridSpacingInVoxels\""
-                         " and \"FinalGridSpacingInPhysicalUnits\" in the parameter file.");
+    itkExceptionMacro("ERROR: You can not specify both \"FinalGridSpacingInVoxels\""
+                      " and \"FinalGridSpacingInPhysicalUnits\" in the parameter file.");
   }
 
   /** Declare variables and set defaults. */
@@ -319,7 +319,7 @@ BSplineStackTransform<TElastix>::PreComputeGridInformation()
       std::ostringstream{}
       << "ERROR: Invalid GridSpacingSchedule! The number of entries behind the GridSpacingSchedule option should equal "
          "the numberOfResolutions, or the numberOfResolutions * ( ImageDimension - 1 ).");
-    itkExceptionMacro(<< "ERROR: Invalid GridSpacingSchedule!");
+    itkExceptionMacro("ERROR: Invalid GridSpacingSchedule!");
   }
 
   /** Set the grid schedule and final grid spacing in the schedule computer. */
@@ -564,7 +564,7 @@ BSplineStackTransform<TElastix>::SetOptimizerScales(const unsigned int edgeWidth
       log::error(std::ostringstream{} << "ERROR: you specified a PassiveEdgeWidth of " << edgeWidth
                                       << ", while the total grid size in dimension " << i << " is only " << gridsize[i]
                                       << ".");
-      itkExceptionMacro(<< "ERROR: the PassiveEdgeWidth is too large!");
+      itkExceptionMacro("ERROR: the PassiveEdgeWidth is too large!");
     }
     insetgridindex[i] = gridindex[i] + edgeWidth;
   }

--- a/Components/Transforms/BSplineStackTransform/itkBSplineStackTransform.h
+++ b/Components/Transforms/BSplineStackTransform/itkBSplineStackTransform.h
@@ -75,8 +75,8 @@ protected:
     const auto numberOfFixedParameters = fixedParameters.size();
     if (numberOfFixedParameters < NumberOfFixedParameters)
     {
-      itkExceptionMacro(<< "The number of FixedParameters (" << numberOfFixedParameters << ") should be at least "
-                        << NumberOfFixedParameters);
+      itkExceptionMacro("The number of FixedParameters (" << numberOfFixedParameters << ") should be at least "
+                                                          << NumberOfFixedParameters);
     }
     const auto lastFixedParameter = fixedParameters.back();
     if (lastFixedParameter >= 1 && lastFixedParameter <= 3 &&
@@ -86,7 +86,7 @@ protected:
     }
     else
     {
-      itkExceptionMacro(<< "The last FixedParameters (" << lastFixedParameter << ") should be a valid spline order.");
+      itkExceptionMacro("The last FixedParameters (" << lastFixedParameter << ") should be a valid spline order.");
     }
 
     if (Superclass::m_FixedParameters != fixedParameters)

--- a/Components/Transforms/DeformationFieldTransform/elxDeformationFieldTransform.hxx
+++ b/Components/Transforms/DeformationFieldTransform/elxDeformationFieldTransform.hxx
@@ -70,7 +70,7 @@ DeformationFieldTransform<TElastix>::ReadFromFile()
   if (fileName.empty())
   {
     log::error("ERROR: the entry (DeformationFieldFileName \"...\") is missing in the transform parameter file!");
-    itkExceptionMacro(<< "Error while reading transform parameter file!");
+    itkExceptionMacro("Error while reading transform parameter file!");
   }
 
   /** Possibly overrule the direction cosines. */
@@ -123,7 +123,7 @@ DeformationFieldTransform<TElastix>::ReadFromFile()
     log::error(
       std::ostringstream{} << "Error while reading DeformationFieldInterpolationOrder from the parameter file\n"
                            << "DeformationFieldInterpolationOrder can only be 0 or 1!");
-    itkExceptionMacro(<< "Invalid deformation field interpolation order selected!");
+    itkExceptionMacro("Invalid deformation field interpolation order selected!");
   }
   this->m_DeformationFieldInterpolatingTransform->SetDeformationFieldInterpolator(interpolator);
 

--- a/Components/Transforms/DeformationFieldTransform/itkDeformationFieldInterpolatingTransform.h
+++ b/Components/Transforms/DeformationFieldTransform/itkDeformationFieldInterpolatingTransform.h
@@ -102,7 +102,7 @@ public:
   void
   SetParameters(const ParametersType &) override
   {
-    itkExceptionMacro(<< "ERROR: SetParameters() is not implemented for DeformationFieldInterpolatingTransform.\n"
+    itkExceptionMacro("ERROR: SetParameters() is not implemented for DeformationFieldInterpolatingTransform.\n"
                       << "Use SetDeformationField() instead.\n"
                       << "Note that this transform is NOT suited for image registration.\n"
                       << "Just use it as an (initial) fixed transform that is not optimized.");
@@ -152,8 +152,8 @@ public:
   OutputCovariantVectorType
   TransformCovariantVector(const InputCovariantVectorType &) const override
   {
-    itkExceptionMacro(<< "TransformCovariantVector(const InputCovariantVectorType &) is not implemented for "
-                         "DeformationFieldInterpolatingTransform");
+    itkExceptionMacro("TransformCovariantVector(const InputCovariantVectorType &) is not implemented for "
+                      "DeformationFieldInterpolatingTransform");
   }
 
 
@@ -186,21 +186,21 @@ public:
               JacobianType &               j,
               NonZeroJacobianIndicesType & nonZeroJacobianIndices) const override
   {
-    itkExceptionMacro(<< "Not implemented for DeformationFieldInterpolatingTransform");
+    itkExceptionMacro("Not implemented for DeformationFieldInterpolatingTransform");
   }
 
 
   void
   GetSpatialJacobian(const InputPointType & inputPoint, SpatialJacobianType & sj) const override
   {
-    itkExceptionMacro(<< "Not implemented for DeformationFieldInterpolatingTransform");
+    itkExceptionMacro("Not implemented for DeformationFieldInterpolatingTransform");
   }
 
 
   void
   GetSpatialHessian(const InputPointType & inputPoint, SpatialHessianType & sh) const override
   {
-    itkExceptionMacro(<< "Not implemented for DeformationFieldInterpolatingTransform");
+    itkExceptionMacro("Not implemented for DeformationFieldInterpolatingTransform");
   }
 
 
@@ -209,7 +209,7 @@ public:
                                JacobianOfSpatialJacobianType & jsj,
                                NonZeroJacobianIndicesType &    nonZeroJacobianIndices) const override
   {
-    itkExceptionMacro(<< "Not implemented for DeformationFieldInterpolatingTransform");
+    itkExceptionMacro("Not implemented for DeformationFieldInterpolatingTransform");
   }
 
 
@@ -219,7 +219,7 @@ public:
                                JacobianOfSpatialJacobianType & jsj,
                                NonZeroJacobianIndicesType &    nonZeroJacobianIndices) const override
   {
-    itkExceptionMacro(<< "Not implemented for DeformationFieldInterpolatingTransform");
+    itkExceptionMacro("Not implemented for DeformationFieldInterpolatingTransform");
   }
 
 
@@ -228,7 +228,7 @@ public:
                               JacobianOfSpatialHessianType & jsh,
                               NonZeroJacobianIndicesType &   nonZeroJacobianIndices) const override
   {
-    itkExceptionMacro(<< "Not implemented for DeformationFieldInterpolatingTransform");
+    itkExceptionMacro("Not implemented for DeformationFieldInterpolatingTransform");
   }
 
 
@@ -238,7 +238,7 @@ public:
                               JacobianOfSpatialHessianType & jsh,
                               NonZeroJacobianIndicesType &   nonZeroJacobianIndices) const override
   {
-    itkExceptionMacro(<< "Not implemented for DeformationFieldInterpolatingTransform");
+    itkExceptionMacro("Not implemented for DeformationFieldInterpolatingTransform");
   }
 
 

--- a/Components/Transforms/EulerStackTransform/elxEulerStackTransform.hxx
+++ b/Components/Transforms/EulerStackTransform/elxEulerStackTransform.hxx
@@ -115,7 +115,7 @@ EulerStackTransform<TElastix>::ReadFromFile()
     if (!pointRead && !indexRead)
     {
       log::error("ERROR: No center of rotation is specified in the transform parameter file");
-      itkExceptionMacro(<< "Transform parameter file is corrupt.")
+      itkExceptionMacro("Transform parameter file is corrupt.")
     }
 
     this->InitializeEulerTransform();
@@ -449,7 +449,7 @@ EulerStackTransform<TElastix>::SetScales()
        * An error is thrown, because using erroneous scales in the optimizer
        * can give unpredictable results.
        */
-      itkExceptionMacro(<< "ERROR: The Scales-option in the parameter-file has not been set properly.");
+      itkExceptionMacro("ERROR: The Scales-option in the parameter-file has not been set properly.");
     }
 
   } // end else: no automaticScalesEstimation

--- a/Components/Transforms/EulerTransform/elxEulerTransform.hxx
+++ b/Components/Transforms/EulerTransform/elxEulerTransform.hxx
@@ -78,7 +78,7 @@ EulerTransformElastix<TElastix>::ReadFromFile()
     if (!pointRead)
     {
       log::error("ERROR: No center of rotation is specified in the transform parameter file");
-      itkExceptionMacro(<< "Transform parameter file is corrupt.")
+      itkExceptionMacro("Transform parameter file is corrupt.")
     }
 
     /** Set the center in this Transform. */
@@ -387,7 +387,7 @@ EulerTransformElastix<TElastix>::SetScales()
        * An error is thrown, because using erroneous scales in the optimizer
        * can give unpredictable results.
        */
-      itkExceptionMacro(<< "ERROR: The Scales-option in the parameter-file has not been set properly.");
+      itkExceptionMacro("ERROR: The Scales-option in the parameter-file has not been set properly.");
     }
 
   } // end else: no automaticScalesEstimation

--- a/Components/Transforms/MultiBSplineTransformWithNormal/elxMultiBSplineTransformWithNormal.hxx
+++ b/Components/Transforms/MultiBSplineTransformWithNormal/elxMultiBSplineTransformWithNormal.hxx
@@ -58,7 +58,7 @@ MultiBSplineTransformWithNormal<TElastix>::InitializeBSplineTransform()
   }
   else
   {
-    itkExceptionMacro(<< "ERROR: The provided spline order is not supported.");
+    itkExceptionMacro("ERROR: The provided spline order is not supported.");
     return 1;
   }
 
@@ -92,7 +92,7 @@ MultiBSplineTransformWithNormal<TElastix>::BeforeAll()
   {
     log::error(std::ostringstream{} << "ERROR: The MultiBSplineTransformWithNormal need a -labels command line option"
                                     << " that indicates where to find the sliding objects segmentation.");
-    itkExceptionMacro(<< "ERROR: Missing -labels argument!");
+    itkExceptionMacro("ERROR: Missing -labels argument!");
   }
 
   return InitializeBSplineTransform();
@@ -229,8 +229,8 @@ MultiBSplineTransformWithNormal<TElastix>::PreComputeGridInformation()
   /** Throw an exception if both methods are used. */
   if (count1 > 0 && count2 > 0)
   {
-    itkExceptionMacro(<< "ERROR: You can not specify both \"FinalGridSpacingInVoxels\""
-                         " and \"FinalGridSpacingInPhysicalUnits\" in the parameter file.");
+    itkExceptionMacro("ERROR: You can not specify both \"FinalGridSpacingInVoxels\""
+                      " and \"FinalGridSpacingInPhysicalUnits\" in the parameter file.");
   }
 
   /** Declare variables and set defaults. */
@@ -305,7 +305,7 @@ MultiBSplineTransformWithNormal<TElastix>::PreComputeGridInformation()
     log::error(std::ostringstream{}
                << "ERROR: Invalid GridSpacingSchedule! The number of entries behind the GridSpacingSchedule "
                   "option should equal the numberOfResolutions, or the numberOfResolutions * ImageDimension.");
-    itkExceptionMacro(<< "ERROR: Invalid GridSpacingSchedule!");
+    itkExceptionMacro("ERROR: Invalid GridSpacingSchedule!");
   }
 
   /** Set the grid schedule and final grid spacing in the schedule computer. */
@@ -651,7 +651,7 @@ MultiBSplineTransformWithNormal<TElastix>::SetOptimizerScales(const unsigned int
       log::error(std::ostringstream{} << "ERROR: you specified a PassiveEdgeWidth of " << edgeWidth
                                       << ", while the total grid size in dimension " << i << " is only " << gridsize[i]
                                       << ".");
-      itkExceptionMacro(<< "ERROR: the PassiveEdgeWidth is too large!");
+      itkExceptionMacro("ERROR: the PassiveEdgeWidth is too large!");
     }
     insetgridindex[i] = gridindex[i] + edgeWidth;
   }

--- a/Components/Transforms/MultiBSplineTransformWithNormal/itkMultiBSplineDeformableTransformWithNormal.h
+++ b/Components/Transforms/MultiBSplineTransformWithNormal/itkMultiBSplineDeformableTransformWithNormal.h
@@ -265,7 +265,7 @@ public:
   OutputVectorType
   TransformVector(const InputVectorType &) const override
   {
-    itkExceptionMacro(<< "Method not applicable for deformable transform.");
+    itkExceptionMacro("Method not applicable for deformable transform.");
     return OutputVectorType();
   }
 
@@ -276,7 +276,7 @@ public:
   OutputVnlVectorType
   TransformVector(const InputVnlVectorType &) const override
   {
-    itkExceptionMacro(<< "Method not applicable for deformable transform. ");
+    itkExceptionMacro("Method not applicable for deformable transform. ");
     return OutputVnlVectorType();
   }
 
@@ -287,7 +287,7 @@ public:
   OutputCovariantVectorType
   TransformCovariantVector(const InputCovariantVectorType &) const override
   {
-    itkExceptionMacro(<< "Method not applicable for deformable transform. ");
+    itkExceptionMacro("Method not applicable for deformable transform. ");
     return OutputCovariantVectorType();
   }
 
@@ -408,8 +408,8 @@ public:
                               JacobianOfSpatialHessianType & jsh,
                               NonZeroJacobianIndicesType &   nonZeroJacobianIndices) const override
   {
-    itkExceptionMacro(<< "ERROR: GetJacobianOfSpatialHessian() not yet implemented in the "
-                         "MultiBSplineDeformableTransformWithNormal class.");
+    itkExceptionMacro("ERROR: GetJacobianOfSpatialHessian() not yet implemented in the "
+                      "MultiBSplineDeformableTransformWithNormal class.");
   }
 
 

--- a/Components/Transforms/MultiBSplineTransformWithNormal/itkMultiBSplineDeformableTransformWithNormal.hxx
+++ b/Components/Transforms/MultiBSplineTransformWithNormal/itkMultiBSplineDeformableTransformWithNormal.hxx
@@ -185,7 +185,7 @@ struct UpdateLocalBases_impl
   static void
   Do(ImageBaseType *, ImageVectorType *)
   {
-    itkGenericExceptionMacro(<< "MultiBSplineDeformableTransformWithNormal only works with 3D image for the moment");
+    itkGenericExceptionMacro("MultiBSplineDeformableTransformWithNormal only works with 3D image for the moment");
   }
 };
 
@@ -462,8 +462,8 @@ MultiBSplineDeformableTransformWithNormal<TScalarType, NDimensions, VSplineOrder
   }
   else
   {
-    itkExceptionMacro(<< "Input parameters for the spline haven't been set ! Set them using the SetParameters or "
-                         "SetCoefficientImage method first.");
+    itkExceptionMacro("Input parameters for the spline haven't been set ! Set them using the SetParameters or "
+                      "SetCoefficientImage method first.");
   }
 }
 
@@ -525,8 +525,8 @@ MultiBSplineDeformableTransformWithNormal<TScalarType, NDimensions, VSplineOrder
   // expected number of parameters
   if (const auto numberOfParameters = parameters.size(); numberOfParameters != this->GetNumberOfParameters())
   {
-    itkExceptionMacro(<< "Mismatched between parameters size " << numberOfParameters << " and region size "
-                      << this->GetNumberOfParameters());
+    itkExceptionMacro("Mismatched between parameters size " << numberOfParameters << " and region size "
+                                                            << this->GetNumberOfParameters());
   }
 
   // Clean up buffered parameters
@@ -564,8 +564,8 @@ MultiBSplineDeformableTransformWithNormal<TScalarType, NDimensions, VSplineOrder
   // expected number of parameters
   if (const auto numberOfParameters = parameters.size(); numberOfParameters != this->GetNumberOfParameters())
   {
-    itkExceptionMacro(<< "Mismatched between parameters size " << numberOfParameters << " and region size "
-                      << this->GetNumberOfParameters());
+    itkExceptionMacro("Mismatched between parameters size " << numberOfParameters << " and region size "
+                                                            << this->GetNumberOfParameters());
   }
 
   // copy it
@@ -591,8 +591,8 @@ MultiBSplineDeformableTransformWithNormal<TScalarType, NDimensions, VSplineOrder
    */
   if (nullptr == this->m_InputParametersPointer)
   {
-    itkExceptionMacro(<< "Cannot GetParameters() because m_InputParametersPointer is NULL. Perhaps "
-                         "SetCoefficientImages() has been called causing the NULL pointer.");
+    itkExceptionMacro("Cannot GetParameters() because m_InputParametersPointer is NULL. Perhaps "
+                      "SetCoefficientImages() has been called causing the NULL pointer.");
   }
 
   return (*this->m_InputParametersPointer);
@@ -711,7 +711,7 @@ MultiBSplineDeformableTransformWithNormal<TScalarType, NDimensions, VSplineOrder
   // SetParameters or SetParametersByValue
   if (this->m_InputParametersPointer == nullptr)
   {
-    itkExceptionMacro(<< "Cannot compute Jacobian: parameters not set");
+    itkExceptionMacro("Cannot compute Jacobian: parameters not set");
   }
 
   int lidx = 0;
@@ -801,7 +801,7 @@ MultiBSplineDeformableTransformWithNormal<TScalarType, NDimensions, VSplineOrder
   // SetParameters or SetParametersByValue
   if (this->m_InputParametersPointer == nullptr)
   {
-    itkExceptionMacro(<< "Cannot compute Jacobian: parameters not set");
+    itkExceptionMacro("Cannot compute Jacobian: parameters not set");
   }
 
   int lidx = 0;
@@ -837,7 +837,7 @@ MultiBSplineDeformableTransformWithNormal<TScalarType, NDimensions, VSplineOrder
   // SetParameters or SetParametersByValue
   if (this->m_InputParametersPointer == nullptr)
   {
-    itkExceptionMacro(<< "Cannot compute Jacobian: parameters not set");
+    itkExceptionMacro("Cannot compute Jacobian: parameters not set");
   }
 
   int lidx = 0;
@@ -874,8 +874,8 @@ MultiBSplineDeformableTransformWithNormal<TScalarType, NDimensions, VSplineOrder
   JacobianOfSpatialJacobianType & jsj,
   NonZeroJacobianIndicesType &    nonZeroJacobianIndices) const
 {
-  itkExceptionMacro(<< "ERROR: GetJacobianOfSpatialJacobian() not yet implemented in the "
-                       "MultiBSplineDeformableTransformWithNormal class.");
+  itkExceptionMacro("ERROR: GetJacobianOfSpatialJacobian() not yet implemented in the "
+                    "MultiBSplineDeformableTransformWithNormal class.");
 } // end GetJacobianOfSpatialJacobian()
 
 
@@ -903,7 +903,7 @@ MultiBSplineDeformableTransformWithNormal<TScalarType, NDimensions, VSplineOrder
   // SetParameters or SetParametersByValue
   if (this->m_InputParametersPointer == nullptr)
   {
-    itkExceptionMacro(<< "Cannot compute Jacobian: parameters not set");
+    itkExceptionMacro("Cannot compute Jacobian: parameters not set");
   }
 
   int lidx = 0;
@@ -1001,7 +1001,7 @@ MultiBSplineDeformableTransformWithNormal<TScalarType, NDimensions, VSplineOrder
   // SetParameters or SetParametersByValue
   if (this->m_InputParametersPointer == nullptr)
   {
-    itkExceptionMacro(<< "Cannot compute Jacobian: parameters not set");
+    itkExceptionMacro("Cannot compute Jacobian: parameters not set");
   }
 
   int lidx = 0;

--- a/Components/Transforms/RecursiveBSplineTransform/elxRecursiveBSplineTransform.hxx
+++ b/Components/Transforms/RecursiveBSplineTransform/elxRecursiveBSplineTransform.hxx
@@ -203,8 +203,8 @@ RecursiveBSplineTransform<TElastix>::PreComputeGridInformation()
   /** Throw an exception if both methods are used. */
   if (count1 > 0 && count2 > 0)
   {
-    itkExceptionMacro(<< "ERROR: You can not specify both \"FinalGridSpacingInVoxels\""
-                         " and \"FinalGridSpacingInPhysicalUnits\" in the parameter file.");
+    itkExceptionMacro("ERROR: You can not specify both \"FinalGridSpacingInVoxels\""
+                      " and \"FinalGridSpacingInPhysicalUnits\" in the parameter file.");
   }
 
   /** Declare variables and set defaults. */
@@ -279,7 +279,7 @@ RecursiveBSplineTransform<TElastix>::PreComputeGridInformation()
     log::error(std::ostringstream{}
                << "ERROR: Invalid GridSpacingSchedule! The number of entries behind the GridSpacingSchedule "
                   "option should equal the numberOfResolutions, or the numberOfResolutions * ImageDimension.");
-    itkExceptionMacro(<< "ERROR: Invalid GridSpacingSchedule!");
+    itkExceptionMacro("ERROR: Invalid GridSpacingSchedule!");
   }
 
   /** Output a warning that the gridspacing may be adapted to fit the Cyclic
@@ -540,7 +540,7 @@ RecursiveBSplineTransform<TElastix>::SetOptimizerScales(const unsigned int edgeW
       log::error(std::ostringstream{} << "ERROR: you specified a PassiveEdgeWidth of " << edgeWidth
                                       << ", while the total grid size in dimension " << i << " is only " << gridsize[i]
                                       << ".");
-      itkExceptionMacro(<< "ERROR: the PassiveEdgeWidth is too large!");
+      itkExceptionMacro("ERROR: the PassiveEdgeWidth is too large!");
     }
     insetgridindex[i] = gridindex[i] + edgeWidth;
   }

--- a/Components/Transforms/SimilarityTransform/elxSimilarityTransform.hxx
+++ b/Components/Transforms/SimilarityTransform/elxSimilarityTransform.hxx
@@ -87,7 +87,7 @@ SimilarityTransformElastix<TElastix>::ReadFromFile()
     if (!pointRead && !indexRead)
     {
       log::error("ERROR: No center of rotation is specified in the transform parameter file.");
-      itkExceptionMacro(<< "Transform parameter file is corrupt.")
+      itkExceptionMacro("Transform parameter file is corrupt.")
     }
 
     /** Set the center in this Transform. */

--- a/Components/Transforms/SplineKernelTransform/elxSplineKernelTransform.hxx
+++ b/Components/Transforms/SplineKernelTransform/elxSplineKernelTransform.hxx
@@ -165,7 +165,7 @@ SplineKernelTransform<TElastix>::BeforeRegistration()
   if (!knownType)
   {
     log::error(std::ostringstream{} << "ERROR: The kernel type " << kernelType << " is not supported.");
-    itkExceptionMacro(<< "ERROR: unable to configure " << this->GetComponentLabel());
+    itkExceptionMacro("ERROR: unable to configure " << this->GetComponentLabel());
   }
 
   /** Interpolating or approximating spline. */
@@ -301,7 +301,7 @@ SplineKernelTransform<TElastix>::ReadLandmarkFile(const std::string & filename,
   catch (const itk::ExceptionObject & err)
   {
     log::error(std::ostringstream{} << "  Error while opening landmark file.\n" << err);
-    itkExceptionMacro(<< "ERROR: unable to configure " << this->GetComponentLabel());
+    itkExceptionMacro("ERROR: unable to configure " << this->GetComponentLabel());
   }
 
   /** Some user-feedback. */
@@ -388,7 +388,7 @@ SplineKernelTransform<TElastix>::ReadFromFile()
   else
   {
     log::error("ERROR: the SplineKernelType is not given in the transform parameter file.");
-    itkExceptionMacro(<< "ERROR: unable to configure transform.");
+    itkExceptionMacro("ERROR: unable to configure transform.");
   }
 
   /** Interpolating or approximating spline. */
@@ -413,7 +413,7 @@ SplineKernelTransform<TElastix>::ReadFromFile()
   if (!retfil)
   {
     log::error("ERROR: the FixedImageLandmarks are not given in the transform parameter file.");
-    itkExceptionMacro(<< "ERROR: unable to configure transform.");
+    itkExceptionMacro("ERROR: unable to configure transform.");
   }
 
   /** Convert to fixedParameters type and set in transform. */

--- a/Components/Transforms/SplineKernelTransform/itkKernelTransform2.h
+++ b/Components/Transforms/SplineKernelTransform/itkKernelTransform2.h
@@ -196,14 +196,14 @@ public:
   OutputVectorType
   TransformVector(const InputVectorType &) const override
   {
-    itkExceptionMacro(<< "TransformVector(const InputVectorType &) is not implemented for KernelTransform");
+    itkExceptionMacro("TransformVector(const InputVectorType &) is not implemented for KernelTransform");
   }
 
 
   OutputVnlVectorType
   TransformVector(const InputVnlVectorType &) const override
   {
-    itkExceptionMacro(<< "TransformVector(const InputVnlVectorType &) is not implemented for KernelTransform");
+    itkExceptionMacro("TransformVector(const InputVnlVectorType &) is not implemented for KernelTransform");
   }
 
 
@@ -305,14 +305,14 @@ public:
   void
   GetSpatialJacobian(const InputPointType & inputPoint, SpatialJacobianType & sj) const override
   {
-    itkExceptionMacro(<< "Not implemented for KernelTransform2");
+    itkExceptionMacro("Not implemented for KernelTransform2");
   }
 
 
   void
   GetSpatialHessian(const InputPointType & inputPoint, SpatialHessianType & sh) const override
   {
-    itkExceptionMacro(<< "Not implemented for KernelTransform2");
+    itkExceptionMacro("Not implemented for KernelTransform2");
   }
 
 
@@ -321,7 +321,7 @@ public:
                                JacobianOfSpatialJacobianType & jsj,
                                NonZeroJacobianIndicesType &    nonZeroJacobianIndices) const override
   {
-    itkExceptionMacro(<< "Not implemented for KernelTransform2");
+    itkExceptionMacro("Not implemented for KernelTransform2");
   }
 
 
@@ -331,7 +331,7 @@ public:
                                JacobianOfSpatialJacobianType & jsj,
                                NonZeroJacobianIndicesType &    nonZeroJacobianIndices) const override
   {
-    itkExceptionMacro(<< "Not implemented for KernelTransform2");
+    itkExceptionMacro("Not implemented for KernelTransform2");
   }
 
 
@@ -340,7 +340,7 @@ public:
                               JacobianOfSpatialHessianType & jsh,
                               NonZeroJacobianIndicesType &   nonZeroJacobianIndices) const override
   {
-    itkExceptionMacro(<< "Not implemented for KernelTransform2");
+    itkExceptionMacro("Not implemented for KernelTransform2");
   }
 
 
@@ -350,7 +350,7 @@ public:
                               JacobianOfSpatialHessianType & jsh,
                               NonZeroJacobianIndicesType &   nonZeroJacobianIndices) const override
   {
-    itkExceptionMacro(<< "Not implemented for KernelTransform2");
+    itkExceptionMacro("Not implemented for KernelTransform2");
   }
 
 

--- a/Components/Transforms/SplineKernelTransform/itkKernelTransform2.hxx
+++ b/Components/Transforms/SplineKernelTransform/itkKernelTransform2.hxx
@@ -100,7 +100,7 @@ template <class TScalarType, unsigned int NDimensions>
 void
 KernelTransform2<TScalarType, NDimensions>::SetSourceLandmarks(PointSetType * landmarks)
 {
-  itkDebugMacro(<< "setting SourceLandmarks to " << landmarks);
+  itkDebugMacro("setting SourceLandmarks to " << landmarks);
   if (this->m_SourceLandmarks != landmarks)
   {
     this->m_SourceLandmarks = landmarks;
@@ -156,7 +156,7 @@ template <class TScalarType, unsigned int NDimensions>
 void
 KernelTransform2<TScalarType, NDimensions>::ComputeG(const InputVectorType &, GMatrixType &) const
 {
-  itkExceptionMacro(<< "ComputeG() should be reimplemented in the subclass !!");
+  itkExceptionMacro("ComputeG() should be reimplemented in the subclass !!");
 } // end ComputeG()
 
 
@@ -282,7 +282,7 @@ KernelTransform2<TScalarType, NDimensions>::ComputeWMatrix()
   }
   else
   {
-    itkExceptionMacro(<< "ERROR: invalid matrix inversion method (" << this->m_MatrixInversionMethod << ")");
+    itkExceptionMacro("ERROR: invalid matrix inversion method (" << this->m_MatrixInversionMethod << ")");
   }
 
   /** Reorganize W. */
@@ -318,7 +318,7 @@ KernelTransform2<TScalarType, NDimensions>::ComputeLInverse()
   }
   else
   {
-    itkExceptionMacro(<< "ERROR: invalid matrix inversion method (" << this->m_MatrixInversionMethod << ")");
+    itkExceptionMacro("ERROR: invalid matrix inversion method (" << this->m_MatrixInversionMethod << ")");
   }
 
 } // end ComputeLInverse()

--- a/Components/Transforms/WeightedCombinationTransform/elxWeightedCombinationTransform.hxx
+++ b/Components/Transforms/WeightedCombinationTransform/elxWeightedCombinationTransform.hxx
@@ -172,7 +172,7 @@ WeightedCombinationTransformElastix<TElastix>::SetScales()
        * An error is thrown, because using erroneous scales in the optimizer
        * can give unpredictable results.
        */
-      itkExceptionMacro(<< "ERROR: The Scales-option in the parameter-file has not been set properly.");
+      itkExceptionMacro("ERROR: The Scales-option in the parameter-file has not been set properly.");
     }
 
   } // end else: no automaticScalesEstimation
@@ -201,7 +201,7 @@ WeightedCombinationTransformElastix<TElastix>::LoadSubTransforms()
 
   if (N == 0)
   {
-    itkExceptionMacro(<< "ERROR: At least one SubTransform should be specified.");
+    itkExceptionMacro("ERROR: At least one SubTransform should be specified.");
   }
   else
   {
@@ -234,7 +234,7 @@ WeightedCombinationTransformElastix<TElastix>::LoadSubTransforms()
     int initfailure = configurationSubTransform->Initialize(argmapSubTransform);
     if (initfailure != 0)
     {
-      itkExceptionMacro(<< "ERROR: Reading SubTransform parameters failed: " << subTransformFileName);
+      itkExceptionMacro("ERROR: Reading SubTransform parameters failed: " << subTransformFileName);
     }
 
     /** Read the SubTransform name. */
@@ -265,7 +265,7 @@ WeightedCombinationTransformElastix<TElastix>::LoadSubTransforms()
     if (subTransforms[i].IsNull())
     {
       log::error(std::ostringstream{} << "ERROR: Error while trying to load the SubTransform " << subTransformFileName);
-      itkExceptionMacro(<< "ERROR: Loading SubTransforms failed!");
+      itkExceptionMacro("ERROR: Loading SubTransforms failed!");
     }
 
   } // end for loop over subTransforms

--- a/Components/Transforms/WeightedCombinationTransform/itkWeightedCombinationTransform.h
+++ b/Components/Transforms/WeightedCombinationTransform/itkWeightedCombinationTransform.h
@@ -110,8 +110,8 @@ public:
   OutputCovariantVectorType
   TransformCovariantVector(const InputCovariantVectorType &) const override
   {
-    itkExceptionMacro(<< "TransformCovariantVector(const InputCovariantVectorType &) is not implemented for "
-                         "WeightedCombinationTransform");
+    itkExceptionMacro("TransformCovariantVector(const InputCovariantVectorType &) is not implemented for "
+                      "WeightedCombinationTransform");
   }
 
 
@@ -188,14 +188,14 @@ public:
   void
   GetSpatialJacobian(const InputPointType & inputPoint, SpatialJacobianType & sj) const override
   {
-    itkExceptionMacro(<< "Not implemented for WeightedCombinationTransform");
+    itkExceptionMacro("Not implemented for WeightedCombinationTransform");
   }
 
 
   void
   GetSpatialHessian(const InputPointType & inputPoint, SpatialHessianType & sh) const override
   {
-    itkExceptionMacro(<< "Not implemented for WeightedCombinationTransform");
+    itkExceptionMacro("Not implemented for WeightedCombinationTransform");
   }
 
 
@@ -204,7 +204,7 @@ public:
                                JacobianOfSpatialJacobianType & jsj,
                                NonZeroJacobianIndicesType &    nonZeroJacobianIndices) const override
   {
-    itkExceptionMacro(<< "Not implemented for WeightedCombinationTransform");
+    itkExceptionMacro("Not implemented for WeightedCombinationTransform");
   }
 
 
@@ -214,7 +214,7 @@ public:
                                JacobianOfSpatialJacobianType & jsj,
                                NonZeroJacobianIndicesType &    nonZeroJacobianIndices) const override
   {
-    itkExceptionMacro(<< "Not implemented for WeightedCombinationTransform");
+    itkExceptionMacro("Not implemented for WeightedCombinationTransform");
   }
 
 
@@ -223,7 +223,7 @@ public:
                               JacobianOfSpatialHessianType & jsh,
                               NonZeroJacobianIndicesType &   nonZeroJacobianIndices) const override
   {
-    itkExceptionMacro(<< "Not implemented for WeightedCombinationTransform");
+    itkExceptionMacro("Not implemented for WeightedCombinationTransform");
   }
 
 
@@ -233,7 +233,7 @@ public:
                               JacobianOfSpatialHessianType & jsh,
                               NonZeroJacobianIndicesType &   nonZeroJacobianIndices) const override
   {
-    itkExceptionMacro(<< "Not implemented for WeightedCombinationTransform");
+    itkExceptionMacro("Not implemented for WeightedCombinationTransform");
   }
 
 

--- a/Components/Transforms/WeightedCombinationTransform/itkWeightedCombinationTransform.hxx
+++ b/Components/Transforms/WeightedCombinationTransform/itkWeightedCombinationTransform.hxx
@@ -60,7 +60,7 @@ WeightedCombinationTransform<TScalarType, NInputDimensions, NOutputDimensions>::
   this->m_SumOfWeights = param.sum();
   if (this->m_SumOfWeights < 1e-10 && this->m_NormalizeWeights)
   {
-    itkExceptionMacro(<< "Sum of weights for WeightedCombinationTransform is smaller than 0.");
+    itkExceptionMacro("Sum of weights for WeightedCombinationTransform is smaller than 0.");
   }
 
   // Precompute the nonzerojacobianindices vector

--- a/Core/ComponentBaseClasses/elxOptimizerBase.hxx
+++ b/Core/ComponentBaseClasses/elxOptimizerBase.hxx
@@ -41,7 +41,7 @@ OptimizerBase<TElastix>::SetCurrentPositionPublic(const ParametersType & /** par
                 "StandardGradientDescentOptimizer? Don't!");
 
   /** Throw an exception if this function is not overridden. */
-  itkExceptionMacro(<< "ERROR: The SetCurrentPositionPublic method is not implemented in your optimizer");
+  itkExceptionMacro("ERROR: The SetCurrentPositionPublic method is not implemented in your optimizer");
 
 } // end SetCurrentPositionPublic()
 

--- a/Core/ComponentBaseClasses/elxResamplerBase.hxx
+++ b/Core/ComponentBaseClasses/elxResamplerBase.hxx
@@ -522,9 +522,9 @@ ResamplerBase<TElastix>::CreateItkResultImage()
 
   if (resultImage.IsNull())
   {
-    itkExceptionMacro(<< "Unable to cast result image: ResultImagePixelType must be one of \"char\", \"unsigned "
-                         "char\", \"short\", \"ushort\", \"unsigned short\", \"int\", \"unsigned int\", \"long\", "
-                         "\"unsigned long\", \"float\" or \"double\" but was \""
+    itkExceptionMacro("Unable to cast result image: ResultImagePixelType must be one of \"char\", \"unsigned "
+                      "char\", \"short\", \"ushort\", \"unsigned short\", \"int\", \"unsigned int\", \"long\", "
+                      "\"unsigned long\", \"float\" or \"double\" but was \""
                       << resultImagePixelType << "\".");
   }
 

--- a/Core/ComponentBaseClasses/elxTransformBase.hxx
+++ b/Core/ComponentBaseClasses/elxTransformBase.hxx
@@ -206,7 +206,7 @@ TransformBase<TElastix>::BeforeRegistrationBase()
       }
       else
       {
-        itkExceptionMacro(<< "ERROR: the file " << fileName << " does not exist!");
+        itkExceptionMacro("ERROR: the file " << fileName << " does not exist!");
       }
     }
   }
@@ -392,8 +392,8 @@ TransformBase<TElastix>::ReadFromFile()
       std::string fullFileName2 = itksys::SystemTools::CollapseFullPath(configuration.GetParameterFileName());
       if (fullFileName1 == fullFileName2)
       {
-        itkExceptionMacro(<< "ERROR: The initial transform parameter filename is identical to the current "
-                             "TransformParameters filename! An infinite loop is not allowed.");
+        itkExceptionMacro("ERROR: The InitialTransformParameterFileName is identical to the current "
+                          "TransformParameters filename! An infinite loop is not allowed.");
       }
 
       /** We can safely read the initial transform. */
@@ -435,7 +435,7 @@ TransformBase<TElastix>::ReadInitialTransformFromFile(const char * transformPara
 
   if (configurationInitialTransform->Initialize({ { "-tp", transformParametersFileName } }) != 0)
   {
-    itkGenericExceptionMacro(<< "ERROR: Reading initial transform parameters failed: " << transformParametersFileName);
+    itkGenericExceptionMacro("ERROR: Reading initial transform parameters failed: " << transformParametersFileName);
   }
 
   this->ReadInitialTransformFromConfiguration(configurationInitialTransform);
@@ -646,7 +646,7 @@ TransformBase<TElastix>::TransformPoints() const
   /** For backwards compatibility def = ipp. */
   if (!def.empty() && !ipp.empty())
   {
-    itkExceptionMacro(<< "ERROR: Can not use both \"-def\" and \"-ipp\"!\n"
+    itkExceptionMacro("ERROR: Can not use both \"-def\" and \"-ipp\"!\n"
                       << "  \"-ipp\" is deprecated, use only \"-def\".\n");
   }
   else if (def.empty() && !ipp.empty())
@@ -1370,7 +1370,7 @@ TransformBase<TElastix>::AutomaticScalesEstimation(ScalesType & scales) const
   if (nrofsamples == 0)
   {
     /** \todo: should we demand a minimum number (~100) of voxels? */
-    itkExceptionMacro(<< "No valid voxels found to estimate the scales.");
+    itkExceptionMacro("No valid voxels found to estimate the scales.");
   }
 
   /** initialize */
@@ -1457,7 +1457,7 @@ TransformBase<TElastix>::AutomaticScalesEstimationStackTransform(const unsigned 
   if (nrofsamples == 0)
   {
     /** \todo: should we demand a minimum number (~100) of voxels? */
-    itkExceptionMacro(<< "No valid voxels found to estimate the scales.");
+    itkExceptionMacro("No valid voxels found to estimate the scales.");
   }
 
   /** Read fixed coordinates and get Jacobian. */

--- a/Core/Kernel/elxElastixMain.cxx
+++ b/Core/Kernel/elxElastixMain.cxx
@@ -550,7 +550,7 @@ ElastixMain::GetImageInformationFromFile(const std::string & filename, ImageDime
     {
       /** Extra check. In principal, ITK the testreader should already have thrown an exception
        * if it was not possible to create the ImageIO object */
-      itkExceptionMacro(<< "ERROR: ImageIO object was not created, but no exception was thrown.");
+      itkExceptionMacro("ERROR: ImageIO object was not created, but no exception was thrown.");
     }
     imageDimension = testImageIO->GetNumberOfDimensions();
   } // end if

--- a/Core/Kernel/elxElastixTemplate.hxx
+++ b/Core/Kernel/elxElastixTemplate.hxx
@@ -32,8 +32,8 @@
     {                                                                                                                  \
       std::string par = "";                                                                                            \
       Deref(ElastixBase::GetConfiguration()).ReadParameter(par, #_name, i, false);                                     \
-      itkExceptionMacro(<< "ERROR: entry " << i << " of " << #_name << " reads \"" << par                              \
-                        << "\", which is not of type " << #_name << "BaseType.");                                      \
+      itkExceptionMacro("ERROR: entry " << i << " of " << #_name << " reads \"" << par << "\", which is not of type "  \
+                                        << #_name << "BaseType.");                                                     \
     }
 // end elxCheckAndSetComponentMacro
 

--- a/Core/Kernel/elxMainBase.cxx
+++ b/Core/Kernel/elxMainBase.cxx
@@ -131,7 +131,7 @@ MainBase::GetElastixBase() const
   const auto elastixBase = dynamic_cast<ElastixBase *>(m_Elastix.GetPointer());
   if (elastixBase == nullptr)
   {
-    itkExceptionMacro(<< "Probably GetElastixBase() is called before having called Run()");
+    itkExceptionMacro("Probably GetElastixBase() is called before having called Run()");
   }
 
   return *elastixBase;
@@ -152,7 +152,7 @@ MainBase::CreateComponent(const ComponentDescriptionType & name)
 
   if (component.IsNull())
   {
-    itkExceptionMacro(<< "The following component could not be created: " << name);
+    itkExceptionMacro("The following component could not be created: " << name);
   }
 
   return component;

--- a/Core/Main/elxParameterObject.cxx
+++ b/Core/Main/elxParameterObject.cxx
@@ -331,7 +331,8 @@ ParameterObject::WriteParameterFile(const ParameterFileNameType & parameterFileN
 
   if (m_ParameterMaps.size() > 1)
   {
-    itkExceptionMacro(<< "Error writing to disk: The number of parameter maps (" << m_ParameterMaps.size()
+    itkExceptionMacro("Error writing to disk: The number of parameter maps ("
+                      << m_ParameterMaps.size()
                       << ") does not match the number of provided filenames (1). Please call WriteParameterFiles "
                          "instead, and provide a vector of filenames.");
   }
@@ -381,9 +382,9 @@ ParameterObject::WriteParameterFiles(const ParameterMapVectorType &      paramet
 {
   if (parameterMapVector.size() != parameterFileNameVector.size())
   {
-    itkGenericExceptionMacro(<< "Error writing to disk: The number of parameter maps (" << parameterMapVector.size()
-                             << ") does not match the number of provided filenames (" << parameterFileNameVector.size()
-                             << ").");
+    itkGenericExceptionMacro("Error writing to disk: The number of parameter maps ("
+                             << parameterMapVector.size() << ") does not match the number of provided filenames ("
+                             << parameterFileNameVector.size() << ").");
   }
 
   // Add initial transform parameter file names. Do not touch the first one,

--- a/Core/Main/itkElastixRegistrationMethod.hxx
+++ b/Core/Main/itkElastixRegistrationMethod.hxx
@@ -256,12 +256,12 @@ ElastixRegistrationMethod<TFixedImage, TMovingImage>::GenerateData()
     }
     catch (const itk::ExceptionObject & e)
     {
-      itkExceptionMacro(<< "Errors occurred during registration: " << e.what());
+      itkExceptionMacro("Errors occurred during registration: " << e.what());
     }
 
     if (isError != 0)
     {
-      itkExceptionMacro(<< "Internal elastix error: See elastix log (use LogToConsoleOn() or LogToFileOn()).");
+      itkExceptionMacro("Internal elastix error: See elastix log (use LogToConsoleOn() or LogToFileOn()).");
     }
 
     // Get stuff in order to put it in the next registration
@@ -446,8 +446,8 @@ ElastixRegistrationMethod<TFixedImage, TMovingImage>::GetFixedImage(const unsign
     }
   }
 
-  itkExceptionMacro(<< "Index exceeds the number of fixed images (index: " << index << ", number of fixed images: " << n
-                    << ")");
+  itkExceptionMacro("Index exceeds the number of fixed images (index: " << index << ", number of fixed images: " << n
+                                                                        << ")");
 }
 
 
@@ -515,8 +515,8 @@ ElastixRegistrationMethod<TFixedImage, TMovingImage>::GetMovingImage(const unsig
     }
   }
 
-  itkExceptionMacro(<< "Index exceeds the number of moving images (index: " << index
-                    << ", number of moving images: " << n << ")");
+  itkExceptionMacro("Index exceeds the number of moving images (index: " << index << ", number of moving images: " << n
+                                                                         << ")");
 }
 
 
@@ -572,8 +572,8 @@ ElastixRegistrationMethod<TFixedImage, TMovingImage>::GetFixedMask(const unsigne
     }
   }
 
-  itkExceptionMacro(<< "Index exceeds the number of fixed masks (index: " << index << ", number of fixed masks: " << n
-                    << ")");
+  itkExceptionMacro("Index exceeds the number of fixed masks (index: " << index << ", number of fixed masks: " << n
+                                                                       << ")");
 }
 
 
@@ -637,8 +637,8 @@ ElastixRegistrationMethod<TFixedImage, TMovingImage>::GetMovingMask(const unsign
     }
   }
 
-  itkExceptionMacro(<< "Index exceeds the number of moving masks (index: " << index << ", number of moving masks: " << n
-                    << ")");
+  itkExceptionMacro("Index exceeds the number of moving masks (index: " << index << ", number of moving masks: " << n
+                                                                        << ")");
 }
 
 

--- a/Core/Main/itkTransformixFilter.hxx
+++ b/Core/Main/itkTransformixFilter.hxx
@@ -80,8 +80,8 @@ TransformixFilter<TImage>::GenerateData()
   // Transformix uses "-def" for path to point sets AND as flag for writing deformation field
   if (m_ComputeDeformationField && !m_FixedPointSetFileName.empty())
   {
-    itkExceptionMacro(<< "For backwards compatibility, only one of ComputeDeformationFieldOn() or "
-                         "SetFixedPointSetFileName() can be active at any one time.")
+    itkExceptionMacro("For backwards compatibility, only one of ComputeDeformationFieldOn() or "
+                      "SetFixedPointSetFileName() can be active at any one time.")
   }
 
   // Setup argument map which transformix uses internally ito figure out what needs to be done

--- a/Testing/itkBSplineTransformPointPerformanceTest.cxx
+++ b/Testing/itkBSplineTransformPointPerformanceTest.cxx
@@ -85,7 +85,7 @@ public:
     /** Check if the coefficient image has been set. */
     if (!this->m_CoefficientImages[0])
     {
-      itkWarningMacro(<< "B-spline coefficients have not been set");
+      itkWarningMacro("B-spline coefficients have not been set");
       for (unsigned int j = 0; j < SpaceDimension; ++j)
       {
         outputPoint[j] = transformedPoint[j];

--- a/Testing/itkOpenCLBufferTest.cxx
+++ b/Testing/itkOpenCLBufferTest.cxx
@@ -60,11 +60,11 @@ main()
     {
       if (context->GetDefaultDevice().HasCompiler())
       {
-        itkGenericExceptionMacro(<< "Could not compile the OpenCL test program");
+        itkGenericExceptionMacro("Could not compile the OpenCL test program");
       }
       else
       {
-        itkGenericExceptionMacro(<< "OpenCL implementation does not have a compiler");
+        itkGenericExceptionMacro("OpenCL implementation does not have a compiler");
       }
     }
 

--- a/Testing/itkOpenCLEventTest.cxx
+++ b/Testing/itkOpenCLEventTest.cxx
@@ -63,11 +63,11 @@ main()
     {
       if (context->GetDefaultDevice().HasCompiler())
       {
-        itkGenericExceptionMacro(<< "Could not compile the OpenCL test program");
+        itkGenericExceptionMacro("Could not compile the OpenCL test program");
       }
       else
       {
-        itkGenericExceptionMacro(<< "OpenCL implementation does not have a compiler");
+        itkGenericExceptionMacro("OpenCL implementation does not have a compiler");
       }
     }
 

--- a/Testing/itkOpenCLImageTest.cxx
+++ b/Testing/itkOpenCLImageTest.cxx
@@ -51,11 +51,11 @@ main()
     {
       if (context->GetDefaultDevice().HasCompiler())
       {
-        itkGenericExceptionMacro(<< "Could not compile the OpenCL test program");
+        itkGenericExceptionMacro("Could not compile the OpenCL test program");
       }
       else
       {
-        itkGenericExceptionMacro(<< "OpenCL implementation does not have a compiler");
+        itkGenericExceptionMacro("OpenCL implementation does not have a compiler");
       }
     }
 

--- a/Testing/itkOpenCLKernelToImageBridgeTest.cxx
+++ b/Testing/itkOpenCLKernelToImageBridgeTest.cxx
@@ -35,11 +35,11 @@ main()
     {
       if (context->GetDefaultDevice().HasCompiler())
       {
-        itkGenericExceptionMacro(<< "Could not compile the OpenCL test program");
+        itkGenericExceptionMacro("Could not compile the OpenCL test program");
       }
       else
       {
-        itkGenericExceptionMacro(<< "OpenCL implementation does not have a compiler");
+        itkGenericExceptionMacro("OpenCL implementation does not have a compiler");
       }
     }
 

--- a/Testing/itkOpenCLSimpleTest.cxx
+++ b/Testing/itkOpenCLSimpleTest.cxx
@@ -39,11 +39,11 @@ main()
     {
       if (context->GetDefaultDevice().HasCompiler())
       {
-        itkGenericExceptionMacro(<< "Could not compile the OpenCL test program");
+        itkGenericExceptionMacro("Could not compile the OpenCL test program");
       }
       else
       {
-        itkGenericExceptionMacro(<< "OpenCL implementation does not have a compiler");
+        itkGenericExceptionMacro("OpenCL implementation does not have a compiler");
       }
     }
     context->Release();
@@ -58,11 +58,11 @@ main()
     {
       if (context->GetDefaultDevice().HasCompiler())
       {
-        itkGenericExceptionMacro(<< "Could not compile the OpenCL test program");
+        itkGenericExceptionMacro("Could not compile the OpenCL test program");
       }
       else
       {
-        itkGenericExceptionMacro(<< "OpenCL implementation does not have a compiler");
+        itkGenericExceptionMacro("OpenCL implementation does not have a compiler");
       }
     }
     context->Release();

--- a/Testing/itkOpenCLVectorTest.cxx
+++ b/Testing/itkOpenCLVectorTest.cxx
@@ -80,11 +80,11 @@ main(int argc, char * argv[])
     {
       if (context->GetDefaultDevice().HasCompiler())
       {
-        itkGenericExceptionMacro(<< "Could not compile the OpenCL test program");
+        itkGenericExceptionMacro("Could not compile the OpenCL test program");
       }
       else
       {
-        itkGenericExceptionMacro(<< "OpenCL implementation does not have a compiler");
+        itkGenericExceptionMacro("OpenCL implementation does not have a compiler");
       }
     }
 

--- a/Testing/itkTestHelper.h
+++ b/Testing/itkTestHelper.h
@@ -61,7 +61,7 @@ struct OCLImageDims
 
 #define ITK_OPENCL_COMPARE(actual, expected)                                                                           \
   if (!itk::Compare(actual, expected, #actual, #expected, __FILE__, __LINE__))                                         \
-  itkGenericExceptionMacro(<< "Compared values are not the same")
+  itkGenericExceptionMacro("Compared values are not the same")
 
 namespace itk
 {


### PR DESCRIPTION
Following ITK pull request https://github.com/InsightSoftwareConsortium/ITK/pull/4059 "Remove initial `<<` insertion of the form `Macro(<< "`...`)` from itk macro calls"