### PR TITLE
Remove assignments to data members from inside constructors of metrics

### DIFF
--- a/Common/CostFunctions/itkImageToImageMetricWithFeatures.h
+++ b/Common/CostFunctions/itkImageToImageMetricWithFeatures.h
@@ -222,7 +222,7 @@ public:
   Initialize();
 
 protected:
-  ImageToImageMetricWithFeatures();
+  ImageToImageMetricWithFeatures() = default;
   virtual ~ImageToImageMetricWithFeatures() {}
   void
   PrintSelf(std::ostream & os, Indent indent) const;
@@ -236,8 +236,8 @@ protected:
   using typename Superclass::MovingImageContinuousIndexType;
 
   /** Member variables. */
-  unsigned int                        m_NumberOfFixedFeatureImages{};
-  unsigned int                        m_NumberOfMovingFeatureImages{};
+  unsigned int                        m_NumberOfFixedFeatureImages{ 0 };
+  unsigned int                        m_NumberOfMovingFeatureImages{ 0 };
   FixedFeatureImageVectorType         m_FixedFeatureImages{};
   MovingFeatureImageVectorType        m_MovingFeatureImages{};
   FixedFeatureInterpolatorVectorType  m_FixedFeatureInterpolators{};

--- a/Common/CostFunctions/itkImageToImageMetricWithFeatures.hxx
+++ b/Common/CostFunctions/itkImageToImageMetricWithFeatures.hxx
@@ -24,20 +24,6 @@ namespace itk
 {
 
 /**
- * ********************* Constructor ****************************
- */
-
-template <class TFixedImage, class TMovingImage, class TFixedFeatureImage, class TMovingFeatureImage>
-ImageToImageMetricWithFeatures<TFixedImage, TMovingImage, TFixedFeatureImage, TMovingFeatureImage>::
-  ImageToImageMetricWithFeatures()
-{
-  this->m_NumberOfFixedFeatureImages = 0;
-  this->m_NumberOfMovingFeatureImages = 0;
-
-} // end Constructor
-
-
-/**
  * ********************* Initialize *****************************
  */
 

--- a/Common/CostFunctions/itkParzenWindowHistogramImageToImageMetric.h
+++ b/Common/CostFunctions/itkParzenWindowHistogramImageToImageMetric.h
@@ -266,33 +266,33 @@ protected:
   /** Protected variables **************************** */
 
   /** Variables for Alpha (the normalization factor of the histogram). */
-  mutable double         m_Alpha{};
+  mutable double         m_Alpha{ 0.0 };
   mutable DerivativeType m_PerturbedAlphaRight{};
   mutable DerivativeType m_PerturbedAlphaLeft{};
 
   /** Variables for the pdfs (actually: histograms). */
   mutable MarginalPDFType       m_FixedImageMarginalPDF{};
   mutable MarginalPDFType       m_MovingImageMarginalPDF{};
-  JointPDFPointer               m_JointPDF{};
-  JointPDFDerivativesPointer    m_JointPDFDerivatives{};
+  JointPDFPointer               m_JointPDF{ nullptr };
+  JointPDFDerivativesPointer    m_JointPDFDerivatives{ nullptr };
   JointPDFDerivativesPointer    m_IncrementalJointPDFRight{};
   JointPDFDerivativesPointer    m_IncrementalJointPDFLeft{};
-  IncrementalMarginalPDFPointer m_FixedIncrementalMarginalPDFRight{};
-  IncrementalMarginalPDFPointer m_MovingIncrementalMarginalPDFRight{};
-  IncrementalMarginalPDFPointer m_FixedIncrementalMarginalPDFLeft{};
-  IncrementalMarginalPDFPointer m_MovingIncrementalMarginalPDFLeft{};
+  IncrementalMarginalPDFPointer m_FixedIncrementalMarginalPDFRight{ nullptr };
+  IncrementalMarginalPDFPointer m_MovingIncrementalMarginalPDFRight{ nullptr };
+  IncrementalMarginalPDFPointer m_FixedIncrementalMarginalPDFLeft{ nullptr };
+  IncrementalMarginalPDFPointer m_MovingIncrementalMarginalPDFLeft{ nullptr };
   mutable JointPDFRegionType    m_JointPDFWindow{}; // no need for mutable anymore?
-  double                        m_MovingImageNormalizedMin{};
-  double                        m_FixedImageNormalizedMin{};
-  double                        m_FixedImageBinSize{};
-  double                        m_MovingImageBinSize{};
-  double                        m_FixedParzenTermToIndexOffset{};
-  double                        m_MovingParzenTermToIndexOffset{};
+  double                        m_MovingImageNormalizedMin{ 0.0 };
+  double                        m_FixedImageNormalizedMin{ 0.0 };
+  double                        m_FixedImageBinSize{ 0.0 };
+  double                        m_MovingImageBinSize{ 0.0 };
+  double                        m_FixedParzenTermToIndexOffset{ 0.5 };
+  double                        m_MovingParzenTermToIndexOffset{ -1.0 };
 
   /** Kernels for computing Parzen histograms and derivatives. */
-  KernelFunctionPointer m_FixedKernel{};
-  KernelFunctionPointer m_MovingKernel{};
-  KernelFunctionPointer m_DerivativeMovingKernel{};
+  KernelFunctionPointer m_FixedKernel{ nullptr };
+  KernelFunctionPointer m_MovingKernel{ nullptr };
+  KernelFunctionPointer m_DerivativeMovingKernel{ nullptr };
 
   /** Initialize threading related parameters. */
   void
@@ -496,14 +496,14 @@ private:
     m_ParzenWindowHistogramGetValueAndDerivativePerThreadVariables;
 
   /** Variables that can/should be accessed by their Set/Get functions. */
-  unsigned long m_NumberOfFixedHistogramBins{};
-  unsigned long m_NumberOfMovingHistogramBins{};
-  unsigned int  m_FixedKernelBSplineOrder{};
-  unsigned int  m_MovingKernelBSplineOrder{};
-  bool          m_UseDerivative{};
-  bool          m_UseExplicitPDFDerivatives{};
-  bool          m_UseFiniteDifferenceDerivative{};
-  double        m_FiniteDifferencePerturbation{};
+  unsigned long m_NumberOfFixedHistogramBins{ 32 };
+  unsigned long m_NumberOfMovingHistogramBins{ 32 };
+  unsigned int  m_FixedKernelBSplineOrder{ 0 };
+  unsigned int  m_MovingKernelBSplineOrder{ 3 };
+  bool          m_UseDerivative{ false };
+  bool          m_UseExplicitPDFDerivatives{ true };
+  bool          m_UseFiniteDifferenceDerivative{ false };
+  double        m_FiniteDifferencePerturbation{ 1.0 };
 };
 
 } // end namespace itk

--- a/Common/CostFunctions/itkParzenWindowHistogramImageToImageMetric.hxx
+++ b/Common/CostFunctions/itkParzenWindowHistogramImageToImageMetric.hxx
@@ -36,37 +36,9 @@ namespace itk
 template <class TFixedImage, class TMovingImage>
 ParzenWindowHistogramImageToImageMetric<TFixedImage, TMovingImage>::ParzenWindowHistogramImageToImageMetric()
 {
-  this->m_NumberOfFixedHistogramBins = 32;
-  this->m_NumberOfMovingHistogramBins = 32;
-  this->m_JointPDF = nullptr;
-  this->m_JointPDFDerivatives = nullptr;
-  this->m_FixedImageNormalizedMin = 0.0;
-  this->m_MovingImageNormalizedMin = 0.0;
-  this->m_FixedImageBinSize = 0.0;
-  this->m_MovingImageBinSize = 0.0;
-  this->m_Alpha = 0.0;
-  this->m_FixedIncrementalMarginalPDFRight = nullptr;
-  this->m_MovingIncrementalMarginalPDFRight = nullptr;
-  this->m_FixedIncrementalMarginalPDFLeft = nullptr;
-  this->m_MovingIncrementalMarginalPDFLeft = nullptr;
-
-  this->m_FixedKernel = nullptr;
-  this->m_MovingKernel = nullptr;
-  this->m_DerivativeMovingKernel = nullptr;
-  this->m_FixedKernelBSplineOrder = 0;
-  this->m_MovingKernelBSplineOrder = 3;
-  this->m_FixedParzenTermToIndexOffset = 0.5;
-  this->m_MovingParzenTermToIndexOffset = -1.0;
-
-  this->m_UseDerivative = false;
-  this->m_UseFiniteDifferenceDerivative = false;
-  this->m_FiniteDifferencePerturbation = 1.0;
-
   this->SetUseImageSampler(true);
   this->SetUseFixedImageLimiter(true);
   this->SetUseMovingImageLimiter(true);
-
-  this->m_UseExplicitPDFDerivatives = true;
 
   /** Initialize the m_ParzenWindowHistogramThreaderParameters */
   this->m_ParzenWindowHistogramThreaderParameters.m_Metric = this;

--- a/Common/CostFunctions/itkScaledSingleValuedCostFunction.cxx
+++ b/Common/CostFunctions/itkScaledSingleValuedCostFunction.cxx
@@ -26,14 +26,7 @@ namespace itk
  * **************** Constructor *****************************
  */
 
-ScaledSingleValuedCostFunction::ScaledSingleValuedCostFunction()
-{
-  this->m_UnscaledCostFunction = nullptr;
-  this->m_UseScales = false;
-  this->m_NegateCostFunction = false;
-
-} // end Constructor
-
+ScaledSingleValuedCostFunction::ScaledSingleValuedCostFunction() = default;
 
 /**
  * ******************** GetValue *****************************

--- a/Common/CostFunctions/itkScaledSingleValuedCostFunction.h
+++ b/Common/CostFunctions/itkScaledSingleValuedCostFunction.h
@@ -146,9 +146,9 @@ private:
   /** Member variables. */
   ScalesType                      m_Scales{};
   ScalesType                      m_SquaredScales{};
-  SingleValuedCostFunctionPointer m_UnscaledCostFunction{};
-  bool                            m_UseScales{};
-  bool                            m_NegateCostFunction{};
+  SingleValuedCostFunctionPointer m_UnscaledCostFunction{ nullptr };
+  bool                            m_UseScales{ false };
+  bool                            m_NegateCostFunction{ false };
 };
 
 } // end namespace itk

--- a/Components/Metrics/AdvancedKappaStatistic/itkAdvancedKappaStatisticImageToImageMetric.h
+++ b/Components/Metrics/AdvancedKappaStatistic/itkAdvancedKappaStatisticImageToImageMetric.h
@@ -222,10 +222,10 @@ protected:
   AccumulateDerivativesThreaderCallback(void * arg);
 
 private:
-  bool     m_UseForegroundValue{};
-  RealType m_ForegroundValue{};
-  RealType m_Epsilon{};
-  bool     m_Complement{};
+  bool     m_UseForegroundValue{ true }; // for backwards compatibility
+  RealType m_ForegroundValue{ 1.0 };
+  RealType m_Epsilon{ 1e-3 };
+  bool     m_Complement{ true };
 
   /** Threading related parameters. */
 

--- a/Components/Metrics/AdvancedKappaStatistic/itkAdvancedKappaStatisticImageToImageMetric.hxx
+++ b/Components/Metrics/AdvancedKappaStatistic/itkAdvancedKappaStatisticImageToImageMetric.hxx
@@ -38,11 +38,6 @@ AdvancedKappaStatisticImageToImageMetric<TFixedImage, TMovingImage>::AdvancedKap
   this->SetUseFixedImageLimiter(false);
   this->SetUseMovingImageLimiter(false);
 
-  this->m_UseForegroundValue = true; // for backwards compatibility
-  this->m_ForegroundValue = 1.0;
-  this->m_Epsilon = 1e-3;
-  this->m_Complement = true;
-
 } // end Constructor
 
 

--- a/Components/Metrics/AdvancedMattesMutualInformation/itkParzenWindowMutualInformationImageToImageMetric.h
+++ b/Components/Metrics/AdvancedMattesMutualInformation/itkParzenWindowMutualInformationImageToImageMetric.h
@@ -258,7 +258,7 @@ private:
   mutable PRatioArrayType m_PRatioArray{};
 
   /** Setting */
-  bool m_UseJacobianPreconditioning{};
+  bool m_UseJacobianPreconditioning{ false };
 
   /** Helper function to compute the derivative for the low memory variant. */
   void

--- a/Components/Metrics/AdvancedMattesMutualInformation/itkParzenWindowMutualInformationImageToImageMetric.hxx
+++ b/Components/Metrics/AdvancedMattesMutualInformation/itkParzenWindowMutualInformationImageToImageMetric.hxx
@@ -41,8 +41,6 @@ template <class TFixedImage, class TMovingImage>
 ParzenWindowMutualInformationImageToImageMetric<TFixedImage,
                                                 TMovingImage>::ParzenWindowMutualInformationImageToImageMetric()
 {
-  this->m_UseJacobianPreconditioning = false;
-
   /** Initialize the m_ParzenWindowHistogramThreaderParameters. */
   this->m_ParzenWindowMutualInformationThreaderParameters.m_Metric = this;
 

--- a/Components/Metrics/AdvancedNormalizedCorrelation/itkAdvancedNormalizedCorrelationImageToImageMetric.h
+++ b/Components/Metrics/AdvancedNormalizedCorrelation/itkAdvancedNormalizedCorrelationImageToImageMetric.h
@@ -235,7 +235,7 @@ protected:
   AccumulateDerivativesThreaderCallback(void * arg);
 
 private:
-  mutable bool m_SubtractMean{};
+  mutable bool m_SubtractMean{ false };
 
   using AccumulateType = typename NumericTraits<MeasureType>::AccumulateType;
 

--- a/Components/Metrics/AdvancedNormalizedCorrelation/itkAdvancedNormalizedCorrelationImageToImageMetric.hxx
+++ b/Components/Metrics/AdvancedNormalizedCorrelation/itkAdvancedNormalizedCorrelationImageToImageMetric.hxx
@@ -37,8 +37,6 @@ template <class TFixedImage, class TMovingImage>
 AdvancedNormalizedCorrelationImageToImageMetric<TFixedImage,
                                                 TMovingImage>::AdvancedNormalizedCorrelationImageToImageMetric()
 {
-  this->m_SubtractMean = false;
-
   this->SetUseImageSampler(true);
   this->SetUseFixedImageLimiter(false);
   this->SetUseMovingImageLimiter(false);

--- a/Components/Metrics/GradientDifference/itkGradientDifferenceImageToImageMetric2.h
+++ b/Components/Metrics/GradientDifference/itkGradientDifferenceImageToImageMetric2.h
@@ -165,7 +165,7 @@ public:
   itkGetConstReferenceMacro(DerivativeDelta, double);
 
 protected:
-  GradientDifferenceImageToImageMetric();
+  GradientDifferenceImageToImageMetric() = default;
   ~GradientDifferenceImageToImageMetric() override = default;
   void
   PrintSelf(std::ostream & os, Indent indent) const override;
@@ -199,10 +199,12 @@ private:
   mutable FixedGradientPixelType m_MaxFixedGradient[FixedImageDimension]{};
 
   /** The filter for transforming the moving image. */
-  typename TransformMovingImageFilterType::Pointer m_TransformMovingImageFilter{};
+  typename TransformMovingImageFilterType::Pointer m_TransformMovingImageFilter{
+    TransformMovingImageFilterType::New()
+  };
 
   /** The Sobel gradients of the fixed image */
-  CastFixedImageFilterPointer m_CastFixedImageFilter{};
+  CastFixedImageFilterPointer m_CastFixedImageFilter{ CastFixedImageFilterType::New() };
 
   SobelOperator<FixedGradientPixelType, Self::FixedImageDimension> m_FixedSobelOperators[FixedImageDimension]{};
 
@@ -212,16 +214,16 @@ private:
   ZeroFluxNeumannBoundaryCondition<FixedGradientImageType> m_FixedBoundCond{};
 
   /** The Sobel gradients of the moving image */
-  CastMovedImageFilterPointer m_CastMovedImageFilter{};
+  CastMovedImageFilterPointer m_CastMovedImageFilter{ CastMovedImageFilterType::New() };
 
   SobelOperator<MovedGradientPixelType, Self::MovedImageDimension> m_MovedSobelOperators[MovedImageDimension]{};
 
   typename MovedSobelFilter::Pointer m_MovedSobelFilters[Self::MovedImageDimension]{};
 
   ScalesType                  m_Scales{};
-  double                      m_DerivativeDelta{};
-  double                      m_Rescalingfactor{};
-  CombinationTransformPointer m_CombinationTransform{};
+  double                      m_DerivativeDelta{ 0.001 };
+  double                      m_Rescalingfactor{ 1.0 };
+  CombinationTransformPointer m_CombinationTransform{ CombinationTransformType::New() };
 };
 
 } // end namespace itk

--- a/Components/Metrics/GradientDifference/itkGradientDifferenceImageToImageMetric2.hxx
+++ b/Components/Metrics/GradientDifference/itkGradientDifferenceImageToImageMetric2.hxx
@@ -49,37 +49,6 @@ namespace itk
 {
 
 /**
- * ********************* Constructor ******************************
- */
-
-template <class TFixedImage, class TMovingImage>
-GradientDifferenceImageToImageMetric<TFixedImage, TMovingImage>::GradientDifferenceImageToImageMetric()
-{
-  unsigned int iDimension;
-  this->m_CastMovedImageFilter = CastMovedImageFilterType::New();
-  this->m_CastFixedImageFilter = CastFixedImageFilterType::New();
-  this->m_CombinationTransform = CombinationTransformType::New();
-  this->m_TransformMovingImageFilter = TransformMovingImageFilterType::New();
-
-  for (iDimension = 0; iDimension < FixedImageDimension; ++iDimension)
-  {
-    this->m_MinFixedGradient[iDimension] = 0;
-    this->m_MaxFixedGradient[iDimension] = 0;
-    this->m_Variance[iDimension] = 0;
-  }
-
-  for (iDimension = 0; iDimension < MovedImageDimension; ++iDimension)
-  {
-    this->m_MinMovedGradient[iDimension] = 0;
-    this->m_MaxMovedGradient[iDimension] = 0;
-  }
-
-  this->m_DerivativeDelta = 0.001;
-  this->m_Rescalingfactor = 1.0;
-}
-
-
-/**
  * ********************* Initialize ******************************
  */
 

--- a/Components/Metrics/KNNGraphAlphaMutualInformation/itkKNNGraphAlphaMutualInformationImageToImageMetric.h
+++ b/Components/Metrics/KNNGraphAlphaMutualInformation/itkKNNGraphAlphaMutualInformationImageToImageMetric.h
@@ -264,16 +264,16 @@ protected:
   PrintSelf(std::ostream & os, Indent indent) const override;
 
   /** Member variables. */
-  BinaryKNNTreePointer m_BinaryKNNTreeFixed{};
-  BinaryKNNTreePointer m_BinaryKNNTreeMoving{};
-  BinaryKNNTreePointer m_BinaryKNNTreeJoint{};
+  BinaryKNNTreePointer m_BinaryKNNTreeFixed{ nullptr };
+  BinaryKNNTreePointer m_BinaryKNNTreeMoving{ nullptr };
+  BinaryKNNTreePointer m_BinaryKNNTreeJoint{ nullptr };
 
-  BinaryKNNTreeSearchPointer m_BinaryKNNTreeSearcherFixed{};
-  BinaryKNNTreeSearchPointer m_BinaryKNNTreeSearcherMoving{};
-  BinaryKNNTreeSearchPointer m_BinaryKNNTreeSearcherJoint{};
+  BinaryKNNTreeSearchPointer m_BinaryKNNTreeSearcherFixed{ nullptr };
+  BinaryKNNTreeSearchPointer m_BinaryKNNTreeSearcherMoving{ nullptr };
+  BinaryKNNTreeSearchPointer m_BinaryKNNTreeSearcherJoint{ nullptr };
 
-  double m_Alpha{};
-  double m_AvoidDivisionBy{};
+  double m_Alpha{ 0.99 };
+  double m_AvoidDivisionBy{ 1e-10 };
 
 private:
   /** Typedef's for the computation of the derivative. */

--- a/Components/Metrics/KNNGraphAlphaMutualInformation/itkKNNGraphAlphaMutualInformationImageToImageMetric.hxx
+++ b/Components/Metrics/KNNGraphAlphaMutualInformation/itkKNNGraphAlphaMutualInformationImageToImageMetric.hxx
@@ -33,16 +33,6 @@ KNNGraphAlphaMutualInformationImageToImageMetric<TFixedImage,
 {
   this->SetComputeGradient(false); // don't use the default gradient
   this->SetUseImageSampler(true);
-  this->m_Alpha = 0.99;
-  this->m_AvoidDivisionBy = 1e-10;
-
-  this->m_BinaryKNNTreeFixed = nullptr;
-  this->m_BinaryKNNTreeMoving = nullptr;
-  this->m_BinaryKNNTreeJoint = nullptr;
-
-  this->m_BinaryKNNTreeSearcherFixed = nullptr;
-  this->m_BinaryKNNTreeSearcherMoving = nullptr;
-  this->m_BinaryKNNTreeSearcherJoint = nullptr;
 
 } // end Constructor()
 

--- a/Components/Metrics/NormalizedGradientCorrelation/itkNormalizedGradientCorrelationImageToImageMetric.h
+++ b/Components/Metrics/NormalizedGradientCorrelation/itkNormalizedGradientCorrelationImageToImageMetric.h
@@ -153,7 +153,7 @@ public:
   SetTransformParameters(const TransformParametersType & parameters) const;
 
 protected:
-  NormalizedGradientCorrelationImageToImageMetric();
+  NormalizedGradientCorrelationImageToImageMetric() = default;
   ~NormalizedGradientCorrelationImageToImageMetric() override = default;
   void
   PrintSelf(std::ostream & os, Indent indent) const override;
@@ -174,8 +174,8 @@ protected:
 
 private:
   ScalesType                  m_Scales{};
-  double                      m_DerivativeDelta{};
-  CombinationTransformPointer m_CombinationTransform{};
+  double                      m_DerivativeDelta{ 0.001 };
+  CombinationTransformPointer m_CombinationTransform{ CombinationTransformType::New() };
 
   /** The mean of the moving image gradients. */
   mutable MovedGradientPixelType m_MeanMovedGradient[MovedImageDimension]{};
@@ -184,10 +184,10 @@ private:
   mutable FixedGradientPixelType m_MeanFixedGradient[FixedImageDimension]{};
 
   /** The filter for transforming the moving images. */
-  TransformMovingImageFilterPointer m_TransformMovingImageFilter{};
+  TransformMovingImageFilterPointer m_TransformMovingImageFilter{ TransformMovingImageFilterType::New() };
 
   /** The Sobel gradients of the fixed image */
-  CastFixedImageFilterPointer m_CastFixedImageFilter{};
+  CastFixedImageFilterPointer m_CastFixedImageFilter{ CastFixedImageFilterType::New() };
 
   SobelOperator<FixedGradientPixelType, Self::FixedImageDimension> m_FixedSobelOperators[FixedImageDimension]{};
 
@@ -197,7 +197,7 @@ private:
   ZeroFluxNeumannBoundaryCondition<FixedGradientImageType> m_FixedBoundCond{};
 
   /** The Sobel gradients of the moving image */
-  CastMovedImageFilterPointer                                      m_CastMovedImageFilter{};
+  CastMovedImageFilterPointer m_CastMovedImageFilter{ CastMovedImageFilterType::New() };
   SobelOperator<MovedGradientPixelType, Self::MovedImageDimension> m_MovedSobelOperators[MovedImageDimension]{};
 
   typename MovedSobelFilter::Pointer m_MovedSobelFilters[Self::MovedImageDimension]{};

--- a/Components/Metrics/NormalizedGradientCorrelation/itkNormalizedGradientCorrelationImageToImageMetric.hxx
+++ b/Components/Metrics/NormalizedGradientCorrelation/itkNormalizedGradientCorrelationImageToImageMetric.hxx
@@ -31,29 +31,6 @@ namespace itk
 {
 
 /**
- * ***************** Constructor *****************
- */
-
-template <class TFixedImage, class TMovingImage>
-NormalizedGradientCorrelationImageToImageMetric<TFixedImage,
-                                                TMovingImage>::NormalizedGradientCorrelationImageToImageMetric()
-{
-  this->m_CastFixedImageFilter = CastFixedImageFilterType::New();
-  this->m_CastMovedImageFilter = CastMovedImageFilterType::New();
-  this->m_CombinationTransform = CombinationTransformType::New();
-  this->m_TransformMovingImageFilter = TransformMovingImageFilterType::New();
-  this->m_DerivativeDelta = 0.001;
-
-  for (unsigned int iDimension = 0; iDimension < MovedImageDimension; ++iDimension)
-  {
-    this->m_MeanFixedGradient[iDimension] = 0;
-    this->m_MeanMovedGradient[iDimension] = 0;
-  }
-
-} // end Constructor
-
-
-/**
  * ***************** Initialize *****************
  */
 

--- a/Components/Metrics/PatternIntensity/itkPatternIntensityImageToImageMetric.h
+++ b/Components/Metrics/PatternIntensity/itkPatternIntensityImageToImageMetric.h
@@ -161,7 +161,7 @@ public:
   itkGetConstReferenceMacro(OptimizeNormalizationFactor, bool);
 
 protected:
-  PatternIntensityImageToImageMetric();
+  PatternIntensityImageToImageMetric() = default;
   ~PatternIntensityImageToImageMetric() override = default;
   void
   PrintSelf(std::ostream & os, Indent indent) const override;
@@ -175,19 +175,19 @@ protected:
   ComputePIDiff(const TransformParametersType & parameters, float scalingfactor) const;
 
 private:
-  TransformMovingImageFilterPointer  m_TransformMovingImageFilter{};
-  DifferenceImageFilterPointer       m_DifferenceImageFilter{};
-  RescaleIntensityImageFilterPointer m_RescaleImageFilter{};
-  MultiplyImageFilterPointer         m_MultiplyImageFilter{};
-  double                             m_NoiseConstant{};
-  unsigned int                       m_NeighborhoodRadius{};
-  double                             m_DerivativeDelta{};
-  double                             m_NormalizationFactor{};
-  double                             m_Rescalingfactor{};
-  bool                               m_OptimizeNormalizationFactor{};
+  TransformMovingImageFilterPointer  m_TransformMovingImageFilter{ TransformMovingImageFilterType::New() };
+  DifferenceImageFilterPointer       m_DifferenceImageFilter{ DifferenceImageFilterType::New() };
+  RescaleIntensityImageFilterPointer m_RescaleImageFilter{ RescaleIntensityImageFilterType::New() };
+  MultiplyImageFilterPointer         m_MultiplyImageFilter{ MultiplyImageFilterType::New() };
+  double                             m_NoiseConstant{ 10000 }; // = sigma * sigma = 100*100 if not specified
+  unsigned int                       m_NeighborhoodRadius{ 3 };
+  double                             m_DerivativeDelta{ 0.001 };
+  double                             m_NormalizationFactor{ 1.0 };
+  double                             m_Rescalingfactor{ 1.0 };
+  bool                               m_OptimizeNormalizationFactor{ false };
   ScalesType                         m_Scales{};
-  MeasureType                        m_FixedMeasure{};
-  CombinationTransformPointer        m_CombinationTransform{};
+  MeasureType                        m_FixedMeasure{ 0 };
+  CombinationTransformPointer        m_CombinationTransform{ CombinationTransformType::New() };
 };
 
 } // end namespace itk

--- a/Components/Metrics/PatternIntensity/itkPatternIntensityImageToImageMetric.hxx
+++ b/Components/Metrics/PatternIntensity/itkPatternIntensityImageToImageMetric.hxx
@@ -32,29 +32,6 @@ namespace itk
 {
 
 /**
- * ********************* Constructor ******************************
- */
-
-template <class TFixedImage, class TMovingImage>
-PatternIntensityImageToImageMetric<TFixedImage, TMovingImage>::PatternIntensityImageToImageMetric()
-{
-  this->m_NormalizationFactor = 1.0;
-  this->m_Rescalingfactor = 1.0;
-  this->m_DerivativeDelta = 0.001;
-  this->m_NoiseConstant = 10000; // = sigma * sigma = 100*100 if not specified
-  this->m_NeighborhoodRadius = 3;
-  this->m_FixedMeasure = 0;
-  this->m_OptimizeNormalizationFactor = false;
-  this->m_TransformMovingImageFilter = TransformMovingImageFilterType::New();
-  this->m_CombinationTransform = CombinationTransformType::New();
-  this->m_RescaleImageFilter = RescaleIntensityImageFilterType::New();
-  this->m_DifferenceImageFilter = DifferenceImageFilterType::New();
-  this->m_MultiplyImageFilter = MultiplyImageFilterType::New();
-
-} // end Constructor
-
-
-/**
  * ********************* Initialize ******************************
  */
 

--- a/Components/Metrics/SumSquaredTissueVolumeDifferenceMetric/itkSumSquaredTissueVolumeDifferenceImageToImageMetric.h
+++ b/Components/Metrics/SumSquaredTissueVolumeDifferenceMetric/itkSumSquaredTissueVolumeDifferenceImageToImageMetric.h
@@ -238,11 +238,11 @@ protected:
   AfterThreadedGetValueAndDerivative(MeasureType & measure, DerivativeType & derivative) const override;
 
 private:
-  /** Intensity value to use for air.  Default is -1000 */
-  RealType m_AirValue{};
+  /** Intensity value to use for air. */
+  RealType m_AirValue{ -1000.0 };
 
-  /** Intensity value to use for tissue.  Default is 55 */
-  RealType m_TissueValue{};
+  /** Intensity value to use for tissue. */
+  RealType m_TissueValue{ 55.0 };
 
 }; // end class SumSquaredTissueVolumeDifferenceImageToImageMetric
 

--- a/Components/Metrics/SumSquaredTissueVolumeDifferenceMetric/itkSumSquaredTissueVolumeDifferenceImageToImageMetric.hxx
+++ b/Components/Metrics/SumSquaredTissueVolumeDifferenceMetric/itkSumSquaredTissueVolumeDifferenceImageToImageMetric.hxx
@@ -39,8 +39,6 @@ SumSquaredTissueVolumeDifferenceImageToImageMetric<TFixedImage,
   this->SetUseImageSampler(true);
   this->SetUseFixedImageLimiter(false);
   this->SetUseMovingImageLimiter(false);
-  this->m_AirValue = -1000.0;
-  this->m_TissueValue = 55.0;
 
 } // end Constructor
 

--- a/Components/Registrations/MultiMetricMultiResolutionRegistration/itkCombinationImageToImageMetric.h
+++ b/Components/Registrations/MultiMetricMultiResolutionRegistration/itkCombinationImageToImageMetric.h
@@ -436,11 +436,11 @@ protected:
   PrintSelf(std::ostream & os, Indent indent) const override;
 
   /** Store the metrics and the corresponding weights. */
-  unsigned int                                 m_NumberOfMetrics{};
+  unsigned int                                 m_NumberOfMetrics{ 0 };
   std::vector<SingleValuedCostFunctionPointer> m_Metrics{};
   std::vector<double>                          m_MetricWeights{};
   std::vector<double>                          m_MetricRelativeWeights{};
-  bool                                         m_UseRelativeWeights{};
+  bool                                         m_UseRelativeWeights{ false };
   std::vector<bool>                            m_UseMetric{};
   mutable std::vector<MeasureType>             m_MetricValues{};
   mutable std::vector<DerivativeType>          m_MetricDerivatives{};

--- a/Components/Registrations/MultiMetricMultiResolutionRegistration/itkCombinationImageToImageMetric.hxx
+++ b/Components/Registrations/MultiMetricMultiResolutionRegistration/itkCombinationImageToImageMetric.hxx
@@ -142,8 +142,6 @@ itkImplementationGetConstObjectMacro1(MovingImage, MovingImageType);
 template <class TFixedImage, class TMovingImage>
 CombinationImageToImageMetric<TFixedImage, TMovingImage>::CombinationImageToImageMetric()
 {
-  this->m_NumberOfMetrics = 0;
-  this->m_UseRelativeWeights = false;
   this->ComputeGradientOff();
 
 } // end Constructor


### PR DESCRIPTION
Moved the values of those data members that were originally assigned to into their default member initializers.

Following C++ Core Guidelines, ["Prefer initialization to assignment in constructors"](http://isocpp.github.io/CppCoreGuidelines/CppCoreGuidelines#Rc-initialize)

