### PR TITLE
STYLE: Remove `PrintSelf` overrides from classes without data members

### DIFF
--- a/Common/ImageSamplers/itkImageFullSampler.h
+++ b/Common/ImageSamplers/itkImageFullSampler.h
@@ -96,9 +96,7 @@ protected:
   /** The destructor. */
   ~ImageFullSampler() override = default;
 
-  /** PrintSelf. */
-  void
-  PrintSelf(std::ostream & os, Indent indent) const override;
+  using Superclass::PrintSelf;
 
   /** Function that does the work. */
   void

--- a/Common/ImageSamplers/itkImageFullSampler.hxx
+++ b/Common/ImageSamplers/itkImageFullSampler.hxx
@@ -211,19 +211,6 @@ ImageFullSampler<TInputImage>::ThreadedGenerateData(const InputImageRegionType &
 
 } // end ThreadedGenerateData()
 
-
-/**
- * ******************* PrintSelf *******************
- */
-
-template <class TInputImage>
-void
-ImageFullSampler<TInputImage>::PrintSelf(std::ostream & os, Indent indent) const
-{
-  Superclass::PrintSelf(os, indent);
-} // end PrintSelf()
-
-
 } // end namespace itk
 
 #endif // end #ifndef itkImageFullSampler_hxx

--- a/Common/Transforms/itkAdvancedRigid3DTransform.h
+++ b/Common/Transforms/itkAdvancedRigid3DTransform.h
@@ -144,11 +144,7 @@ protected:
   AdvancedRigid3DTransform();
   ~AdvancedRigid3DTransform() override = default;
 
-  /**
-   * Print contents of an AdvancedRigid3DTransform
-   **/
-  void
-  PrintSelf(std::ostream & os, Indent indent) const override;
+  using Superclass::PrintSelf;
 };
 
 } // namespace itk

--- a/Common/Transforms/itkAdvancedRigid3DTransform.hxx
+++ b/Common/Transforms/itkAdvancedRigid3DTransform.hxx
@@ -50,14 +50,6 @@ AdvancedRigid3DTransform<TScalarType>::AdvancedRigid3DTransform(unsigned int par
   : Superclass(paramDim)
 {}
 
-// Print self
-template <class TScalarType>
-void
-AdvancedRigid3DTransform<TScalarType>::PrintSelf(std::ostream & os, Indent indent) const
-{
-  Superclass::PrintSelf(os, indent);
-}
-
 
 // Check if input matrix is orthogonal to within tolerance
 template <class TScalarType>

--- a/Common/Transforms/itkAdvancedVersorRigid3DTransform.h
+++ b/Common/Transforms/itkAdvancedVersorRigid3DTransform.h
@@ -135,8 +135,7 @@ protected:
   AdvancedVersorRigid3DTransform();
   ~AdvancedVersorRigid3DTransform() override = default;
 
-  void
-  PrintSelf(std::ostream & os, Indent indent) const override;
+  using Superclass::PrintSelf;
 };
 
 // class AdvancedVersorRigid3DTransform

--- a/Common/Transforms/itkAdvancedVersorRigid3DTransform.hxx
+++ b/Common/Transforms/itkAdvancedVersorRigid3DTransform.hxx
@@ -198,16 +198,6 @@ AdvancedVersorRigid3DTransform<TScalarType>::GetJacobian(const InputPointType & 
   nzji = this->m_NonZeroJacobianIndices;
 }
 
-
-// Print self
-template <class TScalarType>
-void
-AdvancedVersorRigid3DTransform<TScalarType>::PrintSelf(std::ostream & os, Indent indent) const
-{
-  Superclass::PrintSelf(os, indent);
-}
-
-
 } // namespace itk
 
 #endif

--- a/Common/itkMultiResolutionGaussianSmoothingPyramidImageFilter.h
+++ b/Common/itkMultiResolutionGaussianSmoothingPyramidImageFilter.h
@@ -189,8 +189,8 @@ public:
 protected:
   MultiResolutionGaussianSmoothingPyramidImageFilter() = default;
   ~MultiResolutionGaussianSmoothingPyramidImageFilter() override = default;
-  void
-  PrintSelf(std::ostream & os, Indent indent) const override;
+
+  using Superclass::PrintSelf;
 
   /** Generate the output data. */
   void

--- a/Common/itkMultiResolutionGaussianSmoothingPyramidImageFilter.hxx
+++ b/Common/itkMultiResolutionGaussianSmoothingPyramidImageFilter.hxx
@@ -196,18 +196,6 @@ MultiResolutionGaussianSmoothingPyramidImageFilter<TInputImage, TOutputImage>::G
 
 
 /*
- * PrintSelf method
- */
-template <class TInputImage, class TOutputImage>
-void
-MultiResolutionGaussianSmoothingPyramidImageFilter<TInputImage, TOutputImage>::PrintSelf(std::ostream & os,
-                                                                                         Indent         indent) const
-{
-  Superclass::PrintSelf(os, indent);
-}
-
-
-/*
  * GenerateOutputInformation
  */
 template <class TInputImage, class TOutputImage>

--- a/Testing/itkTestOutputWindow.cxx
+++ b/Testing/itkTestOutputWindow.cxx
@@ -21,14 +21,6 @@ namespace itk
 {
 //------------------------------------------------------------------------------
 void
-TestOutputWindow::PrintSelf(std::ostream & os, Indent indent) const
-{
-  Superclass::PrintSelf(os, indent);
-}
-
-
-//------------------------------------------------------------------------------
-void
 TestOutputWindow::DisplayText(const char * text)
 {
   std::cout << text;

--- a/Testing/itkTestOutputWindow.h
+++ b/Testing/itkTestOutputWindow.h
@@ -68,8 +68,7 @@ public:
 protected:
   TestOutputWindow() {}
   ~TestOutputWindow() override {}
-  void
-  PrintSelf(std::ostream & os, Indent indent) const override;
+  using Superclass::PrintSelf;
 };
 
 } // end namespace itk


### PR DESCRIPTION
These overrides were empty anyway! Found by Notepad++ `{\r\n  Superclass::PrintSelf(os, indent);\r\n}`.

Replaced the declarations of those overrides by `using Superclass::PrintSelf`.