### PR TITLE
ENH: Add local `const Configuration &` variables to ImageSamplers

### DIFF
--- a/Components/ImageSamplers/Grid/elxGridSampler.hxx
+++ b/Components/ImageSamplers/Grid/elxGridSampler.hxx
@@ -20,6 +20,7 @@
 #define elxGridSampler_hxx
 
 #include "elxGridSampler.h"
+#include "elxDeref.h"
 
 namespace elastix
 {
@@ -32,6 +33,8 @@ template <class TElastix>
 void
 GridSampler<TElastix>::BeforeEachResolution()
 {
+  const Configuration & configuration = Deref(Superclass2::GetConfiguration());
+
   const unsigned int level = this->m_Registration->GetAsITKBaseType()->GetCurrentLevel();
 
   GridSpacingType gridspacing;
@@ -41,7 +44,7 @@ GridSampler<TElastix>::BeforeEachResolution()
   for (unsigned int dim = 0; dim < InputImageDimension; ++dim)
   {
     spacing_dim = 2;
-    this->GetConfiguration()->ReadParameter(
+    configuration.ReadParameter(
       spacing_dim, "SampleGridSpacing", this->GetComponentLabel(), level * InputImageDimension + dim, -1);
     gridspacing[dim] = static_cast<SampleGridSpacingValueType>(spacing_dim);
   }

--- a/Components/ImageSamplers/MultInputRandomCoordinate/elxMultiInputRandomCoordinateSampler.hxx
+++ b/Components/ImageSamplers/MultInputRandomCoordinate/elxMultiInputRandomCoordinateSampler.hxx
@@ -20,6 +20,7 @@
 #define elxMultiInputRandomCoordinateSampler_hxx
 
 #include "elxMultiInputRandomCoordinateSampler.h"
+#include "elxDeref.h"
 
 namespace elastix
 {
@@ -32,26 +33,25 @@ template <class TElastix>
 void
 MultiInputRandomCoordinateSampler<TElastix>::BeforeEachResolution()
 {
+  const Configuration & configuration = Deref(Superclass2::GetConfiguration());
+
   const unsigned int level = (this->m_Registration->GetAsITKBaseType())->GetCurrentLevel();
 
   /** Set the NumberOfSpatialSamples. */
   unsigned long numberOfSpatialSamples = 5000;
-  this->GetConfiguration()->ReadParameter(
-    numberOfSpatialSamples, "NumberOfSpatialSamples", this->GetComponentLabel(), level, 0);
+  configuration.ReadParameter(numberOfSpatialSamples, "NumberOfSpatialSamples", this->GetComponentLabel(), level, 0);
   this->SetNumberOfSamples(numberOfSpatialSamples);
 
   /** Set up the fixed image interpolator and set the SplineOrder, default value = 1. */
   auto         fixedImageInterpolator = DefaultInterpolatorType::New();
   unsigned int splineOrder = 1;
-  this->GetConfiguration()->ReadParameter(
-    splineOrder, "FixedImageBSplineInterpolationOrder", this->GetComponentLabel(), level, 0);
+  configuration.ReadParameter(splineOrder, "FixedImageBSplineInterpolationOrder", this->GetComponentLabel(), level, 0);
   fixedImageInterpolator->SetSplineOrder(splineOrder);
   this->SetInterpolator(fixedImageInterpolator);
 
   /** Set the UseRandomSampleRegion bool. */
   bool useRandomSampleRegion = false;
-  this->GetConfiguration()->ReadParameter(
-    useRandomSampleRegion, "UseRandomSampleRegion", this->GetComponentLabel(), level, 0);
+  configuration.ReadParameter(useRandomSampleRegion, "UseRandomSampleRegion", this->GetComponentLabel(), level, 0);
   this->SetUseRandomSampleRegion(useRandomSampleRegion);
 
   /** Set the SampleRegionSize. */
@@ -78,7 +78,7 @@ MultiInputRandomCoordinateSampler<TElastix>::BeforeEachResolution()
     /** Read user's choice. */
     for (unsigned int i = 0; i < InputImageDimension; ++i)
     {
-      this->GetConfiguration()->ReadParameter(
+      configuration.ReadParameter(
         sampleRegionSize[i], "SampleRegionSize", this->GetComponentLabel(), level * InputImageDimension + i, 0);
     }
     this->SetSampleRegionSize(sampleRegionSize);

--- a/Components/ImageSamplers/Random/elxRandomSampler.hxx
+++ b/Components/ImageSamplers/Random/elxRandomSampler.hxx
@@ -19,6 +19,7 @@
 #define elxRandomSampler_hxx
 
 #include "elxRandomSampler.h"
+#include "elxDeref.h"
 
 namespace elastix
 {
@@ -31,12 +32,13 @@ template <class TElastix>
 void
 RandomSampler<TElastix>::BeforeEachResolution()
 {
+  const Configuration & configuration = Deref(Superclass2::GetConfiguration());
+
   const unsigned int level = (this->m_Registration->GetAsITKBaseType())->GetCurrentLevel();
 
   /** Set the NumberOfSpatialSamples. */
   unsigned long numberOfSpatialSamples = 5000;
-  this->GetConfiguration()->ReadParameter(
-    numberOfSpatialSamples, "NumberOfSpatialSamples", this->GetComponentLabel(), level, 0);
+  configuration.ReadParameter(numberOfSpatialSamples, "NumberOfSpatialSamples", this->GetComponentLabel(), level, 0);
 
   this->SetNumberOfSamples(numberOfSpatialSamples);
 

--- a/Components/ImageSamplers/RandomCoordinate/elxRandomCoordinateSampler.hxx
+++ b/Components/ImageSamplers/RandomCoordinate/elxRandomCoordinateSampler.hxx
@@ -19,6 +19,7 @@
 #define elxRandomCoordinateSampler_hxx
 
 #include "elxRandomCoordinateSampler.h"
+#include "elxDeref.h"
 #include "itkLinearInterpolateImageFunction.h"
 
 namespace elastix
@@ -32,18 +33,18 @@ template <class TElastix>
 void
 RandomCoordinateSampler<TElastix>::BeforeEachResolution()
 {
+  const Configuration & configuration = Deref(Superclass2::GetConfiguration());
+
   const unsigned int level = this->m_Registration->GetAsITKBaseType()->GetCurrentLevel();
 
   /** Set the NumberOfSpatialSamples. */
   unsigned long numberOfSpatialSamples = 5000;
-  this->GetConfiguration()->ReadParameter(
-    numberOfSpatialSamples, "NumberOfSpatialSamples", this->GetComponentLabel(), level, 0);
+  configuration.ReadParameter(numberOfSpatialSamples, "NumberOfSpatialSamples", this->GetComponentLabel(), level, 0);
   this->SetNumberOfSamples(numberOfSpatialSamples);
 
   /** Set up the fixed image interpolator and set the SplineOrder, default value = 1. */
   unsigned int splineOrder = 1;
-  this->GetConfiguration()->ReadParameter(
-    splineOrder, "FixedImageBSplineInterpolationOrder", this->GetComponentLabel(), level, 0);
+  configuration.ReadParameter(splineOrder, "FixedImageBSplineInterpolationOrder", this->GetComponentLabel(), level, 0);
   if (splineOrder == 1)
   {
     using LinearInterpolatorType = itk::LinearInterpolateImageFunction<InputImageType, CoordRepType>;
@@ -59,8 +60,7 @@ RandomCoordinateSampler<TElastix>::BeforeEachResolution()
 
   /** Set the UseRandomSampleRegion bool. */
   bool useRandomSampleRegion = false;
-  this->GetConfiguration()->ReadParameter(
-    useRandomSampleRegion, "UseRandomSampleRegion", this->GetComponentLabel(), level, 0);
+  configuration.ReadParameter(useRandomSampleRegion, "UseRandomSampleRegion", this->GetComponentLabel(), level, 0);
   this->SetUseRandomSampleRegion(useRandomSampleRegion);
 
   /** Set the SampleRegionSize. */
@@ -87,7 +87,7 @@ RandomCoordinateSampler<TElastix>::BeforeEachResolution()
     /** Read and check user's choice. */
     for (unsigned int i = 0; i < InputImageDimension; ++i)
     {
-      this->GetConfiguration()->ReadParameter(
+      configuration.ReadParameter(
         sampleRegionSize[i], "SampleRegionSize", this->GetComponentLabel(), level * InputImageDimension + i, 0);
     }
     this->SetSampleRegionSize(sampleRegionSize);

--- a/Components/ImageSamplers/RandomSparseMask/elxRandomSamplerSparseMask.hxx
+++ b/Components/ImageSamplers/RandomSparseMask/elxRandomSamplerSparseMask.hxx
@@ -20,6 +20,7 @@
 #define elxRandomSamplerSparseMask_hxx
 
 #include "elxRandomSamplerSparseMask.h"
+#include "elxDeref.h"
 
 namespace elastix
 {
@@ -32,12 +33,13 @@ template <class TElastix>
 void
 RandomSamplerSparseMask<TElastix>::BeforeEachResolution()
 {
+  const Configuration & configuration = Deref(Superclass2::GetConfiguration());
+
   const unsigned int level = (this->m_Registration->GetAsITKBaseType())->GetCurrentLevel();
 
   /** Set the NumberOfSpatialSamples. */
   unsigned long numberOfSpatialSamples = 5000;
-  this->GetConfiguration()->ReadParameter(
-    numberOfSpatialSamples, "NumberOfSpatialSamples", this->GetComponentLabel(), level, 0);
+  configuration.ReadParameter(numberOfSpatialSamples, "NumberOfSpatialSamples", this->GetComponentLabel(), level, 0);
 
   this->SetNumberOfSamples(numberOfSpatialSamples);
 


### PR DESCRIPTION
Follow-up to pull request https://github.com/SuperElastix/elastix/pull/830 commit bfc2ee8498d558b982f008e847dd36220bef0b68 "ENH: Add local `const Configuration &` variables to Optimizers"