### PR TITLE
COMP: Upgrade Azure Pipelines CI from windows-2019 to windows-2022

### DIFF
--- a/Testing/CI/Azure/ci.yml
+++ b/Testing/CI/Azure/ci.yml
@@ -27,7 +27,7 @@ jobs:
 - job: Windows
   timeoutInMinutes: 0
   pool:
-    vmImage: 'windows-2019'
+    vmImage: 'windows-2022'
   strategy:
     matrix:
       ITKv5:
@@ -44,7 +44,7 @@ jobs:
   - task: CMake@1
     displayName: 'CMake Generate ITK'
     inputs:
-      cmakeArgs: -G "Visual Studio 16 2019" -T host=x64 -DBUILD_EXAMPLES=OFF -DBUILD_TESTING=OFF -DITK_LEGACY_REMOVE=ON "$(ITK_SOURCE_DIR)"
+      cmakeArgs: -G "Visual Studio 17 2022" -T host=x64 -DBUILD_EXAMPLES=OFF -DBUILD_TESTING=OFF -DITK_LEGACY_REMOVE=ON "$(ITK_SOURCE_DIR)"
       workingDirectory: "$(ITK_BINARY_DIR)"
   - task: CMake@1
     displayName: 'CMake Build ITK'
@@ -54,7 +54,7 @@ jobs:
   - task: CMake@1
     displayName: 'CMake Generate Elastix'
     inputs:
-      cmakeArgs: -G "Visual Studio 16 2019" -T host=x64 -DITK_DIR="$(ITK_BINARY_DIR)" -DBUILD_TESTING=ON -DELASTIX_USE_GTEST=ON -DUSE_ALL_COMPONENTS=ON "$(ELASTIX_SOURCE_DIR)"
+      cmakeArgs: -G "Visual Studio 17 2022" -T host=x64 -DITK_DIR="$(ITK_BINARY_DIR)" -DBUILD_TESTING=ON -DELASTIX_USE_GTEST=ON -DUSE_ALL_COMPONENTS=ON "$(ELASTIX_SOURCE_DIR)"
       workingDirectory: "$(ELASTIX_BINARY_DIR)"
   - task: CMake@1
     displayName: 'CMake Build Elastix'
@@ -64,7 +64,7 @@ jobs:
   - task: CMake@1
     displayName: 'CMake Generate externalproject'
     inputs:
-      cmakeArgs: -G "Visual Studio 16 2019" -T host=x64 -DElastix_DIR=$(ELASTIX_BINARY_DIR) "$(ELASTIX_SOURCE_DIR)/dox/externalproject"
+      cmakeArgs: -G "Visual Studio 17 2022" -T host=x64 -DElastix_DIR=$(ELASTIX_BINARY_DIR) "$(ELASTIX_SOURCE_DIR)/dox/externalproject"
       workingDirectory: $(Agent.BuildDirectory)/externalproject-build
   - task: CMake@1
     displayName: 'CMake Build externalproject'


### PR DESCRIPTION
Looking at https://github.com/actions/runner-images/tree/562b6b9e90dfd8d81b8b174a0f095be92f18f09c/images/windows it appears that windows-2019 still has Python 3.7.9, which is no longer supported by SimpleITK, while windows-2022 has Python 3.9.13 "out of the box".

Follow-up to:

 - pull request https://github.com/SuperElastix/elastix/pull/985 commit 2c44c331f168a5a11f3c4d4335ee867a261e1064 "COMP: Upgrade GitHub Actions CI to ubuntu-22.04, windows-2022, macos-12"
 - pull request https://github.com/SuperElastix/elastix/pull/985 commit dd65ed43a16067eaa67073baf8f4d3dbd1f642ca "COMP: Upgrade GitHub Actions to Python 3.8"