### PR TITLE
STYLE: Explicitly use SmartPointer for data members in ITK interface

### DIFF
--- a/Core/Main/itkElastixRegistrationMethod.h
+++ b/Core/Main/itkElastixRegistrationMethod.h
@@ -359,12 +359,12 @@ private:
 
   using ElastixTransformBaseType = elx::TransformBase<elx::ElastixTemplate<TFixedImage, TMovingImage>>;
 
-  SmartPointer<const elx::ElastixMain> m_ElastixMain{ nullptr };
+  SmartPointer<const elx::ElastixMain> m_ElastixMain{};
 
-  std::string                        m_InitialTransformParameterFileName{};
-  elx::ParameterObject::ConstPointer m_InitialTransformParameterObject{};
-  SmartPointer<const TransformType>  m_InitialTransform{};
-  SmartPointer<const TransformType>  m_ExternalInitialTransform{};
+  std::string                              m_InitialTransformParameterFileName{};
+  SmartPointer<const elx::ParameterObject> m_InitialTransformParameterObject{};
+  SmartPointer<const TransformType>        m_InitialTransform{};
+  SmartPointer<const TransformType>        m_ExternalInitialTransform{};
 
   std::string m_FixedPointSetFileName{};
   std::string m_MovingPointSetFileName{};

--- a/Core/Main/itkTransformixFilter.h
+++ b/Core/Main/itkTransformixFilter.h
@@ -281,7 +281,7 @@ private:
   const ElastixTransformBaseType *
   GetFirstElastixTransformBase() const;
 
-  SmartPointer<const elx::TransformixMain> m_TransformixMain{ nullptr };
+  SmartPointer<const elx::TransformixMain> m_TransformixMain{};
 
   std::string m_TransformParameterFileName{};
   std::string m_FixedPointSetFileName{};
@@ -298,10 +298,10 @@ private:
 
   ElastixLogLevel m_LogLevel{};
 
-  typename MeshType::ConstPointer m_InputMesh{ nullptr };
-  typename MeshType::Pointer      m_OutputMesh{ nullptr };
+  SmartPointer<const MeshType> m_InputMesh{};
+  SmartPointer<MeshType>       m_OutputMesh{};
 
-  TransformBase::ConstPointer m_Transform{};
+  SmartPointer<const TransformBase> m_Transform{};
 
   SmartPointer<TransformType> m_CombinationTransform;
 };


### PR DESCRIPTION
Avoided use of dependent types (having to use `typename`). Also consistently did initialization by `{}`.

----

Note that some old GCC compilers (before GCC 9.2) produced "error: invalid use of incomplete type" when using `{}` initialization for a SmartPointer to an incomplete type. But nowadays it should be just fine to initialize any SmartPointer by `{}`. Related to an ITK pull request:
- https://github.com/InsightSoftwareConsortium/ITK/pull/3927