### PR TITLE
STYLE: Add const to masks Get/SetFixedImageMask, Get/SetMovingImageMask

### DIFF
--- a/Common/CostFunctions/itkAdvancedImageToImageMetric.h
+++ b/Common/CostFunctions/itkAdvancedImageToImageMetric.h
@@ -128,8 +128,10 @@ public:
   // Overrule the mask type from its base class, ITK ImageToImageMetric.
   using FixedImageMaskType = ImageMaskSpatialObject<Self::FixedImageDimension>;
   using FixedImageMaskPointer = SmartPointer<FixedImageMaskType>;
+  using FixedImageMaskConstPointer = SmartPointer<const FixedImageMaskType>;
   using MovingImageMaskType = ImageMaskSpatialObject<Self::MovingImageDimension>;
   using MovingImageMaskPointer = SmartPointer<MovingImageMaskType>;
+  using MovingImageMaskConstPointer = SmartPointer<const MovingImageMaskType>;
 
   using typename Superclass::MeasureType;
   using typename Superclass::DerivativeType;
@@ -180,14 +182,14 @@ public:
   /** Public methods ********************/
 
   virtual void
-  SetFixedImageMask(FixedImageMaskType * const arg)
+  SetFixedImageMask(const FixedImageMaskType * const arg)
   {
     assert(arg == nullptr || typeid(*arg) == typeid(FixedImageMaskType));
     Superclass::SetFixedImageMask(arg);
   }
 
   virtual void
-  SetMovingImageMask(MovingImageMaskType * const arg)
+  SetMovingImageMask(const MovingImageMaskType * const arg)
   {
     assert(arg == nullptr || typeid(*arg) == typeid(MovingImageMaskType));
     Superclass::SetMovingImageMask(arg);

--- a/Common/CostFunctions/itkMultiInputImageToImageMetricBase.h
+++ b/Common/CostFunctions/itkMultiInputImageToImageMetricBase.h
@@ -91,8 +91,10 @@ public:
   using typename Superclass::GradientImageFilterPointer;
   using typename Superclass::FixedImageMaskType;
   using typename Superclass::FixedImageMaskPointer;
+  using typename Superclass::FixedImageMaskConstPointer;
   using typename Superclass::MovingImageMaskType;
   using typename Superclass::MovingImageMaskPointer;
+  using typename Superclass::MovingImageMaskConstPointer;
   using typename Superclass::MeasureType;
   using typename Superclass::DerivativeType;
   using typename Superclass::ParametersType;
@@ -102,10 +104,10 @@ public:
 
   /** Typedef's for storing multiple inputs. */
   using FixedImageVectorType = std::vector<FixedImageConstPointer>;
-  using FixedImageMaskVectorType = std::vector<FixedImageMaskPointer>;
+  using FixedImageMaskVectorType = std::vector<FixedImageMaskConstPointer>;
   using FixedImageRegionVectorType = std::vector<FixedImageRegionType>;
   using MovingImageVectorType = std::vector<MovingImageConstPointer>;
-  using MovingImageMaskVectorType = std::vector<MovingImageMaskPointer>;
+  using MovingImageMaskVectorType = std::vector<MovingImageMaskConstPointer>;
   using InterpolatorVectorType = std::vector<InterpolatorPointer>;
   using FixedImageInterpolatorVectorType = std::vector<FixedImageInterpolatorPointer>;
 
@@ -145,22 +147,22 @@ public:
 
   /** Set the fixed image masks. */
   virtual void
-  SetFixedImageMask(FixedImageMaskType * _arg, unsigned int pos);
+  SetFixedImageMask(const FixedImageMaskType * _arg, unsigned int pos);
 
   /** Set the first fixed image mask. */
   void
-  SetFixedImageMask(FixedImageMaskType * _arg) override
+  SetFixedImageMask(const FixedImageMaskType * _arg) override
   {
     this->SetFixedImageMask(_arg, 0);
   }
 
 
   /** Get the fixed image masks. */
-  virtual FixedImageMaskType *
+  virtual const FixedImageMaskType *
   GetFixedImageMask(unsigned int pos) const;
 
   /** Get the first fixed image mask. */
-  FixedImageMaskType *
+  const FixedImageMaskType *
   GetFixedImageMask() const override
   {
     return this->GetFixedImageMask(0);
@@ -241,22 +243,22 @@ public:
 
   /** Set the moving image masks. */
   virtual void
-  SetMovingImageMask(MovingImageMaskType * _arg, unsigned int pos);
+  SetMovingImageMask(const MovingImageMaskType * _arg, unsigned int pos);
 
   /** Set the first moving image mask. */
   void
-  SetMovingImageMask(MovingImageMaskType * _arg) override
+  SetMovingImageMask(const MovingImageMaskType * _arg) override
   {
     this->SetMovingImageMask(_arg, 0);
   }
 
 
   /** Get the moving image masks. */
-  virtual MovingImageMaskType *
+  virtual const MovingImageMaskType *
   GetMovingImageMask(unsigned int pos) const;
 
   /** Get the first moving image mask. */
-  MovingImageMaskType *
+  const MovingImageMaskType *
   GetMovingImageMask() const override
   {
     return this->GetMovingImageMask(0);

--- a/Common/CostFunctions/itkMultiInputImageToImageMetricBase.hxx
+++ b/Common/CostFunctions/itkMultiInputImageToImageMetricBase.hxx
@@ -94,17 +94,17 @@ namespace itk
 
 /** Set components. */
 itkImplementationSetObjectMacro(FixedImage, const FixedImageType);
-itkImplementationSetObjectMacro(FixedImageMask, FixedImageMaskType);
+itkImplementationSetObjectMacro(FixedImageMask, const FixedImageMaskType);
 itkImplementationSetObjectMacro(MovingImage, const MovingImageType);
-itkImplementationSetObjectMacro(MovingImageMask, MovingImageMaskType);
+itkImplementationSetObjectMacro(MovingImageMask, const MovingImageMaskType);
 itkImplementationSetObjectMacro(Interpolator, InterpolatorType);
 itkImplementationSetObjectMacro2(FixedImageInterpolator, FixedImageInterpolatorType);
 
 /** Get components. */
 itkImplementationGetConstObjectMacro(FixedImage, FixedImageType);
-itkImplementationGetObjectMacro(FixedImageMask, FixedImageMaskType);
+itkImplementationGetConstObjectMacro(FixedImageMask, FixedImageMaskType);
 itkImplementationGetConstObjectMacro(MovingImage, MovingImageType);
-itkImplementationGetObjectMacro(MovingImageMask, MovingImageMaskType);
+itkImplementationGetConstObjectMacro(MovingImageMask, MovingImageMaskType);
 itkImplementationGetObjectMacro(Interpolator, InterpolatorType);
 itkImplementationGetObjectMacro(FixedImageInterpolator, FixedImageInterpolatorType);
 
@@ -305,8 +305,7 @@ MultiInputImageToImageMetricBase<TFixedImage, TMovingImage>::IsInsideMovingMask(
   bool inside = true;
   for (unsigned int i = 0; i < this->GetNumberOfMovingImageMasks(); ++i)
   {
-    MovingImageMaskPointer movingImageMask = this->GetMovingImageMask(i);
-    if (movingImageMask.IsNotNull())
+    if (const auto * const movingImageMask = this->GetMovingImageMask(i))
     {
       inside &= movingImageMask->IsInsideInWorldSpace(mappedPoint);
     }

--- a/Components/Registrations/MultiMetricMultiResolutionRegistration/itkCombinationImageToImageMetric.h
+++ b/Components/Registrations/MultiMetricMultiResolutionRegistration/itkCombinationImageToImageMetric.h
@@ -315,11 +315,11 @@ public:
 
   /** Pass the fixed image mask to all sub metrics. */
   void
-  SetFixedImageMask(FixedImageMaskType * _arg) override;
+  SetFixedImageMask(const FixedImageMaskType * _arg) override;
 
   /** Pass a fixed image mask to a specific metric */
   virtual void
-  SetFixedImageMask(FixedImageMaskType * _arg, unsigned int pos);
+  SetFixedImageMask(const FixedImageMaskType * _arg, unsigned int pos);
 
   /** Returns the fixedImageMask set in a specific metric. If the
    * submetric is a singlevalued costfunction a zero pointer will
@@ -381,11 +381,11 @@ public:
 
   /** Pass the moving image mask to all sub metrics. */
   void
-  SetMovingImageMask(MovingImageMaskType * _arg) override;
+  SetMovingImageMask(const MovingImageMaskType * _arg) override;
 
   /** Pass a moving image mask to a specific metric */
   virtual void
-  SetMovingImageMask(MovingImageMaskType * _arg, unsigned int pos);
+  SetMovingImageMask(const MovingImageMaskType * _arg, unsigned int pos);
 
   /** Returns the movingImageMask set in a specific metric. If the
    * submetric is a singlevalued costfunction a zero pointer will

--- a/Components/Registrations/MultiMetricMultiResolutionRegistration/itkCombinationImageToImageMetric.hxx
+++ b/Components/Registrations/MultiMetricMultiResolutionRegistration/itkCombinationImageToImageMetric.hxx
@@ -122,8 +122,8 @@ namespace itk
 
 itkImplementationSetObjectMacro2(Transform, , TransformType);
 itkImplementationSetObjectMacro1(Interpolator, , InterpolatorType);
-itkImplementationSetObjectMacro2(FixedImageMask, , FixedImageMaskType);
-itkImplementationSetObjectMacro2(MovingImageMask, , MovingImageMaskType);
+itkImplementationSetObjectMacro2(FixedImageMask, const, FixedImageMaskType);
+itkImplementationSetObjectMacro2(MovingImageMask, const, MovingImageMaskType);
 itkImplementationSetObjectMacro1(FixedImage, const, FixedImageType);
 itkImplementationSetObjectMacro1(MovingImage, const, MovingImageType);
 

--- a/Components/Transforms/AdvancedAffineTransform/itkCenteredTransformInitializer2.h
+++ b/Components/Transforms/AdvancedAffineTransform/itkCenteredTransformInitializer2.h
@@ -124,6 +124,8 @@ public:
   using MovingImageMaskType = Image<unsigned char, OutputSpaceDimension>;
   using FixedImageMaskPointer = typename FixedImageMaskType::ConstPointer;
   using MovingImageMaskPointer = typename MovingImageMaskType::ConstPointer;
+  using FixedImageMaskConstPointer = typename FixedImageMaskType::ConstPointer;
+  using MovingImageMaskConstPointer = typename MovingImageMaskType::ConstPointer;
 
   /** Moment calculators */
   using FixedImageCalculatorType = AdvancedImageMomentsCalculator<FixedImageType>;


### PR DESCRIPTION
Increases const-correctness. Ensures that the right overload is called, when AdvancedImageToImageMetric calls `Superclass::SetFixedImageMask(arg)` or `Superclass::SetMovingImageMask(arg)`.

Related to pull request https://github.com/InsightSoftwareConsortium/ITK/pull/4414 commit https://github.com/InsightSoftwareConsortium/ITK/commit/813ddb3d52955d0e0017ea9690e0afab45047c81 "STYLE: Remove itkSetObjectMacro if itkSetConstObjectMacro is also there" (merged to ITK's master branch on January 22, 2024)