### PR TITLE
 Remove `retdc` variable from ElastixTemplate, replace bitwise with logical _and_ (`&&`) on other retdc variables

### DIFF
--- a/Core/ComponentBaseClasses/elxResamplerBase.hxx
+++ b/Core/ComponentBaseClasses/elxResamplerBase.hxx
@@ -388,7 +388,7 @@ ResamplerBase<TElastix>::WriteResultImage(OutputImageType *   image,
   DirectionType originalDirection;
   bool          retdc = this->GetElastix()->GetOriginalFixedImageDirection(originalDirection);
   infoChanger->SetOutputDirection(originalDirection);
-  infoChanger->SetChangeDirection(retdc & !this->GetElastix()->GetUseDirectionCosines());
+  infoChanger->SetChangeDirection(retdc && !this->GetElastix()->GetUseDirectionCosines());
   infoChanger->SetInput(image);
 
   /** Do the writing. */
@@ -476,7 +476,7 @@ ResamplerBase<TElastix>::CreateItkResultImage()
   DirectionType originalDirection;
   bool          retdc = this->GetElastix()->GetOriginalFixedImageDirection(originalDirection);
   infoChanger->SetOutputDirection(originalDirection);
-  infoChanger->SetChangeDirection(retdc & !this->GetElastix()->GetUseDirectionCosines());
+  infoChanger->SetChangeDirection(retdc && !this->GetElastix()->GetUseDirectionCosines());
   infoChanger->SetInput(resampleImageFilter.GetOutput());
 
   /** cast the image to the correct output image Type */

--- a/Core/ComponentBaseClasses/elxTransformBase.h
+++ b/Core/ComponentBaseClasses/elxTransformBase.h
@@ -360,7 +360,7 @@ private:
     typename FixedImageType::DirectionType originalDirection;
     const bool                             retdc = this->m_Elastix->GetOriginalFixedImageDirection(originalDirection);
     infoChanger->SetOutputDirection(originalDirection);
-    infoChanger->SetChangeDirection(retdc & !this->m_Elastix->GetUseDirectionCosines());
+    infoChanger->SetChangeDirection(retdc && !this->m_Elastix->GetUseDirectionCosines());
     infoChanger->SetInput(image);
 
     return infoChanger;

--- a/Core/ComponentBaseClasses/elxTransformBase.hxx
+++ b/Core/ComponentBaseClasses/elxTransformBase.hxx
@@ -1043,7 +1043,7 @@ TransformBase<TElastix>::GenerateDeformationFieldImage() const -> typename Defor
   typename FixedImageType::DirectionType originalDirection;
   bool                                   retdc = this->GetElastix()->GetOriginalFixedImageDirection(originalDirection);
   infoChanger->SetOutputDirection(originalDirection);
-  infoChanger->SetChangeDirection(retdc & !this->GetElastix()->GetUseDirectionCosines());
+  infoChanger->SetChangeDirection(retdc && !this->GetElastix()->GetUseDirectionCosines());
   infoChanger->SetInput(defGenerator->GetOutput());
 
   const Configuration & configuration = Deref(Superclass::GetConfiguration());

--- a/Core/Kernel/elxElastixTemplate.hxx
+++ b/Core/Kernel/elxElastixTemplate.hxx
@@ -1077,20 +1077,19 @@ ElastixTemplate<TFixedImage, TMovingImage>::GetOriginalFixedImageDirection(Fixed
     const Configuration & configuration = Deref(ElastixBase::GetConfiguration());
 
     /** Try to read direction cosines from (transform-)parameter file. */
-    bool                    retdc = true;
     FixedImageDirectionType directionRead = direction;
     for (unsigned int i = 0; i < FixedDimension; ++i)
     {
       for (unsigned int j = 0; j < FixedDimension; ++j)
       {
-        retdc &= configuration.ReadParameter(directionRead(j, i), "Direction", i * FixedDimension + j, false);
+        if (!configuration.ReadParameter(directionRead(j, i), "Direction", i * FixedDimension + j, false))
+        {
+          return false;
+        }
       }
     }
-    if (retdc)
-    {
-      direction = directionRead;
-    }
-    return retdc;
+    direction = directionRead;
+    return true;
   }
 
   /** Only trust this when the fixed image exists. */


### PR DESCRIPTION
Triggered by questions from Matt McCormick (@thewtex).

The name of the variable "retdc" probably means something like return value of direction cosines estimation. 