### PR TITLE
Replace "-mts" command-line option with `UseMultiThreadingForSamplers` parameter (default "true")

### DIFF
--- a/Common/ImageSamplers/itkImageSamplerBase.h
+++ b/Common/ImageSamplers/itkImageSamplerBase.h
@@ -226,7 +226,7 @@ protected:
   std::vector<ImageSampleContainerPointer> m_ThreaderSampleContainer{};
 
   // tmp?
-  bool m_UseMultiThread{ false };
+  bool m_UseMultiThread{ true };
 
 private:
   /** Member variables. */

--- a/Core/ComponentBaseClasses/elxImageSamplerBase.h
+++ b/Core/ComponentBaseClasses/elxImageSamplerBase.h
@@ -36,6 +36,13 @@ namespace elastix
  *
  * This class contains all the common functionality for ImageSamplers.
  *
+ * The parameter used in this class is:
+ * \parameter UseMultiThreadingForSamplers: Flag that can set to "true" or "false".
+ *    If "true" the sampler may use multi-threading (at least if multi-threading is implemented for the selected
+ *    sampler). If "false", it will run single-threaded. This flag will not affect the output of the samplers.\n
+ *    example: <tt>(UseMultiThreadingForSamplers "false")</tt> \n
+ *    Default is "true".
+ *
  * \ingroup ImageSamplers
  * \ingroup ComponentBaseClasses
  */
@@ -78,6 +85,9 @@ public:
     return &(this->GetSelf());
   }
 
+  /** Retrieves parameters from the configuration, before doing registration. */
+  void
+  BeforeRegistrationBase() override;
 
   /** Execute stuff before each resolution:
    * \li Give a warning when NewSamplesEveryIteration is specified,

--- a/Core/ComponentBaseClasses/elxImageSamplerBase.hxx
+++ b/Core/ComponentBaseClasses/elxImageSamplerBase.hxx
@@ -26,6 +26,19 @@ namespace elastix
 {
 
 /**
+ * ******************* BeforeRegistrationBase ******************
+ */
+
+template <class TElastix>
+void
+ImageSamplerBase<TElastix>::BeforeRegistrationBase()
+{
+  const Configuration & configuration = Deref(Superclass::GetConfiguration());
+  ITKBaseType &         sampler = GetSelf();
+  sampler.SetUseMultiThread(configuration.RetrieveParameterValue(true, "UseMultiThreadingForSamplers", 0, false));
+}
+
+/**
  * ******************* BeforeEachResolutionBase ******************
  */
 

--- a/Core/ComponentBaseClasses/elxImageSamplerBase.hxx
+++ b/Core/ComponentBaseClasses/elxImageSamplerBase.hxx
@@ -53,18 +53,6 @@ ImageSamplerBase<TElastix>::BeforeEachResolutionBase()
                                      << "but the selected ImageSampler is not suited for that.");
     }
   }
-
-  /** Temporary?: Use the multi-threaded version or not. */
-  std::string useMultiThread = configuration.GetCommandLineArgument("-mts"); // mts: multi-threaded samplers
-  if (useMultiThread == "true")
-  {
-    this->GetAsITKBaseType()->SetUseMultiThread(true);
-  }
-  else
-  {
-    this->GetAsITKBaseType()->SetUseMultiThread(false);
-  }
-
 } // end BeforeEachResolutionBase()
 
 


### PR DESCRIPTION
Replaced the "-mts" command-line option with a new elastix parameter, `UseMultiThreadingForSamplers` ("true" by default).