### PR TITLE
`ElastixRegistrationMethod.ConvertToItkTransform` support external initial transforms 

### DIFF
--- a/Common/GTesting/elxConversionGTest.cxx
+++ b/Common/GTesting/elxConversionGTest.cxx
@@ -447,8 +447,8 @@ GTEST_TEST(Conversion, ToString)
 // Tests that conversion of itk::Object pointers to string and back is lossless.
 GTEST_TEST(Conversion, LosslessRoundTripOfObjectPointers)
 {
-  const auto expectLosslessRoundTrip = [](const itk::Object * const ptr) {
-    const itk::Object * actualPtr{};
+  const auto expectLosslessRoundTrip = [](itk::Object * const ptr) {
+    itk::Object * actualPtr{};
     EXPECT_TRUE(Conversion::StringToValue(Conversion::ObjectPtrToString(ptr), actualPtr));
     EXPECT_EQ(actualPtr, ptr);
   };
@@ -456,7 +456,7 @@ GTEST_TEST(Conversion, LosslessRoundTripOfObjectPointers)
   expectLosslessRoundTrip(nullptr);
   expectLosslessRoundTrip(itk::Object::New());
 
-  const elx::DefaultConstruct<itk::Object> localVariable{};
+  elx::DefaultConstruct<itk::Object> localVariable{};
   expectLosslessRoundTrip(&localVariable);
 }
 

--- a/Common/Transforms/elxTransformIO.h
+++ b/Common/Transforms/elxTransformIO.h
@@ -19,6 +19,7 @@
 #define elxTransformIO_h
 
 #include "itkAdvancedCombinationTransform.h"
+#include "ExternalTransform/elxAdvancedTransformAdapter.h"
 
 #include <itkCompositeTransform.h>
 #include <itkTransform.h>
@@ -127,6 +128,10 @@ public:
     using CombinationTransformType = itk::AdvancedCombinationTransform<double, NDimension>;
     assert(dynamic_cast<const CombinationTransformType *>(&elxTransform) == nullptr);
 
+    if (const auto transformAdapter = dynamic_cast<const AdvancedTransformAdapter<double, NDimension> *>(&elxTransform))
+    {
+      return transformAdapter->GetModifiableExternalTransform();
+    }
     return dynamic_cast<itk::Transform<double, NDimension, NDimension> *>(
       ConvertItkTransformBaseToSingleItkTransform(elxTransform).GetPointer());
   }

--- a/Components/Transforms/ExternalTransform/elxAdvancedTransformAdapter.h
+++ b/Components/Transforms/ExternalTransform/elxAdvancedTransformAdapter.h
@@ -187,8 +187,14 @@ public:
   }
 
   using typename Superclass::TransformType;
-  itkSetObjectMacro(ExternalTransform, const TransformType);
-  itkGetConstObjectMacro(ExternalTransform, TransformType);
+  itkSetObjectMacro(ExternalTransform, TransformType);
+
+  /** \note `GetModifiableExternalTransform()` is `const`, because it does not affect the adapter itself. */
+  TransformType *
+  GetModifiableExternalTransform() const
+  {
+    return m_ExternalTransform.GetPointer();
+  }
 
 protected:
   /** Default-constructor. */
@@ -218,7 +224,7 @@ protected:
 private:
   static constexpr const char * unimplementedOverrideMessage = "Not implemented for AdvancedTransformAdapter";
 
-  itk::SmartPointer<const TransformType> m_ExternalTransform{};
+  itk::SmartPointer<TransformType> m_ExternalTransform{};
 };
 
 } // namespace elastix

--- a/Components/Transforms/ExternalTransform/elxAdvancedTransformAdapter.h
+++ b/Components/Transforms/ExternalTransform/elxAdvancedTransformAdapter.h
@@ -34,7 +34,7 @@ namespace elastix
  * \ingroup Transforms
  */
 
-template <class TScalarType, unsigned int NDimensions, class TComponentType>
+template <class TScalarType, unsigned int NDimensions>
 class ITK_TEMPLATE_EXPORT AdvancedTransformAdapter
   : public itk::AdvancedTransform<TScalarType, NDimensions, NDimensions>
 {

--- a/Components/Transforms/ExternalTransform/elxExternalTransform.h
+++ b/Components/Transforms/ExternalTransform/elxExternalTransform.h
@@ -102,7 +102,7 @@ private:
   ParameterMapType
   CreateDerivedTransformParameterMap() const override;
 
-  using AdvancedTransformAdapterType = AdvancedTransformAdapter<CoordRepType, Superclass2::FixedImageDimension, float>;
+  using AdvancedTransformAdapterType = AdvancedTransformAdapter<CoordRepType, Superclass2::FixedImageDimension>;
 
   /** The transform that is set as current transform in the CombinationTransform */
   const itk::SmartPointer<AdvancedTransformAdapterType> m_AdvancedTransformAdapter{

--- a/Components/Transforms/ExternalTransform/elxExternalTransform.hxx
+++ b/Components/Transforms/ExternalTransform/elxExternalTransform.hxx
@@ -47,10 +47,9 @@ ExternalTransform<TElastix>::ReadFromFile()
 
   const Configuration & configuration = Deref(Superclass2::GetConfiguration());
 
-  if (const auto objectPtr =
-        configuration.RetrieveParameterValue<const itk::Object *>(nullptr, "TransformAddress", 0, false))
+  if (const auto objectPtr = configuration.RetrieveParameterValue<itk::Object *>(nullptr, "TransformAddress", 0, false))
   {
-    if (const auto transform = dynamic_cast<const typename AdvancedTransformAdapterType::TransformType *>(objectPtr))
+    if (const auto transform = dynamic_cast<typename AdvancedTransformAdapterType::TransformType *>(objectPtr))
     {
       m_AdvancedTransformAdapter->SetExternalTransform(transform);
     }
@@ -75,7 +74,7 @@ auto
 ExternalTransform<TElastix>::CreateDerivedTransformParameterMap() const -> ParameterMapType
 {
   return { { "TransformAddress",
-             { Conversion::ObjectPtrToString(m_AdvancedTransformAdapter->GetExternalTransform()) } } };
+             { Conversion::ObjectPtrToString(m_AdvancedTransformAdapter->GetModifiableExternalTransform()) } } };
 }
 
 } // namespace elastix

--- a/Core/Install/elxConversion.cxx
+++ b/Core/Install/elxConversion.cxx
@@ -194,7 +194,7 @@ Conversion::SecondsToDHMS(const double totalSeconds, const unsigned int precisio
  */
 
 std::string
-Conversion::ObjectPtrToString(const itk::Object * const objectPtr)
+Conversion::ObjectPtrToString(itk::Object * const objectPtr)
 {
   const void * const voidPtr{ objectPtr };
   std::ostringstream outputStringStream{};
@@ -418,7 +418,7 @@ Conversion::StringToValue(const std::string & str, bool & value)
 
 
 bool
-Conversion::StringToValue(const std::string & str, const itk::Object *& value)
+Conversion::StringToValue(const std::string & str, itk::Object *& value)
 {
   void *     voidPtr{};
   const bool hasSucceeded = StringToValue<void *>(str, voidPtr);

--- a/Core/Install/elxConversion.h
+++ b/Core/Install/elxConversion.h
@@ -62,7 +62,7 @@ public:
 
   /** Converts a raw itk::Object pointer to a text string. */
   static std::string
-  ObjectPtrToString(const itk::Object *);
+  ObjectPtrToString(itk::Object *);
 
   /** Converts the specified `std::vector` to an OptimizerParameters object. */
   static itk::OptimizerParameters<double>
@@ -233,7 +233,7 @@ public:
   /** Overload to cast a string to an itk::Object pointer. Returns true when casting was successful and false otherwise.
    */
   static bool
-  StringToValue(const std::string & str, const itk::Object *& value);
+  StringToValue(const std::string & str, itk::Object *& value);
 };
 
 } // end namespace elastix

--- a/Core/Main/itkElastixRegistrationMethod.h
+++ b/Core/Main/itkElastixRegistrationMethod.h
@@ -212,7 +212,7 @@ public:
 
   /** Set the initial transformation by means of an external ITK Transform. */
   void
-  SetExternalInitialTransform(const TransformType *);
+  SetExternalInitialTransform(TransformType *);
 
   /** Set/Get/Remove fixed point set filename. */
   itkSetMacro(FixedPointSetFileName, std::string);
@@ -364,7 +364,7 @@ private:
   std::string                              m_InitialTransformParameterFileName{};
   SmartPointer<const elx::ParameterObject> m_InitialTransformParameterObject{};
   SmartPointer<const TransformType>        m_InitialTransform{};
-  SmartPointer<const TransformType>        m_ExternalInitialTransform{};
+  SmartPointer<TransformType>              m_ExternalInitialTransform{};
 
   std::string m_FixedPointSetFileName{};
   std::string m_MovingPointSetFileName{};

--- a/Core/Main/itkElastixRegistrationMethod.hxx
+++ b/Core/Main/itkElastixRegistrationMethod.hxx
@@ -258,7 +258,7 @@ ElastixRegistrationMethod<TFixedImage, TMovingImage>::GenerateData()
           transformFound != transformParameterMap.end() &&
           transformFound->second == ParameterValueVectorType{ "ExternalTransform" })
       {
-        const Object * externalTransform{};
+        Object * externalTransform{};
 
         // Retrieve the pointer to the external transform (its address).
         if (const auto transformAddressFound = transformParameterMap.find("TransformAddress");
@@ -893,7 +893,7 @@ ElastixRegistrationMethod<TFixedImage, TMovingImage>::SetInitialTransform(const 
 
 template <typename TFixedImage, typename TMovingImage>
 void
-ElastixRegistrationMethod<TFixedImage, TMovingImage>::SetExternalInitialTransform(const TransformType * const transform)
+ElastixRegistrationMethod<TFixedImage, TMovingImage>::SetExternalInitialTransform(TransformType * const transform)
 {
   if (transform)
   {


### PR DESCRIPTION
When `ConvertToItkTransform` has converted the CombinationTransform produced by a registration that used an external initial transform, the result should be an `itk::CompositeTransform` that has a pointer to the initial transform as its "back transform".

Follow-up on a comment by Dženan Zukić (@dzenanz) at https://github.com/InsightSoftwareConsortium/ITKElastix/pull/241#issuecomment-1682550470