### PR TITLE
ENH: Set SubtractMean parameter "true" (instead of "false") by default

### DIFF
--- a/Components/Metrics/PCAMetric/elxPCAMetric.hxx
+++ b/Components/Metrics/PCAMetric/elxPCAMetric.hxx
@@ -58,7 +58,7 @@ PCAMetric<TElastix>::BeforeEachResolution()
   this->SetNumEigenValues(NumEigenValues);
 
   /** Get and set if we want to subtract the mean from the derivative. */
-  bool subtractMean = false;
+  bool subtractMean = true;
   this->GetConfiguration()->ReadParameter(subtractMean, "SubtractMean", this->GetComponentLabel(), 0, 0);
   this->SetSubtractMean(subtractMean);
 

--- a/Components/Metrics/PCAMetric/itkPCAMetric.h
+++ b/Components/Metrics/PCAMetric/itkPCAMetric.h
@@ -188,7 +188,7 @@ private:
   double m_VarNoise{};
 
   /** Bool to determine if we want to subtract the mean derivate from the derivative elements. */
-  bool m_SubtractMean{};
+  bool m_SubtractMean{ true };
 
   /** GridSize of B-spline transform. */
   FixedImageSizeType m_GridSize{};

--- a/Components/Metrics/PCAMetric/itkPCAMetric.hxx
+++ b/Components/Metrics/PCAMetric/itkPCAMetric.hxx
@@ -37,7 +37,7 @@ namespace itk
 
 template <class TFixedImage, class TMovingImage>
 PCAMetric<TFixedImage, TMovingImage>::PCAMetric()
-  : m_SubtractMean(false)
+  : m_SubtractMean(true)
   , m_TransformIsStackTransform(false)
   , m_NumEigenValues(6)
   , m_UseDerivativeOfMean(false)

--- a/Components/Metrics/PCAMetric/itkPCAMetric_F_multithreaded.h
+++ b/Components/Metrics/PCAMetric/itkPCAMetric_F_multithreaded.h
@@ -223,7 +223,7 @@ private:
   unsigned int m_LastDimIndex{};
 
   /** Bool to determine if we want to subtract the mean derivate from the derivative elements. */
-  bool m_SubtractMean{ false };
+  bool m_SubtractMean{ true };
 
   /** GridSize of B-spline transform. */
   FixedImageSizeType m_GridSize{};

--- a/Components/Metrics/PCAMetric2/elxPCAMetric2.hxx
+++ b/Components/Metrics/PCAMetric2/elxPCAMetric2.hxx
@@ -54,7 +54,7 @@ PCAMetric2<TElastix>::BeforeEachResolution()
   unsigned int level = (this->m_Registration->GetAsITKBaseType())->GetCurrentLevel();
 
   /** Get and set if we want to subtract the mean from the derivative. */
-  bool subtractMean = false;
+  bool subtractMean = true;
   this->GetConfiguration()->ReadParameter(subtractMean, "SubtractMean", this->GetComponentLabel(), 0, 0);
   this->SetSubtractMean(subtractMean);
 

--- a/Components/Metrics/SumOfPairwiseCorrelationsMetric/elxSumOfPairwiseCorrelationCoefficientsMetric.hxx
+++ b/Components/Metrics/SumOfPairwiseCorrelationsMetric/elxSumOfPairwiseCorrelationCoefficientsMetric.hxx
@@ -55,7 +55,7 @@ SumOfPairwiseCorrelationCoefficientsMetric<TElastix>::BeforeEachResolution()
   unsigned int level = (this->m_Registration->GetAsITKBaseType())->GetCurrentLevel();
 
   /** Get and set if we want to subtract the mean from the derivative. */
-  bool subtractMean = false;
+  bool subtractMean = true;
   this->GetConfiguration()->ReadParameter(subtractMean, "SubtractMean", this->GetComponentLabel(), 0, 0);
   this->SetSubtractMean(subtractMean);
 

--- a/Components/Metrics/VarianceOverLastDimension/elxVarianceOverLastDimensionMetric.hxx
+++ b/Components/Metrics/VarianceOverLastDimension/elxVarianceOverLastDimensionMetric.hxx
@@ -97,7 +97,7 @@ VarianceOverLastDimensionMetric<TElastix>::BeforeEachResolution()
   this->SetSampleLastDimensionRandomly(useRandomSampling);
 
   /** Get and set if we want to subtract the mean from the derivative. */
-  bool subtractMean = false;
+  bool subtractMean = true;
   this->GetConfiguration()->ReadParameter(subtractMean, "SubtractMean", this->GetComponentLabel(), 0, 0);
   this->SetSubtractMean(subtractMean);
 

--- a/Components/Metrics/VarianceOverLastDimension/itkVarianceOverLastDimensionImageMetric.h
+++ b/Components/Metrics/VarianceOverLastDimension/itkVarianceOverLastDimensionImageMetric.h
@@ -188,7 +188,7 @@ private:
   unsigned int m_ReducedDimensionIndex{};
 
   /** Bool to determine if we want to subtract the mean derivate from the derivative elements. */
-  bool m_SubtractMean{ false };
+  bool m_SubtractMean{ true };
 
   /** Initial variance in last dimension, used as normalization factor. */
   float m_InitialVariance{};


### PR DESCRIPTION
Let the metrics other than AdvancedNormalizedCorrelation also have default value "true" for their SubtractMean parameter.

Specifically, this affects the following metrics:
- PCAMetric
- PCAMetric2
- SumOfPairwiseCorrelationCoefficients
- VarianceOverLastDimensionImageMetric.

Discussed with Marius Staring (@mstaring) and Stefan Klein (@stefanklein).

- This pull request is _somewhat_ related to pull request #1103 (but this one is _not_ about AdvancedNormalizedCorrelation!)