### PR TITLE
Remove the letter 's' from `ParametersFile`

### DIFF
--- a/Components/Transforms/BSplineDeformableTransformWithDiffusion/elxBSplineTransformWithDiffusion.hxx
+++ b/Components/Transforms/BSplineDeformableTransformWithDiffusion/elxBSplineTransformWithDiffusion.hxx
@@ -974,11 +974,11 @@ BSplineTransformWithDiffusion<TElastix>::ReadFromFile()
     }
   }
 
-  /** Task 4 - Remember the name of the TransformParametersFileName.
+  /** Task 4 - Remember the name of the TransformParameterFileName.
    * This will be needed when another transform will use this transform
    * as an initial transform (see the WriteToFile method)
    */
-  this->SetTransformParametersFileName(this->GetConfiguration()->GetCommandLineArgument("-tp"));
+  this->SetTransformParameterFileName(this->GetConfiguration()->GetCommandLineArgument("-tp"));
 
 } // end ReadFromFile()
 

--- a/Core/ComponentBaseClasses/elxTransformBase.h
+++ b/Core/ComponentBaseClasses/elxTransformBase.h
@@ -223,9 +223,9 @@ public:
   void
   SetInitialTransform(InitialTransformType * _arg);
 
-  /** Set the TransformParametersFileName. */
+  /** Set the TransformParameterFileName. */
   void
-  SetTransformParametersFileName(const std::string & filename);
+  SetTransformParameterFileName(const std::string & filename);
 
   /** Function to read transform-parameters from a file. */
   virtual void
@@ -394,8 +394,8 @@ private:
   const InitialTransformType *
   GetInitialTransform() const;
 
-  /** Get the TransformParametersFileName. */
-  itkGetStringMacro(TransformParametersFileName);
+  /** Get the TransformParameterFileName. */
+  itkGetStringMacro(TransformParameterFileName);
 
   /** Function to transform coordinates from fixed to moving image. */
   void
@@ -423,7 +423,7 @@ private:
   TransformPointsAllPoints() const;
 
   std::string
-  GetInitialTransformParametersFileName() const
+  GetInitialTransformParameterFileName() const
   {
     const InitialTransformType * const initialTransform = this->GetInitialTransform();
 
@@ -433,7 +433,7 @@ private:
     }
 
     const auto t0 = dynamic_cast<const Self *>(initialTransform);
-    return t0->GetTransformParametersFileName();
+    return t0->GetTransformParameterFileName();
   }
 
   virtual ParameterMapType
@@ -445,7 +445,7 @@ private:
   {}
 
   /** Member variables. */
-  std::string    m_TransformParametersFileName;
+  std::string    m_TransformParameterFileName;
   ParametersType m_TransformParameters;
   ParametersType m_FinalParameters;
 

--- a/Core/ComponentBaseClasses/elxTransformBase.hxx
+++ b/Core/ComponentBaseClasses/elxTransformBase.hxx
@@ -436,12 +436,12 @@ TransformBase<TElastix>::ReadFromFile()
    */
   this->GetAsITKBaseType()->SetUseComposition(howToCombineTransforms == "Compose");
 
-  /** Task 4 - Remember the name of the TransformParametersFileName.
+  /** Task 4 - Remember the name of the TransformParameterFileName.
    * This will be needed when another transform will use this transform as an initial transform (see the WriteToFile
    * method), which is relevant for transformix, as well as for elastix (specifically
    * ElastixRegistrationMethod::GenerateData(), when InitialTransformParameterObject is specified).
    */
-  this->SetTransformParametersFileName(configuration.GetCommandLineArgument("-tp"));
+  this->SetTransformParameterFileName(configuration.GetCommandLineArgument("-tp"));
 
 } // end ReadFromFile()
 
@@ -452,15 +452,15 @@ TransformBase<TElastix>::ReadFromFile()
 
 template <class TElastix>
 void
-TransformBase<TElastix>::ReadInitialTransformFromFile(const std::string & transformParametersFileName)
+TransformBase<TElastix>::ReadInitialTransformFromFile(const std::string & transformParameterFileName)
 {
   /** Create a new configuration, which will be initialized with
    * the transformParameterFileName. */
   const auto configurationInitialTransform = Configuration::New();
 
-  if (configurationInitialTransform->Initialize({ { "-tp", transformParametersFileName } }) != 0)
+  if (configurationInitialTransform->Initialize({ { "-tp", transformParameterFileName } }) != 0)
   {
-    itkGenericExceptionMacro("ERROR: Reading initial transform parameters failed: " << transformParametersFileName);
+    itkGenericExceptionMacro("ERROR: Reading initial transform parameters failed: " << transformParameterFileName);
   }
 
   this->ReadInitialTransformFromConfiguration(configurationInitialTransform);
@@ -491,7 +491,7 @@ TransformBase<TElastix>::ReadInitialTransformFromConfiguration(
   /** Call the ReadFromFile method of the initialTransform. */
   if (elx_initialTransform != nullptr)
   {
-    // elx_initialTransform->SetTransformParametersFileName(transformParametersFileName);
+    // elx_initialTransform->SetTransformParameterFileName(transformParameterFileName);
     elx_initialTransform->SetElastix(this->GetElastix());
     elx_initialTransform->SetConfiguration(configurationInitialTransform);
     elx_initialTransform->ReadFromFile();
@@ -535,7 +535,7 @@ TransformBase<TElastix>::WriteToFile(std::ostream & transformationParameterInfo,
     if (firstSingleTransform != nullptr)
     {
       const std::string transformFileName =
-        std::string(m_TransformParametersFileName, 0, m_TransformParametersFileName.rfind('.')) + '.' +
+        std::string(m_TransformParameterFileName, 0, m_TransformParameterFileName.rfind('.')) + '.' +
         itkTransformOutputFileNameExtension;
 
       const itk::TransformBase::ConstPointer itkTransform =
@@ -565,7 +565,7 @@ TransformBase<TElastix>::WriteToFile(std::ostream & transformationParameterInfo,
     else
     {
       TransformIO::Write(*compositeTransform,
-                         std::string(m_TransformParametersFileName, 0, m_TransformParametersFileName.rfind('.')) +
+                         std::string(m_TransformParameterFileName, 0, m_TransformParameterFileName.rfind('.')) +
                            "-Composite." + itkTransformOutputFileNameExtension);
     }
   }
@@ -614,7 +614,7 @@ TransformBase<TElastix>::CreateTransformParametersMap(const ParametersType & par
   /** Write the name of this transform. */
   parameterMap = { { "Transform", { this->elxGetClassName() } },
                    { "NumberOfParameters", { Conversion::ToString(param.GetSize()) } },
-                   { "InitialTransformParameterFileName", { this->GetInitialTransformParametersFileName() } },
+                   { "InitialTransformParameterFileName", { this->GetInitialTransformParameterFileName() } },
                    { "HowToCombineTransforms", { combinationMethod } },
                    { "FixedImageDimension", { Conversion::ToString(FixedImageDimension) } },
                    { "MovingImageDimension", { Conversion::ToString(MovingImageDimension) } },
@@ -1318,22 +1318,22 @@ TransformBase<TElastix>::ComputeAndWriteSpatialJacobianMatrixImage() const
 
 
 /**
- * ************** SetTransformParametersFileName ****************
+ * ************** SetTransformParameterFileName ****************
  */
 
 template <class TElastix>
 void
-TransformBase<TElastix>::SetTransformParametersFileName(const std::string & filename)
+TransformBase<TElastix>::SetTransformParameterFileName(const std::string & filename)
 {
   /** Copied from itkSetStringMacro. */
-  if (filename == this->m_TransformParametersFileName)
+  if (filename == this->m_TransformParameterFileName)
   {
     return;
   }
-  this->m_TransformParametersFileName = filename;
+  this->m_TransformParameterFileName = filename;
   this->GetAsITKBaseType()->Modified();
 
-} // end SetTransformParametersFileName()
+} // end SetTransformParameterFileName()
 
 
 /**

--- a/Core/Kernel/elxElastixTemplate.hxx
+++ b/Core/Kernel/elxElastixTemplate.hxx
@@ -779,7 +779,7 @@ ElastixTemplate<TFixedImage, TMovingImage>::CreateTransformParameterFile(const s
   this->m_CurrentTransformParameterFileName = fileName;
 
   /** Set it in the Transform, for later use. */
-  this->GetElxTransformBase()->SetTransformParametersFileName(fileName);
+  this->GetElxTransformBase()->SetTransformParameterFileName(fileName);
 
   /** Separate clearly in log-file. */
   if (toLog)

--- a/Core/Main/GTesting/itkTransformixFilterGTest.cxx
+++ b/Core/Main/GTesting/itkTransformixFilterGTest.cxx
@@ -178,7 +178,7 @@ template <typename TPixel, unsigned VImageDimension>
 auto
 CreateTransformixFilter(itk::Image<TPixel, VImageDimension> &                            image,
                         const itk::Transform<double, VImageDimension, VImageDimension> & itkTransform,
-                        const std::string & initialTransformParametersFileName = "NoInitialTransform",
+                        const std::string & initialTransformParameterFileName = "NoInitialTransform",
                         const std::string & howToCombineTransforms = "Compose")
 {
   const auto filter = CheckNew<itk::TransformixFilter<itk::Image<TPixel, VImageDimension>>>();
@@ -189,7 +189,7 @@ CreateTransformixFilter(itk::Image<TPixel, VImageDimension> &                   
                             { "Direction", CreateDefaultDirectionParameterValues<VImageDimension>() },
                             { "HowToCombineTransforms", { howToCombineTransforms } },
                             { "Index", ParameterValuesType(VImageDimension, "0") },
-                            { "InitialTransformParameterFileName", { initialTransformParametersFileName } },
+                            { "InitialTransformParameterFileName", { initialTransformParameterFileName } },
                             { "Origin", ParameterValuesType(VImageDimension, "0") },
                             { "ResampleInterpolator", { "FinalLinearInterpolator" } },
                             { "Size", ConvertToParameterValues(image.GetBufferedRegion().GetSize()) },
@@ -203,11 +203,11 @@ template <typename TPixel, unsigned VImageDimension>
 itk::SmartPointer<itk::Image<TPixel, VImageDimension>>
 RetrieveOutputFromTransformixFilter(itk::Image<TPixel, VImageDimension> &                            image,
                                     const itk::Transform<double, VImageDimension, VImageDimension> & itkTransform,
-                                    const std::string & initialTransformParametersFileName = "NoInitialTransform",
+                                    const std::string & initialTransformParameterFileName = "NoInitialTransform",
                                     const std::string & howToCombineTransforms = "Compose")
 {
   const auto transformixFilter =
-    CreateTransformixFilter(image, itkTransform, initialTransformParametersFileName, howToCombineTransforms);
+    CreateTransformixFilter(image, itkTransform, initialTransformParameterFileName, howToCombineTransforms);
   const auto output = transformixFilter->GetOutput();
   EXPECT_NE(output, nullptr);
   return output;
@@ -746,7 +746,7 @@ GTEST_TEST(itkTransformixFilter, CombineTranslationAndDefaultTransform)
   const auto   resampleImageFilter = CreateResampleImageFilter(*inputImage, translationTransform);
   const auto & expectedOutputImage = DerefRawPointer(resampleImageFilter->GetOutput());
 
-  const std::string initialTransformParametersFileName =
+  const std::string initialTransformParameterFileName =
     GetDataDirectoryPath() + "/Translation(1,-2)/TransformParameters.txt";
 
   for (const auto defaultTransform : { CreateTransform<itk::AffineTransform<ParametersValueType, dimension>>(),
@@ -756,7 +756,7 @@ GTEST_TEST(itkTransformixFilter, CombineTranslationAndDefaultTransform)
                                        CreateTransform<itk::TranslationTransform<ParametersValueType, dimension>>() })
   {
     const auto actualOutputImage =
-      RetrieveOutputFromTransformixFilter(*inputImage, *defaultTransform, initialTransformParametersFileName);
+      RetrieveOutputFromTransformixFilter(*inputImage, *defaultTransform, initialTransformParameterFileName);
     EXPECT_EQ(*actualOutputImage, expectedOutputImage);
   }
 
@@ -789,7 +789,7 @@ GTEST_TEST(itkTransformixFilter, CombineTranslationAndInverseTranslation)
 
   using ParametersValueType = double;
 
-  const std::string initialTransformParametersFileName =
+  const std::string initialTransformParameterFileName =
     GetDataDirectoryPath() + "/Translation(1,-2)/TransformParameters.txt";
 
   const auto offset = itk::MakeVector(1.0, -2.0);
@@ -799,7 +799,7 @@ GTEST_TEST(itkTransformixFilter, CombineTranslationAndInverseTranslation)
   // makes the output image unequal to the input image.
   const elx::DefaultConstruct<itk::TranslationTransform<ParametersValueType, dimension>> identityTransform;
 
-  EXPECT_NE(*(RetrieveOutputFromTransformixFilter(*inputImage, identityTransform, initialTransformParametersFileName)),
+  EXPECT_NE(*(RetrieveOutputFromTransformixFilter(*inputImage, identityTransform, initialTransformParameterFileName)),
             *inputImage);
 
   // The inverse of the transform from the TransformParameters.txt file.
@@ -810,7 +810,7 @@ GTEST_TEST(itkTransformixFilter, CombineTranslationAndInverseTranslation)
   }();
 
   EXPECT_EQ(*(RetrieveOutputFromTransformixFilter(
-              *inputImage, *inverseTranslationTransform, initialTransformParametersFileName)),
+              *inputImage, *inverseTranslationTransform, initialTransformParameterFileName)),
             *inputImage);
 
   for (const auto matrixOffsetTransform :
@@ -820,7 +820,7 @@ GTEST_TEST(itkTransformixFilter, CombineTranslationAndInverseTranslation)
   {
     matrixOffsetTransform->SetOffset(inverseOffset);
     EXPECT_EQ(
-      *(RetrieveOutputFromTransformixFilter(*inputImage, *matrixOffsetTransform, initialTransformParametersFileName)),
+      *(RetrieveOutputFromTransformixFilter(*inputImage, *matrixOffsetTransform, initialTransformParameterFileName)),
       *inputImage);
   }
 
@@ -836,7 +836,7 @@ GTEST_TEST(itkTransformixFilter, CombineTranslationAndInverseTranslation)
   }();
 
   const auto inverseBSplineOutputImage = RetrieveOutputFromTransformixFilter(
-    *inputImage, *inverseBSplineTransform, initialTransformParametersFileName, "Add");
+    *inputImage, *inverseBSplineTransform, initialTransformParameterFileName, "Add");
   ExpectAlmostEqualPixelValues(*inverseBSplineOutputImage, *inputImage, 1e-15);
 }
 
@@ -852,7 +852,7 @@ GTEST_TEST(itkTransformixFilter, CombineTranslationAndScale)
 
   using ParametersValueType = double;
 
-  const std::string initialTransformParametersFileName =
+  const std::string initialTransformParameterFileName =
     GetDataDirectoryPath() + "/Translation(1,-2)/TransformParameters.txt";
 
   elx::DefaultConstruct<itk::AffineTransform<ParametersValueType, dimension>> scaleTransform;
@@ -862,7 +862,7 @@ GTEST_TEST(itkTransformixFilter, CombineTranslationAndScale)
   translationTransform.SetOffset(itk::MakeVector(1.0, -2.0));
 
   const auto transformixOutput =
-    RetrieveOutputFromTransformixFilter(*inputImage, scaleTransform, initialTransformParametersFileName);
+    RetrieveOutputFromTransformixFilter(*inputImage, scaleTransform, initialTransformParameterFileName);
 
   elx::DefaultConstruct<itk::CompositeTransform<double, 2>> translationAndScaleTransform;
   translationAndScaleTransform.AddTransform(&translationTransform);

--- a/Core/Main/itkElastixRegistrationMethod.hxx
+++ b/Core/Main/itkElastixRegistrationMethod.hxx
@@ -196,7 +196,7 @@ ElastixRegistrationMethod<TFixedImage, TMovingImage>::GenerateData()
 
     // Pass the last initial transform parameter file name to the argument map, in order to have it stored by
     // elx::TransformBase::ReadFromFile(), so that it can be retrieved later by
-    // elx::TransformBase::GetInitialTransformParametersFileName(). Use "-tp", instead of "-t0", to avoid actual file
+    // elx::TransformBase::GetInitialTransformParameterFileName(). Use "-tp", instead of "-t0", to avoid actual file
     // reading of the initial transforms, as they are already in memory.
     argumentMap["-tp"] = initialTransformParameterFileName;
   }

--- a/Testing/itkTransformixFilterTest.cxx
+++ b/Testing/itkTransformixFilterTest.cxx
@@ -38,7 +38,7 @@ main(int argc, char * argv[])
     return 1;
   }
   const char * movingImageFile = argv[1];
-  const char * transformParametersFile = argv[2];
+  const char * transformParameterFile = argv[2];
   const char * transformedImageFile = argv[3];
 
   /** Other typedef. */
@@ -47,7 +47,7 @@ main(int argc, char * argv[])
   auto movingImage = itk::ReadImage<ImageType>(movingImageFile);
 
   auto parameterObject = elastix::ParameterObject::New();
-  parameterObject->ReadParameterFile(transformParametersFile);
+  parameterObject->ReadParameterFile(transformParameterFile);
   parameterObject->Print(std::cout);
 
   using TransformixType = itk::TransformixFilter<ImageType>;


### PR DESCRIPTION
Follow-up to pull request #903 Remove the letter 's' from "InitialTransformParametersFileName", commit 2170592cbd018cce65698d404cae281f40c28d39