### PR TITLE
ComputeImageExtremaFilter: Remove `UseMask` property and let it only compute min and max 

### DIFF
--- a/Common/CostFunctions/itkAdvancedImageToImageMetric.hxx
+++ b/Common/CostFunctions/itkAdvancedImageToImageMetric.hxx
@@ -192,12 +192,7 @@ AdvancedImageToImageMetric<TFixedImage, TMovingImage>::InitializeLimiters()
 
     const auto computeFixedImageExtrema = ComputeImageExtremaFilter<FixedImageType>::New();
     computeFixedImageExtrema->SetInput(this->GetFixedImage());
-    if (const auto * const fMask = this->GetFixedImageMask())
-    {
-      computeFixedImageExtrema->SetUseMask(true);
-      computeFixedImageExtrema->SetImageSpatialMask(fMask);
-    }
-
+    computeFixedImageExtrema->SetImageSpatialMask(this->GetFixedImageMask());
     computeFixedImageExtrema->Update();
 
     this->m_FixedImageTrueMax = computeFixedImageExtrema->GetMaximum();
@@ -228,11 +223,7 @@ AdvancedImageToImageMetric<TFixedImage, TMovingImage>::InitializeLimiters()
 
     const auto computeMovingImageExtrema = ComputeImageExtremaFilter<MovingImageType>::New();
     computeMovingImageExtrema->SetInput(this->GetMovingImage());
-    if (const auto * const mask = this->GetMovingImageMask())
-    {
-      computeMovingImageExtrema->SetUseMask(true);
-      computeMovingImageExtrema->SetImageSpatialMask(mask);
-    }
+    computeMovingImageExtrema->SetImageSpatialMask(this->GetMovingImageMask());
     computeMovingImageExtrema->Update();
 
     this->m_MovingImageTrueMax = computeMovingImageExtrema->GetMaximum();

--- a/Common/GTesting/itkComputeImageExtremaFilterGTest.cxx
+++ b/Common/GTesting/itkComputeImageExtremaFilterGTest.cxx
@@ -196,7 +196,6 @@ Expect_one_non_zero_pixel_value_masked_in(const typename TImage::SizeType & imag
     const auto filter = CheckNew<FilterType>();
     filter->SetInput(image);
     filter->SetImageSpatialMask(maskSpatialObject);
-    filter->SetUseMask(true);
     filter->Update();
 
     EXPECT_EQ(filter->GetMinimum(), pixelValue);
@@ -247,7 +246,6 @@ Expect_one_positive_pixel_value_all_pixels_masked_in(const typename TImage::Size
     const auto filter = CheckNew<FilterType>();
     filter->SetInput(image);
     filter->SetImageSpatialMask(maskSpatialObject);
-    filter->SetUseMask(true);
     filter->Update();
 
     EXPECT_EQ(filter->GetMinimum(), 0);
@@ -356,8 +354,6 @@ GTEST_TEST(ComputeImageExtremaFilter, MaskSpacingAndDirectionAffectResults)
     elastix::DefaultConstruct<FilterType> filter{};
     filter.SetInput(image);
     filter.SetImageSpatialMask(maskSpatialObject);
-    filter.SetUseMask(true);
-
     filter.Update();
     return filter.GetMaximum();
   };

--- a/Common/itkComputeImageExtremaFilter.h
+++ b/Common/itkComputeImageExtremaFilter.h
@@ -76,8 +76,6 @@ public:
   /** Type to use for computations. */
   using typename Superclass::RealType;
 
-  itkSetMacro(UseMask, bool);
-
   using ImageSpatialMaskType = ImageMaskSpatialObject<Self::ImageDimension>;
   using ImageSpatialMaskPointer = typename ImageSpatialMaskType::Pointer;
   using ImageSpatialMaskConstPointer = typename ImageSpatialMaskType::ConstPointer;
@@ -105,7 +103,6 @@ protected:
 
 private:
   ImageSpatialMaskConstPointer m_ImageSpatialMask{};
-  bool                         m_UseMask{ false };
   bool                         m_SameGeometry{ false };
 
   CompensatedSummation<RealType> m_ThreadSum{ 1 };

--- a/Common/itkComputeImageExtremaFilter.hxx
+++ b/Common/itkComputeImageExtremaFilter.hxx
@@ -29,7 +29,7 @@ template <typename TInputImage>
 void
 ComputeImageExtremaFilter<TInputImage>::BeforeStreamedGenerateData()
 {
-  if (!this->m_UseMask)
+  if (m_ImageSpatialMask == nullptr)
   {
     Superclass::BeforeStreamedGenerateData();
   }
@@ -57,7 +57,7 @@ template <typename TInputImage>
 void
 ComputeImageExtremaFilter<TInputImage>::AfterStreamedGenerateData()
 {
-  if (!this->m_UseMask)
+  if (m_ImageSpatialMask == nullptr)
   {
     Superclass::AfterStreamedGenerateData();
   }
@@ -89,16 +89,13 @@ template <typename TInputImage>
 void
 ComputeImageExtremaFilter<TInputImage>::ThreadedStreamedGenerateData(const RegionType & regionForThread)
 {
-  if (!this->m_UseMask)
+  if (m_ImageSpatialMask == nullptr)
   {
     Superclass::ThreadedStreamedGenerateData(regionForThread);
   }
   else
   {
-    if (this->GetImageSpatialMask())
-    {
-      this->ThreadedGenerateDataImageSpatialMask(regionForThread);
-    }
+    this->ThreadedGenerateDataImageSpatialMask(regionForThread);
   }
 } // end ThreadedGenerateData()
 

--- a/Components/Metrics/AdvancedMeanSquares/itkAdvancedMeanSquaresImageToImageMetric.hxx
+++ b/Components/Metrics/AdvancedMeanSquares/itkAdvancedMeanSquaresImageToImageMetric.hxx
@@ -56,12 +56,7 @@ AdvancedMeanSquaresImageToImageMetric<TFixedImage, TMovingImage>::Initialize()
     /** Try to guess a normalization factor. */
     const auto computeFixedImageExtrema = ComputeImageExtremaFilter<FixedImageType>::New();
     computeFixedImageExtrema->SetInput(this->GetFixedImage());
-    if (const auto * const mask = this->GetFixedImageMask())
-    {
-      computeFixedImageExtrema->SetUseMask(true);
-      computeFixedImageExtrema->SetImageSpatialMask(mask);
-    }
-
+    computeFixedImageExtrema->SetImageSpatialMask(this->GetFixedImageMask());
     computeFixedImageExtrema->Update();
 
     this->m_FixedImageTrueMax = computeFixedImageExtrema->GetMaximum();
@@ -76,12 +71,7 @@ AdvancedMeanSquaresImageToImageMetric<TFixedImage, TMovingImage>::Initialize()
 
     const auto computeMovingImageExtrema = ComputeImageExtremaFilter<MovingImageType>::New();
     computeMovingImageExtrema->SetInput(this->GetMovingImage());
-    if (const auto * const mask = this->GetMovingImageMask())
-    {
-      computeMovingImageExtrema->SetUseMask(true);
-      computeMovingImageExtrema->SetImageSpatialMask(mask);
-    }
-
+    computeMovingImageExtrema->SetImageSpatialMask(this->GetMovingImageMask());
     computeMovingImageExtrema->Update();
 
     this->m_MovingImageTrueMax = computeMovingImageExtrema->GetMaximum();


### PR DESCRIPTION
No longer computed the mean, sigma, variance, sum, or sum of squares. Removed m_ThreadSum, m_SumOfSquares, and m_Count. Removed inheritance from StatisticsImageFilter (which computed the mean, sigma, variance, sum, and sum of squares for images without a mask).

ComputeImageExtremaFilter is only being used in elastix by AdvancedImageToImageMetric and AdvancedMeanSquaresImageToImageMetric, and both of them only need to have the minimum and the maximum from ComputeImageExtremaFilter.

A performance improvement of ~8 percent was observed on a 8192x8192 image with mask. Without a mask, the computation appears even more than six times as fast as before.