### PR TITLE
STYLE: Declare InterpolatorPointer member variables of metric `private`

### DIFF
--- a/Common/CostFunctions/itkAdvancedImageToImageMetric.h
+++ b/Common/CostFunctions/itkAdvancedImageToImageMetric.h
@@ -362,12 +362,6 @@ protected:
    */
   mutable ImageSamplerPointer m_ImageSampler{ nullptr };
 
-  /** Variables for image derivative computation. */
-  LinearInterpolatorPointer         m_LinearInterpolator{ nullptr };
-  BSplineInterpolatorPointer        m_BSplineInterpolator{ nullptr };
-  BSplineInterpolatorFloatPointer   m_BSplineInterpolatorFloat{ nullptr };
-  ReducedBSplineInterpolatorPointer m_ReducedBSplineInterpolator{ nullptr };
-
   /** Variables to store the AdvancedTransform. */
   typename AdvancedTransformType::Pointer m_AdvancedTransform{ nullptr };
   mutable bool                            m_TransformIsBSpline{ false };
@@ -599,7 +593,14 @@ private:
                                                             MovingImageDerivativeType *  gradient,
                                                             const TOptionalThreadId... optionalThreadId) const;
 
+  /** Variables for image derivative computation. */
+  LinearInterpolatorPointer         m_LinearInterpolator{ nullptr };
+  BSplineInterpolatorPointer        m_BSplineInterpolator{ nullptr };
+  BSplineInterpolatorFloatPointer   m_BSplineInterpolatorFloat{ nullptr };
+  ReducedBSplineInterpolatorPointer m_ReducedBSplineInterpolator{ nullptr };
+
   /** Private member variables. */
+
   bool   m_UseImageSampler{ false };
   bool   m_UseFixedImageLimiter{ false };
   bool   m_UseMovingImageLimiter{ false };

--- a/Common/GTesting/itkAdvancedImageToImageMetricGTest.cxx
+++ b/Common/GTesting/itkAdvancedImageToImageMetricGTest.cxx
@@ -54,10 +54,6 @@ public:
 
       // Superclass data members:
       EXPECT_EQ(this->AdvancedImageToImageMetricType::m_ImageSampler, nullptr);
-      EXPECT_EQ(this->AdvancedImageToImageMetricType::m_LinearInterpolator, nullptr);
-      EXPECT_EQ(this->AdvancedImageToImageMetricType::m_BSplineInterpolator, nullptr);
-      EXPECT_EQ(this->AdvancedImageToImageMetricType::m_BSplineInterpolatorFloat, nullptr);
-      EXPECT_EQ(this->AdvancedImageToImageMetricType::m_ReducedBSplineInterpolator, nullptr);
       EXPECT_EQ(this->AdvancedImageToImageMetricType::m_AdvancedTransform, nullptr);
       EXPECT_EQ(this->AdvancedImageToImageMetricType::m_TransformIsBSpline, false);
       EXPECT_EQ(this->AdvancedImageToImageMetricType::m_FixedImageLimiter, nullptr);


### PR DESCRIPTION
Following C++ Core Guidelines, February 15, 2024: "Avoid `protected` data", https://isocpp.github.io/CppCoreGuidelines/CppCoreGuidelines#Rh-protected