### PR TITLE
STYLE: Remove `NumberOfWeights` from RecursiveBSpline WeightFunction

### DIFF
--- a/Common/itkRecursiveBSplineInterpolationWeightFunction.h
+++ b/Common/itkRecursiveBSplineInterpolationWeightFunction.h
@@ -75,9 +75,6 @@ public:
   using typename Superclass::SizeType;
   using typename Superclass::ContinuousIndexType;
 
-  /** The number of weights. */
-  static constexpr unsigned NumberOfWeights = (VSplineOrder + 1) * VSpaceDimension;
-
   /** The number of indices. */
   static constexpr unsigned NumberOfIndices = Math::UnsignedPower(VSplineOrder + 1, VSpaceDimension);
 


### PR DESCRIPTION
`RecursiveBSplineInterpolationWeightFunction::NumberOfWeights` was never used. Its value `(SplineOrder + 1) * SpaceDimension` was different from both `BSplineInterpolationWeightFunctionBase::NumberOfWeights` _and_ `RecursiveBSplineInterpolationWeightFunction::m_NumberOfWeights` (both equivalent to `pow(SplineOrder + 1, SpaceDimension)`), which appeared somewhat confusing.