### PR TITLE
Replace `resize(0)` with `clear()`, do not `clear()` data members in default-constructors

### DIFF
--- a/Common/ImageSamplers/itkImageRandomCoordinateSampler.hxx
+++ b/Common/ImageSamplers/itkImageRandomCoordinateSampler.hxx
@@ -149,7 +149,7 @@ ImageRandomCoordinateSampler<TInputImage>::BeforeThreadedGenerateData()
   interpolator->SetInputImage(this->GetInput()); // only once per resolution?
 
   /** Clear the random number list. */
-  this->m_RandomNumberList.resize(0);
+  this->m_RandomNumberList.clear();
   this->m_RandomNumberList.reserve(this->m_NumberOfSamples * InputImageDimension);
 
   /** Convert inputImageRegion to bounding box in physical space. */

--- a/Common/ImageSamplers/itkImageRandomSamplerBase.hxx
+++ b/Common/ImageSamplers/itkImageRandomSamplerBase.hxx
@@ -52,7 +52,7 @@ ImageRandomSamplerBase<TInputImage>::BeforeThreadedGenerateData()
   // \todo: should probably be global?
 
   /** Clear the random number list. */
-  this->m_RandomNumberList.resize(0);
+  this->m_RandomNumberList.clear();
   this->m_RandomNumberList.reserve(this->m_NumberOfSamples);
 
   /** Fill the list with random numbers. */

--- a/Common/ImageSamplers/itkImageRandomSamplerSparseMask.hxx
+++ b/Common/ImageSamplers/itkImageRandomSamplerSparseMask.hxx
@@ -107,7 +107,7 @@ void
 ImageRandomSamplerSparseMask<TInputImage>::BeforeThreadedGenerateData()
 {
   /** Clear the random number list. */
-  this->m_RandomNumberList.resize(0);
+  this->m_RandomNumberList.clear();
   this->m_RandomNumberList.reserve(this->m_NumberOfSamples);
 
   /** Get a handle to the full sampler output size. */

--- a/Common/Transforms/itkGridScheduleComputer.hxx
+++ b/Common/Transforms/itkGridScheduleComputer.hxx
@@ -37,11 +37,6 @@ GridScheduleComputer<TTransformScalarType, VImageDimension>::GridScheduleCompute
 {
   this->m_BSplineOrder = 3;
   this->m_InitialTransform = nullptr;
-  this->m_GridSpacings.clear();
-  this->m_GridOrigins.clear();
-  this->m_GridDirections.clear();
-  this->m_GridRegions.clear();
-  this->m_GridSpacingFactors.clear();
   this->m_UpsamplingFactor = 2.0;
 
   this->m_ImageOrigin.Fill(0.0);

--- a/Components/Metrics/KNNGraphAlphaMutualInformation/itkKNNGraphAlphaMutualInformationImageToImageMetric.hxx
+++ b/Components/Metrics/KNNGraphAlphaMutualInformation/itkKNNGraphAlphaMutualInformationImageToImageMetric.hxx
@@ -741,9 +741,9 @@ KNNGraphAlphaMutualInformationImageToImageMetric<TFixedImage, TMovingImage>::
 {
   /** Initialize. */
   this->m_NumberOfPixelsCounted = 0;
-  jacobianContainer.resize(0);
-  jacobianIndicesContainer.resize(0);
-  spatialDerivativesContainer.resize(0);
+  jacobianContainer.clear();
+  jacobianIndicesContainer.clear();
+  spatialDerivativesContainer.clear();
 
   /** Get a handle to the sample container. */
   ImageSampleContainerPointer sampleContainer = this->GetImageSampler()->GetOutput();

--- a/Components/Transforms/MultiBSplineTransformWithNormal/itkMultiBSplineDeformableTransformWithNormal.hxx
+++ b/Components/Transforms/MultiBSplineTransformWithNormal/itkMultiBSplineDeformableTransformWithNormal.hxx
@@ -47,7 +47,6 @@ MultiBSplineDeformableTransformWithNormal<TScalarType, NDimensions, VSplineOrder
   this->m_Trans.resize(1);
   // keep transform 0 to store parameters that are not kept here (GridSize, ...)
   this->m_Trans[0] = TransformType::New();
-  this->m_Para.clear();
   this->m_LastJacobian = -1;
   this->m_LocalBases = ImageBaseType::New();
 

--- a/Components/Transforms/MultiBSplineTransformWithNormal/itkMultiBSplineDeformableTransformWithNormal.hxx
+++ b/Components/Transforms/MultiBSplineTransformWithNormal/itkMultiBSplineDeformableTransformWithNormal.hxx
@@ -47,7 +47,7 @@ MultiBSplineDeformableTransformWithNormal<TScalarType, NDimensions, VSplineOrder
   this->m_Trans.resize(1);
   // keep transform 0 to store parameters that are not kept here (GridSize, ...)
   this->m_Trans[0] = TransformType::New();
-  this->m_Para.resize(0);
+  this->m_Para.clear();
   this->m_LastJacobian = -1;
   this->m_LocalBases = ImageBaseType::New();
 
@@ -694,7 +694,7 @@ MultiBSplineDeformableTransformWithNormal<TScalarType, NDimensions, VSplineOrder
   if (this->GetNumberOfParameters() == 0)
   {
     jacobian.SetSize(SpaceDimension, 0);
-    nonZeroJacobianIndices.resize(0);
+    nonZeroJacobianIndices.clear();
     return;
   }
 
@@ -889,8 +889,8 @@ MultiBSplineDeformableTransformWithNormal<TScalarType, NDimensions, VSplineOrder
 {
   if (this->GetNumberOfParameters() == 0)
   {
-    jsj.resize(0);
-    nonZeroJacobianIndices.resize(0);
+    jsj.clear();
+    nonZeroJacobianIndices.clear();
     return;
   }
 
@@ -987,8 +987,8 @@ MultiBSplineDeformableTransformWithNormal<TScalarType, NDimensions, VSplineOrder
 {
   if (this->GetNumberOfParameters() == 0)
   {
-    jsh.resize(0);
-    nonZeroJacobianIndices.resize(0);
+    jsh.clear();
+    nonZeroJacobianIndices.clear();
     return;
   }
 


### PR DESCRIPTION
`clear()` appears slightly clearer.