### PR TITLE
STYLE: Remove `AdvancedImageToImageMetric::m_GetValuePerThreadVariables`

### DIFF
--- a/Common/CostFunctions/itkAdvancedImageToImageMetric.h
+++ b/Common/CostFunctions/itkAdvancedImageToImageMetric.h
@@ -448,17 +448,6 @@ protected:
    */
 
   // test per thread struct with padding and alignment
-  struct GetValuePerThreadStruct
-  {
-    SizeValueType st_NumberOfPixelsCounted;
-    MeasureType   st_Value;
-  };
-  itkPadStruct(ITK_CACHE_LINE_ALIGNMENT, GetValuePerThreadStruct, PaddedGetValuePerThreadStruct);
-  itkAlignedTypedef(ITK_CACHE_LINE_ALIGNMENT, PaddedGetValuePerThreadStruct, AlignedGetValuePerThreadStruct);
-  mutable std::unique_ptr<AlignedGetValuePerThreadStruct[]> m_GetValuePerThreadVariables{ nullptr };
-  mutable ThreadIdType                                      m_GetValuePerThreadVariablesSize{ 0 };
-
-  // test per thread struct with padding and alignment
   struct GetValueAndDerivativePerThreadStruct
   {
     SizeValueType  st_NumberOfPixelsCounted;

--- a/Common/CostFunctions/itkAdvancedImageToImageMetric.hxx
+++ b/Common/CostFunctions/itkAdvancedImageToImageMetric.hxx
@@ -149,13 +149,6 @@ AdvancedImageToImageMetric<TFixedImage, TMovingImage>::InitializeThreadingParame
    */
 
   /** Only resize the array of structs when needed. */
-  if (m_GetValuePerThreadVariablesSize != numberOfThreads)
-  {
-    m_GetValuePerThreadVariables.reset(new AlignedGetValuePerThreadStruct[numberOfThreads]);
-    m_GetValuePerThreadVariablesSize = numberOfThreads;
-  }
-
-  /** Only resize the array of structs when needed. */
   if (m_GetValueAndDerivativePerThreadVariablesSize != numberOfThreads)
   {
     m_GetValueAndDerivativePerThreadVariables.reset(new AlignedGetValueAndDerivativePerThreadStruct[numberOfThreads]);
@@ -165,9 +158,6 @@ AdvancedImageToImageMetric<TFixedImage, TMovingImage>::InitializeThreadingParame
   /** Some initialization. */
   for (ThreadIdType i = 0; i < numberOfThreads; ++i)
   {
-    m_GetValuePerThreadVariables[i].st_NumberOfPixelsCounted = SizeValueType{};
-    m_GetValuePerThreadVariables[i].st_Value = MeasureType{};
-
     m_GetValueAndDerivativePerThreadVariables[i].st_NumberOfPixelsCounted = SizeValueType{};
     m_GetValueAndDerivativePerThreadVariables[i].st_Value = MeasureType{};
     m_GetValueAndDerivativePerThreadVariables[i].st_Derivative.SetSize(this->GetNumberOfParameters());

--- a/Common/GTesting/itkAdvancedImageToImageMetricGTest.cxx
+++ b/Common/GTesting/itkAdvancedImageToImageMetricGTest.cxx
@@ -71,8 +71,6 @@ public:
       EXPECT_EQ(this->AdvancedImageToImageMetricType::m_ThreaderMetricParameters.st_Metric, this);
       EXPECT_EQ(this->AdvancedImageToImageMetricType::m_ThreaderMetricParameters.st_DerivativePointer, nullptr);
       EXPECT_EQ(this->AdvancedImageToImageMetricType::m_ThreaderMetricParameters.st_NormalizationFactor, 0.0);
-      EXPECT_EQ(this->AdvancedImageToImageMetricType::m_GetValuePerThreadVariables, nullptr);
-      EXPECT_EQ(this->AdvancedImageToImageMetricType::m_GetValuePerThreadVariablesSize, 0U);
       EXPECT_EQ(this->AdvancedImageToImageMetricType::m_GetValueAndDerivativePerThreadVariables, nullptr);
       EXPECT_EQ(this->AdvancedImageToImageMetricType::m_GetValueAndDerivativePerThreadVariablesSize, 0U);
       EXPECT_EQ(this->AdvancedImageToImageMetricType::m_FixedLimitRangeRatio, defaultLimitRangeRatio);


### PR DESCRIPTION
The protected AdvancedImageToImageMetric data members m_GetValuePerThreadVariables and m_GetValuePerThreadVariablesSize appear unused.