### PR TITLE
DOC: Explain ElastixRegistrationMethod use "-tp" for initial transforms

### DIFF
--- a/Core/ComponentBaseClasses/elxTransformBase.hxx
+++ b/Core/ComponentBaseClasses/elxTransformBase.hxx
@@ -438,8 +438,9 @@ TransformBase<TElastix>::ReadFromFile()
   this->GetAsITKBaseType()->SetUseComposition(howToCombineTransforms == "Compose");
 
   /** Task 4 - Remember the name of the TransformParametersFileName.
-   * This will be needed when another transform will use this transform
-   * as an initial transform (see the WriteToFile method)
+   * This will be needed when another transform will use this transform as an initial transform (see the WriteToFile
+   * method), which is relevant for transformix, as well as for elastix (specifically
+   * ElastixRegistrationMethod::GenerateData(), when InitialTransformParameterObject is specified).
    */
   this->SetTransformParametersFileName(configuration.GetCommandLineArgument("-tp"));
 

--- a/Core/Main/itkElastixRegistrationMethod.hxx
+++ b/Core/Main/itkElastixRegistrationMethod.hxx
@@ -179,9 +179,10 @@ ElastixRegistrationMethod<TFixedImage, TMovingImage>::GenerateData()
 
   if (m_InitialTransformParameterObject && !m_OutputDirectory.empty())
   {
-    // Write InitialTransformParameters.0.txt, InitialTransformParameters.1.txt, InitialTransformParameters.2.txt, etc.
     std::string initialTransformParameterFileName = "NoInitialTransform";
-    unsigned    i{};
+
+    // Write InitialTransformParameters.0.txt, InitialTransformParameters.1.txt, InitialTransformParameters.2.txt, etc.
+    unsigned i{};
 
     for (auto transformParameterMap : m_InitialTransformParameterObject->GetParameterMaps())
     {
@@ -193,6 +194,10 @@ ElastixRegistrationMethod<TFixedImage, TMovingImage>::GenerateData()
       ++i;
     }
 
+    // Pass the last initial transform parameter file name to the argument map, in order to have it stored by
+    // elx::TransformBase::ReadFromFile(), so that it can be retrieved later by
+    // elx::TransformBase::GetInitialTransformParametersFileName(). Use "-tp", instead of "-t0", to avoid actual file
+    // reading of the initial transforms, as they are already in memory.
     argumentMap["-tp"] = initialTransformParameterFileName;
   }
 


### PR DESCRIPTION
Follow-up to pull request https://github.com/SuperElastix/elastix/pull/909 commit 9e64269bb40f9275015d557263acf1f382436087 "ENH: ElastixRegistrationMethod writes initial transform parameter files"

Requested by Marius Staring (@mstaring).

---

Main part of the explanation:
https://github.com/SuperElastix/elastix/blob/b09c835adc321dbe067a679468b734de6c8f68f8/Core/Main/itkElastixRegistrationMethod.hxx#L197-L200
