### PR TITLE
COMP: Upgrade GitHub Actions CI to ubuntu-22.04, windows-2022, macos-12

### DIFF
--- a/.github/workflows/ElastixGitHubActions.yml
+++ b/.github/workflows/ElastixGitHubActions.yml
@@ -13,23 +13,23 @@ jobs:
     strategy:
       max-parallel: 3
       matrix:
-        os: [macos-11, ubuntu-20.04, windows-2019]
+        os: [ubuntu-22.04, windows-2022, macos-12]
         include:
-          - os: ubuntu-20.04
+          - os: ubuntu-22.04
             c-compiler: "gcc"
             cxx-compiler: "g++"
             itk-git-tag: "v5.4rc02"
             cmake-build-type: "Release"
             ANNLib: "libANNlib-5.1.so"
             ANNLib2: "libANNlib-5.1.so.1"
-          - os: windows-2019
+          - os: windows-2022
             c-compiler: "cl.exe"
             cxx-compiler: "cl.exe"
             itk-git-tag: "v5.4rc02"
             cmake-build-type: "Release"
             ANNLib: "ANNlib-5.1.dll"
-            vcvars64: "C:/Program Files (x86)/Microsoft Visual Studio/2019/Enterprise/VC/Auxiliary/Build/vcvars64.bat"
-          - os: macos-11
+            vcvars64: "C:/Program Files/Microsoft Visual Studio/2022/Enterprise/VC/Auxiliary/Build/vcvars64.bat"
+          - os: macos-12
             c-compiler: "clang"  
             cxx-compiler: "clang++"
             itk-git-tag: "v5.4rc02"


### PR DESCRIPTION
In sync with https://github.com/InsightSoftwareConsortium/ITKRemoteModuleBuildTestPackageAction/blob/3f63de316255a285b0cac4c819d3d45649738999/.github/workflows/build-test-cxx.yml which is being used by the current `main` revision of ITKElastix, at https://github.com/InsightSoftwareConsortium/ITKElastix/commit/f1b09e524138d4ac022e934f20227ceb6c133603