### PR TITLE
STYLE: Skip pointer declarations when `GetCreator` returns null

### DIFF
--- a/Components/Transforms/WeightedCombinationTransform/elxWeightedCombinationTransform.hxx
+++ b/Components/Transforms/WeightedCombinationTransform/elxWeightedCombinationTransform.hxx
@@ -242,23 +242,23 @@ WeightedCombinationTransformElastix<TElastix>::LoadSubTransforms()
     configurationSubTransform->ReadParameter(subTransformName, "Transform", 0);
 
     /** Create a SubTransform. */
-    const PtrToCreator creator =
-      ElastixMain::GetComponentDatabase().GetCreator(subTransformName, this->m_Elastix->GetDBIndex());
-    const itk::Object::Pointer subTransform = (creator == nullptr) ? nullptr : creator();
-
-    /** Cast to TransformBase */
-    Superclass2 * elx_subTransform = dynamic_cast<Superclass2 *>(subTransform.GetPointer());
-
-    /** Call the ReadFromFile method of the elx_subTransform. */
-    if (elx_subTransform)
+    if (const PtrToCreator creator =
+          ElastixMain::GetComponentDatabase().GetCreator(subTransformName, this->m_Elastix->GetDBIndex()))
     {
-      elx_subTransform->SetElastix(this->GetElastix());
-      elx_subTransform->SetConfiguration(configurationSubTransform);
-      elx_subTransform->ReadFromFile();
+      if (const itk::Object::Pointer subTransform = creator())
+      {
+        /** Cast to TransformBase and Call the ReadFromFile method of the elx_subTransform. */
+        if (Superclass2 * elx_subTransform = dynamic_cast<Superclass2 *>(subTransform.GetPointer()))
+        {
+          elx_subTransform->SetElastix(this->GetElastix());
+          elx_subTransform->SetConfiguration(configurationSubTransform);
+          elx_subTransform->ReadFromFile();
 
-      /** Set in vector of subTransforms. */
-      SubTransformType * testPointer = dynamic_cast<SubTransformType *>(subTransform.GetPointer());
-      subTransforms[i] = testPointer;
+          /** Set in vector of subTransforms. */
+          SubTransformType * testPointer = dynamic_cast<SubTransformType *>(subTransform.GetPointer());
+          subTransforms[i] = testPointer;
+        }
+      }
     }
 
     /** Check if no errors occurred: */

--- a/Core/ComponentBaseClasses/elxTransformBase.hxx
+++ b/Core/ComponentBaseClasses/elxTransformBase.hxx
@@ -482,25 +482,24 @@ TransformBase<TElastix>::ReadInitialTransformFromConfiguration(
   configurationInitialTransform->ReadParameter(initialTransformName, "Transform", 0);
 
   /** Create an InitialTransform. */
-  const PtrToCreator testcreator =
-    ElastixMain::GetComponentDatabase().GetCreator(initialTransformName, this->m_Elastix->GetDBIndex());
-  const itk::Object::Pointer initialTransform = (testcreator == nullptr) ? nullptr : testcreator();
-
-  const auto elx_initialTransform = dynamic_cast<Self *>(initialTransform.GetPointer());
-
-  /** Call the ReadFromFile method of the initialTransform. */
-  if (elx_initialTransform != nullptr)
+  if (const PtrToCreator testcreator =
+        ElastixMain::GetComponentDatabase().GetCreator(initialTransformName, this->m_Elastix->GetDBIndex()))
   {
-    // elx_initialTransform->SetTransformParameterFileName(transformParameterFileName);
-    elx_initialTransform->SetElastix(this->GetElastix());
-    elx_initialTransform->SetConfiguration(configurationInitialTransform);
-    elx_initialTransform->ReadFromFile();
+    const itk::Object::Pointer initialTransform = testcreator();
 
-    /** Set initial transform. */
-    const auto testPointer = dynamic_cast<InitialTransformType *>(initialTransform.GetPointer());
-    if (testPointer != nullptr)
+    /** Call the ReadFromFile method of the initialTransform. */
+    if (const auto elx_initialTransform = dynamic_cast<Self *>(initialTransform.GetPointer()))
     {
-      this->SetInitialTransform(testPointer);
+      // elx_initialTransform->SetTransformParameterFileName(transformParameterFileName);
+      elx_initialTransform->SetElastix(this->GetElastix());
+      elx_initialTransform->SetConfiguration(configurationInitialTransform);
+      elx_initialTransform->ReadFromFile();
+
+      /** Set initial transform. */
+      if (const auto testPointer = dynamic_cast<InitialTransformType *>(initialTransform.GetPointer()))
+      {
+        this->SetInitialTransform(testPointer);
+      }
     }
   }
 

--- a/Core/Kernel/elxMainBase.cxx
+++ b/Core/Kernel/elxMainBase.cxx
@@ -147,15 +147,15 @@ MainBase::ObjectPointer
 MainBase::CreateComponent(const ComponentDescriptionType & name)
 {
   /** A pointer to the New() function. */
-  const PtrToCreator  creator = GetComponentDatabase().GetCreator(name, m_DBIndex);
-  const ObjectPointer component = (creator == nullptr) ? nullptr : creator();
-
-  if (component.IsNull())
+  if (const PtrToCreator creator = GetComponentDatabase().GetCreator(name, m_DBIndex))
   {
-    itkExceptionMacro("The following component could not be created: " << name);
+    if (const ObjectPointer component = creator())
+    {
+      return component;
+    }
   }
 
-  return component;
+  itkExceptionMacro("The following component could not be created: " << name);
 
 } // end CreateComponent()
 


### PR DESCRIPTION
Simplified the code, by skipping the declaration of pointers to components when `GetCreator` has already returned `nullptr`.