### PR TITLE
Use `static constexpr` for local constants

### DIFF
--- a/Common/CostFunctions/itkAdvancedImageToImageMetric.h
+++ b/Common/CostFunctions/itkAdvancedImageToImageMetric.h
@@ -661,8 +661,8 @@ private:
   {};
 
   // Prevent accidentally accessing m_FixedImageMask or m_MovingImageMask directly from the ITK's ImageToImageMetric.
-  constexpr static DummyMask m_FixedImageMask{};
-  constexpr static DummyMask m_MovingImageMask{};
+  static constexpr DummyMask m_FixedImageMask{};
+  static constexpr DummyMask m_MovingImageMask{};
 };
 
 } // end namespace itk

--- a/Common/GTesting/elxConversionGTest.cxx
+++ b/Common/GTesting/elxConversionGTest.cxx
@@ -372,7 +372,7 @@ GTEST_TEST(Conversion, ToString)
   // Note that this is different from std::to_string(0.5), which returns "0.500000"
   EXPECT_EQ(Conversion::ToString(0.5), "0.5");
 
-  constexpr auto expectedPrecision = 16;
+  static constexpr auto expectedPrecision = 16;
   static_assert(expectedPrecision == std::numeric_limits<double>::digits10 + 1,
                 "The expected precision for double floating point numbers");
   const auto expectedString = "0." + std::string(expectedPrecision, '3');
@@ -597,15 +597,15 @@ GTEST_TEST(Conversion, ToNativePathNameSeparators)
   EXPECT_EQ(Conversion::ToNativePathNameSeparators(std::string{}), std::string{});
   EXPECT_EQ(Conversion::ToNativePathNameSeparators(" "), std::string{ " " });
 
-  constexpr bool isBackslashNativeSeparator =
+  static constexpr bool isBackslashNativeSeparator =
 #ifdef _WIN32
     true;
 #else
     false;
 #endif
 
-  constexpr char nativeSeparator = isBackslashNativeSeparator ? '\\' : '/';
-  constexpr char nonNativeSeparator = isBackslashNativeSeparator ? '/' : '\\';
+  static constexpr char nativeSeparator = isBackslashNativeSeparator ? '\\' : '/';
+  static constexpr char nonNativeSeparator = isBackslashNativeSeparator ? '/' : '\\';
 
   EXPECT_EQ(Conversion::ToNativePathNameSeparators({ nativeSeparator }), std::string{ nativeSeparator });
   EXPECT_EQ(Conversion::ToNativePathNameSeparators({ nonNativeSeparator }), std::string{ nativeSeparator });

--- a/Common/GTesting/elxTransformIOGTest.cxx
+++ b/Common/GTesting/elxTransformIOGTest.cxx
@@ -289,8 +289,8 @@ struct WithDimension
     Test_CreateTransformParameterMap_double_precision()
     {
       // Use 0.3333333333333333... as test value.
-      constexpr auto testValue = 1.0 / 3.0;
-      constexpr auto expectedPrecision = 16;
+      static constexpr auto testValue = 1.0 / 3.0;
+      static constexpr auto expectedPrecision = 16;
       static_assert(expectedPrecision == std::numeric_limits<double>::digits10 + 1,
                     "The expected precision for double floating point numbers");
       const auto expectedString = "0." + std::string(expectedPrecision, '3');
@@ -576,27 +576,27 @@ Expect_elx_TransformPoint_yields_same_point_as_ITK(const TITKTransform & itkTran
 
   using NumericLimits = std::numeric_limits<double>;
 
-  constexpr double testInputValues[] = { NumericLimits::lowest(),
-                                         -2.0,
-                                         -1.0,
-                                         -0.5,
-                                         -NumericLimits::min(),
-                                         -0.0,
-                                         0.0,
-                                         NumericLimits::min(),
-                                         0.5,
-                                         1.0 - (2 * NumericLimits::epsilon()), // Note: 1.0 fails on BSpline!!!
-                                         1.0 + 1.0e-14,
-                                         2.0,
-                                         NumericLimits::max() };
+  static constexpr double testInputValues[] = { NumericLimits::lowest(),
+                                                -2.0,
+                                                -1.0,
+                                                -0.5,
+                                                -NumericLimits::min(),
+                                                -0.0,
+                                                0.0,
+                                                NumericLimits::min(),
+                                                0.5,
+                                                1.0 - (2 * NumericLimits::epsilon()), // Note: 1.0 fails on BSpline!!!
+                                                1.0 + 1.0e-14,
+                                                2.0,
+                                                NumericLimits::max() };
 
-  constexpr auto numberOfTestInputValues = std::extent_v<decltype(testInputValues)>;
+  static constexpr auto numberOfTestInputValues = std::extent_v<decltype(testInputValues)>;
 
   // Use the test input values as coordinates.
   for (const auto index : itk::ZeroBasedIndexRange<Dimension>(itk::Size<Dimension>::Filled(numberOfTestInputValues)))
   {
     itk::Point<double, Dimension> inputPoint;
-    std::transform(index.begin(), index.end(), inputPoint.begin(), [&testInputValues](const itk::SizeValueType value) {
+    std::transform(index.begin(), index.end(), inputPoint.begin(), [](const itk::SizeValueType value) {
       return testInputValues[value];
     });
 
@@ -857,7 +857,7 @@ GTEST_TEST(Transform, CreateTransformParametersSetUseAddition)
 
 GTEST_TEST(Transform, TransformedPointSameAsITKTranslation2D)
 {
-  constexpr auto Dimension = 2U;
+  static constexpr auto Dimension = 2U;
 
   elx::DefaultConstruct<itk::TranslationTransform<double, Dimension>> itkTransform;
   itkTransform.SetOffset(itk::MakeVector(1.0, 2.0));
@@ -868,7 +868,7 @@ GTEST_TEST(Transform, TransformedPointSameAsITKTranslation2D)
 
 GTEST_TEST(Transform, TransformedPointSameAsITKTranslation3D)
 {
-  constexpr auto Dimension = 3U;
+  static constexpr auto Dimension = 3U;
 
   elx::DefaultConstruct<itk::TranslationTransform<double, Dimension>> itkTransform;
   itkTransform.SetOffset(itk::MakeVector(1.0, 2.0, 3.0));
@@ -879,7 +879,7 @@ GTEST_TEST(Transform, TransformedPointSameAsITKTranslation3D)
 
 GTEST_TEST(Transform, TransformedPointSameAsITKAffine2D)
 {
-  constexpr auto Dimension = 2U;
+  static constexpr auto Dimension = 2U;
 
   elx::DefaultConstruct<itk::AffineTransform<double, Dimension>> itkTransform;
   itkTransform.SetTranslation(itk::MakeVector(1.0, 2.0));
@@ -893,7 +893,7 @@ GTEST_TEST(Transform, TransformedPointSameAsITKAffine2D)
 
 GTEST_TEST(Transform, TransformedPointSameAsITKAffine3D)
 {
-  constexpr auto Dimension = 3U;
+  static constexpr auto Dimension = 3U;
 
   elx::DefaultConstruct<itk::AffineTransform<double, Dimension>> itkTransform;
   itkTransform.SetTranslation(itk::MakeVector(1.0, 2.0, 3.0));

--- a/Common/GTesting/itkAdvancedImageToImageMetricGTest.cxx
+++ b/Common/GTesting/itkAdvancedImageToImageMetricGTest.cxx
@@ -165,7 +165,7 @@ private:
 // Checks if a default-constructed AdvancedImageToImageMetric has the expected properties.
 GTEST_TEST(AdvancedImageToImageMetric, DefaultConstruct)
 {
-  constexpr auto imageDimension = 3U;
+  static constexpr auto imageDimension = 3U;
   using ImageType = itk::Image<int, imageDimension>;
   using MetricType = TestMetric<ImageType>;
   const elx::DefaultConstruct<MetricType> defaultConstructedMetric{};

--- a/Common/GTesting/itkAdvancedMeanSquaresImageToImageMetricGTest.cxx
+++ b/Common/GTesting/itkAdvancedMeanSquaresImageToImageMetricGTest.cxx
@@ -52,10 +52,10 @@ RandomizePixelValues(TImage & image, TRandomNumberEngine && randomNumberEngine)
 // Checks if a default-constructed AdvancedMeanSquaresImageToImageMetric has the expected properties.
 GTEST_TEST(AdvancedMeanSquaresImageToImageMetric, DefaultConstruct)
 {
-  constexpr itk::SizeValueType defaultNumberOfFixedImageSamples{ 50000 };
-  constexpr double             defaultLimitRangeRatio{ 0.01 };
+  static constexpr itk::SizeValueType defaultNumberOfFixedImageSamples{ 50000 };
+  static constexpr double             defaultLimitRangeRatio{ 0.01 };
 
-  constexpr auto imageDimension = 3U;
+  static constexpr auto imageDimension = 3U;
   using ImageType = itk::Image<int, imageDimension>;
   using MetricType = AdvancedMeanSquaresImageToImageMetric<ImageType, ImageType>;
   const elx::DefaultConstruct<MetricType> defaultConstructedMetric{};
@@ -129,7 +129,7 @@ GTEST_TEST(AdvancedMeanSquaresImageToImageMetric, DefaultConstruct)
 // an identity transform is used.
 GTEST_TEST(AdvancedMeanSquaresImageToImageMetric, YieldsZeroWhenFixedAndMovingImageAreEqual)
 {
-  constexpr auto imageDimension = 3U;
+  static constexpr auto imageDimension = 3U;
   using PixelType = float;
   using ImageType = itk::Image<PixelType, imageDimension>;
 
@@ -176,7 +176,7 @@ GTEST_TEST(AdvancedMeanSquaresImageToImageMetric, MultiThreadResultEqualsSingleT
 {
   std::mt19937 randomNumberEngine{};
 
-  constexpr auto imageDimension = 3U;
+  static constexpr auto imageDimension = 3U;
   using PixelType = float;
   using ImageType = itk::Image<PixelType, imageDimension>;
 

--- a/Common/GTesting/itkComputeImageExtremaFilterGTest.cxx
+++ b/Common/GTesting/itkComputeImageExtremaFilterGTest.cxx
@@ -303,10 +303,7 @@ GTEST_TEST(ComputeImageExtremaFilter, OneNonZeroPixelValueMaskedIn)
 GTEST_TEST(ComputeImageExtremaFilter, MaskSpacingAndDirectionAffectResults)
 {
   using PixelType = int;
-  enum
-  {
-    Dimension = 2U
-  };
+  static constexpr auto Dimension = 2U;
   enum class MaskChange
   {
     None,

--- a/Common/GTesting/itkComputeImageExtremaFilterGTest.cxx
+++ b/Common/GTesting/itkComputeImageExtremaFilterGTest.cxx
@@ -174,7 +174,7 @@ Expect_one_non_zero_pixel_value_masked_in(const typename TImage::SizeType & imag
   using FilterType = ComputeImageExtremaFilter<TImage>;
   using ImageSpatialMaskType = typename FilterType::ImageSpatialMaskType;
 
-  constexpr auto ImageDimension = TImage::ImageDimension;
+  static constexpr auto ImageDimension = TImage::ImageDimension;
 
   const auto image = TImage::New();
   image->SetRegions(imageSize);
@@ -223,7 +223,7 @@ Expect_one_positive_pixel_value_all_pixels_masked_in(const typename TImage::Size
   using FilterType = ComputeImageExtremaFilter<TImage>;
   using ImageSpatialMaskType = typename FilterType::ImageSpatialMaskType;
 
-  constexpr auto ImageDimension = TImage::ImageDimension;
+  static constexpr auto ImageDimension = TImage::ImageDimension;
 
   const auto image = TImage::New();
   image->SetRegions(imageSize);

--- a/Common/GTesting/itkImageFullSamplerGTest.cxx
+++ b/Common/GTesting/itkImageFullSamplerGTest.cxx
@@ -37,7 +37,7 @@ using elx::CoreMainGTestUtilities::minimumImageSizeValue;
 GTEST_TEST(ImageFullSampler, OutputHasSameSequenceOfPixelValuesAsInput)
 {
   using PixelType = std::uint8_t;
-  constexpr auto Dimension = 2U;
+  static constexpr auto Dimension = 2U;
   using ImageType = itk::Image<PixelType, Dimension>;
   using ImageFullSamplerType = itk::ImageFullSampler<ImageType>;
 
@@ -64,7 +64,7 @@ GTEST_TEST(ImageFullSampler, OutputHasSameSequenceOfPixelValuesAsInput)
 GTEST_TEST(ImageFullSampler, HasSameOutputWhenUsingMultiThread)
 {
   using PixelType = int;
-  constexpr auto Dimension = 2U;
+  static constexpr auto Dimension = 2U;
   using ImageType = itk::Image<PixelType, Dimension>;
   using SamplerType = itk::ImageFullSampler<ImageType>;
 
@@ -89,10 +89,7 @@ GTEST_TEST(ImageFullSampler, HasSameOutputWhenUsingMultiThread)
 GTEST_TEST(ImageFullSampler, HasSameOutputWhenUsingFullyFilledMask)
 {
   using PixelType = int;
-  enum
-  {
-    Dimension = 2U
-  };
+  static constexpr auto Dimension = 2U;
   using SamplerType = itk::ImageFullSampler<itk::Image<PixelType, Dimension>>;
 
   const ImageDomain<Dimension> imageDomain(itk::Size<Dimension>::Filled(4));
@@ -129,10 +126,7 @@ GTEST_TEST(ImageFullSampler, HasSameOutputWhenUsingFullyFilledMask)
 GTEST_TEST(ImageFullSampler, ExactlyEqualVersusSlightlyDifferentMaskImageDomain)
 {
   using PixelType = int;
-  enum
-  {
-    Dimension = 2U
-  };
+  static constexpr auto Dimension = 2U;
   using SamplerType = itk::ImageFullSampler<itk::Image<PixelType, Dimension>>;
 
   std::mt19937 randomNumberEngine{};

--- a/Common/GTesting/itkImageGridSamplerGTest.cxx
+++ b/Common/GTesting/itkImageGridSamplerGTest.cxx
@@ -251,10 +251,7 @@ GTEST_TEST(ImageGridSampler, HasSameOutputWhenUsingMultiThread)
 GTEST_TEST(ImageGridSampler, HasSameOutputWhenUsingFullyFilledMask)
 {
   using PixelType = int;
-  enum
-  {
-    Dimension = 2U
-  };
+  static constexpr auto Dimension = 2U;
   using SamplerType = itk::ImageGridSampler<itk::Image<PixelType, Dimension>>;
 
   const ImageDomain<Dimension> imageDomain(itk::Size<Dimension>::Filled(4));
@@ -297,10 +294,7 @@ GTEST_TEST(ImageGridSampler, HasSameOutputWhenUsingFullyFilledMask)
 GTEST_TEST(ImageGridSampler, OneOutOfThreeMask)
 {
   using PixelType = int;
-  enum
-  {
-    Dimension = 3U
-  };
+  static constexpr auto Dimension = 2U;
   using SamplerType = itk::ImageGridSampler<itk::Image<PixelType, Dimension>>;
 
   const ImageDomain<Dimension> imageDomain(itk::Size<Dimension>::Filled(8));

--- a/Common/GTesting/itkImageGridSamplerGTest.cxx
+++ b/Common/GTesting/itkImageGridSamplerGTest.cxx
@@ -71,7 +71,7 @@ GTEST_TEST(ImageGridSampler, DefaultConstructFillsSampleGridSpacingWithOne)
 GTEST_TEST(ImageGridSampler, HasSameOutputAsFullSamplerByDefault)
 {
   using PixelType = int;
-  constexpr auto Dimension = 2U;
+  static constexpr auto Dimension = 2U;
   using ImageType = itk::Image<PixelType, Dimension>;
 
   std::mt19937 randomNumberEngine{};
@@ -95,7 +95,7 @@ GTEST_TEST(ImageGridSampler, HasSameOutputAsFullSamplerByDefault)
 GTEST_TEST(ImageGridSampler, MaxSampleGridSpacing)
 {
   using PixelType = int;
-  constexpr auto Dimension = 2U;
+  static constexpr auto Dimension = 2U;
   using ImageType = itk::Image<PixelType, Dimension>;
   using SamplerType = ImageGridSampler<ImageType>;
 
@@ -122,7 +122,7 @@ GTEST_TEST(ImageGridSampler, MaxSampleGridSpacing)
 GTEST_TEST(ImageGridSampler, SampleGridSpacingGreaterEqualToImageSize)
 {
   using PixelType = int;
-  constexpr auto Dimension = 2U;
+  static constexpr auto Dimension = 2U;
   using ImageType = itk::Image<PixelType, Dimension>;
   using SamplerType = ImageGridSampler<ImageType>;
 
@@ -154,7 +154,7 @@ GTEST_TEST(ImageGridSampler, SampleGridSpacingGreaterEqualToImageSize)
 GTEST_TEST(ImageGridSampler, SampleGridSpacingOneLessThanImageSize)
 {
   using PixelType = int;
-  constexpr auto Dimension = 2U;
+  static constexpr auto Dimension = 2U;
   using ImageType = itk::Image<PixelType, Dimension>;
   using SamplerType = ImageGridSampler<ImageType>;
 
@@ -188,7 +188,7 @@ GTEST_TEST(ImageGridSampler, SampleGridSpacingOneLessThanImageSize)
 GTEST_TEST(ImageGridSampler, SampleGridSpacingTwo)
 {
   using PixelType = int;
-  constexpr auto Dimension = 2U;
+  static constexpr auto Dimension = 2U;
   using ImageType = itk::Image<PixelType, Dimension>;
   using SamplerType = ImageGridSampler<ImageType>;
 
@@ -221,7 +221,7 @@ GTEST_TEST(ImageGridSampler, SampleGridSpacingTwo)
 GTEST_TEST(ImageGridSampler, HasSameOutputWhenUsingMultiThread)
 {
   using PixelType = int;
-  constexpr auto Dimension = 2U;
+  static constexpr auto Dimension = 2U;
   using ImageType = itk::Image<PixelType, Dimension>;
   using SamplerType = itk::ImageGridSampler<ImageType>;
 

--- a/Common/GTesting/itkImageRandomSamplerSparseMaskGTest.cxx
+++ b/Common/GTesting/itkImageRandomSamplerSparseMaskGTest.cxx
@@ -43,7 +43,7 @@ using itk::Statistics::MersenneTwisterRandomVariateGenerator;
 GTEST_TEST(ImageRandomSamplerSparseMask, CheckImageValuesOfSamples)
 {
   using PixelType = int;
-  constexpr auto Dimension = 2;
+  static constexpr auto Dimension = 2;
   using ImageType = itk::Image<PixelType, Dimension>;
   using MaskSpatialObjectType = itk::ImageMaskSpatialObject<Dimension>;
 
@@ -85,7 +85,7 @@ GTEST_TEST(ImageRandomSamplerSparseMask, CheckImageValuesOfSamples)
 GTEST_TEST(ImageRandomSamplerSparseMask, SetSeedMakesRandomizationDeterministic)
 {
   using PixelType = int;
-  constexpr auto Dimension = 2;
+  static constexpr auto Dimension = 2;
   using ImageType = itk::Image<PixelType, Dimension>;
   using SamplerType = itk::ImageRandomSamplerSparseMask<ImageType>;
   using MaskSpatialObjectType = itk::ImageMaskSpatialObject<Dimension>;
@@ -127,7 +127,7 @@ GTEST_TEST(ImageRandomSamplerSparseMask, SetSeedMakesRandomizationDeterministic)
 GTEST_TEST(ImageRandomSamplerSparseMask, HasSameOutputWhenUsingMultiThread)
 {
   using PixelType = int;
-  constexpr auto Dimension = 2;
+  static constexpr auto Dimension = 2;
   using ImageType = itk::Image<PixelType, Dimension>;
   using SamplerType = itk::ImageRandomSamplerSparseMask<ImageType>;
   using MaskSpatialObjectType = itk::ImageMaskSpatialObject<Dimension>;

--- a/Common/Transforms/itkAdvancedCombinationTransform.h
+++ b/Common/Transforms/itkAdvancedCombinationTransform.h
@@ -547,7 +547,7 @@ protected:
 
 private:
   /** Exception text. */
-  constexpr static const char * NoCurrentTransformSet = "No current transform set in the AdvancedCombinationTransform";
+  static constexpr const char * NoCurrentTransformSet = "No current transform set in the AdvancedCombinationTransform";
 
   /** Declaration of members. */
   InitialTransformPointer m_InitialTransform{ nullptr };

--- a/Common/elxSupportedImageDimensions.h
+++ b/Common/elxSupportedImageDimensions.h
@@ -64,7 +64,7 @@ struct FixedImageDimensionSupport
 {
   // Adds those dimensions from the specified `dimensionSequence` that are supported.
   template <std::size_t... VIndex>
-  constexpr static auto
+  static constexpr auto
   AddSupportedDimensions(std::index_sequence<VIndex...> dimensionSequence)
   {
     using AddDimensionIfSupported = std::conditional_t<SupportsFixedDimension<VDimension>(),
@@ -80,7 +80,7 @@ template <>
 struct FixedImageDimensionSupport<maxSupportedImageDimension + 1>
 {
   template <std::size_t... VIndex>
-  constexpr static auto
+  static constexpr auto
   AddSupportedDimensions(std::index_sequence<VIndex...> dimensionSequence)
   {
     return dimensionSequence;

--- a/Core/Install/elxPrepareImageTypeSupport.h
+++ b/Core/Install/elxPrepareImageTypeSupport.h
@@ -37,12 +37,12 @@ public:
   /** In the specialisations of this template class */
   /** this typedef will make sense */
   using ElastixType = ::itk::Object;
-  constexpr static const char * FixedPixelTypeString{ "" };
-  constexpr static const char * MovingPixelTypeString{ "" };
-  constexpr static unsigned int FixedDimension{ 0 };
-  constexpr static unsigned int MovingDimension{ 0 };
+  static constexpr const char * FixedPixelTypeString{ "" };
+  static constexpr const char * MovingPixelTypeString{ "" };
+  static constexpr unsigned int FixedDimension{ 0 };
+  static constexpr unsigned int MovingDimension{ 0 };
   /** In the specialisations of this template class, this value will be 'true' */
-  constexpr static bool IsDefined{ false };
+  static constexpr bool IsDefined{ false };
 };
 
 } // namespace elastix
@@ -82,11 +82,11 @@ public:
     using FixedImageType = ::itk::Image<_fPixelType, _fDim>;                                                           \
     using MovingImageType = ::itk::Image<_mPixelType, _mDim>;                                                          \
     using ElastixType = ::elx::ElastixTemplate<FixedImageType, MovingImageType>;                                       \
-    constexpr static const char * FixedPixelTypeString{ #_fPixelType };                                                \
-    constexpr static const char * MovingPixelTypeString{ #_mPixelType };                                               \
-    constexpr static unsigned int FixedDimension{ _fDim };                                                             \
-    constexpr static unsigned int MovingDimension{ _mDim };                                                            \
-    constexpr static bool         IsDefined{ true };                                                                   \
+    static constexpr const char * FixedPixelTypeString{ #_fPixelType };                                                \
+    static constexpr const char * MovingPixelTypeString{ #_mPixelType };                                               \
+    static constexpr unsigned int FixedDimension{ _fDim };                                                             \
+    static constexpr unsigned int MovingDimension{ _mDim };                                                            \
+    static constexpr bool         IsDefined{ true };                                                                   \
   }
 
 #endif // end #ifndef elxPrepareImageTypeSupport_h

--- a/Core/Main/GTesting/ElastixLibGTest.cxx
+++ b/Core/Main/GTesting/ElastixLibGTest.cxx
@@ -86,7 +86,7 @@ GTEST_TEST(ElastixLib, ExampleFromManualRunningElastix)
   using elastix::ELASTIX;
   using RegistrationParametersContainerType = ELASTIX::ParameterMapListType;
   using ITKImageType = itk::Image<float>;
-  constexpr auto ImageDimension = ITKImageType::ImageDimension;
+  static constexpr auto ImageDimension = ITKImageType::ImageDimension;
 
   const auto parameters = CreateParameterMap<ImageDimension>({
     // Parameters with non-default values (A-Z):
@@ -204,7 +204,7 @@ GTEST_TEST(ElastixLib, TransformParametersAreZeroWhenFixedImageIsMovingImage)
   elx::ForEachSupportedImageType([](const auto elxTypedef) {
     using ElxTypedef = decltype(elxTypedef);
     using ImageType = typename ElxTypedef::FixedImageType;
-    constexpr auto Dimension = ImageType::ImageDimension;
+    static constexpr auto Dimension = ImageType::ImageDimension;
     using PixelType = typename ImageType::PixelType;
     using SizeType = itk::Size<Dimension>;
 
@@ -241,7 +241,7 @@ GTEST_TEST(ElastixLib, TransformParametersAreZeroWhenFixedImageIsMovingImage)
 // Tests registering two small binary images.
 GTEST_TEST(ElastixLib, Translation3D)
 {
-  constexpr auto ImageDimension = 3;
+  static constexpr auto ImageDimension = 3;
   using ImageType = itk::Image<float, ImageDimension>;
 
   const auto parameterMap = CreateParameterMap<ImageDimension>({ { "ImageSampler", "Full" },
@@ -276,7 +276,7 @@ GTEST_TEST(ElastixLib, Translation3D)
 // of a single slice, by specifying a mask for the fixed image.
 GTEST_TEST(ElastixLib, SingleSliceMaskedTranslation3D)
 {
-  constexpr auto ImageDimension = 3;
+  static constexpr auto ImageDimension = 3;
   using ImageType = itk::Image<float, ImageDimension>;
 
   const auto parameterMap = CreateParameterMap<ImageDimension>({ { "ImageSampler", "Full" },

--- a/Core/Main/GTesting/elxCoreMainGTestUtilities.cxx
+++ b/Core/Main/GTesting/elxCoreMainGTestUtilities.cxx
@@ -33,7 +33,7 @@ namespace elastix
 std::string
 CoreMainGTestUtilities::GetDataDirectoryPath()
 {
-  constexpr auto sourceDirectoryPath = ELX_CMAKE_SOURCE_DIR;
+  static constexpr auto sourceDirectoryPath = ELX_CMAKE_SOURCE_DIR;
   static_assert(std::is_same<decltype(sourceDirectoryPath), const char * const>(),
                 "CMAKE_SOURCE_DIR must be a character string!");
   static_assert(sourceDirectoryPath != nullptr, "CMAKE_SOURCE_DIR must not be null!");
@@ -46,7 +46,7 @@ CoreMainGTestUtilities::GetDataDirectoryPath()
 std::string
 CoreMainGTestUtilities::GetCurrentBinaryDirectoryPath()
 {
-  constexpr auto binaryDirectoryPath = ELX_CMAKE_CURRENT_BINARY_DIR;
+  static constexpr auto binaryDirectoryPath = ELX_CMAKE_CURRENT_BINARY_DIR;
   static_assert(std::is_same<decltype(binaryDirectoryPath), const char * const>(),
                 "CMAKE_CURRENT_BINARY_DIR must be a character string!");
   static_assert(binaryDirectoryPath != nullptr, "CMAKE_CURRENT_BINARY_DIR must not be null!");

--- a/Core/Main/GTesting/itkElastixRegistrationMethodGTest.cxx
+++ b/Core/Main/GTesting/itkElastixRegistrationMethodGTest.cxx
@@ -992,10 +992,7 @@ GTEST_TEST(itkElastixRegistrationMethod, InitialTransformParameterFile)
 GTEST_TEST(itkElastixRegistrationMethod, InitialTransformParameterFileWithInitialTransformParameterFile)
 {
   using PixelType = float;
-  enum
-  {
-    ImageDimension = 2U
-  };
+  static constexpr auto ImageDimension = 2U;
   using ImageType = itk::Image<PixelType, ImageDimension>;
 
   const auto doDummyRegistration =
@@ -1048,10 +1045,7 @@ GTEST_TEST(itkElastixRegistrationMethod, InitialTransformParameterFileWithInitia
 GTEST_TEST(itkElastixRegistrationMethod, SetInitialTransform)
 {
   using PixelType = float;
-  enum
-  {
-    ImageDimension = 2U
-  };
+  static constexpr auto ImageDimension = 2U;
   using ImageType = itk::Image<PixelType, ImageDimension>;
   using SizeType = itk::Size<ImageDimension>;
   using IndexType = itk::Index<ImageDimension>;
@@ -1420,10 +1414,7 @@ GTEST_TEST(itkElastixRegistrationMethod, SetExternalInitialTransformAndOutputDir
   const std::string outputDirectoryPath = GetCurrentBinaryDirectoryPath() + '/' + GetNameOfTest(*this);
   itk::FileTools::CreateDirectory(outputDirectoryPath);
 
-  enum
-  {
-    ImageDimension = 2
-  };
+  static constexpr auto ImageDimension = 2U;
 
   using PixelType = float;
   using SizeType = itk::Size<ImageDimension>;
@@ -1599,11 +1590,7 @@ GTEST_TEST(itkElastixRegistrationMethod, SetInitialTransformParameterObjectVersu
 
     // ITK's RecursiveSeparableImageFilter "requires a minimum of four pixels along the dimension to be processed", at
     // https://github.com/InsightSoftwareConsortium/ITK/blob/v5.3.0/Modules/Filtering/ImageFilterBase/include/itkRecursiveSeparableImageFilter.hxx#L226
-    enum
-    {
-      smallImageSizeValue = 8
-    };
-
+    static constexpr auto smallImageSizeValue = 8U;
     const ImageDomainType simpleImageDomain{
       ImageDomainType::SizeType::Filled(smallImageSizeValue),
     };

--- a/Core/Main/GTesting/itkElastixRegistrationMethodGTest.cxx
+++ b/Core/Main/GTesting/itkElastixRegistrationMethodGTest.cxx
@@ -441,7 +441,7 @@ Test_WriteBSplineTransformToItkFileFormat(const std::string & rootOutputDirector
   // FixedParameters store the grid size, origin, spacing, and direction, according to the ITK `BSplineTransform`
   // default-constructor at
   // https://github.com/InsightSoftwareConsortium/ITK/blob/v5.2.0/Modules/Core/Transform/include/itkBSplineTransform.hxx#L35-L61.
-  constexpr auto expectedNumberOfFixedParameters = NDimension * (NDimension + 3);
+  static constexpr auto expectedNumberOfFixedParameters = NDimension * (NDimension + 3);
   ASSERT_EQ(defaultFixedParameters.size(), expectedNumberOfFixedParameters);
 
   elx::DefaultConstruct<ElastixRegistrationMethodType<ImageType>> registration{};
@@ -547,7 +547,7 @@ GTEST_TEST(itkElastixRegistrationMethod, LogLevel)
 
 GTEST_TEST(itkElastixRegistrationMethod, IsDefaultInitialized)
 {
-  constexpr auto ImageDimension = 2U;
+  static constexpr auto ImageDimension = 2U;
   using PixelType = float;
   using ImageType = itk::Image<PixelType, ImageDimension>;
 
@@ -567,7 +567,7 @@ GTEST_TEST(itkElastixRegistrationMethod, IsDefaultInitialized)
 // Tests that the value zero is rejected for the "NumberOfResolutions" parameter.
 GTEST_TEST(itkElastixRegistrationMethod, RejectZeroValueForNumberOfResolution)
 {
-  constexpr auto ImageDimension = 2U;
+  static constexpr auto ImageDimension = 2U;
   using PixelType = float;
   using ImageType = itk::Image<PixelType, ImageDimension>;
   const itk::Size<ImageDimension> imageSize{ { 5, 6 } };
@@ -610,7 +610,7 @@ GTEST_TEST(itkElastixRegistrationMethod, RejectZeroValueForNumberOfResolution)
 // Tests registering two small (5x6) binary images, which are translated with respect to each other.
 GTEST_TEST(itkElastixRegistrationMethod, Translation)
 {
-  constexpr auto ImageDimension = 2U;
+  static constexpr auto ImageDimension = 2U;
   using PixelType = float;
   using ImageType = itk::Image<PixelType, ImageDimension>;
   using SizeType = itk::Size<ImageDimension>;
@@ -648,7 +648,7 @@ GTEST_TEST(itkElastixRegistrationMethod, Translation)
 // Tests "MaximumNumberOfIterations" value "0"
 GTEST_TEST(itkElastixRegistrationMethod, MaximumNumberOfIterationsZero)
 {
-  constexpr auto ImageDimension = 2U;
+  static constexpr auto ImageDimension = 2U;
   using PixelType = float;
   using ImageType = itk::Image<PixelType, ImageDimension>;
   using SizeType = itk::Size<ImageDimension>;
@@ -693,7 +693,7 @@ GTEST_TEST(itkElastixRegistrationMethod, MaximumNumberOfIterationsZero)
 // Tests "AutomaticTransformInitializationMethod" "CenterOfGravity".
 GTEST_TEST(itkElastixRegistrationMethod, AutomaticTransformInitializationCenterOfGravity)
 {
-  constexpr auto ImageDimension = 2U;
+  static constexpr auto ImageDimension = 2U;
   using PixelType = float;
   using ImageType = itk::Image<PixelType, ImageDimension>;
   using SizeType = itk::Size<ImageDimension>;
@@ -737,7 +737,7 @@ GTEST_TEST(itkElastixRegistrationMethod, AutomaticTransformInitializationCenterO
 // Tests registering two images, having "WriteResultImage" set.
 GTEST_TEST(itkElastixRegistrationMethod, WriteResultImage)
 {
-  constexpr auto ImageDimension = 2U;
+  static constexpr auto ImageDimension = 2U;
   using PixelType = float;
   using ImageType = itk::Image<PixelType, ImageDimension>;
   using SizeType = itk::Size<ImageDimension>;
@@ -801,7 +801,7 @@ GTEST_TEST(itkElastixRegistrationMethod, WriteResultImage)
 // Tests registering two images, having a custom "ResultImageName" specified.
 GTEST_TEST(itkElastixRegistrationMethod, ResultImageName)
 {
-  constexpr auto ImageDimension = 2U;
+  static constexpr auto ImageDimension = 2U;
   using PixelType = float;
   using ImageType = itk::Image<PixelType, ImageDimension>;
   using SizeType = itk::Size<ImageDimension>;
@@ -876,7 +876,7 @@ GTEST_TEST(itkElastixRegistrationMethod, ResultImageName)
 // Tests that the origin of the output image is equal to the origin of the fixed image (by default).
 GTEST_TEST(itkElastixRegistrationMethod, OutputHasSameOriginAsFixedImage)
 {
-  constexpr auto ImageDimension = 2U;
+  static constexpr auto ImageDimension = 2U;
   using PixelType = float;
   using ImageType = itk::Image<PixelType, ImageDimension>;
   using SizeType = itk::Size<ImageDimension>;
@@ -945,7 +945,7 @@ GTEST_TEST(itkElastixRegistrationMethod, OutputHasSameOriginAsFixedImage)
 GTEST_TEST(itkElastixRegistrationMethod, InitialTransformParameterFile)
 {
   using PixelType = float;
-  constexpr auto ImageDimension = 2U;
+  static constexpr auto ImageDimension = 2U;
   using ImageType = itk::Image<PixelType, ImageDimension>;
   using SizeType = itk::Size<ImageDimension>;
   using IndexType = itk::Index<ImageDimension>;
@@ -1145,7 +1145,7 @@ GTEST_TEST(itkElastixRegistrationMethod, SetInitialTransform)
 GTEST_TEST(itkElastixRegistrationMethod, SetInitialTransformParameterObject)
 {
   using PixelType = float;
-  constexpr auto ImageDimension = 2U;
+  static constexpr auto ImageDimension = 2U;
   using ImageType = itk::Image<PixelType, ImageDimension>;
   using SizeType = itk::Size<ImageDimension>;
   using IndexType = itk::Index<ImageDimension>;
@@ -1241,7 +1241,7 @@ GTEST_TEST(itkElastixRegistrationMethod, SetInitialTransformParameterObject)
 
 GTEST_TEST(itkElastixRegistrationMethod, SetExternalTransformAsInitialTransform)
 {
-  constexpr unsigned int ImageDimension{ 2 };
+  static constexpr unsigned int ImageDimension{ 2 };
 
   using PixelType = float;
   using SizeType = itk::Size<ImageDimension>;
@@ -1321,7 +1321,7 @@ GTEST_TEST(itkElastixRegistrationMethod, SetExternalTransformAsInitialTransform)
 
 GTEST_TEST(itkElastixRegistrationMethod, SetExternalInitialTransform)
 {
-  constexpr unsigned int ImageDimension{ 2 };
+  static constexpr unsigned int ImageDimension{ 2 };
 
   using PixelType = float;
   using SizeType = itk::Size<ImageDimension>;
@@ -1487,7 +1487,7 @@ GTEST_TEST(itkElastixRegistrationMethod, SetExternalInitialTransformAndOutputDir
 // transform".
 GTEST_TEST(itkElastixRegistrationMethod, SetExternalInitialTransformAndConvertToItkTransform)
 {
-  constexpr auto ImageDimension = 2u;
+  static constexpr auto ImageDimension = 2u;
   using PixelType = float;
   using ImageType = itk::Image<PixelType, ImageDimension>;
   const itk::Size<ImageDimension> imageSize{ { 5, 6 } };
@@ -1553,7 +1553,7 @@ GTEST_TEST(itkElastixRegistrationMethod, SetInitialTransformParameterObjectVersu
         NonDefaultTransformParameter(
           { "TransformParameters", elx::Conversion::ToVectorOfStrings(translationTransformParameters) }) });
 
-    constexpr auto gridValueSize = 4U;
+    static constexpr auto gridValueSize = 4U;
 
     std::array<double, ImageDimension * itk::Math::UnsignedPower(gridValueSize, ImageDimension)>
       bsplineTransformParameters;
@@ -1658,7 +1658,7 @@ GTEST_TEST(itkElastixRegistrationMethod, SetInitialTransformParameterObjectVersu
 GTEST_TEST(itkElastixRegistrationMethod, InitialTransformParameterFileLinkToTransformFile)
 {
   using PixelType = float;
-  constexpr auto ImageDimension = 2U;
+  static constexpr auto ImageDimension = 2U;
   using ImageType = itk::Image<PixelType, ImageDimension>;
   using SizeType = itk::Size<ImageDimension>;
   using IndexType = itk::Index<ImageDimension>;
@@ -1740,7 +1740,7 @@ GTEST_TEST(itkElastixRegistrationMethod, InitialTransformParameterFileLinkToTran
 
 GTEST_TEST(itkElastixRegistrationMethod, GetCombinationTransform)
 {
-  constexpr auto ImageDimension = 2U;
+  static constexpr auto ImageDimension = 2U;
   using ImageType = itk::Image<float, ImageDimension>;
   const auto image =
     CreateImageFilledWithSequenceOfNaturalNumbers<ImageType::PixelType>(itk::Size<ImageDimension>{ 5, 6 });
@@ -1794,7 +1794,7 @@ GTEST_TEST(itkElastixRegistrationMethod, GetCombinationTransform)
 
 GTEST_TEST(itkElastixRegistrationMethod, GetNumberOfTransforms)
 {
-  constexpr auto ImageDimension = 2U;
+  static constexpr auto ImageDimension = 2U;
   using ImageType = itk::Image<float, ImageDimension>;
   const auto image =
     CreateImageFilledWithSequenceOfNaturalNumbers<ImageType::PixelType>(itk::Size<ImageDimension>{ 5, 6 });
@@ -1824,7 +1824,7 @@ GTEST_TEST(itkElastixRegistrationMethod, GetNumberOfTransforms)
 
 GTEST_TEST(itkElastixRegistrationMethod, GetNthTransform)
 {
-  constexpr auto ImageDimension = 2U;
+  static constexpr auto ImageDimension = 2U;
   using ImageType = itk::Image<float, ImageDimension>;
   const auto image =
     CreateImageFilledWithSequenceOfNaturalNumbers<ImageType::PixelType>(itk::Size<ImageDimension>{ 5, 6 });
@@ -1861,7 +1861,7 @@ GTEST_TEST(itkElastixRegistrationMethod, GetNthTransform)
 
 GTEST_TEST(itkElastixRegistrationMethod, ConvertToItkTransform)
 {
-  constexpr auto ImageDimension = 2U;
+  static constexpr auto ImageDimension = 2U;
   using ImageType = itk::Image<float, ImageDimension>;
   const auto image =
     CreateImageFilledWithSequenceOfNaturalNumbers<ImageType::PixelType>(itk::Size<ImageDimension>{ 5, 6 });
@@ -1902,7 +1902,7 @@ GTEST_TEST(itkElastixRegistrationMethod, ConvertToItkTransform)
 
 GTEST_TEST(itkElastixRegistrationMethod, WriteCompositeTransform)
 {
-  constexpr auto ImageDimension = 2U;
+  static constexpr auto ImageDimension = 2U;
   using ImageType = itk::Image<float, ImageDimension>;
   const auto image =
     CreateImageFilledWithSequenceOfNaturalNumbers<ImageType::PixelType>(itk::Size<ImageDimension>{ 5, 6 });
@@ -2019,7 +2019,7 @@ GTEST_TEST(itkElastixRegistrationMethod, WriteBSplineTransformToItkFileFormat)
 GTEST_TEST(itkElastixRegistrationMethod, EulerTranslation2D)
 {
   using PixelType = float;
-  constexpr auto ImageDimension = 2U;
+  static constexpr auto ImageDimension = 2U;
   using ImageType = itk::Image<PixelType, ImageDimension>;
   using SizeType = itk::Size<ImageDimension>;
   using IndexType = itk::Index<ImageDimension>;
@@ -2101,7 +2101,7 @@ GTEST_TEST(itkElastixRegistrationMethod, EulerDiscRotation2D)
         offset[i] = index[i] - ((imageSizeValue - 1) / 2.0);
       }
 
-      constexpr auto radius = (imageSizeValue / 2.0) - 2.0;
+      static constexpr auto radius = (imageSizeValue / 2.0) - 2.0;
 
       if (std::inner_product(offset.begin(), offset.end(), offset.begin(), 0.0) < (radius * radius))
       {
@@ -2137,7 +2137,7 @@ GTEST_TEST(itkElastixRegistrationMethod, EulerDiscRotation2D)
 
   for (const auto degree : { -2, 0, 1, 30 })
   {
-    constexpr auto radiansPerDegree = M_PI / 180.0;
+    static constexpr auto radiansPerDegree = M_PI / 180.0;
 
     setPixelsOfDisc(*movingImage, degree * radiansPerDegree);
     registration.SetMovingImage(movingImage);
@@ -2159,7 +2159,7 @@ GTEST_TEST(itkElastixRegistrationMethod, CheckMinimumMovingImageHavingInternalPi
   elx::ForEachSupportedImageType([](const auto elxTypedef) {
     using ElxTypedef = decltype(elxTypedef);
     using ImageType = typename ElxTypedef::MovingImageType;
-    constexpr auto ImageDimension = ElxTypedef::MovingDimension;
+    static constexpr auto ImageDimension = ElxTypedef::MovingDimension;
 
     using PixelType = typename ImageType::PixelType;
 
@@ -2215,7 +2215,7 @@ GTEST_TEST(itkElastixRegistrationMethod, CheckZeroFilledMovingImageWithRandomDom
   elx::ForEachSupportedImageType([&randomNumberEngine](const auto elxTypedef) {
     using ElxTypedef = decltype(elxTypedef);
     using ImageType = typename ElxTypedef::MovingImageType;
-    constexpr auto ImageDimension = ElxTypedef::MovingDimension;
+    static constexpr auto ImageDimension = ElxTypedef::MovingDimension;
 
     using PixelType = typename ImageType::PixelType;
 
@@ -2363,7 +2363,7 @@ GTEST_TEST(itkElastixRegistrationMethod, CheckZeroFilledMovingImageWithRandomDom
 // Checks that InitialTransform and ExternalInitialTransform are mutually exclusive.
 GTEST_TEST(itkElastixRegistrationMethod, SetAndGetInitialTransform)
 {
-  constexpr auto ImageDimension = 2U;
+  static constexpr auto ImageDimension = 2U;
   using ImageType = itk::Image<float, ImageDimension>;
 
   elx::DefaultConstruct<itk::DisplacementFieldTransform<double, ImageDimension>> displacementFieldTransform{};

--- a/Core/Main/GTesting/itkTransformixFilterGTest.cxx
+++ b/Core/Main/GTesting/itkTransformixFilterGTest.cxx
@@ -809,11 +809,8 @@ GTEST_TEST(itkTransformixFilter, CombineTranslationAndDefaultTransform)
 
 GTEST_TEST(itkTransformixFilter, CombineTranslationAndInverseTranslation)
 {
-  const auto imageSize = itk::MakeSize(5, 6);
-  enum
-  {
-    dimension = decltype(imageSize)::Dimension
-  };
+  const auto            imageSize = itk::MakeSize(5, 6);
+  static constexpr auto dimension = decltype(imageSize)::Dimension;
 
   const auto inputImage = itk::Image<float, dimension>::New();
   inputImage->SetRegions(imageSize);
@@ -876,12 +873,9 @@ GTEST_TEST(itkTransformixFilter, CombineTranslationAndInverseTranslation)
 
 GTEST_TEST(itkTransformixFilter, CombineTranslationAndScale)
 {
-  const auto imageSize = itk::MakeSize(5, 6);
-  enum
-  {
-    dimension = decltype(imageSize)::Dimension
-  };
-  const auto inputImage = CreateImageFilledWithSequenceOfNaturalNumbers<float>(imageSize);
+  const auto            imageSize = itk::MakeSize(5, 6);
+  static constexpr auto dimension = decltype(imageSize)::Dimension;
+  const auto            inputImage = CreateImageFilledWithSequenceOfNaturalNumbers<float>(imageSize);
 
   using ParametersValueType = double;
 
@@ -921,9 +915,10 @@ GTEST_TEST(itkTransformixFilter, CombineTranslationAndScale)
 GTEST_TEST(itkTransformixFilter, OutputEqualsRegistrationOutputForStackTransform)
 {
   using PixelType = float;
+  static constexpr auto ImageDimension = 3U;
+
   enum
   {
-    ImageDimension = 3,
     imageSizeX = 5,
     imageSizeY = 6,
     imageSizeZ = 4
@@ -1528,10 +1523,7 @@ GTEST_TEST(itkTransformixFilter, ExternalTransform)
 
 GTEST_TEST(itkTransformixFilter, SetExternalTransform)
 {
-  enum
-  {
-    ImageDimension = 2
-  };
+  static constexpr auto ImageDimension = 2U;
   using PixelType = float;
   using SizeType = itk::Size<ImageDimension>;
   const SizeType imageSize{ { 5, 6 } };

--- a/Core/Main/GTesting/itkTransformixFilterGTest.cxx
+++ b/Core/Main/GTesting/itkTransformixFilterGTest.cxx
@@ -101,8 +101,8 @@ template <unsigned ImageDimension>
 auto
 CreateDefaultDirectionParameterValues()
 {
-  constexpr auto      numberOfValues = ImageDimension * ImageDimension;
-  ParameterValuesType values(numberOfValues, "0");
+  static constexpr auto numberOfValues = ImageDimension * ImageDimension;
+  ParameterValuesType   values(numberOfValues, "0");
 
   for (std::size_t i{}; i < numberOfValues; i += (ImageDimension + 1))
   {
@@ -131,7 +131,7 @@ template <typename TImage>
 itk::SmartPointer<TImage>
 TranslateImage(TImage & image, const typename TImage::OffsetType & translationOffset)
 {
-  constexpr auto ImageDimension = TImage::ImageDimension;
+  static constexpr auto ImageDimension = TImage::ImageDimension;
 
   DefaultConstructibleTransformixFilter<TImage> filter;
 
@@ -421,7 +421,7 @@ Test_BSplineViaExternalTransformFile(const std::string & rootOutputDirectoryPath
 
 GTEST_TEST(itkTransformixFilter, IsDefaultInitialized)
 {
-  constexpr auto ImageDimension = 2U;
+  static constexpr auto ImageDimension = 2U;
   using PixelType = float;
   using TransformixFilterType = itk::TransformixFilter<itk::Image<PixelType, ImageDimension>>;
 
@@ -442,7 +442,7 @@ GTEST_TEST(itkTransformixFilter, IsDefaultInitialized)
 // Tests translating a small (5x6) binary image, having a 2x2 white square.
 GTEST_TEST(itkTransformixFilter, Translation2D)
 {
-  constexpr auto ImageDimension = 2U;
+  static constexpr auto ImageDimension = 2U;
   using ImageType = itk::Image<float, ImageDimension>;
   using SizeType = itk::Size<ImageDimension>;
 
@@ -470,7 +470,7 @@ GTEST_TEST(itkTransformixFilter, Translation2D)
 // Tests translating a small (5x6) binary image, using a TransformParameterFileName.
 GTEST_TEST(itkTransformixFilter, Translation2DTransformParameterFileName)
 {
-  constexpr auto ImageDimension = 2U;
+  static constexpr auto ImageDimension = 2U;
   using ImageType = itk::Image<float, ImageDimension>;
   using SizeType = itk::Size<ImageDimension>;
 
@@ -504,7 +504,7 @@ GTEST_TEST(itkTransformixFilter, Translation2DTransformParameterFileName)
 // Tests translating a mesh of two points.
 GTEST_TEST(itkTransformixFilter, MeshTranslation2D)
 {
-  constexpr auto ImageDimension = 2U;
+  static constexpr auto ImageDimension = 2U;
   using PixelType = float;
   using TransformixFilterType = itk::TransformixFilter<itk::Image<PixelType, ImageDimension>>;
   using VectorType = itk::Vector<float, ImageDimension>;
@@ -559,7 +559,7 @@ GTEST_TEST(itkTransformixFilter, MeshTranslation2D)
 // Tests translating a small (5x7x9) binary 3D image, having a 2x2x2 white cube.
 GTEST_TEST(itkTransformixFilter, Translation3D)
 {
-  constexpr auto ImageDimension = 3U;
+  static constexpr auto ImageDimension = 3U;
   using ImageType = itk::Image<float, ImageDimension>;
   using SizeType = itk::Size<ImageDimension>;
 
@@ -586,7 +586,7 @@ GTEST_TEST(itkTransformixFilter, Translation3D)
 
 GTEST_TEST(itkTransformixFilter, TranslationViaExternalTransformFile)
 {
-  constexpr auto ImageDimension = 2U;
+  static constexpr auto ImageDimension = 2U;
   using PixelType = float;
 
   const itk::Offset<ImageDimension> translationOffset{ { 1, -2 } };
@@ -635,7 +635,7 @@ GTEST_TEST(itkTransformixFilter, BSplineViaExternalTransformFile)
 
 GTEST_TEST(itkTransformixFilter, ITKTranslationTransform2D)
 {
-  constexpr auto ImageDimension = 2U;
+  static constexpr auto ImageDimension = 2U;
 
   elx::DefaultConstruct<itk::TranslationTransform<double, ImageDimension>> itkTransform;
   itkTransform.SetOffset(itk::MakeVector(1.0, -2.0));
@@ -647,7 +647,7 @@ GTEST_TEST(itkTransformixFilter, ITKTranslationTransform2D)
 
 GTEST_TEST(itkTransformixFilter, ITKTranslationTransform3D)
 {
-  constexpr auto ImageDimension = 3U;
+  static constexpr auto ImageDimension = 3U;
 
   elx::DefaultConstruct<itk::TranslationTransform<double, ImageDimension>> itkTransform;
   itkTransform.SetOffset(itk::MakeVector(1.0, -2.0, 3.0));
@@ -659,7 +659,7 @@ GTEST_TEST(itkTransformixFilter, ITKTranslationTransform3D)
 
 GTEST_TEST(itkTransformixFilter, ITKAffineTransform2D)
 {
-  constexpr auto ImageDimension = 2U;
+  static constexpr auto ImageDimension = 2U;
 
   elx::DefaultConstruct<itk::AffineTransform<double, ImageDimension>> itkTransform;
   itkTransform.SetTranslation(itk::MakeVector(1.0, -2.0));
@@ -673,7 +673,7 @@ GTEST_TEST(itkTransformixFilter, ITKAffineTransform2D)
 
 GTEST_TEST(itkTransformixFilter, ITKAffineTransform3D)
 {
-  constexpr auto ImageDimension = 3U;
+  static constexpr auto ImageDimension = 3U;
 
   elx::DefaultConstruct<itk::AffineTransform<double, ImageDimension>> itkTransform;
   itkTransform.SetTranslation(itk::MakeVector(1.0, 2.0, 3.0));
@@ -767,9 +767,9 @@ GTEST_TEST(itkTransformixFilter, ITKBSplineTransform3D)
 
 GTEST_TEST(itkTransformixFilter, CombineTranslationAndDefaultTransform)
 {
-  const auto     imageSize = itk::MakeSize(5, 6);
-  const auto     inputImage = CreateImageFilledWithSequenceOfNaturalNumbers<float>(imageSize);
-  constexpr auto dimension = decltype(imageSize)::Dimension;
+  const auto            imageSize = itk::MakeSize(5, 6);
+  const auto            inputImage = CreateImageFilledWithSequenceOfNaturalNumbers<float>(imageSize);
+  static constexpr auto dimension = decltype(imageSize)::Dimension;
 
   using ParametersValueType = double;
 
@@ -991,7 +991,7 @@ GTEST_TEST(itkTransformixFilter, OutputEqualsRegistrationOutputForBSplineStackTr
 GTEST_TEST(itkTransformixFilter, SetTranslationTransform)
 {
   using PixelType = float;
-  constexpr unsigned int ImageDimension{ 2 };
+  static constexpr unsigned int ImageDimension{ 2 };
 
   using SizeType = itk::Size<ImageDimension>;
   const itk::Offset<ImageDimension> translationOffset{ { 1, -2 } };
@@ -1054,7 +1054,7 @@ GTEST_TEST(itkTransformixFilter, SetTranslationTransform)
 
 GTEST_TEST(itkTransformixFilter, SetCombinationTransform)
 {
-  constexpr auto ImageDimension = 2U;
+  static constexpr auto ImageDimension = 2U;
   using PixelType = float;
   using ImageType = itk::Image<PixelType, ImageDimension>;
   const itk::Size<ImageDimension> imageSize{ { 5, 6 } };
@@ -1134,7 +1134,7 @@ GTEST_TEST(itkTransformixFilter, SetCombinationTransform)
 GTEST_TEST(itkTransformixFilter, UpdateThrowsExceptionOnZeroParameterMaps)
 {
   using PixelType = float;
-  constexpr unsigned int ImageDimension{ 2 };
+  static constexpr unsigned int ImageDimension{ 2 };
   using ImageType = itk::Image<PixelType, ImageDimension>;
   const auto imageSize = ImageType::SizeType::Filled(2);
 
@@ -1183,7 +1183,7 @@ GTEST_TEST(itkTransformixFilter, UpdateThrowsExceptionOnZeroParameterMaps)
 GTEST_TEST(itkTransformixFilter, UpdateThrowsExceptionOnEmptyCompositeTransform)
 {
   using PixelType = float;
-  constexpr unsigned int ImageDimension{ 2 };
+  static constexpr unsigned int ImageDimension{ 2 };
   using ImageType = itk::Image<PixelType, ImageDimension>;
   const itk::Size<ImageDimension> imageSize{ { 5, 6 } };
 
@@ -1224,8 +1224,8 @@ GTEST_TEST(itkTransformixFilter, UpdateThrowsExceptionOnEmptyCompositeTransform)
 GTEST_TEST(itkTransformixFilter, SetCompositeTransformOfTranslationAndScale)
 {
   using PixelType = float;
-  const auto             imageSize = itk::MakeSize(5, 6);
-  constexpr unsigned int ImageDimension{ decltype(imageSize)::Dimension };
+  const auto                    imageSize = itk::MakeSize(5, 6);
+  static constexpr unsigned int ImageDimension{ decltype(imageSize)::Dimension };
   using ImageType = itk::Image<PixelType, ImageDimension>;
 
   const auto inputImage = CreateImageFilledWithSequenceOfNaturalNumbers<PixelType>(imageSize);
@@ -1273,7 +1273,7 @@ GTEST_TEST(itkTransformixFilter, SetCompositeTransformOfTranslationAndScale)
 GTEST_TEST(itkTransformixFilter, ComputeSpatialJacobianDeterminantImage)
 {
   using PixelType = float;
-  constexpr unsigned int ImageDimension{ 2 };
+  static constexpr unsigned int ImageDimension{ 2 };
 
   using SizeType = itk::Size<ImageDimension>;
   const SizeType imageSize{ { 5, 6 } };
@@ -1328,7 +1328,7 @@ GTEST_TEST(itkTransformixFilter, CheckMinimumMovingImageHavingInternalPixelType)
   elx::ForEachSupportedImageType([](const auto elxTypedef) {
     using ElxTypedef = decltype(elxTypedef);
     using ImageType = typename ElxTypedef::MovingImageType;
-    constexpr auto ImageDimension = ElxTypedef::MovingDimension;
+    static constexpr auto ImageDimension = ElxTypedef::MovingDimension;
 
     using PixelType = typename ImageType::PixelType;
     using SizeType = itk::Size<ImageDimension>;
@@ -1378,7 +1378,7 @@ GTEST_TEST(itkTransformixFilter, CheckZeroFilledMovingImageWithRandomDomainHavin
   elx::ForEachSupportedImageType([&randomNumberEngine](const auto elxTypedef) {
     using ElxTypedef = decltype(elxTypedef);
     using ImageType = typename ElxTypedef::MovingImageType;
-    constexpr auto ImageDimension = ElxTypedef::MovingDimension;
+    static constexpr auto ImageDimension = ElxTypedef::MovingDimension;
 
     using PixelType = typename ImageType::PixelType;
     using SizeType = itk::Size<ImageDimension>;
@@ -1491,7 +1491,7 @@ GTEST_TEST(itkTransformixFilter, CheckZeroFilledMovingImageWithRandomDomainUsing
 
 GTEST_TEST(itkTransformixFilter, ExternalTransform)
 {
-  constexpr unsigned int ImageDimension{ 2 };
+  static constexpr unsigned int ImageDimension{ 2 };
 
   using PixelType = float;
   using SizeType = itk::Size<ImageDimension>;


### PR DESCRIPTION
- Replaced `constexpr static` with `static constexpr`, following ITK pull request https://github.com/InsightSoftwareConsortium/ITK/pull/3144 by Lee Newberg (@leengit). In accordance with blog entry [`static constexpr unsigned long` is C++’s “lovely little old French whittling knife”](https://quuxplusone.github.io/blog/2021/04/03/static-constexpr-whittling-knife/), Arthur O’Dwyer, 2021-04-03.
- Replaced local `enum` constants with `static constexpr`
- Added `static` to `constexpr ` local variables in GTest source files, following a suggestion by ["C++ Weekly With Jason Turner"](https://www.youtube.com/@cppweekly) episode 312 - [Stop Using `constexpr` (And Use This Instead!)](https://www.youtube.com/watch?v=4pKtPWcl1Go). Excluded the local variable `pixelTypeNames` from `GetPixelTypeName()`, to avoid compilation errors saying _static variable not permitted in a constexpr function_
