### PR TITLE
STYLE: Let GetNthTransform, GetCombinationTransform return a raw pointer

### DIFF
--- a/Core/Main/itkElastixRegistrationMethod.h
+++ b/Core/Main/itkElastixRegistrationMethod.h
@@ -273,11 +273,11 @@ public:
   GetNumberOfTransforms() const;
 
   /** Returns the nth transformation, produced during the last Update(). */
-  SmartPointer<TransformType>
+  TransformType *
   GetNthTransform(const unsigned int n) const;
 
   /** Returns the combination transformation, produced during the last Update(). */
-  SmartPointer<TransformType>
+  TransformType *
   GetCombinationTransform() const;
 
   /** Converts the specified elastix Transform object to the corresponding ITK Transform object. Returns null if there

--- a/Core/Main/itkElastixRegistrationMethod.hxx
+++ b/Core/Main/itkElastixRegistrationMethod.hxx
@@ -933,8 +933,7 @@ ElastixRegistrationMethod<TFixedImage, TMovingImage>::GetNumberOfTransforms() co
 
 template <typename TFixedImage, typename TMovingImage>
 auto
-ElastixRegistrationMethod<TFixedImage, TMovingImage>::GetNthTransform(const unsigned int n) const
-  -> SmartPointer<TransformType>
+ElastixRegistrationMethod<TFixedImage, TMovingImage>::GetNthTransform(const unsigned int n) const -> TransformType *
 {
   const auto * const transformContainer = m_ElastixMain->GetElastixBase().GetTransformContainer();
 
@@ -956,7 +955,7 @@ ElastixRegistrationMethod<TFixedImage, TMovingImage>::GetNthTransform(const unsi
 
 template <typename TFixedImage, typename TMovingImage>
 auto
-ElastixRegistrationMethod<TFixedImage, TMovingImage>::GetCombinationTransform() const -> SmartPointer<TransformType>
+ElastixRegistrationMethod<TFixedImage, TMovingImage>::GetCombinationTransform() const -> TransformType *
 {
   const auto * const transformContainer = m_ElastixMain->GetElastixBase().GetTransformContainer();
 


### PR DESCRIPTION
In general, the use of a smart pointer as return type allows extending the lifetime of the returned object beyond the function call. But as these two `ElastixRegistrationMethod` member functions both just return a pointer to a transform object that is "owned" by the `ElastixRegistrationMethod` object, the caller of `GetNthTransform` or `GetCombinationTransform` does not need to extend the lifetime of the returned transform object. This returned transform object will stay alive while the `ElastixRegistrationMethod` object is there, even when the return type is a raw pointer.

This adjustment was already proposed by Matt McCormick (@thewtex).

----

Aims to (at least partially) supersede the following pull request: 
- #914 

This little pull request is there just to ensure that these changes to  `GetNthTransform` or `GetCombinationTransform` can already be included with the next ITKElastix release.