### PR TITLE
Add private static `ImageGridSampler::GenerateDataForWorkUnit` member function, reducing duplicate code

### DIFF
--- a/Common/ImageSamplers/itkImageGridSampler.h
+++ b/Common/ImageSamplers/itkImageGridSampler.h
@@ -246,6 +246,15 @@ private:
                             const SampleGridSpacingType &  gridSpacing,
                             std::vector<ImageSampleType> & samples);
 
+  /** Generates the data for one specific work unit. */
+  template <bool VUseMask>
+  static void
+  GenerateDataForWorkUnit(WorkUnit &,
+                          const InputImageType &,
+                          const MaskType *,
+                          const WorldToObjectTransformType *,
+                          const SampleGridSpacingType &);
+
   /** An array of integer spacing factors */
   SampleGridSpacingType m_SampleGridSpacing{ itk::MakeFilled<SampleGridSpacingType>(1) };
 

--- a/Common/ImageSamplers/itkImageGridSampler.hxx
+++ b/Common/ImageSamplers/itkImageGridSampler.hxx
@@ -438,17 +438,30 @@ ImageGridSampler<TInputImage>::ThreaderCallback(void * const arg)
     return ITK_THREAD_RETURN_DEFAULT_VALUE;
   }
 
-  auto & workUnit = userData.WorkUnits[workUnitID];
+  GenerateDataForWorkUnit<VUseMask>(userData.WorkUnits[workUnitID],
+                                    userData.InputImage,
+                                    userData.Mask,
+                                    userData.WorldToObjectTransform,
+                                    userData.GridSpacing);
 
-  auto *             samples = workUnit.Samples;
-  const auto &       inputImage = userData.InputImage;
-  const auto * const mask = userData.Mask;
+  return ITK_THREAD_RETURN_DEFAULT_VALUE;
+}
+
+
+template <class TInputImage>
+template <bool VUseMask>
+void
+ImageGridSampler<TInputImage>::GenerateDataForWorkUnit(WorkUnit &                               workUnit,
+                                                       const InputImageType &                   inputImage,
+                                                       const MaskType * const                   mask,
+                                                       const WorldToObjectTransformType * const worldToObjectTransform,
+                                                       const SampleGridSpacingType &            gridSpacing)
+{
   assert((mask == nullptr) == (!VUseMask));
-
-  const auto * const worldToObjectTransform = userData.WorldToObjectTransform;
   assert((worldToObjectTransform == nullptr) == (!VUseMask));
 
-  const auto                gridSpacing = userData.GridSpacing;
+  auto * samples = workUnit.Samples;
+
   const SampleGridSizeType  gridSizeForThread = workUnit.GridSize;
   const SampleGridIndexType gridIndexForThread = workUnit.GridIndex;
 
@@ -505,10 +518,7 @@ ImageGridSampler<TInputImage>::ThreaderCallback(void * const arg)
   {
     workUnit.NumberOfSamples = samples - workUnit.Samples;
   }
-
-  return ITK_THREAD_RETURN_DEFAULT_VALUE;
 }
-
 
 /**
  * ******************* SetNumberOfSamples *******************


### PR DESCRIPTION
Shared more code between multi-threaded and single-threaded implementations of ImageGridSampler.