### PR TITLE
Remove unreachable error from `ImageRandomSamplerSparseMask`, extend error message on missing mask 

### DIFF
--- a/Common/ImageSamplers/itkImageRandomSamplerSparseMask.hxx
+++ b/Common/ImageSamplers/itkImageRandomSamplerSparseMask.hxx
@@ -38,7 +38,9 @@ ImageRandomSamplerSparseMask<TInputImage>::GenerateData()
   /** Sanity check. */
   if (mask == nullptr)
   {
-    itkExceptionMacro("ERROR: do not call this function when no mask is supplied.");
+    itkExceptionMacro("ERROR: do not call this function when no mask is supplied. When using the "
+                      "ImageRandomSamplerSparseMask sampler, a mask is required. Otherwise you may consider using a "
+                      "sampler that does not require a mask, for example, ImageRandomSampler.");
   }
 
   /** Get handles to the input image and output sample container. */

--- a/Common/ImageSamplers/itkImageRandomSamplerSparseMask.hxx
+++ b/Common/ImageSamplers/itkImageRandomSamplerSparseMask.hxx
@@ -61,24 +61,11 @@ ImageRandomSamplerSparseMask<TInputImage>::GenerateData()
   {
     this->m_InternalFullSampler->Update();
   }
-  catch (ExceptionObject & err)
+  catch (const ExceptionObject & err)
   {
-    std::string message = "ERROR: This ImageSampler internally uses the "
-                          "ImageFullSampler. Updating of this internal sampler raised the "
-                          "exception:\n";
-    message += err.GetDescription();
-
-    std::string            fullSamplerMessage = err.GetDescription();
-    std::string::size_type loc =
-      fullSamplerMessage.find("ERROR: failed to allocate memory for the sample container", 0);
-    if (loc != std::string::npos && mask == nullptr)
-    {
-      message += "\nYou are using the ImageRandomSamplerSparseMask sampler, "
-                 "but you did not set a mask. The internal ImageFullSampler therefore "
-                 "requires a lot of memory. Consider using the ImageRandomSampler "
-                 "instead.";
-    }
-    itkExceptionMacro(<< message);
+    itkExceptionMacro("ERROR: This ImageSampler internally uses the ImageFullSampler. Updating of this internal "
+                      "sampler raised the exception:\n"
+                      << err.GetDescription());
   }
 
   /** Get a handle to the full sampler output. */


### PR DESCRIPTION
Addressed the following issue:
- #1035 

Fixes #1035