### PR TITLE
COMP: Replace include <itkTransformFileWriter.h> with "elxTransformIO.h"

### DIFF
--- a/Common/Transforms/elxTransformIO.cxx
+++ b/Common/Transforms/elxTransformIO.cxx
@@ -189,7 +189,7 @@ elastix::TransformIO::ConvertItkTransformBaseToSingleItkTransform(const itk::Tra
 
 
 void
-elastix::TransformIO::Write(const itk::TransformBase & itkTransform, const std::string & fileName)
+elastix::TransformIO::Write(const itk::Object & itkTransform, const std::string & fileName)
 {
   try
   {

--- a/Common/Transforms/elxTransformIO.h
+++ b/Common/Transforms/elxTransformIO.h
@@ -137,8 +137,12 @@ public:
   }
 
 
+  /// Writes the specified transform to file.
+  /// \note The transform parameter type is a reference to `itk::Object`, rather than `itk::TransformBase`, to support
+  /// the use case of `ElastixRegistrationMethod::GenerateData()`, which uses an `itk::Object` pointer to an external
+  /// transform.
   static void
-  Write(const itk::TransformBase & itkTransform, const std::string & fileName);
+  Write(const itk::Object & itkTransform, const std::string & fileName);
 
   static itk::TransformBase::Pointer
   Read(const std::string & fileName);

--- a/Core/Main/itkElastixRegistrationMethod.hxx
+++ b/Core/Main/itkElastixRegistrationMethod.hxx
@@ -38,9 +38,9 @@
 #include "elxPixelTypeToString.h"
 #include "itkElastixRegistrationMethod.h"
 
+#include "elxDeref.h"
 #include "elxLibUtilities.h"
-
-#include <itkTransformFileWriter.h>
+#include "elxTransformIO.h"
 
 #include <algorithm> // For find.
 #include <memory>    // For unique_ptr.
@@ -269,10 +269,7 @@ ElastixRegistrationMethod<TFixedImage, TMovingImage>::GenerateData()
           const auto transformFileName = "InitialTransform." + std::to_string(i) + '.' + outputFileNameExtension;
 
           // Write the external transform to file.
-          const auto writer = itk::TransformFileWriter::New();
-          writer->SetInput(externalTransform);
-          writer->SetFileName(m_OutputDirectory + transformFileName);
-          writer->Update();
+          elx::TransformIO::Write(elx::Deref(externalTransform), m_OutputDirectory + transformFileName);
 
           // Store the name of the written transform file.
           transformFound->second = { "File" };


### PR DESCRIPTION
Aims to avoid an ITKElastix compile error reported by Dženan Zukić (@dzenanz), saying:

> _deps/elx-src/Core/Main/itkElastixRegistrationMethod.hxx:43:10: fatal error: 'itkTransformFileWriter.h' file not found