### PR TITLE
STYLE: Use range-based `for` to iterate over samples "Common/itkCompute"

### DIFF
--- a/Common/itkComputeDisplacementDistribution.hxx
+++ b/Common/itkComputeDisplacementDistribution.hxx
@@ -124,11 +124,7 @@ ComputeDisplacementDistribution<TFixedImage, TTransform>::ComputeSingleThreaded(
   /** Get transform and set current position. */
   const unsigned int outdim = this->m_Transform->GetOutputSpaceDimension();
 
-  /** Create iterator over the sample container. */
-  typename ImageSampleContainerType::ConstIterator iter;
-  typename ImageSampleContainerType::ConstIterator begin = sampleContainer->Begin();
-  typename ImageSampleContainerType::ConstIterator end = sampleContainer->End();
-  unsigned int                                     samplenr = 0;
+  unsigned int samplenr = 0;
 
   /** Variables for nonzerojacobian indices and the Jacobian. */
   const SizeValueType sizejacind = this->m_Transform->GetNumberOfNonZeroJacobianIndices();
@@ -152,10 +148,10 @@ ComputeDisplacementDistribution<TFixedImage, TTransform>::ComputeSingleThreaded(
   JacobianType        jacjjacj(outdim, outdim);
 
   samplenr = 0;
-  for (iter = begin; iter != end; ++iter)
+  for (const auto & sample : *sampleContainer)
   {
     /** Read fixed coordinates and get Jacobian. */
-    const FixedImagePointType & point = iter->Value().m_ImageCoordinates;
+    const FixedImagePointType & point = sample.m_ImageCoordinates;
     this->m_Transform->GetJacobian(point, jacj, jacind);
 
     /** Apply scales, if necessary. */
@@ -499,11 +495,7 @@ ComputeDisplacementDistribution<TFixedImage, TTransform>::ComputeUsingSearchDire
   typename TransformType::Pointer transform = this->m_Transform;
   const unsigned int              outdim = this->m_Transform->GetOutputSpaceDimension();
 
-  /** Create iterator over the sample container. */
-  typename ImageSampleContainerType::ConstIterator iter;
-  typename ImageSampleContainerType::ConstIterator begin = sampleContainer->Begin();
-  typename ImageSampleContainerType::ConstIterator end = sampleContainer->End();
-  unsigned int                                     samplenr = 0;
+  unsigned int samplenr = 0;
 
   /** Variables for nonzerojacobian indices and the Jacobian. */
   const SizeValueType sizejacind = this->m_Transform->GetNumberOfNonZeroJacobianIndices();
@@ -526,10 +518,10 @@ ComputeDisplacementDistribution<TFixedImage, TTransform>::ComputeUsingSearchDire
   JacobianType        jacjjacj(outdim, outdim);
 
   samplenr = 0;
-  for (iter = begin; iter != end; ++iter)
+  for (const auto & sample : *sampleContainer)
   {
     /** Read fixed coordinates and get Jacobian. */
-    const FixedImagePointType & point = iter->Value().m_ImageCoordinates;
+    const FixedImagePointType & point = sample.m_ImageCoordinates;
     this->m_Transform->GetJacobian(point, jacj, jacind);
 
     /** Apply scales, if necessary. */

--- a/Common/itkComputeJacobianTerms.hxx
+++ b/Common/itkComputeJacobianTerms.hxx
@@ -71,11 +71,7 @@ ComputeJacobianTerms<TFixedImage, TTransform>::Compute(double & TrC, double & Tr
   /** Get scales vector */
   const ScalesType & scales = this->m_Scales;
 
-  /** Create iterator over the sample container. */
-  typename ImageSampleContainerType::ConstIterator iter;
-  typename ImageSampleContainerType::ConstIterator begin = sampleContainer->Begin();
-  typename ImageSampleContainerType::ConstIterator end = sampleContainer->End();
-  unsigned int                                     samplenr = 0;
+  unsigned int samplenr = 0;
 
   /** Variables for nonzerojacobian indices and the Jacobian. */
   const NumberOfParametersType sizejacind = this->m_Transform->GetNumberOfNonZeroJacobianIndices();
@@ -243,14 +239,14 @@ ComputeJacobianTerms<TFixedImage, TTransform>::Compute(double & TrC, double & Tr
   {
     jacind[1] = 0;
   }
-  for (iter = begin; iter != end; ++iter)
+  for (const auto & sample : *sampleContainer)
   {
     /** Print progress 0-50%.
      *progressObserver->UpdateAndPrintProgress( samplenr );*/
     ++samplenr;
 
     /** Read fixed coordinates and get Jacobian J_j. */
-    const FixedImagePointType & point = iter->Value().m_ImageCoordinates;
+    const FixedImagePointType & point = sample.m_ImageCoordinates;
     this->m_Transform->GetJacobian(point, jacj, jacind);
 
     /** Skip invalid Jacobians in the beginning, if any. */
@@ -270,7 +266,7 @@ ComputeJacobianTerms<TFixedImage, TTransform>::Compute(double & TrC, double & Tr
     else
     {
       /** The following should only be done after the first sample. */
-      if (iter != begin)
+      if (&sample != &(sampleContainer->front()))
       {
         /** Update covariance matrix. */
         for (unsigned int pi = 0; pi < sizejacind; ++pi)
@@ -420,10 +416,10 @@ ComputeJacobianTerms<TFixedImage, TTransform>::Compute(double & TrC, double & Tr
   itk::Array<SizeValueType> jacindExpanded(numberOfParameters);
 
   samplenr = 0;
-  for (iter = begin; iter != end; ++iter)
+  for (const auto & sample : *sampleContainer)
   {
     /** Read fixed coordinates and get Jacobian. */
-    const FixedImagePointType & point = iter->Value().m_ImageCoordinates;
+    const FixedImagePointType & point = sample.m_ImageCoordinates;
     this->m_Transform->GetJacobian(point, jacj, jacind);
 
     /** Apply scales, if necessary. */

--- a/Common/itkComputePreconditionerUsingDisplacementDistribution.hxx
+++ b/Common/itkComputePreconditionerUsingDisplacementDistribution.hxx
@@ -120,11 +120,6 @@ ComputePreconditionerUsingDisplacementDistribution<TFixedImage, TTransform>::Com
   typename TransformType::Pointer transform = this->m_Transform;
   const unsigned int              outdim = this->m_Transform->GetOutputSpaceDimension();
 
-  /** Create iterator over the sample container. */
-  typename ImageSampleContainerType::ConstIterator iter;
-  typename ImageSampleContainerType::ConstIterator begin = sampleContainer->Begin();
-  typename ImageSampleContainerType::ConstIterator end = sampleContainer->End();
-
   /** Variables for nonzerojacobian indices and the Jacobian. */
   const SizeValueType sizejacind = this->m_Transform->GetNumberOfNonZeroJacobianIndices();
   JacobianType        jacj(outdim, sizejacind);
@@ -202,10 +197,10 @@ ComputePreconditionerUsingDisplacementDistribution<TFixedImage, TTransform>::Com
   ParametersType binCount(numberOfParameters, 0.0);
   unsigned int   samplenr = 0; // needed for global value only
 
-  for (iter = begin; iter != end; ++iter)
+  for (const auto & sample : *sampleContainer)
   {
     /** Read fixed coordinates and get Jacobian. */
-    const FixedImagePointType & point = iter->Value().m_ImageCoordinates;
+    const FixedImagePointType & point = sample.m_ImageCoordinates;
     this->m_Transform->GetJacobian(point, jacj, jacind);
 
     /** Compute the product jac_j * gradient. */
@@ -363,11 +358,6 @@ ComputePreconditionerUsingDisplacementDistribution<TFixedImage, TTransform>::Com
   typename TransformType::Pointer transform = this->m_Transform;
   const unsigned int              outdim = this->m_Transform->GetOutputSpaceDimension();
 
-  /** Create iterator over the sample container. */
-  typename ImageSampleContainerType::ConstIterator iter;
-  typename ImageSampleContainerType::ConstIterator begin = sampleContainer->Begin();
-  typename ImageSampleContainerType::ConstIterator end = sampleContainer->End();
-
   /** Variables for nonzerojacobian indices and the Jacobian. */
   const SizeValueType sizejacind = this->m_Transform->GetNumberOfNonZeroJacobianIndices();
   JacobianType        jacj(outdim, sizejacind);
@@ -384,10 +374,10 @@ ComputePreconditionerUsingDisplacementDistribution<TFixedImage, TTransform>::Com
   binCount.Fill(0.0);
 
   /** Loop over all voxels in the sample container. */
-  for (iter = begin; iter != end; ++iter)
+  for (const auto & sample : *sampleContainer)
   {
     /** Read fixed coordinates and get Jacobian. */
-    const FixedImagePointType & point = iter->Value().m_ImageCoordinates;
+    const FixedImagePointType & point = sample.m_ImageCoordinates;
     this->m_Transform->GetJacobian(point, jacj, jacind);
 
     /** Compute 1st part of JJ: ||J_j||_F^2. */
@@ -596,11 +586,6 @@ ComputePreconditionerUsingDisplacementDistribution<TFixedImage, TTransform>::Com
   typename TransformType::Pointer transform = this->m_Transform;
   const unsigned int              outdim = this->m_Transform->GetOutputSpaceDimension();
 
-  /** Create iterator over the sample container. */
-  typename ImageSampleContainerType::ConstIterator iter;
-  typename ImageSampleContainerType::ConstIterator begin = sampleContainer->Begin();
-  typename ImageSampleContainerType::ConstIterator end = sampleContainer->End();
-
   /** Variables for nonzerojacobian indices and the Jacobian. */
   const SizeValueType sizejacind = this->m_Transform->GetNumberOfNonZeroJacobianIndices();
   JacobianType        jacj(outdim, sizejacind);
@@ -611,10 +596,10 @@ ComputePreconditionerUsingDisplacementDistribution<TFixedImage, TTransform>::Com
   ParametersType             binCount(numberOfParameters, 0.0);
 
   /** Loop over all voxels in the sample container. */
-  for (iter = begin; iter != end; ++iter)
+  for (const auto & sample : *sampleContainer)
   {
     /** Read fixed coordinates and get Jacobian. */
-    const FixedImagePointType & point = iter->Value().m_ImageCoordinates;
+    const FixedImagePointType & point = sample.m_ImageCoordinates;
     this->m_Transform->GetJacobian(point, jacj, jacind);
 
     /** Compute 1st part of JJ: ||J_j||_F^2. */


### PR DESCRIPTION
Reduced the amount of boilerplate code, and possibly gained some performance improvement, in ComputeJacobianTerms, ComputeDisplacementDistribution, ComputePreconditionerUsingDisplacementDistribution.