### PR TITLE
BUG: ImageRandomSampler (UseMultiThread) should not GetNextSeed()

### DIFF
--- a/Common/ImageSamplers/itkImageRandomSampler.hxx
+++ b/Common/ImageSamplers/itkImageRandomSampler.hxx
@@ -52,10 +52,6 @@ ImageRandomSampler<TInputImage>::GenerateData()
     m_OptionalUserData.emplace(
       randomNumberList, elastix::Deref(inputImage), this->GetCroppedInputImageRegion(), samples);
 
-    using Statistics::MersenneTwisterRandomVariateGenerator;
-    elastix::Deref(MersenneTwisterRandomVariateGenerator::GetInstance())
-      .SetSeed(MersenneTwisterRandomVariateGenerator::GetNextSeed());
-
     MultiThreaderBase & multiThreader = elastix::Deref(this->ProcessObject::GetMultiThreader());
     multiThreader.SetSingleMethod(&Self::ThreaderCallback, &*m_OptionalUserData);
     multiThreader.SingleMethodExecute();


### PR DESCRIPTION
ImageRandomSampler::GenerateData() accidentally did set the seed of the global MersenneTwisterRandomVariateGenerator, while there was no reason to. Doing so causes differences between multi-threaded and single-threaded sampling output.

----
- The bug appears to be introduced by myself, with pull request #973 commit ca9e9ecdf5a1bf7fca2df887feaf5c87365c5b81

https://github.com/SuperElastix/elastix/blob/ca9e9ecdf5a1bf7fca2df887feaf5c87365c5b81/Common/ImageSamplers/itkImageRandomSampler.hxx#L62-L63