### PR TITLE
STYLE: Remove `samplenr` which was used in commented-out code in Compute

### DIFF
--- a/Common/itkComputeJacobianTerms.hxx
+++ b/Common/itkComputeJacobianTerms.hxx
@@ -223,8 +223,6 @@ ComputeJacobianTerms<TFixedImage, TTransform>::Compute(double & TrC, double & Tr
   /** Initialize band matrix. */
   CovarianceMatrixType bandcov(numberOfParameters, bandcovsize, 0.0);
 
-  unsigned int samplenr = 0;
-
   /**
    *    TERM 1
    *
@@ -239,10 +237,6 @@ ComputeJacobianTerms<TFixedImage, TTransform>::Compute(double & TrC, double & Tr
   }
   for (const auto & sample : *sampleContainer)
   {
-    /** Print progress 0-50%.
-     *progressObserver->UpdateAndPrintProgress( samplenr );*/
-    ++samplenr;
-
     /** Read fixed coordinates and get Jacobian J_j. */
     const FixedImagePointType & point = sample.m_ImageCoordinates;
     this->m_Transform->GetJacobian(point, jacj, jacind);
@@ -413,7 +407,6 @@ ComputeJacobianTerms<TFixedImage, TTransform>::Compute(double & TrC, double & Tr
   JacobianType              jacjcovjacj(outdim, outdim);
   itk::Array<SizeValueType> jacindExpanded(numberOfParameters);
 
-  samplenr = 0;
   for (const auto & sample : *sampleContainer)
   {
     /** Read fixed coordinates and get Jacobian. */
@@ -504,10 +497,6 @@ ComputeJacobianTerms<TFixedImage, TTransform>::Compute(double & TrC, double & Tr
 
     /** Max_j [JCJ_j]. */
     maxJCJ = std::max(maxJCJ, JCJ_j);
-
-    /** Show progress 50-100%. */
-    // progressObserver->UpdateAndPrintProgress( samplenr + nrofsamples );
-    ++samplenr;
 
   } // end loop over sample container
 


### PR DESCRIPTION
This particular `samplenr` variable was only used as argument for commented-out `progressObserver->UpdateAndPrintProgress` calls.

Those `progressObserver->UpdateAndPrintProgress` calls were already commented-out with commit e9de4b1281a07d2fdbaa96db865f3c7aaaf4e5d2 (May 25, 2016): https://github.com/SuperElastix/elastix/blob/e9de4b1281a07d2fdbaa96db865f3c7aaaf4e5d2/src/Common/itkComputeJacobianTerms.hxx#L235-L236

Follow-up to pull request https://github.com/SuperElastix/elastix/pull/1111 "COMP: Fix `-Wshadow` warnings on local `samplenr` variable"