### PR TITLE
COMP: Unused parameter `u` BSplineSecondOrderDerivativeKernelFunction2

### DIFF
--- a/Common/Transforms/itkBSplineSecondOrderDerivativeKernelFunction2.h
+++ b/Common/Transforms/itkBSplineSecondOrderDerivativeKernelFunction2.h
@@ -150,7 +150,7 @@ private:
 
 
   static void
-  Evaluate(const Dispatch<2> &, const double u, double * weights)
+  Evaluate(const Dispatch<2> &, const double, double * weights)
   {
     weights[0] = 1.0;
     weights[1] = -2.0;


### PR DESCRIPTION
Removed the name of the unused second parameter of `BSplineSecondOrderDerivativeKernelFunction2::Evaluate(const Dispatch<2> &, const double u, double * weights)`

Found by warnings from Clang and GCC, "unused parameter [-Wunused-parameter]".