### PR TITLE
STYLE: Do `const MaskType * const mask = this->Superclass::GetMask()`

### DIFF
--- a/Common/ImageSamplers/itkImageFullSampler.hxx
+++ b/Common/ImageSamplers/itkImageFullSampler.hxx
@@ -34,7 +34,7 @@ template <class TInputImage>
 void
 ImageFullSampler<TInputImage>::GenerateData()
 {
-  typename MaskType::ConstPointer mask = this->GetMask();
+  const MaskType * const mask = this->Superclass::GetMask();
 
   if (mask)
   {
@@ -63,7 +63,7 @@ ImageFullSampler<TInputImage>::GenerateData()
   using InputImageIterator = ImageRegionConstIteratorWithIndex<InputImageType>;
 
   /** Fill the sample container. */
-  if (mask.IsNull())
+  if (mask == nullptr)
   {
     /** Try to reserve memory. If no mask is used this can raise std exceptions when the input image is large. */
     try
@@ -135,9 +135,9 @@ ImageFullSampler<TInputImage>::ThreadedGenerateData(const InputImageRegionType &
                                                     ThreadIdType                 threadId)
 {
   /** Get handles to the input image, mask and the output. */
-  const InputImageType &          inputImage = elastix::Deref(this->GetInput());
-  typename MaskType::ConstPointer mask = this->GetMask();
-  std::vector<ImageSampleType> &  sampleVectorOfThisThread = Superclass::m_ThreaderSampleVectors[threadId];
+  const InputImageType &         inputImage = elastix::Deref(this->GetInput());
+  const MaskType * const         mask = this->Superclass::GetMask();
+  std::vector<ImageSampleType> & sampleVectorOfThisThread = Superclass::m_ThreaderSampleVectors[threadId];
 
   // Take capacity from the vector of this thread, and clear both.
   std::vector<ImageSampleType> sampleVector = std::move(sampleVectorOfThisThread);
@@ -150,7 +150,7 @@ ImageFullSampler<TInputImage>::ThreadedGenerateData(const InputImageRegionType &
 
   /** Fill the sample container. */
   const unsigned long chunkSize = inputRegionForThread.GetNumberOfPixels();
-  if (mask.IsNull())
+  if (mask == nullptr)
   {
     /** Try to reserve memory. If no mask is used this can raise std exceptions when the input image is large. */
     try

--- a/Common/ImageSamplers/itkImageRandomCoordinateSampler.hxx
+++ b/Common/ImageSamplers/itkImageRandomCoordinateSampler.hxx
@@ -54,8 +54,8 @@ ImageRandomCoordinateSampler<TInputImage>::GenerateData()
   this->GenerateSampleRegion(smallestImageContIndex, largestImageContIndex, smallestContIndex, largestContIndex);
 
   /** Get a handle to the mask. If there was no mask supplied we exercise a multi-threaded version. */
-  typename MaskType::ConstPointer mask = this->GetMask();
-  if (mask.IsNull() && Superclass::m_UseMultiThread)
+  const MaskType * const mask = this->Superclass::GetMask();
+  if (mask == nullptr && Superclass::m_UseMultiThread)
   {
     auto & samples = sampleContainer.CastToSTLContainer();
     samples.resize(this->Superclass::m_NumberOfSamples);
@@ -90,7 +90,7 @@ ImageRandomCoordinateSampler<TInputImage>::GenerateData()
 
   InputImageContinuousIndexType sampleContIndex;
   /** Fill the sample container. */
-  if (mask.IsNull())
+  if (mask == nullptr)
   {
     /** Start looping over the sample container. */
     for (iter = sampleContainer.Begin(); iter != end; ++iter)

--- a/Common/ImageSamplers/itkImageRandomSampler.hxx
+++ b/Common/ImageSamplers/itkImageRandomSampler.hxx
@@ -41,8 +41,8 @@ ImageRandomSampler<TInputImage>::GenerateData()
   ImageSampleContainerType & sampleContainer = elastix::Deref(this->GetOutput());
 
   /** Get a handle to the mask. If there was no mask supplied we exercise a multi-threaded version. */
-  typename MaskType::ConstPointer mask = this->GetMask();
-  if (mask.IsNull() && Superclass::m_UseMultiThread)
+  const MaskType * const mask = this->Superclass::GetMask();
+  if (mask == nullptr && Superclass::m_UseMultiThread)
   {
     Superclass::GenerateRandomNumberList();
     const auto & randomNumberList = Superclass::m_RandomNumberList;
@@ -77,7 +77,7 @@ ImageRandomSampler<TInputImage>::GenerateData()
   typename ImageSampleContainerType::Iterator      iter;
   typename ImageSampleContainerType::ConstIterator end = sampleContainer.End();
 
-  if (mask.IsNull())
+  if (mask == nullptr)
   {
     /** number of samples + 1, because of the initial ++randIter. */
     randIter.SetNumberOfSamples(this->GetNumberOfSamples() + 1);

--- a/Common/ImageSamplers/itkImageRandomSamplerSparseMask.hxx
+++ b/Common/ImageSamplers/itkImageRandomSamplerSparseMask.hxx
@@ -33,10 +33,10 @@ void
 ImageRandomSamplerSparseMask<TInputImage>::GenerateData()
 {
   /** Get a handle to the mask. */
-  typename MaskType::ConstPointer mask = this->GetMask();
+  const MaskType * const mask = this->Superclass::GetMask();
 
   /** Sanity check. */
-  if (mask.IsNull())
+  if (mask == nullptr)
   {
     itkExceptionMacro("ERROR: do not call this function when no mask is supplied.");
   }
@@ -71,7 +71,7 @@ ImageRandomSamplerSparseMask<TInputImage>::GenerateData()
     std::string            fullSamplerMessage = err.GetDescription();
     std::string::size_type loc =
       fullSamplerMessage.find("ERROR: failed to allocate memory for the sample container", 0);
-    if (loc != std::string::npos && this->GetMask() == nullptr)
+    if (loc != std::string::npos && mask == nullptr)
     {
       message += "\nYou are using the ImageRandomSamplerSparseMask sampler, "
                  "but you did not set a mask. The internal ImageFullSampler therefore "

--- a/Common/ImageSamplers/itkMultiInputImageRandomCoordinateSampler.hxx
+++ b/Common/ImageSamplers/itkMultiInputImageRandomCoordinateSampler.hxx
@@ -43,7 +43,7 @@ MultiInputImageRandomCoordinateSampler<TInputImage>::GenerateData()
   /** Get handles to the input image, output sample container, and mask. */
   const InputImageType &             inputImage = elastix::Deref(this->GetInput());
   ImageSampleContainerType &         sampleContainer = elastix::Deref(this->GetOutput());
-  typename MaskType::ConstPointer    mask = this->GetMask();
+  const MaskType * const             mask = this->Superclass::GetMask();
   typename InterpolatorType::Pointer interpolator = this->GetModifiableInterpolator();
 
   /** Set up the interpolator. */
@@ -63,7 +63,7 @@ MultiInputImageRandomCoordinateSampler<TInputImage>::GenerateData()
 
   InputImageContinuousIndexType sampleContIndex;
   /** Fill the sample container. */
-  if (mask.IsNull())
+  if (mask == nullptr)
   {
     /** Start looping over the sample container. */
     for (iter = sampleContainer.Begin(); iter != end; ++iter)


### PR DESCRIPTION
Consistently used a raw pointer to the mask of its superclass (base class), in all samplers.

In these cases a smart pointer (`MaskType::ConstPointer`) is not necessary, as there is no risk for the mask to be deleted while it is being used by the sampler.