### PR TITLE
COMP: Upgrade GitHub Actions to Python 3.8

### DIFF
--- a/.github/workflows/ElastixGitHubActions.yml
+++ b/.github/workflows/ElastixGitHubActions.yml
@@ -58,10 +58,10 @@ jobs:
           ITK-source
         key: ${{ matrix.itk-git-tag }}-${{ matrix.os }}-${{ matrix.cmake-build-type }} 
         
-    - name: Set up Python 3.7
+    - name: Set up Python
       uses: actions/setup-python@v3
       with:
-        python-version: 3.7
+        python-version: 3.8
 
     - name: Install build dependencies
       run: |


### PR DESCRIPTION
Python 3.7 has reached end of life (according to https://devguide.python.org/versions), and SimpleITK has removed Python 3.7 packaging, according to https://github.com/SimpleITK/SimpleITK/releases/tag/v2.3.0