### PR TITLE
STYLE: AdvancedNormalizedCorrelation drop support for SubtractMean=false

### DIFF
--- a/Components/Metrics/AdvancedNormalizedCorrelation/elxAdvancedNormalizedCorrelationMetric.h
+++ b/Components/Metrics/AdvancedNormalizedCorrelation/elxAdvancedNormalizedCorrelationMetric.h
@@ -31,10 +31,11 @@ namespace elastix
  * The parameters used in this class are:
  * \parameter Metric: Select this metric as follows:\n
  *    <tt>(Metric "AdvancedNormalizedCorrelation")</tt>
- * \parameter SubtractMean: Flag to set if the sample mean is subtracted from the
- *    sample values in the cross correlation formula. This typically results in narrower
- *    valleys in the cost function. Default value is true. Can be defined for each resolution\n
- *    example: <tt>(SubtractMean "false")</tt>
+ *
+ * \note The parameter "SubtractMean" is obsolete, and will be ignored. The current elastix version just has the default
+ * behavior of elastix <= version 5.1.0: For this parameter, the default value was true. This means that the sample mean
+ * is subtracted from the sample values in the cross correlation formula. This typically results in narrower valleys in
+ * the cost function.
  *
  * \ingroup Metrics
  *

--- a/Components/Metrics/AdvancedNormalizedCorrelation/elxAdvancedNormalizedCorrelationMetric.hxx
+++ b/Components/Metrics/AdvancedNormalizedCorrelation/elxAdvancedNormalizedCorrelationMetric.hxx
@@ -32,13 +32,28 @@ template <class TElastix>
 void
 AdvancedNormalizedCorrelationMetric<TElastix>::BeforeEachResolution()
 {
-  /** Get the current resolution level. */
-  unsigned int level = (this->m_Registration->GetAsITKBaseType())->GetCurrentLevel();
+  const Configuration & configuration = Deref(Superclass2::GetConfiguration());
 
-  /** Get and set SubtractMean. Default true. */
-  bool subtractMean = true;
-  this->GetConfiguration()->ReadParameter(subtractMean, "SubtractMean", this->GetComponentLabel(), level, 0);
-  this->SetSubtractMean(subtractMean);
+  if (configuration.HasParameter("SubtractMean"))
+  {
+    /** Get the current resolution level. */
+    unsigned int level = (this->m_Registration->GetAsITKBaseType())->GetCurrentLevel();
+
+    /** Get and set SubtractMean. Default true. */
+    bool subtractMean = true;
+    configuration.ReadParameter(subtractMean, "SubtractMean", this->GetComponentLabel(), level, 0);
+
+    if (subtractMean)
+    {
+      log::info("From elastix > version 5.1.0, AdvancedNormalizedCorrelationMetric ignores parameter SubtractMean, and "
+                "just behaves as if its value is true.");
+    }
+    else
+    {
+      log::warn("From elastix > version 5.1.0, AdvancedNormalizedCorrelationMetric no longer supports \"false\" as "
+                "value of parameter SubtractMean! It just behaves as if its value is true!");
+    }
+  }
 
 } // end BeforeEachResolution()
 

--- a/Components/Metrics/AdvancedNormalizedCorrelation/itkAdvancedNormalizedCorrelationImageToImageMetric.h
+++ b/Components/Metrics/AdvancedNormalizedCorrelation/itkAdvancedNormalizedCorrelationImageToImageMetric.h
@@ -174,21 +174,11 @@ public:
                         MeasureType &                   value,
                         DerivativeType &                derivative) const override;
 
-  /** Set/Get SubtractMean boolean. If true, the sample mean is subtracted
-   * from the sample values in the cross-correlation formula and
-   * typically results in narrower valleys in the cost function.
-   * Default value is false.
-   */
-  itkSetMacro(SubtractMean, bool);
-  itkGetConstReferenceMacro(SubtractMean, bool);
-  itkBooleanMacro(SubtractMean);
-
 protected:
   AdvancedNormalizedCorrelationImageToImageMetric();
   ~AdvancedNormalizedCorrelationImageToImageMetric() override = default;
 
-  void
-  PrintSelf(std::ostream & os, Indent indent) const override;
+  using Superclass::PrintSelf;
 
   /** Protected Typedefs ******************/
 
@@ -235,8 +225,6 @@ protected:
   AccumulateDerivativesThreaderCallback(void * arg);
 
 private:
-  mutable bool m_SubtractMean{ false };
-
   using AccumulateType = typename NumericTraits<MeasureType>::AccumulateType;
 
   /** Helper structs that multi-threads the computation of


### PR DESCRIPTION
Let the AdvancedNormalizedCorrelation metric always just act as if the SubtractMean parameter has value "true".

Discussed with Marius Staring (@mstaring  and Stefan Klein (@stefanklein).