### PR TITLE
Remove local "zero" variables

### DIFF
--- a/Common/CostFunctions/itkAdvancedImageToImageMetric.hxx
+++ b/Common/CostFunctions/itkAdvancedImageToImageMetric.hxx
@@ -837,17 +837,16 @@ AdvancedImageToImageMetric<TFixedImage, TMovingImage>::AccumulateDerivativesThre
   /** This thread accumulates all sub-derivatives into a single one, for the
    * range [ jmin, jmax [. Additionally, the sub-derivatives are reset.
    */
-  const DerivativeValueType zero{};
   const DerivativeValueType normalization = 1.0 / userData.st_NormalizationFactor;
   for (unsigned int j = jmin; j < jmax; ++j)
   {
-    DerivativeValueType tmp = zero;
+    DerivativeValueType tmp{};
     for (ThreadIdType i = 0; i < nrOfThreads; ++i)
     {
       tmp += userData.st_Metric->m_GetValueAndDerivativePerThreadVariables[i].st_Derivative[j];
 
       /** Reset this variable for the next iteration. */
-      userData.st_Metric->m_GetValueAndDerivativePerThreadVariables[i].st_Derivative[j] = zero;
+      userData.st_Metric->m_GetValueAndDerivativePerThreadVariables[i].st_Derivative[j] = 0.0;
     }
     userData.st_DerivativePointer[j] = tmp * normalization;
   }

--- a/Common/itkGenericMultiResolutionPyramidImageFilter.hxx
+++ b/Common/itkGenericMultiResolutionPyramidImageFilter.hxx
@@ -801,10 +801,9 @@ bool
 GenericMultiResolutionPyramidImageFilter<TInputImage, TOutputImage, TPrecisionType>::AreSigmasAllZeros(
   const SigmaArrayType & sigmaArray) const
 {
-  const ScalarRealType zero{};
   for (unsigned int dim = 0; dim < ImageDimension; ++dim)
   {
-    if (sigmaArray[dim] != zero)
+    if (sigmaArray[dim] != 0.0)
     {
       return false;
     }

--- a/Components/Metrics/AdvancedKappaStatistic/itkAdvancedKappaStatisticImageToImageMetric.hxx
+++ b/Components/Metrics/AdvancedKappaStatistic/itkAdvancedKappaStatisticImageToImageMetric.hxx
@@ -569,17 +569,16 @@ AdvancedKappaStatisticImageToImageMetric<TFixedImage, TMovingImage>::AfterThread
   this->CheckNumberOfSamples(sampleContainer->Size(), this->m_NumberOfPixelsCounted);
 
   /** Accumulate values. */
-  const MeasureType zero{};
-  MeasureType       areaSum = zero;
-  MeasureType       intersection = zero;
+  MeasureType areaSum{};
+  MeasureType intersection{};
   for (ThreadIdType i = 0; i < numberOfThreads; ++i)
   {
     areaSum += this->m_KappaGetValueAndDerivativePerThreadVariables[i].st_AreaSum;
     intersection += this->m_KappaGetValueAndDerivativePerThreadVariables[i].st_AreaIntersection;
 
     /** Reset these variables for the next iteration. */
-    this->m_KappaGetValueAndDerivativePerThreadVariables[i].st_AreaSum = zero;
-    this->m_KappaGetValueAndDerivativePerThreadVariables[i].st_AreaIntersection = zero;
+    this->m_KappaGetValueAndDerivativePerThreadVariables[i].st_AreaSum = 0.0;
+    this->m_KappaGetValueAndDerivativePerThreadVariables[i].st_AreaIntersection = 0.0;
   }
 
   if (areaSum == 0)

--- a/Components/Metrics/AdvancedKappaStatistic/itkAdvancedKappaStatisticImageToImageMetric.hxx
+++ b/Components/Metrics/AdvancedKappaStatistic/itkAdvancedKappaStatisticImageToImageMetric.hxx
@@ -65,12 +65,11 @@ AdvancedKappaStatisticImageToImageMetric<TFixedImage, TMovingImage>::InitializeT
   m_KappaGetValueAndDerivativePerThreadVariables.resize(numberOfThreads);
 
   /** Some initialization. */
-  const SizeValueType zero1{};
   for (auto & perThreadVariable : m_KappaGetValueAndDerivativePerThreadVariables)
   {
-    perThreadVariable.st_NumberOfPixelsCounted = zero1;
-    perThreadVariable.st_AreaSum = zero1;
-    perThreadVariable.st_AreaIntersection = zero1;
+    perThreadVariable.st_NumberOfPixelsCounted = 0;
+    perThreadVariable.st_AreaSum = 0;
+    perThreadVariable.st_AreaIntersection = 0;
     perThreadVariable.st_DerivativeSum1.SetSize(this->GetNumberOfParameters());
     perThreadVariable.st_DerivativeSum2.SetSize(this->GetNumberOfParameters());
     perThreadVariable.st_DerivativeSum1.Fill(0.0);

--- a/Components/Metrics/AdvancedKappaStatistic/itkAdvancedKappaStatisticImageToImageMetric.hxx
+++ b/Components/Metrics/AdvancedKappaStatistic/itkAdvancedKappaStatisticImageToImageMetric.hxx
@@ -65,8 +65,7 @@ AdvancedKappaStatisticImageToImageMetric<TFixedImage, TMovingImage>::InitializeT
   m_KappaGetValueAndDerivativePerThreadVariables.resize(numberOfThreads);
 
   /** Some initialization. */
-  const SizeValueType       zero1{};
-  const DerivativeValueType zero2{};
+  const SizeValueType zero1{};
   for (auto & perThreadVariable : m_KappaGetValueAndDerivativePerThreadVariables)
   {
     perThreadVariable.st_NumberOfPixelsCounted = zero1;
@@ -74,8 +73,8 @@ AdvancedKappaStatisticImageToImageMetric<TFixedImage, TMovingImage>::InitializeT
     perThreadVariable.st_AreaIntersection = zero1;
     perThreadVariable.st_DerivativeSum1.SetSize(this->GetNumberOfParameters());
     perThreadVariable.st_DerivativeSum2.SetSize(this->GetNumberOfParameters());
-    perThreadVariable.st_DerivativeSum1.Fill(zero2);
-    perThreadVariable.st_DerivativeSum2.Fill(zero2);
+    perThreadVariable.st_DerivativeSum1.Fill(0.0);
+    perThreadVariable.st_DerivativeSum2.Fill(0.0);
   }
 
 } // end InitializeThreadingParameters()
@@ -657,19 +656,19 @@ AdvancedKappaStatisticImageToImageMetric<TFixedImage, TMovingImage>::AccumulateD
   unsigned int jmax = (threadId + 1) * subSize;
   jmax = (jmax > numPar) ? numPar : jmax;
 
-  const DerivativeValueType zero{};
-  DerivativeValueType       sum1, sum2;
   for (unsigned int j = jmin; j < jmax; ++j)
   {
-    sum1 = sum2 = zero;
+    DerivativeValueType sum1{};
+    DerivativeValueType sum2{};
+
     for (auto & perThreadVariable : userData.st_Metric->m_KappaGetValueAndDerivativePerThreadVariables)
     {
       sum1 += perThreadVariable.st_DerivativeSum1[j];
       sum2 += perThreadVariable.st_DerivativeSum2[j];
 
       /** Reset these variables for the next iteration. */
-      perThreadVariable.st_DerivativeSum1[j] = zero;
-      perThreadVariable.st_DerivativeSum2[j] = zero;
+      perThreadVariable.st_DerivativeSum1[j] = 0.0;
+      perThreadVariable.st_DerivativeSum2[j] = 0.0;
     }
     userData.st_DerivativePointer[j] = userData.st_Coefficient1 * sum1 - userData.st_Coefficient2 * sum2;
   }

--- a/Components/Metrics/AdvancedNormalizedCorrelation/itkAdvancedNormalizedCorrelationImageToImageMetric.hxx
+++ b/Components/Metrics/AdvancedNormalizedCorrelation/itkAdvancedNormalizedCorrelationImageToImageMetric.hxx
@@ -65,16 +65,15 @@ AdvancedNormalizedCorrelationImageToImageMetric<TFixedImage, TMovingImage>::Init
   m_CorrelationGetValueAndDerivativePerThreadVariables.resize(numberOfThreads);
 
   /** Some initialization. */
-  const AccumulateType zero1{};
-  const auto           numberOfParameters = this->GetNumberOfParameters();
+  const auto numberOfParameters = this->GetNumberOfParameters();
   for (auto & perThreadVariable : m_CorrelationGetValueAndDerivativePerThreadVariables)
   {
     perThreadVariable.st_NumberOfPixelsCounted = SizeValueType{};
-    perThreadVariable.st_Sff = zero1;
-    perThreadVariable.st_Smm = zero1;
-    perThreadVariable.st_Sfm = zero1;
-    perThreadVariable.st_Sf = zero1;
-    perThreadVariable.st_Sm = zero1;
+    perThreadVariable.st_Sff = 0.0;
+    perThreadVariable.st_Smm = 0.0;
+    perThreadVariable.st_Sfm = 0.0;
+    perThreadVariable.st_Sf = 0.0;
+    perThreadVariable.st_Sm = 0.0;
     perThreadVariable.st_DerivativeF.SetSize(numberOfParameters);
     perThreadVariable.st_DerivativeM.SetSize(numberOfParameters);
     perThreadVariable.st_Differential.SetSize(this->GetNumberOfParameters());
@@ -623,12 +622,11 @@ AdvancedNormalizedCorrelationImageToImageMetric<TFixedImage, TMovingImage>::Afte
   this->CheckNumberOfSamples(sampleContainer->Size(), this->m_NumberOfPixelsCounted);
 
   /** Accumulate values. */
-  const AccumulateType zero{};
-  AccumulateType       sff = this->m_CorrelationGetValueAndDerivativePerThreadVariables[0].st_Sff;
-  AccumulateType       smm = this->m_CorrelationGetValueAndDerivativePerThreadVariables[0].st_Smm;
-  AccumulateType       sfm = this->m_CorrelationGetValueAndDerivativePerThreadVariables[0].st_Sfm;
-  AccumulateType       sf = this->m_CorrelationGetValueAndDerivativePerThreadVariables[0].st_Sf;
-  AccumulateType       sm = this->m_CorrelationGetValueAndDerivativePerThreadVariables[0].st_Sm;
+  AccumulateType sff = this->m_CorrelationGetValueAndDerivativePerThreadVariables[0].st_Sff;
+  AccumulateType smm = this->m_CorrelationGetValueAndDerivativePerThreadVariables[0].st_Smm;
+  AccumulateType sfm = this->m_CorrelationGetValueAndDerivativePerThreadVariables[0].st_Sfm;
+  AccumulateType sf = this->m_CorrelationGetValueAndDerivativePerThreadVariables[0].st_Sf;
+  AccumulateType sm = this->m_CorrelationGetValueAndDerivativePerThreadVariables[0].st_Sm;
   for (ThreadIdType i = 1; i < numberOfThreads; ++i)
   {
     sff += this->m_CorrelationGetValueAndDerivativePerThreadVariables[i].st_Sff;
@@ -638,11 +636,11 @@ AdvancedNormalizedCorrelationImageToImageMetric<TFixedImage, TMovingImage>::Afte
     sm += this->m_CorrelationGetValueAndDerivativePerThreadVariables[i].st_Sm;
 
     /** Reset these variables for the next iteration. */
-    this->m_CorrelationGetValueAndDerivativePerThreadVariables[i].st_Sff = zero;
-    this->m_CorrelationGetValueAndDerivativePerThreadVariables[i].st_Smm = zero;
-    this->m_CorrelationGetValueAndDerivativePerThreadVariables[i].st_Sfm = zero;
-    this->m_CorrelationGetValueAndDerivativePerThreadVariables[i].st_Sf = zero;
-    this->m_CorrelationGetValueAndDerivativePerThreadVariables[i].st_Sm = zero;
+    this->m_CorrelationGetValueAndDerivativePerThreadVariables[i].st_Sff = 0.0;
+    this->m_CorrelationGetValueAndDerivativePerThreadVariables[i].st_Smm = 0.0;
+    this->m_CorrelationGetValueAndDerivativePerThreadVariables[i].st_Sfm = 0.0;
+    this->m_CorrelationGetValueAndDerivativePerThreadVariables[i].st_Sf = 0.0;
+    this->m_CorrelationGetValueAndDerivativePerThreadVariables[i].st_Sm = 0.0;
   }
 
   /** If SubtractMean, then subtract things from sff, smm and sfm. */

--- a/Components/Metrics/AdvancedNormalizedCorrelation/itkAdvancedNormalizedCorrelationImageToImageMetric.hxx
+++ b/Components/Metrics/AdvancedNormalizedCorrelation/itkAdvancedNormalizedCorrelationImageToImageMetric.hxx
@@ -65,9 +65,8 @@ AdvancedNormalizedCorrelationImageToImageMetric<TFixedImage, TMovingImage>::Init
   m_CorrelationGetValueAndDerivativePerThreadVariables.resize(numberOfThreads);
 
   /** Some initialization. */
-  const AccumulateType      zero1{};
-  const DerivativeValueType zero2{};
-  const auto                numberOfParameters = this->GetNumberOfParameters();
+  const AccumulateType zero1{};
+  const auto           numberOfParameters = this->GetNumberOfParameters();
   for (auto & perThreadVariable : m_CorrelationGetValueAndDerivativePerThreadVariables)
   {
     perThreadVariable.st_NumberOfPixelsCounted = SizeValueType{};
@@ -79,9 +78,9 @@ AdvancedNormalizedCorrelationImageToImageMetric<TFixedImage, TMovingImage>::Init
     perThreadVariable.st_DerivativeF.SetSize(numberOfParameters);
     perThreadVariable.st_DerivativeM.SetSize(numberOfParameters);
     perThreadVariable.st_Differential.SetSize(this->GetNumberOfParameters());
-    perThreadVariable.st_DerivativeF.Fill(zero2);
-    perThreadVariable.st_DerivativeM.Fill(zero2);
-    perThreadVariable.st_Differential.Fill(zero2);
+    perThreadVariable.st_DerivativeF.Fill(0.0);
+    perThreadVariable.st_DerivativeM.Fill(0.0);
+    perThreadVariable.st_Differential.Fill(0.0);
   }
 
 } // end InitializeThreadingParameters()
@@ -788,11 +787,12 @@ AdvancedNormalizedCorrelationImageToImageMetric<TFixedImage, TMovingImage>::Accu
   unsigned int jmax = (threadId + 1) * subSize;
   jmax = (jmax > numPar) ? numPar : jmax;
 
-  const DerivativeValueType zero{};
-  DerivativeValueType       derivativeF, derivativeM, differential;
   for (unsigned int j = jmin; j < jmax; ++j)
   {
-    derivativeF = derivativeM = differential = zero;
+    DerivativeValueType derivativeF{};
+    DerivativeValueType derivativeM{};
+    DerivativeValueType differential{};
+
     for (ThreadIdType i = 0; i < nrOfThreads; ++i)
     {
       derivativeF += userData.st_Metric->m_CorrelationGetValueAndDerivativePerThreadVariables[i].st_DerivativeF[j];
@@ -800,9 +800,9 @@ AdvancedNormalizedCorrelationImageToImageMetric<TFixedImage, TMovingImage>::Accu
       differential += userData.st_Metric->m_CorrelationGetValueAndDerivativePerThreadVariables[i].st_Differential[j];
 
       /** Reset these variables for the next iteration. */
-      userData.st_Metric->m_CorrelationGetValueAndDerivativePerThreadVariables[i].st_DerivativeF[j] = zero;
-      userData.st_Metric->m_CorrelationGetValueAndDerivativePerThreadVariables[i].st_DerivativeM[j] = zero;
-      userData.st_Metric->m_CorrelationGetValueAndDerivativePerThreadVariables[i].st_Differential[j] = zero;
+      userData.st_Metric->m_CorrelationGetValueAndDerivativePerThreadVariables[i].st_DerivativeF[j] = 0.0;
+      userData.st_Metric->m_CorrelationGetValueAndDerivativePerThreadVariables[i].st_DerivativeM[j] = 0.0;
+      userData.st_Metric->m_CorrelationGetValueAndDerivativePerThreadVariables[i].st_Differential[j] = 0.0;
     }
 
     if (subtractMean)


### PR DESCRIPTION
Now using `0`, `0.0`, or `{}` initializers instead, whatever is appropriate.