### PR TITLE
PERF: ImageGridSampler replace IsInsideInWorldSpace calls

### DIFF
--- a/Common/CostFunctions/itkAdvancedImageToImageMetric.hxx
+++ b/Common/CostFunctions/itkAdvancedImageToImageMetric.hxx
@@ -196,20 +196,10 @@ AdvancedImageToImageMetric<TFixedImage, TMovingImage>::InitializeLimiters()
       ComputeFixedImageExtremaFilterType::New();
     computeFixedImageExtrema->SetInput(this->GetFixedImage());
     computeFixedImageExtrema->SetImageRegion(this->GetFixedImageRegion());
-    if (this->m_FixedImageMask.IsNotNull())
+    if (const auto * const fMask = this->GetFixedImageMask())
     {
       computeFixedImageExtrema->SetUseMask(true);
-
-      const FixedImageMaskSpatialObject2Type * fMask =
-        dynamic_cast<const FixedImageMaskSpatialObject2Type *>(this->m_FixedImageMask.GetPointer());
-      if (fMask)
-      {
-        computeFixedImageExtrema->SetImageSpatialMask(fMask);
-      }
-      else
-      {
-        computeFixedImageExtrema->SetImageMask(this->GetFixedImageMask());
-      }
+      computeFixedImageExtrema->SetImageSpatialMask(fMask);
     }
 
     computeFixedImageExtrema->Update();
@@ -245,19 +235,10 @@ AdvancedImageToImageMetric<TFixedImage, TMovingImage>::InitializeLimiters()
       ComputeMovingImageExtremaFilterType::New();
     computeMovingImageExtrema->SetInput(this->GetMovingImage());
     computeMovingImageExtrema->SetImageRegion(this->GetMovingImage()->GetBufferedRegion());
-    if (this->m_MovingImageMask.IsNotNull())
+    if (const auto * const mask = this->GetMovingImageMask())
     {
       computeMovingImageExtrema->SetUseMask(true);
-      const MovingImageMaskSpatialObject2Type * mMask =
-        dynamic_cast<const MovingImageMaskSpatialObject2Type *>(this->m_MovingImageMask.GetPointer());
-      if (mMask)
-      {
-        computeMovingImageExtrema->SetImageSpatialMask(mMask);
-      }
-      else
-      {
-        computeMovingImageExtrema->SetImageMask(this->GetMovingImageMask());
-      }
+      computeMovingImageExtrema->SetImageSpatialMask(mask);
     }
     computeMovingImageExtrema->Update();
 
@@ -300,7 +281,7 @@ AdvancedImageToImageMetric<TFixedImage, TMovingImage>::InitializeImageSampler()
 
     /** Initialize the Image Sampler. */
     this->m_ImageSampler->SetInput(this->m_FixedImage);
-    this->m_ImageSampler->SetMask(this->m_FixedImageMask);
+    this->m_ImageSampler->SetMask(this->GetFixedImageMask());
     this->m_ImageSampler->SetInputImageRegion(this->GetFixedImageRegion());
   }
 
@@ -707,9 +688,9 @@ bool
 AdvancedImageToImageMetric<TFixedImage, TMovingImage>::IsInsideMovingMask(const MovingImagePointType & point) const
 {
   /** If a mask has been set: */
-  if (this->m_MovingImageMask.IsNotNull())
+  if (const auto * const mask = this->GetMovingImageMask())
   {
-    return this->m_MovingImageMask->IsInsideInWorldSpace(point);
+    return mask->IsInsideInWorldSpace(point);
   }
 
   /** If no mask has been set, just return true. */

--- a/Common/CostFunctions/itkSingleValuedPointSetToPointSetMetric.h
+++ b/Common/CostFunctions/itkSingleValuedPointSetToPointSetMetric.h
@@ -37,7 +37,7 @@
 #include "itkAdvancedTransform.h"
 #include "itkSingleValuedCostFunction.h"
 #include "itkMacro.h"
-#include "itkSpatialObject.h"
+#include "itkImageMaskSpatialObject.h"
 #include "itkPointSet.h"
 
 namespace itk
@@ -98,10 +98,10 @@ public:
   using TransformParametersType = typename TransformType::ParametersType;
   using TransformJacobianType = typename TransformType::JacobianType;
 
-  using FixedImageMaskType = SpatialObject<Self::FixedPointSetDimension>;
+  using FixedImageMaskType = ImageMaskSpatialObject<Self::FixedPointSetDimension>;
   using FixedImageMaskPointer = typename FixedImageMaskType::Pointer;
   using FixedImageMaskConstPointer = typename FixedImageMaskType::ConstPointer;
-  using MovingImageMaskType = SpatialObject<Self::MovingPointSetDimension>;
+  using MovingImageMaskType = ImageMaskSpatialObject<Self::MovingPointSetDimension>;
   using MovingImageMaskPointer = typename MovingImageMaskType::Pointer;
   using MovingImageMaskConstPointer = typename MovingImageMaskType::ConstPointer;
 

--- a/Common/ImageSamplers/itkImageGridSampler.h
+++ b/Common/ImageSamplers/itkImageGridSampler.h
@@ -150,6 +150,8 @@ protected:
   GenerateData() override;
 
 private:
+  using WorldToObjectTransformType = AffineTransform<double, InputImageDimension>;
+
   struct WorkUnit
   {
     const SampleGridIndexType GridIndex{};
@@ -166,10 +168,11 @@ private:
   {
     ITK_DISALLOW_COPY_AND_MOVE(UserData);
 
-    const InputImageType &      InputImage;
-    const MaskType * const      Mask{};
-    const SampleGridSpacingType GridSpacing{};
-    std::vector<WorkUnit>       WorkUnits{};
+    const InputImageType &                   InputImage;
+    const MaskType * const                   Mask{};
+    const WorldToObjectTransformType * const WorldToObjectTransform{};
+    const SampleGridSpacingType              GridSpacing{};
+    std::vector<WorkUnit>                    WorkUnits{};
   };
 
   template <bool VUseMask>

--- a/Common/ImageSamplers/itkImageGridSampler.h
+++ b/Common/ImageSamplers/itkImageGridSampler.h
@@ -70,7 +70,10 @@ public:
   using typename Superclass::ImageSampleType;
   using typename Superclass::ImageSampleContainerType;
   using typename Superclass::ImageSampleContainerPointer;
-  using typename Superclass::MaskType;
+
+  // Clang/macos-12/Xcode_14.2 does not like `using typename Superclass::MaskType`, saying "error: 'MaskType' is not a
+  // class, namespace, or enumeration"
+  using MaskType = typename Superclass::MaskType;
 
   /** The input image dimension. */
   itkStaticConstMacro(InputImageDimension, unsigned int, Superclass::InputImageDimension);

--- a/Common/ImageSamplers/itkImageGridSampler.hxx
+++ b/Common/ImageSamplers/itkImageGridSampler.hxx
@@ -258,7 +258,7 @@ ImageGridSampler<TInputImage>::SingleThreadedGenerateData(const TInputImage &   
             inputImage.TransformIndexToPhysicalPoint(index, tempSample.m_ImageCoordinates);
 
             // Equivalent to `mask->IsInsideInWorldSpace(tempSample.m_ImageCoordinates)`, but much faster.
-            if (mask->IsInsideInObjectSpace(
+            if (mask->MaskType::IsInsideInObjectSpace(
                   worldToObjectTransform.WorldToObjectTransformType::TransformPoint(tempSample.m_ImageCoordinates)))
             {
               // Get sampled fixed image value.
@@ -470,7 +470,8 @@ ImageGridSampler<TInputImage>::ThreaderCallback(void * const arg)
           if constexpr (VUseMask)
           {
             // Equivalent to `mask->IsInsideInWorldSpace(point)`, but much faster.
-            if (mask->IsInsideInObjectSpace(worldToObjectTransform->WorldToObjectTransformType::TransformPoint(point)))
+            if (mask->MaskType::IsInsideInObjectSpace(
+                  worldToObjectTransform->WorldToObjectTransformType::TransformPoint(point)))
             {
               // Get sampled fixed image value.
               const auto pixel = inputImage.GetPixel(index);

--- a/Common/ImageSamplers/itkImageSamplerBase.h
+++ b/Common/ImageSamplers/itkImageSamplerBase.h
@@ -21,7 +21,7 @@
 #include "itkVectorContainerSource.h"
 #include "itkImageSample.h"
 #include "itkVectorDataContainer.h"
-#include "itkSpatialObject.h"
+#include "itkImageMaskSpatialObject.h"
 
 namespace itk
 {
@@ -81,7 +81,7 @@ public:
   using InputImagePointType = typename InputImageType::PointType;
   using InputImagePointValueType = typename InputImagePointType::ValueType;
   using ImageSampleValueType = typename ImageSampleType::RealType;
-  using MaskType = SpatialObject<Self::InputImageDimension>;
+  using MaskType = ImageMaskSpatialObject<Self::InputImageDimension>;
   using MaskPointer = typename MaskType::Pointer;
   using MaskConstPointer = typename MaskType::ConstPointer;
   using MaskVectorType = std::vector<MaskConstPointer>;

--- a/Common/Transforms/itkAdvancedImageMomentsCalculator.h
+++ b/Common/Transforms/itkAdvancedImageMomentsCalculator.h
@@ -22,7 +22,7 @@
 #include "itkBinaryThresholdImageFilter.h"
 #include "itkAffineTransform.h"
 #include "itkImage.h"
-#include "itkSpatialObject.h"
+#include "itkImageMaskSpatialObject.h"
 #include "itkImageGridSampler.h"
 #include "itkImageFullSampler.h"
 
@@ -90,7 +90,7 @@ public:
   using VectorType = Vector<ScalarType, Self::ImageDimension>;
 
   /** Spatial Object type within this class. */
-  using SpatialObjectType = SpatialObject<Self::ImageDimension>;
+  using SpatialObjectType = ImageMaskSpatialObject<Self::ImageDimension>;
 
   /** Spatial Object member types used within this class. */
   using SpatialObjectPointer = typename SpatialObjectType::Pointer;
@@ -124,7 +124,7 @@ public:
 
   /** Set the spatial object mask. */
   virtual void
-  SetSpatialObjectMask(const SpatialObject<Self::ImageDimension> * so)
+  SetSpatialObjectMask(const ImageMaskSpatialObject<Self::ImageDimension> * so)
   {
     if (m_SpatialObjectMask != so)
     {

--- a/Common/itkComputeDisplacementDistribution.h
+++ b/Common/itkComputeDisplacementDistribution.h
@@ -76,7 +76,7 @@ public:
    * this mask will be considered for the computation of the Jacobian terms.
    */
   itkStaticConstMacro(FixedImageDimension, unsigned int, TFixedImage::ImageDimension);
-  using FixedImageMaskType = SpatialObject<Self::FixedImageDimension>;
+  using FixedImageMaskType = ImageMaskSpatialObject<Self::FixedImageDimension>;
   using FixedImageMaskPointer = typename FixedImageMaskType::Pointer;
   using FixedImageMaskConstPointer = typename FixedImageMaskType::ConstPointer;
   using NonZeroJacobianIndicesType = typename TransformType::NonZeroJacobianIndicesType;

--- a/Common/itkComputeImageExtremaFilter.h
+++ b/Common/itkComputeImageExtremaFilter.h
@@ -19,7 +19,6 @@
 #define itkComputeImageExtremaFilter_h
 
 #include "itkStatisticsImageFilter.h"
-#include "itkSpatialObject.h"
 #include "itkImageMaskSpatialObject.h"
 
 namespace itk
@@ -78,12 +77,6 @@ public:
   itkSetMacro(ImageRegion, RegionType);
   itkSetMacro(UseMask, bool);
 
-  using ImageMaskType = SpatialObject<Self::ImageDimension>;
-  using ImageMaskPointer = typename ImageMaskType::Pointer;
-  using ImageMaskConstPointer = typename ImageMaskType::ConstPointer;
-  itkSetConstObjectMacro(ImageMask, ImageMaskType);
-  itkGetConstObjectMacro(ImageMask, ImageMaskType);
-
   using ImageSpatialMaskType = ImageMaskSpatialObject<Self::ImageDimension>;
   using ImageSpatialMaskPointer = typename ImageSpatialMaskType::Pointer;
   using ImageSpatialMaskConstPointer = typename ImageSpatialMaskType::ConstPointer;
@@ -109,11 +102,8 @@ protected:
   virtual void
   ThreadedGenerateDataImageSpatialMask(const RegionType &);
   virtual void
-  ThreadedGenerateDataImageMask(const RegionType &);
-  virtual void
                                SameGeometry();
   RegionType                   m_ImageRegion{};
-  ImageMaskConstPointer        m_ImageMask{};
   ImageSpatialMaskConstPointer m_ImageSpatialMask{};
   bool                         m_UseMask{ false };
   bool                         m_SameGeometry{ false };

--- a/Common/itkComputeJacobianTerms.h
+++ b/Common/itkComputeJacobianTerms.h
@@ -61,7 +61,7 @@ public:
    * this mask will be considered for the computation of the Jacobian terms.
    */
   itkStaticConstMacro(FixedImageDimension, unsigned int, TFixedImage::ImageDimension);
-  using FixedImageMaskType = SpatialObject<Self::FixedImageDimension>;
+  using FixedImageMaskType = ImageMaskSpatialObject<Self::FixedImageDimension>;
   using FixedImageMaskPointer = typename FixedImageMaskType::Pointer;
   using FixedImageMaskConstPointer = typename FixedImageMaskType::ConstPointer;
 

--- a/Components/Metrics/AdvancedMeanSquares/itkAdvancedMeanSquaresImageToImageMetric.h
+++ b/Components/Metrics/AdvancedMeanSquares/itkAdvancedMeanSquaresImageToImageMetric.h
@@ -118,9 +118,6 @@ public:
   using typename Superclass::ThreaderType;
   using typename Superclass::ThreadInfoType;
 
-  using typename Superclass::FixedImageMaskSpatialObject2Type;
-  using typename Superclass::MovingImageMaskSpatialObject2Type;
-
   /** The fixed image dimension. */
   itkStaticConstMacro(FixedImageDimension, unsigned int, FixedImageType::ImageDimension);
 

--- a/Components/Metrics/AdvancedMeanSquares/itkAdvancedMeanSquaresImageToImageMetric.hxx
+++ b/Components/Metrics/AdvancedMeanSquares/itkAdvancedMeanSquaresImageToImageMetric.hxx
@@ -73,19 +73,10 @@ AdvancedMeanSquaresImageToImageMetric<TFixedImage, TMovingImage>::Initialize()
       ComputeFixedImageExtremaFilterType::New();
     computeFixedImageExtrema->SetInput(this->GetFixedImage());
     computeFixedImageExtrema->SetImageRegion(this->GetFixedImageRegion());
-    if (this->m_FixedImageMask.IsNotNull())
+    if (const auto * const mask = this->GetFixedImageMask())
     {
       computeFixedImageExtrema->SetUseMask(true);
-      const FixedImageMaskSpatialObject2Type * fmask =
-        dynamic_cast<const FixedImageMaskSpatialObject2Type *>(this->m_FixedImageMask.GetPointer());
-      if (fmask)
-      {
-        computeFixedImageExtrema->SetImageSpatialMask(fmask);
-      }
-      else
-      {
-        computeFixedImageExtrema->SetImageMask(this->GetFixedImageMask());
-      }
+      computeFixedImageExtrema->SetImageSpatialMask(mask);
     }
 
     computeFixedImageExtrema->Update();
@@ -105,19 +96,10 @@ AdvancedMeanSquaresImageToImageMetric<TFixedImage, TMovingImage>::Initialize()
       ComputeMovingImageExtremaFilterType::New();
     computeMovingImageExtrema->SetInput(this->GetMovingImage());
     computeMovingImageExtrema->SetImageRegion(this->GetMovingImage()->GetBufferedRegion());
-    if (this->m_MovingImageMask.IsNotNull())
+    if (const auto * const mask = this->GetMovingImageMask())
     {
       computeMovingImageExtrema->SetUseMask(true);
-      const MovingImageMaskSpatialObject2Type * mMask =
-        dynamic_cast<const MovingImageMaskSpatialObject2Type *>(this->m_MovingImageMask.GetPointer());
-      if (mMask)
-      {
-        computeMovingImageExtrema->SetImageSpatialMask(mMask);
-      }
-      else
-      {
-        computeMovingImageExtrema->SetImageMask(this->GetMovingImageMask());
-      }
+      computeMovingImageExtrema->SetImageSpatialMask(mask);
     }
 
     computeMovingImageExtrema->Update();

--- a/Components/Metrics/GradientDifference/itkGradientDifferenceImageToImageMetric2.hxx
+++ b/Components/Metrics/GradientDifference/itkGradientDifferenceImageToImageMetric2.hxx
@@ -240,7 +240,7 @@ GradientDifferenceImageToImageMetric<TFixedImage, TMovingImage>::ComputeVariance
     typename FixedImageType::PointType point;
     bool                               sampleOK = false;
 
-    if (this->m_FixedImageMask.IsNull())
+    if (!this->GetFixedImageMask())
     {
       sampleOK = true;
     }
@@ -252,9 +252,9 @@ GradientDifferenceImageToImageMetric<TFixedImage, TMovingImage>::ComputeVariance
       this->m_FixedImage->TransformIndexToPhysicalPoint(currentIndex, point);
 
       /** if fixedMask is given */
-      if (!this->m_FixedImageMask.IsNull())
+      if (const auto * const mask = this->GetFixedImageMask())
       {
-        if (this->m_FixedImageMask->IsInsideInWorldSpace(point))
+        if (mask->IsInsideInWorldSpace(point))
         {
           sampleOK = true;
         }
@@ -301,9 +301,9 @@ GradientDifferenceImageToImageMetric<TFixedImage, TMovingImage>::ComputeVariance
       this->m_FixedImage->TransformIndexToPhysicalPoint(currentIndex, point);
 
       /** if fixedMask is given */
-      if (!this->m_FixedImageMask.IsNull())
+      if (const auto * const mask = this->GetFixedImageMask())
       {
-        if (this->m_FixedImageMask->IsInsideInWorldSpace(point))
+        if (mask->IsInsideInWorldSpace(point))
         {
           sampleOK = true;
         }
@@ -393,7 +393,7 @@ GradientDifferenceImageToImageMetric<TFixedImage, TMovingImage>::ComputeMeasure(
 
     bool sampleOK = false;
 
-    if (this->m_FixedImageMask.IsNull())
+    if (!this->GetFixedImageMask())
     {
       sampleOK = true;
     }
@@ -405,10 +405,10 @@ GradientDifferenceImageToImageMetric<TFixedImage, TMovingImage>::ComputeMeasure(
       this->m_FixedImage->TransformIndexToPhysicalPoint(currentIndex, point);
 
       /** if fixedMask is given */
-      if (!this->m_FixedImageMask.IsNull())
+      if (const auto * const mask = this->GetFixedImageMask())
       {
 
-        if (this->m_FixedImageMask->IsInsideInWorldSpace(point)) // sample is good
+        if (mask->IsInsideInWorldSpace(point)) // sample is good
         {
           sampleOK = true;
         }

--- a/Components/Metrics/NormalizedGradientCorrelation/itkNormalizedGradientCorrelationImageToImageMetric.hxx
+++ b/Components/Metrics/NormalizedGradientCorrelation/itkNormalizedGradientCorrelationImageToImageMetric.hxx
@@ -166,7 +166,7 @@ NormalizedGradientCorrelationImageToImageMetric<TFixedImage, TMovingImage>::Comp
 
   unsigned long nPixels = 0;
 
-  if (this->m_FixedImageMask.IsNull())
+  if (!this->GetFixedImageMask())
   {
     sampleOK = true;
   }
@@ -178,9 +178,9 @@ NormalizedGradientCorrelationImageToImageMetric<TFixedImage, TMovingImage>::Comp
     this->m_FixedImage->TransformIndexToPhysicalPoint(currentIndex, point);
 
     /** if fixedMask is given */
-    if (!this->m_FixedImageMask.IsNull())
+    if (const auto * const mask = this->GetFixedImageMask())
     {
-      if (this->m_FixedImageMask->IsInsideInWorldSpace(point))
+      if (mask->IsInsideInWorldSpace(point))
       {
         sampleOK = true;
       }
@@ -233,7 +233,7 @@ NormalizedGradientCorrelationImageToImageMetric<TFixedImage, TMovingImage>::Comp
 
   bool sampleOK = false;
 
-  if (this->m_FixedImageMask.IsNull())
+  if (!this->GetFixedImageMask())
   {
     sampleOK = true;
   }
@@ -254,9 +254,9 @@ NormalizedGradientCorrelationImageToImageMetric<TFixedImage, TMovingImage>::Comp
     this->m_FixedImage->TransformIndexToPhysicalPoint(currentIndex, point);
 
     /** if fixedMask is given */
-    if (!this->m_FixedImageMask.IsNull())
+    if (const auto * const mask = this->GetFixedImageMask())
     {
-      if (this->m_FixedImageMask->IsInsideInWorldSpace(point))
+      if (mask->IsInsideInWorldSpace(point))
       {
         sampleOK = true;
       }
@@ -334,7 +334,7 @@ NormalizedGradientCorrelationImageToImageMetric<TFixedImage, TMovingImage>::Comp
   this->m_NumberOfPixelsCounted = 0;
   bool sampleOK = false;
 
-  if (this->m_FixedImageMask.IsNull())
+  if (!this->GetFixedImageMask())
   {
     sampleOK = true;
   }
@@ -345,9 +345,9 @@ NormalizedGradientCorrelationImageToImageMetric<TFixedImage, TMovingImage>::Comp
     this->m_FixedImage->TransformIndexToPhysicalPoint(currentIndex, point);
 
     /** if fixedMask is given */
-    if (!this->m_FixedImageMask.IsNull())
+    if (const auto * const mask = this->GetFixedImageMask())
     {
-      if (this->m_FixedImageMask->IsInsideInWorldSpace(point))
+      if (mask->IsInsideInWorldSpace(point))
       {
         sampleOK = true;
       }

--- a/Components/Metrics/PatternIntensity/itkPatternIntensityImageToImageMetric.hxx
+++ b/Components/Metrics/PatternIntensity/itkPatternIntensityImageToImageMetric.hxx
@@ -160,7 +160,7 @@ PatternIntensityImageToImageMetric<TFixedImage, TMovingImage>::ComputePIFixed() 
 
   bool sampleOK = false;
 
-  if (this->m_FixedImageMask.IsNull())
+  if (!this->GetFixedImageMask())
   {
     sampleOK = true;
   }
@@ -172,9 +172,9 @@ PatternIntensityImageToImageMetric<TFixedImage, TMovingImage>::ComputePIFixed() 
     this->m_FixedImage->TransformIndexToPhysicalPoint(currentIndex, point);
 
     /** if fixedMask is given */
-    if (!this->m_FixedImageMask.IsNull())
+    if (const auto * const mask = this->GetFixedImageMask())
     {
-      if (this->m_FixedImageMask->IsInsideInWorldSpace(point))
+      if (mask->IsInsideInWorldSpace(point))
       {
         sampleOK = true;
       }
@@ -271,7 +271,7 @@ PatternIntensityImageToImageMetric<TFixedImage, TMovingImage>::ComputePIDiff(con
   neighboriterationRegion.SetSize(neighborIterationSize);
 
   bool sampleOK = false;
-  if (this->m_FixedImageMask.IsNull())
+  if (!this->GetFixedImageMask())
   {
     sampleOK = true;
   }
@@ -283,9 +283,9 @@ PatternIntensityImageToImageMetric<TFixedImage, TMovingImage>::ComputePIDiff(con
     this->m_FixedImage->TransformIndexToPhysicalPoint(currentIndex, point);
 
     /** if fixedMask is given */
-    if (!this->m_FixedImageMask.IsNull())
+    if (const auto * const mask = this->GetFixedImageMask())
     {
-      if (this->m_FixedImageMask->IsInsideInWorldSpace(point))
+      if (mask->IsInsideInWorldSpace(point))
       {
         sampleOK = true;
       }

--- a/Components/Transforms/AdvancedAffineTransform/itkCenteredTransformInitializer2.h
+++ b/Components/Transforms/AdvancedAffineTransform/itkCenteredTransformInitializer2.h
@@ -35,7 +35,7 @@
 
 #include "itkObject.h"
 #include "itkObjectFactory.h"
-#include "itkSpatialObject.h"
+#include "itkImageMaskSpatialObject.h"
 #include "itkAdvancedImageMomentsCalculator.h"
 
 #include <iostream>


### PR DESCRIPTION
Made `GenerateData()` around 2x as fast, when having a mask.