### PR TITLE
Speed up `ImageFullSampler`, `ImageGridSampler`, and `ImageRandomSamplerSparseMask`, using a local `sampleVector` variable

### DIFF
--- a/Common/ImageSamplers/itkImageFullSampler.hxx
+++ b/Common/ImageSamplers/itkImageFullSampler.hxx
@@ -76,9 +76,10 @@ ImageFullSampler<TInputImage>::GenerateData()
     }
 
     /** Simply loop over the image and store all samples in the container. */
-    ImageSampleType tempSample;
     for (InputImageIterator iter(inputImage, croppedInputImageRegion); !iter.IsAtEnd(); ++iter)
     {
+      ImageSampleType tempSample;
+
       /** Get sampled index */
       InputImageIndexType index = iter.GetIndex();
 
@@ -98,9 +99,10 @@ ImageFullSampler<TInputImage>::GenerateData()
     mask->UpdateSource();
 
     /** Loop over the image and check if the points falls within the mask. */
-    ImageSampleType tempSample;
     for (InputImageIterator iter(inputImage, croppedInputImageRegion); !iter.IsAtEnd(); ++iter)
     {
+      ImageSampleType tempSample;
+
       /** Get sampled index. */
       InputImageIndexType index = iter.GetIndex();
 
@@ -166,9 +168,10 @@ ImageFullSampler<TInputImage>::ThreadedGenerateData(const InputImageRegionType &
     }
 
     /** Simply loop over the image and store all samples in the container. */
-    ImageSampleType tempSample;
     for (InputImageIterator iter(inputImage, inputRegionForThread); !iter.IsAtEnd(); ++iter)
     {
+      ImageSampleType tempSample;
+
       /** Get sampled index */
       InputImageIndexType index = iter.GetIndex();
 
@@ -188,9 +191,10 @@ ImageFullSampler<TInputImage>::ThreadedGenerateData(const InputImageRegionType &
     mask->UpdateSource();
 
     /** Loop over the image and check if the points falls within the mask. */
-    ImageSampleType tempSample;
     for (InputImageIterator iter(inputImage, inputRegionForThread); !iter.IsAtEnd(); ++iter)
     {
+      ImageSampleType tempSample;
+
       /** Get sampled index. */
       InputImageIndexType index = iter.GetIndex();
 

--- a/Common/ImageSamplers/itkImageFullSampler.hxx
+++ b/Common/ImageSamplers/itkImageFullSampler.hxx
@@ -48,9 +48,11 @@ ImageFullSampler<TInputImage>::GenerateData()
   /** Clear the container. */
   sampleContainer->Initialize();
 
+  const auto croppedInputImageRegion = this->GetCroppedInputImageRegion();
+
   /** Set up a region iterator within the user specified image region. */
   using InputImageIterator = ImageRegionConstIteratorWithIndex<InputImageType>;
-  InputImageIterator iter(inputImage, this->GetCroppedInputImageRegion());
+  InputImageIterator iter(inputImage, croppedInputImageRegion);
 
   /** Fill the sample container. */
   if (mask.IsNull())
@@ -60,7 +62,7 @@ ImageFullSampler<TInputImage>::GenerateData()
      */
     try
     {
-      sampleContainer->Reserve(this->GetCroppedInputImageRegion().GetNumberOfPixels());
+      sampleContainer->Reserve(croppedInputImageRegion.GetNumberOfPixels());
     }
     catch (const std::exception & excp)
     {

--- a/Common/ImageSamplers/itkImageFullSampler.hxx
+++ b/Common/ImageSamplers/itkImageFullSampler.hxx
@@ -46,7 +46,7 @@ ImageFullSampler<TInputImage>::GenerateData()
   typename MaskType::ConstPointer            mask = this->GetMask();
 
   /** Clear the container. */
-  sampleContainer->Initialize();
+  sampleContainer->clear();
 
   const auto croppedInputImageRegion = this->GetCroppedInputImageRegion();
 
@@ -61,7 +61,7 @@ ImageFullSampler<TInputImage>::GenerateData()
      */
     try
     {
-      sampleContainer->Reserve(croppedInputImageRegion.GetNumberOfPixels());
+      sampleContainer->reserve(croppedInputImageRegion.GetNumberOfPixels());
     }
     catch (const std::exception & excp)
     {
@@ -77,8 +77,7 @@ ImageFullSampler<TInputImage>::GenerateData()
 
     /** Simply loop over the image and store all samples in the container. */
     ImageSampleType tempSample;
-    unsigned long   ind = 0;
-    for (InputImageIterator iter(inputImage, croppedInputImageRegion); !iter.IsAtEnd(); ++iter, ++ind)
+    for (InputImageIterator iter(inputImage, croppedInputImageRegion); !iter.IsAtEnd(); ++iter)
     {
       /** Get sampled index */
       InputImageIndexType index = iter.GetIndex();
@@ -90,7 +89,7 @@ ImageFullSampler<TInputImage>::GenerateData()
       tempSample.m_ImageValue = iter.Get();
 
       /** Store in container */
-      sampleContainer->SetElement(ind, tempSample);
+      sampleContainer->push_back(tempSample);
 
     } // end for
   }   // end if no mask
@@ -151,7 +150,8 @@ ImageFullSampler<TInputImage>::ThreadedGenerateData(const InputImageRegionType &
      */
     try
     {
-      sampleContainerThisThread->Reserve(chunkSize);
+      sampleContainerThisThread->clear();
+      sampleContainerThisThread->reserve(chunkSize);
     }
     catch (const std::exception & excp)
     {
@@ -167,8 +167,7 @@ ImageFullSampler<TInputImage>::ThreadedGenerateData(const InputImageRegionType &
 
     /** Simply loop over the image and store all samples in the container. */
     ImageSampleType tempSample;
-    unsigned long   ind = 0;
-    for (InputImageIterator iter(inputImage, inputRegionForThread); !iter.IsAtEnd(); ++iter, ++ind)
+    for (InputImageIterator iter(inputImage, inputRegionForThread); !iter.IsAtEnd(); ++iter)
     {
       /** Get sampled index */
       InputImageIndexType index = iter.GetIndex();
@@ -180,7 +179,7 @@ ImageFullSampler<TInputImage>::ThreadedGenerateData(const InputImageRegionType &
       tempSample.m_ImageValue = iter.Get();
 
       /** Store in container. */
-      sampleContainerThisThread->SetElement(ind, tempSample);
+      sampleContainerThisThread->push_back(tempSample);
 
     } // end for
   }   // end if no mask

--- a/Common/ImageSamplers/itkImageFullSampler.hxx
+++ b/Common/ImageSamplers/itkImageFullSampler.hxx
@@ -52,7 +52,6 @@ ImageFullSampler<TInputImage>::GenerateData()
 
   /** Set up a region iterator within the user specified image region. */
   using InputImageIterator = ImageRegionConstIteratorWithIndex<InputImageType>;
-  InputImageIterator iter(inputImage, croppedInputImageRegion);
 
   /** Fill the sample container. */
   if (mask.IsNull())
@@ -79,7 +78,7 @@ ImageFullSampler<TInputImage>::GenerateData()
     /** Simply loop over the image and store all samples in the container. */
     ImageSampleType tempSample;
     unsigned long   ind = 0;
-    for (iter.GoToBegin(); !iter.IsAtEnd(); ++iter, ++ind)
+    for (InputImageIterator iter(inputImage, croppedInputImageRegion); !iter.IsAtEnd(); ++iter, ++ind)
     {
       /** Get sampled index */
       InputImageIndexType index = iter.GetIndex();
@@ -101,7 +100,7 @@ ImageFullSampler<TInputImage>::GenerateData()
 
     /** Loop over the image and check if the points falls within the mask. */
     ImageSampleType tempSample;
-    for (iter.GoToBegin(); !iter.IsAtEnd(); ++iter)
+    for (InputImageIterator iter(inputImage, croppedInputImageRegion); !iter.IsAtEnd(); ++iter)
     {
       /** Get sampled index. */
       InputImageIndexType index = iter.GetIndex();
@@ -142,7 +141,6 @@ ImageFullSampler<TInputImage>::ThreadedGenerateData(const InputImageRegionType &
   /** Set up a region iterator within the user specified image region. */
   using InputImageIterator = ImageRegionConstIteratorWithIndex<InputImageType>;
   // InputImageIterator iter( inputImage, this->GetCroppedInputImageRegion() );
-  InputImageIterator iter(inputImage, inputRegionForThread);
 
   /** Fill the sample container. */
   const unsigned long chunkSize = inputRegionForThread.GetNumberOfPixels();
@@ -170,7 +168,7 @@ ImageFullSampler<TInputImage>::ThreadedGenerateData(const InputImageRegionType &
     /** Simply loop over the image and store all samples in the container. */
     ImageSampleType tempSample;
     unsigned long   ind = 0;
-    for (iter.GoToBegin(); !iter.IsAtEnd(); ++iter, ++ind)
+    for (InputImageIterator iter(inputImage, inputRegionForThread); !iter.IsAtEnd(); ++iter, ++ind)
     {
       /** Get sampled index */
       InputImageIndexType index = iter.GetIndex();
@@ -192,7 +190,7 @@ ImageFullSampler<TInputImage>::ThreadedGenerateData(const InputImageRegionType &
 
     /** Loop over the image and check if the points falls within the mask. */
     ImageSampleType tempSample;
-    for (iter.GoToBegin(); !iter.IsAtEnd(); ++iter)
+    for (InputImageIterator iter(inputImage, inputRegionForThread); !iter.IsAtEnd(); ++iter)
     {
       /** Get sampled index. */
       InputImageIndexType index = iter.GetIndex();

--- a/Common/ImageSamplers/itkImageGridSampler.hxx
+++ b/Common/ImageSamplers/itkImageGridSampler.hxx
@@ -58,10 +58,6 @@ ImageGridSampler<TInputImage>::GenerateData()
   /** Clear the container. */
   sampleContainer->Initialize();
 
-  /** Set up a region iterator within the user specified image region. */
-  using InputImageIterator = ImageRegionConstIteratorWithIndex<InputImageType>;
-  InputImageIterator iter(inputImage, this->GetCroppedInputImageRegion());
-
   /** Take into account the possibility of a smaller bounding box around the mask */
   this->SetNumberOfSamples(this->m_RequestedNumberOfSamples);
 

--- a/Common/ImageSamplers/itkImageGridSampler.hxx
+++ b/Common/ImageSamplers/itkImageGridSampler.hxx
@@ -108,19 +108,19 @@ ImageGridSampler<TInputImage>::GenerateData()
         {
           for (unsigned int x = 0; x < sampleGridSize[0]; ++x)
           {
-            ImageSampleType tempsample;
+            ImageSampleType tempSample;
 
             // Get sampled fixed image value.
-            tempsample.m_ImageValue = inputImage->GetPixel(index);
+            tempSample.m_ImageValue = inputImage->GetPixel(index);
 
             // Translate index to point.
-            inputImage->TransformIndexToPhysicalPoint(index, tempsample.m_ImageCoordinates);
+            inputImage->TransformIndexToPhysicalPoint(index, tempSample.m_ImageCoordinates);
 
             // Jump to next position on grid.
             index[0] += this->m_SampleGridSpacing[0];
 
             // Store sample in container.
-            sampleContainer->push_back(tempsample);
+            sampleContainer->push_back(tempSample);
 
           } // end x
           index[0] = sampleGridIndex[0];
@@ -154,18 +154,18 @@ ImageGridSampler<TInputImage>::GenerateData()
         {
           for (unsigned int x = 0; x < sampleGridSize[0]; ++x)
           {
-            ImageSampleType tempsample;
+            ImageSampleType tempSample;
 
             // Translate index to point.
-            inputImage->TransformIndexToPhysicalPoint(index, tempsample.m_ImageCoordinates);
+            inputImage->TransformIndexToPhysicalPoint(index, tempSample.m_ImageCoordinates);
 
-            if (mask->IsInsideInWorldSpace(tempsample.m_ImageCoordinates))
+            if (mask->IsInsideInWorldSpace(tempSample.m_ImageCoordinates))
             {
               // Get sampled fixed image value.
-              tempsample.m_ImageValue = inputImage->GetPixel(index);
+              tempSample.m_ImageValue = inputImage->GetPixel(index);
 
               // Store sample in container.
-              sampleContainer->push_back(tempsample);
+              sampleContainer->push_back(tempSample);
 
             } // end if in mask
               // Jump to next position on grid

--- a/Common/ImageSamplers/itkImageGridSampler.hxx
+++ b/Common/ImageSamplers/itkImageGridSampler.hxx
@@ -61,11 +61,13 @@ ImageGridSampler<TInputImage>::GenerateData()
   /** Take into account the possibility of a smaller bounding box around the mask */
   this->SetNumberOfSamples(this->m_RequestedNumberOfSamples);
 
+  const auto croppedInputImageRegion = this->GetCroppedInputImageRegion();
+
   /** Determine the grid. */
   SampleGridIndexType        index;
   SampleGridSizeType         sampleGridSize;
-  SampleGridIndexType        sampleGridIndex = this->GetCroppedInputImageRegion().GetIndex();
-  const InputImageSizeType & inputImageSize = this->GetCroppedInputImageRegion().GetSize();
+  SampleGridIndexType        sampleGridIndex = croppedInputImageRegion.GetIndex();
+  const InputImageSizeType & inputImageSize = croppedInputImageRegion.GetSize();
   unsigned long              numberOfSamplesOnGrid = 1;
   for (unsigned int dim = 0; dim < InputImageDimension; ++dim)
   {

--- a/Common/ImageSamplers/itkImageGridSampler.hxx
+++ b/Common/ImageSamplers/itkImageGridSampler.hxx
@@ -55,8 +55,10 @@ ImageGridSampler<TInputImage>::GenerateData()
   typename ImageSampleContainerType::Pointer sampleContainer = this->GetOutput();
   typename MaskType::ConstPointer            mask = this->GetMask();
 
-  /** Clear the container. */
-  sampleContainer->Initialize();
+  // Take capacity from the output container, and clear it.
+  std::vector<ImageSampleType> sampleVector;
+  sampleContainer->swap(sampleVector);
+  sampleVector.clear();
 
   /** Take into account the possibility of a smaller bounding box around the mask */
   this->SetNumberOfSamples(this->m_RequestedNumberOfSamples);
@@ -120,7 +122,7 @@ ImageGridSampler<TInputImage>::GenerateData()
             index[0] += this->m_SampleGridSpacing[0];
 
             // Store sample in container.
-            sampleContainer->push_back(tempSample);
+            sampleVector.push_back(tempSample);
 
           } // end x
           index[0] = sampleGridIndex[0];
@@ -165,7 +167,7 @@ ImageGridSampler<TInputImage>::GenerateData()
               tempSample.m_ImageValue = inputImage->GetPixel(index);
 
               // Store sample in container.
-              sampleContainer->push_back(tempSample);
+              sampleVector.push_back(tempSample);
 
             } // end if in mask
               // Jump to next position on grid
@@ -189,6 +191,9 @@ ImageGridSampler<TInputImage>::GenerateData()
       }
     } // end t
   }   // else (if mask exists)
+
+  // Move the samples from the vector into the output container.
+  sampleContainer->swap(sampleVector);
 
 } // end GenerateData()
 

--- a/Common/ImageSamplers/itkImageRandomCoordinateSampler.hxx
+++ b/Common/ImageSamplers/itkImageRandomCoordinateSampler.hxx
@@ -48,11 +48,13 @@ ImageRandomCoordinateSampler<TInputImage>::GenerateData()
   /** Set up the interpolator. */
   interpolator->SetInputImage(inputImage); // only once?
 
+  const auto croppedInputImageRegion = this->GetCroppedInputImageRegion();
+
   /** Convert inputImageRegion to bounding box in physical space. */
   InputImageSizeType unitSize;
   unitSize.Fill(1);
-  InputImageIndexType           smallestIndex = this->GetCroppedInputImageRegion().GetIndex();
-  InputImageIndexType           largestIndex = smallestIndex + this->GetCroppedInputImageRegion().GetSize() - unitSize;
+  InputImageIndexType           smallestIndex = croppedInputImageRegion.GetIndex();
+  InputImageIndexType           largestIndex = smallestIndex + croppedInputImageRegion.GetSize() - unitSize;
   InputImageContinuousIndexType smallestImageContIndex(smallestIndex);
   InputImageContinuousIndexType largestImageContIndex(largestIndex);
   InputImageContinuousIndexType smallestContIndex;
@@ -152,11 +154,13 @@ ImageRandomCoordinateSampler<TInputImage>::BeforeThreadedGenerateData()
   this->m_RandomNumberList.clear();
   this->m_RandomNumberList.reserve(this->m_NumberOfSamples * InputImageDimension);
 
+  const auto croppedInputImageRegion = this->GetCroppedInputImageRegion();
+
   /** Convert inputImageRegion to bounding box in physical space. */
   InputImageSizeType unitSize;
   unitSize.Fill(1);
-  InputImageIndexType           smallestIndex = this->GetCroppedInputImageRegion().GetIndex();
-  InputImageIndexType           largestIndex = smallestIndex + this->GetCroppedInputImageRegion().GetSize() - unitSize;
+  InputImageIndexType           smallestIndex = croppedInputImageRegion.GetIndex();
+  InputImageIndexType           largestIndex = smallestIndex + croppedInputImageRegion.GetSize() - unitSize;
   InputImageContinuousIndexType smallestImageCIndex(smallestIndex);
   InputImageContinuousIndexType largestImageCIndex(largestIndex);
   InputImageContinuousIndexType smallestCIndex, largestCIndex, randomCIndex;

--- a/Common/ImageSamplers/itkImageRandomSamplerSparseMask.hxx
+++ b/Common/ImageSamplers/itkImageRandomSamplerSparseMask.hxx
@@ -44,8 +44,10 @@ ImageRandomSamplerSparseMask<TInputImage>::GenerateData()
   InputImageConstPointer      inputImage = this->GetInput();
   ImageSampleContainerPointer sampleContainer = this->GetOutput();
 
-  /** Clear the container. */
-  sampleContainer->Initialize();
+  // Take capacity from the output container, and clear it.
+  std::vector<ImageSampleType> sampleVector;
+  sampleContainer->swap(sampleVector);
+  sampleVector.clear();
 
   /** Make sure the internal full sampler is up-to-date. */
   this->m_InternalFullSampler->SetInput(inputImage);
@@ -92,8 +94,11 @@ ImageRandomSamplerSparseMask<TInputImage>::GenerateData()
   for (unsigned int i = 0; i < this->GetNumberOfSamples(); ++i)
   {
     unsigned long randomIndex = this->m_RandomGenerator->GetIntegerVariate(numberOfValidSamples - 1);
-    sampleContainer->push_back(allValidSamples->ElementAt(randomIndex));
+    sampleVector.push_back(allValidSamples->ElementAt(randomIndex));
   }
+
+  // Move the samples from the vector into the output container.
+  sampleContainer->swap(sampleVector);
 
 } // end GenerateData()
 

--- a/Common/ImageSamplers/itkImageSample.h
+++ b/Common/ImageSamplers/itkImageSample.h
@@ -28,16 +28,13 @@ namespace itk
  * \brief A class that defines an image sample, which is
  * the coordinates of a point and its value.
  *
+ * Its constructors, assignment operators, and destructor are implicitly defaulted, following the C++ "Rule of Zero".
  */
 
 template <class TImage>
 class ITK_TEMPLATE_EXPORT ImageSample
 {
 public:
-  // ImageSample():m_ImageValue(0.0){};
-  ImageSample() = default;
-  ~ImageSample() = default;
-
   /** Typedef's. */
   using ImageType = TImage;
   using PointType = typename ImageType::PointType;


### PR DESCRIPTION
Did speed up `ImageFullSampler`, `ImageGridSampler`, and `ImageRandomSamplerSparseMask` by doing the `push_back`'s of samples to a local `std::vector` of samples (instead of directly to the sample container), and then eventually swapping the vector "into" the sample container.

When using `ImageFullSampler` on a 4096 x 4096 input image, a `sampler.Update()` call originally took more than 0.38 seconds, but it went down to almost 0.20 seconds with this commit, as observed using Visual C++ 2019 (Release configuration).

This pull request also includes various coding style improvements of the implementation of the samplers.