### PR TITLE
Remove CentralDifferenceGradientFilter from the interface of metrics

### DIFF
--- a/Common/CostFunctions/itkAdvancedImageToImageMetric.h
+++ b/Common/CostFunctions/itkAdvancedImageToImageMetric.h
@@ -364,8 +364,6 @@ protected:
   using LinearInterpolatorType = AdvancedLinearInterpolateImageFunction<MovingImageType, CoordinateRepresentationType>;
   using LinearInterpolatorPointer = typename LinearInterpolatorType::Pointer;
   using MovingImageDerivativeType = typename BSplineInterpolatorType::CovariantVectorType;
-  using CentralDifferenceGradientFilterType = GradientImageFilter<MovingImageType, RealType, RealType>;
-  using CentralDifferenceGradientFilterPointer = typename CentralDifferenceGradientFilterType::Pointer;
 
   /** Typedefs for support of sparse Jacobians and compact support of transformations. */
   using NonZeroJacobianIndicesType = typename AdvancedTransformType::NonZeroJacobianIndicesType;
@@ -386,8 +384,6 @@ protected:
   BSplineInterpolatorPointer        m_BSplineInterpolator{ nullptr };
   BSplineInterpolatorFloatPointer   m_BSplineInterpolatorFloat{ nullptr };
   ReducedBSplineInterpolatorPointer m_ReducedBSplineInterpolator{ nullptr };
-
-  CentralDifferenceGradientFilterPointer m_CentralDifferenceGradientFilter{ nullptr };
 
   /** Variables to store the AdvancedTransform. */
   bool                                    m_TransformIsAdvanced{ false };

--- a/Common/CostFunctions/itkAdvancedImageToImageMetric.hxx
+++ b/Common/CostFunctions/itkAdvancedImageToImageMetric.hxx
@@ -19,6 +19,7 @@
 #define _itkAdvancedImageToImageMetric_hxx
 
 #include "itkAdvancedImageToImageMetric.h"
+#include "elxDefaultConstruct.h"
 
 #include "itkAdvancedRayCastInterpolateImageFunction.h"
 #include "itkComputeImageExtremaFilter.h"
@@ -372,15 +373,16 @@ AdvancedImageToImageMetric<TFixedImage, TMovingImage>::CheckForBSplineInterpolat
     if (!this->m_InterpolatorIsBSpline && !this->m_InterpolatorIsBSplineFloat &&
         !this->m_InterpolatorIsReducedBSpline && !this->m_InterpolatorIsLinear && !interpolatorIsRayCast)
     {
-      this->m_CentralDifferenceGradientFilter = CentralDifferenceGradientFilterType::New();
-      this->m_CentralDifferenceGradientFilter->SetUseImageSpacing(true);
-      this->m_CentralDifferenceGradientFilter->SetInput(this->m_MovingImage);
-      this->m_CentralDifferenceGradientFilter->Update();
-      this->m_GradientImage = this->m_CentralDifferenceGradientFilter->GetOutput();
+      using CentralDifferenceGradientFilterType = GradientImageFilter<TMovingImage, RealType, RealType>;
+
+      elastix::DefaultConstruct<CentralDifferenceGradientFilterType> centralDifferenceGradientFilter{};
+      centralDifferenceGradientFilter.SetUseImageSpacing(true);
+      centralDifferenceGradientFilter.SetInput(this->m_MovingImage);
+      centralDifferenceGradientFilter.Update();
+      this->m_GradientImage = centralDifferenceGradientFilter.GetOutput();
     }
     else
     {
-      this->m_CentralDifferenceGradientFilter = nullptr;
       this->m_GradientImage = nullptr;
     }
   }
@@ -908,8 +910,6 @@ AdvancedImageToImageMetric<TFixedImage, TMovingImage>::PrintSelf(std::ostream & 
   os << indent.GetNextIndent() << "InterpolatorIsBSplineFloat: " << this->m_InterpolatorIsBSplineFloat << std::endl;
   os << indent.GetNextIndent() << "BSplineInterpolatorFloat: " << this->m_BSplineInterpolatorFloat.GetPointer()
      << std::endl;
-  os << indent.GetNextIndent()
-     << "CentralDifferenceGradientFilter: " << this->m_CentralDifferenceGradientFilter.GetPointer() << std::endl;
 
   /** Variables used when the transform is a B-spline transform. */
   os << indent << "Variables store the transform as an AdvancedTransform: " << std::endl;

--- a/Common/CostFunctions/itkParzenWindowHistogramImageToImageMetric.h
+++ b/Common/CostFunctions/itkParzenWindowHistogramImageToImageMetric.h
@@ -238,7 +238,6 @@ protected:
   using typename Superclass::MovingImageContinuousIndexType;
   using typename Superclass::BSplineInterpolatorType;
   using typename Superclass::MovingImageDerivativeType;
-  using typename Superclass::CentralDifferenceGradientFilterType;
   using typename Superclass::NonZeroJacobianIndicesType;
 
   /** Typedefs for the PDFs and PDF derivatives. */

--- a/Common/GTesting/itkAdvancedImageToImageMetricGTest.cxx
+++ b/Common/GTesting/itkAdvancedImageToImageMetricGTest.cxx
@@ -62,7 +62,6 @@ public:
       EXPECT_EQ(this->AdvancedImageToImageMetricType::m_BSplineInterpolator, nullptr);
       EXPECT_EQ(this->AdvancedImageToImageMetricType::m_BSplineInterpolatorFloat, nullptr);
       EXPECT_EQ(this->AdvancedImageToImageMetricType::m_ReducedBSplineInterpolator, nullptr);
-      EXPECT_EQ(this->AdvancedImageToImageMetricType::m_CentralDifferenceGradientFilter, nullptr);
       EXPECT_EQ(this->AdvancedImageToImageMetricType::m_TransformIsAdvanced, false);
       EXPECT_EQ(this->AdvancedImageToImageMetricType::m_AdvancedTransform, nullptr);
       EXPECT_EQ(this->AdvancedImageToImageMetricType::m_TransformIsBSpline, false);

--- a/Components/Metrics/AdvancedKappaStatistic/itkAdvancedKappaStatisticImageToImageMetric.h
+++ b/Components/Metrics/AdvancedKappaStatistic/itkAdvancedKappaStatisticImageToImageMetric.h
@@ -187,7 +187,6 @@ protected:
   using typename Superclass::MovingImagePointType;
   using typename Superclass::MovingImageContinuousIndexType;
   using typename Superclass::BSplineInterpolatorType;
-  using typename Superclass::CentralDifferenceGradientFilterType;
   using typename Superclass::MovingImageDerivativeType;
   using typename Superclass::NonZeroJacobianIndicesType;
 

--- a/Components/Metrics/AdvancedMattesMutualInformation/itkParzenWindowMutualInformationImageToImageMetric.h
+++ b/Components/Metrics/AdvancedMattesMutualInformation/itkParzenWindowMutualInformationImageToImageMetric.h
@@ -166,7 +166,6 @@ protected:
   using typename Superclass::MovingImagePointType;
   using typename Superclass::MovingImageContinuousIndexType;
   using typename Superclass::BSplineInterpolatorType;
-  using typename Superclass::CentralDifferenceGradientFilterType;
   using typename Superclass::MovingImageDerivativeType;
   using typename Superclass::PDFValueType;
   using typename Superclass::PDFDerivativeValueType;

--- a/Components/Metrics/AdvancedMeanSquares/itkAdvancedMeanSquaresImageToImageMetric.h
+++ b/Components/Metrics/AdvancedMeanSquares/itkAdvancedMeanSquaresImageToImageMetric.h
@@ -203,7 +203,6 @@ protected:
   using typename Superclass::MovingImagePointType;
   using typename Superclass::MovingImageContinuousIndexType;
   using typename Superclass::BSplineInterpolatorType;
-  using typename Superclass::CentralDifferenceGradientFilterType;
   using typename Superclass::MovingImageDerivativeType;
   using typename Superclass::NonZeroJacobianIndicesType;
 

--- a/Components/Metrics/AdvancedNormalizedCorrelation/itkAdvancedNormalizedCorrelationImageToImageMetric.h
+++ b/Components/Metrics/AdvancedNormalizedCorrelation/itkAdvancedNormalizedCorrelationImageToImageMetric.h
@@ -202,7 +202,6 @@ protected:
   using typename Superclass::MovingImagePointType;
   using typename Superclass::MovingImageContinuousIndexType;
   using typename Superclass::BSplineInterpolatorType;
-  using typename Superclass::CentralDifferenceGradientFilterType;
   using typename Superclass::MovingImageDerivativeType;
   using typename Superclass::NonZeroJacobianIndicesType;
 

--- a/Components/Metrics/NormalizedMutualInformation/itkParzenWindowNormalizedMutualInformationImageToImageMetric.h
+++ b/Components/Metrics/NormalizedMutualInformation/itkParzenWindowNormalizedMutualInformationImageToImageMetric.h
@@ -165,7 +165,6 @@ protected:
   using typename Superclass::MovingImagePointType;
   using typename Superclass::MovingImageContinuousIndexType;
   using typename Superclass::BSplineInterpolatorType;
-  using typename Superclass::CentralDifferenceGradientFilterType;
   using typename Superclass::MovingImageDerivativeType;
   using typename Superclass::PDFValueType;
   using typename Superclass::MarginalPDFType;

--- a/Components/Metrics/PCAMetric/itkPCAMetric.h
+++ b/Components/Metrics/PCAMetric/itkPCAMetric.h
@@ -152,7 +152,6 @@ protected:
   using typename Superclass::MovingImagePointType;
   using typename Superclass::MovingImageContinuousIndexType;
   using typename Superclass::BSplineInterpolatorType;
-  using typename Superclass::CentralDifferenceGradientFilterType;
   using typename Superclass::MovingImageDerivativeType;
   using typename Superclass::NonZeroJacobianIndicesType;
 

--- a/Components/Metrics/PCAMetric/itkPCAMetric_F_multithreaded.h
+++ b/Components/Metrics/PCAMetric/itkPCAMetric_F_multithreaded.h
@@ -154,7 +154,6 @@ protected:
   using typename Superclass::MovingImagePointType;
   using typename Superclass::MovingImageContinuousIndexType;
   using typename Superclass::BSplineInterpolatorType;
-  using typename Superclass::CentralDifferenceGradientFilterType;
   using typename Superclass::MovingImageDerivativeType;
   using typename Superclass::NonZeroJacobianIndicesType;
 

--- a/Components/Metrics/PCAMetric2/itkPCAMetric2.h
+++ b/Components/Metrics/PCAMetric2/itkPCAMetric2.h
@@ -140,7 +140,6 @@ protected:
   using typename Superclass::MovingImagePointType;
   using typename Superclass::MovingImageContinuousIndexType;
   using typename Superclass::BSplineInterpolatorType;
-  using typename Superclass::CentralDifferenceGradientFilterType;
   using typename Superclass::MovingImageDerivativeType;
   using typename Superclass::NonZeroJacobianIndicesType;
 

--- a/Components/Metrics/SumOfPairwiseCorrelationsMetric/itkSumOfPairwiseCorrelationCoefficientsMetric.h
+++ b/Components/Metrics/SumOfPairwiseCorrelationsMetric/itkSumOfPairwiseCorrelationCoefficientsMetric.h
@@ -141,7 +141,6 @@ protected:
   using typename Superclass::MovingImagePointType;
   using typename Superclass::MovingImageContinuousIndexType;
   using typename Superclass::BSplineInterpolatorType;
-  using typename Superclass::CentralDifferenceGradientFilterType;
   using typename Superclass::MovingImageDerivativeType;
   using typename Superclass::NonZeroJacobianIndicesType;
 

--- a/Components/Metrics/SumSquaredTissueVolumeDifferenceMetric/itkSumSquaredTissueVolumeDifferenceImageToImageMetric.h
+++ b/Components/Metrics/SumSquaredTissueVolumeDifferenceMetric/itkSumSquaredTissueVolumeDifferenceImageToImageMetric.h
@@ -178,7 +178,6 @@ protected:
   using typename Superclass::MovingImagePointType;
   using typename Superclass::MovingImageContinuousIndexType;
   using typename Superclass::BSplineInterpolatorType;
-  using typename Superclass::CentralDifferenceGradientFilterType;
   using typename Superclass::MovingImageDerivativeType;
   using typename Superclass::NonZeroJacobianIndicesType;
 

--- a/Components/Metrics/VarianceOverLastDimension/itkVarianceOverLastDimensionImageMetric.h
+++ b/Components/Metrics/VarianceOverLastDimension/itkVarianceOverLastDimensionImageMetric.h
@@ -167,7 +167,6 @@ protected:
   using typename Superclass::MovingImagePointType;
   using typename Superclass::MovingImageContinuousIndexType;
   using typename Superclass::BSplineInterpolatorType;
-  using typename Superclass::CentralDifferenceGradientFilterType;
   using typename Superclass::MovingImageDerivativeType;
   using typename Superclass::NonZeroJacobianIndicesType;
 


### PR DESCRIPTION
The use of CentralDifferenceGradientFilter (using ITK's `GradientImageFilter`) appears to be just an internal implementation detail of `AdvancedImageToImageMetric::CheckForBSplineInterpolator()`.