### PR TITLE
Improve ImageRandomSamplerSparseMask `UseMultiThread` support, add GTest unit tests

### DIFF
--- a/Common/GTesting/itkImageRandomCoordinateSamplerGTest.cxx
+++ b/Common/GTesting/itkImageRandomCoordinateSamplerGTest.cxx
@@ -91,8 +91,14 @@ GTEST_TEST(ImageRandomCoordinateSampler, SetSeedMakesRandomizationDeterministic)
       return std::move(DerefRawPointer(sampler.GetOutput()).CastToSTLContainer());
     };
 
-    // Do the same test twice, to check that the result remains the same.
-    EXPECT_EQ(generateSamples(), generateSamples());
+    const auto samples = generateSamples();
+
+    // The test would be trivial (uninteresting) if there were no samples. Note that itk::ImageSamplerBase does
+    // zero-initialize m_NumberOfSamples, but itk::ImageRandomSamplerBase does m_NumberOfSamples = 1000 afterwards.
+    EXPECT_FALSE(samples.empty());
+
+    // Do the same test another time, to check that the result remains the same.
+    EXPECT_EQ(generateSamples(), samples);
   }
 }
 

--- a/Common/GTesting/itkImageRandomSamplerGTest.cxx
+++ b/Common/GTesting/itkImageRandomSamplerGTest.cxx
@@ -86,8 +86,14 @@ GTEST_TEST(ImageRandomSampler, SetSeedMakesRandomizationDeterministic)
       return std::move(DerefRawPointer(sampler.GetOutput()).CastToSTLContainer());
     };
 
-    // Do the same test twice, to check that the result remains the same.
-    EXPECT_EQ(generateSamples(), generateSamples());
+    const auto samples = generateSamples();
+
+    // The test would be trivial (uninteresting) if there were no samples. Note that itk::ImageSamplerBase does
+    // zero-initialize m_NumberOfSamples, but itk::ImageRandomSamplerBase does m_NumberOfSamples = 1000 afterwards.
+    EXPECT_FALSE(samples.empty());
+
+    // Do the same test another time, to check that the result remains the same.
+    EXPECT_EQ(generateSamples(), samples);
   }
 }
 


### PR DESCRIPTION
ImageRandomSamplerSparseMask now forwards `UseMultiThread` to its internal FullSampler, _and_ uses its own ThreaderCallback, instead of the old `ThreadedGenerateData` mechanism.

Follow-up to:

- pull request #973
- pull request #978

Also added GoogleTest unit tests.