### PR TITLE
STYLE: Place Threader::SetSingleMethod argument `temp` on the stack

### DIFF
--- a/Components/Metrics/AdvancedKappaStatistic/itkAdvancedKappaStatisticImageToImageMetric.hxx
+++ b/Components/Metrics/AdvancedKappaStatistic/itkAdvancedKappaStatisticImageToImageMetric.hxx
@@ -634,17 +634,15 @@ AdvancedKappaStatisticImageToImageMetric<TFixedImage, TMovingImage>::AfterThread
   }
   else // multi-threaded
   {
-    MultiThreaderAccumulateDerivativeType * temp = new MultiThreaderAccumulateDerivativeType;
+    MultiThreaderAccumulateDerivativeType temp;
 
-    temp->st_Metric = const_cast<Self *>(this);
-    temp->st_Coefficient1 = tmp1;
-    temp->st_Coefficient2 = tmp2;
-    temp->st_DerivativePointer = derivative.begin();
+    temp.st_Metric = const_cast<Self *>(this);
+    temp.st_Coefficient1 = tmp1;
+    temp.st_Coefficient2 = tmp2;
+    temp.st_DerivativePointer = derivative.begin();
 
-    this->m_Threader->SetSingleMethod(AccumulateDerivativesThreaderCallback, temp);
+    this->m_Threader->SetSingleMethod(AccumulateDerivativesThreaderCallback, &temp);
     this->m_Threader->SingleMethodExecute();
-
-    delete temp;
   }
 
 } // end AfterThreadedGetValueAndDerivative()

--- a/Components/Metrics/AdvancedNormalizedCorrelation/itkAdvancedNormalizedCorrelationImageToImageMetric.hxx
+++ b/Components/Metrics/AdvancedNormalizedCorrelation/itkAdvancedNormalizedCorrelationImageToImageMetric.hxx
@@ -723,19 +723,17 @@ AdvancedNormalizedCorrelationImageToImageMetric<TFixedImage, TMovingImage>::Afte
   }
   else if (true) // force !this->m_UseOpenMP ) // multi-threaded using ITK threads
   {
-    MultiThreaderAccumulateDerivativeType * temp = new MultiThreaderAccumulateDerivativeType;
+    MultiThreaderAccumulateDerivativeType temp;
 
-    temp->st_Metric = const_cast<Self *>(this);
-    temp->st_sf_N = sf / N;
-    temp->st_sm_N = sm / N;
-    temp->st_sfm_smm = sfm / smm;
-    temp->st_InvertedDenominator = 1.0 / denom;
-    temp->st_DerivativePointer = derivative.begin();
+    temp.st_Metric = const_cast<Self *>(this);
+    temp.st_sf_N = sf / N;
+    temp.st_sm_N = sm / N;
+    temp.st_sfm_smm = sfm / smm;
+    temp.st_InvertedDenominator = 1.0 / denom;
+    temp.st_DerivativePointer = derivative.begin();
 
-    this->m_Threader->SetSingleMethod(AccumulateDerivativesThreaderCallback, temp);
+    this->m_Threader->SetSingleMethod(AccumulateDerivativesThreaderCallback, &temp);
     this->m_Threader->SingleMethodExecute();
-
-    delete temp;
   }
 #ifdef ELASTIX_USE_OPENMP
   // compute multi-threadedly with openmp

--- a/Components/Optimizers/AdaptiveStochasticVarianceReducedGradient/itkStochasticVarianceReducedGradientDescentOptimizer.cxx
+++ b/Components/Optimizers/AdaptiveStochasticVarianceReducedGradient/itkStochasticVarianceReducedGradientDescentOptimizer.cxx
@@ -281,17 +281,15 @@ StochasticVarianceReducedGradientDescentOptimizer::AdvanceOneStep()
   else
   {
     /** Fill the threader parameter struct with information. */
-    MultiThreaderParameterType * temp = new MultiThreaderParameterType;
-    temp->t_NewPosition = &newPosition;
-    temp->t_Optimizer = this;
+    MultiThreaderParameterType temp;
+    temp.t_NewPosition = &newPosition;
+    temp.t_Optimizer = this;
 
     /** Call multi-threaded AdvanceOneStep(). */
     auto local_threader = ThreaderType::New();
     local_threader->SetNumberOfWorkUnits(this->m_Threader->GetNumberOfWorkUnits());
-    local_threader->SetSingleMethod(AdvanceOneStepThreaderCallback, temp);
+    local_threader->SetSingleMethod(AdvanceOneStepThreaderCallback, &temp);
     local_threader->SingleMethodExecute();
-
-    delete temp;
   }
 
   this->InvokeEvent(IterationEvent());


### PR DESCRIPTION
Following C++ Core Guidelines, April 13, 2023, "Prefer scoped objects, don’t heap-allocate unnecessarily", https://isocpp.github.io/CppCoreGuidelines/CppCoreGuidelines#r5-prefer-scoped-objects-dont-heap-allocate-unnecessarily