### PR TITLE
COMP: ITK_THREAD_RETURN_DEFAULT_VALUE with WASI toolchain

### DIFF
--- a/Common/CostFunctions/itkAdvancedImageToImageMetric.hxx
+++ b/Common/CostFunctions/itkAdvancedImageToImageMetric.hxx
@@ -781,7 +781,7 @@ AdvancedImageToImageMetric<TFixedImage, TMovingImage>::GetValueThreaderCallback(
 
   temp->st_Metric->ThreadedGetValue(threadID);
 
-  return itk::ITK_THREAD_RETURN_DEFAULT_VALUE;
+  return ITK_THREAD_RETURN_DEFAULT_VALUE;
 
 } // end GetValueThreaderCallback()
 
@@ -819,7 +819,7 @@ AdvancedImageToImageMetric<TFixedImage, TMovingImage>::GetValueAndDerivativeThre
 
   temp->st_Metric->ThreadedGetValueAndDerivative(threadID);
 
-  return itk::ITK_THREAD_RETURN_DEFAULT_VALUE;
+  return ITK_THREAD_RETURN_DEFAULT_VALUE;
 
 } // end GetValueAndDerivativeThreaderCallback()
 
@@ -881,7 +881,7 @@ AdvancedImageToImageMetric<TFixedImage, TMovingImage>::AccumulateDerivativesThre
     temp->st_DerivativePointer[j] = tmp * normalization;
   }
 
-  return itk::ITK_THREAD_RETURN_DEFAULT_VALUE;
+  return ITK_THREAD_RETURN_DEFAULT_VALUE;
 
 } // end AccumulateDerivativesThreaderCallback()
 

--- a/Common/CostFunctions/itkParzenWindowHistogramImageToImageMetric.hxx
+++ b/Common/CostFunctions/itkParzenWindowHistogramImageToImageMetric.hxx
@@ -1264,7 +1264,7 @@ ParzenWindowHistogramImageToImageMetric<TFixedImage, TMovingImage>::ComputePDFsT
 
   temp->m_Metric->ThreadedComputePDFs(threadId);
 
-  return itk::ITK_THREAD_RETURN_DEFAULT_VALUE;
+  return ITK_THREAD_RETURN_DEFAULT_VALUE;
 
 } // end ComputePDFsThreaderCallback()
 

--- a/Common/ImageSamplers/itkImageToVectorContainerFilter.hxx
+++ b/Common/ImageSamplers/itkImageToVectorContainerFilter.hxx
@@ -281,7 +281,7 @@ ImageToVectorContainerFilter<TInputImage, TOutputVectorContainer>::ThreaderCallb
   //   few threads idle.
   //   }
 
-  return itk::ITK_THREAD_RETURN_DEFAULT_VALUE;
+  return ITK_THREAD_RETURN_DEFAULT_VALUE;
 
 } // end ThreaderCallback()
 

--- a/Common/Transforms/itkAdvancedImageMomentsCalculator.hxx
+++ b/Common/Transforms/itkAdvancedImageMomentsCalculator.hxx
@@ -242,7 +242,7 @@ AdvancedImageMomentsCalculator<TImage>::ComputeThreaderCallback(void * arg)
   /** Call the real implementation. */
   temp->st_Self->ThreadedCompute(threadID);
 
-  return itk::ITK_THREAD_RETURN_DEFAULT_VALUE;
+  return ITK_THREAD_RETURN_DEFAULT_VALUE;
 
 } // end ComputeThreaderCallback()
 

--- a/Common/itkComputeDisplacementDistribution.hxx
+++ b/Common/itkComputeDisplacementDistribution.hxx
@@ -313,7 +313,7 @@ ComputeDisplacementDistribution<TFixedImage, TTransform>::ComputeThreaderCallbac
   /** Call the real implementation. */
   temp->st_Self->ThreadedCompute(threadID);
 
-  return itk::ITK_THREAD_RETURN_DEFAULT_VALUE;
+  return ITK_THREAD_RETURN_DEFAULT_VALUE;
 
 } // end ComputeThreaderCallback()
 

--- a/Components/Metrics/AdvancedMattesMutualInformation/itkParzenWindowMutualInformationImageToImageMetric.hxx
+++ b/Components/Metrics/AdvancedMattesMutualInformation/itkParzenWindowMutualInformationImageToImageMetric.hxx
@@ -626,7 +626,7 @@ ParzenWindowMutualInformationImageToImageMetric<TFixedImage, TMovingImage>::Comp
 
   temp->m_Metric->ThreadedComputeDerivativeLowMemory(threadId);
 
-  return itk::ITK_THREAD_RETURN_DEFAULT_VALUE;
+  return ITK_THREAD_RETURN_DEFAULT_VALUE;
 
 } // end ComputeDerivativeLowMemoryThreaderCallback()
 

--- a/Components/Metrics/AdvancedNormalizedCorrelation/itkAdvancedNormalizedCorrelationImageToImageMetric.hxx
+++ b/Components/Metrics/AdvancedNormalizedCorrelation/itkAdvancedNormalizedCorrelationImageToImageMetric.hxx
@@ -830,7 +830,7 @@ AdvancedNormalizedCorrelationImageToImageMetric<TFixedImage, TMovingImage>::Accu
     temp->st_DerivativePointer[j] = (derivativeF - sfm_smm * derivativeM) * invertedDenominator;
   }
 
-  return itk::ITK_THREAD_RETURN_DEFAULT_VALUE;
+  return ITK_THREAD_RETURN_DEFAULT_VALUE;
 
 } // end AccumulateDerivativesThreaderCallback()
 

--- a/Components/Metrics/PCAMetric/itkPCAMetric_F_multithreaded.hxx
+++ b/Components/Metrics/PCAMetric/itkPCAMetric_F_multithreaded.hxx
@@ -886,7 +886,7 @@ PCAMetric<TFixedImage, TMovingImage>::GetSamplesThreaderCallback(void * arg)
 
   temp->m_Metric->ThreadedGetSamples(threadId);
 
-  return itk::ITK_THREAD_RETURN_DEFAULT_VALUE;
+  return ITK_THREAD_RETURN_DEFAULT_VALUE;
 
 } // GetSamplesThreaderCallback()
 
@@ -1088,7 +1088,7 @@ PCAMetric<TFixedImage, TMovingImage>::ComputeDerivativeThreaderCallback(void * a
 
   temp->m_Metric->ThreadedComputeDerivative(threadId);
 
-  return itk::ITK_THREAD_RETURN_DEFAULT_VALUE;
+  return ITK_THREAD_RETURN_DEFAULT_VALUE;
 
 } // end omputeDerivativeThreaderCallback()
 

--- a/Components/Optimizers/AdaptiveStochasticVarianceReducedGradient/itkStochasticVarianceReducedGradientDescentOptimizer.cxx
+++ b/Components/Optimizers/AdaptiveStochasticVarianceReducedGradient/itkStochasticVarianceReducedGradientDescentOptimizer.cxx
@@ -314,7 +314,7 @@ StochasticVarianceReducedGradientDescentOptimizer::AdvanceOneStepThreaderCallbac
   /** Call the real implementation. */
   temp->t_Optimizer->ThreadedAdvanceOneStep(threadID, *(temp->t_NewPosition));
 
-  return itk::ITK_THREAD_RETURN_DEFAULT_VALUE;
+  return ITK_THREAD_RETURN_DEFAULT_VALUE;
 
 } // end AdvanceOneStepThreaderCallback()
 

--- a/Components/Optimizers/StandardStochasticGradientDescent/itkStochasticGradientDescentOptimizer.cxx
+++ b/Components/Optimizers/StandardStochasticGradientDescent/itkStochasticGradientDescentOptimizer.cxx
@@ -311,7 +311,7 @@ StochasticGradientDescentOptimizer::AdvanceOneStepThreaderCallback(void * arg)
   /** Call the real implementation. */
   temp->t_Optimizer->ThreadedAdvanceOneStep(threadID, *(temp->t_NewPosition));
 
-  return itk::ITK_THREAD_RETURN_DEFAULT_VALUE;
+  return ITK_THREAD_RETURN_DEFAULT_VALUE;
 
 } // end AdvanceOneStepThreaderCallback()
 


### PR DESCRIPTION
To address:

```
In file included from /work/wasi-build/_deps/elx-src/Common/ImageSamplers/itkImageToVectorContainerFilter.h:197:
/work/wasi-build/_deps/elx-src/Common/ImageSamplers/itkImageToVectorContainerFilter.hxx:284:46: error: expected unqualified-id
  return itk::ITK_THREAD_RETURN_DEFAULT_VALUE;
```