### PR TITLE
BUG: Make sure `splitRegion = inputRegion` if SplitRegion cannot split, and some ImageSamplerBase style fixes 

### DIFF
--- a/Common/ImageSamplers/itkImageSamplerBase.h
+++ b/Common/ImageSamplers/itkImageSamplerBase.h
@@ -249,7 +249,7 @@ public:
   itkSetClampMacro(NumberOfSamples, unsigned long, 1, NumericTraits<unsigned long>::max());
   itkGetConstMacro(NumberOfSamples, unsigned long);
 
-  /** \todo: Temporary, should think about interface. */
+  /** Allows disabling the use of multi-threading, by `SetUseMultiThread(false)`. */
   itkSetMacro(UseMultiThread, bool);
 
   /** Static function used as a "callback" by the PlatformMultiThreader.  The threading
@@ -308,7 +308,8 @@ protected:
   unsigned long                             m_NumberOfSamples{ 0 };
   std::vector<std::vector<ImageSampleType>> m_ThreaderSampleVectors{};
 
-  // tmp?
+  /** `UseMultiThread == true` indicated that the sampler _may_ use multi-threading (if implemented), while
+   * `UseMultiThread == false` indicates that the sampler should _not_ use multi-threading */
   bool m_UseMultiThread{ true };
 
 private:

--- a/Common/ImageSamplers/itkImageSamplerBase.h
+++ b/Common/ImageSamplers/itkImageSamplerBase.h
@@ -319,8 +319,8 @@ private:
    * i.e. return value is less than or equal to "numberOfSplits". */
   static unsigned int
   SplitRegion(const InputImageRegionType & inputRegion,
-              const ThreadIdType &         threadId,
-              const ThreadIdType &         numberOfSplits,
+              const ThreadIdType           threadId,
+              const ThreadIdType           numberOfSplits,
               InputImageRegionType &       splitRegion);
 
   /** Member variables. */

--- a/Common/ImageSamplers/itkImageSamplerBase.hxx
+++ b/Common/ImageSamplers/itkImageSamplerBase.hxx
@@ -558,6 +558,7 @@ ImageSamplerBase<TInputImage>::SplitRegion(const InputImageRegionType & inputReg
   {
     if (splitAxis == 0)
     { // cannot split
+      splitRegion = inputRegion;
       return 1;
     }
     --splitAxis;

--- a/Common/ImageSamplers/itkImageSamplerBase.hxx
+++ b/Common/ImageSamplers/itkImageSamplerBase.hxx
@@ -470,7 +470,7 @@ DataObject::Pointer
 ImageSamplerBase<TInputImage>::MakeOutput(unsigned int itkNotUsed(idx))
 {
   OutputVectorContainerPointer outputVectorContainer = OutputVectorContainerType::New();
-  return dynamic_cast<DataObject *>(outputVectorContainer.GetPointer());
+  return outputVectorContainer.GetPointer();
 } // end MakeOutput()
 
 

--- a/Common/ImageSamplers/itkImageSamplerBase.hxx
+++ b/Common/ImageSamplers/itkImageSamplerBase.hxx
@@ -554,7 +554,7 @@ ImageSamplerBase<TInputImage>::SplitRegion(const InputImageRegionType & inputReg
 
   // split on the outermost dimension available
   unsigned int splitAxis{ TInputImage::ImageDimension - 1 };
-  while (inputRegionSize[splitAxis] == 1)
+  while (inputRegionSize[splitAxis] <= 1)
   {
     if (splitAxis == 0)
     { // cannot split
@@ -564,9 +564,9 @@ ImageSamplerBase<TInputImage>::SplitRegion(const InputImageRegionType & inputReg
   }
 
   // determine the actual number of pieces that will be generated
-  const typename TInputImage::SizeType::SizeValueType range = inputRegionSize[splitAxis];
-  const unsigned int valuesPerThread = Math::Ceil<unsigned int>(range / static_cast<double>(numberOfSplits));
-  const unsigned int maxThreadIdUsed = Math::Ceil<unsigned int>(range / static_cast<double>(valuesPerThread)) - 1;
+  const SizeValueType range = inputRegionSize[splitAxis];
+  const auto          valuesPerThread = static_cast<unsigned int>(((range - 1) / numberOfSplits) + 1);
+  const auto          maxThreadIdUsed = static_cast<unsigned int>((range - 1) / valuesPerThread);
 
   // Split the region
   if (threadId < maxThreadIdUsed)

--- a/Common/ImageSamplers/itkImageSamplerBase.hxx
+++ b/Common/ImageSamplers/itkImageSamplerBase.hxx
@@ -550,15 +550,17 @@ ImageSamplerBase<TInputImage>::SplitRegion(const InputImageRegionType & inputReg
   typename TInputImage::IndexType splitIndex = inputRegion.GetIndex();
   typename TInputImage::SizeType  splitSize = inputRegionSize;
 
+  static_assert(TInputImage::ImageDimension > 0);
+
   // split on the outermost dimension available
-  int splitAxis = TInputImage::ImageDimension - 1;
+  unsigned int splitAxis{ TInputImage::ImageDimension - 1 };
   while (inputRegionSize[splitAxis] == 1)
   {
-    --splitAxis;
-    if (splitAxis < 0)
+    if (splitAxis == 0)
     { // cannot split
       return 1;
     }
+    --splitAxis;
   }
 
   // determine the actual number of pieces that will be generated

--- a/Common/ImageSamplers/itkImageSamplerBase.hxx
+++ b/Common/ImageSamplers/itkImageSamplerBase.hxx
@@ -541,8 +541,8 @@ ImageSamplerBase<TInputImage>::GetOutput() -> OutputVectorContainerType *
 template <class TInputImage>
 unsigned int
 ImageSamplerBase<TInputImage>::SplitRegion(const InputImageRegionType & inputRegion,
-                                           const ThreadIdType &         threadId,
-                                           const ThreadIdType &         numberOfSplits,
+                                           const ThreadIdType           threadId,
+                                           const ThreadIdType           numberOfSplits,
                                            InputImageRegionType &       splitRegion)
 {
   const typename TInputImage::SizeType & inputRegionSize = inputRegion.GetSize();


### PR DESCRIPTION
Bug introduced with pull request #1006 commit 81e5fe8d8ae1784179c720662584a6a33997dd70 "STYLE: Rename `SplitRequestedRegion` to "SplitRegion", make it `static`", merged 9 December 2023 (my fault).

Fortunately the bug seems to rarely cause any problem, as it occurs only when the input region has less than 2 pixels.
