### PR TITLE
STYLE: Replace `T x = T(n)` with `T x(n)` for NonZeroJacobianIndicesType

### DIFF
--- a/Components/Metrics/AdvancedKappaStatistic/itkAdvancedKappaStatisticImageToImageMetric.hxx
+++ b/Components/Metrics/AdvancedKappaStatistic/itkAdvancedKappaStatisticImageToImageMetric.hxx
@@ -453,7 +453,7 @@ AdvancedKappaStatisticImageToImageMetric<TFixedImage, TMovingImage>::ThreadedGet
 {
   /** Initialize array that stores dM(x)/dmu, and the sparse Jacobian + indices. */
   const NumberOfParametersType nnzji = this->m_AdvancedTransform->GetNumberOfNonZeroJacobianIndices();
-  NonZeroJacobianIndicesType   nzji = NonZeroJacobianIndicesType(nnzji);
+  NonZeroJacobianIndicesType   nzji(nnzji);
   DerivativeType               imageJacobian(nzji.size());
 
   /** Get handles to the pre-allocated derivatives for the current thread.

--- a/Components/Metrics/AdvancedMattesMutualInformation/itkParzenWindowMutualInformationImageToImageMetric.hxx
+++ b/Components/Metrics/AdvancedMattesMutualInformation/itkParzenWindowMutualInformationImageToImageMetric.hxx
@@ -286,7 +286,7 @@ ParzenWindowMutualInformationImageToImageMetric<TFixedImage, TMovingImage>::Comp
 {
   /** Initialize array that stores dM(x)/dmu, and the sparse Jacobian + indices. */
   const NumberOfParametersType nnzji = this->m_AdvancedTransform->GetNumberOfNonZeroJacobianIndices();
-  NonZeroJacobianIndicesType   nzji = NonZeroJacobianIndicesType(nnzji);
+  NonZeroJacobianIndicesType   nzji(nnzji);
   DerivativeType               imageJacobian(nzji.size());
   TransformJacobianType        jacobian;
   derivative.Fill(0.0);
@@ -425,7 +425,7 @@ ParzenWindowMutualInformationImageToImageMetric<TFixedImage, TMovingImage>::Thre
 {
   /** Initialize array that stores dM(x)/dmu, and the sparse Jacobian + indices. */
   const NumberOfParametersType nnzji = this->m_AdvancedTransform->GetNumberOfNonZeroJacobianIndices();
-  NonZeroJacobianIndicesType   nzji = NonZeroJacobianIndicesType(nnzji);
+  NonZeroJacobianIndicesType   nzji(nnzji);
   DerivativeType               imageJacobian(nzji.size());
 
   /** Get a handle to the pre-allocated derivative for the current thread.

--- a/Components/Metrics/AdvancedMeanSquares/itkAdvancedMeanSquaresImageToImageMetric.hxx
+++ b/Components/Metrics/AdvancedMeanSquares/itkAdvancedMeanSquaresImageToImageMetric.hxx
@@ -570,7 +570,7 @@ AdvancedMeanSquaresImageToImageMetric<TFixedImage, TMovingImage>::ThreadedGetVal
 {
   /** Initialize array that stores dM(x)/dmu, and the sparse Jacobian + indices. */
   const NumberOfParametersType nnzji = this->m_AdvancedTransform->GetNumberOfNonZeroJacobianIndices();
-  NonZeroJacobianIndicesType   nzji = NonZeroJacobianIndicesType(nnzji);
+  NonZeroJacobianIndicesType   nzji(nnzji);
   DerivativeType               imageJacobian(nnzji);
 
   /** Get a handle to the pre-allocated derivative for the current thread.

--- a/Components/Metrics/AdvancedNormalizedCorrelation/itkAdvancedNormalizedCorrelationImageToImageMetric.hxx
+++ b/Components/Metrics/AdvancedNormalizedCorrelation/itkAdvancedNormalizedCorrelationImageToImageMetric.hxx
@@ -500,7 +500,7 @@ AdvancedNormalizedCorrelationImageToImageMetric<TFixedImage, TMovingImage>::Thre
 {
   /** Initialize array that stores dM(x)/dmu, and the sparse Jacobian + indices. */
   const NumberOfParametersType nnzji = this->m_AdvancedTransform->GetNumberOfNonZeroJacobianIndices();
-  NonZeroJacobianIndicesType   nzji = NonZeroJacobianIndicesType(nnzji);
+  NonZeroJacobianIndicesType   nzji(nnzji);
   DerivativeType               imageJacobian(nzji.size());
 
   /** Get handles to the pre-allocated derivatives for the current thread.


### PR DESCRIPTION
Note that NonZeroJacobianIndicesType is an `std::vector` (as defined in `AdvancedTransform`).