### PR TITLE
ENH: ImageRandomSampler `UseMultiThread` now using ITK's ThreadPool

### DIFF
--- a/Common/GTesting/itkImageRandomSamplerGTest.cxx
+++ b/Common/GTesting/itkImageRandomSamplerGTest.cxx
@@ -87,3 +87,25 @@ GTEST_TEST(ImageRandomSampler, SetSeedMakesRandomizationDeterministic)
     EXPECT_EQ(generateSamples(), generateSamples());
   }
 }
+
+
+GTEST_TEST(ImageRandomSampler, HasSameOutputWhenUsingMultiThread)
+{
+  using PixelType = int;
+  using ImageType = itk::Image<PixelType>;
+  using SamplerType = itk::ImageRandomSampler<ImageType>;
+
+  const auto image =
+    CreateImageFilledWithSequenceOfNaturalNumbers<PixelType>(ImageType::SizeType::Filled(minimumImageSizeValue));
+
+  const auto generateSamples = [image](const bool useMultiThread) {
+    elx::DefaultConstruct<SamplerType> sampler{};
+    sampler.SetUseMultiThread(useMultiThread);
+    sampler.SetSeed(1);
+    sampler.SetInput(image);
+    sampler.Update();
+    return std::move(DerefRawPointer(sampler.GetOutput()).CastToSTLContainer());
+  };
+
+  EXPECT_EQ(generateSamples(true), generateSamples(false));
+}

--- a/Common/ImageSamplers/itkImageRandomSampler.h
+++ b/Common/ImageSamplers/itkImageRandomSampler.h
@@ -86,8 +86,22 @@ protected:
   void
   GenerateData() override;
 
-  void
-  ThreadedGenerateData(const InputImageRegionType & inputRegionForThread, ThreadIdType threadId) override;
+private:
+  struct UserData
+  {
+    ITK_DISALLOW_COPY_AND_ASSIGN(UserData);
+
+    const std::vector<double> *    m_RandomNumberList{};
+    std::vector<ImageSampleType> * m_Samples{};
+    const InputImageType *         m_InputImage{};
+    InputImageIndexType            m_RegionIndex{};
+    InputImageSizeType             m_RegionSize{};
+  };
+
+  UserData m_UserData{};
+
+  static ITK_THREAD_RETURN_FUNCTION_CALL_CONVENTION
+  ThreaderCallback(void * arg);
 };
 
 } // end namespace itk

--- a/Common/ImageSamplers/itkImageRandomSamplerBase.h
+++ b/Common/ImageSamplers/itkImageRandomSamplerBase.h
@@ -105,6 +105,10 @@ protected:
   /** The destructor. */
   ~ImageRandomSamplerBase() override = default;
 
+  /** Generates the list of random numbers. */
+  void
+  GenerateRandomNumberList();
+
   /** Multi-threaded function that does the work. */
   void
   BeforeThreadedGenerateData() override;

--- a/Common/ImageSamplers/itkImageRandomSamplerBase.hxx
+++ b/Common/ImageSamplers/itkImageRandomSamplerBase.hxx
@@ -39,17 +39,20 @@ ImageRandomSamplerBase<TInputImage>::ImageRandomSamplerBase()
 
 
 /**
- * ******************* BeforeThreadedGenerateData *******************
+ * ******************* GenerateRandomNumberList *******************
  */
 
 template <class TInputImage>
 void
-ImageRandomSamplerBase<TInputImage>::BeforeThreadedGenerateData()
+ImageRandomSamplerBase<TInputImage>::GenerateRandomNumberList()
 {
   /** Create a random number generator. Also used in the ImageRandomConstIteratorWithIndex. */
-  using GeneratorPointer = typename Statistics::MersenneTwisterRandomVariateGenerator::Pointer;
-  GeneratorPointer localGenerator = Statistics::MersenneTwisterRandomVariateGenerator::GetInstance();
-  // \todo: should probably be global?
+  const auto localGenerator = Statistics::MersenneTwisterRandomVariateGenerator::New();
+
+  if (m_OptionalSeed)
+  {
+    localGenerator->SetSeed(*m_OptionalSeed);
+  }
 
   /** Clear the random number list. */
   this->m_RandomNumberList.clear();
@@ -64,6 +67,17 @@ ImageRandomSamplerBase<TInputImage>::BeforeThreadedGenerateData()
     this->m_RandomNumberList.push_back(randomPosition);
   }
   localGenerator->GetVariateWithOpenRange(numPixels - 0.5); // dummy jump
+}
+
+/**
+ * ******************* BeforeThreadedGenerateData *******************
+ */
+
+template <class TInputImage>
+void
+ImageRandomSamplerBase<TInputImage>::BeforeThreadedGenerateData()
+{
+  GenerateRandomNumberList();
 
   /** Initialize variables needed for threads. */
   Superclass::BeforeThreadedGenerateData();


### PR DESCRIPTION
Internally calling `multiThreader->SingleMethodExecute()`, instead of overriding `ThreadedGenerateData`.

When 10'000 random samples are retrieved, a significant performance improvement is observed by enabling `UseMultiThread`: from ~1.2 millisecond (single-threaded) to ~0.9 millisecond (multi-threaded). When 100'000 random samples are retrieved, even from ~7 to ~3 millisecond: Tested on a Windows 10 PC (6 cores, 12 logical processors), VS2019 Release build.