### PR TITLE
STYLE: `Deref` input and output pointer everywhere in "ImageSamplers"

### DIFF
--- a/Common/ImageSamplers/itkImageGridSampler.hxx
+++ b/Common/ImageSamplers/itkImageGridSampler.hxx
@@ -21,6 +21,7 @@
 #include "itkImageGridSampler.h"
 
 #include "itkImageRegionConstIteratorWithIndex.h"
+#include "elxDeref.h"
 
 #include <algorithm> // For accumulate.
 #include <cassert>
@@ -54,13 +55,13 @@ void
 ImageGridSampler<TInputImage>::GenerateData()
 {
   /** Get handles to the input image, output sample container, and the mask. */
-  InputImageConstPointer                     inputImage = this->GetInput();
-  typename ImageSampleContainerType::Pointer sampleContainer = this->GetOutput();
-  typename MaskType::ConstPointer            mask = this->GetMask();
+  const InputImageType &          inputImage = elastix::Deref(this->GetInput());
+  ImageSampleContainerType &      sampleContainer = elastix::Deref(this->GetOutput());
+  typename MaskType::ConstPointer mask = this->GetMask();
 
   // Take capacity from the output container, and clear it.
   std::vector<ImageSampleType> sampleVector;
-  sampleContainer->swap(sampleVector);
+  sampleContainer.swap(sampleVector);
   sampleVector.clear();
 
   /** Take into account the possibility of a smaller bounding box around the mask */
@@ -106,10 +107,10 @@ ImageGridSampler<TInputImage>::GenerateData()
             ImageSampleType tempSample;
 
             // Get sampled fixed image value.
-            tempSample.m_ImageValue = inputImage->GetPixel(index);
+            tempSample.m_ImageValue = inputImage.GetPixel(index);
 
             // Translate index to point.
-            inputImage->TransformIndexToPhysicalPoint(index, tempSample.m_ImageCoordinates);
+            inputImage.TransformIndexToPhysicalPoint(index, tempSample.m_ImageCoordinates);
 
             // Store sample in container.
             sampleVector.push_back(tempSample);
@@ -143,12 +144,12 @@ ImageGridSampler<TInputImage>::GenerateData()
             ImageSampleType tempSample;
 
             // Translate index to point.
-            inputImage->TransformIndexToPhysicalPoint(index, tempSample.m_ImageCoordinates);
+            inputImage.TransformIndexToPhysicalPoint(index, tempSample.m_ImageCoordinates);
 
             if (mask->IsInsideInWorldSpace(tempSample.m_ImageCoordinates))
             {
               // Get sampled fixed image value.
-              tempSample.m_ImageValue = inputImage->GetPixel(index);
+              tempSample.m_ImageValue = inputImage.GetPixel(index);
 
               // Store sample in container.
               sampleVector.push_back(tempSample);
@@ -167,7 +168,7 @@ ImageGridSampler<TInputImage>::GenerateData()
   } // else (if mask exists)
 
   // Move the samples from the vector into the output container.
-  sampleContainer->swap(sampleVector);
+  sampleContainer.swap(sampleVector);
 
 } // end GenerateData()
 

--- a/Common/ImageSamplers/itkImageToVectorContainerFilter.hxx
+++ b/Common/ImageSamplers/itkImageToVectorContainerFilter.hxx
@@ -21,6 +21,7 @@
 #include "itkImageToVectorContainerFilter.h"
 
 #include "itkMath.h"
+#include "elxDeref.h"
 
 namespace itk
 {
@@ -139,8 +140,8 @@ ImageToVectorContainerFilter<TInputImage, TOutputVectorContainer>::SplitRequeste
   InputImageRegionType & splitRegion)
 {
   // Get the input pointer
-  const InputImageType *                 inputPtr = this->GetInput();
-  const typename TInputImage::SizeType & requestedRegionSize = inputPtr->GetRequestedRegion().GetSize();
+  const InputImageType &                 inputImage = elastix::Deref(this->GetInput());
+  const typename TInputImage::SizeType & requestedRegionSize = inputImage.GetRequestedRegion().GetSize();
   // \todo: requested region -> this->GetCroppedInputImageRegion()
 
   int                             splitAxis;
@@ -148,12 +149,12 @@ ImageToVectorContainerFilter<TInputImage, TOutputVectorContainer>::SplitRequeste
   typename TInputImage::SizeType  splitSize;
 
   // Initialize the splitRegion to the output requested region
-  splitRegion = inputPtr->GetRequestedRegion();
+  splitRegion = inputImage.GetRequestedRegion();
   splitIndex = splitRegion.GetIndex();
   splitSize = splitRegion.GetSize();
 
   // split on the outermost dimension available
-  splitAxis = inputPtr->GetImageDimension() - 1;
+  splitAxis = inputImage.GetImageDimension() - 1;
   while (requestedRegionSize[splitAxis] == 1)
   {
     --splitAxis;


### PR DESCRIPTION
Follow-up to commit 0ef6d0dd6346f80961754fdab2162a9d0021b38d "STYLE: `Deref` sampler input and output at the start of GenerateData()"