### PR TITLE
COMP: Increase maximum number of reported warnings and errors on CDash

### DIFF
--- a/Testing/Dashboard/elxCommonCDash.cmake
+++ b/Testing/Dashboard/elxCommonCDash.cmake
@@ -143,6 +143,12 @@ set(CTEST_UPDATE_VERSION_ONLY 1)
 # For CDash integration with GitHub: https://blog.kitware.com/cdash-integration-with-github
 set(CTEST_CHANGE_ID $ENV{CHANGE_ID})
 
+
+# Override the default maximum number of reported warnings and errors, using the same custom
+# maximum numbers as https://github.com/SimpleITK/SimpleITK/blob/v2.3.1/CMake/CTestCustom.cmake.in
+set(CTEST_CUSTOM_MAXIMUM_NUMBER_OF_ERRORS 99)
+set(CTEST_CUSTOM_MAXIMUM_NUMBER_OF_WARNINGS 999)
+
 # Configure testing.
 if(NOT DEFINED CTEST_TEST_CTEST)
   set(CTEST_TEST_CTEST 1)


### PR DESCRIPTION
Both maximum numbers appear to be `50` by default, causing messages at https://my.cdash.org/index.php?project=elastix saying:

> The maximum number of reported warnings or errors has been reached!!!