### PR TITLE
ENH: Add "ReduceDimension" option to ImageSampler components

### DIFF
--- a/Common/GTesting/itkImageFullSamplerGTest.cxx
+++ b/Common/GTesting/itkImageFullSamplerGTest.cxx
@@ -186,3 +186,41 @@ GTEST_TEST(ImageFullSampler, ExactlyEqualVersusSlightlyDifferentMaskImageDomain)
 
   EXPECT_EQ(samplesOnExactlyEqualImageDomains, samplesOnSlightlyDifferentImageDomains);
 }
+
+
+GTEST_TEST(ImageFullSampler, ReduceDimension)
+{
+  using PixelType = std::uint8_t;
+  static constexpr auto Dimension = 3U;
+  using ImageType = itk::Image<PixelType, Dimension>;
+  using ImageFullSamplerType = itk::ImageFullSampler<ImageType>;
+
+  std::mt19937 randomNumberEngine{};
+  const auto   imageDomain = CreateRandomImageDomain<Dimension>(randomNumberEngine);
+  const auto   image = CreateImageFilledWithSequenceOfNaturalNumbers<PixelType>(imageDomain);
+  elx::DefaultConstruct<ImageFullSamplerType> sampler{};
+
+  sampler.SetInput(image);
+  sampler.SetReduceDimension(true);
+  sampler.Update();
+
+  const auto & output = DerefRawPointer(sampler.GetOutput());
+
+  const auto reducedRegion = [imageDomain] {
+    auto size = imageDomain.size;
+    size.back() = 1;
+    return itk::ImageRegion<Dimension>{ imageDomain.index, size };
+  }();
+
+  const itk::ImageRegionRange imageRegionRange(*image, reducedRegion);
+  const std::size_t           numberOfSamples{ output.size() };
+
+  ASSERT_EQ(numberOfSamples, imageRegionRange.size());
+
+  auto imageRegionIterator = imageRegionRange.cbegin();
+  for (std::size_t i{}; i < numberOfSamples; ++i)
+  {
+    EXPECT_EQ(output[i].m_ImageValue, *imageRegionIterator);
+    ++imageRegionIterator;
+  }
+}

--- a/Common/ImageSamplers/itkImageSamplerBase.h
+++ b/Common/ImageSamplers/itkImageSamplerBase.h
@@ -209,6 +209,12 @@ public:
   /** Allows disabling the use of multi-threading, by `SetUseMultiThread(false)`. */
   itkSetMacro(UseMultiThread, bool);
 
+  /** Tells whether the dimensionality is reduced. */
+  itkGetConstMacro(ReduceDimension, bool);
+
+  /** Allows reducing the dimensionality by 1. */
+  itkSetMacro(ReduceDimension, bool);
+
 protected:
   /** The constructor. */
   ImageSamplerBase();
@@ -264,6 +270,8 @@ private:
 
   InputImageRegionType m_CroppedInputImageRegion{};
   InputImageRegionType m_DummyInputImageRegion{};
+
+  bool m_ReduceDimension{ false };
 };
 
 } // end namespace itk

--- a/Common/ImageSamplers/itkImageSamplerBase.hxx
+++ b/Common/ImageSamplers/itkImageSamplerBase.hxx
@@ -301,6 +301,12 @@ ImageSamplerBase<TInputImage>::CropInputImageRegion()
    * InputImageRegion and the BoundingBoxRegion.
    */
   m_CroppedInputImageRegion = m_InputImageRegion;
+
+  if (m_ReduceDimension)
+  {
+    m_CroppedInputImageRegion.GetModifiableSize().back() = 1;
+  }
+
   if (!m_Mask.IsNull())
   {
     /** Get a handle to the input image. */

--- a/Core/ComponentBaseClasses/elxImageSamplerBase.hxx
+++ b/Core/ComponentBaseClasses/elxImageSamplerBase.hxx
@@ -36,6 +36,7 @@ ImageSamplerBase<TElastix>::BeforeRegistrationBase()
   const Configuration & configuration = Deref(Superclass::GetConfiguration());
   ITKBaseType &         sampler = GetSelf();
   sampler.SetUseMultiThread(configuration.RetrieveParameterValue(true, "UseMultiThreadingForSamplers", 0, false));
+  sampler.SetReduceDimension(configuration.RetrieveParameterValue(false, "ReduceDimension", 0, false));
 }
 
 /**


### PR DESCRIPTION
Allows reducing the dimensionality of any image sampler by a new elastix parameter:

    (ReduceDimension "true")

Aims to implement a generalization to the ReducedFullSampler, pull request #52 proposed by Mathias Polfliet (@MathiasPolfliet) in 2018.