### PR TITLE
COMP: ElastixRegistrationMethod interfaces types for Python wrapping

### DIFF
--- a/Core/Main/GTesting/itkElastixRegistrationMethodGTest.cxx
+++ b/Core/Main/GTesting/itkElastixRegistrationMethodGTest.cxx
@@ -1505,7 +1505,7 @@ GTEST_TEST(itkElastixRegistrationMethod, ConvertToItkTransform)
     for (unsigned int n{ 0 }; n < numberOfTransforms; ++n)
     {
       // TODO Check result
-      ElastixRegistrationMethodType<ImageType>::ConvertToItkTransform(*registration.GetNthTransform(n));
+      ElastixRegistrationMethodType<ImageType>::ConvertToItkTransform(registration.GetNthTransform(n));
     }
   }
 }

--- a/Core/Main/itkElastixRegistrationMethod.h
+++ b/Core/Main/itkElastixRegistrationMethod.h
@@ -267,17 +267,17 @@ public:
   GetNumberOfTransforms() const;
 
   /** Returns the nth transformation, produced during the last Update(). */
-  SmartPointer<TransformType>
+  TransformType *
   GetNthTransform(const unsigned int n) const;
 
   /** Returns the combination transformation, produced during the last Update(). */
-  SmartPointer<TransformType>
+  TransformType *
   GetCombinationTransform() const;
 
   /** Converts the specified elastix Transform object to the corresponding ITK Transform object. Returns null if there
    * is no corresponding ITK Transform type. */
   static SmartPointer<TransformType>
-  ConvertToItkTransform(const TransformType &);
+  ConvertToItkTransform(const TransformType *);
 
 protected:
   ElastixRegistrationMethod();

--- a/Core/Main/itkElastixRegistrationMethod.hxx
+++ b/Core/Main/itkElastixRegistrationMethod.hxx
@@ -825,7 +825,7 @@ ElastixRegistrationMethod<TFixedImage, TMovingImage>::GetNumberOfTransforms() co
 template <typename TFixedImage, typename TMovingImage>
 auto
 ElastixRegistrationMethod<TFixedImage, TMovingImage>::GetNthTransform(const unsigned int n) const
-  -> SmartPointer<TransformType>
+  -> TransformType *
 {
   const auto * const transformContainer = m_ElastixMain->GetElastixBase().GetTransformContainer();
 
@@ -847,7 +847,7 @@ ElastixRegistrationMethod<TFixedImage, TMovingImage>::GetNthTransform(const unsi
 
 template <typename TFixedImage, typename TMovingImage>
 auto
-ElastixRegistrationMethod<TFixedImage, TMovingImage>::GetCombinationTransform() const -> SmartPointer<TransformType>
+ElastixRegistrationMethod<TFixedImage, TMovingImage>::GetCombinationTransform() const -> TransformType *
 {
   const auto * const transformContainer = m_ElastixMain->GetElastixBase().GetTransformContainer();
 
@@ -868,20 +868,20 @@ ElastixRegistrationMethod<TFixedImage, TMovingImage>::GetCombinationTransform() 
 
 template <typename TFixedImage, typename TMovingImage>
 auto
-ElastixRegistrationMethod<TFixedImage, TMovingImage>::ConvertToItkTransform(const TransformType & elxTransform)
+ElastixRegistrationMethod<TFixedImage, TMovingImage>::ConvertToItkTransform(const TransformType * elxTransform)
   -> SmartPointer<TransformType>
 {
   const auto * const combinationTransform =
-    dynamic_cast<const itk::AdvancedCombinationTransform<double, FixedImageDimension> *>(&elxTransform);
+    dynamic_cast<const itk::AdvancedCombinationTransform<double, FixedImageDimension> *>(elxTransform);
 
   const auto itkTransform = combinationTransform
                               ? elx::TransformIO::ConvertToCompositionOfItkTransforms(*combinationTransform)
-                              : elx::TransformIO::ConvertToSingleItkTransform(elxTransform);
+                              : elx::TransformIO::ConvertToSingleItkTransform(*elxTransform);
   if (itkTransform)
   {
     return itkTransform;
   }
-  itkGenericExceptionMacro("Failed to convert transform object " << elxTransform);
+  itkGenericExceptionMacro("Failed to convert transform object " << *elxTransform);
 }
 
 } // namespace itk


### PR DESCRIPTION
In the ITK Python wrapping, we require raw pointers as preferred standard on ITK Object interface types to help with Python<->C++ ownership rules and reduce types wrapped types,
i.e. raw pointers as opposed to SmartPointers and raw pointers. Update the interface type in the ITKElastix wrapped
itk::ElastixRegistrationMethod.