### PR TITLE
COMP: Add `#include <cstdint>` to elxlog.h, for `std::uint8_t`

### DIFF
--- a/Core/Kernel/elxlog.h
+++ b/Core/Kernel/elxlog.h
@@ -18,6 +18,7 @@
 #ifndef elxlog_h
 #define elxlog_h
 
+#include <cstdint> // For uint8_t.
 #include <string>
 #include <sstream>
 
@@ -30,7 +31,7 @@ namespace elastix
 class log
 {
 public:
-  enum class level : uint8_t
+  enum class level : std::uint8_t
   {
     info,
     warn,


### PR DESCRIPTION
Aims to address a note from GCC 13 saying:

> note: ‘uint8_t’ is defined in header ‘<cstdint>’; did you forget to ‘#include <cstdint>’?

Reported by Matt McCormick (@thewtex), issue https://github.com/SuperElastix/elastix/issues/916 "GCC 13 cstdint include".

Explicitly specified its `std` namespace, as `<cstdint>` may not add this typedef to the global namespace.