### PR TITLE
Use `vnl_matrix` instead of `itk::Array2D` (if possible)

### DIFF
--- a/Common/Transforms/itkAdvancedBSplineDeformableTransform.hxx
+++ b/Common/Transforms/itkAdvancedBSplineDeformableTransform.hxx
@@ -315,7 +315,7 @@ AdvancedBSplineDeformableTransform<TScalarType, NDimensions, VSplineOrder>::GetJ
   if ((jacobian.cols() != nnzji) || (jacobian.rows() != SpaceDimension))
   {
     jacobian.set_size(SpaceDimension, nnzji);
-    jacobian.Fill(0.0);
+    jacobian.fill(0.0);
   }
 
   /** NOTE: if the support region does not lie totally within the grid

--- a/Common/Transforms/itkAdvancedBSplineDeformableTransform.hxx
+++ b/Common/Transforms/itkAdvancedBSplineDeformableTransform.hxx
@@ -314,7 +314,7 @@ AdvancedBSplineDeformableTransform<TScalarType, NDimensions, VSplineOrder>::GetJ
   const NumberOfParametersType nnzji = this->GetNumberOfNonZeroJacobianIndices();
   if ((jacobian.cols() != nnzji) || (jacobian.rows() != SpaceDimension))
   {
-    jacobian.SetSize(SpaceDimension, nnzji);
+    jacobian.set_size(SpaceDimension, nnzji);
     jacobian.Fill(0.0);
   }
 

--- a/Common/Transforms/itkAdvancedEuler3DTransform.hxx
+++ b/Common/Transforms/itkAdvancedEuler3DTransform.hxx
@@ -243,7 +243,7 @@ AdvancedEuler3DTransform<TScalarType>::GetJacobian(const InputPointType &       
   // Filling with zeros is needed because the lower loops only visit
   // the nonzero positions.
   j.set_size(OutputSpaceDimension, ParametersDimension);
-  j.Fill(0.0);
+  j.fill(0.0);
 
   /** Compute dR/dmu * (p-c) */
   const InputVectorType                 pp = p - this->GetCenter();

--- a/Common/Transforms/itkAdvancedEuler3DTransform.hxx
+++ b/Common/Transforms/itkAdvancedEuler3DTransform.hxx
@@ -242,7 +242,7 @@ AdvancedEuler3DTransform<TScalarType>::GetJacobian(const InputPointType &       
   // Initialize the Jacobian. Resizing is only performed when needed.
   // Filling with zeros is needed because the lower loops only visit
   // the nonzero positions.
-  j.SetSize(OutputSpaceDimension, ParametersDimension);
+  j.set_size(OutputSpaceDimension, ParametersDimension);
   j.Fill(0.0);
 
   /** Compute dR/dmu * (p-c) */

--- a/Common/Transforms/itkAdvancedMatrixOffsetTransformBase.hxx
+++ b/Common/Transforms/itkAdvancedMatrixOffsetTransformBase.hxx
@@ -432,7 +432,7 @@ AdvancedMatrixOffsetTransformBase<TScalarType, NInputDimensions, NOutputDimensio
   // Initialize the Jacobian. Resizing is only performed when needed.
   // Filling with zeros is needed because the lower loops only visit
   // the nonzero positions.
-  j.SetSize(OutputSpaceDimension, ParametersDimension);
+  j.set_size(OutputSpaceDimension, ParametersDimension);
   j.Fill(0.0);
 
   const InputVectorType v = p - this->GetCenter();

--- a/Common/Transforms/itkAdvancedMatrixOffsetTransformBase.hxx
+++ b/Common/Transforms/itkAdvancedMatrixOffsetTransformBase.hxx
@@ -433,7 +433,7 @@ AdvancedMatrixOffsetTransformBase<TScalarType, NInputDimensions, NOutputDimensio
   // Filling with zeros is needed because the lower loops only visit
   // the nonzero positions.
   j.set_size(OutputSpaceDimension, ParametersDimension);
-  j.Fill(0.0);
+  j.fill(0.0);
 
   const InputVectorType v = p - this->GetCenter();
 

--- a/Common/Transforms/itkAdvancedRigid2DTransform.hxx
+++ b/Common/Transforms/itkAdvancedRigid2DTransform.hxx
@@ -227,7 +227,7 @@ AdvancedRigid2DTransform<TScalarType>::GetJacobian(const InputPointType &       
   // Filling with zeros is needed because the lower loops only visit
   // the nonzero positions.
   j.set_size(OutputSpaceDimension, ParametersDimension);
-  j.Fill(0.0);
+  j.fill(0.0);
 
   // Some helper variables
   const double ca = std::cos(m_Angle);

--- a/Common/Transforms/itkAdvancedRigid2DTransform.hxx
+++ b/Common/Transforms/itkAdvancedRigid2DTransform.hxx
@@ -226,7 +226,7 @@ AdvancedRigid2DTransform<TScalarType>::GetJacobian(const InputPointType &       
   // Initialize the Jacobian. Resizing is only performed when needed.
   // Filling with zeros is needed because the lower loops only visit
   // the nonzero positions.
-  j.SetSize(OutputSpaceDimension, ParametersDimension);
+  j.set_size(OutputSpaceDimension, ParametersDimension);
   j.Fill(0.0);
 
   // Some helper variables

--- a/Common/Transforms/itkAdvancedSimilarity2DTransform.hxx
+++ b/Common/Transforms/itkAdvancedSimilarity2DTransform.hxx
@@ -173,7 +173,7 @@ AdvancedSimilarity2DTransform<TScalarType>::GetJacobian(const InputPointType &  
   // Filling with zeros is needed because the lower loops only visit
   // the nonzero positions.
   j.set_size(OutputSpaceDimension, ParametersDimension);
-  j.Fill(0.0);
+  j.fill(0.0);
 
   // Some helper variables
   const double         angle = this->GetAngle();

--- a/Common/Transforms/itkAdvancedSimilarity2DTransform.hxx
+++ b/Common/Transforms/itkAdvancedSimilarity2DTransform.hxx
@@ -172,7 +172,7 @@ AdvancedSimilarity2DTransform<TScalarType>::GetJacobian(const InputPointType &  
   // Initialize the Jacobian. Resizing is only performed when needed.
   // Filling with zeros is needed because the lower loops only visit
   // the nonzero positions.
-  j.SetSize(OutputSpaceDimension, ParametersDimension);
+  j.set_size(OutputSpaceDimension, ParametersDimension);
   j.Fill(0.0);
 
   // Some helper variables

--- a/Common/Transforms/itkAdvancedSimilarity3DTransform.hxx
+++ b/Common/Transforms/itkAdvancedSimilarity3DTransform.hxx
@@ -217,7 +217,7 @@ AdvancedSimilarity3DTransform<TScalarType>::GetJacobian(const InputPointType &  
   // Initialize the Jacobian. Resizing is only performed when needed.
   // Filling with zeros is needed because the lower loops only visit
   // the nonzero positions.
-  j.SetSize(OutputSpaceDimension, ParametersDimension);
+  j.set_size(OutputSpaceDimension, ParametersDimension);
   j.Fill(0.0);
 
   // Some helper variables

--- a/Common/Transforms/itkAdvancedSimilarity3DTransform.hxx
+++ b/Common/Transforms/itkAdvancedSimilarity3DTransform.hxx
@@ -218,7 +218,7 @@ AdvancedSimilarity3DTransform<TScalarType>::GetJacobian(const InputPointType &  
   // Filling with zeros is needed because the lower loops only visit
   // the nonzero positions.
   j.set_size(OutputSpaceDimension, ParametersDimension);
-  j.Fill(0.0);
+  j.fill(0.0);
 
   // Some helper variables
   const InputVectorType                 pp = p - this->GetCenter();

--- a/Common/Transforms/itkAdvancedVersorRigid3DTransform.hxx
+++ b/Common/Transforms/itkAdvancedVersorRigid3DTransform.hxx
@@ -150,7 +150,7 @@ AdvancedVersorRigid3DTransform<TScalarType>::GetJacobian(const InputPointType & 
   // Initialize the Jacobian. Resizing is only performed when needed.
   // Filling with zeros is needed because the lower loops only visit
   // the nonzero positions.
-  j.SetSize(OutputSpaceDimension, ParametersDimension);
+  j.set_size(OutputSpaceDimension, ParametersDimension);
   j.Fill(0.0);
 
   // compute derivatives with respect to rotation

--- a/Common/Transforms/itkAdvancedVersorRigid3DTransform.hxx
+++ b/Common/Transforms/itkAdvancedVersorRigid3DTransform.hxx
@@ -151,7 +151,7 @@ AdvancedVersorRigid3DTransform<TScalarType>::GetJacobian(const InputPointType & 
   // Filling with zeros is needed because the lower loops only visit
   // the nonzero positions.
   j.set_size(OutputSpaceDimension, ParametersDimension);
-  j.Fill(0.0);
+  j.fill(0.0);
 
   // compute derivatives with respect to rotation
   const ValueType vx = this->GetVersor().GetX();

--- a/Common/Transforms/itkAdvancedVersorTransform.hxx
+++ b/Common/Transforms/itkAdvancedVersorTransform.hxx
@@ -199,7 +199,7 @@ AdvancedVersorTransform<TScalarType>::GetJacobian(const InputPointType &       p
   // Filling with zeros is needed because the lower loops only visit
   // the nonzero positions.
   j.set_size(OutputSpaceDimension, ParametersDimension);
-  j.Fill(0.0);
+  j.fill(0.0);
 
   // compute derivatives with respect to rotation
   const ValueType vx = m_Versor.GetX();

--- a/Common/Transforms/itkAdvancedVersorTransform.hxx
+++ b/Common/Transforms/itkAdvancedVersorTransform.hxx
@@ -198,7 +198,7 @@ AdvancedVersorTransform<TScalarType>::GetJacobian(const InputPointType &       p
   // Initialize the Jacobian. Resizing is only performed when needed.
   // Filling with zeros is needed because the lower loops only visit
   // the nonzero positions.
-  j.SetSize(OutputSpaceDimension, ParametersDimension);
+  j.set_size(OutputSpaceDimension, ParametersDimension);
   j.Fill(0.0);
 
   // compute derivatives with respect to rotation

--- a/Common/Transforms/itkBSplineInterpolationDerivativeWeightFunction.h
+++ b/Common/Transforms/itkBSplineInterpolationDerivativeWeightFunction.h
@@ -83,7 +83,6 @@ protected:
   using typename Superclass::KernelType;
   using typename Superclass::DerivativeKernelType;
   using typename Superclass::SecondOrderDerivativeKernelType;
-  using typename Superclass::TableType;
   using typename Superclass::OneDWeightsType;
 
   /** Compute the 1D weights, which are:

--- a/Common/Transforms/itkBSplineInterpolationSecondOrderDerivativeWeightFunction.h
+++ b/Common/Transforms/itkBSplineInterpolationSecondOrderDerivativeWeightFunction.h
@@ -84,7 +84,6 @@ protected:
   using typename Superclass::KernelType;
   using typename Superclass::DerivativeKernelType;
   using typename Superclass::SecondOrderDerivativeKernelType;
-  using typename Superclass::TableType;
   using typename Superclass::OneDWeightsType;
 
   /** Compute the 1D weights, which are:

--- a/Common/Transforms/itkBSplineInterpolationWeightFunction2.h
+++ b/Common/Transforms/itkBSplineInterpolationWeightFunction2.h
@@ -78,7 +78,6 @@ protected:
   using typename Superclass::KernelType;
   using typename Superclass::DerivativeKernelType;
   using typename Superclass::SecondOrderDerivativeKernelType;
-  using typename Superclass::TableType;
   using typename Superclass::OneDWeightsType;
   using typename Superclass::WeightArrayType;
 

--- a/Common/Transforms/itkBSplineInterpolationWeightFunctionBase.h
+++ b/Common/Transforms/itkBSplineInterpolationWeightFunctionBase.h
@@ -121,7 +121,7 @@ protected:
   using WeightArrayType = typename KernelType::WeightArrayType;
 
   /** Lookup table type. */
-  using TableType = Array2D<unsigned long>;
+  using TableType = vnl_matrix<unsigned long>;
 
   /** Typedef for intermediary 1D weights.
    * The Matrix is at least twice as fast as std::vector< vnl_vector< double > >,

--- a/Common/Transforms/itkBSplineInterpolationWeightFunctionBase.h
+++ b/Common/Transforms/itkBSplineInterpolationWeightFunctionBase.h
@@ -120,9 +120,6 @@ protected:
   using SecondOrderDerivativeKernelPointer = typename SecondOrderDerivativeKernelType::Pointer;
   using WeightArrayType = typename KernelType::WeightArrayType;
 
-  /** Lookup table type. */
-  using TableType = vnl_matrix<unsigned long>;
-
   /** Typedef for intermediary 1D weights.
    * The Matrix is at least twice as fast as std::vector< vnl_vector< double > >,
    * probably because of the fixed size at compile time.
@@ -140,9 +137,9 @@ protected:
   PrintSelf(std::ostream & os, Indent indent) const override;
 
   /** Member variables. */
-  unsigned long m_NumberOfWeights{};
-  SizeType      m_SupportSize{};
-  TableType     m_OffsetToIndexTable{};
+  unsigned long             m_NumberOfWeights{};
+  SizeType                  m_SupportSize{};
+  vnl_matrix<unsigned long> m_OffsetToIndexTable{};
 
 private:
   /** Function to initialize the support region. */

--- a/Common/Transforms/itkRecursiveBSplineTransform.hxx
+++ b/Common/Transforms/itkRecursiveBSplineTransform.hxx
@@ -106,7 +106,7 @@ RecursiveBSplineTransform<TScalar, NDimensions, VSplineOrder>::GetJacobian(
   if ((jacobian.cols() != nnzji) || (jacobian.rows() != SpaceDimension))
   {
     jacobian.set_size(SpaceDimension, nnzji);
-    jacobian.Fill(0.0);
+    jacobian.fill(0.0);
   }
 
   /** NOTE: if the support region does not lie totally within the grid

--- a/Common/Transforms/itkRecursiveBSplineTransform.hxx
+++ b/Common/Transforms/itkRecursiveBSplineTransform.hxx
@@ -105,7 +105,7 @@ RecursiveBSplineTransform<TScalar, NDimensions, VSplineOrder>::GetJacobian(
   const NumberOfParametersType nnzji = this->GetNumberOfNonZeroJacobianIndices();
   if ((jacobian.cols() != nnzji) || (jacobian.rows() != SpaceDimension))
   {
-    jacobian.SetSize(SpaceDimension, nnzji);
+    jacobian.set_size(SpaceDimension, nnzji);
     jacobian.Fill(0.0);
   }
 

--- a/Common/Transforms/itkStackTransform.hxx
+++ b/Common/Transforms/itkStackTransform.hxx
@@ -144,7 +144,7 @@ StackTransform<TScalarType, NInputDimensions, NOutputDimensions>::GetJacobian(co
 
   /** Fill output Jacobian. */
   jac.set_size(InputSpaceDimension, nzji.size());
-  jac.Fill(0.0);
+  jac.fill(0.0);
   for (unsigned int d = 0; d < ReducedInputSpaceDimension; ++d)
   {
     for (unsigned int n = 0; n < nzji.size(); ++n)

--- a/Common/itkComputeJacobianTerms.hxx
+++ b/Common/itkComputeJacobianTerms.hxx
@@ -178,7 +178,7 @@ ComputeJacobianTerms<TFixedImage, TTransform>::Compute(double & TrC, double & Tr
   }
 
   using CovarianceValueType = double;
-  using CovarianceMatrixType = itk::Array2D<CovarianceValueType>;
+  using CovarianceMatrixType = vnl_matrix<CovarianceValueType>;
   using DiagCovarianceMatrixType = vnl_diag_matrix<CovarianceValueType>;
 
   /** Initialize covariance matrix. Sparse, diagonal, and band form. */
@@ -220,12 +220,10 @@ ComputeJacobianTerms<TFixedImage, TTransform>::Compute(double & TrC, double & Tr
   DiagCovarianceMatrixType diagcov(numberOfParameters, 0.0);
 
   /** For temporary storage of J'J. */
-  CovarianceMatrixType jactjac(sizejacind, sizejacind);
-  jactjac.Fill(0.0);
+  CovarianceMatrixType jactjac(sizejacind, sizejacind, 0.0);
 
   /** Initialize band matrix. */
-  CovarianceMatrixType bandcov(numberOfParameters, bandcovsize);
-  bandcov.Fill(0.0);
+  CovarianceMatrixType bandcov(numberOfParameters, bandcovsize, 0.0);
 
   /**
    *    TERM 1

--- a/Common/itkGenericMultiResolutionPyramidImageFilter.h
+++ b/Common/itkGenericMultiResolutionPyramidImageFilter.h
@@ -149,7 +149,7 @@ public:
   using ScalarRealType = typename NumericTraits<PixelType>::ScalarRealType;
 
   /** SmoothingScheduleType typedef support. */
-  using SmoothingScheduleType = Array2D<ScalarRealType>;
+  using SmoothingScheduleType = vnl_matrix<ScalarRealType>;
   using RescaleScheduleType = ScheduleType;
 
   /** Define the type for the sigma array. */

--- a/Common/itkGenericMultiResolutionPyramidImageFilter.hxx
+++ b/Common/itkGenericMultiResolutionPyramidImageFilter.hxx
@@ -36,9 +36,7 @@ GenericMultiResolutionPyramidImageFilter<TInputImage, TOutputImage, TPrecisionTy
 {
   this->m_CurrentLevel = 0;
   this->m_ComputeOnlyForCurrentLevel = false;
-  SmoothingScheduleType temp(this->GetNumberOfLevels(), ImageDimension);
-  temp.Fill(ScalarRealType{});
-  this->m_SmoothingSchedule = temp;
+  this->m_SmoothingSchedule = SmoothingScheduleType(this->GetNumberOfLevels(), ImageDimension, ScalarRealType());
   this->m_SmoothingScheduleDefined = false;
 } // end Constructor
 
@@ -58,9 +56,7 @@ GenericMultiResolutionPyramidImageFilter<TInputImage, TOutputImage, TPrecisionTy
   Superclass::SetNumberOfLevels(num);
 
   /** Resize the smoothing schedule too. */
-  SmoothingScheduleType temp(this->m_NumberOfLevels, ImageDimension);
-  temp.Fill(ScalarRealType{});
-  this->m_SmoothingSchedule = temp;
+  this->m_SmoothingSchedule = SmoothingScheduleType(this->GetNumberOfLevels(), ImageDimension, ScalarRealType());
   this->m_SmoothingScheduleDefined = false;
 
 } // end SetNumberOfLevels()
@@ -130,9 +126,7 @@ GenericMultiResolutionPyramidImageFilter<TInputImage, TOutputImage, TPrecisionTy
    * Only in GenerateData we use SetSmoothingScheduleToDefault, because only
    * there all required information is available.
    */
-  SmoothingScheduleType temp(this->GetNumberOfLevels(), ImageDimension);
-  temp.Fill(0);
-  this->m_SmoothingSchedule = temp;
+  this->m_SmoothingSchedule = SmoothingScheduleType(this->GetNumberOfLevels(), ImageDimension, ScalarRealType());
   this->m_SmoothingScheduleDefined = false;
 } // end SetSchedule()
 
@@ -223,9 +217,7 @@ template <class TInputImage, class TOutputImage, class TPrecisionType>
 void
 GenericMultiResolutionPyramidImageFilter<TInputImage, TOutputImage, TPrecisionType>::SetSmoothingScheduleToZero()
 {
-  SmoothingScheduleType schedule;
-  schedule.Fill(ScalarRealType{});
-  this->SetSmoothingSchedule(schedule);
+  this->SetSmoothingSchedule(SmoothingScheduleType());
 } // end SetSmoothingScheduleToZero()
 
 
@@ -735,9 +727,7 @@ GenericMultiResolutionPyramidImageFilter<TInputImage, TOutputImage, TPrecisionTy
   const SpacingType &    spacing = input->GetSpacing();
 
   // Resize the smoothing schedule
-  SmoothingScheduleType temp(this->GetNumberOfLevels(), ImageDimension);
-  temp.Fill(0);
-  this->m_SmoothingSchedule = temp;
+  this->m_SmoothingSchedule = SmoothingScheduleType(this->GetNumberOfLevels(), ImageDimension, ScalarRealType());
 
   unsigned int factors[ImageDimension];
   for (unsigned int level = 0; level < this->m_NumberOfLevels; ++level)

--- a/Components/Metrics/AdvancedMattesMutualInformation/itkParzenWindowMutualInformationImageToImageMetric.h
+++ b/Components/Metrics/AdvancedMattesMutualInformation/itkParzenWindowMutualInformationImageToImageMetric.h
@@ -257,7 +257,7 @@ protected:
 private:
   /** Helper array for storing the values of the JointPDF ratios. */
   using PRatioType = double;
-  using PRatioArrayType = Array2D<PRatioType>;
+  using PRatioArrayType = vnl_matrix<PRatioType>;
   mutable PRatioArrayType m_PRatioArray{};
 
   /** Setting */

--- a/Components/Metrics/AdvancedMattesMutualInformation/itkParzenWindowMutualInformationImageToImageMetric.hxx
+++ b/Components/Metrics/AdvancedMattesMutualInformation/itkParzenWindowMutualInformationImageToImageMetric.hxx
@@ -63,7 +63,7 @@ ParzenWindowMutualInformationImageToImageMetric<TFixedImage, TMovingImage>::Init
   /** Allocate small amount of memory for the m_PRatioArray. */
   if (!this->GetUseExplicitPDFDerivatives())
   {
-    this->m_PRatioArray.SetSize(this->GetNumberOfFixedHistogramBins(), this->GetNumberOfMovingHistogramBins());
+    this->m_PRatioArray.set_size(this->GetNumberOfFixedHistogramBins(), this->GetNumberOfMovingHistogramBins());
   }
 
 } // end InitializeHistograms()
@@ -664,7 +664,7 @@ ParzenWindowMutualInformationImageToImageMetric<TFixedImage, TMovingImage>::Comp
   const MarginalPDFIteratorType movingPDFend = this->m_MovingImageMarginalPDF.end();
 
   /** Initialize */
-  this->m_PRatioArray.Fill(PRatioType{});
+  this->m_PRatioArray.fill(PRatioType{});
 
   /** Loop over the joint histogram. */
   PDFValueType sum = 0.0;

--- a/Components/Metrics/KNNGraphAlphaMutualInformation/itkKNNGraphAlphaMutualInformationImageToImageMetric.h
+++ b/Components/Metrics/KNNGraphAlphaMutualInformation/itkKNNGraphAlphaMutualInformationImageToImageMetric.h
@@ -286,7 +286,7 @@ private:
   using TransformJacobianContainerType = std::vector<TransformJacobianType>;
   // typedef std::vector<ParameterIndexArrayType>           TransformJacobianIndicesContainerType;
   using TransformJacobianIndicesContainerType = std::vector<NonZeroJacobianIndicesType>;
-  using SpatialDerivativeType = Array2D<double>;
+  using SpatialDerivativeType = vnl_matrix<double>;
   using SpatialDerivativeContainerType = std::vector<SpatialDerivativeType>;
 
   /** This function takes the fixed image samples from the ImageSampler

--- a/Components/Metrics/KNNGraphAlphaMutualInformation/itkKNNGraphAlphaMutualInformationImageToImageMetric.hxx
+++ b/Components/Metrics/KNNGraphAlphaMutualInformation/itkKNNGraphAlphaMutualInformationImageToImageMetric.hxx
@@ -915,7 +915,7 @@ KNNGraphAlphaMutualInformationImageToImageMetric<TFixedImage, TMovingImage>::Eva
       /** Compute the gradient at feature image i. */
       gradient = this->m_BSplineInterpolatorVector[i]->EvaluateDerivativeAtContinuousIndex(cindex);
 
-      /** Set the gradient into the Array2D. */
+      /** Set the gradient into the matrix. */
       featureGradients.set_row(i - 1, gradient.GetDataPointer());
     } // end for-loop
   }   // end if
@@ -938,7 +938,7 @@ KNNGraphAlphaMutualInformationImageToImageMetric<TFixedImage, TMovingImage>::Eva
   //  /** Compute the gradient at feature image i. */
   //  gradient = this->m_GradientFeatureImage[ i ]->GetPixel( index );
   //
-  //  /** Set the gradient into the Array2D. */
+  //  /** Set the gradient into the matrix. */
   //  featureGradients.set_column( i, gradient.GetDataPointer() );
   //  } // end for-loop
   //  } // end if

--- a/Components/Optimizers/CMAEvolutionStrategy/itkCMAEvolutionStrategyOptimizer.cxx
+++ b/Components/Optimizers/CMAEvolutionStrategy/itkCMAEvolutionStrategyOptimizer.cxx
@@ -420,13 +420,13 @@ CMAEvolutionStrategyOptimizer::InitializeBCD()
     const unsigned int N = numberOfParameters;
 
     /** Resize */
-    this->m_B.SetSize(N, N);
-    this->m_C.SetSize(N, N);
+    this->m_B.set_size(N, N);
+    this->m_C.set_size(N, N);
     this->m_D.set_size(N);
 
     /** Initialize */
-    this->m_B.Fill(0.0);
-    this->m_C.Fill(0.0);
+    this->m_B.fill(0.0);
+    this->m_C.fill(0.0);
     this->m_B.fill_diagonal(1.0);
     this->m_C.fill_diagonal(1.0);
     this->m_D.fill(1.0);
@@ -434,8 +434,8 @@ CMAEvolutionStrategyOptimizer::InitializeBCD()
   else
   {
     /** Clear */
-    this->m_B.SetSize(0, 0);
-    this->m_C.SetSize(0, 0);
+    this->m_B.set_size(0, 0);
+    this->m_C.set_size(0, 0);
     this->m_D.clear();
   }
 

--- a/Components/Optimizers/CMAEvolutionStrategy/itkCMAEvolutionStrategyOptimizer.h
+++ b/Components/Optimizers/CMAEvolutionStrategy/itkCMAEvolutionStrategyOptimizer.h
@@ -227,7 +227,7 @@ public:
 protected:
   using RecombinationWeightsType = Array<double>;
   using EigenValueMatrixType = vnl_diag_matrix<double>;
-  using CovarianceMatrixType = Array2D<double>;
+  using CovarianceMatrixType = vnl_matrix<double>;
   using ParameterContainerType = std::vector<ParametersType>;
   using MeasureHistoryType = std::deque<MeasureType>;
 

--- a/Components/Transforms/AffineDTITransform/itkAffineDTI2DTransform.hxx
+++ b/Components/Transforms/AffineDTITransform/itkAffineDTI2DTransform.hxx
@@ -200,7 +200,7 @@ AffineDTI2DTransform<TScalarType>::GetJacobian(const InputPointType &       p,
                                                JacobianType &               j,
                                                NonZeroJacobianIndicesType & nzji) const
 {
-  j.SetSize(OutputSpaceDimension, ParametersDimension);
+  j.set_size(OutputSpaceDimension, ParametersDimension);
   j.Fill(0.0);
   const JacobianOfSpatialJacobianType & jsj = this->m_JacobianOfSpatialJacobian;
 

--- a/Components/Transforms/AffineDTITransform/itkAffineDTI2DTransform.hxx
+++ b/Components/Transforms/AffineDTITransform/itkAffineDTI2DTransform.hxx
@@ -201,7 +201,7 @@ AffineDTI2DTransform<TScalarType>::GetJacobian(const InputPointType &       p,
                                                NonZeroJacobianIndicesType & nzji) const
 {
   j.set_size(OutputSpaceDimension, ParametersDimension);
-  j.Fill(0.0);
+  j.fill(0.0);
   const JacobianOfSpatialJacobianType & jsj = this->m_JacobianOfSpatialJacobian;
 
   /** Compute dR/dmu * (p-c) */

--- a/Components/Transforms/AffineDTITransform/itkAffineDTI3DTransform.hxx
+++ b/Components/Transforms/AffineDTITransform/itkAffineDTI3DTransform.hxx
@@ -284,7 +284,7 @@ AffineDTI3DTransform<TScalarType>::GetJacobian(const InputPointType &       p,
                                                NonZeroJacobianIndicesType & nzji) const
 {
   j.set_size(OutputSpaceDimension, ParametersDimension);
-  j.Fill(0.0);
+  j.fill(0.0);
   const JacobianOfSpatialJacobianType & jsj = this->m_JacobianOfSpatialJacobian;
 
   /** Compute dR/dmu * (p-c) */

--- a/Components/Transforms/AffineDTITransform/itkAffineDTI3DTransform.hxx
+++ b/Components/Transforms/AffineDTITransform/itkAffineDTI3DTransform.hxx
@@ -283,7 +283,7 @@ AffineDTI3DTransform<TScalarType>::GetJacobian(const InputPointType &       p,
                                                JacobianType &               j,
                                                NonZeroJacobianIndicesType & nzji) const
 {
-  j.SetSize(OutputSpaceDimension, ParametersDimension);
+  j.set_size(OutputSpaceDimension, ParametersDimension);
   j.Fill(0.0);
   const JacobianOfSpatialJacobianType & jsj = this->m_JacobianOfSpatialJacobian;
 

--- a/Components/Transforms/AffineLogTransform/itkAffineLogTransform.hxx
+++ b/Components/Transforms/AffineLogTransform/itkAffineLogTransform.hxx
@@ -154,7 +154,7 @@ AffineLogTransform<TScalarType, Dimension>::GetJacobian(const InputPointType &  
   unsigned int d = Dimension;
 
   j.set_size(d, ParametersDimension);
-  j.Fill(ScalarType{});
+  j.fill(ScalarType{});
 
   const JacobianOfSpatialJacobianType & jsj = this->m_JacobianOfSpatialJacobian;
   const InputVectorType                 pp = p - this->GetCenter();

--- a/Components/Transforms/AffineLogTransform/itkAffineLogTransform.hxx
+++ b/Components/Transforms/AffineLogTransform/itkAffineLogTransform.hxx
@@ -153,7 +153,7 @@ AffineLogTransform<TScalarType, Dimension>::GetJacobian(const InputPointType &  
 {
   unsigned int d = Dimension;
 
-  j.SetSize(d, ParametersDimension);
+  j.set_size(d, ParametersDimension);
   j.Fill(ScalarType{});
 
   const JacobianOfSpatialJacobianType & jsj = this->m_JacobianOfSpatialJacobian;

--- a/Components/Transforms/MultiBSplineTransformWithNormal/itkMultiBSplineDeformableTransformWithNormal.hxx
+++ b/Components/Transforms/MultiBSplineTransformWithNormal/itkMultiBSplineDeformableTransformWithNormal.hxx
@@ -669,7 +669,7 @@ MultiBSplineDeformableTransformWithNormal<TScalarType, NDimensions, VSplineOrder
 //::GetJacobian( const InputPointType & point ) const -> const JacobianType&
 //{
 //  this->m_Jacobian.set_size(SpaceDimension, this->GetNumberOfParameters());
-//  this->m_Jacobian.Fill(0.0);
+//  this->m_Jacobian.fill(0.0);
 //  JacobianType jacobian;
 //  NonZeroJacobianIndicesType nonZeroJacobianIndices;
 //  this->GetJacobian(point, jacobian, nonZeroJacobianIndices);

--- a/Components/Transforms/MultiBSplineTransformWithNormal/itkMultiBSplineDeformableTransformWithNormal.hxx
+++ b/Components/Transforms/MultiBSplineTransformWithNormal/itkMultiBSplineDeformableTransformWithNormal.hxx
@@ -692,7 +692,7 @@ MultiBSplineDeformableTransformWithNormal<TScalarType, NDimensions, VSplineOrder
 {
   if (this->GetNumberOfParameters() == 0)
   {
-    jacobian.SetSize(SpaceDimension, 0);
+    jacobian.set_size(SpaceDimension, 0);
     nonZeroJacobianIndices.clear();
     return;
   }
@@ -701,7 +701,7 @@ MultiBSplineDeformableTransformWithNormal<TScalarType, NDimensions, VSplineOrder
   const unsigned int nnzji = this->GetNumberOfNonZeroJacobianIndices();
   if ((jacobian.cols() != nnzji) || (jacobian.rows() != SpaceDimension))
   {
-    jacobian.SetSize(SpaceDimension, nnzji);
+    jacobian.set_size(SpaceDimension, nnzji);
   }
   jacobian.Fill(0.0);
 
@@ -725,8 +725,8 @@ MultiBSplineDeformableTransformWithNormal<TScalarType, NDimensions, VSplineOrder
   }
 
   JacobianType njac, ljac;
-  njac.SetSize(SpaceDimension, nnzji);
-  ljac.SetSize(SpaceDimension, nnzji);
+  njac.set_size(SpaceDimension, nnzji);
+  ljac.set_size(SpaceDimension, nnzji);
 
   // nzji should be the same so keep only one
   m_Trans[0]->GetJacobian(inputPoint, njac, nonZeroJacobianIndices);

--- a/Components/Transforms/SplineKernelTransform/itkKernelTransform2.hxx
+++ b/Components/Transforms/SplineKernelTransform/itkKernelTransform2.hxx
@@ -734,7 +734,7 @@ KernelTransform2<TScalarType, NDimensions>::GetJacobian(const InputPointType &  
 {
   const unsigned long numberOfLandmarks = this->m_SourceLandmarks->GetNumberOfPoints();
   jac.set_size(NDimensions, numberOfLandmarks * NDimensions);
-  jac.Fill(0.0);
+  jac.fill(0.0);
   GMatrixType    Gmatrix; // , GMatrixSym; // dim x dim
   PointsIterator sp = this->m_SourceLandmarks->GetPoints()->Begin();
 

--- a/Components/Transforms/SplineKernelTransform/itkKernelTransform2.hxx
+++ b/Components/Transforms/SplineKernelTransform/itkKernelTransform2.hxx
@@ -733,7 +733,7 @@ KernelTransform2<TScalarType, NDimensions>::GetJacobian(const InputPointType &  
                                                         NonZeroJacobianIndicesType & nonZeroJacobianIndices) const
 {
   const unsigned long numberOfLandmarks = this->m_SourceLandmarks->GetNumberOfPoints();
-  jac.SetSize(NDimensions, numberOfLandmarks * NDimensions);
+  jac.set_size(NDimensions, numberOfLandmarks * NDimensions);
   jac.Fill(0.0);
   GMatrixType    Gmatrix; // , GMatrixSym; // dim x dim
   PointsIterator sp = this->m_SourceLandmarks->GetPoints()->Begin();

--- a/Components/Transforms/WeightedCombinationTransform/itkWeightedCombinationTransform.hxx
+++ b/Components/Transforms/WeightedCombinationTransform/itkWeightedCombinationTransform.hxx
@@ -54,7 +54,7 @@ WeightedCombinationTransform<TScalarType, NInputDimensions, NOutputDimensions>::
     itkExceptionMacro("Number of parameters does not match the number of transforms set in the transform container.");
   }
 
-  // this->m_Jacobian.SetSize( OutputSpaceDimension, param.GetSize() );
+  // this->m_Jacobian.set_size( OutputSpaceDimension, param.GetSize() );
   this->m_Parameters = param;
   this->m_SumOfWeights = param.sum();
   if (this->m_SumOfWeights < 1e-10 && this->m_NormalizeWeights)
@@ -138,7 +138,7 @@ WeightedCombinationTransform<TScalarType, NInputDimensions, NOutputDimensions>::
   const TransformContainerType & tc = this->m_TransformContainer;
   const unsigned int             N = tc.size();
   const ParametersType &         param = this->m_Parameters;
-  jac.SetSize(OutputSpaceDimension, N);
+  jac.set_size(OutputSpaceDimension, N);
 
   /** This transform has only nonzero jacobians. */
   nzji = this->m_NonZeroJacobianIndices;

--- a/Testing/itkAdvancedBSplineDeformableTransformTest.cxx
+++ b/Testing/itkAdvancedBSplineDeformableTransformTest.cxx
@@ -161,7 +161,7 @@ main(int argc, char * argv[])
 
   /** Resize some of the variables. */
   nzji.resize(nonzji);
-  jacobian.SetSize(Dimension, nonzji);
+  jacobian.set_size(Dimension, nonzji);
   jacobianOfSpatialJacobian.resize(nonzji);
   jacobianOfSpatialHessian.resize(nonzji);
   jacobian.Fill(0.0);
@@ -333,7 +333,7 @@ main(int argc, char * argv[])
   JacobianType jacobianITK{};
   transformITK->ComputeJacobianWithRespectToParameters(inputPoint, jacobianITK);
   JacobianType jacobianElastix;
-  jacobianElastix.SetSize(Dimension, nzji.size());
+  jacobianElastix.set_size(Dimension, nzji.size());
   jacobianElastix.Fill(0.0);
   transform->GetJacobian(inputPoint, jacobianElastix, nzji);
   // ITK4 B-spline is non-local and returns a full matrix. Cannot compute diff like this anymore:
@@ -356,7 +356,7 @@ main(int argc, char * argv[])
 
   //// Check
   // JacobianType jacobian1, jacobian2;
-  // jacobian1.SetSize( Dimension, nzji.size() ); jacobian2.SetSize( Dimension, nzji.size() );
+  // jacobian1.set_size( Dimension, nzji.size() ); jacobian2.set_size( Dimension, nzji.size() );
   // jacobian1.Fill( 0.0 ); jacobian2.Fill( 0.0 );
   // transform->GetJacobian( inputPoint, jacobian1, nzji );
   // transform->GetJacobian_opt( inputPoint, jacobian2, nzji );

--- a/Testing/itkAdvancedBSplineDeformableTransformTest.cxx
+++ b/Testing/itkAdvancedBSplineDeformableTransformTest.cxx
@@ -334,7 +334,7 @@ main(int argc, char * argv[])
   transformITK->ComputeJacobianWithRespectToParameters(inputPoint, jacobianITK);
   JacobianType jacobianElastix;
   jacobianElastix.set_size(Dimension, nzji.size());
-  jacobianElastix.Fill(0.0);
+  jacobianElastix.fill(0.0);
   transform->GetJacobian(inputPoint, jacobianElastix, nzji);
   // ITK4 B-spline is non-local and returns a full matrix. Cannot compute diff like this anymore:
   // JacobianType jacobianDifferenceMatrix = jacobianElastix - jacobianITK;
@@ -357,7 +357,7 @@ main(int argc, char * argv[])
   //// Check
   // JacobianType jacobian1, jacobian2;
   // jacobian1.set_size( Dimension, nzji.size() ); jacobian2.set_size( Dimension, nzji.size() );
-  // jacobian1.Fill( 0.0 ); jacobian2.Fill( 0.0 );
+  // jacobian1.fill( 0.0 ); jacobian2.Fill( 0.0 );
   // transform->GetJacobian( inputPoint, jacobian1, nzji );
   // transform->GetJacobian_opt( inputPoint, jacobian2, nzji );
   // JacobianType jacobianDifferenceMatrix = jacobian1 - jacobian2;

--- a/Testing/itkAdvancedRecursiveBSplineTransformTest.cxx
+++ b/Testing/itkAdvancedRecursiveBSplineTransformTest.cxx
@@ -386,12 +386,12 @@ main(int argc, char * argv[])
   /** Jacobian. */
   JacobianType jacobianElastix;
   jacobianElastix.set_size(Dimension, nzji.size());
-  jacobianElastix.Fill(0.0);
+  jacobianElastix.fill(0.0);
   transform->GetJacobian(inputPoint, jacobianElastix, nzjiElastix);
 
   JacobianType jacobianRecursive;
   jacobianRecursive.set_size(Dimension, nzji.size());
-  jacobianRecursive.Fill(0.0);
+  jacobianRecursive.fill(0.0);
   recursiveTransform->GetJacobian(inputPoint, jacobianRecursive, nzjiRecursive);
 
   JacobianType jacobianDifferenceMatrix = jacobianElastix - jacobianRecursive;

--- a/Testing/itkAdvancedRecursiveBSplineTransformTest.cxx
+++ b/Testing/itkAdvancedRecursiveBSplineTransformTest.cxx
@@ -192,7 +192,7 @@ main(int argc, char * argv[])
 
   /** Resize some of the variables. */
   nzji.resize(nonzji);
-  jacobian.SetSize(Dimension, nonzji);
+  jacobian.set_size(Dimension, nonzji);
   jacobianOfSpatialJacobian.resize(nonzji);
   jacobianOfSpatialHessian.resize(nonzji);
   jacobian.Fill(0.0);
@@ -385,12 +385,12 @@ main(int argc, char * argv[])
 
   /** Jacobian. */
   JacobianType jacobianElastix;
-  jacobianElastix.SetSize(Dimension, nzji.size());
+  jacobianElastix.set_size(Dimension, nzji.size());
   jacobianElastix.Fill(0.0);
   transform->GetJacobian(inputPoint, jacobianElastix, nzjiElastix);
 
   JacobianType jacobianRecursive;
-  jacobianRecursive.SetSize(Dimension, nzji.size());
+  jacobianRecursive.set_size(Dimension, nzji.size());
   jacobianRecursive.Fill(0.0);
   recursiveTransform->GetJacobian(inputPoint, jacobianRecursive, nzjiRecursive);
 

--- a/Testing/itkThinPlateSplineTransformPerformanceTest.cxx
+++ b/Testing/itkThinPlateSplineTransformPerformanceTest.cxx
@@ -299,7 +299,7 @@ main(int argc, char * argv[])
     timeCollector.Start("ComputeJacobianOLD");
     JacobianType jac1;
     jac1.set_size(Dimension, numberOfLandmarks * Dimension);
-    jac1.Fill(0.0);
+    jac1.fill(0.0);
     PointsIterator sp = usedLandmarks->GetPoints()->Begin();
     for (unsigned int lnd = 0; lnd < numberOfLandmarks; ++lnd)
     {

--- a/Testing/itkThinPlateSplineTransformPerformanceTest.cxx
+++ b/Testing/itkThinPlateSplineTransformPerformanceTest.cxx
@@ -298,7 +298,7 @@ main(int argc, char * argv[])
     p[2] = 11.0;
     timeCollector.Start("ComputeJacobianOLD");
     JacobianType jac1;
-    jac1.SetSize(Dimension, numberOfLandmarks * Dimension);
+    jac1.set_size(Dimension, numberOfLandmarks * Dimension);
     jac1.Fill(0.0);
     PointsIterator sp = usedLandmarks->GetPoints()->Begin();
     for (unsigned int lnd = 0; lnd < numberOfLandmarks; ++lnd)


### PR DESCRIPTION
It appears that the extra features of ITK's `Array2D` (compared to `vnl_matrix`) are _usually_ not really necessary for elastix, and elastix already uses the `vnl_matrix` interface anyway. Direct use of `vnl_matrix` might be slightly faster.