### PR TITLE
COMP: Fix `-Wshadow` warnings on local `samplenr` variable

### DIFF
--- a/Common/itkComputeJacobianTerms.hxx
+++ b/Common/itkComputeJacobianTerms.hxx
@@ -71,8 +71,6 @@ ComputeJacobianTerms<TFixedImage, TTransform>::Compute(double & TrC, double & Tr
   /** Get scales vector */
   const ScalesType & scales = this->m_Scales;
 
-  unsigned int samplenr = 0;
-
   /** Variables for nonzerojacobian indices and the Jacobian. */
   const NumberOfParametersType sizejacind = this->m_Transform->GetNumberOfNonZeroJacobianIndices();
   JacobianType                 jacj(outdim, sizejacind);
@@ -224,6 +222,8 @@ ComputeJacobianTerms<TFixedImage, TTransform>::Compute(double & TrC, double & Tr
 
   /** Initialize band matrix. */
   CovarianceMatrixType bandcov(numberOfParameters, bandcovsize, 0.0);
+
+  unsigned int samplenr = 0;
 
   /**
    *    TERM 1


### PR DESCRIPTION
Fixed GCC/ubuntu "warning: declaration of 'samplenr' shadows a previous local [-Wshadow]", by moving one local `samplenr` variable beyond the other.