### PR TITLE
STYLE: Add const to `ThreadedGetValueAndDerivative(ThreadIdType)`

### DIFF
--- a/Common/CostFunctions/itkAdvancedImageToImageMetric.h
+++ b/Common/CostFunctions/itkAdvancedImageToImageMetric.h
@@ -428,7 +428,7 @@ protected:
 
   /** Multi-threaded version of GetValueAndDerivative(). */
   virtual void
-  ThreadedGetValueAndDerivative(ThreadIdType threadID)
+  ThreadedGetValueAndDerivative(ThreadIdType threadID) const
   {}
 
   /** Finalize multi-threaded metric computation. */

--- a/Common/CostFunctions/itkAdvancedImageToImageMetric.hxx
+++ b/Common/CostFunctions/itkAdvancedImageToImageMetric.hxx
@@ -792,7 +792,7 @@ AdvancedImageToImageMetric<TFixedImage, TMovingImage>::GetValueAndDerivativeThre
   const auto & userData = *static_cast<MultiThreaderParameterType *>(infoStruct.UserData);
 
   assert(userData.st_Metric);
-  Self & metric = *(userData.st_Metric);
+  const Self & metric = *(userData.st_Metric);
 
   metric.ThreadedGetValueAndDerivative(threadID);
 

--- a/Components/Metrics/AdvancedKappaStatistic/itkAdvancedKappaStatisticImageToImageMetric.h
+++ b/Components/Metrics/AdvancedKappaStatistic/itkAdvancedKappaStatisticImageToImageMetric.h
@@ -214,7 +214,7 @@ protected:
 
   /** Get value and derivatives for each thread. */
   void
-  ThreadedGetValueAndDerivative(ThreadIdType threadID) override;
+  ThreadedGetValueAndDerivative(ThreadIdType threadID) const override;
 
   /** Gather the values and derivatives from all threads */
   void

--- a/Components/Metrics/AdvancedKappaStatistic/itkAdvancedKappaStatisticImageToImageMetric.hxx
+++ b/Components/Metrics/AdvancedKappaStatistic/itkAdvancedKappaStatisticImageToImageMetric.hxx
@@ -439,7 +439,7 @@ AdvancedKappaStatisticImageToImageMetric<TFixedImage, TMovingImage>::GetValueAnd
 template <class TFixedImage, class TMovingImage>
 void
 AdvancedKappaStatisticImageToImageMetric<TFixedImage, TMovingImage>::ThreadedGetValueAndDerivative(
-  ThreadIdType threadId)
+  ThreadIdType threadId) const
 {
   /** Initialize array that stores dM(x)/dmu, and the sparse Jacobian + indices. */
   const NumberOfParametersType nnzji = this->m_AdvancedTransform->GetNumberOfNonZeroJacobianIndices();

--- a/Components/Metrics/AdvancedMeanSquares/itkAdvancedMeanSquaresImageToImageMetric.h
+++ b/Components/Metrics/AdvancedMeanSquares/itkAdvancedMeanSquaresImageToImageMetric.h
@@ -241,7 +241,7 @@ protected:
 
   /** Get value and derivatives for each thread. */
   void
-  ThreadedGetValueAndDerivative(ThreadIdType threadID) override;
+  ThreadedGetValueAndDerivative(ThreadIdType threadID) const override;
 
   /** Gather the values and derivatives from all threads. */
   void

--- a/Components/Metrics/AdvancedMeanSquares/itkAdvancedMeanSquaresImageToImageMetric.hxx
+++ b/Components/Metrics/AdvancedMeanSquares/itkAdvancedMeanSquaresImageToImageMetric.hxx
@@ -541,7 +541,8 @@ AdvancedMeanSquaresImageToImageMetric<TFixedImage, TMovingImage>::GetValueAndDer
 
 template <class TFixedImage, class TMovingImage>
 void
-AdvancedMeanSquaresImageToImageMetric<TFixedImage, TMovingImage>::ThreadedGetValueAndDerivative(ThreadIdType threadId)
+AdvancedMeanSquaresImageToImageMetric<TFixedImage, TMovingImage>::ThreadedGetValueAndDerivative(
+  ThreadIdType threadId) const
 {
   /** Initialize array that stores dM(x)/dmu, and the sparse Jacobian + indices. */
   const NumberOfParametersType nnzji = this->m_AdvancedTransform->GetNumberOfNonZeroJacobianIndices();

--- a/Components/Metrics/AdvancedNormalizedCorrelation/itkAdvancedNormalizedCorrelationImageToImageMetric.h
+++ b/Components/Metrics/AdvancedNormalizedCorrelation/itkAdvancedNormalizedCorrelationImageToImageMetric.h
@@ -227,7 +227,7 @@ protected:
 
   /** Get value and derivatives for each thread. */
   void
-  ThreadedGetValueAndDerivative(ThreadIdType threadID) override;
+  ThreadedGetValueAndDerivative(ThreadIdType threadID) const override;
 
   /** Gather the values and derivatives from all threads */
   void

--- a/Components/Metrics/AdvancedNormalizedCorrelation/itkAdvancedNormalizedCorrelationImageToImageMetric.hxx
+++ b/Components/Metrics/AdvancedNormalizedCorrelation/itkAdvancedNormalizedCorrelationImageToImageMetric.hxx
@@ -486,7 +486,7 @@ AdvancedNormalizedCorrelationImageToImageMetric<TFixedImage, TMovingImage>::GetV
 template <class TFixedImage, class TMovingImage>
 void
 AdvancedNormalizedCorrelationImageToImageMetric<TFixedImage, TMovingImage>::ThreadedGetValueAndDerivative(
-  ThreadIdType threadId)
+  ThreadIdType threadId) const
 {
   /** Initialize array that stores dM(x)/dmu, and the sparse Jacobian + indices. */
   const NumberOfParametersType nnzji = this->m_AdvancedTransform->GetNumberOfNonZeroJacobianIndices();

--- a/Components/Metrics/BendingEnergyPenalty/itkTransformBendingEnergyPenaltyTerm.h
+++ b/Components/Metrics/BendingEnergyPenalty/itkTransformBendingEnergyPenaltyTerm.h
@@ -146,7 +146,7 @@ public:
 
   /** Get value and derivatives for each thread. */
   void
-  ThreadedGetValueAndDerivative(ThreadIdType threadID) override;
+  ThreadedGetValueAndDerivative(ThreadIdType threadID) const override;
 
   /** Gather the values and derivatives from all threads */
   void

--- a/Components/Metrics/BendingEnergyPenalty/itkTransformBendingEnergyPenaltyTerm.hxx
+++ b/Components/Metrics/BendingEnergyPenalty/itkTransformBendingEnergyPenaltyTerm.hxx
@@ -373,7 +373,7 @@ TransformBendingEnergyPenaltyTerm<TFixedImage, TScalarType>::GetValueAndDerivati
 
 template <class TFixedImage, class TScalarType>
 void
-TransformBendingEnergyPenaltyTerm<TFixedImage, TScalarType>::ThreadedGetValueAndDerivative(ThreadIdType threadId)
+TransformBendingEnergyPenaltyTerm<TFixedImage, TScalarType>::ThreadedGetValueAndDerivative(ThreadIdType threadId) const
 {
   /** Create and initialize some variables. */
   SpatialHessianType           spatialHessian;

--- a/Components/Metrics/SumSquaredTissueVolumeDifferenceMetric/itkSumSquaredTissueVolumeDifferenceImageToImageMetric.h
+++ b/Components/Metrics/SumSquaredTissueVolumeDifferenceMetric/itkSumSquaredTissueVolumeDifferenceImageToImageMetric.h
@@ -234,7 +234,7 @@ protected:
 
   /** Get value and derivatives for each thread. */
   void
-  ThreadedGetValueAndDerivative(ThreadIdType threadId) override;
+  ThreadedGetValueAndDerivative(ThreadIdType threadId) const override;
 
   /** Gather the values and derivatives from all threads */
   void

--- a/Components/Metrics/SumSquaredTissueVolumeDifferenceMetric/itkSumSquaredTissueVolumeDifferenceImageToImageMetric.hxx
+++ b/Components/Metrics/SumSquaredTissueVolumeDifferenceMetric/itkSumSquaredTissueVolumeDifferenceImageToImageMetric.hxx
@@ -489,7 +489,7 @@ SumSquaredTissueVolumeDifferenceImageToImageMetric<TFixedImage, TMovingImage>::G
 template <class TFixedImage, class TMovingImage>
 void
 SumSquaredTissueVolumeDifferenceImageToImageMetric<TFixedImage, TMovingImage>::ThreadedGetValueAndDerivative(
-  ThreadIdType threadId)
+  ThreadIdType threadId) const
 {
   /*Create variables to store intermediate results. Circumvent false sharing*/
   unsigned long    numberOfPixelsCounted = 0;


### PR DESCRIPTION
Also added `const` to local `metric` variable in `AdvancedImageToImageMetric::GetValueAndDerivativeThreaderCallback(void *)`.

Eases preserving thread-safety.