### PR TITLE
PERF: `ImageGridSampler` twice as fast, doing `sampleVector.reserve(numberOfSamplesOnGrid)`

### DIFF
--- a/Common/ImageSamplers/itkImageGridSampler.hxx
+++ b/Common/ImageSamplers/itkImageGridSampler.hxx
@@ -21,6 +21,7 @@
 #include "itkImageGridSampler.h"
 
 #include "itkImageRegionConstIteratorWithIndex.h"
+#include <cassert>
 
 namespace itk
 {
@@ -101,6 +102,8 @@ ImageGridSampler<TInputImage>::GenerateData()
 
   if (mask.IsNull())
   {
+    sampleVector.reserve(numberOfSamplesOnGrid);
+
     /** Ugly loop over the grid. */
     for (unsigned int t = 0; t < dim_t; ++t)
     {
@@ -141,6 +144,8 @@ ImageGridSampler<TInputImage>::GenerateData()
         index[3] += this->m_SampleGridSpacing[3];
       }
     } // end t
+
+    assert(sampleVector.size() == numberOfSamplesOnGrid);
 
   } // end if no mask
   else

--- a/Common/ImageSamplers/itkImageGridSampler.hxx
+++ b/Common/ImageSamplers/itkImageGridSampler.hxx
@@ -21,6 +21,8 @@
 #include "itkImageGridSampler.h"
 
 #include "itkImageRegionConstIteratorWithIndex.h"
+
+#include <algorithm> // For accumulate.
 #include <cassert>
 
 namespace itk
@@ -71,7 +73,6 @@ ImageGridSampler<TInputImage>::GenerateData()
   SampleGridSizeType         sampleGridSize;
   SampleGridIndexType        sampleGridIndex = croppedInputImageRegion.GetIndex();
   const InputImageSizeType & inputImageSize = croppedInputImageRegion.GetSize();
-  unsigned long              numberOfSamplesOnGrid = 1;
   for (unsigned int dim = 0; dim < InputImageDimension; ++dim)
   {
     /** The number of sample point along one dimension. */
@@ -82,9 +83,6 @@ ImageGridSampler<TInputImage>::GenerateData()
      */
     sampleGridIndex[dim] +=
       (inputImageSize[dim] - ((sampleGridSize[dim] - 1) * this->GetSampleGridSpacing()[dim] + 1)) / 2;
-
-    /** Update the number of samples on the grid. */
-    numberOfSamplesOnGrid *= sampleGridSize[dim];
   }
 
   /** Prepare for looping over the grid. */
@@ -102,6 +100,10 @@ ImageGridSampler<TInputImage>::GenerateData()
 
   if (mask.IsNull())
   {
+    /** Calculate the number of samples on the grid. */
+    const std::size_t numberOfSamplesOnGrid =
+      std::accumulate(sampleGridSize.cbegin(), sampleGridSize.cend(), std::size_t{ 1 }, std::multiplies<>{});
+
     sampleVector.reserve(numberOfSamplesOnGrid);
 
     /** Ugly loop over the grid. */


### PR DESCRIPTION
Reserving the right number of samples beforehand appears to possibly make ImageGridSampler twice as fast. When having a 4096x4096 grid (no mask), it was observed that the duration of an ImageGridSampler::Update() went from 0.45 second (before this commit) to almost 0.20 second  (after this commit), using Visual C++ 2019, Release configuration.

This pull request also proposes to use std::accumulate to calculate `numberOfSamplesOnGrid`.

----

Note that originally `numberOfSamplesOnGrid` was just calculated without being used. From here, commit 6e0e6f88163dfce901d72bbcb57fb1a388186ac3, July 17, 2006, "implemented grid and full sampler":

https://github.com/SuperElastix/elastix/blob/6e0e6f88163dfce901d72bbcb57fb1a388186ac3/src/Common/ImageSamplers/itkImageGridSampler.txx#L37