### PR TITLE
Refactor EvaluateJacobianWithImageGradientProduct and EvaluateTransformJacobianInnerProduct

### DIFF
--- a/Common/CostFunctions/itkAdvancedImageToImageMetric.hxx
+++ b/Common/CostFunctions/itkAdvancedImageToImageMetric.hxx
@@ -610,21 +610,8 @@ AdvancedImageToImageMetric<TFixedImage, TMovingImage>::EvaluateTransformJacobian
   else
   {
     /** Otherwise perform a full multiplication. */
-    typename TransformJacobianType::const_iterator jac = jacobian.begin();
-    imageJacobian.fill(0.0);
-
-    for (unsigned int dim = 0; dim < FixedImageDimension; ++dim)
-    {
-      const double imDeriv = movingImageDerivative[dim];
-
-      for (auto & imageJacobianElement : imageJacobian)
-      {
-        imageJacobianElement += (*jac) * imDeriv;
-        ++jac;
-      }
-    }
+    ImplementationDetails::EvaluateInnerProduct(jacobian, movingImageDerivative, imageJacobian);
   }
-
 } // end EvaluateTransformJacobianInnerProduct()
 
 

--- a/Common/CostFunctions/itkAdvancedImageToImageMetric.hxx
+++ b/Common/CostFunctions/itkAdvancedImageToImageMetric.hxx
@@ -584,8 +584,6 @@ AdvancedImageToImageMetric<TFixedImage, TMovingImage>::EvaluateTransformJacobian
   const MovingImageDerivativeType & movingImageDerivative,
   DerivativeType &                  imageJacobian) const
 {
-  using JacobianIteratorType = typename TransformJacobianType::const_iterator;
-
   /** Multiple the 1-by-dim vector movingImageDerivative with the
    * dim-by-length matrix jacobian, to get a 1-by-length vector imageJacobian.
    * An optimized route can be taken for B-spline transforms.
@@ -612,7 +610,7 @@ AdvancedImageToImageMetric<TFixedImage, TMovingImage>::EvaluateTransformJacobian
   else
   {
     /** Otherwise perform a full multiplication. */
-    JacobianIteratorType jac = jacobian.begin();
+    typename TransformJacobianType::const_iterator jac = jacobian.begin();
     imageJacobian.Fill(0.0);
 
     for (unsigned int dim = 0; dim < FixedImageDimension; ++dim)

--- a/Common/CostFunctions/itkAdvancedImageToImageMetric.hxx
+++ b/Common/CostFunctions/itkAdvancedImageToImageMetric.hxx
@@ -611,7 +611,7 @@ AdvancedImageToImageMetric<TFixedImage, TMovingImage>::EvaluateTransformJacobian
   {
     /** Otherwise perform a full multiplication. */
     typename TransformJacobianType::const_iterator jac = jacobian.begin();
-    imageJacobian.Fill(0.0);
+    imageJacobian.fill(0.0);
 
     for (unsigned int dim = 0; dim < FixedImageDimension; ++dim)
     {

--- a/Common/Transforms/itkAdvancedBSplineDeformableTransform.hxx
+++ b/Common/Transforms/itkAdvancedBSplineDeformableTransform.hxx
@@ -386,7 +386,7 @@ AdvancedBSplineDeformableTransform<TScalarType, NDimensions, VSplineOrder>::Eval
   {
     nonZeroJacobianIndices.resize(nnzji);
     std::iota(nonZeroJacobianIndices.begin(), nonZeroJacobianIndices.end(), 0u);
-    imageJacobian.Fill(0.0);
+    imageJacobian.fill(0.0);
     return;
   }
 

--- a/Common/Transforms/itkAdvancedTransform.h
+++ b/Common/Transforms/itkAdvancedTransform.h
@@ -36,6 +36,7 @@
 #include "itkTransform.h"
 #include "itkMatrix.h"
 #include "itkFixedArray.h"
+#include <cassert>
 
 namespace itk
 {
@@ -302,6 +303,33 @@ protected:
   bool m_HasNonZeroSpatialHessian{ true };
   bool m_HasNonZeroJacobianOfSpatialHessian{ true };
 };
+
+namespace ImplementationDetails
+{
+/** Multiplies the input matrix and the input vector. */
+template <class TScalarType, unsigned int VInputVectorSize>
+void
+EvaluateInnerProduct(const vnl_matrix<TScalarType> &                        inputMatrix,
+                     const CovariantVector<TScalarType, VInputVectorSize> & inputVector,
+                     vnl_vector<TScalarType> &                              outputVector)
+{
+  assert(inputMatrix.rows() == inputVector.size());
+  assert(inputMatrix.columns() == outputVector.size());
+
+  auto inputMatrixIterator = inputMatrix.begin();
+
+  outputVector.fill(0.0);
+
+  for (const double inputVectorElement : inputVector)
+  {
+    for (auto & outputVectorElement : outputVector)
+    {
+      outputVectorElement += (*inputMatrixIterator) * inputVectorElement;
+      ++inputMatrixIterator;
+    }
+  }
+}
+} // namespace ImplementationDetails
 
 } // end namespace itk
 

--- a/Common/Transforms/itkAdvancedTransform.hxx
+++ b/Common/Transforms/itkAdvancedTransform.hxx
@@ -56,8 +56,7 @@ AdvancedTransform<TScalarType, NInputDimensions, NOutputDimensions>::EvaluateJac
   this->GetJacobian(inputPoint, jacobian, nonZeroJacobianIndices);
 
   /** Perform a full multiplication. */
-  using JacobianIteratorType = typename JacobianType::const_iterator;
-  JacobianIteratorType jac = jacobian.begin();
+  typename JacobianType::const_iterator jac = jacobian.begin();
   imageJacobian.Fill(0.0);
 
   for (unsigned int dim = 0; dim < InputSpaceDimension; ++dim)

--- a/Common/Transforms/itkAdvancedTransform.hxx
+++ b/Common/Transforms/itkAdvancedTransform.hxx
@@ -56,19 +56,7 @@ AdvancedTransform<TScalarType, NInputDimensions, NOutputDimensions>::EvaluateJac
   this->GetJacobian(inputPoint, jacobian, nonZeroJacobianIndices);
 
   /** Perform a full multiplication. */
-  typename JacobianType::const_iterator jac = jacobian.begin();
-  imageJacobian.fill(0.0);
-
-  for (unsigned int dim = 0; dim < InputSpaceDimension; ++dim)
-  {
-    const double imDeriv = movingImageGradient[dim];
-
-    for (auto & imageJacobianElement : imageJacobian)
-    {
-      imageJacobianElement += (*jac) * imDeriv;
-      ++jac;
-    }
-  }
+  ImplementationDetails::EvaluateInnerProduct(jacobian, movingImageGradient, imageJacobian);
 
 } // end EvaluateJacobianWithImageGradientProduct()
 

--- a/Common/Transforms/itkAdvancedTransform.hxx
+++ b/Common/Transforms/itkAdvancedTransform.hxx
@@ -57,7 +57,7 @@ AdvancedTransform<TScalarType, NInputDimensions, NOutputDimensions>::EvaluateJac
 
   /** Perform a full multiplication. */
   typename JacobianType::const_iterator jac = jacobian.begin();
-  imageJacobian.Fill(0.0);
+  imageJacobian.fill(0.0);
 
   for (unsigned int dim = 0; dim < InputSpaceDimension; ++dim)
   {

--- a/Components/Metrics/PCAMetric/itkPCAMetric.hxx
+++ b/Components/Metrics/PCAMetric/itkPCAMetric.hxx
@@ -136,8 +136,7 @@ PCAMetric<TFixedImage, TMovingImage>::EvaluateTransformJacobianInnerProduct(
   const MovingImageDerivativeType & movingImageDerivative,
   DerivativeType &                  imageJacobian) const
 {
-  using JacobianIteratorType = typename TransformJacobianType::const_iterator;
-  JacobianIteratorType jac = jacobian.begin();
+  typename TransformJacobianType::const_iterator jac = jacobian.begin();
   imageJacobian.Fill(0.0);
 
   for (unsigned int dim = 0; dim < FixedImageDimension; ++dim)

--- a/Components/Metrics/PCAMetric/itkPCAMetric.hxx
+++ b/Components/Metrics/PCAMetric/itkPCAMetric.hxx
@@ -137,7 +137,7 @@ PCAMetric<TFixedImage, TMovingImage>::EvaluateTransformJacobianInnerProduct(
   DerivativeType &                  imageJacobian) const
 {
   typename TransformJacobianType::const_iterator jac = jacobian.begin();
-  imageJacobian.Fill(0.0);
+  imageJacobian.fill(0.0);
 
   for (unsigned int dim = 0; dim < FixedImageDimension; ++dim)
   {

--- a/Components/Metrics/PCAMetric/itkPCAMetric.hxx
+++ b/Components/Metrics/PCAMetric/itkPCAMetric.hxx
@@ -136,21 +136,8 @@ PCAMetric<TFixedImage, TMovingImage>::EvaluateTransformJacobianInnerProduct(
   const MovingImageDerivativeType & movingImageDerivative,
   DerivativeType &                  imageJacobian) const
 {
-  typename TransformJacobianType::const_iterator jac = jacobian.begin();
-  imageJacobian.fill(0.0);
-
-  for (unsigned int dim = 0; dim < FixedImageDimension; ++dim)
-  {
-    const double imDeriv = movingImageDerivative[dim];
-
-    for (auto & imageJacobianElement : imageJacobian)
-    {
-      imageJacobianElement += (*jac) * imDeriv;
-      ++jac;
-    }
-  }
-} // end EvaluateTransformJacobianInnerProduct()
-
+  ImplementationDetails::EvaluateInnerProduct(jacobian, movingImageDerivative, imageJacobian);
+}
 
 /**
  * ******************* GetValue *******************

--- a/Components/Metrics/PCAMetric/itkPCAMetric_F_multithreaded.hxx
+++ b/Components/Metrics/PCAMetric/itkPCAMetric_F_multithreaded.hxx
@@ -131,7 +131,7 @@ PCAMetric<TFixedImage, TMovingImage>::EvaluateTransformJacobianInnerProduct(
   DerivativeType &                  imageJacobian) const
 {
   typename TransformJacobianType::const_iterator jac = jacobian.begin();
-  imageJacobian.Fill(0.0);
+  imageJacobian.fill(0.0);
 
   for (unsigned int dim = 0; dim < FixedImageDimension; ++dim)
   {

--- a/Components/Metrics/PCAMetric/itkPCAMetric_F_multithreaded.hxx
+++ b/Components/Metrics/PCAMetric/itkPCAMetric_F_multithreaded.hxx
@@ -130,8 +130,7 @@ PCAMetric<TFixedImage, TMovingImage>::EvaluateTransformJacobianInnerProduct(
   const MovingImageDerivativeType & movingImageDerivative,
   DerivativeType &                  imageJacobian) const
 {
-  using JacobianIteratorType = typename TransformJacobianType::const_iterator;
-  JacobianIteratorType jac = jacobian.begin();
+  typename TransformJacobianType::const_iterator jac = jacobian.begin();
   imageJacobian.Fill(0.0);
 
   for (unsigned int dim = 0; dim < FixedImageDimension; ++dim)

--- a/Components/Metrics/PCAMetric/itkPCAMetric_F_multithreaded.hxx
+++ b/Components/Metrics/PCAMetric/itkPCAMetric_F_multithreaded.hxx
@@ -130,21 +130,8 @@ PCAMetric<TFixedImage, TMovingImage>::EvaluateTransformJacobianInnerProduct(
   const MovingImageDerivativeType & movingImageDerivative,
   DerivativeType &                  imageJacobian) const
 {
-  typename TransformJacobianType::const_iterator jac = jacobian.begin();
-  imageJacobian.fill(0.0);
-
-  for (unsigned int dim = 0; dim < FixedImageDimension; ++dim)
-  {
-    const double imDeriv = movingImageDerivative[dim];
-
-    for (auto & imageJacobianElement : imageJacobian)
-    {
-      imageJacobianElement += (*jac) * imDeriv;
-      ++jac;
-    }
-  }
-} // end EvaluateTransformJacobianInnerProduct()
-
+  ImplementationDetails::EvaluateInnerProduct(jacobian, movingImageDerivative, imageJacobian);
+}
 
 /**
  * ******************* GetValue *******************

--- a/Components/Metrics/PCAMetric2/itkPCAMetric2.hxx
+++ b/Components/Metrics/PCAMetric2/itkPCAMetric2.hxx
@@ -119,8 +119,7 @@ PCAMetric2<TFixedImage, TMovingImage>::EvaluateTransformJacobianInnerProduct(
   const MovingImageDerivativeType & movingImageDerivative,
   DerivativeType &                  imageJacobian) const
 {
-  using JacobianIteratorType = typename TransformJacobianType::const_iterator;
-  JacobianIteratorType jac = jacobian.begin();
+  typename TransformJacobianType::const_iterator jac = jacobian.begin();
   imageJacobian.Fill(0.0);
   for (unsigned int dim = 0; dim < FixedImageDimension; ++dim)
   {

--- a/Components/Metrics/PCAMetric2/itkPCAMetric2.hxx
+++ b/Components/Metrics/PCAMetric2/itkPCAMetric2.hxx
@@ -120,7 +120,7 @@ PCAMetric2<TFixedImage, TMovingImage>::EvaluateTransformJacobianInnerProduct(
   DerivativeType &                  imageJacobian) const
 {
   typename TransformJacobianType::const_iterator jac = jacobian.begin();
-  imageJacobian.Fill(0.0);
+  imageJacobian.fill(0.0);
   for (unsigned int dim = 0; dim < FixedImageDimension; ++dim)
   {
     const double imDeriv = movingImageDerivative[dim];

--- a/Components/Metrics/PCAMetric2/itkPCAMetric2.hxx
+++ b/Components/Metrics/PCAMetric2/itkPCAMetric2.hxx
@@ -119,19 +119,8 @@ PCAMetric2<TFixedImage, TMovingImage>::EvaluateTransformJacobianInnerProduct(
   const MovingImageDerivativeType & movingImageDerivative,
   DerivativeType &                  imageJacobian) const
 {
-  typename TransformJacobianType::const_iterator jac = jacobian.begin();
-  imageJacobian.fill(0.0);
-  for (unsigned int dim = 0; dim < FixedImageDimension; ++dim)
-  {
-    const double imDeriv = movingImageDerivative[dim];
-
-    for (auto & imageJacobianElement : imageJacobian)
-    {
-      imageJacobianElement += (*jac) * imDeriv;
-      ++jac;
-    }
-  }
-} // end EvaluateTransformJacobianInnerProduct()
+  ImplementationDetails::EvaluateInnerProduct(jacobian, movingImageDerivative, imageJacobian);
+}
 
 
 /**

--- a/Components/Metrics/SumOfPairwiseCorrelationsMetric/itkSumOfPairwiseCorrelationCoefficientsMetric.hxx
+++ b/Components/Metrics/SumOfPairwiseCorrelationsMetric/itkSumOfPairwiseCorrelationCoefficientsMetric.hxx
@@ -114,7 +114,7 @@ SumOfPairwiseCorrelationCoefficientsMetric<TFixedImage, TMovingImage>::EvaluateT
   DerivativeType &                  imageJacobian) const
 {
   typename TransformJacobianType::const_iterator jac = jacobian.begin();
-  imageJacobian.Fill(0.0);
+  imageJacobian.fill(0.0);
 
   for (unsigned int dim = 0; dim < FixedImageDimension; ++dim)
   {

--- a/Components/Metrics/SumOfPairwiseCorrelationsMetric/itkSumOfPairwiseCorrelationCoefficientsMetric.hxx
+++ b/Components/Metrics/SumOfPairwiseCorrelationsMetric/itkSumOfPairwiseCorrelationCoefficientsMetric.hxx
@@ -113,21 +113,8 @@ SumOfPairwiseCorrelationCoefficientsMetric<TFixedImage, TMovingImage>::EvaluateT
   const MovingImageDerivativeType & movingImageDerivative,
   DerivativeType &                  imageJacobian) const
 {
-  typename TransformJacobianType::const_iterator jac = jacobian.begin();
-  imageJacobian.fill(0.0);
-
-  for (unsigned int dim = 0; dim < FixedImageDimension; ++dim)
-  {
-    const double imDeriv = movingImageDerivative[dim];
-
-    for (auto & imageJacobianElement : imageJacobian)
-    {
-      imageJacobianElement += (*jac) * imDeriv;
-      ++jac;
-    }
-  }
-} // end EvaluateTransformJacobianInnerProduct
-
+  ImplementationDetails::EvaluateInnerProduct(jacobian, movingImageDerivative, imageJacobian);
+}
 
 /**
  * ******************* GetValue *******************

--- a/Components/Metrics/SumOfPairwiseCorrelationsMetric/itkSumOfPairwiseCorrelationCoefficientsMetric.hxx
+++ b/Components/Metrics/SumOfPairwiseCorrelationsMetric/itkSumOfPairwiseCorrelationCoefficientsMetric.hxx
@@ -113,8 +113,7 @@ SumOfPairwiseCorrelationCoefficientsMetric<TFixedImage, TMovingImage>::EvaluateT
   const MovingImageDerivativeType & movingImageDerivative,
   DerivativeType &                  imageJacobian) const
 {
-  using JacobianIteratorType = typename TransformJacobianType::const_iterator;
-  JacobianIteratorType jac = jacobian.begin();
+  typename TransformJacobianType::const_iterator jac = jacobian.begin();
   imageJacobian.Fill(0.0);
 
   for (unsigned int dim = 0; dim < FixedImageDimension; ++dim)

--- a/Components/Metrics/SumSquaredTissueVolumeDifferenceMetric/itkSumSquaredTissueVolumeDifferenceImageToImageMetric.hxx
+++ b/Components/Metrics/SumSquaredTissueVolumeDifferenceMetric/itkSumSquaredTissueVolumeDifferenceImageToImageMetric.hxx
@@ -698,7 +698,7 @@ SumSquaredTissueVolumeDifferenceImageToImageMetric<TFixedImage, TMovingImage>::E
   DerivativeType &                  imageJacobian) const
 {
   typename TransformJacobianType::const_iterator jac = jacobian.begin();
-  imageJacobian.Fill(0.0);
+  imageJacobian.fill(0.0);
 
   for (unsigned int dim = 0; dim < FixedImageDimension; ++dim)
   {

--- a/Components/Metrics/SumSquaredTissueVolumeDifferenceMetric/itkSumSquaredTissueVolumeDifferenceImageToImageMetric.hxx
+++ b/Components/Metrics/SumSquaredTissueVolumeDifferenceMetric/itkSumSquaredTissueVolumeDifferenceImageToImageMetric.hxx
@@ -697,8 +697,7 @@ SumSquaredTissueVolumeDifferenceImageToImageMetric<TFixedImage, TMovingImage>::E
   const MovingImageDerivativeType & movingImageDerivative,
   DerivativeType &                  imageJacobian) const
 {
-  using JacobianIteratorType = typename TransformJacobianType::const_iterator;
-  JacobianIteratorType jac = jacobian.begin();
+  typename TransformJacobianType::const_iterator jac = jacobian.begin();
   imageJacobian.Fill(0.0);
 
   for (unsigned int dim = 0; dim < FixedImageDimension; ++dim)

--- a/Components/Metrics/VarianceOverLastDimension/itkVarianceOverLastDimensionImageMetric.hxx
+++ b/Components/Metrics/VarianceOverLastDimension/itkVarianceOverLastDimensionImageMetric.hxx
@@ -164,19 +164,8 @@ VarianceOverLastDimensionImageMetric<TFixedImage, TMovingImage>::EvaluateTransfo
   const MovingImageDerivativeType & movingImageDerivative,
   DerivativeType &                  imageJacobian) const
 {
-  typename TransformJacobianType::const_iterator jac = jacobian.begin();
-  imageJacobian.fill(0.0);
+  ImplementationDetails::EvaluateInnerProduct(jacobian, movingImageDerivative, imageJacobian);
 
-  for (unsigned int dim = 0; dim < FixedImageDimension; ++dim)
-  {
-    const double imDeriv = movingImageDerivative[dim];
-
-    for (auto & imageJacobianElement : imageJacobian)
-    {
-      imageJacobianElement += (*jac) * imDeriv;
-      ++jac;
-    }
-  }
 } // end EvaluateTransformJacobianInnerProduct()
 
 

--- a/Components/Metrics/VarianceOverLastDimension/itkVarianceOverLastDimensionImageMetric.hxx
+++ b/Components/Metrics/VarianceOverLastDimension/itkVarianceOverLastDimensionImageMetric.hxx
@@ -165,7 +165,7 @@ VarianceOverLastDimensionImageMetric<TFixedImage, TMovingImage>::EvaluateTransfo
   DerivativeType &                  imageJacobian) const
 {
   typename TransformJacobianType::const_iterator jac = jacobian.begin();
-  imageJacobian.Fill(0.0);
+  imageJacobian.fill(0.0);
 
   for (unsigned int dim = 0; dim < FixedImageDimension; ++dim)
   {

--- a/Components/Metrics/VarianceOverLastDimension/itkVarianceOverLastDimensionImageMetric.hxx
+++ b/Components/Metrics/VarianceOverLastDimension/itkVarianceOverLastDimensionImageMetric.hxx
@@ -164,8 +164,7 @@ VarianceOverLastDimensionImageMetric<TFixedImage, TMovingImage>::EvaluateTransfo
   const MovingImageDerivativeType & movingImageDerivative,
   DerivativeType &                  imageJacobian) const
 {
-  using JacobianIteratorType = typename TransformJacobianType::const_iterator;
-  JacobianIteratorType jac = jacobian.begin();
+  typename TransformJacobianType::const_iterator jac = jacobian.begin();
   imageJacobian.Fill(0.0);
 
   for (unsigned int dim = 0; dim < FixedImageDimension; ++dim)


### PR DESCRIPTION
Various EvaluateTransformJacobianInnerProduct member functions appear very similar. This refactoring aims to help analyzing and understandingthe metrics. 

There are 17 metrics derived from AdvancedImageToImageMetric:

- CostFunctions/ImageToImageMetricWithFeatures
- CostFunctions/MultiInputImageToImageMetricBase
- CostFunctions/ParzenWindowHistogramImageToImageMetric
- CostFunctions/TransformPenaltyTerm
- AdvancedKappaStatisticImageToImageMetric
- AdvancedMeanSquaresImageToImageMetric
- AdvancedNormalizedCorrelationImageToImageMetric
- GradientDifferenceImageToImageMetric2/GradientDifferenceImageToImageMetric
- NormalizedGradientCorrelationImageToImageMetric
- PatternIntensityImageToImageMetric
- PCAMetric2
- PCAMetric
- PCAMetric_F_multithreaded/PCAMetric
- SumOfPairwiseCorrelationCoefficientsMetric
- SumSquaredTissueVolumeDifferenceImageToImageMetric
- VarianceOverLastDimensionImageMetric
- CombinationImageToImageMetric

Six of them override AdvancedImageToImageMetric::EvaluateTransformJacobianInnerProduct.

The overrides of five (of those six) metrics are exactly the same:

- PCAMetric
- PCAMetric_F_multithreaded
- PCAMetric2
- SumOfPairwiseCorrelationCoefficientsMetric
- VarianceOverLastDimensionImageMetric

The override of SumSquaredTissueVolumeDifferenceImageToImageMetric is different, because it takes TissueValue - AirValue into account.

AdvancedImageToImageMetric has a different implementation, for if TransformIsBSpline is true.

AdvancedTransform::EvaluateJacobianWithImageGradientProduct is just different because it uses a thread_local jacobian matrix.
