### PR TITLE
COMP: Add missing `#include <cassert>` directives

### DIFF
--- a/Common/CostFunctions/itkParzenWindowHistogramImageToImageMetric.hxx
+++ b/Common/CostFunctions/itkParzenWindowHistogramImageToImageMetric.hxx
@@ -25,6 +25,7 @@
 #include "itkImageLinearIteratorWithIndex.h"
 #include "itkImageScanlineIterator.h"
 #include <vnl/vnl_math.h>
+#include <cassert>
 
 namespace itk
 {

--- a/Common/ImageSamplers/itkImageRandomCoordinateSampler.hxx
+++ b/Common/ImageSamplers/itkImageRandomCoordinateSampler.hxx
@@ -21,6 +21,7 @@
 #include "itkImageRandomCoordinateSampler.h"
 #include "elxDeref.h"
 #include <vnl/vnl_math.h>
+#include <cassert>
 
 namespace itk
 {

--- a/Common/ImageSamplers/itkImageRandomSamplerSparseMask.hxx
+++ b/Common/ImageSamplers/itkImageRandomSamplerSparseMask.hxx
@@ -20,6 +20,7 @@
 
 #include "itkImageRandomSamplerSparseMask.h"
 #include "elxDeref.h"
+#include <cassert>
 
 namespace itk
 {

--- a/Common/Transforms/elxTransformIO.cxx
+++ b/Common/Transforms/elxTransformIO.cxx
@@ -35,6 +35,7 @@
 #include <itkTransformFileReader.h>
 #include <itkTransformFileWriter.h>
 
+#include <cassert>
 #include <string>
 
 

--- a/Common/Transforms/itkAdvancedImageMomentsCalculator.hxx
+++ b/Common/Transforms/itkAdvancedImageMomentsCalculator.hxx
@@ -23,6 +23,7 @@
 #include <vnl/algo/vnl_real_eigensystem.h>
 #include <vnl/algo/vnl_symmetric_eigensystem.h>
 #include "itkImageRegionConstIteratorWithIndex.h"
+#include <cassert>
 
 namespace itk
 {

--- a/Common/Transforms/itkStackTransform.h
+++ b/Common/Transforms/itkStackTransform.h
@@ -21,6 +21,8 @@
 #include "itkAdvancedTransform.h"
 #include "itkIndex.h"
 
+#include <cassert>
+
 namespace itk
 {
 

--- a/Common/itkComputeDisplacementDistribution.hxx
+++ b/Common/itkComputeDisplacementDistribution.hxx
@@ -32,6 +32,8 @@
 #include "itkZeroFluxNeumannPadImageFilter.h"
 #include "itkSmoothingRecursiveGaussianImageFilter.h"
 
+#include <cassert>
+
 namespace itk
 {
 

--- a/Components/Metrics/AdvancedKappaStatistic/itkAdvancedKappaStatisticImageToImageMetric.hxx
+++ b/Components/Metrics/AdvancedKappaStatistic/itkAdvancedKappaStatisticImageToImageMetric.hxx
@@ -21,7 +21,8 @@
 #include "itkAdvancedKappaStatisticImageToImageMetric.h"
 
 #include <algorithm> // For min.
-#include <cmath>     // For abs.
+#include <cassert>
+#include <cmath> // For abs.
 
 namespace itk
 {

--- a/Components/Metrics/AdvancedMattesMutualInformation/itkParzenWindowMutualInformationImageToImageMetric.hxx
+++ b/Components/Metrics/AdvancedMattesMutualInformation/itkParzenWindowMutualInformationImageToImageMetric.hxx
@@ -31,6 +31,8 @@
 #  include <omp.h>
 #endif
 
+#include <cassert>
+
 namespace itk
 {
 /**

--- a/Components/Metrics/AdvancedNormalizedCorrelation/itkAdvancedNormalizedCorrelationImageToImageMetric.hxx
+++ b/Components/Metrics/AdvancedNormalizedCorrelation/itkAdvancedNormalizedCorrelationImageToImageMetric.hxx
@@ -25,6 +25,7 @@
 #endif
 
 #include <algorithm> // For min.
+#include <cassert>
 
 namespace itk
 {

--- a/Components/Metrics/MissingStructurePenalty/vnl_adjugate_fixed.h
+++ b/Components/Metrics/MissingStructurePenalty/vnl_adjugate_fixed.h
@@ -19,6 +19,8 @@
 #include <vnl/vnl_matrix.h>
 #include <vnl/vnl_det.h>
 
+#include <cassert>
+
 //: Calculates adjugate of a small vnl_matrix_fixed (not using svd)
 //  This allows you to write e.g.
 //

--- a/Components/Metrics/PCAMetric/itkPCAMetric_F_multithreaded.hxx
+++ b/Components/Metrics/PCAMetric/itkPCAMetric_F_multithreaded.hxx
@@ -26,6 +26,7 @@
 #include <vnl/algo/vnl_svd.h>
 #include <vnl/vnl_trace.h>
 #include <vnl/algo/vnl_symmetric_eigensystem.h>
+#include <cassert>
 #include <numeric>
 #include <fstream>
 

--- a/Components/Optimizers/AdaptiveStochasticVarianceReducedGradient/itkStochasticVarianceReducedGradientDescentOptimizer.cxx
+++ b/Components/Optimizers/AdaptiveStochasticVarianceReducedGradient/itkStochasticVarianceReducedGradientDescentOptimizer.cxx
@@ -32,6 +32,7 @@
 #endif
 
 #include <algorithm> // For min.
+#include <cassert>
 
 namespace itk
 {

--- a/Components/Optimizers/StandardStochasticGradientDescent/itkStochasticGradientDescentOptimizer.cxx
+++ b/Components/Optimizers/StandardStochasticGradientDescent/itkStochasticGradientDescentOptimizer.cxx
@@ -31,6 +31,7 @@
 #endif
 
 #include <algorithm> // For min.
+#include <cassert>
 
 namespace itk
 {

--- a/Components/Transforms/MultiBSplineTransformWithNormal/itkMultiBSplineDeformableTransformWithNormal.hxx
+++ b/Components/Transforms/MultiBSplineTransformWithNormal/itkMultiBSplineDeformableTransformWithNormal.hxx
@@ -29,6 +29,7 @@
 #include "itkMaskImageFilter.h"
 #include "itkConstantPadImageFilter.h"
 
+#include <cassert>
 #include <numeric> // For iota.
 
 namespace itk

--- a/Components/Transforms/RecursiveBSplineTransform/elxRecursiveBSplineTransform.hxx
+++ b/Components/Transforms/RecursiveBSplineTransform/elxRecursiveBSplineTransform.hxx
@@ -22,6 +22,7 @@
 
 #include "itkImageRegionExclusionConstIteratorWithIndex.h"
 #include <vnl/vnl_math.h>
+#include <cassert>
 #include <regex>
 
 

--- a/Core/ComponentBaseClasses/elxResampleInterpolatorBase.hxx
+++ b/Core/ComponentBaseClasses/elxResampleInterpolatorBase.hxx
@@ -22,6 +22,8 @@
 #include "elxResampleInterpolatorBase.h"
 #include "elxConversion.h"
 
+#include <cassert>
+
 namespace elastix
 {
 

--- a/Core/ComponentBaseClasses/elxResamplerBase.hxx
+++ b/Core/ComponentBaseClasses/elxResamplerBase.hxx
@@ -27,6 +27,8 @@
 #include "itkAdvancedRayCastInterpolateImageFunction.h"
 #include "itkTimeProbe.h"
 
+#include <cassert>
+
 namespace elastix
 {
 

--- a/Core/Main/itkElastixRegistrationMethod.hxx
+++ b/Core/Main/itkElastixRegistrationMethod.hxx
@@ -43,7 +43,8 @@
 #include "elxTransformIO.h"
 
 #include <algorithm> // For find.
-#include <memory>    // For unique_ptr.
+#include <cassert>
+#include <memory> // For unique_ptr.
 
 namespace itk
 {

--- a/Core/Main/itkTransformixFilter.hxx
+++ b/Core/Main/itkTransformixFilter.hxx
@@ -45,6 +45,7 @@
 
 #include <itkCompositeTransform.h>
 
+#include <cassert>
 #include <memory> // For unique_ptr.
 
 namespace itk

--- a/Core/Main/transformix.cxx
+++ b/Core/Main/transformix.cxx
@@ -28,6 +28,7 @@
 #include <itkTimeProbe.h>
 
 // Standard C++ header files:
+#include <cassert>
 #include <iostream>
 
 

--- a/Testing/itkAccumulateDerivativesParallellizationTest.cxx
+++ b/Testing/itkAccumulateDerivativesParallellizationTest.cxx
@@ -35,6 +35,8 @@
 #  include <omp.h>
 #endif
 
+#include <cassert>
+
 // select double or float internal type of array
 #if 0
 typedef float InternalScalarType;

--- a/Testing/itkAdvanceOneStepParallellizationTest.cxx
+++ b/Testing/itkAdvanceOneStepParallellizationTest.cxx
@@ -40,6 +40,8 @@
 #  include <Eigen/Core>
 #endif
 
+#include <cassert>
+
 // select double or float internal type of array
 #if 0
 typedef float InternalScalarType;


### PR DESCRIPTION
Aims to prevent errors like:

> Components/Optimizers/StandardStochasticGradientDescent/itkStochasticGradientDescentOptimizer.cxx:309:3: error: 'assert' was not declared in this scope

At https://my.cdash.org/viewBuildError.php?buildid=2537950 (Build Name: SuperElastix/elastix-ubuntu-22.04-WIP-back-to-ITK-v530-9a39f9931e9207e164c410a92c71e09f76002ee4)