### PR TITLE
STYLE: Remove dummy jump ImageRandomSamplerBase GenerateRandomNumberList

### DIFF
--- a/Common/ImageSamplers/itkImageRandomSamplerBase.hxx
+++ b/Common/ImageSamplers/itkImageRandomSamplerBase.hxx
@@ -66,7 +66,6 @@ ImageRandomSamplerBase<TInputImage>::GenerateRandomNumberList()
     const double randomPosition = localGenerator->GetVariateWithOpenRange(numPixels - 0.5);
     this->m_RandomNumberList.push_back(randomPosition);
   }
-  localGenerator->GetVariateWithOpenRange(numPixels - 0.5); // dummy jump
 }
 
 /**


### PR DESCRIPTION
This "dummy jump" on a local `MersenneTwisterRandomVariateGenerator` variable appears unnecessary, even though it has been there already from the initial version of ImageRandomSamplerBase, November 14, 2013:

 https://github.com/SuperElastix/elastix/blob/2fc2c495837f64416263fa7c5d1e2bc4e3e061fa/src/Common/ImageSamplers/itkImageRandomSamplerBase.txx#L66