### PR TITLE
Add "ExternalTransform" component and `ElastixRegistrationMethod::SetExternalInitialTransform`

### DIFF
--- a/Common/GTesting/elxConversionGTest.cxx
+++ b/Common/GTesting/elxConversionGTest.cxx
@@ -444,6 +444,23 @@ GTEST_TEST(Conversion, ToString)
 }
 
 
+// Tests that conversion of itk::Object pointers to string and back is lossless.
+GTEST_TEST(Conversion, LosslessRoundTripOfObjectPointers)
+{
+  const auto expectLosslessRoundTrip = [](const itk::Object * const ptr) {
+    const itk::Object * actualPtr{};
+    EXPECT_TRUE(Conversion::StringToValue(Conversion::ObjectPtrToString(ptr), actualPtr));
+    EXPECT_EQ(actualPtr, ptr);
+  };
+
+  expectLosslessRoundTrip(nullptr);
+  expectLosslessRoundTrip(itk::Object::New());
+
+  const elx::DefaultConstruct<itk::Object> localVariable{};
+  expectLosslessRoundTrip(&localVariable);
+}
+
+
 GTEST_TEST(Conversion, ToVectorOfStrings)
 {
   using VectorOfStrings = std::vector<std::string>;

--- a/Components/Transforms/ExternalTransform/CMakeLists.txt
+++ b/Components/Transforms/ExternalTransform/CMakeLists.txt
@@ -1,0 +1,7 @@
+
+ADD_ELXCOMPONENT( ExternalTransform
+ elxAdvancedTransformAdapter.h
+ elxExternalTransform.h
+ elxExternalTransform.hxx
+ elxExternalTransform.cxx)
+

--- a/Components/Transforms/ExternalTransform/elxAdvancedTransformAdapter.h
+++ b/Components/Transforms/ExternalTransform/elxAdvancedTransformAdapter.h
@@ -1,0 +1,227 @@
+/*=========================================================================
+ *
+ *  Copyright UMC Utrecht and contributors
+ *
+ *  Licensed under the Apache License, Version 2.0 (the "License");
+ *  you may not use this file except in compliance with the License.
+ *  You may obtain a copy of the License at
+ *
+ *        http://www.apache.org/licenses/LICENSE-2.0.txt
+ *
+ *  Unless required by applicable law or agreed to in writing, software
+ *  distributed under the License is distributed on an "AS IS" BASIS,
+ *  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *  See the License for the specific language governing permissions and
+ *  limitations under the License.
+ *
+ *=========================================================================*/
+#ifndef itkAdvancedTransformAdapter_h
+#define itkAdvancedTransformAdapter_h
+
+#include "itkAdvancedTransform.h"
+#include "itkMacro.h"
+#include "elxDeref.h"
+
+
+namespace elastix
+{
+
+/** \brief Adapts the ITK transform that is specified by AdvancedTransformAdapter::SetExternalTransform to the elastix
+ * AdvancedTransform interface.
+ *
+ * DO NOT USE IT FOR REGISTRATION. DO NOT USE IT TO RETRIEVE JACOBIAN OR THE HESSIAN VALUES.
+ *
+ * \ingroup Transforms
+ */
+
+template <class TScalarType, unsigned int NDimensions, class TComponentType>
+class ITK_TEMPLATE_EXPORT AdvancedTransformAdapter
+  : public itk::AdvancedTransform<TScalarType, NDimensions, NDimensions>
+{
+public:
+  ITK_DISALLOW_COPY_AND_MOVE(AdvancedTransformAdapter);
+
+  /** Standard class typedefs. */
+  using Self = AdvancedTransformAdapter;
+  using Superclass = itk::AdvancedTransform<TScalarType, NDimensions, NDimensions>;
+  using Pointer = itk::SmartPointer<Self>;
+  using ConstPointer = itk::SmartPointer<const Self>;
+
+  /** New macro for creation of through the object factory.*/
+  itkNewMacro(Self);
+
+  /** Run-time type information (and related methods). */
+  itkTypeMacro(AdvancedTransformAdapter, AdvancedTransform);
+
+  /** Dimension of the domain spaces. */
+  itkStaticConstMacro(InputSpaceDimension, unsigned int, Superclass::InputSpaceDimension);
+  itkStaticConstMacro(OutputSpaceDimension, unsigned int, Superclass::OutputSpaceDimension);
+
+  /** Superclass typedefs */
+  using typename Superclass::ParametersType;
+  using typename Superclass::JacobianType;
+  using typename Superclass::InputVectorType;
+  using typename Superclass::OutputVectorType;
+  using typename Superclass::InputCovariantVectorType;
+  using typename Superclass::OutputCovariantVectorType;
+  using typename Superclass::InputVnlVectorType;
+  using typename Superclass::OutputVnlVectorType;
+  using typename Superclass::InputPointType;
+  using typename Superclass::OutputPointType;
+  using typename Superclass::NonZeroJacobianIndicesType;
+  using typename Superclass::SpatialHessianType;
+  using typename Superclass::SpatialJacobianType;
+  using typename Superclass::JacobianOfSpatialHessianType;
+  using typename Superclass::JacobianOfSpatialJacobianType;
+
+  /** Set the transformation parameters. */
+  void
+  SetParameters(const ParametersType & parameters) override
+  {
+    // SetParameters may be called by elx::TransformBase<TElastix>::ReadFromFile(), but only for an empty list of
+    // parameters _and_ an unspecified (null) m_ExternalTransform.
+    if (m_ExternalTransform || !parameters.empty())
+    {
+      itkExceptionMacro("The parameters of an external transform cannot be set! Only the trivial case of setting an "
+                        "empty parameters to an unspecified (null) external transform is supported!");
+    }
+  }
+
+  /** Set the fixed parameters. Not implemented for this transform. */
+  void
+  SetFixedParameters(const ParametersType & fixedParameters) override
+  {
+    itkExceptionMacro(<< unimplementedOverrideMessage);
+  }
+
+  /** Get the fixed parameters. */
+  const ParametersType &
+  GetFixedParameters() const override
+  {
+    return Deref(m_ExternalTransform).GetFixedParameters();
+  }
+
+  /** Transform a point. */
+  OutputPointType
+  TransformPoint(const InputPointType & point) const override
+  {
+    return Deref(m_ExternalTransform).TransformPoint(point);
+  }
+
+  /** These vector transforms are not implemented for this transform. */
+  OutputVectorType
+  TransformVector(const InputVectorType &) const override
+  {
+    itkExceptionMacro(<< unimplementedOverrideMessage);
+  }
+
+  OutputVnlVectorType
+  TransformVector(const InputVnlVectorType &) const override
+  {
+    itkExceptionMacro(<< unimplementedOverrideMessage);
+  }
+
+  OutputCovariantVectorType
+  TransformCovariantVector(const InputCovariantVectorType &) const override
+  {
+    itkExceptionMacro(<< unimplementedOverrideMessage);
+  }
+
+  bool
+  IsLinear() const override
+  {
+    return Deref(m_ExternalTransform).IsLinear();
+  }
+
+  /** Must be provided. */
+  void
+  GetJacobian(const InputPointType &, JacobianType &, NonZeroJacobianIndicesType &) const override
+  {
+    itkExceptionMacro(<< unimplementedOverrideMessage);
+  }
+
+  void
+  GetSpatialJacobian(const InputPointType &, SpatialJacobianType &) const override
+  {
+    itkExceptionMacro(<< unimplementedOverrideMessage);
+  }
+
+  void
+  GetSpatialHessian(const InputPointType &, SpatialHessianType &) const override
+  {
+    itkExceptionMacro(<< unimplementedOverrideMessage);
+  }
+
+  void
+  GetJacobianOfSpatialJacobian(const InputPointType &,
+                               JacobianOfSpatialJacobianType &,
+                               NonZeroJacobianIndicesType &) const override
+  {
+    itkExceptionMacro(<< unimplementedOverrideMessage);
+  }
+
+  void
+  GetJacobianOfSpatialJacobian(const InputPointType &,
+                               SpatialJacobianType &,
+                               JacobianOfSpatialJacobianType &,
+                               NonZeroJacobianIndicesType &) const override
+  {
+    itkExceptionMacro(<< unimplementedOverrideMessage);
+  }
+
+  void
+  GetJacobianOfSpatialHessian(const InputPointType &,
+                              JacobianOfSpatialHessianType &,
+                              NonZeroJacobianIndicesType &) const override
+  {
+    itkExceptionMacro(<< unimplementedOverrideMessage);
+  }
+
+  void
+  GetJacobianOfSpatialHessian(const InputPointType &,
+                              SpatialHessianType &,
+                              JacobianOfSpatialHessianType &,
+                              NonZeroJacobianIndicesType &) const override
+  {
+    itkExceptionMacro(<< unimplementedOverrideMessage);
+  }
+
+  using typename Superclass::TransformType;
+  itkSetObjectMacro(ExternalTransform, const TransformType);
+  itkGetConstObjectMacro(ExternalTransform, TransformType);
+
+protected:
+  /** Default-constructor. */
+  AdvancedTransformAdapter() = default;
+
+  /** Destructor. */
+  ~AdvancedTransformAdapter() override = default;
+
+  /** Print contents of an AdvancedTransformAdapter. */
+  void
+  PrintSelf(std::ostream & os, itk::Indent indent) const override
+  {
+    Superclass::PrintSelf(os, indent);
+
+    os << indent << "ExternalTransform: ";
+
+    if (m_ExternalTransform)
+    {
+      os << *m_ExternalTransform << std::endl;
+    }
+    else
+    {
+      os << indent << "null" << std::endl;
+    }
+  }
+
+private:
+  static constexpr const char * unimplementedOverrideMessage = "Not implemented for AdvancedTransformAdapter";
+
+  itk::SmartPointer<const TransformType> m_ExternalTransform{};
+};
+
+} // namespace elastix
+
+
+#endif /* itkAdvancedTransformAdapter_h */

--- a/Components/Transforms/ExternalTransform/elxExternalTransform.cxx
+++ b/Components/Transforms/ExternalTransform/elxExternalTransform.cxx
@@ -1,0 +1,21 @@
+/*=========================================================================
+ *
+ *  Copyright UMC Utrecht and contributors
+ *
+ *  Licensed under the Apache License, Version 2.0 (the "License");
+ *  you may not use this file except in compliance with the License.
+ *  You may obtain a copy of the License at
+ *
+ *        http://www.apache.org/licenses/LICENSE-2.0.txt
+ *
+ *  Unless required by applicable law or agreed to in writing, software
+ *  distributed under the License is distributed on an "AS IS" BASIS,
+ *  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *  See the License for the specific language governing permissions and
+ *  limitations under the License.
+ *
+ *=========================================================================*/
+
+#include "elxExternalTransform.h"
+
+elxInstallMacro(ExternalTransform);

--- a/Components/Transforms/ExternalTransform/elxExternalTransform.h
+++ b/Components/Transforms/ExternalTransform/elxExternalTransform.h
@@ -1,0 +1,119 @@
+/*=========================================================================
+ *
+ *  Copyright UMC Utrecht and contributors
+ *
+ *  Licensed under the Apache License, Version 2.0 (the "License");
+ *  you may not use this file except in compliance with the License.
+ *  You may obtain a copy of the License at
+ *
+ *        http://www.apache.org/licenses/LICENSE-2.0.txt
+ *
+ *  Unless required by applicable law or agreed to in writing, software
+ *  distributed under the License is distributed on an "AS IS" BASIS,
+ *  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *  See the License for the specific language governing permissions and
+ *  limitations under the License.
+ *
+ *=========================================================================*/
+#ifndef elxExternalTransform_h
+#define elxExternalTransform_h
+
+#include "elxIncludes.h" // include first to avoid MSVS warning
+#include "elxAdvancedTransformAdapter.h"
+#include "elxDefaultConstruct.h"
+#include "itkAdvancedCombinationTransform.h"
+
+namespace elastix
+{
+
+/**
+ * \class ExternalTransform
+ * \brief An external transform.
+ *
+ * This transform warps an external transform.
+ * This transform is NOT meant to be used for optimization. Just use it as an initial transform, or with transformix.
+ *
+ * The parameters used in this class are:
+ * \parameter Transform: Select this transform as follows:\n
+ *    <tt>(%Transform "ExternalTransform")</tt>
+ *
+ * The transform parameters necessary for transformix, additionally defined by this class, are:
+ * \transformparameter TransformAddress: specifies the memory address of the external transform. \n
+ *    example: <tt>(TransformAddress "000002A3CB9AACC0")</tt>
+ *
+ * \ingroup Transforms
+ */
+
+template <class TElastix>
+class ITK_TEMPLATE_EXPORT ExternalTransform
+  : public itk::AdvancedCombinationTransform<typename elx::TransformBase<TElastix>::CoordRepType,
+                                             elx::TransformBase<TElastix>::FixedImageDimension>
+  , public TransformBase<TElastix>
+{
+public:
+  ITK_DISALLOW_COPY_AND_MOVE(ExternalTransform);
+
+  /** Standard ITK-stuff. */
+  using Self = ExternalTransform;
+
+  /** The ITK-class that provides most of the functionality */
+  using Superclass1 = itk::AdvancedCombinationTransform<typename elx::TransformBase<TElastix>::CoordRepType,
+                                                        elx::TransformBase<TElastix>::FixedImageDimension>;
+
+  using Superclass2 = elx::TransformBase<TElastix>;
+
+  using Pointer = itk::SmartPointer<Self>;
+  using ConstPointer = itk::SmartPointer<const Self>;
+
+  /** Typedef's from TransformBase. */
+  using typename Superclass2::ParameterMapType;
+  using typename Superclass2::CoordRepType;
+
+  /** Method for creation through the object factory. */
+  itkNewMacro(Self);
+
+  /** Run-time type information (and related methods). */
+  itkTypeMacro(ExternalTransform, itk::AdvancedCombinationTransform);
+
+  /** Name of this class.
+   * Use this name in the parameter file to select this specific transform. \n
+   * example: <tt>(Transform "ExternalTransform")</tt>\n
+   */
+  elxClassNameMacro("ExternalTransform");
+
+  /** Dimension of the domain space. */
+  itkStaticConstMacro(SpaceDimension, unsigned int, Superclass2::FixedImageDimension);
+
+  /** Function to read transform-parameters from a file. */
+  void
+  ReadFromFile() override;
+
+protected:
+  /** Default-constructor. */
+  ExternalTransform();
+
+  /** Destructor. */
+  ~ExternalTransform() override = default;
+
+private:
+  elxOverrideGetSelfMacro;
+
+  /** Creates a map of the parameters specific for this (derived) transform type. */
+  ParameterMapType
+  CreateDerivedTransformParameterMap() const override;
+
+  using AdvancedTransformAdapterType = AdvancedTransformAdapter<CoordRepType, Superclass2::FixedImageDimension, float>;
+
+  /** The transform that is set as current transform in the CombinationTransform */
+  const itk::SmartPointer<AdvancedTransformAdapterType> m_AdvancedTransformAdapter{
+    AdvancedTransformAdapterType::New()
+  };
+};
+
+} // end namespace elastix
+
+#ifndef ITK_MANUAL_INSTANTIATION
+#  include "elxExternalTransform.hxx"
+#endif
+
+#endif

--- a/Components/Transforms/ExternalTransform/elxExternalTransform.hxx
+++ b/Components/Transforms/ExternalTransform/elxExternalTransform.hxx
@@ -1,0 +1,83 @@
+/*=========================================================================
+ *
+ *  Copyright UMC Utrecht and contributors
+ *
+ *  Licensed under the Apache License, Version 2.0 (the "License");
+ *  you may not use this file except in compliance with the License.
+ *  You may obtain a copy of the License at
+ *
+ *        http://www.apache.org/licenses/LICENSE-2.0.txt
+ *
+ *  Unless required by applicable law or agreed to in writing, software
+ *  distributed under the License is distributed on an "AS IS" BASIS,
+ *  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *  See the License for the specific language governing permissions and
+ *  limitations under the License.
+ *
+ *=========================================================================*/
+
+#ifndef elxExternalTransform_hxx
+#define elxExternalTransform_hxx
+
+#include "elxExternalTransform.h"
+
+namespace elastix
+{
+
+/**
+ * ********************* Constructor ****************************
+ */
+
+template <class TElastix>
+ExternalTransform<TElastix>::ExternalTransform()
+{
+  Superclass1::SetCurrentTransform(m_AdvancedTransformAdapter);
+}
+
+/**
+ * ************************* ReadFromFile ************************
+ */
+
+template <class TElastix>
+void
+ExternalTransform<TElastix>::ReadFromFile()
+{
+  /** Call the ReadFromFile from the TransformBase. */
+  Superclass2::ReadFromFile();
+
+  const Configuration & configuration = Deref(Superclass2::GetConfiguration());
+
+  if (const auto objectPtr =
+        configuration.RetrieveParameterValue<const itk::Object *>(nullptr, "TransformAddress", 0, false))
+  {
+    if (const auto transform = dynamic_cast<const typename AdvancedTransformAdapterType::TransformType *>(objectPtr))
+    {
+      m_AdvancedTransformAdapter->SetExternalTransform(transform);
+    }
+    else
+    {
+      itkExceptionMacro("The specified TransformAddress is not the address of the correct transform type!");
+    }
+  }
+  else
+  {
+    m_AdvancedTransformAdapter->SetExternalTransform(nullptr);
+  }
+}
+
+
+/**
+ * ************************* CreateDerivedTransformParameterMap ************************
+ */
+
+template <class TElastix>
+auto
+ExternalTransform<TElastix>::CreateDerivedTransformParameterMap() const -> ParameterMapType
+{
+  return { { "TransformAddress",
+             { Conversion::ObjectPtrToString(m_AdvancedTransformAdapter->GetExternalTransform()) } } };
+}
+
+} // namespace elastix
+
+#endif

--- a/Core/Install/elxConversion.cxx
+++ b/Core/Install/elxConversion.cxx
@@ -190,6 +190,20 @@ Conversion::SecondsToDHMS(const double totalSeconds, const unsigned int precisio
 
 
 /**
+ ******************* ObjectPtrToString ****************************
+ */
+
+std::string
+Conversion::ObjectPtrToString(const itk::Object * const objectPtr)
+{
+  const void * const voidPtr{ objectPtr };
+  std::ostringstream outputStringStream{};
+  outputStringStream << voidPtr;
+  return outputStringStream.str();
+}
+
+
+/**
  * ****************** ToOptimizerParameters ****************************
  */
 
@@ -402,5 +416,14 @@ Conversion::StringToValue(const std::string & str, bool & value)
   return false;
 }
 
+
+bool
+Conversion::StringToValue(const std::string & str, const itk::Object *& value)
+{
+  void *     voidPtr{};
+  const bool hasSucceeded = StringToValue<void *>(str, voidPtr);
+  value = static_cast<itk::Object *>(voidPtr);
+  return hasSucceeded;
+}
 
 } // end namespace elastix

--- a/Core/Install/elxConversion.h
+++ b/Core/Install/elxConversion.h
@@ -60,6 +60,9 @@ public:
     return arg ? "true" : "false";
   }
 
+  /** Converts a raw itk::Object pointer to a text string. */
+  static std::string
+  ObjectPtrToString(const itk::Object *);
 
   /** Converts the specified `std::vector` to an OptimizerParameters object. */
   static itk::OptimizerParameters<double>
@@ -226,6 +229,11 @@ public:
   /** Overload to cast a string to a bool. Returns true when casting was successful and false otherwise. */
   static bool
   StringToValue(const std::string & str, bool & value);
+
+  /** Overload to cast a string to an itk::Object pointer. Returns true when casting was successful and false otherwise.
+   */
+  static bool
+  StringToValue(const std::string & str, const itk::Object *& value);
 };
 
 } // end namespace elastix

--- a/Core/Main/itkElastixRegistrationMethod.h
+++ b/Core/Main/itkElastixRegistrationMethod.h
@@ -210,6 +210,10 @@ public:
   void
   SetInitialTransform(const TransformType *);
 
+  /** Set the initial transformation by means of an external ITK Transform. */
+  void
+  SetExternalInitialTransform(const TransformType *);
+
   /** Set/Get/Remove fixed point set filename. */
   itkSetMacro(FixedPointSetFileName, std::string);
   itkGetConstMacro(FixedPointSetFileName, std::string);
@@ -336,12 +340,14 @@ private:
     m_InitialTransform = nullptr;
     m_InitialTransformParameterFileName.clear();
     m_InitialTransformParameterObject = nullptr;
+    m_ExternalInitialTransform = nullptr;
   }
 
   void
   ResetInitialTransformAndModified()
   {
-    if (m_InitialTransform || m_InitialTransformParameterObject || !m_InitialTransformParameterFileName.empty())
+    if (m_InitialTransform || m_InitialTransformParameterObject || m_ExternalInitialTransform ||
+        !m_InitialTransformParameterFileName.empty())
     {
       ResetInitialTransformWithoutModified();
       this->Modified();
@@ -358,6 +364,7 @@ private:
   std::string                        m_InitialTransformParameterFileName{};
   elx::ParameterObject::ConstPointer m_InitialTransformParameterObject{};
   SmartPointer<const TransformType>  m_InitialTransform{};
+  SmartPointer<const TransformType>  m_ExternalInitialTransform{};
 
   std::string m_FixedPointSetFileName{};
   std::string m_MovingPointSetFileName{};

--- a/Core/Main/itkElastixRegistrationMethod.hxx
+++ b/Core/Main/itkElastixRegistrationMethod.hxx
@@ -220,6 +220,13 @@ ElastixRegistrationMethod<TFixedImage, TMovingImage>::GenerateData()
       // For a single transform, there should be only a single transform parameter map.
       return ParameterMapVectorType{ transformToMap(*m_InitialTransform) };
     }
+    if (m_ExternalInitialTransform)
+    {
+      return ParameterMapVectorType{ ParameterMapType{
+        { "NumberOfParameters", { "0" } },
+        { "Transform", { "ExternalTransform" } },
+        { "TransformAddress", { elx::Conversion::ObjectPtrToString(m_ExternalInitialTransform) } } } };
+    }
     return {};
   };
 
@@ -836,6 +843,26 @@ ElastixRegistrationMethod<TFixedImage, TMovingImage>::SetInitialTransform(const 
     {
       ResetInitialTransformWithoutModified();
       m_InitialTransform = transform;
+      this->Modified();
+    }
+  }
+  else
+  {
+    ResetInitialTransformAndModified();
+  }
+}
+
+
+template <typename TFixedImage, typename TMovingImage>
+void
+ElastixRegistrationMethod<TFixedImage, TMovingImage>::SetExternalInitialTransform(const TransformType * const transform)
+{
+  if (transform)
+  {
+    if (m_ExternalInitialTransform != transform)
+    {
+      ResetInitialTransformWithoutModified();
+      m_ExternalInitialTransform = transform;
       this->Modified();
     }
   }


### PR DESCRIPTION
Adds a component that allows specifying an ITK transform by its address in memory. The transform is then _not_ converted to the corresponding elastix AdvancedTransform. Instead, it is only "adapted", meaning that its `TransformPoint` is still called directly, when using the transform. This component is only meant to be used with the elastix/transformix library, not with the elastix/transformix executable. It only serves as input transform, so it is meant not to be adjusted during registration.

Adds a `SetExternalInitialTransform` member function to `ElastixRegistrationMethod`, allowing to specify any ITK transform (for example an `itk::DisplacementFieldTransform`) as initial transform. Aims to address the following issue:
- #874