### PR TITLE
Remove `this->` from data access AdvancedImageToImageMetric, replace `this->` with `Superclass::` on data access by derived classes

### DIFF
--- a/Common/CostFunctions/itkAdvancedImageToImageMetric.h
+++ b/Common/CostFunctions/itkAdvancedImageToImageMetric.h
@@ -209,9 +209,9 @@ public:
   SetTransform(AdvancedTransformType * arg)
   {
     this->Superclass::SetTransform(arg);
-    if (this->m_AdvancedTransform != arg)
+    if (m_AdvancedTransform != arg)
     {
-      this->m_AdvancedTransform = arg;
+      m_AdvancedTransform = arg;
       this->Modified();
     }
   }
@@ -221,7 +221,7 @@ public:
   const AdvancedTransformType *
   GetTransform() const override
   {
-    return this->m_AdvancedTransform.GetPointer();
+    return m_AdvancedTransform.GetPointer();
   }
 
 
@@ -230,7 +230,7 @@ public:
   ImageSamplerType *
   GetImageSampler() const
   {
-    return this->m_ImageSampler.GetPointer();
+    return m_ImageSampler.GetPointer();
   }
 
 

--- a/Common/CostFunctions/itkAdvancedImageToImageMetric.h
+++ b/Common/CostFunctions/itkAdvancedImageToImageMetric.h
@@ -364,7 +364,9 @@ protected:
 
   /** Variables to store the AdvancedTransform. */
   typename AdvancedTransformType::Pointer m_AdvancedTransform{ nullptr };
-  mutable bool                            m_TransformIsBSpline{ false };
+
+  /** Member variable for TransformPenaltyTerm::CheckForBSplineTransform2 */
+  mutable bool m_TransformIsBSpline{ false };
 
   /** Variables for the Limiters. */
   FixedImagePixelType          m_FixedImageTrueMin{ 0 };

--- a/Common/CostFunctions/itkAdvancedImageToImageMetric.h
+++ b/Common/CostFunctions/itkAdvancedImageToImageMetric.h
@@ -367,8 +367,6 @@ protected:
   mutable bool                            m_TransformIsBSpline{ false };
 
   /** Variables for the Limiters. */
-  FixedImageLimiterPointer     m_FixedImageLimiter{ nullptr };
-  MovingImageLimiterPointer    m_MovingImageLimiter{ nullptr };
   FixedImagePixelType          m_FixedImageTrueMin{ 0 };
   FixedImagePixelType          m_FixedImageTrueMax{ 1 };
   MovingImagePixelType         m_MovingImageTrueMin{ 0 };
@@ -593,14 +591,15 @@ private:
                                                             MovingImageDerivativeType *  gradient,
                                                             const TOptionalThreadId... optionalThreadId) const;
 
-  /** Variables for image derivative computation. */
+  /** Private member variables for limiters and for image derivative computation. */
+  FixedImageLimiterPointer          m_FixedImageLimiter{ nullptr };
+  MovingImageLimiterPointer         m_MovingImageLimiter{ nullptr };
   LinearInterpolatorPointer         m_LinearInterpolator{ nullptr };
   BSplineInterpolatorPointer        m_BSplineInterpolator{ nullptr };
   BSplineInterpolatorFloatPointer   m_BSplineInterpolatorFloat{ nullptr };
   ReducedBSplineInterpolatorPointer m_ReducedBSplineInterpolator{ nullptr };
 
-  /** Private member variables. */
-
+  /** Other private member variables. */
   bool   m_UseImageSampler{ false };
   bool   m_UseFixedImageLimiter{ false };
   bool   m_UseMovingImageLimiter{ false };

--- a/Common/CostFunctions/itkMultiInputImageToImageMetricBase.hxx
+++ b/Common/CostFunctions/itkMultiInputImageToImageMetricBase.hxx
@@ -231,7 +231,7 @@ MultiInputImageToImageMetricBase<TFixedImage, TMovingImage>::InitializeImageSamp
   if (this->GetUseImageSampler())
   {
     /** Check if the ImageSampler is set. */
-    if (!this->m_ImageSampler)
+    if (!Superclass::m_ImageSampler)
     {
       itkExceptionMacro("ImageSampler is not present");
     }
@@ -239,19 +239,19 @@ MultiInputImageToImageMetricBase<TFixedImage, TMovingImage>::InitializeImageSamp
     /** Initialize the Image Sampler: set the fixed images. */
     for (unsigned int i = 0; i < this->GetNumberOfFixedImages(); ++i)
     {
-      this->m_ImageSampler->SetInput(i, this->m_FixedImageVector[i]);
+      Superclass::m_ImageSampler->SetInput(i, this->m_FixedImageVector[i]);
     }
 
     /** Initialize the Image Sampler: set the fixed image masks. */
     for (unsigned int i = 0; i < this->GetNumberOfFixedImageMasks(); ++i)
     {
-      this->m_ImageSampler->SetMask(this->m_FixedImageMaskVector[i], i);
+      Superclass::m_ImageSampler->SetMask(this->m_FixedImageMaskVector[i], i);
     }
 
     /** Initialize the Image Sampler: set the fixed image regions. */
     for (unsigned int i = 0; i < this->GetNumberOfFixedImages(); ++i)
     {
-      this->m_ImageSampler->SetInputImageRegion(this->m_FixedImageRegionVector[i], i);
+      Superclass::m_ImageSampler->SetInputImageRegion(this->m_FixedImageRegionVector[i], i);
     }
   }
 

--- a/Common/CostFunctions/itkParzenWindowHistogramImageToImageMetric.hxx
+++ b/Common/CostFunctions/itkParzenWindowHistogramImageToImageMetric.hxx
@@ -143,9 +143,11 @@ ParzenWindowHistogramImageToImageMetric<TFixedImage, TMovingImage>::InitializeHi
 
   /** The ratio times the expected bin size will be added twice to the image range. */
   const double smallNumberRatio = 0.001;
-  const double smallNumberFixed = smallNumberRatio * (this->m_FixedImageMaxLimit - this->m_FixedImageMinLimit) /
+  const double smallNumberFixed = smallNumberRatio *
+                                  (Superclass::m_FixedImageMaxLimit - Superclass::m_FixedImageMinLimit) /
                                   static_cast<double>(this->m_NumberOfFixedHistogramBins - 2 * fixedPadding - 1);
-  const double smallNumberMoving = smallNumberRatio * (this->m_MovingImageMaxLimit - this->m_MovingImageMinLimit) /
+  const double smallNumberMoving = smallNumberRatio *
+                                   (Superclass::m_MovingImageMaxLimit - Superclass::m_MovingImageMinLimit) /
                                    static_cast<double>(this->m_NumberOfFixedHistogramBins - 2 * movingPadding - 1);
 
   /** Compute binsizes. */
@@ -153,21 +155,24 @@ ParzenWindowHistogramImageToImageMetric<TFixedImage, TMovingImage>::InitializeHi
     static_cast<OffsetValueType>(this->m_NumberOfFixedHistogramBins) // requires cast to signed type!
     - 2.0 * fixedPadding - 1.0);
   this->m_FixedImageBinSize =
-    (this->m_FixedImageMaxLimit - this->m_FixedImageMinLimit + 2.0 * smallNumberFixed) / fixedHistogramWidth;
+    (Superclass::m_FixedImageMaxLimit - Superclass::m_FixedImageMinLimit + 2.0 * smallNumberFixed) /
+    fixedHistogramWidth;
   this->m_FixedImageBinSize = std::max(this->m_FixedImageBinSize, 1e-10);
   this->m_FixedImageBinSize = std::min(this->m_FixedImageBinSize, 1e+10);
-  this->m_FixedImageNormalizedMin =
-    (this->m_FixedImageMinLimit - smallNumberFixed) / this->m_FixedImageBinSize - static_cast<double>(fixedPadding);
+  this->m_FixedImageNormalizedMin = (Superclass::m_FixedImageMinLimit - smallNumberFixed) / this->m_FixedImageBinSize -
+                                    static_cast<double>(fixedPadding);
 
   const double movingHistogramWidth = static_cast<double>(
     static_cast<OffsetValueType>(this->m_NumberOfMovingHistogramBins) // requires cast to signed type!
     - 2.0 * movingPadding - 1.0);
   this->m_MovingImageBinSize =
-    (this->m_MovingImageMaxLimit - this->m_MovingImageMinLimit + 2.0 * smallNumberMoving) / movingHistogramWidth;
+    (Superclass::m_MovingImageMaxLimit - Superclass::m_MovingImageMinLimit + 2.0 * smallNumberMoving) /
+    movingHistogramWidth;
   this->m_MovingImageBinSize = std::max(this->m_MovingImageBinSize, 1e-10);
   this->m_MovingImageBinSize = std::min(this->m_MovingImageBinSize, 1e+10);
   this->m_MovingImageNormalizedMin =
-    (this->m_MovingImageMinLimit - smallNumberMoving) / this->m_MovingImageBinSize - static_cast<double>(movingPadding);
+    (Superclass::m_MovingImageMinLimit - smallNumberMoving) / this->m_MovingImageBinSize -
+    static_cast<double>(movingPadding);
 
   /** Allocate memory for the marginal PDF. */
   this->m_FixedImageMarginalPDF.SetSize(this->m_NumberOfFixedHistogramBins);

--- a/Common/CostFunctions/itkParzenWindowHistogramImageToImageMetric.hxx
+++ b/Common/CostFunctions/itkParzenWindowHistogramImageToImageMetric.hxx
@@ -1045,7 +1045,7 @@ void
 ParzenWindowHistogramImageToImageMetric<TFixedImage, TMovingImage>::ComputePDFs(const ParametersType & parameters) const
 {
   /** Option for now to still use the single threaded code. */
-  if (!this->m_UseMultiThread)
+  if (!Superclass::m_UseMultiThread)
   {
     return this->ComputePDFsSingleThreaded(parameters);
   }

--- a/Common/CostFunctions/itkTransformPenaltyTerm.hxx
+++ b/Common/CostFunctions/itkTransformPenaltyTerm.hxx
@@ -40,9 +40,9 @@ TransformPenaltyTerm<TFixedImage, TScalarType>::CheckForBSplineTransform2(BSplin
 
   /** We will return the B-spline by reference, but only in case it is a third order B-spline. */
   BSplineOrder3TransformType * testPtr1 =
-    dynamic_cast<BSplineOrder3TransformType *>(this->m_AdvancedTransform.GetPointer());
+    dynamic_cast<BSplineOrder3TransformType *>(Superclass::m_AdvancedTransform.GetPointer());
   CombinationTransformType * testPtr2a =
-    dynamic_cast<CombinationTransformType *>(this->m_AdvancedTransform.GetPointer());
+    dynamic_cast<CombinationTransformType *>(Superclass::m_AdvancedTransform.GetPointer());
 
   if (testPtr1)
   {

--- a/Common/CostFunctions/itkTransformPenaltyTerm.hxx
+++ b/Common/CostFunctions/itkTransformPenaltyTerm.hxx
@@ -35,7 +35,7 @@ TransformPenaltyTerm<TFixedImage, TScalarType>::CheckForBSplineTransform2(BSplin
   this->CheckForBSplineTransform();
 
   /** Quit if the advanced transform is not a B-spline. */
-  if (!this->m_TransformIsBSpline)
+  if (!Superclass::m_TransformIsBSpline)
     return false;
 
   /** We will return the B-spline by reference, but only in case it is a third order B-spline. */
@@ -61,7 +61,7 @@ TransformPenaltyTerm<TFixedImage, TScalarType>::CheckForBSplineTransform2(BSplin
     }
   }
 
-  return this->m_TransformIsBSpline;
+  return true;
 
 } // end CheckForBSplineTransform()
 

--- a/Common/GTesting/itkAdvancedImageToImageMetricGTest.cxx
+++ b/Common/GTesting/itkAdvancedImageToImageMetricGTest.cxx
@@ -56,8 +56,6 @@ public:
       EXPECT_EQ(this->AdvancedImageToImageMetricType::m_ImageSampler, nullptr);
       EXPECT_EQ(this->AdvancedImageToImageMetricType::m_AdvancedTransform, nullptr);
       EXPECT_EQ(this->AdvancedImageToImageMetricType::m_TransformIsBSpline, false);
-      EXPECT_EQ(this->AdvancedImageToImageMetricType::m_FixedImageLimiter, nullptr);
-      EXPECT_EQ(this->AdvancedImageToImageMetricType::m_MovingImageLimiter, nullptr);
       EXPECT_EQ(this->AdvancedImageToImageMetricType::m_FixedImageTrueMin, 0);
       EXPECT_EQ(this->AdvancedImageToImageMetricType::m_FixedImageTrueMax, 1);
       EXPECT_EQ(this->AdvancedImageToImageMetricType::m_MovingImageTrueMin, 0);

--- a/Components/Metrics/AdvancedKappaStatistic/itkAdvancedKappaStatisticImageToImageMetric.hxx
+++ b/Components/Metrics/AdvancedKappaStatistic/itkAdvancedKappaStatisticImageToImageMetric.hxx
@@ -264,7 +264,7 @@ AdvancedKappaStatisticImageToImageMetric<TFixedImage, TMovingImage>::GetValueAnd
   derivative = DerivativeType(this->GetNumberOfParameters());
 
   /** Array that stores dM(x)/dmu, and the sparse jacobian+indices. */
-  NonZeroJacobianIndicesType nzji(this->m_AdvancedTransform->GetNumberOfNonZeroJacobianIndices());
+  NonZeroJacobianIndicesType nzji(Superclass::m_AdvancedTransform->GetNumberOfNonZeroJacobianIndices());
   DerivativeType             imageJacobian(nzji.size());
   TransformJacobianType      jacobian;
 
@@ -438,7 +438,7 @@ AdvancedKappaStatisticImageToImageMetric<TFixedImage, TMovingImage>::ThreadedGet
   ThreadIdType threadId) const
 {
   /** Initialize array that stores dM(x)/dmu, and the sparse Jacobian + indices. */
-  const NumberOfParametersType nnzji = this->m_AdvancedTransform->GetNumberOfNonZeroJacobianIndices();
+  const NumberOfParametersType nnzji = Superclass::m_AdvancedTransform->GetNumberOfNonZeroJacobianIndices();
   NonZeroJacobianIndicesType   nzji(nnzji);
   DerivativeType               imageJacobian(nzji.size());
 
@@ -512,7 +512,7 @@ AdvancedKappaStatisticImageToImageMetric<TFixedImage, TMovingImage>::ThreadedGet
         jacobian, movingImageDerivative, imageJacobian );
 #else
       /** Compute the inner product of the transform Jacobian dT/dmu and the moving image gradient dM/dx. */
-      this->m_AdvancedTransform->EvaluateJacobianWithImageGradientProduct(
+      Superclass::m_AdvancedTransform->EvaluateJacobianWithImageGradientProduct(
         fixedPoint, movingImageDerivative, imageJacobian, nzji);
 #endif
 

--- a/Components/Metrics/AdvancedKappaStatistic/itkAdvancedKappaStatisticImageToImageMetric.hxx
+++ b/Components/Metrics/AdvancedKappaStatistic/itkAdvancedKappaStatisticImageToImageMetric.hxx
@@ -399,7 +399,7 @@ AdvancedKappaStatisticImageToImageMetric<TFixedImage, TMovingImage>::GetValueAnd
   DerivativeType &                derivative) const
 {
   /** Option for now to still use the single threaded code. */
-  if (!this->m_UseMultiThread)
+  if (!Superclass::m_UseMultiThread)
   {
     return this->GetValueAndDerivativeSingleThreaded(parameters, value, derivative);
   }
@@ -599,7 +599,7 @@ AdvancedKappaStatisticImageToImageMetric<TFixedImage, TMovingImage>::AfterThread
   const MeasureType tmp2 = 2.0 * intersection / areaSumSquare;
 
   /** Accumulate intermediate values and calculate derivative. */
-  if (!this->m_UseMultiThread) // single-threaded
+  if (!Superclass::m_UseMultiThread) // single-threaded
   {
     DerivativeType vecSum1 = this->m_KappaGetValueAndDerivativePerThreadVariables[0].st_DerivativeSum1;
     DerivativeType vecSum2 = this->m_KappaGetValueAndDerivativePerThreadVariables[0].st_DerivativeSum2;

--- a/Components/Metrics/AdvancedMattesMutualInformation/itkParzenWindowMutualInformationImageToImageMetric.hxx
+++ b/Components/Metrics/AdvancedMattesMutualInformation/itkParzenWindowMutualInformationImageToImageMetric.hxx
@@ -589,11 +589,12 @@ ParzenWindowMutualInformationImageToImageMetric<TFixedImage, TMovingImage>::Afte
   // compute multi-threadedly with itk threads
   else
   {
-    this->m_ThreaderMetricParameters.st_DerivativePointer = derivative.begin();
-    this->m_ThreaderMetricParameters.st_NormalizationFactor = 1.0;
+    Superclass::m_ThreaderMetricParameters.st_DerivativePointer = derivative.begin();
+    Superclass::m_ThreaderMetricParameters.st_NormalizationFactor = 1.0;
 
-    this->m_Threader->SetSingleMethod(this->AccumulateDerivativesThreaderCallback,
-                                      const_cast<void *>(static_cast<const void *>(&this->m_ThreaderMetricParameters)));
+    this->m_Threader->SetSingleMethod(
+      this->AccumulateDerivativesThreaderCallback,
+      const_cast<void *>(static_cast<const void *>(&(Superclass::m_ThreaderMetricParameters))));
     this->m_Threader->SingleMethodExecute();
   }
 

--- a/Components/Metrics/AdvancedMattesMutualInformation/itkParzenWindowMutualInformationImageToImageMetric.hxx
+++ b/Components/Metrics/AdvancedMattesMutualInformation/itkParzenWindowMutualInformationImageToImageMetric.hxx
@@ -395,7 +395,7 @@ ParzenWindowMutualInformationImageToImageMetric<TFixedImage, TMovingImage>::Comp
   DerivativeType & derivative) const
 {
   /** Option for now to still use the single threaded code. */
-  if (!this->m_UseMultiThread)
+  if (!Superclass::m_UseMultiThread)
   {
     return this->ComputeDerivativeLowMemorySingleThreaded(derivative);
   }
@@ -560,7 +560,7 @@ ParzenWindowMutualInformationImageToImageMetric<TFixedImage, TMovingImage>::Afte
 
   /** Accumulate derivatives. */
   // compute single-threadedly
-  if (!this->m_UseMultiThread && false) // force multi-threaded
+  if (!Superclass::m_UseMultiThread && false) // force multi-threaded
   {
     derivative = this->m_GetValueAndDerivativePerThreadVariables[0].st_Derivative;
     for (ThreadIdType i = 1; i < numberOfThreads; ++i)

--- a/Components/Metrics/AdvancedMattesMutualInformation/itkParzenWindowMutualInformationImageToImageMetric.hxx
+++ b/Components/Metrics/AdvancedMattesMutualInformation/itkParzenWindowMutualInformationImageToImageMetric.hxx
@@ -428,7 +428,7 @@ ParzenWindowMutualInformationImageToImageMetric<TFixedImage, TMovingImage>::Thre
    * InitializeThreadingParameters(), and at the end of each iteration in
    * AfterThreadedGetValueAndDerivative() and the accumulate functions.
    */
-  DerivativeType & derivative = this->m_GetValueAndDerivativePerThreadVariables[threadId].st_Derivative;
+  DerivativeType & derivative = Superclass::m_GetValueAndDerivativePerThreadVariables[threadId].st_Derivative;
 
   /** Declare and allocate arrays for Jacobian preconditioning. */
   DerivativeType jacobianPreconditioner, preconditioningDivisor;
@@ -562,10 +562,10 @@ ParzenWindowMutualInformationImageToImageMetric<TFixedImage, TMovingImage>::Afte
   // compute single-threadedly
   if (!Superclass::m_UseMultiThread && false) // force multi-threaded
   {
-    derivative = this->m_GetValueAndDerivativePerThreadVariables[0].st_Derivative;
+    derivative = Superclass::m_GetValueAndDerivativePerThreadVariables[0].st_Derivative;
     for (ThreadIdType i = 1; i < numberOfThreads; ++i)
     {
-      derivative += this->m_GetValueAndDerivativePerThreadVariables[i].st_Derivative;
+      derivative += Superclass::m_GetValueAndDerivativePerThreadVariables[i].st_Derivative;
     }
   }
 #ifdef ELASTIX_USE_OPENMP
@@ -577,10 +577,10 @@ ParzenWindowMutualInformationImageToImageMetric<TFixedImage, TMovingImage>::Afte
 #  pragma omp parallel for
     for (int j = 0; j < spaceDimension; ++j)
     {
-      DerivativeValueType sum = this->m_GetValueAndDerivativePerThreadVariables[0].st_Derivative[j];
+      DerivativeValueType sum = Superclass::m_GetValueAndDerivativePerThreadVariables[0].st_Derivative[j];
       for (ThreadIdType i = 1; i < numberOfThreads; ++i)
       {
-        sum += this->m_GetValueAndDerivativePerThreadVariables[i].st_Derivative[j];
+        sum += Superclass::m_GetValueAndDerivativePerThreadVariables[i].st_Derivative[j];
       }
       derivative[j] = sum;
     }

--- a/Components/Metrics/AdvancedMattesMutualInformation/itkParzenWindowMutualInformationImageToImageMetric.hxx
+++ b/Components/Metrics/AdvancedMattesMutualInformation/itkParzenWindowMutualInformationImageToImageMetric.hxx
@@ -570,7 +570,7 @@ ParzenWindowMutualInformationImageToImageMetric<TFixedImage, TMovingImage>::Afte
   }
 #ifdef ELASTIX_USE_OPENMP
   // compute multi-threadedly with openmp
-  else if (false) // this->m_UseOpenMP )
+  else if (false) // Superclass::m_UseOpenMP )
   {
     const int spaceDimension = static_cast<int>(this->GetNumberOfParameters());
 

--- a/Components/Metrics/AdvancedMeanSquares/itkAdvancedMeanSquaresImageToImageMetric.hxx
+++ b/Components/Metrics/AdvancedMeanSquares/itkAdvancedMeanSquaresImageToImageMetric.hxx
@@ -677,7 +677,7 @@ AdvancedMeanSquaresImageToImageMetric<TFixedImage, TMovingImage>::AfterThreadedG
     }
   }
   // compute multi-threadedly with itk threads
-  else if (true) // force ITK threads !this->m_UseOpenMP )
+  else if (true) // force ITK threads !Superclass::m_UseOpenMP )
   {
     this->m_ThreaderMetricParameters.st_DerivativePointer = derivative.begin();
     this->m_ThreaderMetricParameters.st_NormalizationFactor = 1.0 / normal_sum;

--- a/Components/Metrics/AdvancedMeanSquares/itkAdvancedMeanSquaresImageToImageMetric.hxx
+++ b/Components/Metrics/AdvancedMeanSquares/itkAdvancedMeanSquaresImageToImageMetric.hxx
@@ -313,8 +313,8 @@ AdvancedMeanSquaresImageToImageMetric<TFixedImage, TMovingImage>::ThreadedGetVal
   } // end for loop over the image sample container
 
   /** Only update these variables at the end to prevent unnecessary "false sharing". */
-  this->m_GetValueAndDerivativePerThreadVariables[threadId].st_NumberOfPixelsCounted = numberOfPixelsCounted;
-  this->m_GetValueAndDerivativePerThreadVariables[threadId].st_Value = measure;
+  Superclass::m_GetValueAndDerivativePerThreadVariables[threadId].st_NumberOfPixelsCounted = numberOfPixelsCounted;
+  Superclass::m_GetValueAndDerivativePerThreadVariables[threadId].st_Value = measure;
 
 } // end ThreadedGetValue()
 
@@ -330,10 +330,12 @@ AdvancedMeanSquaresImageToImageMetric<TFixedImage, TMovingImage>::AfterThreadedG
   const ThreadIdType numberOfThreads = Self::GetNumberOfWorkUnits();
 
   /** Accumulate the number of pixels. */
-  Superclass::m_NumberOfPixelsCounted = this->m_GetValueAndDerivativePerThreadVariables[0].st_NumberOfPixelsCounted;
+  Superclass::m_NumberOfPixelsCounted =
+    Superclass::m_GetValueAndDerivativePerThreadVariables[0].st_NumberOfPixelsCounted;
   for (ThreadIdType i = 1; i < numberOfThreads; ++i)
   {
-    Superclass::m_NumberOfPixelsCounted += this->m_GetValueAndDerivativePerThreadVariables[i].st_NumberOfPixelsCounted;
+    Superclass::m_NumberOfPixelsCounted +=
+      Superclass::m_GetValueAndDerivativePerThreadVariables[i].st_NumberOfPixelsCounted;
   }
 
   /** Check if enough samples were valid. */
@@ -348,10 +350,10 @@ AdvancedMeanSquaresImageToImageMetric<TFixedImage, TMovingImage>::AfterThreadedG
   value = MeasureType{};
   for (ThreadIdType i = 0; i < numberOfThreads; ++i)
   {
-    value += this->m_GetValueAndDerivativePerThreadVariables[i].st_Value;
+    value += Superclass::m_GetValueAndDerivativePerThreadVariables[i].st_Value;
 
     /** Reset this variable for the next iteration. */
-    this->m_GetValueAndDerivativePerThreadVariables[i].st_Value = MeasureType{};
+    Superclass::m_GetValueAndDerivativePerThreadVariables[i].st_Value = MeasureType{};
   }
   value *= normal_sum;
 
@@ -549,7 +551,7 @@ AdvancedMeanSquaresImageToImageMetric<TFixedImage, TMovingImage>::ThreadedGetVal
    * InitializeThreadingParameters(), and at the end of each iteration in
    * AfterThreadedGetValueAndDerivative() and the accumulate functions.
    */
-  DerivativeType & derivative = this->m_GetValueAndDerivativePerThreadVariables[threadId].st_Derivative;
+  DerivativeType & derivative = Superclass::m_GetValueAndDerivativePerThreadVariables[threadId].st_Derivative;
 
   /** Get a handle to the sample container. */
   ImageSampleContainerPointer sampleContainer = this->GetImageSampler()->GetOutput();
@@ -622,8 +624,8 @@ AdvancedMeanSquaresImageToImageMetric<TFixedImage, TMovingImage>::ThreadedGetVal
   } // end for loop over the image sample container
 
   /** Only update these variables at the end to prevent unnecessary "false sharing". */
-  this->m_GetValueAndDerivativePerThreadVariables[threadId].st_NumberOfPixelsCounted = numberOfPixelsCounted;
-  this->m_GetValueAndDerivativePerThreadVariables[threadId].st_Value = measure;
+  Superclass::m_GetValueAndDerivativePerThreadVariables[threadId].st_NumberOfPixelsCounted = numberOfPixelsCounted;
+  Superclass::m_GetValueAndDerivativePerThreadVariables[threadId].st_Value = measure;
 
 } // end ThreadedGetValueAndDerivative()
 
@@ -641,10 +643,12 @@ AdvancedMeanSquaresImageToImageMetric<TFixedImage, TMovingImage>::AfterThreadedG
   const ThreadIdType numberOfThreads = Self::GetNumberOfWorkUnits();
 
   /** Accumulate the number of pixels. */
-  Superclass::m_NumberOfPixelsCounted = this->m_GetValueAndDerivativePerThreadVariables[0].st_NumberOfPixelsCounted;
+  Superclass::m_NumberOfPixelsCounted =
+    Superclass::m_GetValueAndDerivativePerThreadVariables[0].st_NumberOfPixelsCounted;
   for (ThreadIdType i = 1; i < numberOfThreads; ++i)
   {
-    Superclass::m_NumberOfPixelsCounted += this->m_GetValueAndDerivativePerThreadVariables[i].st_NumberOfPixelsCounted;
+    Superclass::m_NumberOfPixelsCounted +=
+      Superclass::m_GetValueAndDerivativePerThreadVariables[i].st_NumberOfPixelsCounted;
   }
 
   /** Check if enough samples were valid. */
@@ -659,10 +663,10 @@ AdvancedMeanSquaresImageToImageMetric<TFixedImage, TMovingImage>::AfterThreadedG
   value = MeasureType{};
   for (ThreadIdType i = 0; i < numberOfThreads; ++i)
   {
-    value += this->m_GetValueAndDerivativePerThreadVariables[i].st_Value;
+    value += Superclass::m_GetValueAndDerivativePerThreadVariables[i].st_Value;
 
     /** Reset this variable for the next iteration. */
-    this->m_GetValueAndDerivativePerThreadVariables[i].st_Value = MeasureType{};
+    Superclass::m_GetValueAndDerivativePerThreadVariables[i].st_Value = MeasureType{};
   }
   value *= normal_sum;
 
@@ -670,10 +674,10 @@ AdvancedMeanSquaresImageToImageMetric<TFixedImage, TMovingImage>::AfterThreadedG
   // compute single-threadedly
   if (!Superclass::m_UseMultiThread && false) // force multi-threaded
   {
-    derivative = this->m_GetValueAndDerivativePerThreadVariables[0].st_Derivative * normal_sum;
+    derivative = Superclass::m_GetValueAndDerivativePerThreadVariables[0].st_Derivative * normal_sum;
     for (ThreadIdType i = 1; i < numberOfThreads; ++i)
     {
-      derivative += this->m_GetValueAndDerivativePerThreadVariables[i].st_Derivative * normal_sum;
+      derivative += Superclass::m_GetValueAndDerivativePerThreadVariables[i].st_Derivative * normal_sum;
     }
   }
   // compute multi-threadedly with itk threads
@@ -699,7 +703,7 @@ AdvancedMeanSquaresImageToImageMetric<TFixedImage, TMovingImage>::AfterThreadedG
       DerivativeValueType sum{};
       for (ThreadIdType i = 0; i < numberOfThreads; ++i)
       {
-        sum += this->m_GetValueAndDerivativePerThreadVariables[i].st_Derivative[j];
+        sum += Superclass::m_GetValueAndDerivativePerThreadVariables[i].st_Derivative[j];
       }
       derivative[j] = sum * normal_sum;
     }

--- a/Components/Metrics/AdvancedMeanSquares/itkAdvancedMeanSquaresImageToImageMetric.hxx
+++ b/Components/Metrics/AdvancedMeanSquares/itkAdvancedMeanSquaresImageToImageMetric.hxx
@@ -64,10 +64,10 @@ AdvancedMeanSquaresImageToImageMetric<TFixedImage, TMovingImage>::Initialize()
 
     Superclass::m_FixedImageMinLimit = static_cast<FixedImageLimiterOutputType>(
       Superclass::m_FixedImageTrueMin -
-      this->m_FixedLimitRangeRatio * (Superclass::m_FixedImageTrueMax - Superclass::m_FixedImageTrueMin));
+      Superclass::m_FixedLimitRangeRatio * (Superclass::m_FixedImageTrueMax - Superclass::m_FixedImageTrueMin));
     Superclass::m_FixedImageMaxLimit = static_cast<FixedImageLimiterOutputType>(
       Superclass::m_FixedImageTrueMax +
-      this->m_FixedLimitRangeRatio * (Superclass::m_FixedImageTrueMax - Superclass::m_FixedImageTrueMin));
+      Superclass::m_FixedLimitRangeRatio * (Superclass::m_FixedImageTrueMax - Superclass::m_FixedImageTrueMin));
 
     const auto computeMovingImageExtrema = ComputeImageExtremaFilter<MovingImageType>::New();
     computeMovingImageExtrema->SetInput(this->GetMovingImage());
@@ -79,10 +79,10 @@ AdvancedMeanSquaresImageToImageMetric<TFixedImage, TMovingImage>::Initialize()
 
     Superclass::m_MovingImageMinLimit = static_cast<MovingImageLimiterOutputType>(
       Superclass::m_MovingImageTrueMin -
-      this->m_MovingLimitRangeRatio * (Superclass::m_MovingImageTrueMax - Superclass::m_MovingImageTrueMin));
+      Superclass::m_MovingLimitRangeRatio * (Superclass::m_MovingImageTrueMax - Superclass::m_MovingImageTrueMin));
     Superclass::m_MovingImageMaxLimit = static_cast<MovingImageLimiterOutputType>(
       Superclass::m_MovingImageTrueMax +
-      this->m_MovingLimitRangeRatio * (Superclass::m_MovingImageTrueMax - Superclass::m_MovingImageTrueMin));
+      Superclass::m_MovingLimitRangeRatio * (Superclass::m_MovingImageTrueMax - Superclass::m_MovingImageTrueMin));
 
     // TODO: we may actually reuse these values from AdvancedImageToImageMetric::InitializeLimiters
     // without recomputing them here.

--- a/Components/Metrics/AdvancedMeanSquares/itkAdvancedMeanSquaresImageToImageMetric.hxx
+++ b/Components/Metrics/AdvancedMeanSquares/itkAdvancedMeanSquaresImageToImageMetric.hxx
@@ -679,11 +679,12 @@ AdvancedMeanSquaresImageToImageMetric<TFixedImage, TMovingImage>::AfterThreadedG
   // compute multi-threadedly with itk threads
   else if (true) // force ITK threads !Superclass::m_UseOpenMP )
   {
-    this->m_ThreaderMetricParameters.st_DerivativePointer = derivative.begin();
-    this->m_ThreaderMetricParameters.st_NormalizationFactor = 1.0 / normal_sum;
+    Superclass::m_ThreaderMetricParameters.st_DerivativePointer = derivative.begin();
+    Superclass::m_ThreaderMetricParameters.st_NormalizationFactor = 1.0 / normal_sum;
 
-    this->m_Threader->SetSingleMethod(this->AccumulateDerivativesThreaderCallback,
-                                      const_cast<void *>(static_cast<const void *>(&this->m_ThreaderMetricParameters)));
+    this->m_Threader->SetSingleMethod(
+      this->AccumulateDerivativesThreaderCallback,
+      const_cast<void *>(static_cast<const void *>(&(Superclass::m_ThreaderMetricParameters))));
     this->m_Threader->SingleMethodExecute();
   }
 #ifdef ELASTIX_USE_OPENMP

--- a/Components/Metrics/AdvancedMeanSquares/itkAdvancedMeanSquaresImageToImageMetric.hxx
+++ b/Components/Metrics/AdvancedMeanSquares/itkAdvancedMeanSquaresImageToImageMetric.hxx
@@ -59,35 +59,35 @@ AdvancedMeanSquaresImageToImageMetric<TFixedImage, TMovingImage>::Initialize()
     computeFixedImageExtrema->SetImageSpatialMask(this->GetFixedImageMask());
     computeFixedImageExtrema->Update();
 
-    this->m_FixedImageTrueMax = computeFixedImageExtrema->GetMaximum();
-    this->m_FixedImageTrueMin = computeFixedImageExtrema->GetMinimum();
+    Superclass::m_FixedImageTrueMax = computeFixedImageExtrema->GetMaximum();
+    Superclass::m_FixedImageTrueMin = computeFixedImageExtrema->GetMinimum();
 
     this->m_FixedImageMinLimit = static_cast<FixedImageLimiterOutputType>(
-      this->m_FixedImageTrueMin -
-      this->m_FixedLimitRangeRatio * (this->m_FixedImageTrueMax - this->m_FixedImageTrueMin));
+      Superclass::m_FixedImageTrueMin -
+      this->m_FixedLimitRangeRatio * (Superclass::m_FixedImageTrueMax - Superclass::m_FixedImageTrueMin));
     this->m_FixedImageMaxLimit = static_cast<FixedImageLimiterOutputType>(
-      this->m_FixedImageTrueMax +
-      this->m_FixedLimitRangeRatio * (this->m_FixedImageTrueMax - this->m_FixedImageTrueMin));
+      Superclass::m_FixedImageTrueMax +
+      this->m_FixedLimitRangeRatio * (Superclass::m_FixedImageTrueMax - Superclass::m_FixedImageTrueMin));
 
     const auto computeMovingImageExtrema = ComputeImageExtremaFilter<MovingImageType>::New();
     computeMovingImageExtrema->SetInput(this->GetMovingImage());
     computeMovingImageExtrema->SetImageSpatialMask(this->GetMovingImageMask());
     computeMovingImageExtrema->Update();
 
-    this->m_MovingImageTrueMax = computeMovingImageExtrema->GetMaximum();
-    this->m_MovingImageTrueMin = computeMovingImageExtrema->GetMinimum();
+    Superclass::m_MovingImageTrueMax = computeMovingImageExtrema->GetMaximum();
+    Superclass::m_MovingImageTrueMin = computeMovingImageExtrema->GetMinimum();
 
     this->m_MovingImageMinLimit = static_cast<MovingImageLimiterOutputType>(
-      this->m_MovingImageTrueMin -
-      this->m_MovingLimitRangeRatio * (this->m_MovingImageTrueMax - this->m_MovingImageTrueMin));
+      Superclass::m_MovingImageTrueMin -
+      this->m_MovingLimitRangeRatio * (Superclass::m_MovingImageTrueMax - Superclass::m_MovingImageTrueMin));
     this->m_MovingImageMaxLimit = static_cast<MovingImageLimiterOutputType>(
-      this->m_MovingImageTrueMax +
-      this->m_MovingLimitRangeRatio * (this->m_MovingImageTrueMax - this->m_MovingImageTrueMin));
+      Superclass::m_MovingImageTrueMax +
+      this->m_MovingLimitRangeRatio * (Superclass::m_MovingImageTrueMax - Superclass::m_MovingImageTrueMin));
 
     // TODO: we may actually reuse these values from AdvancedImageToImageMetric::InitializeLimiters
     // without recomputing them here.
-    const double diff1 = this->m_FixedImageTrueMax - this->m_MovingImageTrueMin;
-    const double diff2 = this->m_MovingImageTrueMax - this->m_FixedImageTrueMin;
+    const double diff1 = Superclass::m_FixedImageTrueMax - Superclass::m_MovingImageTrueMin;
+    const double diff2 = Superclass::m_MovingImageTrueMax - Superclass::m_FixedImageTrueMin;
     const double maxdiff = std::max(diff1, diff2);
 
     /** We guess that maxdiff/10 is the maximum average difference that will

--- a/Components/Metrics/AdvancedMeanSquares/itkAdvancedMeanSquaresImageToImageMetric.hxx
+++ b/Components/Metrics/AdvancedMeanSquares/itkAdvancedMeanSquaresImageToImageMetric.hxx
@@ -217,7 +217,7 @@ AdvancedMeanSquaresImageToImageMetric<TFixedImage, TMovingImage>::GetValue(
   const TransformParametersType & parameters) const -> MeasureType
 {
   /** Option for now to still use the single threaded code. */
-  if (!this->m_UseMultiThread)
+  if (!Superclass::m_UseMultiThread)
   {
     return this->GetValueSingleThreaded(parameters);
   }
@@ -501,7 +501,7 @@ AdvancedMeanSquaresImageToImageMetric<TFixedImage, TMovingImage>::GetValueAndDer
   DerivativeType &                derivative) const
 {
   /** Option for now to still use the single threaded code. */
-  if (!this->m_UseMultiThread)
+  if (!Superclass::m_UseMultiThread)
   {
     return this->GetValueAndDerivativeSingleThreaded(parameters, value, derivative);
   }
@@ -668,7 +668,7 @@ AdvancedMeanSquaresImageToImageMetric<TFixedImage, TMovingImage>::AfterThreadedG
 
   /** Accumulate derivatives. */
   // compute single-threadedly
-  if (!this->m_UseMultiThread && false) // force multi-threaded
+  if (!Superclass::m_UseMultiThread && false) // force multi-threaded
   {
     derivative = this->m_GetValueAndDerivativePerThreadVariables[0].st_Derivative * normal_sum;
     for (ThreadIdType i = 1; i < numberOfThreads; ++i)

--- a/Components/Metrics/AdvancedMeanSquares/itkAdvancedMeanSquaresImageToImageMetric.hxx
+++ b/Components/Metrics/AdvancedMeanSquares/itkAdvancedMeanSquaresImageToImageMetric.hxx
@@ -62,10 +62,10 @@ AdvancedMeanSquaresImageToImageMetric<TFixedImage, TMovingImage>::Initialize()
     Superclass::m_FixedImageTrueMax = computeFixedImageExtrema->GetMaximum();
     Superclass::m_FixedImageTrueMin = computeFixedImageExtrema->GetMinimum();
 
-    this->m_FixedImageMinLimit = static_cast<FixedImageLimiterOutputType>(
+    Superclass::m_FixedImageMinLimit = static_cast<FixedImageLimiterOutputType>(
       Superclass::m_FixedImageTrueMin -
       this->m_FixedLimitRangeRatio * (Superclass::m_FixedImageTrueMax - Superclass::m_FixedImageTrueMin));
-    this->m_FixedImageMaxLimit = static_cast<FixedImageLimiterOutputType>(
+    Superclass::m_FixedImageMaxLimit = static_cast<FixedImageLimiterOutputType>(
       Superclass::m_FixedImageTrueMax +
       this->m_FixedLimitRangeRatio * (Superclass::m_FixedImageTrueMax - Superclass::m_FixedImageTrueMin));
 
@@ -77,10 +77,10 @@ AdvancedMeanSquaresImageToImageMetric<TFixedImage, TMovingImage>::Initialize()
     Superclass::m_MovingImageTrueMax = computeMovingImageExtrema->GetMaximum();
     Superclass::m_MovingImageTrueMin = computeMovingImageExtrema->GetMinimum();
 
-    this->m_MovingImageMinLimit = static_cast<MovingImageLimiterOutputType>(
+    Superclass::m_MovingImageMinLimit = static_cast<MovingImageLimiterOutputType>(
       Superclass::m_MovingImageTrueMin -
       this->m_MovingLimitRangeRatio * (Superclass::m_MovingImageTrueMax - Superclass::m_MovingImageTrueMin));
-    this->m_MovingImageMaxLimit = static_cast<MovingImageLimiterOutputType>(
+    Superclass::m_MovingImageMaxLimit = static_cast<MovingImageLimiterOutputType>(
       Superclass::m_MovingImageTrueMax +
       this->m_MovingLimitRangeRatio * (Superclass::m_MovingImageTrueMax - Superclass::m_MovingImageTrueMin));
 

--- a/Components/Metrics/AdvancedNormalizedCorrelation/itkAdvancedNormalizedCorrelationImageToImageMetric.hxx
+++ b/Components/Metrics/AdvancedNormalizedCorrelation/itkAdvancedNormalizedCorrelationImageToImageMetric.hxx
@@ -701,7 +701,7 @@ AdvancedNormalizedCorrelationImageToImageMetric<TFixedImage, TMovingImage>::Afte
       }
     }
   }
-  else if (true) // force !this->m_UseOpenMP ) // multi-threaded using ITK threads
+  else if (true) // force !Superclass::m_UseOpenMP ) // multi-threaded using ITK threads
   {
     MultiThreaderAccumulateDerivativeType userData;
 

--- a/Components/Metrics/AdvancedNormalizedCorrelation/itkAdvancedNormalizedCorrelationImageToImageMetric.hxx
+++ b/Components/Metrics/AdvancedNormalizedCorrelation/itkAdvancedNormalizedCorrelationImageToImageMetric.hxx
@@ -449,7 +449,7 @@ AdvancedNormalizedCorrelationImageToImageMetric<TFixedImage, TMovingImage>::GetV
   DerivativeType &                derivative) const
 {
   /** Option for now to still use the single threaded code. */
-  if (!this->m_UseMultiThread)
+  if (!Superclass::m_UseMultiThread)
   {
     return this->GetValueAndDerivativeSingleThreaded(parameters, value, derivative);
   }
@@ -666,7 +666,7 @@ AdvancedNormalizedCorrelationImageToImageMetric<TFixedImage, TMovingImage>::Afte
 
   /** Calculate the metric derivative. */
   // single-threaded
-  if (!this->m_UseMultiThread && false) // force multi-threaded
+  if (!Superclass::m_UseMultiThread && false) // force multi-threaded
   {
     DerivativeType & derivativeF = this->m_CorrelationGetValueAndDerivativePerThreadVariables[0].st_DerivativeF;
     DerivativeType & derivativeM = this->m_CorrelationGetValueAndDerivativePerThreadVariables[0].st_DerivativeM;

--- a/Components/Metrics/AdvancedNormalizedCorrelation/itkAdvancedNormalizedCorrelationImageToImageMetric.hxx
+++ b/Components/Metrics/AdvancedNormalizedCorrelation/itkAdvancedNormalizedCorrelationImageToImageMetric.hxx
@@ -314,7 +314,7 @@ AdvancedNormalizedCorrelationImageToImageMetric<TFixedImage, TMovingImage>::GetV
   differential.Fill(DerivativeValueType{});
 
   /** Array that stores dM(x)/dmu, and the sparse Jacobian + indices. */
-  NonZeroJacobianIndicesType nzji(this->m_AdvancedTransform->GetNumberOfNonZeroJacobianIndices());
+  NonZeroJacobianIndicesType nzji(Superclass::m_AdvancedTransform->GetNumberOfNonZeroJacobianIndices());
   DerivativeType             imageJacobian(nzji.size());
   TransformJacobianType      jacobian;
 
@@ -488,7 +488,7 @@ AdvancedNormalizedCorrelationImageToImageMetric<TFixedImage, TMovingImage>::Thre
   ThreadIdType threadId) const
 {
   /** Initialize array that stores dM(x)/dmu, and the sparse Jacobian + indices. */
-  const NumberOfParametersType nnzji = this->m_AdvancedTransform->GetNumberOfNonZeroJacobianIndices();
+  const NumberOfParametersType nnzji = Superclass::m_AdvancedTransform->GetNumberOfNonZeroJacobianIndices();
   NonZeroJacobianIndicesType   nzji(nnzji);
   DerivativeType               imageJacobian(nzji.size());
 
@@ -564,7 +564,7 @@ AdvancedNormalizedCorrelationImageToImageMetric<TFixedImage, TMovingImage>::Thre
         jacobian, movingImageDerivative, imageJacobian );
 #else
       /** Compute the inner product of the transform Jacobian dT/dmu and the moving image gradient dM/dx. */
-      this->m_AdvancedTransform->EvaluateJacobianWithImageGradientProduct(
+      Superclass::m_AdvancedTransform->EvaluateJacobianWithImageGradientProduct(
         fixedPoint, movingImageDerivative, imageJacobian, nzji);
 #endif
 

--- a/Components/Metrics/BendingEnergyPenalty/itkTransformBendingEnergyPenaltyTerm.hxx
+++ b/Components/Metrics/BendingEnergyPenalty/itkTransformBendingEnergyPenaltyTerm.hxx
@@ -583,12 +583,13 @@ TransformBendingEnergyPenaltyTerm<TFixedImage, TScalarType>::AfterThreadedGetVal
   // compute multi-threadedly with itk threads
   else if (!Superclass::m_UseOpenMP || true) // force
   {
-    this->m_ThreaderMetricParameters.st_DerivativePointer = derivative.begin();
-    this->m_ThreaderMetricParameters.st_NormalizationFactor =
+    Superclass::m_ThreaderMetricParameters.st_DerivativePointer = derivative.begin();
+    Superclass::m_ThreaderMetricParameters.st_NormalizationFactor =
       static_cast<DerivativeValueType>(this->m_NumberOfPixelsCounted);
 
-    this->m_Threader->SetSingleMethod(this->AccumulateDerivativesThreaderCallback,
-                                      const_cast<void *>(static_cast<const void *>(&this->m_ThreaderMetricParameters)));
+    this->m_Threader->SetSingleMethod(
+      this->AccumulateDerivativesThreaderCallback,
+      const_cast<void *>(static_cast<const void *>(&(Superclass::m_ThreaderMetricParameters))));
     this->m_Threader->SingleMethodExecute();
   }
 #ifdef ELASTIX_USE_OPENMP

--- a/Components/Metrics/BendingEnergyPenalty/itkTransformBendingEnergyPenaltyTerm.hxx
+++ b/Components/Metrics/BendingEnergyPenalty/itkTransformBendingEnergyPenaltyTerm.hxx
@@ -336,7 +336,7 @@ TransformBendingEnergyPenaltyTerm<TFixedImage, TScalarType>::GetValueAndDerivati
                                                                                    DerivativeType & derivative) const
 {
   /** Option for now to still use the single threaded code. */
-  if (!this->m_UseMultiThread)
+  if (!Superclass::m_UseMultiThread)
   {
     return this->GetValueAndDerivativeSingleThreaded(parameters, value, derivative);
   }
@@ -571,7 +571,7 @@ TransformBendingEnergyPenaltyTerm<TFixedImage, TScalarType>::AfterThreadedGetVal
   // it seems that multi-threaded adding is faster than single-threaded
   // it seems that openmp is faster than itk threads
   // compute single-threadedly
-  if (!this->m_UseMultiThread)
+  if (!Superclass::m_UseMultiThread)
   {
     derivative = this->m_GetValueAndDerivativePerThreadVariables[0].st_Derivative;
     for (ThreadIdType i = 1; i < numberOfThreads; ++i)

--- a/Components/Metrics/BendingEnergyPenalty/itkTransformBendingEnergyPenaltyTerm.hxx
+++ b/Components/Metrics/BendingEnergyPenalty/itkTransformBendingEnergyPenaltyTerm.hxx
@@ -581,7 +581,7 @@ TransformBendingEnergyPenaltyTerm<TFixedImage, TScalarType>::AfterThreadedGetVal
     derivative /= static_cast<DerivativeValueType>(this->m_NumberOfPixelsCounted);
   }
   // compute multi-threadedly with itk threads
-  else if (!this->m_UseOpenMP || true) // force
+  else if (!Superclass::m_UseOpenMP || true) // force
   {
     this->m_ThreaderMetricParameters.st_DerivativePointer = derivative.begin();
     this->m_ThreaderMetricParameters.st_NormalizationFactor =

--- a/Components/Metrics/BendingEnergyPenalty/itkTransformBendingEnergyPenaltyTerm.hxx
+++ b/Components/Metrics/BendingEnergyPenalty/itkTransformBendingEnergyPenaltyTerm.hxx
@@ -399,7 +399,7 @@ TransformBendingEnergyPenaltyTerm<TFixedImage, TScalarType>::ThreadedGetValueAnd
    * InitializeThreadingParameters(), and at the end of each iteration in
    * AfterThreadedGetValueAndDerivative() and the accumulate functions.
    */
-  DerivativeType & derivative = this->m_GetValueAndDerivativePerThreadVariables[threadId].st_Derivative;
+  DerivativeType & derivative = Superclass::m_GetValueAndDerivativePerThreadVariables[threadId].st_Derivative;
 
   /** Get a handle to the sample container. */
   ImageSampleContainerPointer sampleContainer = this->GetImageSampler()->GetOutput();
@@ -527,8 +527,8 @@ TransformBendingEnergyPenaltyTerm<TFixedImage, TScalarType>::ThreadedGetValueAnd
   }     // end for loop over the image sample container
 
   /** Only update these variables at the end to prevent unnecessary "false sharing". */
-  this->m_GetValueAndDerivativePerThreadVariables[threadId].st_NumberOfPixelsCounted = numberOfPixelsCounted;
-  this->m_GetValueAndDerivativePerThreadVariables[threadId].st_Value = measure;
+  Superclass::m_GetValueAndDerivativePerThreadVariables[threadId].st_NumberOfPixelsCounted = numberOfPixelsCounted;
+  Superclass::m_GetValueAndDerivativePerThreadVariables[threadId].st_Value = measure;
 
 } // end ThreadedGetValueAndDerivative()
 
@@ -549,7 +549,7 @@ TransformBendingEnergyPenaltyTerm<TFixedImage, TScalarType>::AfterThreadedGetVal
   this->m_NumberOfPixelsCounted = 0;
   for (ThreadIdType i = 0; i < numberOfThreads; ++i)
   {
-    this->m_NumberOfPixelsCounted += this->m_GetValueAndDerivativePerThreadVariables[i].st_NumberOfPixelsCounted;
+    this->m_NumberOfPixelsCounted += Superclass::m_GetValueAndDerivativePerThreadVariables[i].st_NumberOfPixelsCounted;
   }
 
   /** Check if enough samples were valid. */
@@ -560,10 +560,10 @@ TransformBendingEnergyPenaltyTerm<TFixedImage, TScalarType>::AfterThreadedGetVal
   value = MeasureType{};
   for (ThreadIdType i = 0; i < numberOfThreads; ++i)
   {
-    value += this->m_GetValueAndDerivativePerThreadVariables[i].st_Value;
+    value += Superclass::m_GetValueAndDerivativePerThreadVariables[i].st_Value;
 
     /** Reset this variable for the next iteration. */
-    this->m_GetValueAndDerivativePerThreadVariables[i].st_Value = MeasureType{};
+    Superclass::m_GetValueAndDerivativePerThreadVariables[i].st_Value = MeasureType{};
   }
   value /= static_cast<RealType>(this->m_NumberOfPixelsCounted);
 
@@ -573,10 +573,10 @@ TransformBendingEnergyPenaltyTerm<TFixedImage, TScalarType>::AfterThreadedGetVal
   // compute single-threadedly
   if (!Superclass::m_UseMultiThread)
   {
-    derivative = this->m_GetValueAndDerivativePerThreadVariables[0].st_Derivative;
+    derivative = Superclass::m_GetValueAndDerivativePerThreadVariables[0].st_Derivative;
     for (ThreadIdType i = 1; i < numberOfThreads; ++i)
     {
-      derivative += this->m_GetValueAndDerivativePerThreadVariables[i].st_Derivative;
+      derivative += Superclass::m_GetValueAndDerivativePerThreadVariables[i].st_Derivative;
     }
     derivative /= static_cast<DerivativeValueType>(this->m_NumberOfPixelsCounted);
   }
@@ -606,7 +606,7 @@ TransformBendingEnergyPenaltyTerm<TFixedImage, TScalarType>::AfterThreadedGetVal
       DerivativeValueType sum{};
       for (ThreadIdType i = 0; i < numberOfThreads; ++i)
       {
-        sum += this->m_GetValueAndDerivativePerThreadVariables[i].st_Derivative[j];
+        sum += Superclass::m_GetValueAndDerivativePerThreadVariables[i].st_Derivative[j];
       }
       derivative[j] = sum / numPix;
     }

--- a/Components/Metrics/BendingEnergyPenalty/itkTransformBendingEnergyPenaltyTerm.hxx
+++ b/Components/Metrics/BendingEnergyPenalty/itkTransformBendingEnergyPenaltyTerm.hxx
@@ -57,7 +57,7 @@ TransformBendingEnergyPenaltyTerm<TFixedImage, TScalarType>::GetValue(const Para
   SpatialHessianType spatialHessian;
 
   /** Check if the SpatialHessian is nonzero. */
-  if (!this->m_AdvancedTransform->GetHasNonZeroSpatialHessian())
+  if (!Superclass::m_AdvancedTransform->GetHasNonZeroSpatialHessian())
   {
     return static_cast<MeasureType>(measure);
   }
@@ -99,7 +99,7 @@ TransformBendingEnergyPenaltyTerm<TFixedImage, TScalarType>::GetValue(const Para
       /** Get the spatial Hessian of the transformation at the current point.
        * This is needed to compute the bending energy.
        */
-      this->m_AdvancedTransform->GetSpatialHessian(fixedPoint, spatialHessian);
+      Superclass::m_AdvancedTransform->GetSpatialHessian(fixedPoint, spatialHessian);
 
       /** Compute the contribution of this point. */
       for (unsigned int k = 0; k < FixedImageDimension; ++k)
@@ -160,13 +160,13 @@ TransformBendingEnergyPenaltyTerm<TFixedImage, TScalarType>::GetValueAndDerivati
   JacobianOfSpatialHessianType jacobianOfSpatialHessian;
   NonZeroJacobianIndicesType   nonZeroJacobianIndices;
   const NumberOfParametersType numberOfNonZeroJacobianIndices =
-    this->m_AdvancedTransform->GetNumberOfNonZeroJacobianIndices();
+    Superclass::m_AdvancedTransform->GetNumberOfNonZeroJacobianIndices();
   jacobianOfSpatialHessian.resize(numberOfNonZeroJacobianIndices);
   nonZeroJacobianIndices.resize(numberOfNonZeroJacobianIndices);
 
   /** Check if the SpatialHessian is nonzero. */
-  if (!this->m_AdvancedTransform->GetHasNonZeroSpatialHessian() &&
-      !this->m_AdvancedTransform->GetHasNonZeroJacobianOfSpatialHessian())
+  if (!Superclass::m_AdvancedTransform->GetHasNonZeroSpatialHessian() &&
+      !Superclass::m_AdvancedTransform->GetHasNonZeroJacobianOfSpatialHessian())
   {
     value = static_cast<MeasureType>(measure);
     return;
@@ -219,11 +219,11 @@ TransformBendingEnergyPenaltyTerm<TFixedImage, TScalarType>::GetValueAndDerivati
       /** Get the spatial Hessian of the transformation at the current point.
        * This is needed to compute the bending energy.
        */
-      //       this->m_AdvancedTransform->GetSpatialHessian( fixedPoint,
+      //       Superclass::m_AdvancedTransform->GetSpatialHessian( fixedPoint,
       //         spatialHessian );
-      //       this->m_AdvancedTransform->GetJacobianOfSpatialHessian( fixedPoint,
+      //       Superclass::m_AdvancedTransform->GetJacobianOfSpatialHessian( fixedPoint,
       //         jacobianOfSpatialHessian, nonZeroJacobianIndices );
-      this->m_AdvancedTransform->GetJacobianOfSpatialHessian(
+      Superclass::m_AdvancedTransform->GetJacobianOfSpatialHessian(
         fixedPoint, spatialHessian, jacobianOfSpatialHessian, nonZeroJacobianIndices);
 
       /** Prepare some stuff for the computation of the metric (derivative). */
@@ -378,13 +378,13 @@ TransformBendingEnergyPenaltyTerm<TFixedImage, TScalarType>::ThreadedGetValueAnd
   JacobianOfSpatialHessianType jacobianOfSpatialHessian;
   NonZeroJacobianIndicesType   nonZeroJacobianIndices;
   const NumberOfParametersType numberOfNonZeroJacobianIndices =
-    this->m_AdvancedTransform->GetNumberOfNonZeroJacobianIndices();
+    Superclass::m_AdvancedTransform->GetNumberOfNonZeroJacobianIndices();
   jacobianOfSpatialHessian.resize(numberOfNonZeroJacobianIndices);
   nonZeroJacobianIndices.resize(numberOfNonZeroJacobianIndices);
 
   /** Check if the SpatialHessian is nonzero. */
-  if (!this->m_AdvancedTransform->GetHasNonZeroSpatialHessian() &&
-      !this->m_AdvancedTransform->GetHasNonZeroJacobianOfSpatialHessian())
+  if (!Superclass::m_AdvancedTransform->GetHasNonZeroSpatialHessian() &&
+      !Superclass::m_AdvancedTransform->GetHasNonZeroJacobianOfSpatialHessian())
   {
     return;
   }
@@ -445,7 +445,7 @@ TransformBendingEnergyPenaltyTerm<TFixedImage, TScalarType>::ThreadedGetValueAnd
       /** Get the spatial Hessian of the transformation at the current point.
        * This is needed to compute the bending energy.
        */
-      this->m_AdvancedTransform->GetJacobianOfSpatialHessian(
+      Superclass::m_AdvancedTransform->GetJacobianOfSpatialHessian(
         fixedPoint, spatialHessian, jacobianOfSpatialHessian, nonZeroJacobianIndices);
 
       /** Prepare some stuff for the computation of the metric (derivative). */

--- a/Components/Metrics/DisplacementMagnitudePenalty/itkDisplacementMagnitudePenaltyTerm.hxx
+++ b/Components/Metrics/DisplacementMagnitudePenalty/itkDisplacementMagnitudePenaltyTerm.hxx
@@ -150,7 +150,7 @@ DisplacementMagnitudePenaltyTerm<TFixedImage, TScalarType>::GetValueAndDerivativ
   derivative.Fill(DerivativeValueType{});
 
   /** Array that stores sparse jacobian+indices. */
-  NonZeroJacobianIndicesType nzji(this->m_AdvancedTransform->GetNumberOfNonZeroJacobianIndices());
+  NonZeroJacobianIndicesType nzji(Superclass::m_AdvancedTransform->GetNumberOfNonZeroJacobianIndices());
   const unsigned long        nrNonZeroJacobianIndices = nzji.size();
   TransformJacobianType      jacobian(FixedImageDimension, nrNonZeroJacobianIndices);
   jacobian.Fill(0.0);

--- a/Components/Metrics/KNNGraphAlphaMutualInformation/itkKNNGraphAlphaMutualInformationImageToImageMetric.hxx
+++ b/Components/Metrics/KNNGraphAlphaMutualInformation/itkKNNGraphAlphaMutualInformationImageToImageMetric.hxx
@@ -763,7 +763,7 @@ KNNGraphAlphaMutualInformationImageToImageMetric<TFixedImage, TMovingImage>::
   RealType                   movingImageValue;
   double                     fixedFeatureValue = 0.0;
   double                     movingFeatureValue = 0.0;
-  NonZeroJacobianIndicesType nzji(this->m_AdvancedTransform->GetNumberOfNonZeroJacobianIndices());
+  NonZeroJacobianIndicesType nzji(Superclass::m_AdvancedTransform->GetNumberOfNonZeroJacobianIndices());
   TransformJacobianType      jacobian;
 
   /** Loop over the fixed image samples to calculate the list samples. */

--- a/Components/Metrics/PCAMetric/itkPCAMetric.hxx
+++ b/Components/Metrics/PCAMetric/itkPCAMetric.hxx
@@ -598,9 +598,9 @@ PCAMetric<TFixedImage, TMovingImage>::GetValueAndDerivative(const TransformParam
   MatrixType eigenVectorMatrixTranspose(eigenVectorMatrix.transpose());
 
   /** Create variables to store intermediate results in. */
-  TransformJacobianType                   jacobian;
-  DerivativeType                          dMTdmu;
-  DerivativeType                          imageJacobian(this->m_AdvancedTransform->GetNumberOfNonZeroJacobianIndices());
+  TransformJacobianType jacobian;
+  DerivativeType        dMTdmu;
+  DerivativeType        imageJacobian(Superclass::m_AdvancedTransform->GetNumberOfNonZeroJacobianIndices());
   std::vector<NonZeroJacobianIndicesType> nzjis(G, NonZeroJacobianIndicesType());
 
   /** Sub components of metric derivative */

--- a/Components/Metrics/PCAMetric/itkPCAMetric_F_multithreaded.hxx
+++ b/Components/Metrics/PCAMetric/itkPCAMetric_F_multithreaded.hxx
@@ -462,9 +462,9 @@ PCAMetric<TFixedImage, TMovingImage>::GetValueAndDerivativeSingleThreaded(const 
   MatrixType eigenVectorMatrixTranspose(eigenVectorMatrix.transpose());
 
   /** Create variables to store intermediate results in. */
-  TransformJacobianType                   jacobian;
-  DerivativeType                          dMTdmu;
-  DerivativeType                          imageJacobian(this->m_AdvancedTransform->GetNumberOfNonZeroJacobianIndices());
+  TransformJacobianType jacobian;
+  DerivativeType        dMTdmu;
+  DerivativeType        imageJacobian(Superclass::m_AdvancedTransform->GetNumberOfNonZeroJacobianIndices());
   std::vector<NonZeroJacobianIndicesType> nzjis(this->m_G, NonZeroJacobianIndicesType());
 
   /** Sub components of metric derivative */
@@ -905,8 +905,8 @@ PCAMetric<TFixedImage, TMovingImage>::ThreadedComputeDerivative(ThreadIdType thr
   MovingImageDerivativeType movingImageDerivative;
 
   TransformJacobianType      jacobian;
-  DerivativeType             imageJacobian(this->m_AdvancedTransform->GetNumberOfNonZeroJacobianIndices());
-  NonZeroJacobianIndicesType nzjis(this->m_AdvancedTransform->GetNumberOfNonZeroJacobianIndices());
+  DerivativeType             imageJacobian(Superclass::m_AdvancedTransform->GetNumberOfNonZeroJacobianIndices());
+  NonZeroJacobianIndicesType nzjis(Superclass::m_AdvancedTransform->GetNumberOfNonZeroJacobianIndices());
 
   unsigned int dummyindex = 0;
   /** Second loop over fixed image samples. */

--- a/Components/Metrics/PCAMetric/itkPCAMetric_F_multithreaded.hxx
+++ b/Components/Metrics/PCAMetric/itkPCAMetric_F_multithreaded.hxx
@@ -622,7 +622,7 @@ PCAMetric<TFixedImage, TMovingImage>::GetValueAndDerivative(const TransformParam
                                                             DerivativeType &                derivative) const
 {
   /** Option for now to still use the single threaded code. */
-  if (!this->m_UseMultiThread)
+  if (!Superclass::m_UseMultiThread)
   {
     return this->GetValueAndDerivativeSingleThreaded(parameters, value, derivative);
   }

--- a/Components/Metrics/PCAMetric2/itkPCAMetric2.hxx
+++ b/Components/Metrics/PCAMetric2/itkPCAMetric2.hxx
@@ -493,9 +493,9 @@ PCAMetric2<TFixedImage, TMovingImage>::GetValueAndDerivative(const TransformPara
   MatrixType eigenVectorMatrixTranspose(eigenVectorMatrix.transpose());
 
   /** Create variables to store intermediate results in. */
-  TransformJacobianType                   jacobian;
-  DerivativeType                          dMTdmu;
-  DerivativeType                          imageJacobian(this->m_AdvancedTransform->GetNumberOfNonZeroJacobianIndices());
+  TransformJacobianType jacobian;
+  DerivativeType        dMTdmu;
+  DerivativeType        imageJacobian(Superclass::m_AdvancedTransform->GetNumberOfNonZeroJacobianIndices());
   std::vector<NonZeroJacobianIndicesType> nzjis(G, NonZeroJacobianIndicesType());
 
   /** Sub components of metric derivative */

--- a/Components/Metrics/PatternIntensity/itkPatternIntensityImageToImageMetric.hxx
+++ b/Components/Metrics/PatternIntensity/itkPatternIntensityImageToImageMetric.hxx
@@ -65,7 +65,7 @@ PatternIntensityImageToImageMetric<TFixedImage, TMovingImage>::Initialize()
 
   // this->InitializeLimiters();
 
-  this->m_NormalizationFactor = this->m_FixedImageTrueMax / this->m_MovingImageTrueMax;
+  this->m_NormalizationFactor = Superclass::m_FixedImageTrueMax / Superclass::m_MovingImageTrueMax;
   this->m_MultiplyImageFilter->SetInput(this->m_TransformMovingImageFilter->GetOutput());
   this->m_MultiplyImageFilter->SetConstant(this->m_NormalizationFactor);
   this->m_DifferenceImageFilter->SetInput1(this->m_FixedImage);

--- a/Components/Metrics/RigidityPenalty/itkTransformRigidityPenaltyTerm.hxx
+++ b/Components/Metrics/RigidityPenalty/itkTransformRigidityPenaltyTerm.hxx
@@ -872,7 +872,7 @@ TransformRigidityPenaltyTerm<TFixedImage, TScalarType>::BeforeThreadedGetValueAn
   /** In this function do all stuff that cannot be multi-threaded.
    * Meant for use in the combo-metric. So, I did not think about general usage yet.
    */
-  if (this->m_UseMetricSingleThreaded)
+  if (Superclass::m_UseMetricSingleThreaded)
   {
     this->m_BSplineTransform->SetParameters(parameters);
   }

--- a/Components/Metrics/SumOfPairwiseCorrelationsMetric/itkSumOfPairwiseCorrelationCoefficientsMetric.hxx
+++ b/Components/Metrics/SumOfPairwiseCorrelationsMetric/itkSumOfPairwiseCorrelationCoefficientsMetric.hxx
@@ -421,8 +421,8 @@ SumOfPairwiseCorrelationCoefficientsMetric<TFixedImage, TMovingImage>::GetValueA
   DerivativeMatrixType K(S * C * S);
 
   /** Create variables to store intermediate results in. */
-  TransformJacobianType                   jacobian;
-  DerivativeType                          imageJacobian(this->m_AdvancedTransform->GetNumberOfNonZeroJacobianIndices());
+  TransformJacobianType jacobian;
+  DerivativeType        imageJacobian(Superclass::m_AdvancedTransform->GetNumberOfNonZeroJacobianIndices());
   std::vector<NonZeroJacobianIndicesType> nzjis(G, NonZeroJacobianIndicesType());
 
   DerivativeType dMTdmu;

--- a/Components/Metrics/SumSquaredTissueVolumeDifferenceMetric/itkSumSquaredTissueVolumeDifferenceImageToImageMetric.hxx
+++ b/Components/Metrics/SumSquaredTissueVolumeDifferenceMetric/itkSumSquaredTissueVolumeDifferenceImageToImageMetric.hxx
@@ -155,7 +155,7 @@ SumSquaredTissueVolumeDifferenceImageToImageMetric<TFixedImage, TMovingImage>::G
 {
 
   /** Option for now to still use the single threaded code. */
-  if (!this->m_UseMultiThread)
+  if (!Superclass::m_UseMultiThread)
   {
     return this->GetValueSingleThreaded(parameters);
   }
@@ -460,7 +460,7 @@ SumSquaredTissueVolumeDifferenceImageToImageMetric<TFixedImage, TMovingImage>::G
   DerivativeType &                derivative) const
 {
   /** Option for now to still use the single threaded code. */
-  if (!this->m_UseMultiThread)
+  if (!Superclass::m_UseMultiThread)
   {
     return this->GetValueAndDerivativeSingleThreaded(parameters, value, derivative);
   }
@@ -634,7 +634,7 @@ SumSquaredTissueVolumeDifferenceImageToImageMetric<TFixedImage, TMovingImage>::A
 
   /** Accumulate derivatives. */
   /** compute single-threadedly */
-  if (!this->m_UseMultiThread && false) // force multi-threaded as in AdvancedMeanSquares
+  if (!Superclass::m_UseMultiThread && false) // force multi-threaded as in AdvancedMeanSquares
   {
     derivative = this->m_GetValueAndDerivativePerThreadVariables[0].st_Derivative;
     for (ThreadIdType i = 1; i < numberOfThreads; ++i)

--- a/Components/Metrics/SumSquaredTissueVolumeDifferenceMetric/itkSumSquaredTissueVolumeDifferenceImageToImageMetric.hxx
+++ b/Components/Metrics/SumSquaredTissueVolumeDifferenceMetric/itkSumSquaredTissueVolumeDifferenceImageToImageMetric.hxx
@@ -647,12 +647,13 @@ SumSquaredTissueVolumeDifferenceImageToImageMetric<TFixedImage, TMovingImage>::A
   // compute multi-threadedly with itk threads
   else if (true) // force ITK threads !Superclass::m_UseOpenMP )
   {
-    this->m_ThreaderMetricParameters.st_DerivativePointer = derivative.begin();
-    this->m_ThreaderMetricParameters.st_NormalizationFactor =
+    Superclass::m_ThreaderMetricParameters.st_DerivativePointer = derivative.begin();
+    Superclass::m_ThreaderMetricParameters.st_NormalizationFactor =
       static_cast<DerivativeValueType>(this->m_NumberOfPixelsCounted);
 
-    this->m_Threader->SetSingleMethod(this->AccumulateDerivativesThreaderCallback,
-                                      const_cast<void *>(static_cast<const void *>(&this->m_ThreaderMetricParameters)));
+    this->m_Threader->SetSingleMethod(
+      this->AccumulateDerivativesThreaderCallback,
+      const_cast<void *>(static_cast<const void *>(&(Superclass::m_ThreaderMetricParameters))));
     this->m_Threader->SingleMethodExecute();
   }
 

--- a/Components/Metrics/SumSquaredTissueVolumeDifferenceMetric/itkSumSquaredTissueVolumeDifferenceImageToImageMetric.hxx
+++ b/Components/Metrics/SumSquaredTissueVolumeDifferenceMetric/itkSumSquaredTissueVolumeDifferenceImageToImageMetric.hxx
@@ -262,8 +262,8 @@ SumSquaredTissueVolumeDifferenceImageToImageMetric<TFixedImage, TMovingImage>::T
   } // end for loop over the image sample container
 
   /** Only update these variables at the end to prevent unnecessary "false sharing". */
-  this->m_GetValueAndDerivativePerThreadVariables[threadId].st_NumberOfPixelsCounted = numberOfPixelsCounted;
-  this->m_GetValueAndDerivativePerThreadVariables[threadId].st_Value = measure;
+  Superclass::m_GetValueAndDerivativePerThreadVariables[threadId].st_NumberOfPixelsCounted = numberOfPixelsCounted;
+  Superclass::m_GetValueAndDerivativePerThreadVariables[threadId].st_Value = measure;
 
 } // end ThreadedGetValue()
 
@@ -280,10 +280,10 @@ SumSquaredTissueVolumeDifferenceImageToImageMetric<TFixedImage, TMovingImage>::A
   const ThreadIdType numberOfThreads = Self::GetNumberOfWorkUnits();
 
   /** Accumulate the number of pixels. */
-  this->m_NumberOfPixelsCounted = this->m_GetValueAndDerivativePerThreadVariables[0].st_NumberOfPixelsCounted;
+  this->m_NumberOfPixelsCounted = Superclass::m_GetValueAndDerivativePerThreadVariables[0].st_NumberOfPixelsCounted;
   for (ThreadIdType i = 1; i < numberOfThreads; ++i)
   {
-    this->m_NumberOfPixelsCounted += this->m_GetValueAndDerivativePerThreadVariables[i].st_NumberOfPixelsCounted;
+    this->m_NumberOfPixelsCounted += Superclass::m_GetValueAndDerivativePerThreadVariables[i].st_NumberOfPixelsCounted;
   }
 
   /** Check if enough samples were valid. */
@@ -294,10 +294,10 @@ SumSquaredTissueVolumeDifferenceImageToImageMetric<TFixedImage, TMovingImage>::A
   value = MeasureType{};
   for (ThreadIdType i = 0; i < numberOfThreads; ++i)
   {
-    value += this->m_GetValueAndDerivativePerThreadVariables[i].st_Value;
+    value += Superclass::m_GetValueAndDerivativePerThreadVariables[i].st_Value;
 
     /** Reset this variable for the next iteration. */
-    this->m_GetValueAndDerivativePerThreadVariables[i].st_Value = MeasureType{};
+    Superclass::m_GetValueAndDerivativePerThreadVariables[i].st_Value = MeasureType{};
   }
   value /= static_cast<DerivativeValueType>(this->m_NumberOfPixelsCounted);
 
@@ -490,7 +490,7 @@ SumSquaredTissueVolumeDifferenceImageToImageMetric<TFixedImage, TMovingImage>::T
   /*Create variables to store intermediate results. Circumvent false sharing*/
   unsigned long    numberOfPixelsCounted = 0;
   MeasureType      measure{};
-  DerivativeType & derivative = this->m_GetValueAndDerivativePerThreadVariables[threadId].st_Derivative;
+  DerivativeType & derivative = Superclass::m_GetValueAndDerivativePerThreadVariables[threadId].st_Derivative;
 
   /** Array that stores dM(x)/dmu, and the sparse jacobian+indices. */
   NonZeroJacobianIndicesType nzji(Superclass::m_AdvancedTransform->GetNumberOfNonZeroJacobianIndices());
@@ -592,8 +592,8 @@ SumSquaredTissueVolumeDifferenceImageToImageMetric<TFixedImage, TMovingImage>::T
   }
 
   /** Only update these variables at the end to prevent unnecessary "false sharing". */
-  this->m_GetValueAndDerivativePerThreadVariables[threadId].st_NumberOfPixelsCounted = numberOfPixelsCounted;
-  this->m_GetValueAndDerivativePerThreadVariables[threadId].st_Value = measure;
+  Superclass::m_GetValueAndDerivativePerThreadVariables[threadId].st_NumberOfPixelsCounted = numberOfPixelsCounted;
+  Superclass::m_GetValueAndDerivativePerThreadVariables[threadId].st_Value = measure;
 } // end ThreadedGetValueAndDerivative()
 
 
@@ -610,10 +610,10 @@ SumSquaredTissueVolumeDifferenceImageToImageMetric<TFixedImage, TMovingImage>::A
   const ThreadIdType numberOfThreads = Self::GetNumberOfWorkUnits();
 
   /** Accumulate the number of pixels. */
-  this->m_NumberOfPixelsCounted = this->m_GetValueAndDerivativePerThreadVariables[0].st_NumberOfPixelsCounted;
+  this->m_NumberOfPixelsCounted = Superclass::m_GetValueAndDerivativePerThreadVariables[0].st_NumberOfPixelsCounted;
   for (ThreadIdType i = 1; i < numberOfThreads; ++i)
   {
-    this->m_NumberOfPixelsCounted += this->m_GetValueAndDerivativePerThreadVariables[i].st_NumberOfPixelsCounted;
+    this->m_NumberOfPixelsCounted += Superclass::m_GetValueAndDerivativePerThreadVariables[i].st_NumberOfPixelsCounted;
   }
 
   /** Check if enough samples were valid. */
@@ -624,10 +624,10 @@ SumSquaredTissueVolumeDifferenceImageToImageMetric<TFixedImage, TMovingImage>::A
   value = MeasureType{};
   for (ThreadIdType i = 0; i < numberOfThreads; ++i)
   {
-    value += this->m_GetValueAndDerivativePerThreadVariables[i].st_Value;
+    value += Superclass::m_GetValueAndDerivativePerThreadVariables[i].st_Value;
 
     /** Reset this variable for the next iteration. */
-    this->m_GetValueAndDerivativePerThreadVariables[i].st_Value = MeasureType{};
+    Superclass::m_GetValueAndDerivativePerThreadVariables[i].st_Value = MeasureType{};
   }
 
   value /= static_cast<RealType>(this->m_NumberOfPixelsCounted);
@@ -636,10 +636,10 @@ SumSquaredTissueVolumeDifferenceImageToImageMetric<TFixedImage, TMovingImage>::A
   /** compute single-threadedly */
   if (!Superclass::m_UseMultiThread && false) // force multi-threaded as in AdvancedMeanSquares
   {
-    derivative = this->m_GetValueAndDerivativePerThreadVariables[0].st_Derivative;
+    derivative = Superclass::m_GetValueAndDerivativePerThreadVariables[0].st_Derivative;
     for (ThreadIdType i = 1; i < numberOfThreads; ++i)
     {
-      derivative += this->m_GetValueAndDerivativePerThreadVariables[i].st_Derivative;
+      derivative += Superclass::m_GetValueAndDerivativePerThreadVariables[i].st_Derivative;
     }
 
     derivative /= static_cast<DerivativeValueType>(this->m_NumberOfPixelsCounted);
@@ -669,7 +669,7 @@ SumSquaredTissueVolumeDifferenceImageToImageMetric<TFixedImage, TMovingImage>::A
       DerivativeValueType sum{};
       for (ThreadIdType i = 0; i < numberOfThreads; ++i)
       {
-        sum += this->m_GetValueAndDerivativePerThreadVariables[i].st_Derivative[j];
+        sum += Superclass::m_GetValueAndDerivativePerThreadVariables[i].st_Derivative[j];
       }
       derivative[j] = sum / static_cast<DerivativeValueType>(this->m_NumberOfPixelsCounted);
     }

--- a/Components/Metrics/SumSquaredTissueVolumeDifferenceMetric/itkSumSquaredTissueVolumeDifferenceImageToImageMetric.hxx
+++ b/Components/Metrics/SumSquaredTissueVolumeDifferenceMetric/itkSumSquaredTissueVolumeDifferenceImageToImageMetric.hxx
@@ -645,7 +645,7 @@ SumSquaredTissueVolumeDifferenceImageToImageMetric<TFixedImage, TMovingImage>::A
     derivative /= static_cast<DerivativeValueType>(this->m_NumberOfPixelsCounted);
   }
   // compute multi-threadedly with itk threads
-  else if (true) // force ITK threads !this->m_UseOpenMP )
+  else if (true) // force ITK threads !Superclass::m_UseOpenMP )
   {
     this->m_ThreaderMetricParameters.st_DerivativePointer = derivative.begin();
     this->m_ThreaderMetricParameters.st_NormalizationFactor =

--- a/Components/Metrics/SumSquaredTissueVolumeDifferenceMetric/itkSumSquaredTissueVolumeDifferenceImageToImageMetric.hxx
+++ b/Components/Metrics/SumSquaredTissueVolumeDifferenceMetric/itkSumSquaredTissueVolumeDifferenceImageToImageMetric.hxx
@@ -110,7 +110,7 @@ SumSquaredTissueVolumeDifferenceImageToImageMetric<TFixedImage, TMovingImage>::G
       this->m_NumberOfPixelsCounted++;
 
       /** Get the SpatialJacobian dT/dx. */
-      this->m_AdvancedTransform->GetSpatialJacobian(fixedPoint, spatialJac);
+      Superclass::m_AdvancedTransform->GetSpatialJacobian(fixedPoint, spatialJac);
 
       /** Compute the determinant of the Transform Jacobian |dT/dx|. */
       const RealType detjac = static_cast<RealType>(vnl_det(spatialJac.GetVnlMatrix()));
@@ -247,7 +247,7 @@ SumSquaredTissueVolumeDifferenceImageToImageMetric<TFixedImage, TMovingImage>::T
       const RealType fixedImageValue = static_cast<RealType>(threader_fiter->m_ImageValue);
 
       /** Get the SpatialJacobian dT/dx. */
-      this->m_AdvancedTransform->GetSpatialJacobian(fixedPoint, spatialJac);
+      Superclass::m_AdvancedTransform->GetSpatialJacobian(fixedPoint, spatialJac);
 
       /** Compute the determinant of the Transform Jacobian |dT/dx|. */
       const RealType detjac = static_cast<RealType>(vnl_det(spatialJac.GetVnlMatrix()));
@@ -342,7 +342,7 @@ SumSquaredTissueVolumeDifferenceImageToImageMetric<TFixedImage, TMovingImage>::G
   derivative.Fill(DerivativeValueType{});
 
   /** Array that stores dM(x)/dmu, and the sparse jacobian+indices. */
-  NonZeroJacobianIndicesType nzji(this->m_AdvancedTransform->GetNumberOfNonZeroJacobianIndices());
+  NonZeroJacobianIndicesType nzji(Superclass::m_AdvancedTransform->GetNumberOfNonZeroJacobianIndices());
   DerivativeType             imageJacobian(nzji.size());
   TransformJacobianType      jacobian;
 
@@ -401,7 +401,7 @@ SumSquaredTissueVolumeDifferenceImageToImageMetric<TFixedImage, TMovingImage>::G
       this->EvaluateTransformJacobianInnerProduct(jacobian, movingImageDerivative, imageJacobian);
 
       /** Get the SpatialJacobian dT/dx. */
-      this->m_AdvancedTransform->GetSpatialJacobian(fixedPoint, spatialJac);
+      Superclass::m_AdvancedTransform->GetSpatialJacobian(fixedPoint, spatialJac);
 
       /** Compute the determinant of the Transform Jacobian |dT/dx|. */
       const RealType detjac = static_cast<RealType>(vnl_det(spatialJac.GetVnlMatrix()));
@@ -410,7 +410,7 @@ SumSquaredTissueVolumeDifferenceImageToImageMetric<TFixedImage, TMovingImage>::G
       inverseSpatialJacobian = spatialJac.GetInverse();
 
       /** Compute the JacobianOfSpatialJacobian. */
-      this->m_AdvancedTransform->GetJacobianOfSpatialJacobian(fixedPoint, jacobianOfSpatialJacobian, nzji);
+      Superclass::m_AdvancedTransform->GetJacobianOfSpatialJacobian(fixedPoint, jacobianOfSpatialJacobian, nzji);
 
       /** Compute the dot product of the inverse spatialJacobian and JacobianOfSpatialJacobian
        * to support calculation of the JacobianOfSpatialJacobianDeterminant. */
@@ -493,7 +493,7 @@ SumSquaredTissueVolumeDifferenceImageToImageMetric<TFixedImage, TMovingImage>::T
   DerivativeType & derivative = this->m_GetValueAndDerivativePerThreadVariables[threadId].st_Derivative;
 
   /** Array that stores dM(x)/dmu, and the sparse jacobian+indices. */
-  NonZeroJacobianIndicesType nzji(this->m_AdvancedTransform->GetNumberOfNonZeroJacobianIndices());
+  NonZeroJacobianIndicesType nzji(Superclass::m_AdvancedTransform->GetNumberOfNonZeroJacobianIndices());
   DerivativeType             imageJacobian(nzji.size());
   TransformJacobianType      jacobian;
 
@@ -561,7 +561,7 @@ SumSquaredTissueVolumeDifferenceImageToImageMetric<TFixedImage, TMovingImage>::T
       this->EvaluateTransformJacobianInnerProduct(jacobian, movingImageDerivative, imageJacobian);
 
       /** Get the SpatialJacobian dT/dx. */
-      this->m_AdvancedTransform->GetSpatialJacobian(fixedPoint, spatialJac);
+      Superclass::m_AdvancedTransform->GetSpatialJacobian(fixedPoint, spatialJac);
 
       /** Compute the determinant of the Transform Jacobian |dT/dx|. */
       const RealType detjac = static_cast<RealType>(vnl_det(spatialJac.GetVnlMatrix()));
@@ -570,7 +570,7 @@ SumSquaredTissueVolumeDifferenceImageToImageMetric<TFixedImage, TMovingImage>::T
       inverseSpatialJacobian = spatialJac.GetInverse();
 
       /** Compute the JacobianOfSpatialJacobian. */
-      this->m_AdvancedTransform->GetJacobianOfSpatialJacobian(fixedPoint, jacobianOfSpatialJacobian, nzji);
+      Superclass::m_AdvancedTransform->GetJacobianOfSpatialJacobian(fixedPoint, jacobianOfSpatialJacobian, nzji);
 
       /** Compute the dot product of the inverse spatialJacobian and JacobianOfSpatialJacobian
        * to support calculation of the JacobianOfSpatialJacobianDeterminant.


### PR DESCRIPTION
Made it clearer when AdvancedImageToImageMetric accesses its own data members, and when those data members are accessed by a derived metric class.