### PR TITLE
STYLE: Move definitions of defaulted constructors into class definitions

### DIFF
--- a/Common/Transforms/itkBSplineInterpolationWeightFunction2.h
+++ b/Common/Transforms/itkBSplineInterpolationWeightFunction2.h
@@ -71,7 +71,7 @@ public:
   using typename Superclass::ContinuousIndexType;
 
 protected:
-  BSplineInterpolationWeightFunction2();
+  BSplineInterpolationWeightFunction2() = default;
   ~BSplineInterpolationWeightFunction2() override = default;
 
   /** Interpolation kernel types. */

--- a/Common/Transforms/itkBSplineInterpolationWeightFunction2.hxx
+++ b/Common/Transforms/itkBSplineInterpolationWeightFunction2.hxx
@@ -24,15 +24,6 @@ namespace itk
 {
 
 /**
- * ****************** Constructor *******************************
- */
-
-template <class TCoordRep, unsigned int VSpaceDimension, unsigned int VSplineOrder>
-BSplineInterpolationWeightFunction2<TCoordRep, VSpaceDimension, VSplineOrder>::BSplineInterpolationWeightFunction2() =
-  default;
-
-
-/**
  * ******************* Compute1DWeights *******************
  */
 

--- a/Common/Transforms/itkCyclicGridScheduleComputer.h
+++ b/Common/Transforms/itkCyclicGridScheduleComputer.h
@@ -86,7 +86,7 @@ public:
 
 protected:
   /** The constructor. */
-  CyclicGridScheduleComputer();
+  CyclicGridScheduleComputer() = default;
 
   /** The destructor. */
   ~CyclicGridScheduleComputer() override = default;

--- a/Common/Transforms/itkCyclicGridScheduleComputer.hxx
+++ b/Common/Transforms/itkCyclicGridScheduleComputer.hxx
@@ -27,14 +27,6 @@ namespace itk
 {
 
 /**
- * ********************* Constructor ****************************
- */
-
-template <typename TTransformScalarType, unsigned int VImageDimension>
-CyclicGridScheduleComputer<TTransformScalarType, VImageDimension>::CyclicGridScheduleComputer() =
-  default; // end Constructor()
-
-/**
  * ********************* ComputeBSplineGrid ****************************
  */
 

--- a/Components/Metrics/CorrespondingPointsEuclideanDistanceMetric/itkCorrespondingPointsEuclideanDistancePointMetric.h
+++ b/Components/Metrics/CorrespondingPointsEuclideanDistanceMetric/itkCorrespondingPointsEuclideanDistancePointMetric.h
@@ -93,7 +93,7 @@ public:
                         DerivativeType &                Derivative) const override;
 
 protected:
-  CorrespondingPointsEuclideanDistancePointMetric();
+  CorrespondingPointsEuclideanDistancePointMetric() = default;
   ~CorrespondingPointsEuclideanDistancePointMetric() override = default;
 };
 

--- a/Components/Metrics/CorrespondingPointsEuclideanDistanceMetric/itkCorrespondingPointsEuclideanDistancePointMetric.hxx
+++ b/Components/Metrics/CorrespondingPointsEuclideanDistanceMetric/itkCorrespondingPointsEuclideanDistancePointMetric.hxx
@@ -24,15 +24,6 @@ namespace itk
 {
 
 /**
- * ******************* Constructor *******************
- */
-
-template <class TFixedPointSet, class TMovingPointSet>
-CorrespondingPointsEuclideanDistancePointMetric<TFixedPointSet,
-                                                TMovingPointSet>::CorrespondingPointsEuclideanDistancePointMetric() =
-  default; // end Constructor
-
-/**
  * ******************* GetValue *******************
  */
 


### PR DESCRIPTION
When a constructor is defaulted within a hxx file, it might as well be defaulted directly with its first declaration, in the corresponding h file.