### PR TITLE
STYLE: Remove GradientImageFilterType, GradientImageFilterPointer types

### DIFF
--- a/Common/CostFunctions/itkAdvancedImageToImageMetric.h
+++ b/Common/CostFunctions/itkAdvancedImageToImageMetric.h
@@ -122,8 +122,6 @@ public:
   using typename Superclass::GradientPixelType;
   using typename Superclass::GradientImageType;
   using typename Superclass::GradientImagePointer;
-  using typename Superclass::GradientImageFilterType;
-  using typename Superclass::GradientImageFilterPointer;
 
   // Overrule the mask type from its base class, ITK ImageToImageMetric.
   using FixedImageMaskType = ImageMaskSpatialObject<Self::FixedImageDimension>;

--- a/Common/CostFunctions/itkImageToImageMetricWithFeatures.h
+++ b/Common/CostFunctions/itkImageToImageMetricWithFeatures.h
@@ -72,8 +72,6 @@ public:
   using typename Superclass::GradientPixelType;
   using typename Superclass::GradientImageType;
   using typename Superclass::GradientImagePointer;
-  using typename Superclass::GradientImageFilterType;
-  using typename Superclass::GradientImageFilterPointer;
   using typename Superclass::FixedImageMaskType;
   using typename Superclass::FixedImageMaskPointer;
   using typename Superclass::MovingImageMaskType;

--- a/Common/CostFunctions/itkMultiInputImageToImageMetricBase.h
+++ b/Common/CostFunctions/itkMultiInputImageToImageMetricBase.h
@@ -87,8 +87,6 @@ public:
   using typename Superclass::GradientPixelType;
   using typename Superclass::GradientImageType;
   using typename Superclass::GradientImagePointer;
-  using typename Superclass::GradientImageFilterType;
-  using typename Superclass::GradientImageFilterPointer;
   using typename Superclass::FixedImageMaskType;
   using typename Superclass::FixedImageMaskPointer;
   using typename Superclass::FixedImageMaskConstPointer;

--- a/Common/CostFunctions/itkParzenWindowHistogramImageToImageMetric.h
+++ b/Common/CostFunctions/itkParzenWindowHistogramImageToImageMetric.h
@@ -107,8 +107,6 @@ public:
   using typename Superclass::GradientPixelType;
   using typename Superclass::GradientImageType;
   using typename Superclass::GradientImagePointer;
-  using typename Superclass::GradientImageFilterType;
-  using typename Superclass::GradientImageFilterPointer;
   using typename Superclass::FixedImageMaskType;
   using typename Superclass::FixedImageMaskPointer;
   using typename Superclass::MovingImageMaskType;

--- a/Common/CostFunctions/itkTransformPenaltyTerm.h
+++ b/Common/CostFunctions/itkTransformPenaltyTerm.h
@@ -79,8 +79,6 @@ public:
   using typename Superclass::GradientPixelType;
   using typename Superclass::GradientImageType;
   using typename Superclass::GradientImagePointer;
-  using typename Superclass::GradientImageFilterType;
-  using typename Superclass::GradientImageFilterPointer;
   using typename Superclass::FixedImageMaskType;
   using typename Superclass::FixedImageMaskPointer;
   using typename Superclass::MovingImageMaskType;

--- a/Components/Metrics/AdvancedKappaStatistic/elxAdvancedKappaStatisticMetric.h
+++ b/Components/Metrics/AdvancedKappaStatistic/elxAdvancedKappaStatisticMetric.h
@@ -94,8 +94,6 @@ public:
   using typename Superclass1::GradientPixelType;
   using typename Superclass1::GradientImageType;
   using typename Superclass1::GradientImagePointer;
-  using typename Superclass1::GradientImageFilterType;
-  using typename Superclass1::GradientImageFilterPointer;
   using typename Superclass1::FixedImageMaskType;
   using typename Superclass1::FixedImageMaskPointer;
   using typename Superclass1::MovingImageMaskType;

--- a/Components/Metrics/AdvancedKappaStatistic/itkAdvancedKappaStatisticImageToImageMetric.h
+++ b/Components/Metrics/AdvancedKappaStatistic/itkAdvancedKappaStatisticImageToImageMetric.h
@@ -93,8 +93,6 @@ public:
   using typename Superclass::GradientPixelType;
   using typename Superclass::GradientImageType;
   using typename Superclass::GradientImagePointer;
-  using typename Superclass::GradientImageFilterType;
-  using typename Superclass::GradientImageFilterPointer;
   using typename Superclass::FixedImageMaskType;
   using typename Superclass::FixedImageMaskPointer;
   using typename Superclass::MovingImageMaskType;

--- a/Components/Metrics/AdvancedMattesMutualInformation/elxAdvancedMattesMutualInformationMetric.h
+++ b/Components/Metrics/AdvancedMattesMutualInformation/elxAdvancedMattesMutualInformationMetric.h
@@ -146,8 +146,6 @@ public:
   using typename Superclass1::GradientPixelType;
   using typename Superclass1::GradientImageType;
   using typename Superclass1::GradientImagePointer;
-  using typename Superclass1::GradientImageFilterType;
-  using typename Superclass1::GradientImageFilterPointer;
   using typename Superclass1::FixedImageMaskType;
   using typename Superclass1::FixedImageMaskPointer;
   using typename Superclass1::MovingImageMaskType;

--- a/Components/Metrics/AdvancedMattesMutualInformation/itkParzenWindowMutualInformationImageToImageMetric.h
+++ b/Components/Metrics/AdvancedMattesMutualInformation/itkParzenWindowMutualInformationImageToImageMetric.h
@@ -111,8 +111,6 @@ public:
   using typename Superclass::GradientPixelType;
   using typename Superclass::GradientImageType;
   using typename Superclass::GradientImagePointer;
-  using typename Superclass::GradientImageFilterType;
-  using typename Superclass::GradientImageFilterPointer;
   using typename Superclass::FixedImageMaskType;
   using typename Superclass::FixedImageMaskPointer;
   using typename Superclass::MovingImageMaskType;

--- a/Components/Metrics/AdvancedMeanSquares/elxAdvancedMeanSquaresMetric.h
+++ b/Components/Metrics/AdvancedMeanSquares/elxAdvancedMeanSquaresMetric.h
@@ -90,8 +90,6 @@ public:
   using typename Superclass1::GradientPixelType;
   using typename Superclass1::GradientImageType;
   using typename Superclass1::GradientImagePointer;
-  using typename Superclass1::GradientImageFilterType;
-  using typename Superclass1::GradientImageFilterPointer;
   using typename Superclass1::FixedImageMaskType;
   using typename Superclass1::FixedImageMaskPointer;
   using typename Superclass1::MovingImageMaskType;

--- a/Components/Metrics/AdvancedMeanSquares/itkAdvancedMeanSquaresImageToImageMetric.h
+++ b/Components/Metrics/AdvancedMeanSquares/itkAdvancedMeanSquaresImageToImageMetric.h
@@ -92,8 +92,6 @@ public:
   using typename Superclass::GradientPixelType;
   using typename Superclass::GradientImageType;
   using typename Superclass::GradientImagePointer;
-  using typename Superclass::GradientImageFilterType;
-  using typename Superclass::GradientImageFilterPointer;
   using typename Superclass::FixedImageMaskType;
   using typename Superclass::FixedImageMaskPointer;
   using typename Superclass::MovingImageMaskType;

--- a/Components/Metrics/AdvancedNormalizedCorrelation/elxAdvancedNormalizedCorrelationMetric.h
+++ b/Components/Metrics/AdvancedNormalizedCorrelation/elxAdvancedNormalizedCorrelationMetric.h
@@ -90,8 +90,6 @@ public:
   using typename Superclass1::GradientPixelType;
   using typename Superclass1::GradientImageType;
   using typename Superclass1::GradientImagePointer;
-  using typename Superclass1::GradientImageFilterType;
-  using typename Superclass1::GradientImageFilterPointer;
   using typename Superclass1::FixedImageMaskType;
   using typename Superclass1::FixedImageMaskPointer;
   using typename Superclass1::MovingImageMaskType;

--- a/Components/Metrics/AdvancedNormalizedCorrelation/itkAdvancedNormalizedCorrelationImageToImageMetric.h
+++ b/Components/Metrics/AdvancedNormalizedCorrelation/itkAdvancedNormalizedCorrelationImageToImageMetric.h
@@ -127,8 +127,6 @@ public:
   using typename Superclass::GradientPixelType;
   using typename Superclass::GradientImageType;
   using typename Superclass::GradientImagePointer;
-  using typename Superclass::GradientImageFilterType;
-  using typename Superclass::GradientImageFilterPointer;
   using typename Superclass::FixedImageMaskType;
   using typename Superclass::FixedImageMaskPointer;
   using typename Superclass::MovingImageMaskType;

--- a/Components/Metrics/BendingEnergyPenalty/elxTransformBendingEnergyPenaltyTerm.h
+++ b/Components/Metrics/BendingEnergyPenalty/elxTransformBendingEnergyPenaltyTerm.h
@@ -91,8 +91,6 @@ public:
   using typename Superclass1::GradientPixelType;
   using typename Superclass1::GradientImageType;
   using typename Superclass1::GradientImagePointer;
-  using typename Superclass1::GradientImageFilterType;
-  using typename Superclass1::GradientImageFilterPointer;
   using typename Superclass1::FixedImageMaskType;
   using typename Superclass1::FixedImageMaskPointer;
   using typename Superclass1::MovingImageMaskType;

--- a/Components/Metrics/BendingEnergyPenalty/itkTransformBendingEnergyPenaltyTerm.h
+++ b/Components/Metrics/BendingEnergyPenalty/itkTransformBendingEnergyPenaltyTerm.h
@@ -87,8 +87,6 @@ public:
   using typename Superclass::GradientPixelType;
   using typename Superclass::GradientImageType;
   using typename Superclass::GradientImagePointer;
-  using typename Superclass::GradientImageFilterType;
-  using typename Superclass::GradientImageFilterPointer;
   using typename Superclass::FixedImageMaskType;
   using typename Superclass::FixedImageMaskPointer;
   using typename Superclass::MovingImageMaskType;

--- a/Components/Metrics/DisplacementMagnitudePenalty/elxDisplacementMagnitudePenalty.h
+++ b/Components/Metrics/DisplacementMagnitudePenalty/elxDisplacementMagnitudePenalty.h
@@ -88,8 +88,6 @@ public:
   using typename Superclass1::GradientPixelType;
   using typename Superclass1::GradientImageType;
   using typename Superclass1::GradientImagePointer;
-  using typename Superclass1::GradientImageFilterType;
-  using typename Superclass1::GradientImageFilterPointer;
   using typename Superclass1::FixedImageMaskType;
   using typename Superclass1::FixedImageMaskPointer;
   using typename Superclass1::MovingImageMaskType;

--- a/Components/Metrics/DisplacementMagnitudePenalty/itkDisplacementMagnitudePenaltyTerm.h
+++ b/Components/Metrics/DisplacementMagnitudePenalty/itkDisplacementMagnitudePenaltyTerm.h
@@ -70,8 +70,6 @@ public:
   using typename Superclass::GradientPixelType;
   using typename Superclass::GradientImageType;
   using typename Superclass::GradientImagePointer;
-  using typename Superclass::GradientImageFilterType;
-  using typename Superclass::GradientImageFilterPointer;
   using typename Superclass::FixedImageMaskType;
   using typename Superclass::FixedImageMaskPointer;
   using typename Superclass::MovingImageMaskType;

--- a/Components/Metrics/DistancePreservingRigidityPenalty/elxDistancePreservingRigidityPenaltyTerm.h
+++ b/Components/Metrics/DistancePreservingRigidityPenalty/elxDistancePreservingRigidityPenaltyTerm.h
@@ -107,8 +107,6 @@ public:
   using typename Superclass1::GradientPixelType;
   using typename Superclass1::GradientImageType;
   using typename Superclass1::GradientImagePointer;
-  using typename Superclass1::GradientImageFilterType;
-  using typename Superclass1::GradientImageFilterPointer;
   using typename Superclass1::FixedImageMaskType;
   using typename Superclass1::FixedImageMaskPointer;
   using typename Superclass1::MovingImageMaskType;

--- a/Components/Metrics/DistancePreservingRigidityPenalty/itkDistancePreservingRigidityPenaltyTerm.h
+++ b/Components/Metrics/DistancePreservingRigidityPenalty/itkDistancePreservingRigidityPenaltyTerm.h
@@ -112,8 +112,6 @@ public:
   using typename Superclass::GradientPixelType;
   using typename Superclass::GradientImageType;
   using typename Superclass::GradientImagePointer;
-  using typename Superclass::GradientImageFilterType;
-  using typename Superclass::GradientImageFilterPointer;
   using typename Superclass::FixedImageMaskType;
   using typename Superclass::FixedImageMaskPointer;
   using typename Superclass::MovingImageMaskType;

--- a/Components/Metrics/GradientDifference/elxGradientDifferenceMetric.h
+++ b/Components/Metrics/GradientDifference/elxGradientDifferenceMetric.h
@@ -82,8 +82,6 @@ public:
   using typename Superclass1::GradientPixelType;
   using typename Superclass1::GradientImageType;
   using typename Superclass1::GradientImagePointer;
-  using typename Superclass1::GradientImageFilterType;
-  using typename Superclass1::GradientImageFilterPointer;
   using typename Superclass1::FixedImageMaskType;
   using typename Superclass1::FixedImageMaskPointer;
   using typename Superclass1::MovingImageMaskType;

--- a/Components/Metrics/KNNGraphAlphaMutualInformation/itkKNNGraphAlphaMutualInformationImageToImageMetric.h
+++ b/Components/Metrics/KNNGraphAlphaMutualInformation/itkKNNGraphAlphaMutualInformationImageToImageMetric.h
@@ -109,8 +109,6 @@ public:
   using typename Superclass::GradientPixelType;
   using typename Superclass::GradientImageType;
   using typename Superclass::GradientImagePointer;
-  using typename Superclass::GradientImageFilterType;
-  using typename Superclass::GradientImageFilterPointer;
   using typename Superclass::FixedImageMaskType;
   using typename Superclass::FixedImageMaskPointer;
   using typename Superclass::MovingImageMaskType;

--- a/Components/Metrics/NormalizedGradientCorrelation/elxNormalizedGradientCorrelationMetric.h
+++ b/Components/Metrics/NormalizedGradientCorrelation/elxNormalizedGradientCorrelationMetric.h
@@ -83,8 +83,6 @@ public:
   using typename Superclass1::GradientPixelType;
   using typename Superclass1::GradientImageType;
   using typename Superclass1::GradientImagePointer;
-  using typename Superclass1::GradientImageFilterType;
-  using typename Superclass1::GradientImageFilterPointer;
   using typename Superclass1::FixedImageMaskType;
   using typename Superclass1::FixedImageMaskPointer;
   using typename Superclass1::MovingImageMaskType;

--- a/Components/Metrics/NormalizedMutualInformation/elxNormalizedMutualInformationMetric.h
+++ b/Components/Metrics/NormalizedMutualInformation/elxNormalizedMutualInformationMetric.h
@@ -120,8 +120,6 @@ public:
   using typename Superclass1::GradientPixelType;
   using typename Superclass1::GradientImageType;
   using typename Superclass1::GradientImagePointer;
-  using typename Superclass1::GradientImageFilterType;
-  using typename Superclass1::GradientImageFilterPointer;
   using typename Superclass1::FixedImageMaskType;
   using typename Superclass1::FixedImageMaskPointer;
   using typename Superclass1::MovingImageMaskType;

--- a/Components/Metrics/NormalizedMutualInformation/itkParzenWindowNormalizedMutualInformationImageToImageMetric.h
+++ b/Components/Metrics/NormalizedMutualInformation/itkParzenWindowNormalizedMutualInformationImageToImageMetric.h
@@ -107,8 +107,6 @@ public:
   using typename Superclass::GradientPixelType;
   using typename Superclass::GradientImageType;
   using typename Superclass::GradientImagePointer;
-  using typename Superclass::GradientImageFilterType;
-  using typename Superclass::GradientImageFilterPointer;
   using typename Superclass::FixedImageMaskType;
   using typename Superclass::FixedImageMaskPointer;
   using typename Superclass::MovingImageMaskType;

--- a/Components/Metrics/PCAMetric/elxPCAMetric.h
+++ b/Components/Metrics/PCAMetric/elxPCAMetric.h
@@ -109,8 +109,6 @@ public:
   using typename Superclass1::GradientPixelType;
   using typename Superclass1::GradientImageType;
   using typename Superclass1::GradientImagePointer;
-  using typename Superclass1::GradientImageFilterType;
-  using typename Superclass1::GradientImageFilterPointer;
   using typename Superclass1::FixedImageMaskType;
   using typename Superclass1::FixedImageMaskPointer;
   using typename Superclass1::MovingImageMaskType;

--- a/Components/Metrics/PCAMetric/itkPCAMetric.h
+++ b/Components/Metrics/PCAMetric/itkPCAMetric.h
@@ -86,8 +86,6 @@ public:
   using typename Superclass::GradientPixelType;
   using typename Superclass::GradientImageType;
   using typename Superclass::GradientImagePointer;
-  using typename Superclass::GradientImageFilterType;
-  using typename Superclass::GradientImageFilterPointer;
   using typename Superclass::FixedImageMaskType;
   using typename Superclass::FixedImageMaskPointer;
   using typename Superclass::MovingImageMaskType;

--- a/Components/Metrics/PCAMetric/itkPCAMetric_F_multithreaded.h
+++ b/Components/Metrics/PCAMetric/itkPCAMetric_F_multithreaded.h
@@ -74,8 +74,6 @@ public:
   using typename Superclass::GradientPixelType;
   using typename Superclass::GradientImageType;
   using typename Superclass::GradientImagePointer;
-  using typename Superclass::GradientImageFilterType;
-  using typename Superclass::GradientImageFilterPointer;
   using typename Superclass::FixedImageMaskType;
   using typename Superclass::FixedImageMaskPointer;
   using typename Superclass::MovingImageMaskType;

--- a/Components/Metrics/PCAMetric2/elxPCAMetric2.h
+++ b/Components/Metrics/PCAMetric2/elxPCAMetric2.h
@@ -110,8 +110,6 @@ public:
   using typename Superclass1::GradientPixelType;
   using typename Superclass1::GradientImageType;
   using typename Superclass1::GradientImagePointer;
-  using typename Superclass1::GradientImageFilterType;
-  using typename Superclass1::GradientImageFilterPointer;
   using typename Superclass1::FixedImageMaskType;
   using typename Superclass1::FixedImageMaskPointer;
   using typename Superclass1::MovingImageMaskType;

--- a/Components/Metrics/PCAMetric2/itkPCAMetric2.h
+++ b/Components/Metrics/PCAMetric2/itkPCAMetric2.h
@@ -74,8 +74,6 @@ public:
   using typename Superclass::GradientPixelType;
   using typename Superclass::GradientImageType;
   using typename Superclass::GradientImagePointer;
-  using typename Superclass::GradientImageFilterType;
-  using typename Superclass::GradientImageFilterPointer;
   using typename Superclass::FixedImageMaskType;
   using typename Superclass::FixedImageMaskPointer;
   using typename Superclass::MovingImageMaskType;

--- a/Components/Metrics/PatternIntensity/elxPatternIntensityMetric.h
+++ b/Components/Metrics/PatternIntensity/elxPatternIntensityMetric.h
@@ -82,8 +82,6 @@ public:
   using typename Superclass1::GradientPixelType;
   using typename Superclass1::GradientImageType;
   using typename Superclass1::GradientImagePointer;
-  using typename Superclass1::GradientImageFilterType;
-  using typename Superclass1::GradientImageFilterPointer;
   using typename Superclass1::FixedImageMaskType;
   using typename Superclass1::FixedImageMaskPointer;
   using typename Superclass1::MovingImageMaskType;

--- a/Components/Metrics/PatternIntensity/itkPatternIntensityImageToImageMetric.h
+++ b/Components/Metrics/PatternIntensity/itkPatternIntensityImageToImageMetric.h
@@ -82,8 +82,6 @@ public:
   using typename Superclass::GradientPixelType;
   using typename Superclass::GradientImageType;
   using typename Superclass::GradientImagePointer;
-  using typename Superclass::GradientImageFilterType;
-  using typename Superclass::GradientImageFilterPointer;
   using typename Superclass::FixedImageMaskType;
   using typename Superclass::FixedImageMaskPointer;
   using typename Superclass::MovingImageMaskType;

--- a/Components/Metrics/RigidityPenalty/elxTransformRigidityPenaltyTerm.h
+++ b/Components/Metrics/RigidityPenalty/elxTransformRigidityPenaltyTerm.h
@@ -153,8 +153,6 @@ public:
   using typename Superclass1::GradientPixelType;
   using typename Superclass1::GradientImageType;
   using typename Superclass1::GradientImagePointer;
-  using typename Superclass1::GradientImageFilterType;
-  using typename Superclass1::GradientImageFilterPointer;
   using typename Superclass1::FixedImageMaskType;
   using typename Superclass1::FixedImageMaskPointer;
   using typename Superclass1::MovingImageMaskType;

--- a/Components/Metrics/RigidityPenalty/itkTransformRigidityPenaltyTerm.h
+++ b/Components/Metrics/RigidityPenalty/itkTransformRigidityPenaltyTerm.h
@@ -107,8 +107,6 @@ public:
   using typename Superclass::GradientPixelType;
   using typename Superclass::GradientImageType;
   using typename Superclass::GradientImagePointer;
-  using typename Superclass::GradientImageFilterType;
-  using typename Superclass::GradientImageFilterPointer;
   using typename Superclass::FixedImageMaskType;
   using typename Superclass::FixedImageMaskPointer;
   using typename Superclass::MovingImageMaskType;

--- a/Components/Metrics/SumOfPairwiseCorrelationsMetric/elxSumOfPairwiseCorrelationCoefficientsMetric.h
+++ b/Components/Metrics/SumOfPairwiseCorrelationsMetric/elxSumOfPairwiseCorrelationCoefficientsMetric.h
@@ -110,8 +110,6 @@ public:
   using typename Superclass1::GradientPixelType;
   using typename Superclass1::GradientImageType;
   using typename Superclass1::GradientImagePointer;
-  using typename Superclass1::GradientImageFilterType;
-  using typename Superclass1::GradientImageFilterPointer;
   using typename Superclass1::FixedImageMaskType;
   using typename Superclass1::FixedImageMaskPointer;
   using typename Superclass1::MovingImageMaskType;

--- a/Components/Metrics/SumOfPairwiseCorrelationsMetric/itkSumOfPairwiseCorrelationCoefficientsMetric.h
+++ b/Components/Metrics/SumOfPairwiseCorrelationsMetric/itkSumOfPairwiseCorrelationCoefficientsMetric.h
@@ -75,8 +75,6 @@ public:
   using typename Superclass::GradientPixelType;
   using typename Superclass::GradientImageType;
   using typename Superclass::GradientImagePointer;
-  using typename Superclass::GradientImageFilterType;
-  using typename Superclass::GradientImageFilterPointer;
   using typename Superclass::FixedImageMaskType;
   using typename Superclass::FixedImageMaskPointer;
   using typename Superclass::MovingImageMaskType;

--- a/Components/Metrics/SumSquaredTissueVolumeDifferenceMetric/elxSumSquaredTissueVolumeDifferenceMetric.h
+++ b/Components/Metrics/SumSquaredTissueVolumeDifferenceMetric/elxSumSquaredTissueVolumeDifferenceMetric.h
@@ -96,8 +96,6 @@ public:
   using typename Superclass1::GradientPixelType;
   using typename Superclass1::GradientImageType;
   using typename Superclass1::GradientImagePointer;
-  using typename Superclass1::GradientImageFilterType;
-  using typename Superclass1::GradientImageFilterPointer;
   using typename Superclass1::FixedImageMaskType;
   using typename Superclass1::FixedImageMaskPointer;
   using typename Superclass1::MovingImageMaskType;

--- a/Components/Metrics/SumSquaredTissueVolumeDifferenceMetric/itkSumSquaredTissueVolumeDifferenceImageToImageMetric.h
+++ b/Components/Metrics/SumSquaredTissueVolumeDifferenceMetric/itkSumSquaredTissueVolumeDifferenceImageToImageMetric.h
@@ -94,8 +94,6 @@ public:
   using typename Superclass::GradientPixelType;
   using typename Superclass::GradientImageType;
   using typename Superclass::GradientImagePointer;
-  using typename Superclass::GradientImageFilterType;
-  using typename Superclass::GradientImageFilterPointer;
   using typename Superclass::FixedImageMaskType;
   using typename Superclass::FixedImageMaskPointer;
   using typename Superclass::MovingImageMaskType;

--- a/Components/Metrics/VarianceOverLastDimension/elxVarianceOverLastDimensionMetric.h
+++ b/Components/Metrics/VarianceOverLastDimension/elxVarianceOverLastDimensionMetric.h
@@ -114,8 +114,6 @@ public:
   using typename Superclass1::GradientPixelType;
   using typename Superclass1::GradientImageType;
   using typename Superclass1::GradientImagePointer;
-  using typename Superclass1::GradientImageFilterType;
-  using typename Superclass1::GradientImageFilterPointer;
   using typename Superclass1::FixedImageMaskType;
   using typename Superclass1::FixedImageMaskPointer;
   using typename Superclass1::MovingImageMaskType;

--- a/Components/Metrics/VarianceOverLastDimension/itkVarianceOverLastDimensionImageMetric.h
+++ b/Components/Metrics/VarianceOverLastDimension/itkVarianceOverLastDimensionImageMetric.h
@@ -102,8 +102,6 @@ public:
   using typename Superclass::GradientPixelType;
   using typename Superclass::GradientImageType;
   using typename Superclass::GradientImagePointer;
-  using typename Superclass::GradientImageFilterType;
-  using typename Superclass::GradientImageFilterPointer;
   using typename Superclass::FixedImageMaskType;
   using typename Superclass::FixedImageMaskPointer;
   using typename Superclass::MovingImageMaskType;

--- a/Components/Registrations/MultiMetricMultiResolutionRegistration/itkCombinationImageToImageMetric.h
+++ b/Components/Registrations/MultiMetricMultiResolutionRegistration/itkCombinationImageToImageMetric.h
@@ -99,8 +99,6 @@ public:
   using typename Superclass::GradientPixelType;
   using typename Superclass::GradientImageType;
   using typename Superclass::GradientImagePointer;
-  using typename Superclass::GradientImageFilterType;
-  using typename Superclass::GradientImageFilterPointer;
   using typename Superclass::FixedImageMaskType;
   using typename Superclass::FixedImageMaskPointer;
   using typename Superclass::MovingImageMaskType;


### PR DESCRIPTION
elastix does not use them.

For the record, `ImageToImageMetric::GradientImageFilterType` is defined as `GradientRecursiveGaussianImageFilter<MovingImageType, GradientImageType>`, at https://github.com/InsightSoftwareConsortium/ITK/blob/be79ceb0a9343c02dba310f5faee371941f6fa40/Modules/Registration/Common/include/itkImageToImageMetric.h#L112

This pull request is somewhat related to:
- pull request #1070 