### PR TITLE
ENH: `WriteParameterFile` write floating points without rounding errors

### DIFF
--- a/Core/Main/elxParameterObject.cxx
+++ b/Core/Main/elxParameterObject.cxx
@@ -17,6 +17,7 @@
  *=========================================================================*/
 
 #include "elxParameterObject.h"
+#include "elxConversion.h"
 
 #include "itkParameterFileParser.h"
 
@@ -279,31 +280,7 @@ ParameterObject::WriteParameterFile(const ParameterMapType &      parameterMap,
 
   try
   {
-    ParameterMapConstIterator parameterMapIterator = parameterMap.begin();
-    ParameterMapConstIterator parameterMapIteratorEnd = parameterMap.end();
-    while (parameterMapIterator != parameterMapIteratorEnd)
-    {
-      parameterFile << "(" << parameterMapIterator->first;
-
-      ParameterValueVectorType parameterMapValueVector = parameterMapIterator->second;
-      for (unsigned int i = 0; i < parameterMapValueVector.size(); ++i)
-      {
-        std::istringstream stream(parameterMapValueVector[i]);
-        float              number;
-        stream >> number;
-        if (stream.fail() || stream.bad())
-        {
-          parameterFile << " \"" << parameterMapValueVector[i] << "\"";
-        }
-        else
-        {
-          parameterFile << " " << number;
-        }
-      }
-
-      parameterFile << ")" << std::endl;
-      ++parameterMapIterator;
-    }
+    parameterFile << Conversion::ParameterMapToString(parameterMap);
   }
   catch (const std::ios_base::failure & e)
   {


### PR DESCRIPTION
For numeric parameter values, `ParameterObject::WriteParameterFile` did an unnecessary conversion from string to `float` and back, before writing the value to file, which potentially introduced rounding errors, as well as overly verbose string representations of floating point numbers. These are avoided now, by internally using the lossless `Conversion::ParameterMapToString` helper function.

----

The original code printed a whole number with unnecessary trailing decimals, for example:

    (NumberOfParameters 2.000000)