### PR TITLE
ENH: Add GetInitialTransform() and GetExternalInitialTransform()

### DIFF
--- a/Core/Main/GTesting/itkElastixRegistrationMethodGTest.cxx
+++ b/Core/Main/GTesting/itkElastixRegistrationMethodGTest.cxx
@@ -2370,3 +2370,34 @@ GTEST_TEST(itkElastixRegistrationMethod, CheckZeroFilledMovingImageWithRandomDom
   check(TypeHolder<float>{});
   check(TypeHolder<double>{});
 }
+
+
+// Checks that InitialTransform and ExternalInitialTransform are mutually exclusive.
+GTEST_TEST(itkElastixRegistrationMethod, SetAndGetInitialTransform)
+{
+  constexpr auto ImageDimension = 2U;
+  using ImageType = itk::Image<float, ImageDimension>;
+
+  elx::DefaultConstruct<itk::DisplacementFieldTransform<double, ImageDimension>> displacementFieldTransform{};
+  const elx::DefaultConstruct<itk::TranslationTransform<double, ImageDimension>> translationTransform{};
+
+  elx::DefaultConstruct<ElastixRegistrationMethodType<ImageType>> registration{};
+  EXPECT_EQ(registration.GetInitialTransform(), nullptr);
+  EXPECT_EQ(registration.GetExternalInitialTransform(), nullptr);
+
+  registration.SetInitialTransform(&translationTransform);
+  EXPECT_EQ(registration.GetInitialTransform(), &translationTransform);
+  EXPECT_EQ(registration.GetExternalInitialTransform(), nullptr);
+
+  registration.SetExternalInitialTransform(&displacementFieldTransform);
+  EXPECT_EQ(registration.GetInitialTransform(), nullptr);
+  EXPECT_EQ(registration.GetExternalInitialTransform(), &displacementFieldTransform);
+
+  registration.SetInitialTransform(nullptr);
+  EXPECT_EQ(registration.GetInitialTransform(), nullptr);
+  EXPECT_EQ(registration.GetExternalInitialTransform(), nullptr);
+
+  registration.SetExternalInitialTransform(nullptr);
+  EXPECT_EQ(registration.GetInitialTransform(), nullptr);
+  EXPECT_EQ(registration.GetExternalInitialTransform(), nullptr);
+}

--- a/Core/Main/itkElastixRegistrationMethod.h
+++ b/Core/Main/itkElastixRegistrationMethod.h
@@ -206,9 +206,25 @@ public:
   void
   SetInitialTransformParameterObject(const elx::ParameterObject *);
 
+  /** Returns the previously specified initial ITK Transform. Only allows const access to the transform. */
+  const TransformType *
+  GetInitialTransform() const
+  {
+    return m_InitialTransform;
+  }
+
   /** Set the initial transformation by means of an ITK Transform. */
   void
   SetInitialTransform(const TransformType *);
+
+  /** Returns the previously specified external ITK Transform. Note that it allows full access to the transform, even
+   * when having const-only access to this ElastixRegistrationMethod, because the transform is external to the
+   * ElastixRegistrationMethod object. */
+  TransformType *
+  GetExternalInitialTransform() const
+  {
+    return m_ExternalInitialTransform;
+  }
 
   /** Set the initial transformation by means of an external ITK Transform. */
   void


### PR DESCRIPTION
Added GetInitialTransform() and GetExternalInitialTransform() to ElastixRegistrationMethod, and tested that these two properties are mutually exclusive.