### PR TITLE
Adjust or replace `itk::Math::Round<TReturn>` calls, whenever `TReturn` is a floating point type

### DIFF
--- a/Common/CostFunctions/itkAdvancedImageToImageMetric.hxx
+++ b/Common/CostFunctions/itkAdvancedImageToImageMetric.hxx
@@ -550,7 +550,7 @@ AdvancedImageToImageMetric<TFixedImage, TMovingImage>::EvaluateMovingImageValueA
         MovingImageIndexType index;
         for (unsigned int j = 0; j < MovingImageDimension; ++j)
         {
-          index[j] = static_cast<long>(Math::Round<double>(cindex[j]));
+          index[j] = static_cast<long>(Math::Round<int64_t>(cindex[j]));
         }
         (*gradient) = this->m_GradientImage->GetPixel(index);
       }

--- a/Common/ImageSamplers/itkImageGridSampler.hxx
+++ b/Common/ImageSamplers/itkImageGridSampler.hxx
@@ -543,7 +543,7 @@ ImageGridSampler<TInputImage>::SetNumberOfSamples(unsigned long nrofsamples)
   /** Compute the grid spacing. */
   const double indimd = static_cast<double>(InputImageDimension);
   int          gridSpacing = static_cast<int>( // no unsigned int version of rnd, max
-    Math::Round<double>(std::pow(fraction, 1.0 / indimd)));
+    Math::Round<int64_t>(std::pow(fraction, 1.0 / indimd)));
   gridSpacing = std::max(1, gridSpacing);
 
   /** Set gridSpacings for all dimensions

--- a/Components/Metrics/CorrespondingPointsEuclideanDistanceMetric/elxCorrespondingPointsEuclideanDistanceMetric.hxx
+++ b/Components/Metrics/CorrespondingPointsEuclideanDistanceMetric/elxCorrespondingPointsEuclideanDistanceMetric.hxx
@@ -21,6 +21,7 @@
 #include "elxCorrespondingPointsEuclideanDistanceMetric.h"
 #include "itkTransformixInputPointFileReader.h"
 #include "itkTimeProbe.h"
+#include <cstdint> // For int64_t.
 
 namespace elastix
 {
@@ -196,7 +197,7 @@ CorrespondingPointsEuclideanDistanceMetric<TElastix>::ReadLandmarks(const std::s
       pointSet->GetPoint(j, &point);
       for (unsigned int d = 0; d < FixedImageDimension; ++d)
       {
-        index[d] = static_cast<IndexValueType>(itk::Math::Round<double>(point[d]));
+        index[d] = static_cast<IndexValueType>(itk::Math::Round<std::int64_t>(point[d]));
       }
 
       /** Compute the input point in physical coordinates. */

--- a/Components/Transforms/SplineKernelTransform/elxSplineKernelTransform.hxx
+++ b/Components/Transforms/SplineKernelTransform/elxSplineKernelTransform.hxx
@@ -22,6 +22,7 @@
 #include "itkTransformixInputPointFileReader.h"
 #include <vnl/vnl_math.h>
 #include "itkTimeProbe.h"
+#include <cstdint> // For int64_t.
 
 namespace elastix
 {
@@ -338,7 +339,7 @@ SplineKernelTransform<TElastix>::ReadLandmarkFile(const std::string & filename,
       landmarkPointSet->GetPoint(j, &landmarkPoint);
       for (unsigned int d = 0; d < SpaceDimension; ++d)
       {
-        landmarkIndex[d] = static_cast<IndexValueType>(itk::Math::Round<double>(landmarkPoint[d]));
+        landmarkIndex[d] = static_cast<IndexValueType>(itk::Math::Round<std::int64_t>(landmarkPoint[d]));
       }
 
       /** Compute the input point in physical coordinates and replace the point. */

--- a/Core/ComponentBaseClasses/elxOptimizerBase.hxx
+++ b/Core/ComponentBaseClasses/elxOptimizerBase.hxx
@@ -23,6 +23,7 @@
 
 #include "itkSingleValuedNonLinearOptimizer.h"
 #include "itk_zlib.h"
+#include <cmath> // For round.
 
 namespace elastix
 {
@@ -83,7 +84,7 @@ OptimizerBase<TElastix>::AfterRegistrationBase()
   ParametersType      roundedTP(N);
   for (unsigned int i = 0; i < N; ++i)
   {
-    roundedTP[i] = itk::Math::Round<ParametersValueType>(finalTP[i] * 1.0e6);
+    roundedTP[i] = std::round(finalTP[i] * 1.0e6);
   }
 
   /** Compute the crc checksum using zlib crc32 function. */

--- a/Core/ComponentBaseClasses/elxTransformBase.hxx
+++ b/Core/ComponentBaseClasses/elxTransformBase.hxx
@@ -803,7 +803,7 @@ TransformBase<TElastix>::TransformPointsSomePoints(const std::string & filename)
       inputPointSet->GetPoint(j, &point);
       for (unsigned int i = 0; i < FixedImageDimension; ++i)
       {
-        inputindexvec[j][i] = static_cast<FixedImageIndexValueType>(itk::Math::Round<double>(point[i]));
+        inputindexvec[j][i] = static_cast<FixedImageIndexValueType>(itk::Math::Round<int64_t>(point[i]));
       }
       /** Compute the input point in physical coordinates. */
       dummyImage->TransformIndexToPhysicalPoint(inputindexvec[j], inputpointvec[j]);
@@ -820,7 +820,7 @@ TransformBase<TElastix>::TransformPointsSomePoints(const std::string & filename)
       const auto fixedcindex = dummyImage->template TransformPhysicalPointToContinuousIndex<double>(point);
       for (unsigned int i = 0; i < FixedImageDimension; ++i)
       {
-        inputindexvec[j][i] = static_cast<FixedImageIndexValueType>(itk::Math::Round<double>(fixedcindex[i]));
+        inputindexvec[j][i] = static_cast<FixedImageIndexValueType>(itk::Math::Round<int64_t>(fixedcindex[i]));
       }
     }
   }
@@ -836,7 +836,7 @@ TransformBase<TElastix>::TransformPointsSomePoints(const std::string & filename)
     const auto fixedcindex = dummyImage->template TransformPhysicalPointToContinuousIndex<double>(outputpointvec[j]);
     for (unsigned int i = 0; i < FixedImageDimension; ++i)
     {
-      outputindexfixedvec[j][i] = static_cast<FixedImageIndexValueType>(itk::Math::Round<double>(fixedcindex[i]));
+      outputindexfixedvec[j][i] = static_cast<FixedImageIndexValueType>(itk::Math::Round<int64_t>(fixedcindex[i]));
     }
 
     if (alsoMovingIndices)
@@ -846,7 +846,7 @@ TransformBase<TElastix>::TransformPointsSomePoints(const std::string & filename)
         movingImage->template TransformPhysicalPointToContinuousIndex<double>(outputpointvec[j]);
       for (unsigned int i = 0; i < MovingImageDimension; ++i)
       {
-        outputindexmovingvec[j][i] = static_cast<MovingImageIndexValueType>(itk::Math::Round<double>(movingcindex[i]));
+        outputindexmovingvec[j][i] = static_cast<MovingImageIndexValueType>(itk::Math::Round<int64_t>(movingcindex[i]));
       }
     }
 

--- a/Core/elxProgressCommand.cxx
+++ b/Core/elxProgressCommand.cxx
@@ -167,7 +167,7 @@ void
 ProgressCommand::PrintProgress(const float progress) const
 {
   /** Print the progress to the screen. */
-  const int progressInt = itk::Math::Round<float>(100 * progress);
+  const int progressInt = itk::Math::Round<int>(100 * progress);
 
   // Pass the entire message at once, rather than having multiple `<<` insertions.
   const std::string message = '\r' + m_StartString + std::to_string(progressInt) + m_EndString;


### PR DESCRIPTION
According to https://github.com/InsightSoftwareConsortium/ITK/blob/66ab5b14c476d057ed46a4daba05b710681160e6/Modules/Core/Common/include/itkMath.h#L127 the `TReturn` template argument of `Math::Round` must be an integer type.

Anticipating the following ITK pull request:
- https://github.com/InsightSoftwareConsortium/ITK/pull/4409