### PR TITLE
STYLE: Remove the letter 's' from `ParametersMap`

### DIFF
--- a/Common/GTesting/elxResampleInterpolatorGTest.cxx
+++ b/Common/GTesting/elxResampleInterpolatorGTest.cxx
@@ -65,7 +65,7 @@ struct WithDimension
     using InterpolatorType = TInterpolatorTemplate<ElastixType<NDimension>>;
 
     static void
-    Test_CreateTransformParametersMap_for_default_interpolator(const ParameterMapType & expectedDerivedParameterMap)
+    Test_CreateTransformParameterMap_for_default_interpolator(const ParameterMapType & expectedDerivedParameterMap)
     {
       SCOPED_TRACE(std::string("Function = ")
                      .append(__func__)
@@ -76,7 +76,7 @@ struct WithDimension
       const elx::ResampleInterpolatorBase<ElastixType<NDimension>> & interpolator = *newInterpolator;
 
       ParameterMapType actualParameterMap;
-      interpolator.CreateTransformParametersMap(actualParameterMap);
+      interpolator.CreateTransformParameterMap(actualParameterMap);
 
       const ParameterMapType expectedBaseParameterMap = { { "ResampleInterpolator",
                                                             { interpolator.elxGetClassName() } } };
@@ -88,24 +88,24 @@ struct WithDimension
 
 
   static void
-  Test_CreateTransformParametersMap_for_default_interpolator()
+  Test_CreateTransformParameterMap_for_default_interpolator()
   {
     using namespace elx;
 
     const std::string expectedFinalBSplineInterpolationOrderKey = "FinalBSplineInterpolationOrder";
     const std::string expectedZero = "0";
 
-    WithInterpolator<BSplineResampleInterpolator>::Test_CreateTransformParametersMap_for_default_interpolator(
+    WithInterpolator<BSplineResampleInterpolator>::Test_CreateTransformParameterMap_for_default_interpolator(
       { { expectedFinalBSplineInterpolationOrderKey, { "3" } } });
-    WithInterpolator<BSplineResampleInterpolatorFloat>::Test_CreateTransformParametersMap_for_default_interpolator(
+    WithInterpolator<BSplineResampleInterpolatorFloat>::Test_CreateTransformParameterMap_for_default_interpolator(
       { { expectedFinalBSplineInterpolationOrderKey, { "3" } } });
-    WithInterpolator<LinearResampleInterpolator>::Test_CreateTransformParametersMap_for_default_interpolator({});
-    WithInterpolator<NearestNeighborResampleInterpolator>::Test_CreateTransformParametersMap_for_default_interpolator(
+    WithInterpolator<LinearResampleInterpolator>::Test_CreateTransformParameterMap_for_default_interpolator({});
+    WithInterpolator<NearestNeighborResampleInterpolator>::Test_CreateTransformParameterMap_for_default_interpolator(
       {});
 
     const auto skippedTest = [expectedZero] {
       // Note: The following crashes when trying to retrieve "PreParameters" by `m_PreTransform->GetParameters()`.
-      WithInterpolator<RayCastResampleInterpolator>::Test_CreateTransformParametersMap_for_default_interpolator(
+      WithInterpolator<RayCastResampleInterpolator>::Test_CreateTransformParameterMap_for_default_interpolator(
         { { "FocalPoint", ParameterValuesType(NDimension, expectedZero) },
           { "PreParameters", { expectedZero } },
           { "Threshold", { expectedZero } } });
@@ -113,7 +113,7 @@ struct WithDimension
     (void)skippedTest;
 
     WithInterpolator<ReducedDimensionBSplineResampleInterpolator>::
-      Test_CreateTransformParametersMap_for_default_interpolator(
+      Test_CreateTransformParameterMap_for_default_interpolator(
         { { expectedFinalBSplineInterpolationOrderKey, { "1" } } });
   }
 };
@@ -121,8 +121,8 @@ struct WithDimension
 } // namespace
 
 
-GTEST_TEST(ResampleInterpolator, CreateTransformParametersMapForDefaultInterpolator)
+GTEST_TEST(ResampleInterpolator, CreateTransformParameterMapForDefaultInterpolator)
 {
-  WithDimension<2>::Test_CreateTransformParametersMap_for_default_interpolator();
-  WithDimension<3>::Test_CreateTransformParametersMap_for_default_interpolator();
+  WithDimension<2>::Test_CreateTransformParameterMap_for_default_interpolator();
+  WithDimension<3>::Test_CreateTransformParameterMap_for_default_interpolator();
 }

--- a/Common/GTesting/elxResamplerGTest.cxx
+++ b/Common/GTesting/elxResamplerGTest.cxx
@@ -64,7 +64,7 @@ struct WithDimension
     using ResamplerType = TResamplerTemplate<ElastixType<NDimension>>;
 
     static void
-    Test_CreateTransformParametersMap_for_default_resampler(const ParameterMapType & expectedDerivedParameterMap)
+    Test_CreateTransformParameterMap_for_default_resampler(const ParameterMapType & expectedDerivedParameterMap)
     {
       SCOPED_TRACE(std::string("Function = ")
                      .append(__func__)
@@ -80,7 +80,7 @@ struct WithDimension
       resampler.SetElastix(elastixObject);
 
       ParameterMapType actualParameterMap;
-      resampler.CreateTransformParametersMap(actualParameterMap);
+      resampler.CreateTransformParameterMap(actualParameterMap);
 
       const ParameterMapType expectedBaseParameterMap = { { "Resampler", { resampler.elxGetClassName() } },
                                                           { "DefaultPixelValue", { "0" } },
@@ -95,11 +95,11 @@ struct WithDimension
 
 
   static void
-  Test_CreateTransformParametersMap_for_default_resampler()
+  Test_CreateTransformParameterMap_for_default_resampler()
   {
-    WithResampler<elx::DefaultResampler>::Test_CreateTransformParametersMap_for_default_resampler({});
+    WithResampler<elx::DefaultResampler>::Test_CreateTransformParameterMap_for_default_resampler({});
 #ifdef ELASTIX_USE_OPENCL
-    WithResampler<elx::OpenCLResampler>::Test_CreateTransformParametersMap_for_default_resampler(
+    WithResampler<elx::OpenCLResampler>::Test_CreateTransformParameterMap_for_default_resampler(
       { { "OpenCLResamplerUseOpenCL", { "true" } } });
 #endif
   }
@@ -108,8 +108,8 @@ struct WithDimension
 } // namespace
 
 
-GTEST_TEST(Resampler, CreateTransformParametersMapForDefaultResampler)
+GTEST_TEST(Resampler, CreateTransformParameterMapForDefaultResampler)
 {
-  WithDimension<2>::Test_CreateTransformParametersMap_for_default_resampler();
-  WithDimension<3>::Test_CreateTransformParametersMap_for_default_resampler();
+  WithDimension<2>::Test_CreateTransformParameterMap_for_default_resampler();
+  WithDimension<3>::Test_CreateTransformParameterMap_for_default_resampler();
 }

--- a/Common/GTesting/elxTransformIOGTest.cxx
+++ b/Common/GTesting/elxTransformIOGTest.cxx
@@ -234,7 +234,7 @@ struct WithDimension
 
 
     static void
-    Test_CreateTransformParametersMap_for_default_transform(const ParameterMapType & expectedDerivedParameterMap)
+    Test_CreateTransformParameterMap_for_default_transform(const ParameterMapType & expectedDerivedParameterMap)
     {
       SCOPED_TRACE(std::string("Function = ")
                      .append(__func__)
@@ -258,7 +258,7 @@ struct WithDimension
       elxTransform->SetReadWriteTransformParameters(true);
 
       ParameterMapType actualParameterMap;
-      elxTransform->CreateTransformParametersMap(itk::OptimizerParameters<double>{}, actualParameterMap);
+      elxTransform->CreateTransformParameterMap(itk::OptimizerParameters<double>{}, actualParameterMap);
 
       const std::string expectedImageDimension{ char{ '0' + NDimension } };
       const std::string expectedInternalImagePixelType = "float";
@@ -288,7 +288,7 @@ struct WithDimension
     }
 
     static void
-    Test_CreateTransformParametersMap_double_precision()
+    Test_CreateTransformParameterMap_double_precision()
     {
       // Use 0.3333333333333333... as test value.
       constexpr auto testValue = 1.0 / 3.0;
@@ -315,7 +315,7 @@ struct WithDimension
 
       ParameterMapType parameterMap;
 
-      elxTransform->CreateTransformParametersMap(itk::OptimizerParameters<double>(2U, testValue), parameterMap);
+      elxTransform->CreateTransformParameterMap(itk::OptimizerParameters<double>(2U, testValue), parameterMap);
 
       for (const auto key : { "TransformParameters", "Origin", "Spacing" })
       {
@@ -329,7 +329,7 @@ struct WithDimension
     }
 
     static void
-    Test_CreateTransformParametersMap_SetUseAddition()
+    Test_CreateTransformParameterMap_SetUseAddition()
     {
       const auto elxTransform = CheckNew<ElastixTransformType>();
 
@@ -342,7 +342,7 @@ struct WithDimension
 
       const auto expectHowToCombineTransforms = [&elxTransform](const char * const expectedParameterValue) {
         ParameterMapType parameterMap;
-        elxTransform->CreateTransformParametersMap({}, parameterMap);
+        elxTransform->CreateTransformParameterMap({}, parameterMap);
 
         const auto found = parameterMap.find("HowToCombineTransforms");
         ASSERT_NE(found, end(parameterMap));
@@ -382,7 +382,7 @@ struct WithDimension
   }
 
   static void
-  Test_CreateTransformParametersMap_for_default_transform()
+  Test_CreateTransformParameterMap_for_default_transform()
   {
     // Converts the specified string to an std::vector<std::string>. Each vector element contains a character of the
     // specified string.
@@ -418,9 +418,9 @@ struct WithDimension
 
     using namespace elx;
 
-    WithElastixTransform<AdvancedAffineTransformElastix>::Test_CreateTransformParametersMap_for_default_transform(
+    WithElastixTransform<AdvancedAffineTransformElastix>::Test_CreateTransformParameterMap_for_default_transform(
       { { "CenterOfRotationPoint", expectedZeros } });
-    WithElastixTransform<AdvancedBSplineTransform>::Test_CreateTransformParametersMap_for_default_transform(
+    WithElastixTransform<AdvancedBSplineTransform>::Test_CreateTransformParameterMap_for_default_transform(
       { { "BSplineTransformSplineOrder", { "3" } },
         { "GridDirection", expectedGridDirection },
         { "GridIndex", expectedZeros },
@@ -428,45 +428,45 @@ struct WithDimension
         { "GridSize", expectedZeros },
         { "GridSpacing", expectedOnes },
         { "UseCyclicTransform", { "false" } } });
-    WithElastixTransform<AffineDTITransformElastix>::Test_CreateTransformParametersMap_for_default_transform(
+    WithElastixTransform<AffineDTITransformElastix>::Test_CreateTransformParameterMap_for_default_transform(
       { { "CenterOfRotationPoint", expectedZeros }, { "MatrixTranslation", expectedMatrixTranslation } });
-    WithElastixTransform<AffineLogStackTransform>::Test_CreateTransformParametersMap_for_default_transform(
+    WithElastixTransform<AffineLogStackTransform>::Test_CreateTransformParameterMap_for_default_transform(
       { { "CenterOfRotationPoint", ParameterValuesType(NDimension - 1, expectedZero) },
         { "NumberOfSubTransforms", { expectedZero } },
         { "StackOrigin", { expectedZero } },
         { "StackSpacing", { expectedOne } } });
-    WithElastixTransform<AffineLogTransformElastix>::Test_CreateTransformParametersMap_for_default_transform(
+    WithElastixTransform<AffineLogTransformElastix>::Test_CreateTransformParameterMap_for_default_transform(
       { { "CenterOfRotationPoint", expectedZeros }, { "MatrixTranslation", expectedMatrixTranslation } });
 
     const auto skippedTest = [] {
       // Appears to crash when internally calling GetSubTransform(0) while m_SubTransformContainer is still empty.
-      WithElastixTransform<BSplineStackTransform>::Test_CreateTransformParametersMap_for_default_transform({});
+      WithElastixTransform<BSplineStackTransform>::Test_CreateTransformParameterMap_for_default_transform({});
     };
     (void)skippedTest;
 
-    WithElastixTransform<BSplineTransformWithDiffusion>::Test_CreateTransformParametersMap_for_default_transform(
+    WithElastixTransform<BSplineTransformWithDiffusion>::Test_CreateTransformParameterMap_for_default_transform(
       { { "DeformationFieldFileName", { expectedDeformationFieldFileName } },
         { "GridIndex", expectedZeros },
         { "GridOrigin", expectedZeros },
         { "GridSize", expectedZeros },
         { "GridSpacing", expectedOnes } });
-    WithElastixTransform<DeformationFieldTransform>::Test_CreateTransformParametersMap_for_default_transform(
+    WithElastixTransform<DeformationFieldTransform>::Test_CreateTransformParameterMap_for_default_transform(
       { { "DeformationFieldFileName", { expectedDeformationFieldFileName } },
         { "DeformationFieldInterpolationOrder", { expectedZero } } });
-    WithElastixTransform<EulerStackTransform>::Test_CreateTransformParametersMap_for_default_transform(
+    WithElastixTransform<EulerStackTransform>::Test_CreateTransformParameterMap_for_default_transform(
       { { "CenterOfRotationPoint", ParameterValuesType(NDimension - 1, expectedZero) },
         { "NumberOfSubTransforms", { expectedZero } },
         { "StackOrigin", { expectedZero } },
         { "StackSpacing", { expectedOne } } });
 
-    WithElastixTransform<EulerTransformElastix>::Test_CreateTransformParametersMap_for_default_transform(
+    WithElastixTransform<EulerTransformElastix>::Test_CreateTransformParameterMap_for_default_transform(
       (NDimension == 3)
         ? ParameterMapType{ { "CenterOfRotationPoint", expectedZeros }, { "ComputeZYX", { expectedFalse } } }
         : ParameterMapType{ { "CenterOfRotationPoint", expectedZeros } });
 
     try
     {
-      WithElastixTransform<MultiBSplineTransformWithNormal>::Test_CreateTransformParametersMap_for_default_transform(
+      WithElastixTransform<MultiBSplineTransformWithNormal>::Test_CreateTransformParameterMap_for_default_transform(
         { { "GridIndex", expectedZeros },
           { "GridOrigin", expectedZeros },
           { "GridSize", expectedZeros },
@@ -474,7 +474,7 @@ struct WithDimension
           { "BSplineTransformSplineOrder", { "3" } },
           { "GridDirection", expectedGridDirection },
           { "MultiBSplineTransformWithNormalLabels", { itksys::SystemTools::GetCurrentWorkingDirectory() } } });
-      EXPECT_FALSE("MultiBSplineTransformWithNormal::CreateTransformParametersMap is expected to throw an exception!");
+      EXPECT_FALSE("MultiBSplineTransformWithNormal::CreateTransformParameterMap is expected to throw an exception!");
     }
     catch (const itk::ExceptionObject & exceptionObject)
     {
@@ -482,7 +482,7 @@ struct WithDimension
       EXPECT_NE(std::strstr(exceptionObject.GetDescription(), "ERROR: Missing -labels argument!"), nullptr);
     }
 
-    WithElastixTransform<RecursiveBSplineTransform>::Test_CreateTransformParametersMap_for_default_transform(
+    WithElastixTransform<RecursiveBSplineTransform>::Test_CreateTransformParameterMap_for_default_transform(
       { { "BSplineTransformSplineOrder", { "3" } },
         { "GridDirection", expectedGridDirection },
         { "GridIndex", expectedZeros },
@@ -490,19 +490,19 @@ struct WithDimension
         { "GridSize", expectedZeros },
         { "GridSpacing", expectedOnes },
         { "UseCyclicTransform", { expectedFalse } } });
-    WithElastixTransform<SimilarityTransformElastix>::Test_CreateTransformParametersMap_for_default_transform(
+    WithElastixTransform<SimilarityTransformElastix>::Test_CreateTransformParameterMap_for_default_transform(
       { { "CenterOfRotationPoint", expectedZeros } });
-    WithElastixTransform<SplineKernelTransform>::Test_CreateTransformParametersMap_for_default_transform(
+    WithElastixTransform<SplineKernelTransform>::Test_CreateTransformParameterMap_for_default_transform(
       { { "FixedImageLandmarks", {} },
         { "SplineKernelType", { "unknown" } },
         { "SplinePoissonRatio", { "0.3" } },
         { "SplineRelaxationFactor", { expectedZero } } });
-    WithElastixTransform<TranslationStackTransform>::Test_CreateTransformParametersMap_for_default_transform(
+    WithElastixTransform<TranslationStackTransform>::Test_CreateTransformParameterMap_for_default_transform(
       { { "NumberOfSubTransforms", { expectedZero } },
         { "StackOrigin", { expectedZero } },
         { "StackSpacing", { expectedOne } } });
-    WithElastixTransform<TranslationTransformElastix>::Test_CreateTransformParametersMap_for_default_transform({});
-    WithElastixTransform<WeightedCombinationTransformElastix>::Test_CreateTransformParametersMap_for_default_transform(
+    WithElastixTransform<TranslationTransformElastix>::Test_CreateTransformParameterMap_for_default_transform({});
+    WithElastixTransform<WeightedCombinationTransformElastix>::Test_CreateTransformParameterMap_for_default_transform(
       { { "NormalizeCombinationWeights", { expectedFalse } }, { "SubTransforms", {} } });
   }
 };
@@ -830,20 +830,20 @@ GTEST_TEST(TransformIO, CopyParametersToCorrespondingItkTransform)
 }
 
 
-GTEST_TEST(Transform, CreateTransformParametersMapForDefaultTransform)
+GTEST_TEST(Transform, CreateTransformParameterMapForDefaultTransform)
 {
-  WithDimension<2>::Test_CreateTransformParametersMap_for_default_transform();
-  WithDimension<3>::Test_CreateTransformParametersMap_for_default_transform();
+  WithDimension<2>::Test_CreateTransformParameterMap_for_default_transform();
+  WithDimension<3>::Test_CreateTransformParameterMap_for_default_transform();
 }
 
 
-GTEST_TEST(Transform, CreateTransformParametersMapDoublePrecision)
+GTEST_TEST(Transform, CreateTransformParameterMapDoublePrecision)
 {
   // Checks two different transform types, just to be sure.
   WithDimension<2>::WithElastixTransform<
-    elx::AdvancedAffineTransformElastix>::Test_CreateTransformParametersMap_double_precision();
+    elx::AdvancedAffineTransformElastix>::Test_CreateTransformParameterMap_double_precision();
   WithDimension<3>::WithElastixTransform<
-    elx::TranslationTransformElastix>::Test_CreateTransformParametersMap_double_precision();
+    elx::TranslationTransformElastix>::Test_CreateTransformParameterMap_double_precision();
 }
 
 
@@ -851,9 +851,9 @@ GTEST_TEST(Transform, CreateTransformParametersSetUseAddition)
 {
   // Checks two different transform types, just to be sure.
   WithDimension<2>::WithElastixTransform<
-    elx::AdvancedAffineTransformElastix>::Test_CreateTransformParametersMap_SetUseAddition();
+    elx::AdvancedAffineTransformElastix>::Test_CreateTransformParameterMap_SetUseAddition();
   WithDimension<3>::WithElastixTransform<
-    elx::TranslationTransformElastix>::Test_CreateTransformParametersMap_SetUseAddition();
+    elx::TranslationTransformElastix>::Test_CreateTransformParameterMap_SetUseAddition();
 }
 
 

--- a/Components/ResampleInterpolators/BSplineResampleInterpolator/elxBSplineResampleInterpolator.h
+++ b/Components/ResampleInterpolators/BSplineResampleInterpolator/elxBSplineResampleInterpolator.h
@@ -127,7 +127,7 @@ private:
 
   /** Creates a map of the parameters specific for this (derived) interpolator type. */
   ParameterMapType
-  CreateDerivedTransformParametersMap() const override;
+  CreateDerivedTransformParameterMap() const override;
 };
 
 } // end namespace elastix

--- a/Components/ResampleInterpolators/BSplineResampleInterpolator/elxBSplineResampleInterpolator.hxx
+++ b/Components/ResampleInterpolators/BSplineResampleInterpolator/elxBSplineResampleInterpolator.hxx
@@ -71,16 +71,16 @@ BSplineResampleInterpolator<TElastix>::ReadFromFile()
 
 
 /**
- * ******************* CreateDerivedTransformParametersMap ******************************
+ * ******************* CreateDerivedTransformParameterMap ******************************
  */
 
 template <class TElastix>
 auto
-BSplineResampleInterpolator<TElastix>::CreateDerivedTransformParametersMap() const -> ParameterMapType
+BSplineResampleInterpolator<TElastix>::CreateDerivedTransformParameterMap() const -> ParameterMapType
 {
   return { { "FinalBSplineInterpolationOrder", { Conversion::ToString(this->GetSplineOrder()) } } };
 
-} // end CreateDerivedTransformParametersMap()
+} // end CreateDerivedTransformParameterMap()
 
 
 } // end namespace elastix

--- a/Components/ResampleInterpolators/BSplineResampleInterpolatorFloat/elxBSplineResampleInterpolatorFloat.h
+++ b/Components/ResampleInterpolators/BSplineResampleInterpolatorFloat/elxBSplineResampleInterpolatorFloat.h
@@ -125,7 +125,7 @@ private:
 
   /** Creates a map of the parameters specific for this (derived) interpolator type. */
   ParameterMapType
-  CreateDerivedTransformParametersMap() const override;
+  CreateDerivedTransformParameterMap() const override;
 };
 
 } // end namespace elastix

--- a/Components/ResampleInterpolators/BSplineResampleInterpolatorFloat/elxBSplineResampleInterpolatorFloat.hxx
+++ b/Components/ResampleInterpolators/BSplineResampleInterpolatorFloat/elxBSplineResampleInterpolatorFloat.hxx
@@ -72,16 +72,16 @@ BSplineResampleInterpolatorFloat<TElastix>::ReadFromFile()
 
 
 /**
- * ******************* CreateDerivedTransformParametersMap ******************************
+ * ******************* CreateDerivedTransformParameterMap ******************************
  */
 
 template <class TElastix>
 auto
-BSplineResampleInterpolatorFloat<TElastix>::CreateDerivedTransformParametersMap() const -> ParameterMapType
+BSplineResampleInterpolatorFloat<TElastix>::CreateDerivedTransformParameterMap() const -> ParameterMapType
 {
   return { { "FinalBSplineInterpolationOrder", { Conversion::ToString(this->GetSplineOrder()) } } };
 
-} // end CreateDerivedTransformParametersMap()
+} // end CreateDerivedTransformParameterMap()
 
 
 } // end namespace elastix

--- a/Components/ResampleInterpolators/RDBSplineResampleInterpolator/elxRDBSplineResampleInterpolator.h
+++ b/Components/ResampleInterpolators/RDBSplineResampleInterpolator/elxRDBSplineResampleInterpolator.h
@@ -126,7 +126,7 @@ private:
 
   /** Creates a map of the parameters specific for this (derived) interpolator type. */
   ParameterMapType
-  CreateDerivedTransformParametersMap() const override;
+  CreateDerivedTransformParameterMap() const override;
 };
 
 } // end namespace elastix

--- a/Components/ResampleInterpolators/RDBSplineResampleInterpolator/elxRDBSplineResampleInterpolator.hxx
+++ b/Components/ResampleInterpolators/RDBSplineResampleInterpolator/elxRDBSplineResampleInterpolator.hxx
@@ -87,16 +87,16 @@ ReducedDimensionBSplineResampleInterpolator<TElastix>::ReadFromFile()
 
 
 /**
- * ******************* CreateDerivedTransformParametersMap ******************************
+ * ******************* CreateDerivedTransformParameterMap ******************************
  */
 
 template <class TElastix>
 auto
-ReducedDimensionBSplineResampleInterpolator<TElastix>::CreateDerivedTransformParametersMap() const -> ParameterMapType
+ReducedDimensionBSplineResampleInterpolator<TElastix>::CreateDerivedTransformParameterMap() const -> ParameterMapType
 {
   return { { "FinalBSplineInterpolationOrder", { Conversion::ToString(this->GetSplineOrder()) } } };
 
-} // end CreateDerivedTransformParametersMap()
+} // end CreateDerivedTransformParameterMap()
 
 
 } // end namespace elastix

--- a/Components/ResampleInterpolators/RayCastResampleInterpolator/elxRayCastResampleInterpolator.h
+++ b/Components/ResampleInterpolators/RayCastResampleInterpolator/elxRayCastResampleInterpolator.h
@@ -123,7 +123,7 @@ private:
 
   /** Creates a map of the parameters specific for this (derived) interpolator type. */
   ParameterMapType
-  CreateDerivedTransformParametersMap() const override;
+  CreateDerivedTransformParameterMap() const override;
 
   EulerTransformPointer       m_PreTransform;
   TransformParametersType     m_PreParameters;

--- a/Components/ResampleInterpolators/RayCastResampleInterpolator/elxRayCastResampleInterpolator.hxx
+++ b/Components/ResampleInterpolators/RayCastResampleInterpolator/elxRayCastResampleInterpolator.hxx
@@ -146,18 +146,18 @@ RayCastResampleInterpolator<TElastix>::ReadFromFile()
 
 
 /**
- * ******************* CreateDerivedTransformParametersMap ******************************
+ * ******************* CreateDerivedTransformParameterMap ******************************
  */
 
 template <class TElastix>
 auto
-RayCastResampleInterpolator<TElastix>::CreateDerivedTransformParametersMap() const -> ParameterMapType
+RayCastResampleInterpolator<TElastix>::CreateDerivedTransformParameterMap() const -> ParameterMapType
 {
   return { { "FocalPoint", Conversion::ToVectorOfStrings(this->GetFocalPoint()) },
            { "PreParameters", Conversion::ToVectorOfStrings(this->m_PreTransform->GetParameters()) },
            { "Threshold", { Conversion::ToString(this->GetThreshold()) } } };
 
-} // end CreateDerivedTransformParametersMap()
+} // end CreateDerivedTransformParameterMap()
 
 } // end namespace elastix
 

--- a/Components/Resamplers/OpenCLResampler/elxOpenCLResampler.h
+++ b/Components/Resamplers/OpenCLResampler/elxOpenCLResampler.h
@@ -157,7 +157,7 @@ private:
 
   /** Creates a map of the parameters specific for this (derived) resampler type. */
   ParameterMapType
-  CreateDerivedTransformParametersMap() const override;
+  CreateDerivedTransformParameterMap() const override;
 
   /** Helper method to report switching to CPU mode. */
   void

--- a/Components/Resamplers/OpenCLResampler/elxOpenCLResampler.hxx
+++ b/Components/Resamplers/OpenCLResampler/elxOpenCLResampler.hxx
@@ -292,16 +292,16 @@ OpenCLResampler<TElastix>::ReadFromFile()
 
 
 /**
- * ************************* CreateDerivedTransformParametersMap ************************
+ * ************************* CreateDerivedTransformParameterMap ************************
  */
 
 template <class TElastix>
 auto
-OpenCLResampler<TElastix>::CreateDerivedTransformParametersMap() const -> ParameterMapType
+OpenCLResampler<TElastix>::CreateDerivedTransformParameterMap() const -> ParameterMapType
 {
   return { { "OpenCLResamplerUseOpenCL", { Conversion::ToString(this->m_UseOpenCL) } } };
 
-} // end CreateDerivedTransformParametersMap()
+} // end CreateDerivedTransformParameterMap()
 
 
 /**

--- a/Components/Transforms/AdvancedAffineTransform/elxAdvancedAffineTransform.h
+++ b/Components/Transforms/AdvancedAffineTransform/elxAdvancedAffineTransform.h
@@ -215,7 +215,7 @@ private:
 
   /** Creates a map of the parameters specific for this (derived) transform type. */
   ParameterMapType
-  CreateDerivedTransformParametersMap() const override;
+  CreateDerivedTransformParameterMap() const override;
 
   const AffineTransformPointer m_AffineTransform{ AffineTransformType::New() };
 };

--- a/Components/Transforms/AdvancedAffineTransform/elxAdvancedAffineTransform.hxx
+++ b/Components/Transforms/AdvancedAffineTransform/elxAdvancedAffineTransform.hxx
@@ -122,16 +122,16 @@ AdvancedAffineTransformElastix<TElastix>::ReadFromFile()
 
 
 /**
- * ************************* CreateDerivedTransformParametersMap ************************
+ * ************************* CreateDerivedTransformParameterMap ************************
  */
 
 template <class TElastix>
 auto
-AdvancedAffineTransformElastix<TElastix>::CreateDerivedTransformParametersMap() const -> ParameterMapType
+AdvancedAffineTransformElastix<TElastix>::CreateDerivedTransformParameterMap() const -> ParameterMapType
 {
   return { { "CenterOfRotationPoint", Conversion::ToVectorOfStrings(m_AffineTransform->GetCenter()) } };
 
-} // end CreateDerivedTransformParametersMap()
+} // end CreateDerivedTransformParameterMap()
 
 
 /**

--- a/Components/Transforms/AdvancedBSplineTransform/elxAdvancedBSplineTransform.h
+++ b/Components/Transforms/AdvancedBSplineTransform/elxAdvancedBSplineTransform.h
@@ -260,7 +260,7 @@ private:
 
   /** Creates a map of the parameters specific for this (derived) transform type. */
   ParameterMapType
-  CreateDerivedTransformParametersMap() const override;
+  CreateDerivedTransformParameterMap() const override;
 
   /** Private variables. */
   BSplineTransformBasePointer m_BSplineTransform;

--- a/Components/Transforms/AdvancedBSplineTransform/elxAdvancedBSplineTransform.hxx
+++ b/Components/Transforms/AdvancedBSplineTransform/elxAdvancedBSplineTransform.hxx
@@ -445,12 +445,12 @@ AdvancedBSplineTransform<TElastix>::ReadFromFile()
 
 
 /**
- * ************************* CreateDerivedTransformParametersMap ************************
+ * ************************* CreateDerivedTransformParameterMap ************************
  */
 
 template <class TElastix>
 auto
-AdvancedBSplineTransform<TElastix>::CreateDerivedTransformParametersMap() const -> ParameterMapType
+AdvancedBSplineTransform<TElastix>::CreateDerivedTransformParameterMap() const -> ParameterMapType
 {
   const auto gridRegion = m_BSplineTransform->GetGridRegion();
 
@@ -462,7 +462,7 @@ AdvancedBSplineTransform<TElastix>::CreateDerivedTransformParametersMap() const 
            { "BSplineTransformSplineOrder", { Conversion::ToString(m_SplineOrder) } },
            { "UseCyclicTransform", { Conversion::ToString(m_Cyclic) } } };
 
-} // end CreateDerivedTransformParametersMap()
+} // end CreateDerivedTransformParameterMap()
 
 
 /**

--- a/Components/Transforms/AffineDTITransform/elxAffineDTITransform.h
+++ b/Components/Transforms/AffineDTITransform/elxAffineDTITransform.h
@@ -215,7 +215,7 @@ private:
 
   /** Creates a map of the parameters specific for this (derived) transform type. */
   ParameterMapType
-  CreateDerivedTransformParametersMap() const override;
+  CreateDerivedTransformParameterMap() const override;
 
   const AffineDTITransformPointer m_AffineDTITransform{ AffineDTITransformType::New() };
 };

--- a/Components/Transforms/AffineDTITransform/elxAffineDTITransform.hxx
+++ b/Components/Transforms/AffineDTITransform/elxAffineDTITransform.hxx
@@ -95,12 +95,12 @@ AffineDTITransformElastix<TElastix>::ReadFromFile()
 
 
 /**
- * ************************* CreateDerivedTransformParametersMap ************************
+ * ************************* CreateDerivedTransformParameterMap ************************
  */
 
 template <class TElastix>
 auto
-AffineDTITransformElastix<TElastix>::CreateDerivedTransformParametersMap() const -> ParameterMapType
+AffineDTITransformElastix<TElastix>::CreateDerivedTransformParameterMap() const -> ParameterMapType
 {
   const auto & itkTransform = *m_AffineDTITransform;
 
@@ -109,7 +109,7 @@ AffineDTITransformElastix<TElastix>::CreateDerivedTransformParametersMap() const
              Conversion::ConcatenateVectors(Conversion::ToVectorOfStrings(itkTransform.GetMatrix()),
                                             Conversion::ToVectorOfStrings(itkTransform.GetTranslation())) } };
 
-} // end CreateDerivedTransformParametersMap()
+} // end CreateDerivedTransformParameterMap()
 
 
 /**

--- a/Components/Transforms/AffineLogStackTransform/elxAffineLogStackTransform.h
+++ b/Components/Transforms/AffineLogStackTransform/elxAffineLogStackTransform.h
@@ -172,7 +172,7 @@ private:
 
   /** Creates a map of the parameters specific for this (derived) transform type. */
   ParameterMapType
-  CreateDerivedTransformParametersMap() const override;
+  CreateDerivedTransformParameterMap() const override;
 
   /** The deleted copy constructor and assignment operator. */
   /** Typedef for stack transform. */

--- a/Components/Transforms/AffineLogStackTransform/elxAffineLogStackTransform.hxx
+++ b/Components/Transforms/AffineLogStackTransform/elxAffineLogStackTransform.hxx
@@ -140,12 +140,12 @@ AffineLogStackTransform<TElastix>::ReadFromFile()
 
 
 /**
- * ************************* CreateDerivedTransformParametersMap ************************
+ * ************************* CreateDerivedTransformParameterMap ************************
  */
 
 template <class TElastix>
 auto
-AffineLogStackTransform<TElastix>::CreateDerivedTransformParametersMap() const -> ParameterMapType
+AffineLogStackTransform<TElastix>::CreateDerivedTransformParameterMap() const -> ParameterMapType
 {
   const auto & itkTransform = *m_StackTransform;
 
@@ -154,7 +154,7 @@ AffineLogStackTransform<TElastix>::CreateDerivedTransformParametersMap() const -
            { "StackOrigin", { Conversion::ToString(itkTransform.GetStackOrigin()) } },
            { "NumberOfSubTransforms", { Conversion::ToString(itkTransform.GetNumberOfSubTransforms()) } } };
 
-} // end CreateDerivedTransformParametersMap()
+} // end CreateDerivedTransformParameterMap()
 
 
 /**

--- a/Components/Transforms/AffineLogTransform/elxAffineLogTransform.h
+++ b/Components/Transforms/AffineLogTransform/elxAffineLogTransform.h
@@ -179,7 +179,7 @@ private:
 
   /** Creates a map of the parameters specific for this (derived) transform type. */
   ParameterMapType
-  CreateDerivedTransformParametersMap() const override;
+  CreateDerivedTransformParameterMap() const override;
 
   const AffineLogTransformPointer m_AffineLogTransform{ AffineLogTransformType::New() };
 };

--- a/Components/Transforms/AffineLogTransform/elxAffineLogTransform.hxx
+++ b/Components/Transforms/AffineLogTransform/elxAffineLogTransform.hxx
@@ -93,12 +93,12 @@ AffineLogTransformElastix<TElastix>::ReadFromFile()
 
 
 /**
- * ************************* CreateDerivedTransformParametersMap ************************
+ * ************************* CreateDerivedTransformParameterMap ************************
  */
 
 template <class TElastix>
 auto
-AffineLogTransformElastix<TElastix>::CreateDerivedTransformParametersMap() const -> ParameterMapType
+AffineLogTransformElastix<TElastix>::CreateDerivedTransformParameterMap() const -> ParameterMapType
 {
   const auto & itkTransform = *m_AffineLogTransform;
 
@@ -107,7 +107,7 @@ AffineLogTransformElastix<TElastix>::CreateDerivedTransformParametersMap() const
              Conversion::ConcatenateVectors(Conversion::ToVectorOfStrings(itkTransform.GetMatrix()),
                                             Conversion::ToVectorOfStrings(itkTransform.GetTranslation())) } };
 
-} // end CreateDerivedTransformParametersMap()
+} // end CreateDerivedTransformParameterMap()
 
 
 /**

--- a/Components/Transforms/BSplineDeformableTransformWithDiffusion/elxBSplineTransformWithDiffusion.h
+++ b/Components/Transforms/BSplineDeformableTransformWithDiffusion/elxBSplineTransformWithDiffusion.h
@@ -357,7 +357,7 @@ private:
 
   /** Creates a map of the parameters specific for this (derived) transform type. */
   ParameterMapType
-  CreateDerivedTransformParametersMap() const override;
+  CreateDerivedTransformParameterMap() const override;
 
   /** Writes its deformation field to a file. */
   void

--- a/Components/Transforms/BSplineDeformableTransformWithDiffusion/elxBSplineTransformWithDiffusion.hxx
+++ b/Components/Transforms/BSplineDeformableTransformWithDiffusion/elxBSplineTransformWithDiffusion.hxx
@@ -1014,12 +1014,12 @@ BSplineTransformWithDiffusion<TElastix>::WriteDerivedTransformDataToFile() const
 
 
 /**
- * ************************* CustomizeTransformParametersMap ************************
+ * ************************* CustomizeTransformParameterMap ************************
  */
 
 template <class TElastix>
 auto
-BSplineTransformWithDiffusion<TElastix>::CreateDerivedTransformParametersMap() const -> ParameterMapType
+BSplineTransformWithDiffusion<TElastix>::CreateDerivedTransformParameterMap() const -> ParameterMapType
 {
   const auto & itkTransform = *m_BSplineTransform;
   const auto   gridRegion = itkTransform.GetGridRegion();
@@ -1033,7 +1033,7 @@ BSplineTransformWithDiffusion<TElastix>::CreateDerivedTransformParametersMap() c
            { "GridSpacing", Conversion::ToVectorOfStrings(itkTransform.GetGridSpacing()) },
            { "GridOrigin", Conversion::ToVectorOfStrings(itkTransform.GetGridOrigin()) } };
 
-} // end CustomizeTransformParametersMap()
+} // end CustomizeTransformParameterMap()
 
 
 /**

--- a/Components/Transforms/BSplineStackTransform/elxBSplineStackTransform.h
+++ b/Components/Transforms/BSplineStackTransform/elxBSplineStackTransform.h
@@ -271,7 +271,7 @@ private:
 
   /** Creates a map of the parameters specific for this (derived) transform type. */
   ParameterMapType
-  CreateDerivedTransformParametersMap() const override;
+  CreateDerivedTransformParameterMap() const override;
 
   /** The deleted copy constructor and assignment operator. */
   /** Typedef for stack transform. */

--- a/Components/Transforms/BSplineStackTransform/elxBSplineStackTransform.hxx
+++ b/Components/Transforms/BSplineStackTransform/elxBSplineStackTransform.hxx
@@ -598,12 +598,12 @@ BSplineStackTransform<TElastix>::SetOptimizerScales(const unsigned int edgeWidth
 
 
 /**
- * ************************* CreateDerivedTransformParametersMap ************************
+ * ************************* CreateDerivedTransformParameterMap ************************
  */
 
 template <class TElastix>
 auto
-BSplineStackTransform<TElastix>::CreateDerivedTransformParametersMap() const -> ParameterMapType
+BSplineStackTransform<TElastix>::CreateDerivedTransformParameterMap() const -> ParameterMapType
 {
   ReducedDimensionBSplineTransformBasePointer firstSubTransform =
     dynamic_cast<ReducedDimensionBSplineTransformBaseType *>(this->m_StackTransform->GetSubTransform(0).GetPointer());
@@ -620,7 +620,7 @@ BSplineStackTransform<TElastix>::CreateDerivedTransformParametersMap() const -> 
            { "StackOrigin", { Conversion::ToString(m_StackTransform->GetStackOrigin()) } },
            { "NumberOfSubTransforms", { Conversion::ToString(m_StackTransform->GetNumberOfSubTransforms()) } } };
 
-} // end CreateDerivedTransformParametersMap()
+} // end CreateDerivedTransformParameterMap()
 
 
 } // end namespace elastix

--- a/Components/Transforms/DeformationFieldTransform/elxDeformationFieldTransform.h
+++ b/Components/Transforms/DeformationFieldTransform/elxDeformationFieldTransform.h
@@ -137,7 +137,7 @@ private:
 
   /** Creates a map of the parameters specific for this (derived) transform type. */
   ParameterMapType
-  CreateDerivedTransformParametersMap() const override;
+  CreateDerivedTransformParameterMap() const override;
 
   /** Writes its deformation field to a file. */
   void

--- a/Components/Transforms/DeformationFieldTransform/elxDeformationFieldTransform.hxx
+++ b/Components/Transforms/DeformationFieldTransform/elxDeformationFieldTransform.hxx
@@ -173,12 +173,12 @@ DeformationFieldTransform<TElastix>::WriteDerivedTransformDataToFile() const
 
 
 /**
- * ************************* CustomizeTransformParametersMap ************************
+ * ************************* CustomizeTransformParameterMap ************************
  */
 
 template <class TElastix>
 auto
-DeformationFieldTransform<TElastix>::CreateDerivedTransformParametersMap() const -> ParameterMapType
+DeformationFieldTransform<TElastix>::CreateDerivedTransformParameterMap() const -> ParameterMapType
 {
   const std::string interpolatorName =
     m_DeformationFieldInterpolatingTransform->GetDeformationFieldInterpolator()->GetNameOfClass();
@@ -187,7 +187,7 @@ DeformationFieldTransform<TElastix>::CreateDerivedTransformParametersMap() const
   return { { "DeformationFieldFileName", { TransformIO::MakeDeformationFieldFileName(*this) } },
            { "DeformationFieldInterpolationOrder", { Conversion::ToString(interpolationOrder) } } };
 
-} // end CustomizeTransformParametersMap()
+} // end CustomizeTransformParameterMap()
 
 
 } // end namespace elastix

--- a/Components/Transforms/EulerStackTransform/elxEulerStackTransform.h
+++ b/Components/Transforms/EulerStackTransform/elxEulerStackTransform.h
@@ -219,7 +219,7 @@ private:
 
   /** Creates a map of the parameters specific for this (derived) transform type. */
   ParameterMapType
-  CreateDerivedTransformParametersMap() const override;
+  CreateDerivedTransformParameterMap() const override;
 
   /** The deleted copy constructor and assignment operator. */
   /** Typedef for stack transform. */

--- a/Components/Transforms/EulerStackTransform/elxEulerStackTransform.hxx
+++ b/Components/Transforms/EulerStackTransform/elxEulerStackTransform.hxx
@@ -138,12 +138,12 @@ EulerStackTransform<TElastix>::ReadFromFile()
 
 
 /**
- * ************************* CreateDerivedTransformParametersMap ************************
+ * ************************* CreateDerivedTransformParameterMap ************************
  */
 
 template <class TElastix>
 auto
-EulerStackTransform<TElastix>::CreateDerivedTransformParametersMap() const -> ParameterMapType
+EulerStackTransform<TElastix>::CreateDerivedTransformParameterMap() const -> ParameterMapType
 {
   const auto & itkTransform = *m_StackTransform;
 
@@ -152,7 +152,7 @@ EulerStackTransform<TElastix>::CreateDerivedTransformParametersMap() const -> Pa
            { "StackOrigin", { Conversion::ToString(itkTransform.GetStackOrigin()) } },
            { "NumberOfSubTransforms", { Conversion::ToString(itkTransform.GetNumberOfSubTransforms()) } } };
 
-} // end CreateDerivedTransformParametersMap()
+} // end CreateDerivedTransformParameterMap()
 
 
 /**

--- a/Components/Transforms/EulerTransform/elxEulerTransform.h
+++ b/Components/Transforms/EulerTransform/elxEulerTransform.h
@@ -218,7 +218,7 @@ private:
 
   /** Creates a map of the parameters specific for this (derived) transform type. */
   ParameterMapType
-  CreateDerivedTransformParametersMap() const override;
+  CreateDerivedTransformParameterMap() const override;
 
   const EulerTransformPointer m_EulerTransform{ EulerTransformType::New() };
 };

--- a/Components/Transforms/EulerTransform/elxEulerTransform.hxx
+++ b/Components/Transforms/EulerTransform/elxEulerTransform.hxx
@@ -106,12 +106,12 @@ EulerTransformElastix<TElastix>::ReadFromFile()
 
 
 /**
- * ************************* CreateDerivedTransformParametersMap ************************
+ * ************************* CreateDerivedTransformParameterMap ************************
  */
 
 template <class TElastix>
 auto
-EulerTransformElastix<TElastix>::CreateDerivedTransformParametersMap() const -> ParameterMapType
+EulerTransformElastix<TElastix>::CreateDerivedTransformParameterMap() const -> ParameterMapType
 {
   ParameterMapType parameterMap{ { "CenterOfRotationPoint",
                                    Conversion::ToVectorOfStrings(m_EulerTransform->GetCenter()) } };
@@ -124,7 +124,7 @@ EulerTransformElastix<TElastix>::CreateDerivedTransformParametersMap() const -> 
 
   return parameterMap;
 
-} // end CreateDerivedTransformParametersMap()
+} // end CreateDerivedTransformParameterMap()
 
 
 /**

--- a/Components/Transforms/MultiBSplineTransformWithNormal/elxMultiBSplineTransformWithNormal.h
+++ b/Components/Transforms/MultiBSplineTransformWithNormal/elxMultiBSplineTransformWithNormal.h
@@ -256,7 +256,7 @@ private:
 
   /** Creates a map of the parameters specific for this (derived) transform type. */
   ParameterMapType
-  CreateDerivedTransformParametersMap() const override;
+  CreateDerivedTransformParameterMap() const override;
 
   /** Private variables. */
   typename MultiBSplineTransformWithNormalCubicType::Pointer m_MultiBSplineTransformWithNormal;

--- a/Components/Transforms/MultiBSplineTransformWithNormal/elxMultiBSplineTransformWithNormal.hxx
+++ b/Components/Transforms/MultiBSplineTransformWithNormal/elxMultiBSplineTransformWithNormal.hxx
@@ -580,12 +580,12 @@ MultiBSplineTransformWithNormal<TElastix>::ReadFromFile()
 
 
 /**
- * ************************* CustomizeTransformParametersMap ************************
+ * ************************* CustomizeTransformParameterMap ************************
  */
 
 template <class TElastix>
 auto
-MultiBSplineTransformWithNormal<TElastix>::CreateDerivedTransformParametersMap() const -> ParameterMapType
+MultiBSplineTransformWithNormal<TElastix>::CreateDerivedTransformParameterMap() const -> ParameterMapType
 {
   const auto & itkTransform = *m_MultiBSplineTransformWithNormal;
   const auto   gridRegion = itkTransform.GetGridRegion();
@@ -598,7 +598,7 @@ MultiBSplineTransformWithNormal<TElastix>::CreateDerivedTransformParametersMap()
            { "BSplineTransformSplineOrder", { Conversion::ToString(m_SplineOrder) } },
            { "MultiBSplineTransformWithNormalLabels", { itksys::SystemTools::CollapseFullPath(m_LabelsPath) } } };
 
-} // end CustomizeTransformParametersMap()
+} // end CustomizeTransformParameterMap()
 
 
 /**

--- a/Components/Transforms/RecursiveBSplineTransform/elxRecursiveBSplineTransform.h
+++ b/Components/Transforms/RecursiveBSplineTransform/elxRecursiveBSplineTransform.h
@@ -260,7 +260,7 @@ private:
 
   /** Creates a map of the parameters specific for this (derived) transform type. */
   ParameterMapType
-  CreateDerivedTransformParametersMap() const override;
+  CreateDerivedTransformParameterMap() const override;
 
   /** Private variables. */
   BSplineTransformBasePointer m_BSplineTransform;

--- a/Components/Transforms/RecursiveBSplineTransform/elxRecursiveBSplineTransform.hxx
+++ b/Components/Transforms/RecursiveBSplineTransform/elxRecursiveBSplineTransform.hxx
@@ -472,12 +472,12 @@ RecursiveBSplineTransform<TElastix>::ReadFromFile()
 
 
 /**
- * ************************* CreateDerivedTransformParametersMap ************************
+ * ************************* CreateDerivedTransformParameterMap ************************
  */
 
 template <class TElastix>
 auto
-RecursiveBSplineTransform<TElastix>::CreateDerivedTransformParametersMap() const -> ParameterMapType
+RecursiveBSplineTransform<TElastix>::CreateDerivedTransformParameterMap() const -> ParameterMapType
 {
   const auto gridRegion = m_BSplineTransform->GetGridRegion();
 
@@ -489,7 +489,7 @@ RecursiveBSplineTransform<TElastix>::CreateDerivedTransformParametersMap() const
            { "BSplineTransformSplineOrder", { Conversion::ToString(m_SplineOrder) } },
            { "UseCyclicTransform", { Conversion::ToString(this->m_Cyclic) } } };
 
-} // end CreateDerivedTransformParametersMap()
+} // end CreateDerivedTransformParameterMap()
 
 
 /**

--- a/Components/Transforms/SimilarityTransform/elxSimilarityTransform.h
+++ b/Components/Transforms/SimilarityTransform/elxSimilarityTransform.h
@@ -228,7 +228,7 @@ private:
 
   /** Creates a map of the parameters specific for this (derived) transform type. */
   ParameterMapType
-  CreateDerivedTransformParametersMap() const override;
+  CreateDerivedTransformParameterMap() const override;
 
   const SimilarityTransformPointer m_SimilarityTransform{ SimilarityTransformType::New() };
 };

--- a/Components/Transforms/SimilarityTransform/elxSimilarityTransform.hxx
+++ b/Components/Transforms/SimilarityTransform/elxSimilarityTransform.hxx
@@ -104,16 +104,16 @@ SimilarityTransformElastix<TElastix>::ReadFromFile()
 
 
 /**
- * ************************* CreateDerivedTransformParametersMap ************************
+ * ************************* CreateDerivedTransformParameterMap ************************
  */
 
 template <class TElastix>
 auto
-SimilarityTransformElastix<TElastix>::CreateDerivedTransformParametersMap() const -> ParameterMapType
+SimilarityTransformElastix<TElastix>::CreateDerivedTransformParameterMap() const -> ParameterMapType
 {
   return { { "CenterOfRotationPoint", Conversion::ToVectorOfStrings(m_SimilarityTransform->GetCenter()) } };
 
-} // end CreateDerivedTransformParametersMap()
+} // end CreateDerivedTransformParameterMap()
 
 
 /**

--- a/Components/Transforms/SplineKernelTransform/elxSplineKernelTransform.h
+++ b/Components/Transforms/SplineKernelTransform/elxSplineKernelTransform.h
@@ -241,7 +241,7 @@ private:
 
   /** Creates a map of the parameters specific for this (derived) transform type. */
   ParameterMapType
-  CreateDerivedTransformParametersMap() const override;
+  CreateDerivedTransformParameterMap() const override;
 
   std::string m_SplineKernelType;
 };

--- a/Components/Transforms/SplineKernelTransform/elxSplineKernelTransform.hxx
+++ b/Components/Transforms/SplineKernelTransform/elxSplineKernelTransform.hxx
@@ -436,12 +436,12 @@ SplineKernelTransform<TElastix>::ReadFromFile()
 
 
 /**
- * ************************* CustomizeTransformParametersMap ************************
+ * ************************* CustomizeTransformParameterMap ************************
  */
 
 template <class TElastix>
 auto
-SplineKernelTransform<TElastix>::CreateDerivedTransformParametersMap() const -> ParameterMapType
+SplineKernelTransform<TElastix>::CreateDerivedTransformParameterMap() const -> ParameterMapType
 {
   auto & itkTransform = *m_KernelTransform;
 
@@ -450,7 +450,7 @@ SplineKernelTransform<TElastix>::CreateDerivedTransformParametersMap() const -> 
            { "SplineRelaxationFactor", { Conversion::ToString(itkTransform.GetStiffness()) } },
            { "FixedImageLandmarks", Conversion::ToVectorOfStrings(itkTransform.GetFixedParameters()) } };
 
-} // end CustomizeTransformParametersMap()
+} // end CustomizeTransformParameterMap()
 
 
 } // end namespace elastix

--- a/Components/Transforms/TranslationStackTransform/elxTranslationStackTransform.h
+++ b/Components/Transforms/TranslationStackTransform/elxTranslationStackTransform.h
@@ -145,7 +145,7 @@ private:
 
   /** Creates a map of the parameters specific for this (derived) transform type. */
   ParameterMapType
-  CreateDerivedTransformParametersMap() const override;
+  CreateDerivedTransformParameterMap() const override;
 
   /** The deleted copy constructor and assignment operator. */
   /** Typedef for stack transform. */

--- a/Components/Transforms/TranslationStackTransform/elxTranslationStackTransform.hxx
+++ b/Components/Transforms/TranslationStackTransform/elxTranslationStackTransform.hxx
@@ -150,12 +150,12 @@ TranslationStackTransform<TElastix>::ReadFromFile()
 
 
 /**
- * ************************* CustomizeTransformParametersMap ************************
+ * ************************* CustomizeTransformParameterMap ************************
  */
 
 template <class TElastix>
 auto
-TranslationStackTransform<TElastix>::CreateDerivedTransformParametersMap() const -> ParameterMapType
+TranslationStackTransform<TElastix>::CreateDerivedTransformParameterMap() const -> ParameterMapType
 {
   const auto & itkTransform = *m_StackTransform;
 
@@ -163,7 +163,7 @@ TranslationStackTransform<TElastix>::CreateDerivedTransformParametersMap() const
            { "StackOrigin", { Conversion::ToString(itkTransform.GetStackOrigin()) } },
            { "NumberOfSubTransforms", { Conversion::ToString(itkTransform.GetNumberOfSubTransforms()) } } };
 
-} // end CustomizeTransformParametersMap()
+} // end CustomizeTransformParameterMap()
 
 
 } // end namespace elastix

--- a/Components/Transforms/TranslationTransform/elxTranslationTransform.h
+++ b/Components/Transforms/TranslationTransform/elxTranslationTransform.h
@@ -145,7 +145,7 @@ private:
 
   /** Creates a map of the parameters specific for this (derived) transform type. */
   ParameterMapType
-  CreateDerivedTransformParametersMap() const override;
+  CreateDerivedTransformParameterMap() const override;
 };
 
 } // end namespace elastix

--- a/Components/Transforms/TranslationTransform/elxTranslationTransform.hxx
+++ b/Components/Transforms/TranslationTransform/elxTranslationTransform.hxx
@@ -104,17 +104,17 @@ TranslationTransformElastix<TElastix>::InitializeTransform()
 
 
 /**
- * ************************* CustomizeTransformParametersMap ************************
+ * ************************* CustomizeTransformParameterMap ************************
  */
 
 template <class TElastix>
 auto
-TranslationTransformElastix<TElastix>::CreateDerivedTransformParametersMap() const -> ParameterMapType
+TranslationTransformElastix<TElastix>::CreateDerivedTransformParameterMap() const -> ParameterMapType
 {
   // This transform type has no specific extra parameters.
   return {};
 
-} // end CustomizeTransformParametersMap()
+} // end CustomizeTransformParameterMap()
 
 
 } // end namespace elastix

--- a/Components/Transforms/WeightedCombinationTransform/elxWeightedCombinationTransform.h
+++ b/Components/Transforms/WeightedCombinationTransform/elxWeightedCombinationTransform.h
@@ -209,7 +209,7 @@ private:
 
   /** Creates a map of the parameters specific for this (derived) transform type. */
   ParameterMapType
-  CreateDerivedTransformParametersMap() const override;
+  CreateDerivedTransformParameterMap() const override;
 };
 
 } // end namespace elastix

--- a/Components/Transforms/WeightedCombinationTransform/elxWeightedCombinationTransform.hxx
+++ b/Components/Transforms/WeightedCombinationTransform/elxWeightedCombinationTransform.hxx
@@ -115,19 +115,19 @@ WeightedCombinationTransformElastix<TElastix>::ReadFromFile()
 
 
 /**
- * ************************* CustomizeTransformParametersMap ************************
+ * ************************* CustomizeTransformParameterMap ************************
  */
 
 template <class TElastix>
 auto
-WeightedCombinationTransformElastix<TElastix>::CreateDerivedTransformParametersMap() const -> ParameterMapType
+WeightedCombinationTransformElastix<TElastix>::CreateDerivedTransformParameterMap() const -> ParameterMapType
 {
   const auto & itkTransform = *m_WeightedCombinationTransform;
 
   return { { "NormalizeCombinationWeights", { Conversion::ToString(itkTransform.GetNormalizeWeights()) } },
            { "SubTransforms", m_SubTransformFileNames } };
 
-} // end CustomizeTransformParametersMap()
+} // end CustomizeTransformParameterMap()
 
 
 /**

--- a/Core/ComponentBaseClasses/elxResampleInterpolatorBase.h
+++ b/Core/ComponentBaseClasses/elxResampleInterpolatorBase.h
@@ -101,7 +101,7 @@ public:
 
   /** Function to create transform-parameters map. */
   void
-  CreateTransformParametersMap(ParameterMapType & parameterMap) const;
+  CreateTransformParameterMap(ParameterMapType & parameterMap) const;
 
 protected:
   /** The constructor. */
@@ -113,7 +113,7 @@ private:
   elxDeclarePureVirtualGetSelfMacro(ITKBaseType);
 
   virtual ParameterMapType
-  CreateDerivedTransformParametersMap() const
+  CreateDerivedTransformParameterMap() const
   {
     return {};
   }

--- a/Core/ComponentBaseClasses/elxResampleInterpolatorBase.hxx
+++ b/Core/ComponentBaseClasses/elxResampleInterpolatorBase.hxx
@@ -47,7 +47,7 @@ void
 ResampleInterpolatorBase<TElastix>::WriteToFile(std::ostream & transformationParameterInfo) const
 {
   ParameterMapType parameterMap;
-  this->CreateTransformParametersMap(parameterMap);
+  this->CreateTransformParameterMap(parameterMap);
 
   /** Write ResampleInterpolator specific things. */
   transformationParameterInfo << ("\n// ResampleInterpolator specific\n" +
@@ -57,25 +57,25 @@ ResampleInterpolatorBase<TElastix>::WriteToFile(std::ostream & transformationPar
 
 
 /**
- * ******************* CreateTransformParametersMap ****************
+ * ******************* CreateTransformParameterMap ****************
  */
 
 template <class TElastix>
 void
-ResampleInterpolatorBase<TElastix>::CreateTransformParametersMap(ParameterMapType & parameterMap) const
+ResampleInterpolatorBase<TElastix>::CreateTransformParameterMap(ParameterMapType & parameterMap) const
 {
   /** Store the name of this transform. */
   parameterMap["ResampleInterpolator"] = { this->elxGetClassName() };
 
   // Derived classes may add some extra parameters
-  for (auto & keyAndValue : this->CreateDerivedTransformParametersMap())
+  for (auto & keyAndValue : this->CreateDerivedTransformParameterMap())
   {
     const auto & key = keyAndValue.first;
     assert(parameterMap.count(key) == 0);
     parameterMap[key] = std::move(keyAndValue.second);
   }
 
-} // end CreateTransformParametersMap()
+} // end CreateTransformParameterMap()
 
 
 } // end namespace elastix

--- a/Core/ComponentBaseClasses/elxResamplerBase.h
+++ b/Core/ComponentBaseClasses/elxResamplerBase.h
@@ -178,7 +178,7 @@ public:
 
   /** Function to create transform-parameters map. */
   void
-  CreateTransformParametersMap(ParameterMapType & parameterMap) const;
+  CreateTransformParameterMap(ParameterMapType & parameterMap) const;
 
   /** Function to perform resample and write the result output image to a file. */
   void
@@ -202,7 +202,7 @@ private:
   elxDeclarePureVirtualGetSelfMacro(ITKBaseType);
 
   virtual ParameterMapType
-  CreateDerivedTransformParametersMap() const
+  CreateDerivedTransformParameterMap() const
   {
     return {};
   }

--- a/Core/ComponentBaseClasses/elxResamplerBase.hxx
+++ b/Core/ComponentBaseClasses/elxResamplerBase.hxx
@@ -640,7 +640,7 @@ void
 ResamplerBase<TElastix>::WriteToFile(std::ostream & transformationParameterInfo) const
 {
   ParameterMapType parameterMap;
-  Self::CreateTransformParametersMap(parameterMap);
+  Self::CreateTransformParameterMap(parameterMap);
 
   /** Write resampler specific things. */
   transformationParameterInfo << ("\n// Resampler specific\n" + Conversion::ParameterMapToString(parameterMap));
@@ -649,12 +649,12 @@ ResamplerBase<TElastix>::WriteToFile(std::ostream & transformationParameterInfo)
 
 
 /**
- * ******************* CreateTransformParametersMap ******************************
+ * ******************* CreateTransformParameterMap ******************************
  */
 
 template <class TElastix>
 void
-ResamplerBase<TElastix>::CreateTransformParametersMap(ParameterMapType & parameterMap) const
+ResamplerBase<TElastix>::CreateTransformParameterMap(ParameterMapType & parameterMap) const
 {
   /** Store the name of this transform. */
   parameterMap["Resampler"] = { this->elxGetClassName() };
@@ -680,14 +680,14 @@ ResamplerBase<TElastix>::CreateTransformParametersMap(ParameterMapType & paramet
   parameterMap["CompressResultImage"] = { doCompression };
 
   // Derived classes may add some extra parameters
-  for (auto & keyAndValue : this->CreateDerivedTransformParametersMap())
+  for (auto & keyAndValue : this->CreateDerivedTransformParameterMap())
   {
     const auto & key = keyAndValue.first;
     assert(parameterMap.count(key) == 0);
     parameterMap[key] = std::move(keyAndValue.second);
   }
 
-} // end CreateTransformParametersMap()
+} // end CreateTransformParameterMap()
 
 
 /**

--- a/Core/ComponentBaseClasses/elxTransformBase.h
+++ b/Core/ComponentBaseClasses/elxTransformBase.h
@@ -233,9 +233,9 @@ public:
 
   /** Function to create transform-parameters map. */
   void
-  CreateTransformParametersMap(const ParametersType & param,
-                               ParameterMapType &     parameterMap,
-                               const bool             includeDerivedTransformParameters = true) const;
+  CreateTransformParameterMap(const ParametersType & param,
+                              ParameterMapType &     parameterMap,
+                              const bool             includeDerivedTransformParameters = true) const;
 
   /** Function to write transform-parameters to a file. */
   void
@@ -437,7 +437,7 @@ private:
   }
 
   virtual ParameterMapType
-  CreateDerivedTransformParametersMap() const = 0;
+  CreateDerivedTransformParameterMap() const = 0;
 
   /** Allows a derived transform class to write its data to file, by overriding this member function. */
   virtual void

--- a/Core/ComponentBaseClasses/elxTransformBase.hxx
+++ b/Core/ComponentBaseClasses/elxTransformBase.hxx
@@ -524,7 +524,7 @@ TransformBase<TElastix>::WriteToFile(std::ostream & transformationParameterInfo,
 
   ParameterMapType parameterMap;
 
-  this->CreateTransformParametersMap(param, parameterMap, itkTransformOutputFileNameExtension.empty());
+  this->CreateTransformParameterMap(param, parameterMap, itkTransformOutputFileNameExtension.empty());
 
   const auto & self = GetSelf();
 
@@ -578,14 +578,14 @@ TransformBase<TElastix>::WriteToFile(std::ostream & transformationParameterInfo,
 
 
 /**
- * ******************* CreateTransformParametersMap ******************************
+ * ******************* CreateTransformParameterMap ******************************
  */
 
 template <class TElastix>
 void
-TransformBase<TElastix>::CreateTransformParametersMap(const ParametersType & param,
-                                                      ParameterMapType &     parameterMap,
-                                                      const bool             includeDerivedTransformParameters) const
+TransformBase<TElastix>::CreateTransformParameterMap(const ParametersType & param,
+                                                     ParameterMapType &     parameterMap,
+                                                     const bool             includeDerivedTransformParameters) const
 {
   const Configuration & configuration = Deref(Superclass::GetConfiguration());
 
@@ -637,7 +637,7 @@ TransformBase<TElastix>::CreateTransformParametersMap(const ParametersType & par
   if (includeDerivedTransformParameters)
   {
     // Derived transform classes may add some extra parameters
-    for (auto & keyAndValue : this->CreateDerivedTransformParametersMap())
+    for (auto & keyAndValue : this->CreateDerivedTransformParameterMap())
     {
       const auto & key = keyAndValue.first;
       assert(parameterMap.count(key) == 0);
@@ -645,7 +645,7 @@ TransformBase<TElastix>::CreateTransformParametersMap(const ParametersType & par
     }
   }
 
-} // end CreateTransformParametersMap()
+} // end CreateTransformParameterMap()
 
 
 /**

--- a/Core/Kernel/elxElastixBase.cxx
+++ b/Core/Kernel/elxElastixBase.cxx
@@ -457,14 +457,14 @@ ElastixBase::GetOriginalFixedImageDirectionFlat() const
 
 
 /**
- * ************** GetTransformParametersMap *****************
+ * ************** GetTransformParameterMap *****************
  */
 
 itk::ParameterMapInterface::ParameterMapType
-ElastixBase::GetTransformParametersMap() const
+ElastixBase::GetTransformParameterMap() const
 {
-  return m_TransformParametersMap;
-} // end GetTransformParametersMap()
+  return m_TransformParameterMap;
+} // end GetTransformParameterMap()
 
 
 /**

--- a/Core/Kernel/elxElastixBase.h
+++ b/Core/Kernel/elxElastixBase.h
@@ -342,11 +342,11 @@ public:
 
   /** Creates transformation parameters map. */
   virtual void
-  CreateTransformParametersMap() = 0;
+  CreateTransformParameterMap() = 0;
 
   /** Gets transformation parameters map. */
   ParameterMapType
-  GetTransformParametersMap() const;
+  GetTransformParameterMap() const;
 
   /** Set configuration vector. Library only. */
   void
@@ -403,7 +403,7 @@ protected:
   unsigned int m_IterationCounter{};
 
   /** Stores transformation parameters map. */
-  ParameterMapType m_TransformParametersMap;
+  ParameterMapType m_TransformParameterMap;
 
   std::ofstream m_IterationInfoFile;
 

--- a/Core/Kernel/elxElastixMain.cxx
+++ b/Core/Kernel/elxElastixMain.cxx
@@ -190,7 +190,7 @@ ElastixMain::Run()
   this->m_FinalTransform = elastixBase.GetFinalTransform();
 
   /** Get the transformation parameter map */
-  this->m_TransformParametersMap = elastixBase.GetTransformParametersMap();
+  this->m_TransformParameterMap = elastixBase.GetTransformParameterMap();
 
   /** Store the images in ElastixMain. */
   this->SetFixedImageContainer(elastixBase.GetFixedImageContainer());
@@ -510,14 +510,14 @@ ElastixMain::GetOriginalFixedImageDirectionFlat() const
 
 
 /**
- * ******************** GetTransformParametersMap ********************
+ * ******************** GetTransformParameterMap ********************
  */
 
 ElastixMain::ParameterMapType
-ElastixMain::GetTransformParametersMap() const
+ElastixMain::GetTransformParameterMap() const
 {
-  return this->m_TransformParametersMap;
-} // end GetTransformParametersMap()
+  return this->m_TransformParameterMap;
+} // end GetTransformParameterMap()
 
 
 /**

--- a/Core/Kernel/elxElastixMain.h
+++ b/Core/Kernel/elxElastixMain.h
@@ -149,9 +149,9 @@ public:
                                        const ParameterMapType &              inputMap,
                                        const std::vector<ParameterMapType> & initialTransformParameterMaps);
 
-  /** GetTransformParametersMap */
+  /** GetTransformParameterMap */
   virtual ParameterMapType
-  GetTransformParametersMap() const;
+  GetTransformParameterMap() const;
 
 protected:
   ElastixMain();
@@ -172,7 +172,7 @@ protected:
   /** Transformation parameters map containing parameters that is the
    *  result of registration.
    */
-  ParameterMapType m_TransformParametersMap{};
+  ParameterMapType m_TransformParameterMap{};
 
   FlatDirectionCosinesType m_OriginalFixedImageDirection{};
 

--- a/Core/Kernel/elxElastixTemplate.h
+++ b/Core/Kernel/elxElastixTemplate.h
@@ -267,9 +267,9 @@ private:
   void
   CreateTransformParameterFile(const std::string & FileName, const bool ToLog);
 
-  /** CreateTransformParametersMap. */
+  /** CreateTransformParameterMap. */
   void
-  CreateTransformParametersMap() override;
+  CreateTransformParameterMap() override;
 
   /** Open the IterationInfoFile, where the table with iteration info is written to. */
   void

--- a/Core/Kernel/elxElastixTemplate.hxx
+++ b/Core/Kernel/elxElastixTemplate.hxx
@@ -744,7 +744,7 @@ ElastixTemplate<TFixedImage, TMovingImage>::AfterRegistration()
   if (BaseComponent::IsElastixLibrary())
   {
     /** Get the transform parameters. */
-    this->CreateTransformParametersMap(); // only relevant for dll!
+    this->CreateTransformParameterMap(); // only relevant for dll!
   }
 
   timer.Stop();
@@ -821,19 +821,19 @@ ElastixTemplate<TFixedImage, TMovingImage>::CreateTransformParameterFile(const s
 
 
 /**
- * ************** CreateTransformParametersMap ******************
+ * ************** CreateTransformParameterMap ******************
  */
 
 template <class TFixedImage, class TMovingImage>
 void
-ElastixTemplate<TFixedImage, TMovingImage>::CreateTransformParametersMap()
+ElastixTemplate<TFixedImage, TMovingImage>::CreateTransformParameterMap()
 {
-  this->GetElxTransformBase()->CreateTransformParametersMap(
-    this->GetElxOptimizerBase()->GetAsITKBaseType()->GetCurrentPosition(), this->m_TransformParametersMap);
-  this->GetElxResampleInterpolatorBase()->CreateTransformParametersMap(this->m_TransformParametersMap);
-  this->GetElxResamplerBase()->CreateTransformParametersMap(this->m_TransformParametersMap);
+  this->GetElxTransformBase()->CreateTransformParameterMap(
+    this->GetElxOptimizerBase()->GetAsITKBaseType()->GetCurrentPosition(), this->m_TransformParameterMap);
+  this->GetElxResampleInterpolatorBase()->CreateTransformParameterMap(this->m_TransformParameterMap);
+  this->GetElxResamplerBase()->CreateTransformParameterMap(this->m_TransformParameterMap);
 
-} // end CreateTransformParametersMap()
+} // end CreateTransformParameterMap()
 
 
 /**

--- a/Core/Main/elastixlib.cxx
+++ b/Core/Main/elastixlib.cxx
@@ -301,7 +301,7 @@ ELASTIX::RegisterImages(ImagePointer                          fixedImage,
                                         << ConvertSecondsToDHMS(timer.GetMean(), 1) << ".\n");
 
     /** Get the transformation parameter map. */
-    this->m_TransformParametersList.push_back(elastixMain->GetTransformParametersMap());
+    this->m_TransformParametersList.push_back(elastixMain->GetTransformParameterMap());
 
   } // end loop over registrations
 

--- a/Core/Main/itkElastixRegistrationMethod.hxx
+++ b/Core/Main/itkElastixRegistrationMethod.hxx
@@ -295,7 +295,7 @@ ElastixRegistrationMethod<TFixedImage, TMovingImage>::GenerateData()
     resultImageContainer = elastixMain->GetResultImageContainer();
     fixedImageOriginalDirection = elastixMain->GetOriginalFixedImageDirectionFlat();
 
-    transformParameterMapVector.push_back(elastixMain->GetTransformParametersMap());
+    transformParameterMapVector.push_back(elastixMain->GetTransformParameterMap());
 
     // TODO: Fix elastix corrupting default pixel value parameter
     transformParameterMapVector.back()["DefaultPixelValue"] = parameterMap["DefaultPixelValue"];


### PR DESCRIPTION
The term "ParameterMap" was already much more common than "ParametersMap" (1075 versus 192 occurrences, throughout the entire source tree).

Follow-up to pull request https://github.com/SuperElastix/elastix/pull/913 "Remove the letter 's' from `ParametersFile`" commit 74e613fdc7acbc9e4197c53224931e0e2e9e0ae8 and 5c0cce7ec919941d98dd99399871fada44560ff3