### PR TITLE
Remove const_cast and static_cast from m_ThreaderMetricParameters and m_ThreaderParameters 

### DIFF
--- a/Common/CostFunctions/itkAdvancedImageToImageMetric.hxx
+++ b/Common/CostFunctions/itkAdvancedImageToImageMetric.hxx
@@ -687,8 +687,7 @@ void
 AdvancedImageToImageMetric<TFixedImage, TMovingImage>::LaunchGetValueThreaderCallback() const
 {
   /** Setup threader. */
-  Superclass::m_Threader->SetSingleMethod(this->GetValueThreaderCallback,
-                                          const_cast<void *>(static_cast<const void *>(&m_ThreaderMetricParameters)));
+  Superclass::m_Threader->SetSingleMethod(this->GetValueThreaderCallback, &m_ThreaderMetricParameters);
 
   /** Launch. */
   Superclass::m_Threader->SingleMethodExecute();
@@ -730,8 +729,7 @@ void
 AdvancedImageToImageMetric<TFixedImage, TMovingImage>::LaunchGetValueAndDerivativeThreaderCallback() const
 {
   /** Setup threader. */
-  Superclass::m_Threader->SetSingleMethod(this->GetValueAndDerivativeThreaderCallback,
-                                          const_cast<void *>(static_cast<const void *>(&m_ThreaderMetricParameters)));
+  Superclass::m_Threader->SetSingleMethod(this->GetValueAndDerivativeThreaderCallback, &m_ThreaderMetricParameters);
 
   /** Launch. */
   Superclass::m_Threader->SingleMethodExecute();

--- a/Common/Transforms/itkAdvancedImageMomentsCalculator.hxx
+++ b/Common/Transforms/itkAdvancedImageMomentsCalculator.hxx
@@ -219,8 +219,7 @@ void
 AdvancedImageMomentsCalculator<TImage>::LaunchComputeThreaderCallback() const
 {
   /** Setup threader. */
-  this->m_Threader->SetSingleMethod(this->ComputeThreaderCallback,
-                                    const_cast<void *>(static_cast<const void *>(&this->m_ThreaderParameters)));
+  this->m_Threader->SetSingleMethod(this->ComputeThreaderCallback, &m_ThreaderParameters);
 
   /** Launch. */
   this->m_Threader->SingleMethodExecute();

--- a/Common/itkComputeDisplacementDistribution.hxx
+++ b/Common/itkComputeDisplacementDistribution.hxx
@@ -286,8 +286,7 @@ void
 ComputeDisplacementDistribution<TFixedImage, TTransform>::LaunchComputeThreaderCallback() const
 {
   /** Setup threader. */
-  this->m_Threader->SetSingleMethod(this->ComputeThreaderCallback,
-                                    const_cast<void *>(static_cast<const void *>(&this->m_ThreaderParameters)));
+  this->m_Threader->SetSingleMethod(this->ComputeThreaderCallback, &m_ThreaderParameters);
 
   /** Launch. */
   this->m_Threader->SingleMethodExecute();

--- a/Components/Metrics/AdvancedMattesMutualInformation/itkParzenWindowMutualInformationImageToImageMetric.hxx
+++ b/Components/Metrics/AdvancedMattesMutualInformation/itkParzenWindowMutualInformationImageToImageMetric.hxx
@@ -592,9 +592,8 @@ ParzenWindowMutualInformationImageToImageMetric<TFixedImage, TMovingImage>::Afte
     Superclass::m_ThreaderMetricParameters.st_DerivativePointer = derivative.begin();
     Superclass::m_ThreaderMetricParameters.st_NormalizationFactor = 1.0;
 
-    this->m_Threader->SetSingleMethod(
-      this->AccumulateDerivativesThreaderCallback,
-      const_cast<void *>(static_cast<const void *>(&(Superclass::m_ThreaderMetricParameters))));
+    this->m_Threader->SetSingleMethod(this->AccumulateDerivativesThreaderCallback,
+                                      &(Superclass::m_ThreaderMetricParameters));
     this->m_Threader->SingleMethodExecute();
   }
 

--- a/Components/Metrics/AdvancedMeanSquares/itkAdvancedMeanSquaresImageToImageMetric.hxx
+++ b/Components/Metrics/AdvancedMeanSquares/itkAdvancedMeanSquaresImageToImageMetric.hxx
@@ -686,9 +686,8 @@ AdvancedMeanSquaresImageToImageMetric<TFixedImage, TMovingImage>::AfterThreadedG
     Superclass::m_ThreaderMetricParameters.st_DerivativePointer = derivative.begin();
     Superclass::m_ThreaderMetricParameters.st_NormalizationFactor = 1.0 / normal_sum;
 
-    this->m_Threader->SetSingleMethod(
-      this->AccumulateDerivativesThreaderCallback,
-      const_cast<void *>(static_cast<const void *>(&(Superclass::m_ThreaderMetricParameters))));
+    this->m_Threader->SetSingleMethod(this->AccumulateDerivativesThreaderCallback,
+                                      &(Superclass::m_ThreaderMetricParameters));
     this->m_Threader->SingleMethodExecute();
   }
 #ifdef ELASTIX_USE_OPENMP

--- a/Components/Metrics/BendingEnergyPenalty/itkTransformBendingEnergyPenaltyTerm.hxx
+++ b/Components/Metrics/BendingEnergyPenalty/itkTransformBendingEnergyPenaltyTerm.hxx
@@ -587,9 +587,8 @@ TransformBendingEnergyPenaltyTerm<TFixedImage, TScalarType>::AfterThreadedGetVal
     Superclass::m_ThreaderMetricParameters.st_NormalizationFactor =
       static_cast<DerivativeValueType>(this->m_NumberOfPixelsCounted);
 
-    this->m_Threader->SetSingleMethod(
-      this->AccumulateDerivativesThreaderCallback,
-      const_cast<void *>(static_cast<const void *>(&(Superclass::m_ThreaderMetricParameters))));
+    this->m_Threader->SetSingleMethod(this->AccumulateDerivativesThreaderCallback,
+                                      &(Superclass::m_ThreaderMetricParameters));
     this->m_Threader->SingleMethodExecute();
   }
 #ifdef ELASTIX_USE_OPENMP

--- a/Components/Metrics/SumSquaredTissueVolumeDifferenceMetric/itkSumSquaredTissueVolumeDifferenceImageToImageMetric.hxx
+++ b/Components/Metrics/SumSquaredTissueVolumeDifferenceMetric/itkSumSquaredTissueVolumeDifferenceImageToImageMetric.hxx
@@ -651,9 +651,8 @@ SumSquaredTissueVolumeDifferenceImageToImageMetric<TFixedImage, TMovingImage>::A
     Superclass::m_ThreaderMetricParameters.st_NormalizationFactor =
       static_cast<DerivativeValueType>(this->m_NumberOfPixelsCounted);
 
-    this->m_Threader->SetSingleMethod(
-      this->AccumulateDerivativesThreaderCallback,
-      const_cast<void *>(static_cast<const void *>(&(Superclass::m_ThreaderMetricParameters))));
+    this->m_Threader->SetSingleMethod(this->AccumulateDerivativesThreaderCallback,
+                                      &(Superclass::m_ThreaderMetricParameters));
     this->m_Threader->SingleMethodExecute();
   }
 

--- a/Testing/itkAccumulateDerivativesParallellizationTest.cxx
+++ b/Testing/itkAccumulateDerivativesParallellizationTest.cxx
@@ -120,9 +120,7 @@ public:
       this->m_ThreaderMetricParameters.st_DerivativePointer = derivative.begin();
       this->m_ThreaderMetricParameters.st_NormalizationFactor = 1.0 / normal_sum;
 
-      this->m_Threader->SetSingleMethod(
-        this->AccumulateDerivativesThreaderCallback,
-        const_cast<void *>(static_cast<const void *>(&this->m_ThreaderMetricParameters)));
+      this->m_Threader->SetSingleMethod(this->AccumulateDerivativesThreaderCallback, &this->m_ThreaderMetricParameters);
       this->m_Threader->SingleMethodExecute();
     }
 #ifdef ELASTIX_USE_OPENMP


### PR DESCRIPTION
These member variables were already declared `mutable`, so there appears no need at all for those `const_cast<void *>(static_cast<const void *>())` casts.

Following C++ Core Guidelines, [Avoid casts](https://isocpp.github.io/CppCoreGuidelines/CppCoreGuidelines#Res-casts) 