### PR TITLE
STYLE: Do not use const-references for "real" values

### DIFF
--- a/Common/CostFunctions/itkParzenWindowHistogramImageToImageMetric.h
+++ b/Common/CostFunctions/itkParzenWindowHistogramImageToImageMetric.h
@@ -332,8 +332,8 @@ protected:
    * pdf derivatives (if the Jacobian pointers are nonzero).
    */
   virtual void
-  UpdateJointPDFAndDerivatives(const RealType &                   fixedImageValue,
-                               const RealType &                   movingImageValue,
+  UpdateJointPDFAndDerivatives(const RealType                     fixedImageValue,
+                               const RealType                     movingImageValue,
                                const DerivativeType *             imageJacobian,
                                const NonZeroJacobianIndicesType * nzji,
                                JointPDFType *                     jointPDF) const;

--- a/Common/CostFunctions/itkParzenWindowHistogramImageToImageMetric.hxx
+++ b/Common/CostFunctions/itkParzenWindowHistogramImageToImageMetric.hxx
@@ -529,8 +529,8 @@ ParzenWindowHistogramImageToImageMetric<TFixedImage, TMovingImage>::EvaluateParz
 template <class TFixedImage, class TMovingImage>
 void
 ParzenWindowHistogramImageToImageMetric<TFixedImage, TMovingImage>::UpdateJointPDFAndDerivatives(
-  const RealType &                   fixedImageValue,
-  const RealType &                   movingImageValue,
+  const RealType                     fixedImageValue,
+  const RealType                     movingImageValue,
   const DerivativeType *             imageJacobian,
   const NonZeroJacobianIndicesType * nzji,
   JointPDFType *                     jointPDF) const

--- a/Components/Metrics/AdvancedKappaStatistic/itkAdvancedKappaStatisticImageToImageMetric.h
+++ b/Components/Metrics/AdvancedKappaStatistic/itkAdvancedKappaStatisticImageToImageMetric.h
@@ -195,8 +195,8 @@ protected:
    * Called by GetValueAndDerivative().
    */
   void
-  UpdateValueAndDerivativeTerms(const RealType &                   fixedImageValue,
-                                const RealType &                   movingImageValue,
+  UpdateValueAndDerivativeTerms(const RealType                     fixedImageValue,
+                                const RealType                     movingImageValue,
                                 std::size_t &                      fixedForegroundArea,
                                 std::size_t &                      movingForegroundArea,
                                 std::size_t &                      intersection,

--- a/Components/Metrics/AdvancedKappaStatistic/itkAdvancedKappaStatisticImageToImageMetric.hxx
+++ b/Components/Metrics/AdvancedKappaStatistic/itkAdvancedKappaStatisticImageToImageMetric.hxx
@@ -505,7 +505,7 @@ AdvancedKappaStatisticImageToImageMetric<TFixedImage, TMovingImage>::ThreadedGet
       ++numberOfPixelsCounted;
 
       /** Get the fixed image value. */
-      const RealType & fixedImageValue = static_cast<RealType>(fiter->m_ImageValue);
+      const RealType fixedImageValue = static_cast<RealType>(fiter->m_ImageValue);
 
 #if 0
       /** Get the TransformJacobian dT/dmu. */
@@ -685,8 +685,8 @@ AdvancedKappaStatisticImageToImageMetric<TFixedImage, TMovingImage>::AccumulateD
 template <class TFixedImage, class TMovingImage>
 void
 AdvancedKappaStatisticImageToImageMetric<TFixedImage, TMovingImage>::UpdateValueAndDerivativeTerms(
-  const RealType &                   fixedImageValue,
-  const RealType &                   movingImageValue,
+  const RealType                     fixedImageValue,
+  const RealType                     movingImageValue,
   std::size_t &                      fixedForegroundArea,
   std::size_t &                      movingForegroundArea,
   std::size_t &                      intersection,

--- a/Components/Metrics/AdvancedMattesMutualInformation/itkParzenWindowMutualInformationImageToImageMetric.h
+++ b/Components/Metrics/AdvancedMattesMutualInformation/itkParzenWindowMutualInformationImageToImageMetric.h
@@ -272,8 +272,8 @@ private:
 
   /** Helper function to update the derivative for the low memory variant. */
   void
-  UpdateDerivativeLowMemory(const RealType &                   fixedImageValue,
-                            const RealType &                   movingImageValue,
+  UpdateDerivativeLowMemory(const RealType                     fixedImageValue,
+                            const RealType                     movingImageValue,
                             const DerivativeType &             imageJacobian,
                             const NonZeroJacobianIndicesType & nzji,
                             DerivativeType &                   derivative) const;

--- a/Components/Metrics/AdvancedMattesMutualInformation/itkParzenWindowMutualInformationImageToImageMetric.hxx
+++ b/Components/Metrics/AdvancedMattesMutualInformation/itkParzenWindowMutualInformationImageToImageMetric.hxx
@@ -724,8 +724,8 @@ ParzenWindowMutualInformationImageToImageMetric<TFixedImage, TMovingImage>::Comp
 template <class TFixedImage, class TMovingImage>
 void
 ParzenWindowMutualInformationImageToImageMetric<TFixedImage, TMovingImage>::UpdateDerivativeLowMemory(
-  const RealType &                   fixedImageValue,
-  const RealType &                   movingImageValue,
+  const RealType                     fixedImageValue,
+  const RealType                     movingImageValue,
   const DerivativeType &             imageJacobian,
   const NonZeroJacobianIndicesType & nzji,
   DerivativeType &                   derivative) const

--- a/Components/Metrics/AdvancedMeanSquares/itkAdvancedMeanSquaresImageToImageMetric.hxx
+++ b/Components/Metrics/AdvancedMeanSquares/itkAdvancedMeanSquaresImageToImageMetric.hxx
@@ -304,7 +304,7 @@ AdvancedMeanSquaresImageToImageMetric<TFixedImage, TMovingImage>::ThreadedGetVal
       ++numberOfPixelsCounted;
 
       /** Get the fixed image value. */
-      const RealType & fixedImageValue = static_cast<RealType>(threader_fiter->m_ImageValue);
+      const RealType fixedImageValue = static_cast<RealType>(threader_fiter->m_ImageValue);
 
       /** The difference squared. */
       const RealType diff = movingImageValue - fixedImageValue;
@@ -603,7 +603,7 @@ AdvancedMeanSquaresImageToImageMetric<TFixedImage, TMovingImage>::ThreadedGetVal
       ++numberOfPixelsCounted;
 
       /** Get the fixed image value. */
-      const RealType & fixedImageValue = static_cast<RealType>(threader_fiter->m_ImageValue);
+      const RealType fixedImageValue = static_cast<RealType>(threader_fiter->m_ImageValue);
 
 #if 0
       /** Get the TransformJacobian dT/dmu. */

--- a/Components/Metrics/AdvancedNormalizedCorrelation/itkAdvancedNormalizedCorrelationImageToImageMetric.h
+++ b/Components/Metrics/AdvancedNormalizedCorrelation/itkAdvancedNormalizedCorrelationImageToImageMetric.h
@@ -210,8 +210,8 @@ protected:
    * Called by GetValueAndDerivative().
    */
   void
-  UpdateDerivativeTerms(const RealType &                   fixedImageValue,
-                        const RealType &                   movingImageValue,
+  UpdateDerivativeTerms(const RealType                     fixedImageValue,
+                        const RealType                     movingImageValue,
                         const DerivativeType &             imageJacobian,
                         const NonZeroJacobianIndicesType & nzji,
                         DerivativeType &                   derivativeF,

--- a/Components/Metrics/AdvancedNormalizedCorrelation/itkAdvancedNormalizedCorrelationImageToImageMetric.hxx
+++ b/Components/Metrics/AdvancedNormalizedCorrelation/itkAdvancedNormalizedCorrelationImageToImageMetric.hxx
@@ -109,8 +109,8 @@ AdvancedNormalizedCorrelationImageToImageMetric<TFixedImage, TMovingImage>::Prin
 template <class TFixedImage, class TMovingImage>
 void
 AdvancedNormalizedCorrelationImageToImageMetric<TFixedImage, TMovingImage>::UpdateDerivativeTerms(
-  const RealType &                   fixedImageValue,
-  const RealType &                   movingImageValue,
+  const RealType                     fixedImageValue,
+  const RealType                     movingImageValue,
   const DerivativeType &             imageJacobian,
   const NonZeroJacobianIndicesType & nzji,
   DerivativeType &                   derivativeF,
@@ -220,7 +220,7 @@ AdvancedNormalizedCorrelationImageToImageMetric<TFixedImage, TMovingImage>::GetV
       this->m_NumberOfPixelsCounted++;
 
       /** Get the fixed image value. */
-      const RealType & fixedImageValue = static_cast<double>(fixedImageSample.m_ImageValue);
+      const RealType fixedImageValue = static_cast<double>(fixedImageSample.m_ImageValue);
 
       /** Update some sums needed to calculate NC. */
       sff += fixedImageValue * fixedImageValue;
@@ -554,7 +554,7 @@ AdvancedNormalizedCorrelationImageToImageMetric<TFixedImage, TMovingImage>::Thre
       ++numberOfPixelsCounted;
 
       /** Get the fixed image value. */
-      const RealType & fixedImageValue = static_cast<RealType>(threader_fiter->m_ImageValue);
+      const RealType fixedImageValue = static_cast<RealType>(threader_fiter->m_ImageValue);
 
 #if 0
       /** Get the TransformJacobian dT/dmu. */

--- a/Components/Metrics/SumSquaredTissueVolumeDifferenceMetric/itkSumSquaredTissueVolumeDifferenceImageToImageMetric.hxx
+++ b/Components/Metrics/SumSquaredTissueVolumeDifferenceMetric/itkSumSquaredTissueVolumeDifferenceImageToImageMetric.hxx
@@ -245,7 +245,7 @@ SumSquaredTissueVolumeDifferenceImageToImageMetric<TFixedImage, TMovingImage>::T
       ++numberOfPixelsCounted;
 
       /** Get the fixed image value. */
-      const RealType & fixedImageValue = static_cast<RealType>(threader_fiter->m_ImageValue);
+      const RealType fixedImageValue = static_cast<RealType>(threader_fiter->m_ImageValue);
 
       /** Get the SpatialJacobian dT/dx. */
       this->m_AdvancedTransform->GetSpatialJacobian(fixedPoint, spatialJac);
@@ -556,7 +556,7 @@ SumSquaredTissueVolumeDifferenceImageToImageMetric<TFixedImage, TMovingImage>::T
       ++numberOfPixelsCounted;
 
       /** Get the fixed image value. */
-      const RealType & fixedImageValue = static_cast<RealType>(threader_fiter->m_ImageValue);
+      const RealType fixedImageValue = static_cast<RealType>(threader_fiter->m_ImageValue);
 
       /** Get the TransformJacobian dT/dmu. */
       this->EvaluateTransformJacobian(fixedPoint, jacobian, nzji);


### PR DESCRIPTION
Values of built-in types are usually preferably passed "by value".