### PR TITLE
Remove m_ImageRegion and SameGeometry() from ComputeFixedImageExtrema

### DIFF
--- a/Common/CostFunctions/itkAdvancedImageToImageMetric.hxx
+++ b/Common/CostFunctions/itkAdvancedImageToImageMetric.hxx
@@ -193,7 +193,6 @@ AdvancedImageToImageMetric<TFixedImage, TMovingImage>::InitializeLimiters()
 
     const auto computeFixedImageExtrema = ComputeImageExtremaFilter<FixedImageType>::New();
     computeFixedImageExtrema->SetInput(this->GetFixedImage());
-    computeFixedImageExtrema->SetImageRegion(this->GetFixedImageRegion());
     if (const auto * const fMask = this->GetFixedImageMask())
     {
       computeFixedImageExtrema->SetUseMask(true);
@@ -230,7 +229,6 @@ AdvancedImageToImageMetric<TFixedImage, TMovingImage>::InitializeLimiters()
 
     const auto computeMovingImageExtrema = ComputeImageExtremaFilter<MovingImageType>::New();
     computeMovingImageExtrema->SetInput(this->GetMovingImage());
-    computeMovingImageExtrema->SetImageRegion(this->GetMovingImage()->GetBufferedRegion());
     if (const auto * const mask = this->GetMovingImageMask())
     {
       computeMovingImageExtrema->SetUseMask(true);

--- a/Common/CostFunctions/itkAdvancedImageToImageMetric.hxx
+++ b/Common/CostFunctions/itkAdvancedImageToImageMetric.hxx
@@ -191,9 +191,7 @@ AdvancedImageToImageMetric<TFixedImage, TMovingImage>::InitializeLimiters()
       itkExceptionMacro("No fixed image limiter has been set!");
     }
 
-    using ComputeFixedImageExtremaFilterType = typename itk::ComputeImageExtremaFilter<FixedImageType>;
-    typename ComputeFixedImageExtremaFilterType::Pointer computeFixedImageExtrema =
-      ComputeFixedImageExtremaFilterType::New();
+    const auto computeFixedImageExtrema = ComputeImageExtremaFilter<FixedImageType>::New();
     computeFixedImageExtrema->SetInput(this->GetFixedImage());
     computeFixedImageExtrema->SetImageRegion(this->GetFixedImageRegion());
     if (const auto * const fMask = this->GetFixedImageMask())
@@ -230,9 +228,7 @@ AdvancedImageToImageMetric<TFixedImage, TMovingImage>::InitializeLimiters()
       itkExceptionMacro("No moving image limiter has been set!");
     }
 
-    using ComputeMovingImageExtremaFilterType = typename itk::ComputeImageExtremaFilter<MovingImageType>;
-    typename ComputeMovingImageExtremaFilterType::Pointer computeMovingImageExtrema =
-      ComputeMovingImageExtremaFilterType::New();
+    const auto computeMovingImageExtrema = ComputeImageExtremaFilter<MovingImageType>::New();
     computeMovingImageExtrema->SetInput(this->GetMovingImage());
     computeMovingImageExtrema->SetImageRegion(this->GetMovingImage()->GetBufferedRegion());
     if (const auto * const mask = this->GetMovingImageMask())

--- a/Common/itkComputeImageExtremaFilter.h
+++ b/Common/itkComputeImageExtremaFilter.h
@@ -74,7 +74,6 @@ public:
   /** Type to use for computations. */
   using typename Superclass::RealType;
 
-  itkSetMacro(ImageRegion, RegionType);
   itkSetMacro(UseMask, bool);
 
   using ImageSpatialMaskType = ImageMaskSpatialObject<Self::ImageDimension>;
@@ -102,7 +101,6 @@ protected:
   virtual void
   ThreadedGenerateDataImageSpatialMask(const RegionType &);
 
-  RegionType                   m_ImageRegion{};
   ImageSpatialMaskConstPointer m_ImageSpatialMask{};
   bool                         m_UseMask{ false };
   bool                         m_SameGeometry{ false };

--- a/Common/itkComputeImageExtremaFilter.h
+++ b/Common/itkComputeImageExtremaFilter.h
@@ -101,8 +101,7 @@ protected:
   ThreadedStreamedGenerateData(const RegionType &) override;
   virtual void
   ThreadedGenerateDataImageSpatialMask(const RegionType &);
-  virtual void
-                               SameGeometry();
+
   RegionType                   m_ImageRegion{};
   ImageSpatialMaskConstPointer m_ImageSpatialMask{};
   bool                         m_UseMask{ false };

--- a/Common/itkComputeImageExtremaFilter.hxx
+++ b/Common/itkComputeImageExtremaFilter.hxx
@@ -44,22 +44,12 @@ ComputeImageExtremaFilter<TInputImage>::BeforeStreamedGenerateData()
 
     if (this->GetImageSpatialMask())
     {
-      this->SameGeometry();
+      this->m_SameGeometry = elastix::HaveSameImageDomain(*(this->GetInput()), *(this->m_ImageSpatialMask->GetImage()));
     }
     else
     {
       this->m_SameGeometry = false;
     }
-  }
-}
-
-template <typename TInputImage>
-void
-ComputeImageExtremaFilter<TInputImage>::SameGeometry()
-{
-  if (elastix::HaveSameImageDomain(*(this->GetInput()), *(this->m_ImageSpatialMask->GetImage())))
-  {
-    this->m_SameGeometry = true;
   }
 }
 

--- a/Components/Metrics/AdvancedMeanSquares/itkAdvancedMeanSquaresImageToImageMetric.hxx
+++ b/Components/Metrics/AdvancedMeanSquares/itkAdvancedMeanSquaresImageToImageMetric.hxx
@@ -70,7 +70,6 @@ AdvancedMeanSquaresImageToImageMetric<TFixedImage, TMovingImage>::Initialize()
     /** Try to guess a normalization factor. */
     const auto computeFixedImageExtrema = ComputeImageExtremaFilter<FixedImageType>::New();
     computeFixedImageExtrema->SetInput(this->GetFixedImage());
-    computeFixedImageExtrema->SetImageRegion(this->GetFixedImageRegion());
     if (const auto * const mask = this->GetFixedImageMask())
     {
       computeFixedImageExtrema->SetUseMask(true);
@@ -91,7 +90,6 @@ AdvancedMeanSquaresImageToImageMetric<TFixedImage, TMovingImage>::Initialize()
 
     const auto computeMovingImageExtrema = ComputeImageExtremaFilter<MovingImageType>::New();
     computeMovingImageExtrema->SetInput(this->GetMovingImage());
-    computeMovingImageExtrema->SetImageRegion(this->GetMovingImage()->GetBufferedRegion());
     if (const auto * const mask = this->GetMovingImageMask())
     {
       computeMovingImageExtrema->SetUseMask(true);

--- a/Components/Metrics/AdvancedMeanSquares/itkAdvancedMeanSquaresImageToImageMetric.hxx
+++ b/Components/Metrics/AdvancedMeanSquares/itkAdvancedMeanSquaresImageToImageMetric.hxx
@@ -68,9 +68,7 @@ AdvancedMeanSquaresImageToImageMetric<TFixedImage, TMovingImage>::Initialize()
   if (this->GetUseNormalization())
   {
     /** Try to guess a normalization factor. */
-    using ComputeFixedImageExtremaFilterType = typename itk::ComputeImageExtremaFilter<FixedImageType>;
-    typename ComputeFixedImageExtremaFilterType::Pointer computeFixedImageExtrema =
-      ComputeFixedImageExtremaFilterType::New();
+    const auto computeFixedImageExtrema = ComputeImageExtremaFilter<FixedImageType>::New();
     computeFixedImageExtrema->SetInput(this->GetFixedImage());
     computeFixedImageExtrema->SetImageRegion(this->GetFixedImageRegion());
     if (const auto * const mask = this->GetFixedImageMask())
@@ -91,9 +89,7 @@ AdvancedMeanSquaresImageToImageMetric<TFixedImage, TMovingImage>::Initialize()
       this->m_FixedImageTrueMax +
       this->m_FixedLimitRangeRatio * (this->m_FixedImageTrueMax - this->m_FixedImageTrueMin));
 
-    using ComputeMovingImageExtremaFilterType = typename itk::ComputeImageExtremaFilter<MovingImageType>;
-    typename ComputeMovingImageExtremaFilterType::Pointer computeMovingImageExtrema =
-      ComputeMovingImageExtremaFilterType::New();
+    const auto computeMovingImageExtrema = ComputeImageExtremaFilter<MovingImageType>::New();
     computeMovingImageExtrema->SetInput(this->GetMovingImage());
     computeMovingImageExtrema->SetImageRegion(this->GetMovingImage()->GetBufferedRegion());
     if (const auto * const mask = this->GetMovingImageMask())


### PR DESCRIPTION
Three style improvements related to ComputeFixedImageExtrema.

@mstaring @stefanklein Note that ComputeFixedImageExtrema did not use its `m_ImageRegion` property internally, even though both AdvancedImageToImageMetric and AdvancedMeanSquaresImageToImageMetric did call `computeFixedImageExtrema->SetImageRegion`. This pull request proposes to just remove this property.

Also addressed the following issue:
- #1025