### PR TITLE
BUG: Fix reference count in ConvertItkTransformBaseToSingleItkTransform

### DIFF
--- a/Core/Main/GTesting/itkElastixRegistrationMethodGTest.cxx
+++ b/Core/Main/GTesting/itkElastixRegistrationMethodGTest.cxx
@@ -1501,7 +1501,11 @@ GTEST_TEST(itkElastixRegistrationMethod, ConvertToItkTransform)
     for (unsigned int n{ 0 }; n < numberOfTransforms; ++n)
     {
       // TODO Check result
-      ElastixRegistrationMethodType<ImageType>::ConvertToItkTransform(*registration.GetNthTransform(n));
+      const auto result =
+        ElastixRegistrationMethodType<ImageType>::ConvertToItkTransform(*registration.GetNthTransform(n));
+
+      ASSERT_NE(result, nullptr);
+      EXPECT_EQ(result->GetReferenceCount(), 1);
     }
   }
 }


### PR DESCRIPTION
itk::ObjectFactoryBase::CreateInstance appears to return an object whose reference count is 2, while the object returned by ConvertItkTransformBaseToSingleItkTransform should have reference count 1.

Related to commit https://github.com/InsightSoftwareConsortium/ITK/commit/8e3c544ae5b331577f3b7c923886d1de77d5fd8e "BUG: The ability to override classes with factories was not working", Bill Lorensen, November 8, 2007.

----

@thewtex @tbirdso Do I understand correctly that after a successful `instance = itk::ObjectFactoryBase::CreateInstance(instanceName.c_str())` call, `instance` has a reference count of `2` (as returned by `instance->GetReferenceCount()`), while it should have reference count = `1`?

Do you agree that the following `while` loop is recommended after doing such a `itk::ObjectFactoryBase::CreateInstance` call?

    while (instance->GetReferenceCount() > 1)
    {
      instance->UnRegister();
    }
