### PR TITLE
Replace `GetNumberOfWeights()`, `GetSupportSize()`, and `m_SupportSize` with compile-time equivalents (STYLE/PERF)

### DIFF
--- a/Common/Transforms/itkAdvancedBSplineDeformableTransform.h
+++ b/Common/Transforms/itkAdvancedBSplineDeformableTransform.h
@@ -216,14 +216,8 @@ public:
   /** Parameter index array type. */
   using typename Superclass::ParameterIndexArrayType;
 
-
-  /** Get number of weights. */
-  unsigned long
-  GetNumberOfWeights() const
-  {
-    return this->m_WeightsFunction->GetNumberOfWeights();
-  }
-
+  /** The number of weights. */
+  static constexpr unsigned NumberOfWeights = WeightsFunctionType::NumberOfWeights;
 
   unsigned int
   GetNumberOfAffectedWeights() const override;

--- a/Common/Transforms/itkAdvancedBSplineDeformableTransform.hxx
+++ b/Common/Transforms/itkAdvancedBSplineDeformableTransform.hxx
@@ -269,7 +269,7 @@ template <class TScalarType, unsigned int NDimensions, unsigned int VSplineOrder
 unsigned int
 AdvancedBSplineDeformableTransform<TScalarType, NDimensions, VSplineOrder>::GetNumberOfAffectedWeights() const
 {
-  return this->m_WeightsFunction->GetNumberOfWeights();
+  return NumberOfWeights;
 } // end GetNumberOfAffectedWeights()
 
 
@@ -282,7 +282,7 @@ auto
 AdvancedBSplineDeformableTransform<TScalarType, NDimensions, VSplineOrder>::GetNumberOfNonZeroJacobianIndices() const
   -> NumberOfParametersType
 {
-  return this->m_WeightsFunction->GetNumberOfWeights() * SpaceDimension;
+  return NumberOfWeights * SpaceDimension;
 } // end GetNumberOfNonZeroJacobianIndices()
 
 
@@ -331,8 +331,7 @@ AdvancedBSplineDeformableTransform<TScalarType, NDimensions, VSplineOrder>::GetJ
   /** Compute the number of affected B-spline parameters.
    * Allocate memory on the stack.
    */
-  const unsigned long numberOfWeights = WeightsFunctionType::NumberOfWeights;
-  WeightsType         weights;
+  WeightsType weights;
 
   /** Compute the weights. */
   IndexType supportIndex;
@@ -346,8 +345,8 @@ AdvancedBSplineDeformableTransform<TScalarType, NDimensions, VSplineOrder>::GetJ
   ParametersValueType * jacobianPointer = jacobian.data_block();
   for (unsigned int d = 0; d < SpaceDimension; ++d)
   {
-    unsigned long offset = d * SpaceDimension * numberOfWeights + d * numberOfWeights;
-    std::copy_n(weights.begin(), numberOfWeights, jacobianPointer + offset);
+    unsigned long offset = d * SpaceDimension * NumberOfWeights + d * NumberOfWeights;
+    std::copy_n(weights.begin(), NumberOfWeights, jacobianPointer + offset);
   }
 
   /** Compute the nonzero Jacobian indices.
@@ -393,8 +392,7 @@ AdvancedBSplineDeformableTransform<TScalarType, NDimensions, VSplineOrder>::Eval
   /** Compute the number of affected B-spline parameters.
    * Allocate memory on the stack.
    */
-  const unsigned long numberOfWeights = WeightsFunctionType::NumberOfWeights;
-  WeightsType         weights;
+  WeightsType weights;
 
   /** Compute the B-spline derivative weights. */
   IndexType supportIndex;
@@ -449,11 +447,10 @@ AdvancedBSplineDeformableTransform<TScalarType, NDimensions, VSplineOrder>::GetS
 
   /** Compute the number of affected B-spline parameters. */
   /** Allocate memory on the stack: */
-  const unsigned long numberOfWeights = WeightsFunctionType::NumberOfWeights;
-  WeightsType         weights;
+  WeightsType weights;
 
   /** Array for CoefficientImage values */
-  std::array<typename WeightsType::ValueType, numberOfWeights * SpaceDimension> coeffs;
+  std::array<typename WeightsType::ValueType, NumberOfWeights * SpaceDimension> coeffs;
 
   IndexType supportIndex;
   this->m_DerivativeWeightsFunctions[0]->ComputeStartIndex(cindex, supportIndex);
@@ -500,7 +497,7 @@ AdvancedBSplineDeformableTransform<TScalarType, NDimensions, VSplineOrder>::GetS
       typename WeightsType::const_iterator itWeights = weights.begin();
 
       /** Compute the sum for this dimension. */
-      for (unsigned int mu = 0; mu < numberOfWeights; ++mu)
+      for (unsigned int mu = 0; mu < NumberOfWeights; ++mu)
       {
         sj(dim, i) += (*itCoeffs) * (*itWeights);
         ++itWeights;
@@ -551,11 +548,10 @@ AdvancedBSplineDeformableTransform<TScalarType, NDimensions, VSplineOrder>::GetS
 
   /** Helper variables. */
   /** Allocate memory on the stack: */
-  const unsigned long numberOfWeights = WeightsFunctionType::NumberOfWeights;
-  WeightsType         weights;
+  WeightsType weights;
 
   /** Array for CoefficientImage values */
-  std::array<WeightsValueType, numberOfWeights * SpaceDimension> coeffs;
+  std::array<WeightsValueType, NumberOfWeights * SpaceDimension> coeffs;
 
   IndexType supportIndex;
   this->m_SODerivativeWeightsFunctions[0][0]->ComputeStartIndex(cindex, supportIndex);
@@ -567,7 +563,7 @@ AdvancedBSplineDeformableTransform<TScalarType, NDimensions, VSplineOrder>::GetS
   {
     ImageScanlineConstIterator<ImageType> itCoef(this->m_CoefficientImages[dim], supportRegion);
 
-    // for( unsigned int mu = 0; mu < numberOfWeights; ++mu )
+    // for( unsigned int mu = 0; mu < NumberOfWeights; ++mu )
     while (!itCoef.IsAtEnd())
     {
       while (!itCoef.IsAtEndOfLine())
@@ -604,7 +600,7 @@ AdvancedBSplineDeformableTransform<TScalarType, NDimensions, VSplineOrder>::GetS
         /** Compute the sum for this dimension. */
         double sum = 0.0;
 
-        for (unsigned int mu = 0; mu < numberOfWeights; ++mu)
+        for (unsigned int mu = 0; mu < NumberOfWeights; ++mu)
         {
           sum += (*itCoeffs) * (*itWeights);
           ++itWeights;
@@ -671,15 +667,14 @@ AdvancedBSplineDeformableTransform<TScalarType, NDimensions, VSplineOrder>::GetJ
   /** Helper variables. */
 
   /** Allocate memory on the stack: */
-  const unsigned long numberOfWeights = WeightsFunctionType::NumberOfWeights;
-  WeightsType         weights;
+  WeightsType weights;
 
   IndexType supportIndex;
   this->m_DerivativeWeightsFunctions[0]->ComputeStartIndex(cindex, supportIndex);
   const RegionType supportRegion(supportIndex, Superclass::m_SupportSize);
 
   /** On the stack instead of heap is faster. */
-  double weightVector[SpaceDimension * numberOfWeights];
+  double weightVector[SpaceDimension * NumberOfWeights];
 
   /** For all derivative directions, compute the derivatives of the
    * spatial Jacobian to the transformation parameters mu:
@@ -691,7 +686,7 @@ AdvancedBSplineDeformableTransform<TScalarType, NDimensions, VSplineOrder>::GetJ
     this->m_DerivativeWeightsFunctions[i]->Evaluate(cindex, supportIndex, weights);
 
     /** Remember the weights. */
-    std::copy_n(weights.begin(), numberOfWeights, weightVector + i * numberOfWeights);
+    std::copy_n(weights.begin(), NumberOfWeights, weightVector + i * NumberOfWeights);
 
   } // end for i
 
@@ -699,14 +694,14 @@ AdvancedBSplineDeformableTransform<TScalarType, NDimensions, VSplineOrder>::GetJ
    *    d/dmu dT_{dim} / dx_i = weights.
    */
   SpatialJacobianType * basepointer = &jsj[0];
-  for (unsigned int mu = 0; mu < numberOfWeights; ++mu)
+  for (unsigned int mu = 0; mu < NumberOfWeights; ++mu)
   {
     for (unsigned int i = 0; i < SpaceDimension; ++i)
     {
-      double tmp = *(weightVector + i * numberOfWeights + mu);
+      double tmp = *(weightVector + i * NumberOfWeights + mu);
       for (unsigned int dim = 0; dim < SpaceDimension; ++dim)
       {
-        (*(basepointer + dim * numberOfWeights + mu))(dim, i) = tmp;
+        (*(basepointer + dim * NumberOfWeights + mu))(dim, i) = tmp;
       }
     }
   }
@@ -770,11 +765,10 @@ AdvancedBSplineDeformableTransform<TScalarType, NDimensions, VSplineOrder>::GetJ
 
   /** Allocate weight on the stack. */
   using WeightsValueType = typename WeightsType::ValueType;
-  const unsigned long numberOfWeights = WeightsFunctionType::NumberOfWeights;
-  WeightsType         weights;
+  WeightsType weights;
 
   /** Allocate coefficients on the stack. */
-  std::array<WeightsValueType, numberOfWeights * SpaceDimension> coeffs;
+  std::array<WeightsValueType, NumberOfWeights * SpaceDimension> coeffs;
 
   /** Copy values from coefficient image to linear coeffs array. */
   // takes considerable amount of time : 27% of this function. // with old region iterator, check with new
@@ -797,7 +791,7 @@ AdvancedBSplineDeformableTransform<TScalarType, NDimensions, VSplineOrder>::GetJ
 
   /** On the stack instead of heap is faster. */
   const unsigned int d = SpaceDimension * (SpaceDimension + 1) / 2;
-  double             weightVector[d * numberOfWeights];
+  double             weightVector[d * NumberOfWeights];
 
   /** Initialize the spatial Jacobian sj: */
   sj.Fill(0.0);
@@ -813,7 +807,7 @@ AdvancedBSplineDeformableTransform<TScalarType, NDimensions, VSplineOrder>::GetJ
      * weights at once for all dimensions */
 
     /** Remember the weights. */
-    std::copy_n(weights.begin(), numberOfWeights, weightVector + i * numberOfWeights);
+    std::copy_n(weights.begin(), NumberOfWeights, weightVector + i * NumberOfWeights);
 
     /** Reset coeffs iterator */
     auto itCoeffs = coeffs.cbegin();
@@ -827,7 +821,7 @@ AdvancedBSplineDeformableTransform<TScalarType, NDimensions, VSplineOrder>::GetJ
       typename WeightsType::const_iterator itWeights = weights.begin();
 
       /** Compute the sum for this dimension. */
-      for (unsigned int mu = 0; mu < numberOfWeights; ++mu)
+      for (unsigned int mu = 0; mu < NumberOfWeights; ++mu)
       {
         sj(dim, i) += (*itCoeffs) * (*itWeights);
         ++itWeights;
@@ -850,14 +844,14 @@ AdvancedBSplineDeformableTransform<TScalarType, NDimensions, VSplineOrder>::GetJ
    *    d/dmu dT_{dim} / dx_i = weights.
    */
   SpatialJacobianType * basepointer = &jsj[0];
-  for (unsigned int mu = 0; mu < numberOfWeights; ++mu)
+  for (unsigned int mu = 0; mu < NumberOfWeights; ++mu)
   {
     for (unsigned int i = 0; i < SpaceDimension; ++i)
     {
-      const double tmp = *(weightVector + i * numberOfWeights + mu);
+      const double tmp = *(weightVector + i * NumberOfWeights + mu);
       for (unsigned int dim = 0; dim < SpaceDimension; ++dim)
       {
-        (*(basepointer + dim * numberOfWeights + mu))(dim, i) = tmp;
+        (*(basepointer + dim * NumberOfWeights + mu))(dim, i) = tmp;
       }
     }
   }
@@ -918,8 +912,7 @@ AdvancedBSplineDeformableTransform<TScalarType, NDimensions, VSplineOrder>::GetJ
   /** Compute the number of affected B-spline parameters. */
 
   /** Allocate memory on the stack: */
-  const unsigned long numberOfWeights = WeightsFunctionType::NumberOfWeights;
-  WeightsType         weights;
+  WeightsType weights;
 
   IndexType supportIndex;
   this->m_SODerivativeWeightsFunctions[0][0]->ComputeStartIndex(cindex, supportIndex);
@@ -949,7 +942,7 @@ AdvancedBSplineDeformableTransform<TScalarType, NDimensions, VSplineOrder>::GetJ
   }   // end for i
 
   /** Compute d/dmu d^2T_{dim} / dx_i dx_j = weights. */
-  for (unsigned int mu = 0; mu < numberOfWeights; ++mu)
+  for (unsigned int mu = 0; mu < NumberOfWeights; ++mu)
   {
     SpatialJacobianType matrix;
     unsigned int        count = 0;
@@ -973,7 +966,7 @@ AdvancedBSplineDeformableTransform<TScalarType, NDimensions, VSplineOrder>::GetJ
     /** Copy the matrix to the right locations. */
     for (unsigned int dim = 0; dim < SpaceDimension; ++dim)
     {
-      jsh[mu + dim * numberOfWeights][dim] = matrix;
+      jsh[mu + dim * NumberOfWeights][dim] = matrix;
     }
   }
 
@@ -1038,11 +1031,10 @@ AdvancedBSplineDeformableTransform<TScalarType, NDimensions, VSplineOrder>::GetJ
 
   /** Allocate weight on the stack. */
   using WeightsValueType = typename WeightsType::ValueType;
-  const unsigned long numberOfWeights = WeightsFunctionType::NumberOfWeights;
-  WeightsType         weights;
+  WeightsType weights;
 
   /** Allocate coefficients on the stack. */
-  std::array<WeightsValueType, numberOfWeights * SpaceDimension> coeffs;
+  std::array<WeightsValueType, NumberOfWeights * SpaceDimension> coeffs;
 
   /** Copy values from coefficient image to linear coeffs array. */
   // takes considerable amount of time : 27% of this function. // with old region iterator, check with new
@@ -1065,7 +1057,7 @@ AdvancedBSplineDeformableTransform<TScalarType, NDimensions, VSplineOrder>::GetJ
 
   /** On the stack instead of heap is faster. */
   const unsigned int d = SpaceDimension * (SpaceDimension + 1) / 2;
-  double             weightVector[d * numberOfWeights];
+  double             weightVector[d * NumberOfWeights];
 
   /** For all derivative directions, compute the derivatives of the
    * spatial Hessian to the transformation parameters mu:
@@ -1082,7 +1074,7 @@ AdvancedBSplineDeformableTransform<TScalarType, NDimensions, VSplineOrder>::GetJ
       this->m_SODerivativeWeightsFunctions[i][j]->Evaluate(cindex, supportIndex, weights);
 
       /** Remember the weights. */
-      std::copy_n(weights.begin(), numberOfWeights, weightVector + count * numberOfWeights);
+      std::copy_n(weights.begin(), NumberOfWeights, weightVector + count * NumberOfWeights);
       ++count;
 
       /** Reset coeffs iterator */
@@ -1098,7 +1090,7 @@ AdvancedBSplineDeformableTransform<TScalarType, NDimensions, VSplineOrder>::GetJ
 
         /** Compute the sum for this dimension. */
         double sum = 0.0;
-        for (unsigned int mu = 0; mu < numberOfWeights; ++mu)
+        for (unsigned int mu = 0; mu < NumberOfWeights; ++mu)
         {
           sum += (*itCoeffs) * (*itWeights);
           ++itWeights;
@@ -1126,14 +1118,14 @@ AdvancedBSplineDeformableTransform<TScalarType, NDimensions, VSplineOrder>::GetJ
    *    d/dmu d^2T_{dim} / dx_i dx_j = weights.
    */
   SpatialJacobianType matrix;
-  for (unsigned int mu = 0; mu < numberOfWeights; ++mu)
+  for (unsigned int mu = 0; mu < NumberOfWeights; ++mu)
   {
     unsigned int count = 0;
     for (unsigned int i = 0; i < SpaceDimension; ++i)
     {
       for (unsigned int j = 0; j <= i; ++j)
       {
-        const double tmp = *(weightVector + count * numberOfWeights + mu);
+        const double tmp = *(weightVector + count * NumberOfWeights + mu);
         matrix[i][j] = tmp;
         if (i != j)
         {
@@ -1162,7 +1154,7 @@ AdvancedBSplineDeformableTransform<TScalarType, NDimensions, VSplineOrder>::GetJ
     /** Copy the matrix to the right locations. */
     for (unsigned int dim = 0; dim < SpaceDimension; ++dim)
     {
-      jsh[mu + dim * numberOfWeights][dim] = matrix;
+      jsh[mu + dim * NumberOfWeights][dim] = matrix;
     }
   }
 
@@ -1183,7 +1175,6 @@ AdvancedBSplineDeformableTransform<TScalarType, NDimensions, VSplineOrder>::Comp
   const RegionType &           supportRegion) const
 {
   /** Initialize some helper variables. */
-  const unsigned long numberOfWeights = WeightsFunctionType::NumberOfWeights;
   const unsigned long parametersPerDim = this->GetNumberOfParametersPerDimension();
 
   nonZeroJacobianIndices.resize(this->GetNumberOfNonZeroJacobianIndices());
@@ -1211,7 +1202,7 @@ AdvancedBSplineDeformableTransform<TScalarType, NDimensions, VSplineOrder>::Comp
       for (unsigned int x = 0; x < sx; ++x)
       {
         nonZeroJacobianIndices[localParNum] = globalParNum;
-        nonZeroJacobianIndices[localParNum + numberOfWeights] = globalParNum + parametersPerDim;
+        nonZeroJacobianIndices[localParNum + NumberOfWeights] = globalParNum + parametersPerDim;
         ++localParNum;
         ++globalParNum;
       }
@@ -1239,8 +1230,8 @@ AdvancedBSplineDeformableTransform<TScalarType, NDimensions, VSplineOrder>::Comp
         for (unsigned int x = 0; x < sx; ++x)
         {
           nonZeroJacobianIndices[localParNum] = globalParNum;
-          nonZeroJacobianIndices[localParNum + numberOfWeights] = globalParNum + parametersPerDim;
-          nonZeroJacobianIndices[localParNum + 2 * numberOfWeights] = globalParNum + 2 * parametersPerDim;
+          nonZeroJacobianIndices[localParNum + NumberOfWeights] = globalParNum + parametersPerDim;
+          nonZeroJacobianIndices[localParNum + 2 * NumberOfWeights] = globalParNum + 2 * parametersPerDim;
           ++localParNum;
           ++globalParNum;
         }
@@ -1259,8 +1250,8 @@ AdvancedBSplineDeformableTransform<TScalarType, NDimensions, VSplineOrder>::Comp
     }
 
     /** Loop over the support region and compute the nzji. */
-    for (unsigned int localParNum = 0; localParNum < numberOfWeights; ++localParNum)
-    // Note that numberOfWeights == supportRegion.GetNumberOfPixels()
+    for (unsigned int localParNum = 0; localParNum < NumberOfWeights; ++localParNum)
+    // Note that NumberOfWeights == supportRegion.GetNumberOfPixels()
     {
       // translate localParNum to a local index
       GridOffsetType localParIndex;
@@ -1288,7 +1279,7 @@ AdvancedBSplineDeformableTransform<TScalarType, NDimensions, VSplineOrder>::Comp
       /** Update the nonZeroJacobianIndices for all directions. */
       for (unsigned int dim = 0; dim < SpaceDimension; ++dim)
       {
-        nonZeroJacobianIndices[localParNum + dim * numberOfWeights] = globalParNum + dim * parametersPerDim;
+        nonZeroJacobianIndices[localParNum + dim * NumberOfWeights] = globalParNum + dim * parametersPerDim;
       }
     } // end for
   }   // end general case

--- a/Common/Transforms/itkAdvancedBSplineDeformableTransform.hxx
+++ b/Common/Transforms/itkAdvancedBSplineDeformableTransform.hxx
@@ -69,7 +69,6 @@ AdvancedBSplineDeformableTransform<TScalarType, NDimensions, VSplineOrder>::Adva
       this->m_SODerivativeWeightsFunctions[i][j]->SetDerivativeDirections(i, j);
     }
   }
-  this->m_SupportSize = WeightsFunctionType::SupportSize;
 
   this->m_InternalParametersBuffer = ParametersType(0);
   // Make sure the parameters pointer is not NULL after construction.
@@ -216,7 +215,7 @@ AdvancedBSplineDeformableTransform<TScalarType, NDimensions, VSplineOrder>::Tran
   this->m_WeightsFunction->Evaluate(cindex, supportIndex, weights);
 
   // For each dimension, correlate coefficient with weights
-  const RegionType supportRegion(supportIndex, Superclass::m_SupportSize);
+  const RegionType supportRegion(supportIndex, WeightsFunctionType::SupportSize);
 
   OutputPointType outputPoint{};
 
@@ -339,7 +338,7 @@ AdvancedBSplineDeformableTransform<TScalarType, NDimensions, VSplineOrder>::GetJ
   this->m_WeightsFunction->Evaluate(cindex, supportIndex, weights);
 
   /** Setup support region */
-  const RegionType supportRegion(supportIndex, Superclass::m_SupportSize);
+  const RegionType supportRegion(supportIndex, WeightsFunctionType::SupportSize);
 
   /** Put at the right positions. */
   ParametersValueType * jacobianPointer = jacobian.data_block();
@@ -412,7 +411,7 @@ AdvancedBSplineDeformableTransform<TScalarType, NDimensions, VSplineOrder>::Eval
   }
 
   /** Setup support region needed for the nonZeroJacobianIndices. */
-  const RegionType supportRegion(supportIndex, Superclass::m_SupportSize);
+  const RegionType supportRegion(supportIndex, WeightsFunctionType::SupportSize);
 
   /** Compute the nonzero Jacobian indices.
    * Takes a significant portion of the computation time of this function.
@@ -454,7 +453,7 @@ AdvancedBSplineDeformableTransform<TScalarType, NDimensions, VSplineOrder>::GetS
 
   IndexType supportIndex;
   this->m_DerivativeWeightsFunctions[0]->ComputeStartIndex(cindex, supportIndex);
-  const RegionType supportRegion(supportIndex, Superclass::m_SupportSize);
+  const RegionType supportRegion(supportIndex, WeightsFunctionType::SupportSize);
 
   /** Copy values from coefficient image to linear coeffs array. */
   auto itCoeffsLinear = coeffs.begin();
@@ -555,7 +554,7 @@ AdvancedBSplineDeformableTransform<TScalarType, NDimensions, VSplineOrder>::GetS
 
   IndexType supportIndex;
   this->m_SODerivativeWeightsFunctions[0][0]->ComputeStartIndex(cindex, supportIndex);
-  const RegionType supportRegion(supportIndex, Superclass::m_SupportSize);
+  const RegionType supportRegion(supportIndex, WeightsFunctionType::SupportSize);
 
   /** Copy values from coefficient image to linear coeffs array. */
   auto itCoeffsLinear = coeffs.begin();
@@ -671,7 +670,7 @@ AdvancedBSplineDeformableTransform<TScalarType, NDimensions, VSplineOrder>::GetJ
 
   IndexType supportIndex;
   this->m_DerivativeWeightsFunctions[0]->ComputeStartIndex(cindex, supportIndex);
-  const RegionType supportRegion(supportIndex, Superclass::m_SupportSize);
+  const RegionType supportRegion(supportIndex, WeightsFunctionType::SupportSize);
 
   /** On the stack instead of heap is faster. */
   double weightVector[SpaceDimension * NumberOfWeights];
@@ -761,7 +760,7 @@ AdvancedBSplineDeformableTransform<TScalarType, NDimensions, VSplineOrder>::GetJ
   /** Helper variables. */
   IndexType supportIndex;
   this->m_DerivativeWeightsFunctions[0]->ComputeStartIndex(cindex, supportIndex);
-  const RegionType supportRegion(supportIndex, Superclass::m_SupportSize);
+  const RegionType supportRegion(supportIndex, WeightsFunctionType::SupportSize);
 
   /** Allocate weight on the stack. */
   using WeightsValueType = typename WeightsType::ValueType;
@@ -916,7 +915,7 @@ AdvancedBSplineDeformableTransform<TScalarType, NDimensions, VSplineOrder>::GetJ
 
   IndexType supportIndex;
   this->m_SODerivativeWeightsFunctions[0][0]->ComputeStartIndex(cindex, supportIndex);
-  const RegionType supportRegion(supportIndex, Superclass::m_SupportSize);
+  const RegionType supportRegion(supportIndex, WeightsFunctionType::SupportSize);
 
   /** For all derivative directions, compute the derivatives of the
    * spatial Hessian to the transformation parameters mu:
@@ -1027,7 +1026,7 @@ AdvancedBSplineDeformableTransform<TScalarType, NDimensions, VSplineOrder>::GetJ
   /** Get the support region. */
   IndexType supportIndex;
   this->m_SODerivativeWeightsFunctions[0][0]->ComputeStartIndex(cindex, supportIndex);
-  const RegionType supportRegion(supportIndex, Superclass::m_SupportSize);
+  const RegionType supportRegion(supportIndex, WeightsFunctionType::SupportSize);
 
   /** Allocate weight on the stack. */
   using WeightsValueType = typename WeightsType::ValueType;

--- a/Common/Transforms/itkAdvancedBSplineDeformableTransform.hxx
+++ b/Common/Transforms/itkAdvancedBSplineDeformableTransform.hxx
@@ -69,7 +69,7 @@ AdvancedBSplineDeformableTransform<TScalarType, NDimensions, VSplineOrder>::Adva
       this->m_SODerivativeWeightsFunctions[i][j]->SetDerivativeDirections(i, j);
     }
   }
-  this->m_SupportSize = this->m_WeightsFunction->GetSupportSize();
+  this->m_SupportSize = WeightsFunctionType::SupportSize;
 
   this->m_InternalParametersBuffer = ParametersType(0);
   // Make sure the parameters pointer is not NULL after construction.

--- a/Common/Transforms/itkAdvancedBSplineDeformableTransformBase.h
+++ b/Common/Transforms/itkAdvancedBSplineDeformableTransformBase.h
@@ -387,7 +387,6 @@ protected:
 
   /** Variables defining the interpolation support region. */
   unsigned long       m_Offset{};
-  SizeType            m_SupportSize{};
   ContinuousIndexType m_ValidRegionBegin{};
   ContinuousIndexType m_ValidRegionEnd{};
 

--- a/Common/Transforms/itkBSplineInterpolationDerivativeWeightFunction.hxx
+++ b/Common/Transforms/itkBSplineInterpolationDerivativeWeightFunction.hxx
@@ -91,7 +91,7 @@ BSplineInterpolationDerivativeWeightFunction<TCoordRep, VSpaceDimension, VSpline
 
     if (i != this->m_DerivativeDirection)
     {
-      for (unsigned int k = 0; k < this->m_SupportSize[i]; ++k)
+      for (unsigned int k = 0; k < VSplineOrder + 1; ++k)
       {
         weights1D[i][k] = KernelType::FastEvaluate(x);
         x -= 1.0;
@@ -99,7 +99,7 @@ BSplineInterpolationDerivativeWeightFunction<TCoordRep, VSpaceDimension, VSpline
     }
     else
     {
-      for (unsigned int k = 0; k < this->m_SupportSize[i]; ++k)
+      for (unsigned int k = 0; k < VSplineOrder + 1; ++k)
       {
         weights1D[i][k] = DerivativeKernelType::FastEvaluate(x);
         x -= 1.0;

--- a/Common/Transforms/itkBSplineInterpolationSecondOrderDerivativeWeightFunction.hxx
+++ b/Common/Transforms/itkBSplineInterpolationSecondOrderDerivativeWeightFunction.hxx
@@ -106,7 +106,7 @@ BSplineInterpolationSecondOrderDerivativeWeightFunction<TCoordRep, VSpaceDimensi
 
     if (i != this->m_DerivativeDirections[0] && i != this->m_DerivativeDirections[1])
     {
-      for (unsigned int k = 0; k < this->m_SupportSize[i]; ++k)
+      for (unsigned int k = 0; k < VSplineOrder + 1; ++k)
       {
         weights1D[i][k] = KernelType::FastEvaluate(x);
         x -= 1.0;
@@ -116,7 +116,7 @@ BSplineInterpolationSecondOrderDerivativeWeightFunction<TCoordRep, VSpaceDimensi
     {
       if (this->m_EqualDerivativeDirections)
       {
-        for (unsigned int k = 0; k < this->m_SupportSize[i]; ++k)
+        for (unsigned int k = 0; k < VSplineOrder + 1; ++k)
         {
           weights1D[i][k] = SecondOrderDerivativeKernelType::FastEvaluate(x);
           x -= 1.0;
@@ -124,7 +124,7 @@ BSplineInterpolationSecondOrderDerivativeWeightFunction<TCoordRep, VSpaceDimensi
       }
       else
       {
-        for (unsigned int k = 0; k < this->m_SupportSize[i]; ++k)
+        for (unsigned int k = 0; k < VSplineOrder + 1; ++k)
         {
           weights1D[i][k] = DerivativeKernelType::FastEvaluate(x);
           x -= 1.0;

--- a/Common/Transforms/itkBSplineInterpolationWeightFunction2.hxx
+++ b/Common/Transforms/itkBSplineInterpolationWeightFunction2.hxx
@@ -44,7 +44,7 @@ BSplineInterpolationWeightFunction2<TCoordRep, VSpaceDimension, VSplineOrder>::C
     KernelType::FastEvaluate(x, weights);
 
     // Copy
-    for (unsigned int k = 0; k < this->m_SupportSize[i]; ++k)
+    for (unsigned int k = 0; k < VSplineOrder + 1; ++k)
     {
       weights1D[i][k] = weights[k];
     }

--- a/Common/Transforms/itkBSplineInterpolationWeightFunctionBase.h
+++ b/Common/Transforms/itkBSplineInterpolationWeightFunctionBase.h
@@ -104,9 +104,6 @@ public:
   /** Get support region size. */
   itkGetConstReferenceMacro(SupportSize, SizeType);
 
-  /** Get number of weights. */
-  itkGetConstMacro(NumberOfWeights, unsigned long);
-
 protected:
   BSplineInterpolationWeightFunctionBase();
   ~BSplineInterpolationWeightFunctionBase() override = default;
@@ -137,7 +134,6 @@ protected:
   PrintSelf(std::ostream & os, Indent indent) const override;
 
   /** Member variables. */
-  unsigned long             m_NumberOfWeights{};
   SizeType                  m_SupportSize{};
   vnl_matrix<unsigned long> m_OffsetToIndexTable{};
 

--- a/Common/Transforms/itkBSplineInterpolationWeightFunctionBase.h
+++ b/Common/Transforms/itkBSplineInterpolationWeightFunctionBase.h
@@ -101,8 +101,8 @@ public:
   void
   ComputeStartIndex(const ContinuousIndexType & index, IndexType & startIndex) const;
 
-  /** Get support region size. */
-  itkGetConstReferenceMacro(SupportSize, SizeType);
+  /** The support region size: a hypercube of length SplineOrder + 1 */
+  static constexpr SizeType SupportSize{ SizeType::Filled(VSplineOrder + 1) };
 
 protected:
   BSplineInterpolationWeightFunctionBase();
@@ -134,14 +134,9 @@ protected:
   PrintSelf(std::ostream & os, Indent indent) const override;
 
   /** Member variables. */
-  SizeType                  m_SupportSize{};
   vnl_matrix<unsigned long> m_OffsetToIndexTable{};
 
 private:
-  /** Function to initialize the support region. */
-  void
-  InitializeSupport();
-
   /** Function to initialize the offset table.
    * The offset table is a convenience table, just to
    * keep track where is what.

--- a/Common/Transforms/itkBSplineInterpolationWeightFunctionBase.hxx
+++ b/Common/Transforms/itkBSplineInterpolationWeightFunctionBase.hxx
@@ -52,13 +52,6 @@ BSplineInterpolationWeightFunctionBase<TCoordRep, VSpaceDimension, VSplineOrder>
   /** Initialize support region. */
   this->m_SupportSize.Fill(SplineOrder + 1);
 
-  /** Initialize the number of weights. */
-  this->m_NumberOfWeights = 1;
-  for (unsigned int i = 0; i < SpaceDimension; ++i)
-  {
-    this->m_NumberOfWeights *= this->m_SupportSize[i];
-  }
-
 } // end InitializeSupport()
 
 
@@ -82,7 +75,7 @@ BSplineInterpolationWeightFunctionBase<TCoordRep, VSpaceDimension, VSplineOrder>
   it.GoToBegin();
 
   /** Fill the OffsetToIndexTable. */
-  this->m_OffsetToIndexTable.set_size(this->m_NumberOfWeights, SpaceDimension);
+  this->m_OffsetToIndexTable.set_size(NumberOfWeights, SpaceDimension);
   unsigned long counter = 0;
   while (!it.IsAtEnd())
   {
@@ -110,7 +103,6 @@ BSplineInterpolationWeightFunctionBase<TCoordRep, VSpaceDimension, VSplineOrder>
 {
   Superclass::PrintSelf(os, indent);
 
-  os << indent << "NumberOfWeights: " << this->m_NumberOfWeights << std::endl;
   os << indent << "SupportSize: " << this->m_SupportSize << std::endl;
   os << indent << "OffsetToIndexTable: " << this->m_OffsetToIndexTable << std::endl;
 
@@ -171,7 +163,7 @@ BSplineInterpolationWeightFunctionBase<TCoordRep, VSpaceDimension, VSplineOrder>
   WeightsType &               weights) const
 {
   /** Don't initialize the weights!
-   * weights.SetSize( this->m_NumberOfWeights );
+   * weights.SetSize( NumberOfWeights );
    * This will result in a big performance penalty (50%). In Evaluate( index )
    * we have set the size correctly anyway. We just assume that when this
    * function is called directly, the user has set the size correctly.
@@ -182,7 +174,7 @@ BSplineInterpolationWeightFunctionBase<TCoordRep, VSpaceDimension, VSplineOrder>
   this->Compute1DWeights(cindex, startIndex, weights1D);
 
   /** Compute the vector of weights. */
-  for (unsigned int k = 0; k < this->m_NumberOfWeights; ++k)
+  for (unsigned int k = 0; k < NumberOfWeights; ++k)
   {
     double                tmp1 = 1.0;
     const unsigned long * tmp2 = this->m_OffsetToIndexTable[k];

--- a/Common/Transforms/itkBSplineInterpolationWeightFunctionBase.hxx
+++ b/Common/Transforms/itkBSplineInterpolationWeightFunctionBase.hxx
@@ -35,24 +35,9 @@ BSplineInterpolationWeightFunctionBase<TCoordRep, VSpaceDimension, VSplineOrder>
   BSplineInterpolationWeightFunctionBase()
 {
   /** Initialize members. */
-  this->InitializeSupport();
   this->InitializeOffsetToIndexTable();
 
 } // end Constructor
-
-
-/**
- * ******************* InitializeSupport *******************
- */
-
-template <class TCoordRep, unsigned int VSpaceDimension, unsigned int VSplineOrder>
-void
-BSplineInterpolationWeightFunctionBase<TCoordRep, VSpaceDimension, VSplineOrder>::InitializeSupport()
-{
-  /** Initialize support region. */
-  this->m_SupportSize.Fill(SplineOrder + 1);
-
-} // end InitializeSupport()
 
 
 /**
@@ -66,7 +51,7 @@ BSplineInterpolationWeightFunctionBase<TCoordRep, VSpaceDimension, VSplineOrder>
   /** Create a temporary image. */
   using CharImageType = Image<char, SpaceDimension>;
   auto tempImage = CharImageType::New();
-  tempImage->SetRegions(this->m_SupportSize);
+  tempImage->SetRegions(SupportSize);
   tempImage->Allocate();
 
   /** Create an iterator over the image. */
@@ -103,7 +88,6 @@ BSplineInterpolationWeightFunctionBase<TCoordRep, VSpaceDimension, VSplineOrder>
 {
   Superclass::PrintSelf(os, indent);
 
-  os << indent << "SupportSize: " << this->m_SupportSize << std::endl;
   os << indent << "OffsetToIndexTable: " << this->m_OffsetToIndexTable << std::endl;
 
 } // end PrintSelf()
@@ -123,7 +107,7 @@ BSplineInterpolationWeightFunctionBase<TCoordRep, VSpaceDimension, VSplineOrder>
   for (unsigned int i = 0; i < SpaceDimension; ++i)
   {
     startIndex[i] = static_cast<typename IndexType::IndexValueType>(
-      std::floor(cindex[i] - static_cast<double>(this->m_SupportSize[i] - 2.0) / 2.0));
+      std::floor(cindex[i] - static_cast<double>(VSplineOrder - 1.0) / 2.0));
   }
 
 } // end ComputeStartIndex()

--- a/Common/Transforms/itkCyclicBSplineDeformableTransform.hxx
+++ b/Common/Transforms/itkCyclicBSplineDeformableTransform.hxx
@@ -42,7 +42,10 @@ CyclicBSplineDeformableTransform<TScalarType, NDimensions, VSplineOrder>::SetGri
   /** Check if last dimension of supportregion < last dimension of grid. */
   const int lastDim = this->m_GridRegion.GetImageDimension() - 1;
   const int lastDimSize = this->m_GridRegion.GetSize(lastDim);
-  const int supportLastDimSize = this->m_SupportSize.GetElement(lastDim);
+
+  // The support size is the same for all dimensions.
+  const int supportLastDimSize = VSplineOrder + 1;
+
   if (supportLastDimSize > lastDimSize)
   {
     itkExceptionMacro("Last dimension (" << lastDim << ") of support size (" << supportLastDimSize
@@ -163,7 +166,7 @@ CyclicBSplineDeformableTransform<TScalarType, NDimensions, VSplineOrder>::Transf
   this->m_WeightsFunction->Evaluate(cindex, supportIndex, weights);
 
   /** For each dimension, correlate coefficient with weights. */
-  const RegionType supportRegion(supportIndex, Superclass::m_SupportSize);
+  const RegionType supportRegion(supportIndex, WeightsFunctionType::SupportSize);
 
   /** Split support region into two parts. */
   RegionType supportRegions[2];
@@ -220,7 +223,7 @@ CyclicBSplineDeformableTransform<TScalarType, NDimensions, VSplineOrder>::GetJac
   ParameterIndexArrayType & indexes) const
 {
   RegionType supportRegion;
-  supportRegion.SetSize(this->m_SupportSize);
+  supportRegion.SetSize(WeightsFunctionType::SupportSize);
   const PixelType * basePointer = this->m_CoefficientImages[0]->GetBufferPointer();
 
   /** Tranform from world coordinates to grid coordinates. */
@@ -302,7 +305,7 @@ CyclicBSplineDeformableTransform<TScalarType, NDimensions, VSplineOrder>::GetSpa
 
   IndexType supportIndex;
   this->m_DerivativeWeightsFunctions[0]->ComputeStartIndex(cindex, supportIndex);
-  const RegionType supportRegion(supportIndex, Superclass::m_SupportSize);
+  const RegionType supportRegion(supportIndex, WeightsFunctionType::SupportSize);
 
   /** Split support region into two parts. */
   RegionType supportRegions[2];

--- a/Common/Transforms/itkRecursiveBSplineTransform.hxx
+++ b/Common/Transforms/itkRecursiveBSplineTransform.hxx
@@ -136,7 +136,7 @@ RecursiveBSplineTransform<TScalar, NDimensions, VSplineOrder>::GetJacobian(
   /** Compute the nonzero Jacobian indices.
    * Takes a significant portion of the computation time of this function.
    */
-  const RegionType supportRegion(supportIndex, Superclass::m_SupportSize);
+  const RegionType supportRegion(supportIndex, WeightsFunctionType::SupportSize);
   this->ComputeNonZeroJacobianIndices(nonZeroJacobianIndices, supportRegion);
 
 } // end GetJacobian()
@@ -190,7 +190,7 @@ RecursiveBSplineTransform<TScalar, NDimensions, VSplineOrder>::EvaluateJacobianW
   ImplementationType::EvaluateJacobianWithImageGradientProduct(imageJacobianPointer, migArray, weights1D.data(), 1.0);
 
   /** Setup support region needed for the nonZeroJacobianIndices. */
-  const RegionType supportRegion(supportIndex, Superclass::m_SupportSize);
+  const RegionType supportRegion(supportIndex, WeightsFunctionType::SupportSize);
 
   /** Compute the nonzero Jacobian indices.
    * Takes a significant portion of the computation time of this function.
@@ -425,7 +425,7 @@ RecursiveBSplineTransform<TScalar, NDimensions, VSplineOrder>::GetJacobianOfSpat
   ImplementationType::GetJacobianOfSpatialJacobian(jsjPtr2, weights1D.data(), derivativeWeights1D.data(), dc, dummy);
 
   /** Setup support region needed for the nonZeroJacobianIndices. */
-  const RegionType supportRegion(supportIndex, Superclass::m_SupportSize);
+  const RegionType supportRegion(supportIndex, WeightsFunctionType::SupportSize);
 
   /** Compute the nonzero Jacobian indices. */
   this->ComputeNonZeroJacobianIndices(nonZeroJacobianIndices, supportRegion);
@@ -515,7 +515,7 @@ RecursiveBSplineTransform<TScalar, NDimensions, VSplineOrder>::GetJacobianOfSpat
     jshPtr, weights1D.data(), derivativeWeights1D.data(), hessianWeights1D.data(), dc, dummy);
 
   /** Setup support region needed for the nonZeroJacobianIndices. */
-  const RegionType supportRegion(supportIndex, Superclass::m_SupportSize);
+  const RegionType supportRegion(supportIndex, WeightsFunctionType::SupportSize);
 
   /** Compute the nonzero Jacobian indices. */
   this->ComputeNonZeroJacobianIndices(nonZeroJacobianIndices, supportRegion);

--- a/Common/itkRecursiveBSplineInterpolationWeightFunction.h
+++ b/Common/itkRecursiveBSplineInterpolationWeightFunction.h
@@ -114,7 +114,6 @@ private:
   Evaluate(const ContinuousIndexType & index, WeightsType & weights, IndexType & startIndex) const override;
 
   /** Private members; We unfortunatly cannot use those of the superclass. */
-  unsigned int m_NumberOfWeights{};
   unsigned int m_NumberOfIndices{};
   SizeType     m_SupportSize{};
 

--- a/Common/itkRecursiveBSplineInterpolationWeightFunction.h
+++ b/Common/itkRecursiveBSplineInterpolationWeightFunction.h
@@ -91,10 +91,9 @@ public:
   EvaluateSecondOrderDerivative(const ContinuousIndexType & index, const IndexType & startIndex) const;
 
 protected:
-  RecursiveBSplineInterpolationWeightFunction();
+  RecursiveBSplineInterpolationWeightFunction() = default;
   ~RecursiveBSplineInterpolationWeightFunction() override = default;
-  void
-  PrintSelf(std::ostream & os, Indent indent) const override;
+  using Superclass::PrintSelf;
 
 private:
   /** Evaluate the weights at specified ContinousIndex position.
@@ -115,7 +114,6 @@ private:
 
   /** Private members; We unfortunatly cannot use those of the superclass. */
   unsigned int m_NumberOfIndices{};
-  SizeType     m_SupportSize{};
 
   /** Interpolation kernel type. */
   using KernelType = BSplineKernelFunction2<VSplineOrder>;

--- a/Common/itkRecursiveBSplineInterpolationWeightFunction.hxx
+++ b/Common/itkRecursiveBSplineInterpolationWeightFunction.hxx
@@ -39,12 +39,6 @@ RecursiveBSplineInterpolationWeightFunction<TCoordRep, VSpaceDimension, VSplineO
   // Initialize support region is a hypercube of length SplineOrder + 1
   this->m_SupportSize.Fill(SplineOrder + 1);
 
-  this->m_NumberOfWeights = 1;
-  for (unsigned int i = 0; i < SpaceDimension; ++i)
-  {
-    this->m_NumberOfWeights *= this->m_SupportSize[i];
-  }
-
 } // end Constructor
 
 
@@ -59,7 +53,6 @@ RecursiveBSplineInterpolationWeightFunction<TCoordRep, VSpaceDimension, VSplineO
 {
   Superclass::PrintSelf(os, indent);
 
-  os << indent << "NumberOfWeights: " << m_NumberOfWeights << std::endl;
   os << indent << "SupportSize: " << m_SupportSize << std::endl;
 } // end PrintSelf()
 

--- a/Common/itkRecursiveBSplineInterpolationWeightFunction.hxx
+++ b/Common/itkRecursiveBSplineInterpolationWeightFunction.hxx
@@ -29,35 +29,6 @@ namespace itk
 {
 
 /**
- * ********************* Constructor ****************************
- */
-
-template <typename TCoordRep, unsigned int VSpaceDimension, unsigned int VSplineOrder>
-RecursiveBSplineInterpolationWeightFunction<TCoordRep, VSpaceDimension, VSplineOrder>::
-  RecursiveBSplineInterpolationWeightFunction()
-{
-  // Initialize support region is a hypercube of length SplineOrder + 1
-  this->m_SupportSize.Fill(SplineOrder + 1);
-
-} // end Constructor
-
-
-/**
- * ********************* PrintSelf ****************************
- */
-
-template <typename TCoordRep, unsigned int VSpaceDimension, unsigned int VSplineOrder>
-void
-RecursiveBSplineInterpolationWeightFunction<TCoordRep, VSpaceDimension, VSplineOrder>::PrintSelf(std::ostream & os,
-                                                                                                 Indent indent) const
-{
-  Superclass::PrintSelf(os, indent);
-
-  os << indent << "SupportSize: " << m_SupportSize << std::endl;
-} // end PrintSelf()
-
-
-/**
  * ********************* Evaluate ****************************
  */
 
@@ -124,7 +95,7 @@ RecursiveBSplineInterpolationWeightFunction<TCoordRep, VSpaceDimension, VSplineO
   for (unsigned int i = 0; i < SpaceDimension; ++i)
   {
     double x = cindex[i] - static_cast<double>(startIndex[i]);
-    DerivativeKernelType::FastEvaluate(x, &derivativeWeights[i * this->m_SupportSize[i]]);
+    DerivativeKernelType::FastEvaluate(x, &derivativeWeights[i * (VSplineOrder + 1)]);
   }
 
   return derivativeWeights;
@@ -147,7 +118,7 @@ RecursiveBSplineInterpolationWeightFunction<TCoordRep, VSpaceDimension, VSplineO
   for (unsigned int i = 0; i < SpaceDimension; ++i)
   {
     double x = cindex[i] - static_cast<double>(startIndex[i]);
-    SecondOrderDerivativeKernelType::FastEvaluate(x, &hessianWeights[i * this->m_SupportSize[i]]);
+    SecondOrderDerivativeKernelType::FastEvaluate(x, &hessianWeights[i * (VSplineOrder + 1)]);
   }
 
   return hessianWeights;

--- a/Components/Transforms/MultiBSplineTransformWithNormal/itkMultiBSplineDeformableTransformWithNormal.h
+++ b/Components/Transforms/MultiBSplineTransformWithNormal/itkMultiBSplineDeformableTransformWithNormal.h
@@ -319,25 +319,18 @@ public:
     return false;
   }
 
-  /** Get number of weights. */
-  virtual unsigned long
-  GetNumberOfWeights() const
-  {
-    return m_Trans[0]->m_WeightsFunction->GetNumberOfWeights();
-  }
-
 
   virtual unsigned int
   GetNumberOfAffectedWeights() const
   {
-    return m_Trans[0]->m_WeightsFunction->GetNumberOfWeights();
+    return NumberOfWeights;
   }
 
 
   NumberOfParametersType
   GetNumberOfNonZeroJacobianIndices() const override
   {
-    return m_Trans[0]->m_WeightsFunction->GetNumberOfWeights() * SpaceDimension;
+    return NumberOfWeights * SpaceDimension;
   }
 
 
@@ -509,6 +502,9 @@ protected:
   ImageBasePointer                             m_LocalBases{};
 
 private:
+  /** The number of weights. */
+  static constexpr unsigned NumberOfWeights = TransformType::NumberOfWeights;
+
   void
   DispatchParameters(const ParametersType & parameters);
 

--- a/Components/Transforms/MultiBSplineTransformWithNormal/itkMultiBSplineDeformableTransformWithNormal.hxx
+++ b/Components/Transforms/MultiBSplineTransformWithNormal/itkMultiBSplineDeformableTransformWithNormal.hxx
@@ -751,13 +751,12 @@ MultiBSplineDeformableTransformWithNormal<TScalarType, NDimensions, VSplineOrder
   using BaseContainer = typename ImageBaseType::PixelContainer;
   const BaseContainer & bases = *m_LocalBases->GetPixelContainer();
 
-  const unsigned nweights = this->GetNumberOfWeights();
-  for (unsigned i = 0; i < nweights; ++i)
+  for (unsigned i = 0; i < NumberOfWeights; ++i)
   {
     VectorType tmp = bases[nonZeroJacobianIndices[i]][0];
     for (unsigned j = 0; j < SpaceDimension; ++j)
     {
-      jacobian[j][i] = tmp[j] * njac[j][i + j * nweights];
+      jacobian[j][i] = tmp[j] * njac[j][i + j * NumberOfWeights];
     }
 
     for (unsigned d = 1; d < SpaceDimension; ++d)
@@ -765,7 +764,7 @@ MultiBSplineDeformableTransformWithNormal<TScalarType, NDimensions, VSplineOrder
       tmp = bases[nonZeroJacobianIndices[i]][d];
       for (unsigned j = 0; j < SpaceDimension; ++j)
       {
-        jacobian[j][i + d * nweights] = tmp[j] * ljac[j][i + j * nweights];
+        jacobian[j][i + d * NumberOfWeights] = tmp[j] * ljac[j][i + j * NumberOfWeights];
       }
     }
   }
@@ -774,11 +773,11 @@ MultiBSplineDeformableTransformWithNormal<TScalarType, NDimensions, VSplineOrder
   if (lidx > 1)
   {
     unsigned to_add = (lidx - 1) * m_Trans[0]->GetNumberOfParametersPerDimension() * (SpaceDimension - 1);
-    for (unsigned i = 0; i < nweights; ++i)
+    for (unsigned i = 0; i < NumberOfWeights; ++i)
     {
       for (unsigned d = 1; d < SpaceDimension; ++d)
       {
-        nonZeroJacobianIndices[d * nweights + i] += to_add;
+        nonZeroJacobianIndices[d * NumberOfWeights + i] += to_add;
       }
     }
   }
@@ -936,15 +935,14 @@ MultiBSplineDeformableTransformWithNormal<TScalarType, NDimensions, VSplineOrder
   using BaseContainer = typename ImageBaseType::PixelContainer;
   const BaseContainer & bases = *m_LocalBases->GetPixelContainer();
 
-  const unsigned nweights = this->GetNumberOfWeights();
-  for (unsigned i = 0; i < nweights; ++i)
+  for (unsigned i = 0; i < NumberOfWeights; ++i)
   {
     VectorType tmp = bases[nonZeroJacobianIndices[i]][0];
     for (unsigned j = 0; j < SpaceDimension; ++j)
     {
       for (unsigned k = 0; k < SpaceDimension; ++k)
       {
-        jsj[j][i][k] = tmp[j] * njsj[j][i + j * nweights][k];
+        jsj[j][i][k] = tmp[j] * njsj[j][i + j * NumberOfWeights][k];
       }
     }
 
@@ -955,7 +953,7 @@ MultiBSplineDeformableTransformWithNormal<TScalarType, NDimensions, VSplineOrder
       {
         for (unsigned k = 0; k < SpaceDimension; ++k)
         {
-          jsj[j][i + d * nweights][k] = tmp[j] * ljsj[j][i + j * nweights][k];
+          jsj[j][i + d * NumberOfWeights][k] = tmp[j] * ljsj[j][i + j * NumberOfWeights][k];
         }
       }
     }
@@ -966,11 +964,11 @@ MultiBSplineDeformableTransformWithNormal<TScalarType, NDimensions, VSplineOrder
   if (lidx > 1)
   {
     unsigned to_add = (lidx - 1) * m_Trans[0]->GetNumberOfParametersPerDimension() * (SpaceDimension - 1);
-    for (unsigned i = 0; i < nweights; ++i)
+    for (unsigned i = 0; i < NumberOfWeights; ++i)
     {
       for (unsigned d = 1; d < SpaceDimension; ++d)
       {
-        nonZeroJacobianIndices[d * nweights + i] += to_add;
+        nonZeroJacobianIndices[d * NumberOfWeights + i] += to_add;
       }
     }
   }
@@ -1041,8 +1039,7 @@ MultiBSplineDeformableTransformWithNormal<TScalarType, NDimensions, VSplineOrder
   using BaseContainer = typename ImageBaseType::PixelContainer;
   const BaseContainer & bases = *m_LocalBases->GetPixelContainer();
 
-  const unsigned nweights = this->GetNumberOfWeights();
-  for (unsigned i = 0; i < nweights; ++i)
+  for (unsigned i = 0; i < NumberOfWeights; ++i)
   {
     VectorType tmp = bases[nonZeroJacobianIndices[i]][0];
     for (unsigned j = 0; j < SpaceDimension; ++j)
@@ -1051,7 +1048,7 @@ MultiBSplineDeformableTransformWithNormal<TScalarType, NDimensions, VSplineOrder
       {
         for (unsigned l = 0; l < SpaceDimension; ++l)
         {
-          jsh[j][i][k][l] = tmp[j] * njsh[j][i + j * nweights][k][l];
+          jsh[j][i][k][l] = tmp[j] * njsh[j][i + j * NumberOfWeights][k][l];
         }
       }
     }
@@ -1065,7 +1062,7 @@ MultiBSplineDeformableTransformWithNormal<TScalarType, NDimensions, VSplineOrder
         {
           for (unsigned l = 0; l < SpaceDimension; ++l)
           {
-            jsh[j][i + l * nweights][k][l] = tmp[j] * ljsh[j][i + j * nweights][k][l];
+            jsh[j][i + l * NumberOfWeights][k][l] = tmp[j] * ljsh[j][i + j * NumberOfWeights][k][l];
           }
         }
       }
@@ -1087,11 +1084,11 @@ MultiBSplineDeformableTransformWithNormal<TScalarType, NDimensions, VSplineOrder
   if (lidx > 1)
   {
     unsigned to_add = (lidx - 1) * m_Trans[0]->GetNumberOfParametersPerDimension() * (SpaceDimension - 1);
-    for (unsigned i = 0; i < nweights; ++i)
+    for (unsigned i = 0; i < NumberOfWeights; ++i)
     {
       for (unsigned d = 1; d < SpaceDimension; ++d)
       {
-        nonZeroJacobianIndices[d * nweights + i] += to_add;
+        nonZeroJacobianIndices[d * NumberOfWeights + i] += to_add;
       }
     }
   }

--- a/Testing/itkBSplineInterpolationDerivativeWeightFunctionTest.cxx
+++ b/Testing/itkBSplineInterpolationDerivativeWeightFunctionTest.cxx
@@ -161,7 +161,7 @@ main()
 
   DerivativeWeightFunctionType::SizeType trueSize;
   trueSize.Fill(SplineOrder + 1);
-  if (foWeightFunction->GetSupportSize() != trueSize)
+  if (DerivativeWeightFunctionType::SupportSize != trueSize)
   {
     std::cerr << "ERROR: wrong support size was computed." << std::endl;
     return 1;

--- a/Testing/itkBSplineInterpolationDerivativeWeightFunctionTest.cxx
+++ b/Testing/itkBSplineInterpolationDerivativeWeightFunctionTest.cxx
@@ -167,7 +167,7 @@ main()
     return 1;
   }
 
-  if (foWeightFunction->GetNumberOfWeights() !=
+  if (DerivativeWeightFunctionType::NumberOfWeights !=
       static_cast<unsigned long>(std::pow(static_cast<float>(SplineOrder + 1), 2.0f)))
   {
     std::cerr << "ERROR: wrong number of weights was computed." << std::endl;

--- a/Testing/itkBSplineInterpolationSODerivativeWeightFunctionTest.cxx
+++ b/Testing/itkBSplineInterpolationSODerivativeWeightFunctionTest.cxx
@@ -256,7 +256,7 @@ main()
     return 1;
   }
 
-  if (soWeightFunction->GetNumberOfWeights() !=
+  if (SODerivativeWeightFunctionType::NumberOfWeights !=
       static_cast<unsigned long>(std::pow(static_cast<float>(SplineOrder + 1), 2.0f)))
   {
     std::cerr << "ERROR: wrong number of weights was computed." << std::endl;

--- a/Testing/itkBSplineInterpolationSODerivativeWeightFunctionTest.cxx
+++ b/Testing/itkBSplineInterpolationSODerivativeWeightFunctionTest.cxx
@@ -250,7 +250,7 @@ main()
 
   SODerivativeWeightFunctionType::SizeType trueSize;
   trueSize.Fill(SplineOrder + 1);
-  if (soWeightFunction->GetSupportSize() != trueSize)
+  if (SODerivativeWeightFunctionType::SupportSize != trueSize)
   {
     std::cerr << "ERROR: wrong support size was computed." << std::endl;
     return 1;

--- a/Testing/itkBSplineInterpolationWeightFunctionTest.cxx
+++ b/Testing/itkBSplineInterpolationWeightFunctionTest.cxx
@@ -253,7 +253,7 @@ main()
     return EXIT_FAILURE;
   }
 
-  if (weight2Function2D->GetNumberOfWeights() !=
+  if (WeightFunction2Type2D::NumberOfWeights !=
       static_cast<unsigned long>(std::pow(static_cast<float>(SplineOrder + 1), 2.0f)))
   {
     std::cerr << "ERROR: wrong number of weights was computed." << std::endl;

--- a/Testing/itkBSplineInterpolationWeightFunctionTest.cxx
+++ b/Testing/itkBSplineInterpolationWeightFunctionTest.cxx
@@ -247,7 +247,7 @@ main()
 
   WeightFunction2Type2D::SizeType trueSize;
   trueSize.Fill(SplineOrder + 1);
-  if (weight2Function2D->GetSupportSize() != trueSize)
+  if (WeightFunction2Type2D::SupportSize != trueSize)
   {
     std::cerr << "ERROR: wrong support size was computed." << std::endl;
     return EXIT_FAILURE;

--- a/Testing/itkBSplineTransformPointPerformanceTest.cxx
+++ b/Testing/itkBSplineTransformPointPerformanceTest.cxx
@@ -112,7 +112,7 @@ public:
 
     // For each dimension, correlate coefficient with weights
     RegionType supportRegion;
-    supportRegion.SetSize(this->m_SupportSize);
+    supportRegion.SetSize(WeightsFunctionType::SupportSize);
     supportRegion.SetIndex(supportIndex);
 
     outputPoint.Fill(ScalarType{});


### PR DESCRIPTION
Replaced run-time evaluation of number of weights and support size with compile-time evaluation of those values. Might improve the run-time performance of bspline transformations and interpolations. Just marked as style improvement, because the changes are not benchmarked (yet). 