### PR TITLE
WebAssembly Support

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -31,6 +31,23 @@ if(ELASTIX_USE_OPENCL)
   list(APPEND _GPU_depends ITKGPUCommon)
 endif()
 
+set(_ITK_io_depends
+    ITKImageIO
+    ITKTransformIO
+    ITKMeshIO
+    ITKIOImageBase
+    ITKIOMeshBase
+    ITKIOMeshOBJ
+    ITKIOMeta
+    ITKIOTransformBase
+    ITKIOXML
+)
+
+if(WASI OR EMSCRIPTEN)
+  # Keep Wasm binaries small
+  set(_ITK_io_depends)
+endif()
+
 # Find ITK.
 find_package(ITK 5.3 REQUIRED COMPONENTS
     ITKCommon
@@ -43,12 +60,6 @@ find_package(ITK 5.3 REQUIRED COMPONENTS
     ITKImageGrid
     ITKImageIntensity
     ITKImageStatistics
-    ITKIOImageBase
-    ITKIOMeshBase
-    ITKIOMeshOBJ
-    ITKIOMeta
-    ITKIOTransformBase
-    ITKIOXML
     ITKMathematicalMorphology
     ITKMesh
     ITKOptimizers
@@ -61,9 +72,7 @@ find_package(ITK 5.3 REQUIRED COMPONENTS
     ITKTransform
     ITKTransformFactory
     ${_GPU_depends}
-    ITKImageIO
-    ITKTransformIO
-    ITKMeshIO
+    ${_ITK_io_depends}
     )
 include(${ITK_USE_FILE})
 

--- a/Common/ImageSamplers/itkImageToVectorContainerFilter.hxx
+++ b/Common/ImageSamplers/itkImageToVectorContainerFilter.hxx
@@ -18,8 +18,6 @@
 #ifndef itkImageToVectorContainerFilter_hxx
 #define itkImageToVectorContainerFilter_hxx
 
-#include "itkImageToVectorContainerFilter.h"
-
 #include "itkMath.h"
 
 namespace itk

--- a/Common/Transforms/elxTransformIO.cxx
+++ b/Common/Transforms/elxTransformIO.cxx
@@ -32,8 +32,10 @@
 
 #include <itkTransformBase.h>
 #include <itkTransformFactoryBase.h>
+#ifndef __wasm32__
 #include <itkTransformFileReader.h>
 #include <itkTransformFileWriter.h>
+#endif
 
 #include <string>
 
@@ -191,6 +193,11 @@ elastix::TransformIO::ConvertItkTransformBaseToSingleItkTransform(const itk::Tra
 void
 elastix::TransformIO::Write(const itk::Object & itkTransform, const std::string & fileName)
 {
+#ifdef __wasm32__
+  const std::string message = "File IO not supported in WebAssembly builds.";
+  log::error(message);
+  throw std::runtime_error(message);
+#else
   try
   {
     const auto writer = itk::TransformFileWriter::New();
@@ -203,12 +210,20 @@ elastix::TransformIO::Write(const itk::Object & itkTransform, const std::string 
   {
     log::error(std::ostringstream{} << "Error trying to write " << fileName << ":\n" << stdException.what());
   }
+#endif
 }
 
 
 itk::SmartPointer<itk::TransformBase>
 elastix::TransformIO::Read(const std::string & fileName)
 {
+#ifdef __wasm32__
+  const std::string message = "File IO not supported in WebAssembly builds.";
+  log::error(message);
+  throw std::runtime_error(message);
+  return nullptr;
+#else
+
   const auto reader = itk::TransformFileReader::New();
 
   reader->SetFileName(fileName);
@@ -221,6 +236,7 @@ elastix::TransformIO::Read(const std::string & fileName)
   assert(transformList->size() <= 1);
 
   return transformList->empty() ? nullptr : transformList->front();
+#endif
 }
 
 

--- a/Common/itkComputeImageExtremaFilter.h
+++ b/Common/itkComputeImageExtremaFilter.h
@@ -129,7 +129,9 @@ private:
   PixelType                      m_ThreadMin{ 1 };
   PixelType                      m_ThreadMax{ 1 };
 
+#ifndef __wasi__
   std::mutex m_Mutex{};
+#endif
 }; // end of class
 } // end namespace itk
 

--- a/Common/itkComputeImageExtremaFilter.hxx
+++ b/Common/itkComputeImageExtremaFilter.hxx
@@ -176,7 +176,9 @@ ComputeImageExtremaFilter<TInputImage>::ThreadedGenerateDataImageSpatialMask(con
     } // end for
   }   // end if
 
+#ifndef __wasi__
   std::lock_guard<std::mutex> mutexHolder(m_Mutex);
+#endif
   m_ThreadSum += sum;
   m_SumOfSquares += sumOfSquares;
   m_Count += count;
@@ -227,7 +229,9 @@ ComputeImageExtremaFilter<TInputImage>::ThreadedGenerateDataImageMask(const Regi
     ++it;
   } // end while
 
+#ifndef __wasi__
   std::lock_guard<std::mutex> mutexHolder(m_Mutex);
+#endif
   m_ThreadSum += sum;
   m_SumOfSquares += sumOfSquares;
   m_Count += count;

--- a/Common/itkMeshFileReaderBase.h
+++ b/Common/itkMeshFileReaderBase.h
@@ -20,7 +20,11 @@
 
 #include "itkMeshSource.h"
 #include "itkMacro.h"
-#include "itkMeshFileReader.h" // for MeshFileReaderException
+#ifndef __wasm32__
+#include "itkMeshFileReaderException.h"
+#else
+#define MeshFileReaderException ExceptionObject
+#endif
 
 namespace itk
 {

--- a/Components/Metrics/MissingStructurePenalty/elxMissingStructurePenalty.h
+++ b/Components/Metrics/MissingStructurePenalty/elxMissingStructurePenalty.h
@@ -21,9 +21,6 @@
 #include "elxIncludes.h"
 #include "itkMissingStructurePenalty.h"
 
-#include "itkMeshFileReader.h"
-#include "itkMeshFileWriter.h"
-
 namespace elastix
 {
 

--- a/Components/Metrics/MissingStructurePenalty/elxMissingStructurePenalty.hxx
+++ b/Components/Metrics/MissingStructurePenalty/elxMissingStructurePenalty.hxx
@@ -21,6 +21,11 @@
 #include "elxMissingStructurePenalty.h"
 #include "itkTimeProbe.h"
 
+#ifndef __wasm32__
+#include "itkMeshFileReader.h"
+#include "itkMeshFileWriter.h"
+#endif
+
 namespace elastix
 {
 
@@ -145,6 +150,11 @@ MissingStructurePenalty<TElastix>::BeforeRegistration()
     fmeshArgument << ch << metricNumber;
     std::string                fixedMeshName = this->GetConfiguration()->GetCommandLineArgument(fmeshArgument.str());
     typename MeshType::Pointer fixedMesh; // default-constructed (null)
+#ifdef __wasm32__
+  const std::string message = "File IO not supported in WebAssembly builds.";
+  log::error(message);
+  itkExceptionMacro(<< message);
+#else
     if (itksys::SystemTools::GetFilenameLastExtension(fixedMeshName) == ".txt")
     {
       this->ReadTransformixPoints(fixedMeshName, fixedMesh);
@@ -153,6 +163,7 @@ MissingStructurePenalty<TElastix>::BeforeRegistration()
     {
       this->ReadMesh(fixedMeshName, fixedMesh);
     }
+#endif
 
     meshPointerContainer->SetElement(meshNumber, fixedMesh.GetPointer());
   }
@@ -281,6 +292,12 @@ template <class TElastix>
 unsigned int
 MissingStructurePenalty<TElastix>::ReadMesh(const std::string & meshFileName, typename FixedMeshType::Pointer & mesh)
 {
+#ifdef __wasm32__
+  const std::string message = "File IO not supported in WebAssembly builds.";
+  log::error(message);
+  itkExceptionMacro(<< message);
+  return 0;
+#else
   /** Read the input mesh. */
   auto meshReader = itk::MeshFileReader<MeshType>::New();
   meshReader->SetFileName(meshFileName);
@@ -300,6 +317,7 @@ MissingStructurePenalty<TElastix>::ReadMesh(const std::string & meshFileName, ty
   log::info(std::ostringstream{} << "  Number of specified input points: " << nrofpoints);
 
   return nrofpoints;
+#endif
 } // end ReadMesh()
 
 
@@ -311,6 +329,11 @@ template <class TElastix>
 void
 MissingStructurePenalty<TElastix>::WriteResultMesh(const std::string & filename, MeshIdType meshId)
 {
+#ifdef __wasm32__
+  const std::string message = "File IO not supported in WebAssembly builds.";
+  log::error(message);
+  itkExceptionMacro(<< message);
+#else
   /** Setup the pipeline. */
 
   /** Set the points of the latest transformation. */
@@ -376,7 +399,7 @@ MissingStructurePenalty<TElastix>::WriteResultMesh(const std::string & filename,
     // restore celldata as undefined
     mappedMesh->SetCellData(nullptr);
   }
-
+#endif
 } // end WriteResultMesh()
 
 
@@ -389,6 +412,12 @@ unsigned int
 MissingStructurePenalty<TElastix>::ReadTransformixPoints(const std::string &          filename,
                                                          typename MeshType::Pointer & mesh) // const
 {
+#ifdef __wasm32__
+  const std::string message = "File IO not supported in WebAssembly builds.";
+  log::error(message);
+  itkExceptionMacro(<< message);
+  return 0;
+#else
   /*
   FB: Majority of the code is copied from elxTransformBase.hxx: TransformPointsSomePoints()
 Function to read 2d structures by reading elastix point files (transformix format) and connecting
@@ -528,6 +557,7 @@ the sequence of points to form a 2d connected polydata contour.
     }
   }
   return nrofpoints;
+#endif
 } // end ReadTransformixPoints()
 
 

--- a/Components/Metrics/PolydataDummyPenalty/elxPolydataDummyPenalty.h
+++ b/Components/Metrics/PolydataDummyPenalty/elxPolydataDummyPenalty.h
@@ -23,9 +23,6 @@
 
 //#include "elxMetricBase.h"
 
-#include "itkMeshFileReader.h"
-#include "itkMeshFileWriter.h"
-
 namespace elastix
 {
 /**

--- a/Components/Metrics/PolydataDummyPenalty/elxPolydataDummyPenalty.hxx
+++ b/Components/Metrics/PolydataDummyPenalty/elxPolydataDummyPenalty.hxx
@@ -20,6 +20,11 @@
 
 #include <typeinfo>
 
+#ifndef __wasm32__
+#include "itkMeshFileReader.h"
+#include "itkMeshFileWriter.h"
+#endif
+
 namespace elastix
 {
 
@@ -270,6 +275,12 @@ template <class TElastix>
 unsigned int
 PolydataDummyPenalty<TElastix>::ReadMesh(const std::string & meshFileName, typename FixedMeshType::Pointer & mesh)
 {
+#ifdef __wasm32__
+  const std::string message = "File IO not supported in WebAssembly builds.";
+  log::error(message);
+  itkExceptionMacro(<< message);
+  return 0;
+#else
   /** Read the input mesh. */
   auto meshReader = itk::MeshFileReader<MeshType>::New();
   meshReader->SetFileName(meshFileName);
@@ -291,6 +302,7 @@ PolydataDummyPenalty<TElastix>::ReadMesh(const std::string & meshFileName, typen
   log::info(std::ostringstream{} << "  Number of specified input points: " << nrofpoints);
 
   return nrofpoints;
+#endif
 } // end ReadMesh()
 
 
@@ -302,6 +314,11 @@ template <class TElastix>
 void
 PolydataDummyPenalty<TElastix>::WriteResultMesh(const std::string & filename, MeshIdType meshId)
 {
+#ifdef __wasm32__
+  const std::string message = "File IO not supported in WebAssembly builds.";
+  log::error(message);
+  itkExceptionMacro(<< message);
+#else
   /** Set the points of the latest transformation. */
   const MappedMeshContainerPointer mappedMeshContainer = this->GetModifiableMappedMeshContainer();
   FixedMeshPointer                 mappedMesh = mappedMeshContainer->ElementAt(meshId);
@@ -360,7 +377,7 @@ PolydataDummyPenalty<TElastix>::WriteResultMesh(const std::string & filename, Me
   {
     mappedMesh->SetCellData(nullptr);
   }
-
+#endif
 } // end WriteResultMesh()
 
 

--- a/Components/Metrics/StatisticalShapePenalty/elxStatisticalShapePenalty.hxx
+++ b/Components/Metrics/StatisticalShapePenalty/elxStatisticalShapePenalty.hxx
@@ -25,7 +25,9 @@
 #include "itkDefaultStaticMeshTraits.h"
 #include "itkTransformMeshFilter.h"
 #include <itkMesh.h>
+#ifndef __wasm32__
 #include <itkMeshFileReader.h>
+#endif
 
 #include <fstream>
 #include <typeinfo>
@@ -352,6 +354,12 @@ StatisticalShapePenalty<TElastix>::ReadShape(const std::string &                
                                              typename PointSetType::Pointer &       pointSet,
                                              const typename ImageType::ConstPointer image)
 {
+#ifdef __wasm32__
+  const std::string message = "File IO not supported in WebAssembly builds.";
+  log::error(message);
+  itkExceptionMacro(<< message);
+  return 0;
+#else
   /** Typedef's. \todo test DummyIPPPixelType=bool. */
   using DummyIPPPixelType = double;
   using MeshTraitsType =
@@ -380,7 +388,7 @@ StatisticalShapePenalty<TElastix>::ReadShape(const std::string &                
   pointSet = PointSetType::New();
   pointSet->SetPoints(mesh->GetPoints());
   return nrofpoints;
-
+#endif
 } // end ReadShape()
 
 

--- a/Core/ComponentBaseClasses/elxFixedImagePyramidBase.hxx
+++ b/Core/ComponentBaseClasses/elxFixedImagePyramidBase.hxx
@@ -178,12 +178,17 @@ FixedImagePyramidBase<TElastix>::WritePyramidImage(const std::string & filename,
 
   /** Do the writing. */
   log::to_stdout("  Writing fixed pyramid image ...");
+#ifndef __wasm32__
   try
   {
-    itk::WriteCastedImage(*(this->GetAsITKBaseType()->GetOutput(level)), filename, resultImagePixelType, doCompression);
+ itk::WriteCastedImage(*(this->GetAsITKBaseType()->GetOutput(level)), filename, resultImagePixelType, doCompression);
   }
   catch (itk::ExceptionObject & excp)
   {
+#else
+// Always throw -- do not include support code or access filesystem with wasm
+    itk::ExceptionObject excp;
+#endif
     /** Add information to the exception. */
     excp.SetLocation("FixedImagePyramidBase - BeforeEachResolutionBase()");
     std::string err_str = excp.GetDescription();
@@ -191,8 +196,12 @@ FixedImagePyramidBase<TElastix>::WritePyramidImage(const std::string & filename,
     excp.SetDescription(err_str);
 
     /** Pass the exception to an higher level. */
+#ifndef __wasm32__
     throw;
   }
+#else
+    throw excp;
+#endif
 
 } // end WritePyramidImage()
 

--- a/Core/ComponentBaseClasses/elxFixedImagePyramidBase.hxx
+++ b/Core/ComponentBaseClasses/elxFixedImagePyramidBase.hxx
@@ -20,7 +20,10 @@
 
 #include "elxFixedImagePyramidBase.h"
 #include "elxDeref.h"
+
+#ifndef __wasm32__
 #include "itkImageFileCastWriter.h"
+#endif
 
 namespace elastix
 {

--- a/Core/ComponentBaseClasses/elxMovingImagePyramidBase.hxx
+++ b/Core/ComponentBaseClasses/elxMovingImagePyramidBase.hxx
@@ -21,7 +21,10 @@
 
 #include "elxMovingImagePyramidBase.h"
 #include "elxDeref.h"
+
+#ifndef __wasm32__
 #include "itkImageFileCastWriter.h"
+#endif
 
 namespace elastix
 {

--- a/Core/ComponentBaseClasses/elxMovingImagePyramidBase.hxx
+++ b/Core/ComponentBaseClasses/elxMovingImagePyramidBase.hxx
@@ -179,12 +179,17 @@ MovingImagePyramidBase<TElastix>::WritePyramidImage(const std::string & filename
 
   /** Do the writing. */
   log::to_stdout("  Writing moving pyramid image ...");
+#ifndef __wasm32__
   try
   {
     itk::WriteCastedImage(*(this->GetAsITKBaseType()->GetOutput(level)), filename, resultImagePixelType, doCompression);
   }
   catch (itk::ExceptionObject & excp)
   {
+#else
+// Always throw -- do not include support code or access filesystem with wasm
+    itk::ExceptionObject excp;
+#endif
     /** Add information to the exception. */
     excp.SetLocation("MovingImagePyramidBase - BeforeEachResolutionBase()");
     std::string err_str = excp.GetDescription();
@@ -192,8 +197,12 @@ MovingImagePyramidBase<TElastix>::WritePyramidImage(const std::string & filename
     excp.SetDescription(err_str);
 
     /** Pass the exception to an higher level. */
+#ifndef __wasm32__
     throw;
   }
+#else
+    throw excp;
+#endif
 
 } // end WritePyramidImage()
 

--- a/Core/ComponentBaseClasses/elxResamplerBase.hxx
+++ b/Core/ComponentBaseClasses/elxResamplerBase.hxx
@@ -22,7 +22,6 @@
 #include "elxConversion.h"
 #include "elxDeref.h"
 
-#include "itkImageFileCastWriter.h"
 #include "itkChangeInformationImageFilter.h"
 #include "itkAdvancedRayCastInterpolateImageFunction.h"
 #include "itkTimeProbe.h"

--- a/Core/ComponentBaseClasses/elxResamplerBase.hxx
+++ b/Core/ComponentBaseClasses/elxResamplerBase.hxx
@@ -395,12 +395,17 @@ ResamplerBase<TElastix>::WriteResultImage(OutputImageType *   image,
   {
     log::to_stdout("\n  Writing image ...");
   }
+#ifndef __wasm32__
   try
   {
-    itk::WriteCastedImage(*(infoChanger->GetOutput()), filename, resultImagePixelType, doCompression);
+   itk::WriteCastedImage(*(infoChanger->GetOutput()), filename, resultImagePixelType, doCompression);
   }
   catch (itk::ExceptionObject & excp)
   {
+#else
+// Always throw -- do not include support code or access filesystem with wasm
+    itk::ExceptionObject excp;
+#endif
     /** Add information to the exception. */
     excp.SetLocation("ResamplerBase - AfterRegistrationBase()");
     std::string err_str = excp.GetDescription();
@@ -408,8 +413,12 @@ ResamplerBase<TElastix>::WriteResultImage(OutputImageType *   image,
     excp.SetDescription(err_str);
 
     /** Pass the exception to an higher level. */
+#ifndef __wasm32__
     throw;
   }
+#else
+    throw excp;
+#endif
 } // end WriteResultImage()
 
 

--- a/Core/ComponentBaseClasses/elxTransformBase.hxx
+++ b/Core/ComponentBaseClasses/elxTransformBase.hxx
@@ -38,8 +38,10 @@
 #include "itkContinuousIndex.h"
 #include "itkChangeInformationImageFilter.h"
 #include "itkMesh.h"
+#ifndef __wasm32__
 #include "itkMeshFileReader.h"
 #include "itkMeshFileWriter.h"
+#endif
 #include "itkCommonEnums.h"
 
 #include <cassert>
@@ -924,6 +926,11 @@ template <class TElastix>
 void
 TransformBase<TElastix>::TransformPointsSomePointsVTK(const std::string & filename) const
 {
+#ifdef __wasm32__
+  const std::string message = "File IO not supported in WebAssembly builds.";
+  log::error(message);
+  itkExceptionMacro(<< message);
+#else
   /** Typedef's. \todo test DummyIPPPixelType=bool. */
   using DummyIPPPixelType = float;
   using MeshTraitsType =
@@ -982,7 +989,7 @@ TransformBase<TElastix>::TransformPointsSomePointsVTK(const std::string & filena
       log::error(std::ostringstream{} << "  Error while saving points.\n" << err);
     }
   }
-
+#endif
 } // end TransformPointsSomePointsVTK()
 
 

--- a/Core/Install/elxComponentLoader.cxx
+++ b/Core/Install/elxComponentLoader.cxx
@@ -142,6 +142,7 @@ ComponentLoader::LoadComponents()
                     itk::MeshIOFactoryRegisterManagerInstance,
                     itk::TransformIOFactoryRegisterManagerInstance);
   (void)ioFactoryRegisterManagerInstances;
+#endif
 
   int installReturnCode = 0;
 
@@ -168,7 +169,6 @@ ComponentLoader::LoadComponents()
   }
 
   log::info("InstallingComponents was successful.\n");
-#endif
 
   return 0;
 

--- a/Core/Install/elxComponentLoader.cxx
+++ b/Core/Install/elxComponentLoader.cxx
@@ -23,9 +23,11 @@
 #include "elxInstallAllComponents.h"
 
 // ITKFactoryRegistration headers:
+#ifndef __wasm32__
 #include <itkImageIOFactoryRegisterManager.h>
 #include <itkMeshIOFactoryRegisterManager.h>
 #include <itkTransformIOFactoryRegisterManager.h>
+#endif
 
 #include <iostream>
 #include <string>
@@ -133,6 +135,7 @@ ComponentLoader::InstallSupportedImageTypes()
 int
 ComponentLoader::LoadComponents()
 {
+#ifndef __wasm32__
   // Retrieve those IOFactoryRegisterManager instances, just to ensure that they are really constructed.
   const volatile auto ioFactoryRegisterManagerInstances =
     std::make_tuple(itk::ImageIOFactoryRegisterManagerInstance,
@@ -165,6 +168,7 @@ ComponentLoader::LoadComponents()
   }
 
   log::info("InstallingComponents was successful.\n");
+#endif
 
   return 0;
 

--- a/Core/Kernel/elxlog.cxx
+++ b/Core/Kernel/elxlog.cxx
@@ -22,7 +22,9 @@
 #include <cassert>
 #include <fstream>
 #include <iostream>
+#ifndef __wasi__
 #include <mutex>
+#endif
 
 namespace elastix
 {
@@ -50,7 +52,9 @@ public:
   void
   to_file(const std::string & message)
   {
+#ifndef __wasi__
     const std::lock_guard<std::mutex> lock(m_file_mutex);
+#endif
 
     if (!m_data.log_filename.empty())
     {
@@ -66,7 +70,9 @@ public:
   void
   to_stdout(const std::string & message)
   {
+#ifndef __wasi__
     const std::lock_guard<std::mutex> lock(m_stdout_mutex);
+#endif
     std::cout << message << std::endl;
   }
 
@@ -115,8 +121,10 @@ private:
 
   data m_data{};
 
+#ifndef __wasi__
   std::mutex m_file_mutex{};
   std::mutex m_stdout_mutex{};
+#endif
 };
 
 

--- a/Core/Main/elxParameterObject.cxx
+++ b/Core/Main/elxParameterObject.cxx
@@ -21,7 +21,7 @@
 
 #include "itkParameterFileParser.h"
 
-#include "itkFileTools.h"
+#include "itksys/SystemTools.hxx"
 #include <fstream>
 #include <iostream>
 #include <cmath>

--- a/Core/Main/itkElastixRegistrationMethod.hxx
+++ b/Core/Main/itkElastixRegistrationMethod.hxx
@@ -268,6 +268,7 @@ ElastixRegistrationMethod<TFixedImage, TMovingImage>::GenerateData()
         {
           const auto transformFileName = "InitialTransform." + std::to_string(i) + '.' + outputFileNameExtension;
 
+#ifndef __wasm32__
           // Write the external transform to file.
           elx::TransformIO::Write(elx::Deref(externalTransform), m_OutputDirectory + transformFileName);
 
@@ -275,6 +276,7 @@ ElastixRegistrationMethod<TFixedImage, TMovingImage>::GenerateData()
           transformFound->second = { "File" };
           transformParameterMap["TransformFileName"] = { transformFileName };
           transformParameterMap.erase("TransformAddress");
+#endif
         }
       }
 

--- a/Core/Main/itkTransformixFilter.hxx
+++ b/Core/Main/itkTransformixFilter.hxx
@@ -35,8 +35,6 @@
 #ifndef itkTransformixFilter_hxx
 #define itkTransformixFilter_hxx
 
-#include "itkTransformixFilter.h"
-
 #include "elxLibUtilities.h"
 #include "elxPixelTypeToString.h"
 #include "elxTransformBase.h"
@@ -44,6 +42,7 @@
 #include "elxDefaultConstruct.h"
 
 #include <itkCompositeTransform.h>
+#include <itkNumberToString.h>
 
 #include <memory> // For unique_ptr.
 


### PR DESCRIPTION
1. Fixes build issues with WebAssembly (Wasm) toolchains (both Emscripten and WASI)
2. Remove file-IO for Wasm builds because Wasm requires special handling of filesystem access and the ITK libraries required for IO will bloat the WASM binary size.