### PR TITLE
STYLE: Simplify GetAndSetFixedImageInterpolators(), avoiding `-Wshadow`

### DIFF
--- a/Components/Registrations/MultiResolutionRegistrationWithFeatures/elxMultiResolutionRegistrationWithFeatures.hxx
+++ b/Components/Registrations/MultiResolutionRegistrationWithFeatures/elxMultiResolutionRegistrationWithFeatures.hxx
@@ -203,14 +203,11 @@ MultiResolutionRegistrationWithFeatures<TElastix>::GetAndSetFixedImageInterpolat
   }
 
   /** Create and set interpolators for the fixed feature images. */
-  using FixedImageInterpolatorType = itk::BSplineInterpolateImageFunction<FixedImageType>;
-  using FixedImageInterpolatorVectorType = std::vector<typename FixedImageInterpolatorType::Pointer>;
-  FixedImageInterpolatorVectorType interpolators(noFixIm);
   for (unsigned int i = 0; i < noFixIm; ++i)
   {
-    interpolators[i] = FixedImageInterpolatorType::New();
-    interpolators[i]->SetSplineOrder(soFII[i]);
-    this->SetFixedImageInterpolator(interpolators[i], i);
+    const auto interpolator = itk::BSplineInterpolateImageFunction<FixedImageType>::New();
+    interpolator->SetSplineOrder(soFII[i]);
+    this->SetFixedImageInterpolator(interpolator, i);
   }
 
 } // end GetAndSetFixedImageInterpolators()


### PR DESCRIPTION
It appears unnecessary to place the interpolators created by GetAndSetFixedImageInterpolators() in a local `std::vector`, before passing each of them to SetFixedImageInterpolator.

This commit also prevents a warning, saying:

> warning: declaration of 'using FixedImageInterpolatorType = ...' shadows a member of 'elastix::MultiResolutionRegistrationWithFeatures' [-Wshadow]