### PR TITLE
PERF: DisplacementDistribution, ImageMomentsCalculator use thread pools

### DIFF
--- a/Common/Transforms/itkAdvancedImageMomentsCalculator.h
+++ b/Common/Transforms/itkAdvancedImageMomentsCalculator.h
@@ -30,7 +30,7 @@
 #include <vnl/vnl_matrix_fixed.h>
 #include <vnl/vnl_diag_matrix.h>
 
-#include "itkPlatformMultiThreader.h"
+#include "itkMultiThreaderBase.h"
 
 #include <vector>
 
@@ -257,7 +257,7 @@ protected:
   PrintSelf(std::ostream & os, Indent indent) const override;
 
   /** Typedefs for multi-threading. */
-  using ThreaderType = itk::PlatformMultiThreader;
+  using ThreaderType = itk::MultiThreaderBase;
   using ThreadInfoType = ThreaderType::WorkUnitInfo;
 
   /** Launch MultiThread Compute. */

--- a/Common/itkComputeDisplacementDistribution.h
+++ b/Common/itkComputeDisplacementDistribution.h
@@ -24,7 +24,7 @@
 #include "itkImageRandomSamplerBase.h"
 #include "itkImageRandomCoordinateSampler.h"
 #include "itkImageFullSampler.h"
-#include "itkPlatformMultiThreader.h"
+#include "itkMultiThreaderBase.h"
 
 #include <vector>
 
@@ -139,7 +139,7 @@ protected:
   ~ComputeDisplacementDistribution() override = default;
 
   /** Typedefs for multi-threading. */
-  using ThreaderType = itk::PlatformMultiThreader;
+  using ThreaderType = itk::MultiThreaderBase;
   using ThreadInfoType = ThreaderType::WorkUnitInfo;
 
   typename FixedImageType::ConstPointer   m_FixedImage{};


### PR DESCRIPTION
Allowed `ComputeDisplacementDistribution` and `AdvancedImageMomentsCalculator` to internally use ITK's `PoolMultiThreader`, by using ITK's `MultiThreaderBase`, rather than `PlatformMultiThreader`. (By default, `MultiThreaderBase::New()` creates a `PoolMultiThreader`.)

Part of issue https://github.com/SuperElastix/elastix/issues/460 "Thread pools"