### PR TITLE
STYLE: Add const to `ThreadedGetValue(ThreadIdType)`

### DIFF
--- a/Common/CostFunctions/itkAdvancedImageToImageMetric.h
+++ b/Common/CostFunctions/itkAdvancedImageToImageMetric.h
@@ -410,7 +410,7 @@ protected:
 
   /** Multi-threaded version of GetValue(). */
   virtual void
-  ThreadedGetValue(ThreadIdType threadID)
+  ThreadedGetValue(ThreadIdType threadID) const
   {}
 
   /** Finalize multi-threaded metric computation. */

--- a/Common/CostFunctions/itkAdvancedImageToImageMetric.hxx
+++ b/Common/CostFunctions/itkAdvancedImageToImageMetric.hxx
@@ -749,7 +749,7 @@ AdvancedImageToImageMetric<TFixedImage, TMovingImage>::GetValueThreaderCallback(
   const auto & userData = *static_cast<MultiThreaderParameterType *>(infoStruct.UserData);
 
   assert(userData.st_Metric);
-  Self & metric = *(userData.st_Metric);
+  const Self & metric = *(userData.st_Metric);
 
   metric.ThreadedGetValue(threadID);
 

--- a/Components/Metrics/AdvancedMeanSquares/itkAdvancedMeanSquaresImageToImageMetric.h
+++ b/Components/Metrics/AdvancedMeanSquares/itkAdvancedMeanSquaresImageToImageMetric.h
@@ -233,7 +233,7 @@ protected:
 
   /** Get value for each thread. */
   void
-  ThreadedGetValue(ThreadIdType threadID) override;
+  ThreadedGetValue(ThreadIdType threadID) const override;
 
   /** Gather the values from all threads. */
   void

--- a/Components/Metrics/AdvancedMeanSquares/itkAdvancedMeanSquaresImageToImageMetric.hxx
+++ b/Components/Metrics/AdvancedMeanSquares/itkAdvancedMeanSquaresImageToImageMetric.hxx
@@ -256,7 +256,7 @@ AdvancedMeanSquaresImageToImageMetric<TFixedImage, TMovingImage>::GetValue(
 
 template <class TFixedImage, class TMovingImage>
 void
-AdvancedMeanSquaresImageToImageMetric<TFixedImage, TMovingImage>::ThreadedGetValue(ThreadIdType threadId)
+AdvancedMeanSquaresImageToImageMetric<TFixedImage, TMovingImage>::ThreadedGetValue(ThreadIdType threadId) const
 {
   /** Get a handle to the sample container. */
   ImageSampleContainerPointer sampleContainer = this->GetImageSampler()->GetOutput();

--- a/Components/Metrics/SumSquaredTissueVolumeDifferenceMetric/itkSumSquaredTissueVolumeDifferenceImageToImageMetric.h
+++ b/Components/Metrics/SumSquaredTissueVolumeDifferenceMetric/itkSumSquaredTissueVolumeDifferenceImageToImageMetric.h
@@ -226,7 +226,7 @@ protected:
 
   /** Get value for each thread. */
   void
-  ThreadedGetValue(ThreadIdType threadID) override;
+  ThreadedGetValue(ThreadIdType threadID) const override;
 
   /** Gather the values from all threads. */
   void

--- a/Components/Metrics/SumSquaredTissueVolumeDifferenceMetric/itkSumSquaredTissueVolumeDifferenceImageToImageMetric.hxx
+++ b/Components/Metrics/SumSquaredTissueVolumeDifferenceMetric/itkSumSquaredTissueVolumeDifferenceImageToImageMetric.hxx
@@ -194,7 +194,8 @@ SumSquaredTissueVolumeDifferenceImageToImageMetric<TFixedImage, TMovingImage>::G
 
 template <class TFixedImage, class TMovingImage>
 void
-SumSquaredTissueVolumeDifferenceImageToImageMetric<TFixedImage, TMovingImage>::ThreadedGetValue(ThreadIdType threadId)
+SumSquaredTissueVolumeDifferenceImageToImageMetric<TFixedImage, TMovingImage>::ThreadedGetValue(
+  ThreadIdType threadId) const
 {
   /*Create variables to store intermediate results. Circumvent false sharing*/
   unsigned long numberOfPixelsCounted = 0;


### PR DESCRIPTION
Also added `const` to local `metric` variable in `AdvancedImageToImageMetric::GetValueThreaderCallback(void *)`.

- Follow-up to pull request https://github.com/SuperElastix/elastix/pull/1059 commit d44f13e69cc3fef678df740835a5f762cd66f422

----

@mstaring @stefanklein I noticed that there are only two `ThreadedGetValue` overrides: only from the AdvancedMeanSquares and SumSquaredTissueVolumeDifference metrics. (`ThreadedGetValueAndDerivative` has three more overrides, from AdvancedKappaStatistic and AdvancedNormalizedCorrelation metrics, as well as by TransformBendingEnergyPenaltyTerm). Should the other metric classes also get a `ThreadedGetValue` override? Or is `ThreadedGetValue` no longer necessary?

Update: it looks like `ThreadedGetValue` is never actually called in any of the tests. So I guess we can just remove it 😃 But I see now, ITK's `SingleValuedCostFunction` (a common base class of metrics) requires implementing its pure virtual function `GetValue(const ParametersType &) const` 🤔 