### PR TITLE
BUG: `ParameterObject::WriteParameterFiles` should write all maps

### DIFF
--- a/Common/GTesting/elxGTestUtilities.h
+++ b/Common/GTesting/elxGTestUtilities.h
@@ -18,6 +18,9 @@
 #ifndef elxGTestUtilities_h
 #define elxGTestUtilities_h
 
+#include <elxConfiguration.h>
+#include <elxElastixBase.h>
+
 #include <itkOptimizerParameters.h>
 #include <itkPoint.h>
 #include <itkSize.h>

--- a/Core/Main/GTesting/CMakeLists.txt
+++ b/Core/Main/GTesting/CMakeLists.txt
@@ -4,6 +4,7 @@ add_executable(ElastixLibGTest
   ElastixLibGTest.cxx
   itkElastixRegistrationMethodGTest.cxx
   itkTransformixFilterGTest.cxx
+  ParameterObjectGTest.cxx
 )
 
 target_compile_definitions(ElastixLibGTest PRIVATE

--- a/Core/Main/GTesting/ParameterObjectGTest.cxx
+++ b/Core/Main/GTesting/ParameterObjectGTest.cxx
@@ -1,0 +1,75 @@
+/*=========================================================================
+ *
+ *  Copyright UMC Utrecht and contributors
+ *
+ *  Licensed under the Apache License, Version 2.0 (the "License");
+ *  you may not use this file except in compliance with the License.
+ *  You may obtain a copy of the License at
+ *
+ *        http://www.apache.org/licenses/LICENSE-2.0.txt
+ *
+ *  Unless required by applicable law or agreed to in writing, software
+ *  distributed under the License is distributed on an "AS IS" BASIS,
+ *  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *  See the License for the specific language governing permissions and
+ *  limitations under the License.
+ *
+ *=========================================================================*/
+
+// First include the header file to be tested:
+#include "elxParameterObject.h"
+
+#include "GTesting/elxGTestUtilities.h"
+
+#include "elxCoreMainGTestUtilities.h"
+#include "elxDefaultConstruct.h"
+
+// ITK header file:
+#include <itkFileTools.h>
+#include <itksys/SystemTools.hxx>
+
+// GoogleTest header file:
+#include <gtest/gtest.h>
+
+#include <string>
+
+// Type aliases:
+using ParameterMapType = elx::ParameterObject::ParameterMapType;
+using ParameterMapVectorType = elx::ParameterObject::ParameterMapVectorType;
+using ParameterFileNameVectorType = elx::ParameterObject::ParameterFileNameVectorType;
+
+// Using-declarations:
+using elx::CoreMainGTestUtilities::GetCurrentBinaryDirectoryPath;
+using elx::CoreMainGTestUtilities::GetNameOfTest;
+
+// Tests that ParameterObject::WriteParameterFiles writes all the specified files.
+GTEST_TEST(ParameterObject, WriteParameterFiles)
+{
+  const std::string rootOutputDirectoryPath = GetCurrentBinaryDirectoryPath() + '/' + GetNameOfTest(*this);
+  itk::FileTools::CreateDirectory(rootOutputDirectoryPath);
+
+  elx::DefaultConstruct<elx::ParameterObject> parameterObject{};
+
+  for (const std::size_t numberOfMaps : { 0, 1, 2 })
+  {
+    const std::string outputDirectoryPath = rootOutputDirectoryPath + '/' + std::to_string(numberOfMaps);
+    itk::FileTools::CreateDirectory(outputDirectoryPath);
+
+    parameterObject.SetParameterMaps(ParameterMapVectorType(numberOfMaps));
+
+    ParameterFileNameVectorType fileNames{};
+
+    for (std::size_t i{}; i < numberOfMaps; ++i)
+    {
+      fileNames.push_back(outputDirectoryPath + '/' + "ParameterFile." + std::to_string(i) + ".txt");
+    }
+
+    parameterObject.WriteParameterFiles(fileNames);
+
+    // Check that each of the specified files is written to disk.
+    for (const auto & fileName : fileNames)
+    {
+      EXPECT_TRUE(itksys::SystemTools::FileExists(fileName.c_str(), true));
+    }
+  }
+}

--- a/Core/Main/elxParameterObject.cxx
+++ b/Core/Main/elxParameterObject.cxx
@@ -364,6 +364,11 @@ ParameterObject::WriteParameterFiles(const ParameterMapVectorType &      paramet
                              << parameterFileNameVector.size() << ").");
   }
 
+  if (!parameterMapVector.empty())
+  {
+    Self::WriteParameterFile(parameterMapVector.front(), parameterFileNameVector.front());
+  }
+
   // Add initial transform parameter file names. Do not touch the first one,
   // since it may have one already
   for (unsigned int i = 1; i < parameterMapVector.size(); ++i)


### PR DESCRIPTION
With this commit `ParameterObject::WriteParameterFiles` writes _each_ maps to a file, including the first one. Aims to address issue https://github.com/SuperElastix/elastix/issues/904 "ParameterObject::WriteParameterFiles does not write the first map!"

A GoogleTest unit test is added, testing that each of the files specified by the `parameterFileNameVector` parameter is indeed written to disk.