### PR TITLE
BUG: Fix ElastixRegistrationMethod GetNumberOfTransforms GetNthTransform

### DIFF
--- a/Core/Main/GTesting/itkElastixRegistrationMethodGTest.cxx
+++ b/Core/Main/GTesting/itkElastixRegistrationMethodGTest.cxx
@@ -2306,6 +2306,9 @@ GTEST_TEST(itkElastixRegistrationMethod, CheckMinimumMovingImageUsingAnyInternal
       registration.Update();
 
       EXPECT_EQ(DerefRawPointer(registration.GetOutput()), DerefSmartPointer(movingImage));
+      EXPECT_EQ(registration.GetNumberOfTransforms(), 1);
+      EXPECT_NE(registration.GetNthTransform(0), nullptr);
+      EXPECT_NE(registration.GetCombinationTransform(), nullptr);
     });
   };
 

--- a/Core/Main/itkElastixRegistrationMethod.h
+++ b/Core/Main/itkElastixRegistrationMethod.h
@@ -36,10 +36,12 @@
 #define itkElastixRegistrationMethod_h
 
 #include "itkImageSource.h"
+#include "itkAdvancedCombinationTransform.h"
 #include "itkElastixLogLevel.h"
 
 #include "elxElastixMain.h"
 #include "elxElastixTemplate.h"
+#include "elxElastixBase.h"
 #include "elxTransformBase.h"
 #include "elxParameterObject.h"
 
@@ -373,7 +375,11 @@ private:
   /** Private using-declaration, just to avoid GCC compilation warnings: '...' was hidden [-Woverloaded-virtual] */
   using Superclass::SetInput;
 
-  using ElastixTransformBaseType = elx::TransformBase<elx::ElastixTemplate<TFixedImage, TMovingImage>>;
+  using AdvancedCombinationTransformType =
+    AdvancedCombinationTransform<elx::ElastixBase::CoordRepType, FixedImageDimension>;
+
+  AdvancedCombinationTransformType *
+  GetAdvancedCombinationTransform() const;
 
   SmartPointer<const elx::ElastixMain> m_ElastixMain{};
 

--- a/Core/Main/itkElastixRegistrationMethod.hxx
+++ b/Core/Main/itkElastixRegistrationMethod.hxx
@@ -979,17 +979,8 @@ template <typename TFixedImage, typename TMovingImage>
 unsigned int
 ElastixRegistrationMethod<TFixedImage, TMovingImage>::GetNumberOfTransforms() const
 {
-  const auto * const transformContainer = m_ElastixMain->GetElastixBase().GetTransformContainer();
-
-  if ((transformContainer == nullptr) || transformContainer->empty())
-  {
-    return 0;
-  }
-
-  const auto * const elxTransformBase =
-    dynamic_cast<ElastixTransformBaseType *>(transformContainer->front().GetPointer());
-
-  return (elxTransformBase == nullptr) ? 0 : elxTransformBase->GetAsITKBaseType()->GetNumberOfTransforms();
+  const auto advancedCombinationTransform = GetAdvancedCombinationTransform();
+  return advancedCombinationTransform ? advancedCombinationTransform->GetNumberOfTransforms() : 0;
 }
 
 
@@ -997,21 +988,30 @@ template <typename TFixedImage, typename TMovingImage>
 auto
 ElastixRegistrationMethod<TFixedImage, TMovingImage>::GetNthTransform(const unsigned int n) const -> TransformType *
 {
-  const auto * const transformContainer = m_ElastixMain->GetElastixBase().GetTransformContainer();
+  const auto advancedCombinationTransform = GetAdvancedCombinationTransform();
+  return advancedCombinationTransform ? advancedCombinationTransform->GetNthTransform(n) : nullptr;
+}
 
-  if ((transformContainer == nullptr) || transformContainer->empty())
+
+template <typename TFixedImage, typename TMovingImage>
+auto
+ElastixRegistrationMethod<TFixedImage, TMovingImage>::GetAdvancedCombinationTransform() const
+  -> AdvancedCombinationTransformType *
+{
   {
+    if (m_ElastixMain)
+    {
+      if (const auto transformContainer = m_ElastixMain->GetElastixBase().GetTransformContainer();
+          (transformContainer != nullptr) && !transformContainer->empty())
+      {
+        if (const auto firstTransform = transformContainer->front().GetPointer())
+        {
+          return static_cast<AdvancedCombinationTransformType *>(firstTransform);
+        }
+      }
+    }
     return nullptr;
   }
-
-  const auto * const elxTransformBase =
-    dynamic_cast<ElastixTransformBaseType *>(transformContainer->front().GetPointer());
-
-  if (elxTransformBase == nullptr)
-  {
-    return nullptr;
-  }
-  return elxTransformBase->GetAsITKBaseType()->GetNthTransform(n);
 }
 
 
@@ -1019,20 +1019,7 @@ template <typename TFixedImage, typename TMovingImage>
 auto
 ElastixRegistrationMethod<TFixedImage, TMovingImage>::GetCombinationTransform() const -> TransformType *
 {
-  const auto * const transformContainer = m_ElastixMain->GetElastixBase().GetTransformContainer();
-
-  if ((transformContainer == nullptr) || transformContainer->empty())
-  {
-    return nullptr;
-  }
-
-  auto * const elxTransformBase = dynamic_cast<ElastixTransformBaseType *>(transformContainer->front().GetPointer());
-
-  if (elxTransformBase == nullptr)
-  {
-    return nullptr;
-  }
-  return elxTransformBase->GetAsITKBaseType();
+  return GetAdvancedCombinationTransform();
 }
 
 


### PR DESCRIPTION
ElastixRegistrationMethod member functions `GetNumberOfTransforms`, `GetNthTransform`, and `GetCombinationTransform` did always just return zero or null, erroneously, when the pixel type of the input images (specified by `TFixedImage` and `TMovingImage`) would be different from the internal pixel type (specified by "FixedInternalImagePixelType" and "MovingInternalImagePixelType", `float` by default). The code incorrectly assumed that the objects stored in the ElastixBase `TransformContainer` are always of type `elx::TransformBase<ElastixTemplate<TFixedImage, TMovingImage>>`.

This commit just assumes that the objects stored in `TransformContainer` are of type `AdvancedCombinationTransform<double, FixedImageDimension>`.

The commit aims to fix issue https://github.com/SuperElastix/elastix/issues/965 "ElastixRegistrationMethod GetNumberOfTransforms, GetCombinationTransform, etc. does not work with non-float ImageType", reported by Matt McCormick (@thewtex).

Extended the GoogleTest `itkElastixRegistrationMethod.CheckMinimumMovingImageUsingAnyInternalPixelType` unit test to check this issue.

----

@mstaring @stefanklein This fix depends on the assumption that a transform from the ElastixBase `TransformContainer` is always a "combination transform". That's a correct assumption, right? `ElastixBase::m_TransformContainer` is declared as a generic `ObjectContainerPointer` (but it seems to me that it only contains combination transforms):

https://github.com/SuperElastix/elastix/blob/03bf07851c95f9e8a771ff9ba344feae8f1f5d6f/Core/Kernel/elxElastixBase.h#L505 