### PR TITLE
Enable and address `-wshadow` warnings from both GCC and clang

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -81,6 +81,10 @@ include(elastixExportTarget)
 
 if (MSVC)
   add_compile_options(/W3)
+else()
+  add_compile_options(
+    -Wshadow
+    )
 endif()
 
 #---------------------------------------------------------------------

--- a/Common/GTesting/itkImageFullSamplerGTest.cxx
+++ b/Common/GTesting/itkImageFullSamplerGTest.cxx
@@ -129,9 +129,11 @@ GTEST_TEST(ImageFullSampler, ExactlyEqualVersusSlightlyDifferentMaskImageDomain)
   static constexpr auto Dimension = 2U;
   using SamplerType = itk::ImageFullSampler<itk::Image<PixelType, Dimension>>;
 
-  std::mt19937 randomNumberEngine{};
-  const auto   image =
-    CreateImageFilledWithSequenceOfNaturalNumbers<PixelType>(CreateRandomImageDomain<Dimension>(randomNumberEngine));
+  const auto image = [] {
+    std::mt19937 randomNumberEngine{};
+    return CreateImageFilledWithSequenceOfNaturalNumbers<PixelType>(
+      CreateRandomImageDomain<Dimension>(randomNumberEngine));
+  }();
 
   const auto generateSamples = [image](const bool exactlyEqualImageDomain) {
     elx::DefaultConstruct<SamplerType> sampler{};

--- a/Common/ImageSamplers/itkImageSamplerBase.hxx
+++ b/Common/ImageSamplers/itkImageSamplerBase.hxx
@@ -337,8 +337,7 @@ ImageSamplerBase<TInputImage>::CropInputImageRegion()
     bbIndex->ComputeBoundingBox();
 
     /** Create a bounding box region. */
-    InputImageIndexType minIndex, maxIndex;
-    using IndexValueType = typename InputImageIndexType::IndexValueType;
+    InputImageIndexType  minIndex, maxIndex;
     InputImageSizeType   size;
     InputImageRegionType boundingBoxRegion;
     for (unsigned int i = 0; i < InputImageDimension; ++i)

--- a/Common/ImageSamplers/itkVectorDataContainer.hxx
+++ b/Common/ImageSamplers/itkVectorDataContainer.hxx
@@ -286,9 +286,9 @@ VectorDataContainer<TElementIdentifier, TElement>::Initialize()
  */
 template <typename TElementIdentifier, typename TElement>
 void
-VectorDataContainer<TElementIdentifier, TElement>::Reserve(ElementIdentifier size)
+VectorDataContainer<TElementIdentifier, TElement>::Reserve(ElementIdentifier numberOfElements)
 {
-  this->CreateIndex(size - 1);
+  this->CreateIndex(numberOfElements - 1);
 }
 
 

--- a/Common/Transforms/elxTransformFactoryRegistration.cxx
+++ b/Common/Transforms/elxTransformFactoryRegistration.cxx
@@ -38,9 +38,6 @@ template <template <unsigned> class TTransform, std::size_t... VDimension>
 static void
 RegisterTransformForEachDimension(std::index_sequence<VDimension...>)
 {
-  struct EmptyStruct
-  {};
-
   const EmptyStruct registered[] = { (itk::TransformFactory<TTransform<VDimension>>::RegisterTransform(),
                                       EmptyStruct())... };
   (void)registered;

--- a/Common/Transforms/itkBSplineInterpolationWeightFunctionBase.hxx
+++ b/Common/Transforms/itkBSplineInterpolationWeightFunctionBase.hxx
@@ -55,8 +55,7 @@ BSplineInterpolationWeightFunctionBase<TCoordRep, VSpaceDimension, VSplineOrder>
   tempImage->Allocate();
 
   /** Create an iterator over the image. */
-  using IteratorType = ImageRegionConstIteratorWithIndex<CharImageType>;
-  IteratorType it(tempImage, tempImage->GetBufferedRegion());
+  ImageRegionConstIteratorWithIndex<CharImageType> it(tempImage, tempImage->GetBufferedRegion());
   it.GoToBegin();
 
   /** Fill the OffsetToIndexTable. */

--- a/Common/Transforms/itkCyclicBSplineDeformableTransform.hxx
+++ b/Common/Transforms/itkCyclicBSplineDeformableTransform.hxx
@@ -252,10 +252,9 @@ CyclicBSplineDeformableTransform<TScalarType, NDimensions, VSplineOrder>::GetJac
 
   /** For each dimension, copy the weight to the support region. */
   unsigned long counter = 0;
-  using IteratorType = ImageRegionIterator<JacobianImageType>;
   for (unsigned int r = 0; r < 2; ++r)
   {
-    IteratorType iterator = IteratorType(this->m_CoefficientImages[0], supportRegions[r]);
+    ImageRegionIterator<JacobianImageType> iterator(this->m_CoefficientImages[0], supportRegions[r]);
 
     while (!iterator.IsAtEnd())
     {

--- a/Common/Transforms/itkCyclicGridScheduleComputer.h
+++ b/Common/Transforms/itkCyclicGridScheduleComputer.h
@@ -67,7 +67,6 @@ public:
   using SpacingType = typename ImageBaseType::SpacingType;
   using DirectionType = typename ImageBaseType::DirectionType;
   using SizeType = typename ImageBaseType::SizeType;
-  using SizeValueType = typename ImageBaseType::SizeValueType;
   using RegionType = typename ImageBaseType::RegionType;
   using GridSpacingFactorType = SpacingType;
   using VectorOriginType = std::vector<OriginType>;

--- a/Common/Transforms/itkGridScheduleComputer.h
+++ b/Common/Transforms/itkGridScheduleComputer.h
@@ -65,7 +65,6 @@ public:
   using SpacingType = typename ImageBaseType::SpacingType;
   using DirectionType = typename ImageBaseType::DirectionType;
   using SizeType = typename ImageBaseType::SizeType;
-  using SizeValueType = typename ImageBaseType::SizeValueType;
   using RegionType = typename ImageBaseType::RegionType;
   using GridSpacingFactorType = SpacingType;
   using VectorOriginType = std::vector<OriginType>;

--- a/Common/Transforms/itkRecursiveBSplineTransform.hxx
+++ b/Common/Transforms/itkRecursiveBSplineTransform.hxx
@@ -336,14 +336,16 @@ RecursiveBSplineTransform<TScalar, NDimensions, VSplineOrder>::GetSpatialHessian
    * function GetSpatialHessian() has the TransformPoint as a free by-product.
    * In addition, the spatial Jacobian is a by-product.
    */
-  unsigned int k = 2 * SpaceDimension;
-  for (unsigned int i = 0; i < SpaceDimension; ++i)
   {
-    for (unsigned int j = 0; j < (i + 1) * SpaceDimension; ++j)
+    unsigned int k = 2 * SpaceDimension;
+    for (unsigned int i = 0; i < SpaceDimension; ++i)
     {
-      sh[j % SpaceDimension](i, j / SpaceDimension) = spatialHessian[k + j];
+      for (unsigned int j = 0; j < (i + 1) * SpaceDimension; ++j)
+      {
+        sh[j % SpaceDimension](i, j / SpaceDimension) = spatialHessian[k + j];
+      }
+      k += (i + 2) * SpaceDimension;
     }
-    k += (i + 2) * SpaceDimension;
   }
 
   /** Mirror, as only the lower triangle is now filled. */

--- a/Common/itkMultiResolutionGaussianSmoothingPyramidImageFilter.hxx
+++ b/Common/itkMultiResolutionGaussianSmoothingPyramidImageFilter.hxx
@@ -214,8 +214,6 @@ MultiResolutionGaussianSmoothingPyramidImageFilter<TInputImage, TOutputImage>::G
     itkExceptionMacro("Input has not been set");
   }
 
-  OutputImagePointer outputPtr;
-
   unsigned int ilevel;
   for (ilevel = 0; ilevel < this->m_NumberOfLevels; ++ilevel)
   {

--- a/Common/itkMultiResolutionImageRegistrationMethod2.hxx
+++ b/Common/itkMultiResolutionImageRegistrationMethod2.hxx
@@ -228,8 +228,6 @@ MultiResolutionImageRegistrationMethod2<TFixedImage, TMovingImage>::PreparePyram
   // the result of the fixed image pyramid.
   using PointType = typename FixedImageType::PointType;
   using CoordRepType = typename PointType::CoordRepType;
-  using IndexValueType = typename IndexType::IndexValueType;
-  using SizeValueType = typename SizeType::SizeValueType;
 
   PointType inputStartPoint;
   PointType inputEndPoint;

--- a/Common/itkNDImageBase.h
+++ b/Common/itkNDImageBase.h
@@ -90,8 +90,6 @@ public:
 
   using SpacingValueType = typename Spacing2DType::ValueType;
   using PointValueType = typename Point2DType::ValueType;
-  using IndexValueType = typename ImageBase<2>::IndexValueType;
-  using SizeValueType = typename ImageBase<2>::SizeValueType;
   using OffsetValueType = typename ImageBase<2>::OffsetValueType;
 
   /** ND versions of the index and sizetypes. Unlike in

--- a/Common/itkNDImageTemplate.h
+++ b/Common/itkNDImageTemplate.h
@@ -78,8 +78,6 @@ public:
 
   using typename Superclass::SpacingValueType;
   using typename Superclass::PointValueType;
-  using typename Superclass::IndexValueType;
-  using typename Superclass::SizeValueType;
   using typename Superclass::OffsetValueType;
 
   /** ND versions of the index and sizetypes etc. */

--- a/Components/Metrics/AdvancedNormalizedCorrelation/itkAdvancedNormalizedCorrelationImageToImageMetric.hxx
+++ b/Components/Metrics/AdvancedNormalizedCorrelation/itkAdvancedNormalizedCorrelationImageToImageMetric.hxx
@@ -282,8 +282,6 @@ AdvancedNormalizedCorrelationImageToImageMetric<TFixedImage, TMovingImage>::GetV
 {
   itkDebugMacro("GetValueAndDerivative( " << parameters << " ) ");
 
-  using DerivativeValueType = typename DerivativeType::ValueType;
-
   /** Initialize some variables. */
   this->m_NumberOfPixelsCounted = 0;
   derivative = DerivativeType(this->GetNumberOfParameters());

--- a/Components/Metrics/DistancePreservingRigidityPenalty/elxDistancePreservingRigidityPenaltyTerm.hxx
+++ b/Components/Metrics/DistancePreservingRigidityPenalty/elxDistancePreservingRigidityPenaltyTerm.hxx
@@ -97,8 +97,7 @@ DistancePreservingRigidityPenalty<TElastix>::BeforeRegistration()
   auto identityTransform = IdentityTransformType::New();
   identityTransform->SetIdentity();
 
-  using LinearInterpolatorType = itk::LinearInterpolateImageFunction<SegmentedImageType, double>;
-  auto linearInterpolator = LinearInterpolatorType::New();
+  auto linearInterpolator = itk::LinearInterpolateImageFunction<SegmentedImageType, double>::New();
 
   /** Configure the resampler and run it. */
   resampler->SetInterpolator(linearInterpolator);

--- a/Components/Metrics/DistancePreservingRigidityPenalty/elxDistancePreservingRigidityPenaltyTerm.hxx
+++ b/Components/Metrics/DistancePreservingRigidityPenalty/elxDistancePreservingRigidityPenaltyTerm.hxx
@@ -40,7 +40,6 @@ DistancePreservingRigidityPenalty<TElastix>::BeforeRegistration()
   this->GetConfiguration()->ReadParameter(
     segmentedImageName, "SegmentedImageName", this->GetComponentLabel(), 0, -1, false);
 
-  using SegmentedImageType = typename Superclass1::SegmentedImageType;
   using DirectionType = typename SegmentedImageType::DirectionType;
   using SizeValueType = typename SegmentedImageType::SizeType::SizeValueType;
 

--- a/Components/Metrics/DistancePreservingRigidityPenalty/itkDistancePreservingRigidityPenaltyTerm.hxx
+++ b/Components/Metrics/DistancePreservingRigidityPenalty/itkDistancePreservingRigidityPenaltyTerm.hxx
@@ -219,9 +219,9 @@ DistancePreservingRigidityPenaltyTerm<TFixedImage, TScalarType>::GetValue(const 
       {
         numberOfRigidGridsNeighbor = 0;
 
-        for (unsigned int kk = 0; kk < numberOfNeighborhood; ++kk)
+        for (unsigned int neighbor = 0; neighbor < numberOfNeighborhood; ++neighbor)
         {
-          neighborPenaltyGridIndex = ni.GetIndex(kk);
+          neighborPenaltyGridIndex = ni.GetIndex(neighbor);
 
           this->m_PenaltyGridImage->TransformIndexToPhysicalPoint(neighborPenaltyGridIndex, neighborPenaltyGridPoint);
 
@@ -236,9 +236,9 @@ DistancePreservingRigidityPenaltyTerm<TFixedImage, TScalarType>::GetValue(const 
 
         if (numberOfRigidGridsNeighbor > 1)
         {
-          for (unsigned int kk = 0; kk < numberOfNeighborhood; ++kk)
+          for (unsigned int neighbor = 0; neighbor < numberOfNeighborhood; ++neighbor)
           {
-            neighborPenaltyGridIndex = ni.GetIndex(kk);
+            neighborPenaltyGridIndex = ni.GetIndex(neighbor);
 
             this->m_PenaltyGridImage->TransformIndexToPhysicalPoint(neighborPenaltyGridIndex, neighborPenaltyGridPoint);
 
@@ -381,9 +381,9 @@ DistancePreservingRigidityPenaltyTerm<TFixedImage, TScalarType>::GetValueAndDeri
       {
         numberOfRigidGridsNeighbor = 0;
 
-        for (unsigned int kk = 0; kk < numberOfNeighborhood; ++kk)
+        for (unsigned int neighbor = 0; neighbor < numberOfNeighborhood; ++neighbor)
         {
-          neighborPenaltyGridIndex = ni.GetIndex(kk);
+          neighborPenaltyGridIndex = ni.GetIndex(neighbor);
 
           this->m_PenaltyGridImage->TransformIndexToPhysicalPoint(neighborPenaltyGridIndex, neighborPenaltyGridPoint);
 
@@ -398,9 +398,9 @@ DistancePreservingRigidityPenaltyTerm<TFixedImage, TScalarType>::GetValueAndDeri
 
         if (numberOfRigidGridsNeighbor > 1)
         {
-          for (unsigned int kk = 0; kk < numberOfNeighborhood; ++kk)
+          for (unsigned int neighbor = 0; neighbor < numberOfNeighborhood; ++neighbor)
           {
-            neighborPenaltyGridIndex = ni.GetIndex(kk);
+            neighborPenaltyGridIndex = ni.GetIndex(neighbor);
 
             this->m_PenaltyGridImage->TransformIndexToPhysicalPoint(neighborPenaltyGridIndex, neighborPenaltyGridPoint);
 

--- a/Components/Metrics/GradientDifference/elxGradientDifferenceMetric.hxx
+++ b/Components/Metrics/GradientDifference/elxGradientDifferenceMetric.hxx
@@ -74,9 +74,7 @@ template <class TElastix>
 void
 GradientDifferenceMetric<TElastix>::BeforeEachResolution()
 {
-  using ScalesType = typename elastix::OptimizerBase<TElastix>::ITKBaseType::ScalesType;
-  ScalesType scales = this->m_Elastix->GetElxOptimizerBase()->GetAsITKBaseType()->GetScales();
-  this->SetScales(scales);
+  this->SetScales(this->m_Elastix->GetElxOptimizerBase()->GetAsITKBaseType()->GetScales());
 
 } // end BeforeEachResolution()
 

--- a/Components/Metrics/GradientDifference/itkGradientDifferenceImageToImageMetric2.hxx
+++ b/Components/Metrics/GradientDifference/itkGradientDifferenceImageToImageMetric2.hxx
@@ -150,9 +150,8 @@ GradientDifferenceImageToImageMetric<TFixedImage, TMovingImage>::ComputeMovedGra
 
   for (iDimension = 0; iDimension < FixedImageDimension; ++iDimension)
   {
-    using IteratorType = itk::ImageRegionConstIteratorWithIndex<MovedGradientImageType>;
-
-    IteratorType iterate(m_MovedSobelFilters[iDimension]->GetOutput(), this->GetFixedImageRegion());
+    ImageRegionConstIteratorWithIndex<MovedGradientImageType> iterate(m_MovedSobelFilters[iDimension]->GetOutput(),
+                                                                      this->GetFixedImageRegion());
 
     gradient = iterate.Get();
 
@@ -193,9 +192,8 @@ GradientDifferenceImageToImageMetric<TFixedImage, TMovingImage>::ComputeVariance
 
   for (iDimension = 0; iDimension < FixedImageDimension; ++iDimension)
   {
-    using IteratorType = itk::ImageRegionConstIteratorWithIndex<FixedGradientImageType>;
-
-    IteratorType iterate(this->m_FixedSobelFilters[iDimension]->GetOutput(), this->GetFixedImageRegion());
+    ImageRegionConstIteratorWithIndex<FixedGradientImageType> iterate(
+      this->m_FixedSobelFilters[iDimension]->GetOutput(), this->GetFixedImageRegion());
 
     /** Calculate the mean gradients */
     nPixels = 0;

--- a/Components/Metrics/KNNGraphAlphaMutualInformation/itkKNNGraphAlphaMutualInformationImageToImageMetric.h
+++ b/Components/Metrics/KNNGraphAlphaMutualInformation/itkKNNGraphAlphaMutualInformationImageToImageMetric.h
@@ -164,7 +164,7 @@ public:
   using IndexArrayType = typename BinaryKNNTreeSearchType::IndexArrayType;
   using DistanceArrayType = typename BinaryKNNTreeSearchType::DistanceArrayType;
 
-  using DerivativeValueType = typename DerivativeType::ValueType;
+  using typename Superclass::DerivativeValueType;
   using TransformJacobianValueType = typename TransformJacobianType::ValueType;
 
   /**

--- a/Components/Metrics/MissingStructurePenalty/elxMissingStructurePenalty.hxx
+++ b/Components/Metrics/MissingStructurePenalty/elxMissingStructurePenalty.hxx
@@ -404,13 +404,13 @@ the sequence of points to form a 2d connected polydata contour.
   using FixedImageDirectionType = typename FixedImageType::DirectionType;
 
   using DummyIPPPixelType = unsigned char;
-  using MeshTraitsType =
+  using DummyMeshTraitsType =
     itk::DefaultStaticMeshTraits<DummyIPPPixelType, FixedImageDimension, FixedImageDimension, CoordRepType>;
-  using PointSetType = itk::PointSet<DummyIPPPixelType, FixedImageDimension, MeshTraitsType>;
+  using DummyPointSetType = itk::PointSet<DummyIPPPixelType, FixedImageDimension, DummyMeshTraitsType>;
   using DeformationVectorType = itk::Vector<float, FixedImageDimension>;
 
   /** Construct an ipp-file reader. */
-  auto ippReader = itk::TransformixInputPointFileReader<PointSetType>::New();
+  auto ippReader = itk::TransformixInputPointFileReader<DummyPointSetType>::New();
   ippReader->SetFileName(filename);
 
   /** Read the input points. */
@@ -437,7 +437,7 @@ the sequence of points to form a 2d connected polydata contour.
   log::info(std::ostringstream{} << "  Number of specified input points: " << nrofpoints);
 
   /** Get the set of input points. */
-  typename PointSetType::Pointer inputPointSet = ippReader->GetOutput();
+  typename DummyPointSetType::Pointer inputPointSet = ippReader->GetOutput();
 
   /** Create the storage classes. */
   std::vector<FixedImageIndexType> inputindexvec(nrofpoints);

--- a/Components/Metrics/NormalizedGradientCorrelation/elxNormalizedGradientCorrelationMetric.hxx
+++ b/Components/Metrics/NormalizedGradientCorrelation/elxNormalizedGradientCorrelationMetric.hxx
@@ -73,9 +73,7 @@ template <class TElastix>
 void
 NormalizedGradientCorrelationMetric<TElastix>::BeforeEachResolution()
 {
-  using ScalesType = typename elastix::OptimizerBase<TElastix>::ITKBaseType::ScalesType;
-  ScalesType scales = this->m_Elastix->GetElxOptimizerBase()->GetAsITKBaseType()->GetScales();
-  this->SetScales(scales);
+  this->SetScales(this->m_Elastix->GetElxOptimizerBase()->GetAsITKBaseType()->GetScales());
 
 } // end BeforeEachResolution()
 

--- a/Components/Metrics/PCAMetric/itkPCAMetric_F_multithreaded.h
+++ b/Components/Metrics/PCAMetric/itkPCAMetric_F_multithreaded.h
@@ -92,7 +92,7 @@ public:
   using typename Superclass::FixedImageLimiterOutputType;
   using typename Superclass::MovingImageLimiterOutputType;
   using typename Superclass::MovingImageDerivativeScalesType;
-  using DerivativeValueType = typename DerivativeType::ValueType;
+  using typename Superclass::DerivativeValueType;
   using typename Superclass::ThreaderType;
   using typename Superclass::ThreadInfoType;
 

--- a/Components/Metrics/PCAMetric/itkPCAMetric_F_multithreaded.hxx
+++ b/Components/Metrics/PCAMetric/itkPCAMetric_F_multithreaded.hxx
@@ -230,26 +230,27 @@ PCAMetric<TFixedImage, TMovingImage>::GetValue(const TransformParametersType & p
   this->CheckNumberOfSamples(numberOfSamples, this->m_NumberOfPixelsCounted);
   MatrixType A(datablock.extract(this->m_NumberOfPixelsCounted, this->m_G));
 
-  /** Calculate mean of from columns */
-  vnl_vector<RealType> mean(this->m_G);
-  mean.fill(RealType{});
-  for (unsigned int i = 0; i < this->m_NumberOfPixelsCounted; ++i)
-  {
-    for (unsigned int j = 0; j < this->m_G; ++j)
-    {
-      mean(j) += A(i, j);
-    }
-  }
-  mean /= RealType(this->m_NumberOfPixelsCounted);
-
   MatrixType Amm(this->m_NumberOfPixelsCounted, this->m_G);
   Amm.fill(RealType{});
-
-  for (unsigned int i = 0; i < this->m_NumberOfPixelsCounted; ++i)
   {
-    for (unsigned int j = 0; j < this->m_G; ++j)
+    /** Calculate mean of from columns */
+    vnl_vector<RealType> mean(this->m_G);
+    mean.fill(RealType{});
+    for (unsigned int i = 0; i < this->m_NumberOfPixelsCounted; ++i)
     {
-      Amm(i, j) = A(i, j) - mean(j);
+      for (unsigned int j = 0; j < this->m_G; ++j)
+      {
+        mean(j) += A(i, j);
+      }
+    }
+    mean /= RealType(this->m_NumberOfPixelsCounted);
+
+    for (unsigned int i = 0; i < this->m_NumberOfPixelsCounted; ++i)
+    {
+      for (unsigned int j = 0; j < this->m_G; ++j)
+      {
+        Amm(i, j) = A(i, j) - mean(j);
+      }
     }
   }
 
@@ -407,26 +408,28 @@ PCAMetric<TFixedImage, TMovingImage>::GetValueAndDerivativeSingleThreaded(const 
 
   MatrixType A(datablock.extract(this->m_NumberOfPixelsCounted, this->m_G));
 
-  /** Calculate mean of from columns */
-  vnl_vector<RealType> mean(this->m_G);
-  mean.fill(RealType{});
-  for (unsigned int i = 0; i < this->m_NumberOfPixelsCounted; ++i)
-  {
-    for (unsigned int j = 0; j < this->m_G; ++j)
-    {
-      mean(j) += A(i, j);
-    }
-  }
-  mean /= RealType(this->m_NumberOfPixelsCounted);
-
   /** Calculate standard deviation from columns */
   MatrixType Amm(this->m_NumberOfPixelsCounted, this->m_G);
   Amm.fill(RealType{});
-  for (unsigned int i = 0; i < this->m_NumberOfPixelsCounted; ++i)
   {
-    for (unsigned int j = 0; j < this->m_G; ++j)
+    /** Calculate mean of from columns */
+    vnl_vector<RealType> mean(this->m_G);
+    mean.fill(RealType{});
+    for (unsigned int i = 0; i < this->m_NumberOfPixelsCounted; ++i)
     {
-      Amm(i, j) = A(i, j) - mean(j);
+      for (unsigned int j = 0; j < this->m_G; ++j)
+      {
+        mean(j) += A(i, j);
+      }
+    }
+    mean /= RealType(this->m_NumberOfPixelsCounted);
+
+    for (unsigned int i = 0; i < this->m_NumberOfPixelsCounted; ++i)
+    {
+      for (unsigned int j = 0; j < this->m_G; ++j)
+      {
+        Amm(i, j) = A(i, j) - mean(j);
+      }
     }
   }
 
@@ -775,26 +778,28 @@ PCAMetric<TFixedImage, TMovingImage>::AfterThreadedGetSamples(MeasureType & valu
     row_start += this->m_PCAMetricGetSamplesPerThreadVariables[i].st_DataBlock.rows();
   }
 
-  /** Calculate mean of from columns */
-  vnl_vector<RealType> mean(this->m_G);
-  mean.fill(RealType{});
-  for (unsigned int i = 0; i < this->m_NumberOfPixelsCounted; ++i)
-  {
-    for (unsigned int j = 0; j < this->m_G; ++j)
-    {
-      mean(j) += A(i, j);
-    }
-  }
-  mean /= RealType(this->m_NumberOfPixelsCounted);
-
   /** Calculate standard deviation from columns */
   MatrixType Amm(this->m_NumberOfPixelsCounted, this->m_G);
   Amm.fill(RealType{});
-  for (unsigned int i = 0; i < this->m_NumberOfPixelsCounted; ++i)
   {
-    for (unsigned int j = 0; j < this->m_G; ++j)
+    /** Calculate mean of from columns */
+    vnl_vector<RealType> mean(this->m_G);
+    mean.fill(RealType{});
+    for (unsigned int i = 0; i < this->m_NumberOfPixelsCounted; ++i)
     {
-      Amm(i, j) = A(i, j) - mean(j);
+      for (unsigned int j = 0; j < this->m_G; ++j)
+      {
+        mean(j) += A(i, j);
+      }
+    }
+    mean /= RealType(this->m_NumberOfPixelsCounted);
+
+    for (unsigned int i = 0; i < this->m_NumberOfPixelsCounted; ++i)
+    {
+      for (unsigned int j = 0; j < this->m_G; ++j)
+      {
+        Amm(i, j) = A(i, j) - mean(j);
+      }
     }
   }
 

--- a/Components/Metrics/PCAMetric2/itkPCAMetric2.h
+++ b/Components/Metrics/PCAMetric2/itkPCAMetric2.h
@@ -92,6 +92,7 @@ public:
   using typename Superclass::FixedImageLimiterOutputType;
   using typename Superclass::MovingImageLimiterOutputType;
   using typename Superclass::MovingImageDerivativeScalesType;
+  using typename Superclass::DerivativeValueType;
 
   /** The fixed image dimension. */
   itkStaticConstMacro(FixedImageDimension, unsigned int, FixedImageType::ImageDimension);

--- a/Components/Metrics/PCAMetric2/itkPCAMetric2.hxx
+++ b/Components/Metrics/PCAMetric2/itkPCAMetric2.hxx
@@ -136,7 +136,6 @@ PCAMetric2<TFixedImage, TMovingImage>::GetValue(const TransformParametersType & 
 
   if (UseGetValueAndDerivative)
   {
-    using DerivativeValueType = typename DerivativeType::ValueType;
     const unsigned int numberOfParameters = this->GetNumberOfParameters();
     MeasureType        dummymeasure{};
     DerivativeType     dummyderivative = DerivativeType(numberOfParameters);
@@ -336,9 +335,6 @@ PCAMetric2<TFixedImage, TMovingImage>::GetValueAndDerivative(const TransformPara
                                                              DerivativeType &                derivative) const
 {
   itkDebugMacro("GetValueAndDerivative( " << parameters << " ) ");
-  /** Define derivative and Jacobian types. */
-  using DerivativeValueType = typename DerivativeType::ValueType;
-  // typedef typename TransformJacobianType::ValueType TransformJacobianValueType;
 
   /** Initialize some variables */
   const unsigned int numberOfParameters = this->GetNumberOfParameters();

--- a/Components/Metrics/PCAMetric2/itkPCAMetric2.hxx
+++ b/Components/Metrics/PCAMetric2/itkPCAMetric2.hxx
@@ -237,26 +237,27 @@ PCAMetric2<TFixedImage, TMovingImage>::GetValue(const TransformParametersType & 
   const unsigned int N = this->m_NumberOfPixelsCounted;
   MatrixType         A(datablock.extract(N, G));
 
-  /** Calculate mean of from columns */
-  vnl_vector<RealType> mean(G);
-  mean.fill(RealType{});
-  for (unsigned int i = 0; i < N; ++i)
-  {
-    for (unsigned int j = 0; j < G; ++j)
-    {
-      mean(j) += A(i, j);
-    }
-  }
-  mean /= RealType(N);
-
   MatrixType Amm(N, G);
   Amm.fill(RealType{});
-
-  for (unsigned int i = 0; i < N; ++i)
   {
-    for (unsigned int j = 0; j < G; ++j)
+    /** Calculate mean of from columns */
+    vnl_vector<RealType> mean(G);
+    mean.fill(RealType{});
+    for (unsigned int i = 0; i < N; ++i)
     {
-      Amm(i, j) = A(i, j) - mean(j);
+      for (unsigned int j = 0; j < G; ++j)
+      {
+        mean(j) += A(i, j);
+      }
+    }
+    mean /= RealType(N);
+
+    for (unsigned int i = 0; i < N; ++i)
+    {
+      for (unsigned int j = 0; j < G; ++j)
+      {
+        Amm(i, j) = A(i, j) - mean(j);
+      }
     }
   }
 
@@ -437,26 +438,28 @@ PCAMetric2<TFixedImage, TMovingImage>::GetValueAndDerivative(const TransformPara
 
   MatrixType A(datablock.extract(N, G));
 
-  /** Calculate mean of columns */
-  vnl_vector<RealType> mean(G);
-  mean.fill(RealType{});
-  for (unsigned int i = 0; i < N; ++i)
-  {
-    for (unsigned int j = 0; j < G; ++j)
-    {
-      mean(j) += A(i, j);
-    }
-  }
-  mean /= RealType(N);
-
   /** Calculate standard deviation of columns */
   MatrixType Amm(N, G);
   Amm.fill(RealType{});
-  for (unsigned int i = 0; i < N; ++i)
   {
-    for (unsigned int j = 0; j < G; ++j)
+    /** Calculate mean of columns */
+    vnl_vector<RealType> mean(G);
+    mean.fill(RealType{});
+    for (unsigned int i = 0; i < N; ++i)
     {
-      Amm(i, j) = A(i, j) - mean(j);
+      for (unsigned int j = 0; j < G; ++j)
+      {
+        mean(j) += A(i, j);
+      }
+    }
+    mean /= RealType(N);
+
+    for (unsigned int i = 0; i < N; ++i)
+    {
+      for (unsigned int j = 0; j < G; ++j)
+      {
+        Amm(i, j) = A(i, j) - mean(j);
+      }
     }
   }
 

--- a/Components/Metrics/PCAMetric2/itkPCAMetric2.hxx
+++ b/Components/Metrics/PCAMetric2/itkPCAMetric2.hxx
@@ -527,8 +527,6 @@ PCAMetric2<TFixedImage, TMovingImage>::GetValueAndDerivative(const TransformPara
     auto voxelCoord =
       this->GetFixedImage()->template TransformPhysicalPointToContinuousIndex<CoordinateRepresentationType>(fixedPoint);
 
-    const unsigned int G = lastDimPositions.size();
-
     for (unsigned int d = 0; d < G; ++d)
     {
       /** Initialize some variables. */

--- a/Components/Metrics/PatternIntensity/elxPatternIntensityMetric.hxx
+++ b/Components/Metrics/PatternIntensity/elxPatternIntensityMetric.hxx
@@ -87,9 +87,7 @@ PatternIntensityMetric<TElastix>::BeforeEachResolution()
     optimizenormalizationfactor, "OptimizeNormalizationFactor", this->GetComponentLabel(), level, 0);
   this->SetOptimizeNormalizationFactor(optimizenormalizationfactor);
 
-  using ScalesType = typename elastix::OptimizerBase<TElastix>::ITKBaseType::ScalesType;
-  ScalesType scales = this->m_Elastix->GetElxOptimizerBase()->GetAsITKBaseType()->GetScales();
-  this->SetScales(scales);
+  this->SetScales(this->m_Elastix->GetElxOptimizerBase()->GetAsITKBaseType()->GetScales());
 
 } // end BeforeEachResolution()
 

--- a/Components/Metrics/PolydataDummyPenalty/elxPolydataDummyPenalty.hxx
+++ b/Components/Metrics/PolydataDummyPenalty/elxPolydataDummyPenalty.hxx
@@ -386,13 +386,13 @@ PolydataDummyPenalty<TElastix>::ReadTransformixPoints(const std::string &       
   using FixedImageDirectionType = typename FixedImageType::DirectionType;
 
   using DummyIPPPixelType = unsigned char;
-  using MeshTraitsType =
+  using DummyMeshTraitsType =
     itk::DefaultStaticMeshTraits<DummyIPPPixelType, FixedImageDimension, FixedImageDimension, CoordRepType>;
-  using PointSetType = itk::PointSet<DummyIPPPixelType, FixedImageDimension, MeshTraitsType>;
+  using DummyPointSetType = itk::PointSet<DummyIPPPixelType, FixedImageDimension, DummyMeshTraitsType>;
   using DeformationVectorType = itk::Vector<float, FixedImageDimension>;
 
   /** Construct an ipp-file reader. */
-  auto ippReader = itk::TransformixInputPointFileReader<PointSetType>::New();
+  auto ippReader = itk::TransformixInputPointFileReader<DummyPointSetType>::New();
   ippReader->SetFileName(filename);
 
   /** Read the input points. */
@@ -419,7 +419,7 @@ PolydataDummyPenalty<TElastix>::ReadTransformixPoints(const std::string &       
   log::info(std::ostringstream{} << "  Number of specified input points: " << nrofpoints);
 
   /** Get the set of input points. */
-  typename PointSetType::Pointer inputPointSet = ippReader->GetOutput();
+  typename DummyPointSetType::Pointer inputPointSet = ippReader->GetOutput();
 
   /** Create the storage classes. */
   std::vector<FixedImageIndexType>   inputindexvec(nrofpoints);

--- a/Components/Metrics/RigidityPenalty/elxTransformRigidityPenaltyTerm.h
+++ b/Components/Metrics/RigidityPenalty/elxTransformRigidityPenaltyTerm.h
@@ -172,6 +172,7 @@ public:
   using typename Superclass1::MovingImageLimiterOutputType;
 
   using typename Superclass1::CoefficientImageType;
+  using typename Superclass1::RigidityImageType;
 
   /** The fixed image dimension. */
   itkStaticConstMacro(FixedImageDimension, unsigned int, FixedImageType::ImageDimension);

--- a/Components/Metrics/RigidityPenalty/elxTransformRigidityPenaltyTerm.hxx
+++ b/Components/Metrics/RigidityPenalty/elxTransformRigidityPenaltyTerm.hxx
@@ -39,7 +39,6 @@ TransformRigidityPenalty<TElastix>::BeforeRegistration()
   this->GetConfiguration()->ReadParameter(
     fixedRigidityImageName, "FixedRigidityImageName", this->GetComponentLabel(), 0, -1, false);
 
-  using RigidityImageType = typename Superclass1::RigidityImageType;
   using DirectionType = typename RigidityImageType::DirectionType;
 
   if (!fixedRigidityImageName.empty())

--- a/Components/Metrics/SumOfPairwiseCorrelationsMetric/itkSumOfPairwiseCorrelationCoefficientsMetric.h
+++ b/Components/Metrics/SumOfPairwiseCorrelationsMetric/itkSumOfPairwiseCorrelationCoefficientsMetric.h
@@ -81,6 +81,7 @@ public:
   using typename Superclass::MovingImageMaskPointer;
   using typename Superclass::MeasureType;
   using typename Superclass::DerivativeType;
+  using typename Superclass::DerivativeValueType;
   using typename Superclass::ParametersType;
   using typename Superclass::FixedImagePixelType;
   using typename Superclass::MovingImageRegionType;

--- a/Components/Metrics/SumOfPairwiseCorrelationsMetric/itkSumOfPairwiseCorrelationCoefficientsMetric.hxx
+++ b/Components/Metrics/SumOfPairwiseCorrelationsMetric/itkSumOfPairwiseCorrelationCoefficientsMetric.hxx
@@ -291,10 +291,6 @@ SumOfPairwiseCorrelationCoefficientsMetric<TFixedImage, TMovingImage>::GetValueA
 {
   itkDebugMacro("GetValueAndDerivative( " << parameters << " ) ");
 
-  /** Define derivative and Jacobian types. */
-  using DerivativeValueType = typename DerivativeType::ValueType;
-  // typedef typename TransformJacobianType::ValueType TransformJacobianValueType;
-
   /** Initialize some variables */
   const unsigned int numberOfParameters = this->GetNumberOfParameters();
   this->m_NumberOfPixelsCounted = 0;

--- a/Components/Metrics/SumOfPairwiseCorrelationsMetric/itkSumOfPairwiseCorrelationCoefficientsMetric.hxx
+++ b/Components/Metrics/SumOfPairwiseCorrelationsMetric/itkSumOfPairwiseCorrelationCoefficientsMetric.hxx
@@ -210,25 +210,27 @@ SumOfPairwiseCorrelationCoefficientsMetric<TFixedImage, TMovingImage>::GetValue(
 
   MatrixType A(datablock.extract(N, G));
 
-  /** Calculate mean of from columns */
-  vnl_vector<RealType> mean(G);
-  mean.fill(RealType{});
-  for (unsigned int i = 0; i < N; ++i)
-  {
-    for (unsigned int j = 0; j < G; ++j)
-    {
-      mean(j) += A(i, j);
-    }
-  }
-  mean /= RealType(N);
-
   MatrixType Amm(N, G);
   Amm.fill(RealType{});
-  for (unsigned int i = 0; i < N; ++i)
   {
-    for (unsigned int j = 0; j < G; ++j)
+    /** Calculate mean of from columns */
+    vnl_vector<RealType> mean(G);
+    mean.fill(RealType{});
+    for (unsigned int i = 0; i < N; ++i)
     {
-      Amm(i, j) = A(i, j) - mean(j);
+      for (unsigned int j = 0; j < G; ++j)
+      {
+        mean(j) += A(i, j);
+      }
+    }
+    mean /= RealType(N);
+
+    for (unsigned int i = 0; i < N; ++i)
+    {
+      for (unsigned int j = 0; j < G; ++j)
+      {
+        Amm(i, j) = A(i, j) - mean(j);
+      }
     }
   }
 
@@ -384,25 +386,27 @@ SumOfPairwiseCorrelationCoefficientsMetric<TFixedImage, TMovingImage>::GetValueA
 
   MatrixType A(datablock.extract(N, G));
 
-  /** Calculate mean of from columns */
-  vnl_vector<RealType> mean(G);
-  mean.fill(RealType{});
-  for (unsigned int i = 0; i < N; ++i)
-  {
-    for (unsigned int j = 0; j < G; ++j)
-    {
-      mean(j) += A(i, j);
-    }
-  }
-  mean /= RealType(N);
-
   MatrixType Amm(N, G);
   Amm.fill(RealType{});
-  for (unsigned int i = 0; i < N; ++i)
   {
-    for (unsigned int j = 0; j < G; ++j)
+    /** Calculate mean of from columns */
+    vnl_vector<RealType> mean(G);
+    mean.fill(RealType{});
+    for (unsigned int i = 0; i < N; ++i)
     {
-      Amm(i, j) = A(i, j) - mean(j);
+      for (unsigned int j = 0; j < G; ++j)
+      {
+        mean(j) += A(i, j);
+      }
+    }
+    mean /= RealType(N);
+
+    for (unsigned int i = 0; i < N; ++i)
+    {
+      for (unsigned int j = 0; j < G; ++j)
+      {
+        Amm(i, j) = A(i, j) - mean(j);
+      }
     }
   }
 

--- a/Components/Metrics/VarianceOverLastDimension/itkVarianceOverLastDimensionImageMetric.h
+++ b/Components/Metrics/VarianceOverLastDimension/itkVarianceOverLastDimensionImageMetric.h
@@ -108,6 +108,7 @@ public:
   using typename Superclass::MovingImageMaskPointer;
   using typename Superclass::MeasureType;
   using typename Superclass::DerivativeType;
+  using typename Superclass::DerivativeValueType;
   using typename Superclass::ParametersType;
   using typename Superclass::FixedImagePixelType;
   using typename Superclass::MovingImageRegionType;

--- a/Components/Metrics/VarianceOverLastDimension/itkVarianceOverLastDimensionImageMetric.hxx
+++ b/Components/Metrics/VarianceOverLastDimension/itkVarianceOverLastDimensionImageMetric.hxx
@@ -333,9 +333,6 @@ VarianceOverLastDimensionImageMetric<TFixedImage, TMovingImage>::GetValueAndDeri
 {
   itkDebugMacro("GetValueAndDerivative( " << parameters << " ) ");
 
-  /** Define derivative and Jacobian types. */
-  using DerivativeValueType = typename DerivativeType::ValueType;
-
   /** Initialize some variables */
   Superclass::m_NumberOfPixelsCounted = 0;
   MeasureType measure{};

--- a/Components/Optimizers/ConjugateGradient/elxConjugateGradient.hxx
+++ b/Components/Optimizers/ConjugateGradient/elxConjugateGradient.hxx
@@ -130,7 +130,7 @@ ConjugateGradient<TElastix>::LineSearch(const ParametersType searchDir,
     {
       throw;
     }
-    else if (this->GetStopCondition() != LineSearchError)
+    else if (this->GetStopCondition() != StopConditionType::LineSearchError)
     {
       throw;
     }
@@ -367,7 +367,7 @@ ConjugateGradient<TElastix>::AfterEachIteration()
       }
       catch (const itk::ExceptionObject &)
       {
-        this->m_StopCondition = MetricError;
+        this->m_StopCondition = StopConditionType::MetricError;
         this->StopOptimization();
         throw;
       }
@@ -406,27 +406,27 @@ ConjugateGradient<TElastix>::AfterEachResolution()
     switch (this->GetStopCondition())
     {
 
-      case MetricError:
+      case StopConditionType::MetricError:
         stopcondition = "Error in metric";
         break;
 
-      case LineSearchError:
+      case StopConditionType::LineSearchError:
         stopcondition = "Error in LineSearch";
         break;
 
-      case MaximumNumberOfIterations:
+      case StopConditionType::MaximumNumberOfIterations:
         stopcondition = "Maximum number of iterations has been reached";
         break;
 
-      case GradientMagnitudeTolerance:
+      case StopConditionType::GradientMagnitudeTolerance:
         stopcondition = "The gradient magnitude has (nearly) vanished";
         break;
 
-      case ValueTolerance:
+      case StopConditionType::ValueTolerance:
         stopcondition = "Almost no decrease in function value anymore";
         break;
 
-      case InfiniteBeta:
+      case StopConditionType::InfiniteBeta:
         stopcondition = "The beta factor became infinite";
         break;
 
@@ -497,7 +497,7 @@ ConjugateGradient<TElastix>::GetLineSearchStopCondition() const
   /** Must be repeated here; otherwise the StopconditionTypes of the
    * GenericConjugateGradientOptimizer and the LineSearchOptimizer
    * are mixed up. */
-  enum LineSearchStopConditionType
+  enum class LineSearchStopConditionType
   {
     StrongWolfeConditionsSatisfied,
     MetricError,
@@ -518,35 +518,35 @@ ConjugateGradient<TElastix>::GetLineSearchStopCondition() const
   switch (lineSearchStopCondition)
   {
 
-    case StrongWolfeConditionsSatisfied:
+    case LineSearchStopConditionType::StrongWolfeConditionsSatisfied:
       stopcondition = "WolfeSatisfied";
       break;
 
-    case MetricError:
+    case LineSearchStopConditionType::MetricError:
       stopcondition = "MetricError";
       break;
 
-    case MaximumNumberOfIterations:
+    case LineSearchStopConditionType::MaximumNumberOfIterations:
       stopcondition = "MaxNrIterations";
       break;
 
-    case StepTooSmall:
+    case LineSearchStopConditionType::StepTooSmall:
       stopcondition = "StepTooSmall";
       break;
 
-    case StepTooLarge:
+    case LineSearchStopConditionType::StepTooLarge:
       stopcondition = "StepTooLarge";
       break;
 
-    case IntervalTooSmall:
+    case LineSearchStopConditionType::IntervalTooSmall:
       stopcondition = "IntervalTooSmall";
       break;
 
-    case RoundingError:
+    case LineSearchStopConditionType::RoundingError:
       stopcondition = "RoundingError";
       break;
 
-    case AscentSearchDirection:
+    case LineSearchStopConditionType::AscentSearchDirection:
       stopcondition = "AscentSearchDir";
       break;
 

--- a/Components/Optimizers/ConjugateGradient/itkGenericConjugateGradientOptimizer.cxx
+++ b/Components/Optimizers/ConjugateGradient/itkGenericConjugateGradientOptimizer.cxx
@@ -53,7 +53,7 @@ GenericConjugateGradientOptimizer::StartOptimization()
 
   /** Reset some variables */
   this->m_Stop = false;
-  this->m_StopCondition = Unknown;
+  this->m_StopCondition = StopConditionType::Unknown;
   this->m_CurrentIteration = 0;
   this->m_CurrentStepLength = 0.0;
   this->m_CurrentValue = MeasureType{};
@@ -95,7 +95,7 @@ GenericConjugateGradientOptimizer::ResumeOptimization()
 {
   itkDebugMacro("ResumeOptimization");
 
-  this->m_StopCondition = Unknown;
+  this->m_StopCondition = StopConditionType::Unknown;
   this->m_PreviousGradientAndSearchDirValid = false;
   const double TINY_NUMBER = 1e-20;
   unsigned int limitCount = 0;
@@ -113,7 +113,7 @@ GenericConjugateGradientOptimizer::ResumeOptimization()
   }
   catch (const ExceptionObject &)
   {
-    this->m_StopCondition = MetricError;
+    this->m_StopCondition = StopConditionType::MetricError;
     this->StopOptimization();
     throw;
   }
@@ -179,7 +179,7 @@ GenericConjugateGradientOptimizer::ResumeOptimization()
       }
       else
       {
-        this->m_StopCondition = ValueTolerance;
+        this->m_StopCondition = StopConditionType::ValueTolerance;
         this->StopOptimization();
         break;
       }
@@ -279,7 +279,7 @@ GenericConjugateGradientOptimizer::LineSearch(const ParametersType searchDir,
 
   if (LSO.IsNull())
   {
-    this->m_StopCondition = LineSearchError;
+    this->m_StopCondition = StopConditionType::LineSearchError;
     this->StopOptimization();
     itkExceptionMacro("No line search optimizer set");
   }
@@ -297,7 +297,7 @@ GenericConjugateGradientOptimizer::LineSearch(const ParametersType searchDir,
   }
   catch (const ExceptionObject &)
   {
-    this->m_StopCondition = LineSearchError;
+    this->m_StopCondition = StopConditionType::LineSearchError;
     this->StopOptimization();
     throw;
   }
@@ -312,7 +312,7 @@ GenericConjugateGradientOptimizer::LineSearch(const ParametersType searchDir,
   }
   catch (const ExceptionObject &)
   {
-    this->m_StopCondition = MetricError;
+    this->m_StopCondition = StopConditionType::MetricError;
     this->StopOptimization();
     throw;
   }
@@ -378,7 +378,7 @@ GenericConjugateGradientOptimizer::ComputeBetaFR(const DerivativeType & previous
 
   if (den <= NumericTraits<double>::epsilon())
   {
-    this->m_StopCondition = InfiniteBeta;
+    this->m_StopCondition = StopConditionType::InfiniteBeta;
     this->StopOptimization();
     return 0.0;
   }
@@ -410,7 +410,7 @@ GenericConjugateGradientOptimizer::ComputeBetaPR(const DerivativeType & previous
 
   if (den <= NumericTraits<double>::epsilon())
   {
-    this->m_StopCondition = InfiniteBeta;
+    this->m_StopCondition = StopConditionType::InfiniteBeta;
     this->StopOptimization();
     return 0.0;
   }
@@ -441,7 +441,7 @@ GenericConjugateGradientOptimizer::ComputeBetaDY(const DerivativeType & previous
 
   if (den <= NumericTraits<double>::epsilon())
   {
-    this->m_StopCondition = InfiniteBeta;
+    this->m_StopCondition = StopConditionType::InfiniteBeta;
     this->StopOptimization();
     return 0.0;
   }
@@ -471,7 +471,7 @@ GenericConjugateGradientOptimizer::ComputeBetaHS(const DerivativeType & previous
 
   if (den <= NumericTraits<double>::epsilon())
   {
-    this->m_StopCondition = InfiniteBeta;
+    this->m_StopCondition = StopConditionType::InfiniteBeta;
     this->StopOptimization();
     return 0.0;
   }
@@ -558,7 +558,7 @@ GenericConjugateGradientOptimizer::TestConvergence(bool itkNotUsed(firstLineSear
   /** Check if the maximum number of iterations will not be exceeded in the following iteration */
   if ((this->GetCurrentIteration() + 1) >= this->GetMaximumNumberOfIterations())
   {
-    this->m_StopCondition = MaximumNumberOfIterations;
+    this->m_StopCondition = StopConditionType::MaximumNumberOfIterations;
     return true;
   }
 
@@ -567,7 +567,7 @@ GenericConjugateGradientOptimizer::TestConvergence(bool itkNotUsed(firstLineSear
   const double xnorm = this->GetScaledCurrentPosition().magnitude();
   if (gnorm / std::max(1.0, xnorm) <= this->GetGradientMagnitudeTolerance())
   {
-    this->m_StopCondition = GradientMagnitudeTolerance;
+    this->m_StopCondition = StopConditionType::GradientMagnitudeTolerance;
     return true;
   }
 
@@ -589,7 +589,7 @@ GenericConjugateGradientOptimizer::PrintSelf(std::ostream & os, Indent indent) c
   os << indent << "m_CurrentGradient: " << this->m_CurrentGradient << std::endl;
   os << indent << "m_CurrentValue: " << this->m_CurrentValue << std::endl;
   os << indent << "m_CurrentIteration: " << this->m_CurrentIteration << std::endl;
-  os << indent << "m_StopCondition: " << this->m_StopCondition << std::endl;
+  os << indent << "m_StopCondition: " << static_cast<unsigned int>(this->m_StopCondition) << std::endl;
   os << indent << "m_Stop: " << (this->m_Stop ? "true" : "false") << std::endl;
   os << indent << "m_CurrentStepLength: " << this->m_CurrentStepLength << std::endl;
   os << indent << "m_UseDefaultMaxNrOfItWithoutImprovement: "

--- a/Components/Optimizers/ConjugateGradient/itkGenericConjugateGradientOptimizer.h
+++ b/Components/Optimizers/ConjugateGradient/itkGenericConjugateGradientOptimizer.h
@@ -68,7 +68,7 @@ public:
   using BetaDefinitionType = std::string;
   using BetaDefinitionMapType = std::map<BetaDefinitionType, ComputeBetaFunctionType>;
 
-  enum StopConditionType
+  enum class StopConditionType : unsigned int
   {
     MetricError,
     LineSearchError,
@@ -147,7 +147,7 @@ protected:
   DerivativeType    m_CurrentGradient{};
   MeasureType       m_CurrentValue{ 0.0 };
   unsigned long     m_CurrentIteration{ 0 };
-  StopConditionType m_StopCondition{ Unknown };
+  StopConditionType m_StopCondition{ StopConditionType::Unknown };
   bool              m_Stop{ false };
   double            m_CurrentStepLength{ 0.0 };
 

--- a/Components/Optimizers/PreconditionedStochasticGradientDescent/elxPreconditionedStochasticGradientDescent.hxx
+++ b/Components/Optimizers/PreconditionedStochasticGradientDescent/elxPreconditionedStochasticGradientDescent.hxx
@@ -810,12 +810,12 @@ PreconditionedStochasticGradientDescent<TElastix>::SampleGradients(const Paramet
   double         approxgg = 0.0;
 
   /** Compute gg for some random parameters. */
-  for (unsigned int i = 0; i < this->m_NumberOfGradientMeasurements; ++i)
+  for (unsigned int measurementIndex = 0; measurementIndex < this->m_NumberOfGradientMeasurements; ++measurementIndex)
   {
     if (progressObserver != nullptr)
     {
       /** Show progress 0-100% */
-      progressObserver->UpdateAndPrintProgress(i);
+      progressObserver->UpdateAndPrintProgress(measurementIndex);
     }
     /** Generate a perturbation, according to:
      *    \mu_i ~ N( \mu_0, perturbationsigma^2 I ).

--- a/Components/Optimizers/PreconditionedStochasticGradientDescent/elxPreconditionedStochasticGradientDescent.hxx
+++ b/Components/Optimizers/PreconditionedStochasticGradientDescent/elxPreconditionedStochasticGradientDescent.hxx
@@ -255,9 +255,7 @@ PreconditionedStochasticGradientDescent<TElastix>::BeforeEachResolution()
     /** If no automatic parameter estimation is used, a and alpha also need
      * to be specified.
      */
-    double a = 1.0; // arbitrary guess
     double alpha = 0.602;
-    configuration.ReadParameter(a, "SP_a", this->GetComponentLabel(), level, 0);
     configuration.ReadParameter(alpha, "SP_alpha", this->GetComponentLabel(), level, 0);
     this->SetParam_a(a);
     this->SetParam_alpha(alpha);

--- a/Components/Optimizers/QuasiNewtonLBFGS/elxQuasiNewtonLBFGS.hxx
+++ b/Components/Optimizers/QuasiNewtonLBFGS/elxQuasiNewtonLBFGS.hxx
@@ -130,7 +130,7 @@ QuasiNewtonLBFGS<TElastix>::LineSearch(const ParametersType searchDir,
     {
       throw;
     }
-    else if (this->GetStopCondition() != LineSearchError)
+    else if (this->GetStopCondition() != StopConditionType::LineSearchError)
     {
       throw;
     }
@@ -355,7 +355,7 @@ QuasiNewtonLBFGS<TElastix>::AfterEachIteration()
       }
       catch (const itk::ExceptionObject &)
       {
-        this->m_StopCondition = MetricError;
+        this->m_StopCondition = StopConditionType::MetricError;
         this->StopOptimization();
         throw;
       }
@@ -395,27 +395,27 @@ QuasiNewtonLBFGS<TElastix>::AfterEachResolution()
     switch (this->GetStopCondition())
     {
 
-      case MetricError:
+      case StopConditionType::MetricError:
         stopcondition = "Error in metric";
         break;
 
-      case LineSearchError:
+      case StopConditionType::LineSearchError:
         stopcondition = "Error in LineSearch";
         break;
 
-      case MaximumNumberOfIterations:
+      case StopConditionType::MaximumNumberOfIterations:
         stopcondition = "Maximum number of iterations has been reached";
         break;
 
-      case InvalidDiagonalMatrix:
+      case StopConditionType::InvalidDiagonalMatrix:
         stopcondition = "The diagonal matrix is invalid";
         break;
 
-      case GradientMagnitudeTolerance:
+      case StopConditionType::GradientMagnitudeTolerance:
         stopcondition = "The gradient magnitude has (nearly) vanished";
         break;
 
-      case ZeroStep:
+      case StopConditionType::ZeroStep:
         stopcondition = "The last step size was (nearly) zero";
         break;
 
@@ -485,7 +485,7 @@ QuasiNewtonLBFGS<TElastix>::GetLineSearchStopCondition() const
 {
   /** Must be repeated here; otherwise the StopconditionTypes of the
    * QuasiNewtonOptimizer and the LineSearchOptimizer are mixed up. */
-  enum LineSearchStopConditionType
+  enum class LineSearchStopConditionType
   {
     StrongWolfeConditionsSatisfied,
     MetricError,
@@ -506,35 +506,35 @@ QuasiNewtonLBFGS<TElastix>::GetLineSearchStopCondition() const
   switch (lineSearchStopCondition)
   {
 
-    case StrongWolfeConditionsSatisfied:
+    case LineSearchStopConditionType::StrongWolfeConditionsSatisfied:
       stopcondition = "WolfeSatisfied";
       break;
 
-    case MetricError:
+    case LineSearchStopConditionType::MetricError:
       stopcondition = "MetricError";
       break;
 
-    case MaximumNumberOfIterations:
+    case LineSearchStopConditionType::MaximumNumberOfIterations:
       stopcondition = "MaxNrIterations";
       break;
 
-    case StepTooSmall:
+    case LineSearchStopConditionType::StepTooSmall:
       stopcondition = "StepTooSmall";
       break;
 
-    case StepTooLarge:
+    case LineSearchStopConditionType::StepTooLarge:
       stopcondition = "StepTooLarge";
       break;
 
-    case IntervalTooSmall:
+    case LineSearchStopConditionType::IntervalTooSmall:
       stopcondition = "IntervalTooSmall";
       break;
 
-    case RoundingError:
+    case LineSearchStopConditionType::RoundingError:
       stopcondition = "RoundingError";
       break;
 
-    case AscentSearchDirection:
+    case LineSearchStopConditionType::AscentSearchDirection:
       stopcondition = "AscentSearchDir";
       break;
 

--- a/Components/Optimizers/QuasiNewtonLBFGS/itkQuasiNewtonLBFGSOptimizer.cxx
+++ b/Components/Optimizers/QuasiNewtonLBFGS/itkQuasiNewtonLBFGSOptimizer.cxx
@@ -48,7 +48,7 @@ QuasiNewtonLBFGSOptimizer::StartOptimization()
   this->m_PreviousPoint = 0;
   this->m_Bound = 0;
   this->m_Stop = false;
-  this->m_StopCondition = Unknown;
+  this->m_StopCondition = StopConditionType::Unknown;
   this->m_CurrentIteration = 0;
   this->m_CurrentStepLength = 0.0;
   this->m_CurrentValue = MeasureType{};
@@ -90,7 +90,7 @@ QuasiNewtonLBFGSOptimizer::ResumeOptimization()
   itkDebugMacro("ResumeOptimization");
 
   this->m_Stop = false;
-  this->m_StopCondition = Unknown;
+  this->m_StopCondition = StopConditionType::Unknown;
   this->m_CurrentStepLength = 0.0;
 
   ParametersType searchDir;
@@ -105,7 +105,7 @@ QuasiNewtonLBFGSOptimizer::ResumeOptimization()
   }
   catch (const ExceptionObject &)
   {
-    this->m_StopCondition = MetricError;
+    this->m_StopCondition = StopConditionType::MetricError;
     this->StopOptimization();
     throw;
   }
@@ -226,7 +226,7 @@ QuasiNewtonLBFGSOptimizer::ComputeDiagonalMatrix(DiagonalMatrixType & diag_H0)
     fill_value = ys / yy;
     if (fill_value <= 0.)
     {
-      this->m_StopCondition = InvalidDiagonalMatrix;
+      this->m_StopCondition = StopConditionType::InvalidDiagonalMatrix;
       this->StopOptimization();
     }
   }
@@ -328,7 +328,7 @@ QuasiNewtonLBFGSOptimizer::LineSearch(const ParametersType searchDir,
 
   if (LSO.IsNull())
   {
-    this->m_StopCondition = LineSearchError;
+    this->m_StopCondition = StopConditionType::LineSearchError;
     this->StopOptimization();
     itkExceptionMacro("No line search optimizer set");
   }
@@ -346,7 +346,7 @@ QuasiNewtonLBFGSOptimizer::LineSearch(const ParametersType searchDir,
   }
   catch (const ExceptionObject &)
   {
-    this->m_StopCondition = LineSearchError;
+    this->m_StopCondition = StopConditionType::LineSearchError;
     this->StopOptimization();
     throw;
   }
@@ -361,7 +361,7 @@ QuasiNewtonLBFGSOptimizer::LineSearch(const ParametersType searchDir,
   }
   catch (const ExceptionObject &)
   {
-    this->m_StopCondition = MetricError;
+    this->m_StopCondition = StopConditionType::MetricError;
     this->StopOptimization();
     throw;
   }
@@ -399,7 +399,7 @@ QuasiNewtonLBFGSOptimizer::TestConvergence(bool firstLineSearchDone)
   {
     if (this->m_CurrentStepLength < NumericTraits<double>::epsilon())
     {
-      this->m_StopCondition = ZeroStep;
+      this->m_StopCondition = StopConditionType::ZeroStep;
       return true;
     }
   }
@@ -407,7 +407,7 @@ QuasiNewtonLBFGSOptimizer::TestConvergence(bool firstLineSearchDone)
   /** Check if the maximum number of iterations will not be exceeded in the following iteration */
   if ((this->GetCurrentIteration() + 1) >= this->GetMaximumNumberOfIterations())
   {
-    this->m_StopCondition = MaximumNumberOfIterations;
+    this->m_StopCondition = StopConditionType::MaximumNumberOfIterations;
     return true;
   }
 
@@ -416,7 +416,7 @@ QuasiNewtonLBFGSOptimizer::TestConvergence(bool firstLineSearchDone)
   const double xnorm = this->GetScaledCurrentPosition().magnitude();
   if (gnorm / std::max(1.0, xnorm) <= this->GetGradientMagnitudeTolerance())
   {
-    this->m_StopCondition = GradientMagnitudeTolerance;
+    this->m_StopCondition = StopConditionType::GradientMagnitudeTolerance;
     return true;
   }
 

--- a/Components/Optimizers/QuasiNewtonLBFGS/itkQuasiNewtonLBFGSOptimizer.h
+++ b/Components/Optimizers/QuasiNewtonLBFGS/itkQuasiNewtonLBFGSOptimizer.h
@@ -83,7 +83,7 @@ public:
 
   using LineSearchOptimizerPointer = LineSearchOptimizerType::Pointer;
 
-  enum StopConditionType
+  enum class StopConditionType
   {
     MetricError,
     LineSearchError,
@@ -145,7 +145,7 @@ protected:
   DerivativeType    m_CurrentGradient{};
   MeasureType       m_CurrentValue{ 0.0 };
   unsigned long     m_CurrentIteration{ 0 };
-  StopConditionType m_StopCondition{ Unknown };
+  StopConditionType m_StopCondition{ StopConditionType::Unknown };
   bool              m_Stop{ false };
   double            m_CurrentStepLength{ 0.0 };
 

--- a/Components/Registrations/MultiMetricMultiResolutionRegistration/itkMultiMetricMultiResolutionImageRegistrationMethod.hxx
+++ b/Components/Registrations/MultiMetricMultiResolutionRegistration/itkMultiMetricMultiResolutionImageRegistrationMethod.hxx
@@ -258,8 +258,6 @@ MultiMetricMultiResolutionImageRegistrationMethod<TFixedImage, TMovingImage>::Pr
       // the result of the fixed image pyramid.
       using PointType = typename FixedImageType::PointType;
       using CoordRepType = typename PointType::CoordRepType;
-      using IndexValueType = typename IndexType::IndexValueType;
-      using SizeValueType = typename SizeType::SizeValueType;
 
       PointType inputStartPoint;
       PointType inputEndPoint;

--- a/Components/Registrations/MultiResolutionRegistrationWithFeatures/itkMultiInputMultiResolutionImageRegistrationMethodBase.hxx
+++ b/Components/Registrations/MultiResolutionRegistrationWithFeatures/itkMultiInputMultiResolutionImageRegistrationMethodBase.hxx
@@ -386,8 +386,6 @@ MultiInputMultiResolutionImageRegistrationMethodBase<TFixedImage, TMovingImage>:
       // the result of the fixed image pyramid.
       using PointType = typename FixedImageType::PointType;
       using CoordRepType = typename PointType::CoordRepType;
-      using IndexValueType = typename IndexType::IndexValueType;
-      using SizeValueType = typename SizeType::SizeValueType;
 
       PointType inputStartPoint;
       PointType inputEndPoint;

--- a/Components/Transforms/AdvancedBSplineTransform/elxAdvancedBSplineTransform.hxx
+++ b/Components/Transforms/AdvancedBSplineTransform/elxAdvancedBSplineTransform.hxx
@@ -474,15 +474,12 @@ AdvancedBSplineTransform<TElastix>::SetOptimizerScales(const unsigned int edgeWi
 {
   /** Some typedefs. */
   using IteratorType = itk::ImageRegionExclusionConstIteratorWithIndex<ImageType>;
-  using ITKRegistrationType = typename RegistrationType::ITKBaseType;
-  using OptimizerType = typename ITKRegistrationType::OptimizerType;
-  using ScalesType = typename OptimizerType::ScalesType;
-  using ScalesValueType = typename ScalesType::ValueType;
+  using ScalesValueType = itk::Optimizer::ScalesType::ValueType;
 
   /** Define new scales. */
   const NumberOfParametersType numberOfParameters = this->m_BSplineTransform->GetNumberOfParameters();
   const unsigned long          offset = numberOfParameters / SpaceDimension;
-  ScalesType                   newScales(numberOfParameters, ScalesValueType{ 1.0 });
+  itk::Optimizer::ScalesType   newScales(numberOfParameters, ScalesValueType{ 1.0 });
   const ScalesValueType        infScale = 10000.0;
 
   if (edgeWidth == 0)

--- a/Components/Transforms/AdvancedBSplineTransform/elxAdvancedBSplineTransform.hxx
+++ b/Components/Transforms/AdvancedBSplineTransform/elxAdvancedBSplineTransform.hxx
@@ -473,7 +473,6 @@ void
 AdvancedBSplineTransform<TElastix>::SetOptimizerScales(const unsigned int edgeWidth)
 {
   /** Some typedefs. */
-  using IteratorType = itk::ImageRegionExclusionConstIteratorWithIndex<ImageType>;
   using ScalesValueType = itk::Optimizer::ScalesType::ValueType;
 
   /** Define new scales. */
@@ -517,7 +516,7 @@ AdvancedBSplineTransform<TElastix>::SetOptimizerScales(const unsigned int edgeWi
   insetgridregion.SetIndex(insetgridindex);
 
   /** Set up iterator over the coefficient image. */
-  IteratorType cIt(coeff, coeff->GetLargestPossibleRegion());
+  itk::ImageRegionExclusionConstIteratorWithIndex<ImageType> cIt(coeff, coeff->GetLargestPossibleRegion());
   cIt.SetExclusionRegion(insetgridregion);
   cIt.GoToBegin();
 

--- a/Components/Transforms/BSplineDeformableTransformWithDiffusion/elxBSplineTransformWithDiffusion.hxx
+++ b/Components/Transforms/BSplineDeformableTransformWithDiffusion/elxBSplineTransformWithDiffusion.hxx
@@ -686,7 +686,6 @@ BSplineTransformWithDiffusion<TElastix>::IncreaseScale()
   using IdentityTransformType = itk::IdentityTransform<CoordRepType, SpaceDimension>;
   using CoefficientUpsampleFunctionType = itk::BSplineResampleImageFunction<ImageType, CoordRepType>;
   using DecompositionFilterType = itk::BSplineDecompositionImageFilter<ImageType, ImageType>;
-  using IteratorType = itk::ImageRegionConstIterator<ImageType>;
 
   /** The current region/spacing settings of the grid. */
   RegionType gridregionLow = this->m_BSplineTransform->GetGridRegion();
@@ -806,7 +805,7 @@ BSplineTransformWithDiffusion<TElastix>::IncreaseScale()
     ImagePointer coeffs2 = decompositionFilter->GetOutput();
 
     /** Create an iterator on the new coefficient image. */
-    IteratorType iterator(coeffs2, gridregionHigh);
+    itk::ImageRegionConstIterator<ImageType> iterator(coeffs2, gridregionHigh);
     iterator.GoToBegin();
     while (!iterator.IsAtEnd())
     {

--- a/Components/Transforms/BSplineStackTransform/elxBSplineStackTransform.hxx
+++ b/Components/Transforms/BSplineStackTransform/elxBSplineStackTransform.hxx
@@ -523,7 +523,6 @@ void
 BSplineStackTransform<TElastix>::SetOptimizerScales(const unsigned int edgeWidth)
 {
   /** Some typedefs. */
-  using IteratorType = itk::ImageRegionExclusionConstIteratorWithIndex<ImageType>;
   using ScalesValueType = itk::Optimizer::ScalesType::ValueType;
 
   /** Define new scales. */
@@ -569,7 +568,7 @@ BSplineStackTransform<TElastix>::SetOptimizerScales(const unsigned int edgeWidth
   insetgridregion.SetIndex(insetgridindex);
 
   /** Set up iterator over the coefficient image. */
-  IteratorType cIt(coeff, coeff->GetLargestPossibleRegion());
+  itk::ImageRegionExclusionConstIteratorWithIndex<ImageType> cIt(coeff, coeff->GetLargestPossibleRegion());
   cIt.SetExclusionRegion(insetgridregion);
   cIt.GoToBegin();
 

--- a/Components/Transforms/BSplineStackTransform/elxBSplineStackTransform.hxx
+++ b/Components/Transforms/BSplineStackTransform/elxBSplineStackTransform.hxx
@@ -524,15 +524,12 @@ BSplineStackTransform<TElastix>::SetOptimizerScales(const unsigned int edgeWidth
 {
   /** Some typedefs. */
   using IteratorType = itk::ImageRegionExclusionConstIteratorWithIndex<ImageType>;
-  using ITKRegistrationType = typename RegistrationType::ITKBaseType;
-  using OptimizerType = typename ITKRegistrationType::OptimizerType;
-  using ScalesType = typename OptimizerType::ScalesType;
-  using ScalesValueType = typename ScalesType::ValueType;
+  using ScalesValueType = itk::Optimizer::ScalesType::ValueType;
 
   /** Define new scales. */
   const NumberOfParametersType numberOfParameters = this->m_DummySubTransform->GetNumberOfParameters();
   const unsigned long          offset = numberOfParameters / SpaceDimension;
-  ScalesType                   newScales(numberOfParameters, ScalesValueType{ 1.0 });
+  itk::Optimizer::ScalesType   newScales(numberOfParameters, ScalesValueType{ 1.0 });
   const ScalesValueType        infScale = 10000.0;
 
   if (edgeWidth == 0)

--- a/Components/Transforms/MultiBSplineTransformWithNormal/elxMultiBSplineTransformWithNormal.hxx
+++ b/Components/Transforms/MultiBSplineTransformWithNormal/elxMultiBSplineTransformWithNormal.hxx
@@ -426,7 +426,6 @@ MultiBSplineTransformWithNormal<TElastix>::IncreaseScale()
   ImageBasePointer      new_Bases = this->m_MultiBSplineTransformWithNormal->GetLocalBases();
   const BaseContainer & new_bases = *new_Bases->GetPixelContainer();
 
-  using ImageLabelType = itk::Image<unsigned char, Self::SpaceDimension>;
   typename ImageLabelType::Pointer labels1 = this->m_MultiBSplineTransformWithNormal->GetLabels();
   typename itk::ResampleImageFilter<ImageLabelType, ImageLabelType>::Pointer filter =
     itk::ResampleImageFilter<ImageLabelType, ImageLabelType>::New();

--- a/Components/Transforms/MultiBSplineTransformWithNormal/elxMultiBSplineTransformWithNormal.hxx
+++ b/Components/Transforms/MultiBSplineTransformWithNormal/elxMultiBSplineTransformWithNormal.hxx
@@ -612,7 +612,6 @@ void
 MultiBSplineTransformWithNormal<TElastix>::SetOptimizerScales(const unsigned int edgeWidth)
 {
   /** Some typedefs. */
-  using IteratorType = itk::ImageRegionExclusionConstIteratorWithIndex<ImageType>;
   using ScalesValueType = itk::Optimizer::ScalesType::ValueType;
 
   /** Define new scales. */
@@ -656,7 +655,7 @@ MultiBSplineTransformWithNormal<TElastix>::SetOptimizerScales(const unsigned int
   insetgridregion.SetIndex(insetgridindex);
 
   /** Set up iterator over the coefficient image. */
-  IteratorType cIt(coeff, coeff->GetLargestPossibleRegion());
+  itk::ImageRegionExclusionConstIteratorWithIndex<ImageType> cIt(coeff, coeff->GetLargestPossibleRegion());
   cIt.SetExclusionRegion(insetgridregion);
   cIt.GoToBegin();
 

--- a/Components/Transforms/MultiBSplineTransformWithNormal/elxMultiBSplineTransformWithNormal.hxx
+++ b/Components/Transforms/MultiBSplineTransformWithNormal/elxMultiBSplineTransformWithNormal.hxx
@@ -613,16 +613,13 @@ MultiBSplineTransformWithNormal<TElastix>::SetOptimizerScales(const unsigned int
 {
   /** Some typedefs. */
   using IteratorType = itk::ImageRegionExclusionConstIteratorWithIndex<ImageType>;
-  using ITKRegistrationType = typename RegistrationType::ITKBaseType;
-  using OptimizerType = typename ITKRegistrationType::OptimizerType;
-  using ScalesType = typename OptimizerType::ScalesType;
-  using ScalesValueType = typename ScalesType::ValueType;
+  using ScalesValueType = itk::Optimizer::ScalesType::ValueType;
 
   /** Define new scales. */
-  const unsigned long   numberOfParameters = this->m_MultiBSplineTransformWithNormal->GetNumberOfParameters();
-  const unsigned long   offset = numberOfParameters / SpaceDimension;
-  ScalesType            newScales(numberOfParameters, ScalesValueType{ 1.0 });
-  const ScalesValueType infScale = 10000.0;
+  const unsigned long        numberOfParameters = this->m_MultiBSplineTransformWithNormal->GetNumberOfParameters();
+  const unsigned long        offset = numberOfParameters / SpaceDimension;
+  itk::Optimizer::ScalesType newScales(numberOfParameters, ScalesValueType{ 1.0 });
+  const ScalesValueType      infScale = 10000.0;
 
   if (edgeWidth == 0)
   {

--- a/Components/Transforms/MultiBSplineTransformWithNormal/itkMultiBSplineDeformableTransformWithNormal.h
+++ b/Components/Transforms/MultiBSplineTransformWithNormal/itkMultiBSplineDeformableTransformWithNormal.h
@@ -194,7 +194,7 @@ public:
 
   using IndexType = typename RegionType::IndexType;
   using SizeType = typename RegionType::SizeType;
-  using SpacingType = typename ImageType::SpacingType;
+  using SpacingType = typename ImageBase<NDimensions>::SpacingType;
   using DirectionType = typename ImageType::DirectionType;
   using OriginType = typename ImageType::PointType;
   using GridOffsetType = IndexType;

--- a/Components/Transforms/MultiBSplineTransformWithNormal/itkMultiBSplineDeformableTransformWithNormal.hxx
+++ b/Components/Transforms/MultiBSplineTransformWithNormal/itkMultiBSplineDeformableTransformWithNormal.hxx
@@ -1051,9 +1051,9 @@ MultiBSplineDeformableTransformWithNormal<TScalarType, NDimensions, VSplineOrder
       }
     }
 
-    for (unsigned l = 1; l <= m_NbLabels; ++l)
+    for (unsigned labelIndex = 1; labelIndex <= m_NbLabels; ++labelIndex)
     {
-      VectorType tmp = bases[nonZeroJacobianIndices[i]][l];
+      VectorType tmp = bases[nonZeroJacobianIndices[i]][labelIndex];
       for (unsigned j = 0; j < SpaceDimension; ++j)
       {
         for (unsigned k = 0; k < SpaceDimension; ++k)

--- a/Components/Transforms/MultiBSplineTransformWithNormal/itkMultiBSplineDeformableTransformWithNormal.hxx
+++ b/Components/Transforms/MultiBSplineTransformWithNormal/itkMultiBSplineDeformableTransformWithNormal.hxx
@@ -356,8 +356,6 @@ MultiBSplineDeformableTransformWithNormal<TScalarType, NDimensions, VSplineOrder
   using AddVectorImageType = itk::AddImageFilter<ImageVectorType, ImageVectorType, ImageVectorType>;
   using MaskVectorImageType = itk::MaskImageFilter<ImageVectorType, ImageLabelType, ImageVectorType>;
   using PointType = typename ImageLabelType::PointType;
-  using RegionType = typename ImageLabelType::RegionType;
-  using SpacingType = typename ImageLabelType::SpacingType;
 
   PointType transOrig = GetGridOrigin();
   PointType transEnd;

--- a/Components/Transforms/MultiBSplineTransformWithNormal/itkMultiBSplineDeformableTransformWithNormal.hxx
+++ b/Components/Transforms/MultiBSplineTransformWithNormal/itkMultiBSplineDeformableTransformWithNormal.hxx
@@ -211,8 +211,7 @@ struct UpdateLocalBases_impl<TScalarType, 2>
     ImageVectorInterpolatorPointer vinterp = ImageVectorInterpolator::New();
     vinterp->SetInputImage(normals);
 
-    using IteratorType = ImageRegionIterator<ImageBaseType>;
-    IteratorType it(bases, bases->GetLargestPossibleRegion());
+    ImageRegionIterator<ImageBaseType> it(bases, bases->GetLargestPossibleRegion());
     for (it.GoToBegin(); !it.IsAtEnd(); ++it)
     {
       BaseType                          b;
@@ -272,8 +271,7 @@ struct UpdateLocalBases_impl<TScalarType, 3>
     ImageVectorInterpolatorPointer vinterp = ImageVectorInterpolator::New();
     vinterp->SetInputImage(normals);
 
-    using IteratorType = ImageRegionIterator<ImageBaseType>;
-    IteratorType it(bases, bases->GetLargestPossibleRegion());
+    ImageRegionIterator<ImageBaseType> it(bases, bases->GetLargestPossibleRegion());
     for (it.GoToBegin(); !it.IsAtEnd(); ++it)
     {
       BaseType                          b;

--- a/Components/Transforms/MultiBSplineTransformWithNormal/itkMultiBSplineDeformableTransformWithNormal.hxx
+++ b/Components/Transforms/MultiBSplineTransformWithNormal/itkMultiBSplineDeformableTransformWithNormal.hxx
@@ -1037,14 +1037,16 @@ MultiBSplineDeformableTransformWithNormal<TScalarType, NDimensions, VSplineOrder
 
   for (unsigned i = 0; i < NumberOfWeights; ++i)
   {
-    VectorType tmp = bases[nonZeroJacobianIndices[i]][0];
-    for (unsigned j = 0; j < SpaceDimension; ++j)
     {
-      for (unsigned k = 0; k < SpaceDimension; ++k)
+      VectorType tmp = bases[nonZeroJacobianIndices[i]][0];
+      for (unsigned j = 0; j < SpaceDimension; ++j)
       {
-        for (unsigned l = 0; l < SpaceDimension; ++l)
+        for (unsigned k = 0; k < SpaceDimension; ++k)
         {
-          jsh[j][i][k][l] = tmp[j] * njsh[j][i + j * NumberOfWeights][k][l];
+          for (unsigned l = 0; l < SpaceDimension; ++l)
+          {
+            jsh[j][i][k][l] = tmp[j] * njsh[j][i + j * NumberOfWeights][k][l];
+          }
         }
       }
     }

--- a/Components/Transforms/RecursiveBSplineTransform/elxRecursiveBSplineTransform.hxx
+++ b/Components/Transforms/RecursiveBSplineTransform/elxRecursiveBSplineTransform.hxx
@@ -502,15 +502,12 @@ RecursiveBSplineTransform<TElastix>::SetOptimizerScales(const unsigned int edgeW
 {
   /** Some typedefs. */
   using IteratorType = itk::ImageRegionExclusionConstIteratorWithIndex<ImageType>;
-  using ITKRegistrationType = typename RegistrationType::ITKBaseType;
-  using OptimizerType = typename ITKRegistrationType::OptimizerType;
-  using ScalesType = typename OptimizerType::ScalesType;
-  using ScalesValueType = typename ScalesType::ValueType;
+  using ScalesValueType = itk::Optimizer::ScalesType::ValueType;
 
   /** Define new scales. */
   const NumberOfParametersType numberOfParameters = this->m_BSplineTransform->GetNumberOfParameters();
   const unsigned long          offset = numberOfParameters / SpaceDimension;
-  ScalesType                   newScales(numberOfParameters, ScalesValueType{ 1.0 });
+  itk::Optimizer::ScalesType   newScales(numberOfParameters, ScalesValueType{ 1.0 });
   const ScalesValueType        infScale = 10000.0;
 
   if (edgeWidth == 0)

--- a/Components/Transforms/RecursiveBSplineTransform/elxRecursiveBSplineTransform.hxx
+++ b/Components/Transforms/RecursiveBSplineTransform/elxRecursiveBSplineTransform.hxx
@@ -501,7 +501,6 @@ void
 RecursiveBSplineTransform<TElastix>::SetOptimizerScales(const unsigned int edgeWidth)
 {
   /** Some typedefs. */
-  using IteratorType = itk::ImageRegionExclusionConstIteratorWithIndex<ImageType>;
   using ScalesValueType = itk::Optimizer::ScalesType::ValueType;
 
   /** Define new scales. */
@@ -545,7 +544,7 @@ RecursiveBSplineTransform<TElastix>::SetOptimizerScales(const unsigned int edgeW
   insetgridregion.SetIndex(insetgridindex);
 
   /** Set up iterator over the coefficient image. */
-  IteratorType cIt(coeff, coeff->GetLargestPossibleRegion());
+  itk::ImageRegionExclusionConstIteratorWithIndex<ImageType> cIt(coeff, coeff->GetLargestPossibleRegion());
   cIt.SetExclusionRegion(insetgridregion);
   cIt.GoToBegin();
 

--- a/Components/Transforms/SplineKernelTransform/itkKernelTransform2.hxx
+++ b/Components/Transforms/SplineKernelTransform/itkKernelTransform2.hxx
@@ -809,13 +809,15 @@ KernelTransform2<TScalarType, NDimensions>::GetJacobian(const InputPointType &  
       // Property A: G = G(0,0) * I_d.
       ScalarType g = gVector[lnd];
 
-      // Property C: First process the diagonal only
-      unsigned int lIdx = lnd * NDimensions;
-      ScalarType   linv = this->m_LMatrixInverse[lIdx][lIdx];
-      // Property B: only access non-zero values
-      for (unsigned int dim = 0; dim < NDimensions; ++dim)
       {
-        jac[dim][lIdx + dim] += g * linv;
+        // Property C: First process the diagonal only
+        unsigned int lIdx = lnd * NDimensions;
+        ScalarType   linv = this->m_LMatrixInverse[lIdx][lIdx];
+        // Property B: only access non-zero values
+        for (unsigned int dim = 0; dim < NDimensions; ++dim)
+        {
+          jac[dim][lIdx + dim] += g * linv;
+        }
       }
 
       // Property C: Then process right of diagonal

--- a/Components/Transforms/WeightedCombinationTransform/elxWeightedCombinationTransform.hxx
+++ b/Components/Transforms/WeightedCombinationTransform/elxWeightedCombinationTransform.hxx
@@ -193,10 +193,6 @@ template <class TElastix>
 void
 WeightedCombinationTransformElastix<TElastix>::LoadSubTransforms()
 {
-  /** Typedef's from ComponentDatabase. */
-  using ComponentDescriptionType = typename Superclass2::ComponentDescriptionType;
-  using PtrToCreator = typename Superclass2::PtrToCreator;
-
   const std::size_t N = this->m_Configuration->CountNumberOfParameterEntries("SubTransforms");
 
   if (N == 0)
@@ -238,11 +234,11 @@ WeightedCombinationTransformElastix<TElastix>::LoadSubTransforms()
     }
 
     /** Read the SubTransform name. */
-    ComponentDescriptionType subTransformName = "AffineTransform";
+    typename Superclass2::ComponentDescriptionType subTransformName = "AffineTransform";
     configurationSubTransform->ReadParameter(subTransformName, "Transform", 0);
 
     /** Create a SubTransform. */
-    if (const PtrToCreator creator =
+    if (const typename Superclass2::PtrToCreator creator =
           ElastixMain::GetComponentDatabase().GetCreator(subTransformName, this->m_Elastix->GetDBIndex()))
     {
       if (const itk::Object::Pointer subTransform = creator())

--- a/Core/ComponentBaseClasses/elxTransformBase.h
+++ b/Core/ComponentBaseClasses/elxTransformBase.h
@@ -187,7 +187,7 @@ public:
   /** Typedefs needed for AutomaticScalesEstimation function */
   using ITKRegistrationType = typename RegistrationType::ITKBaseType;
   using OptimizerType = typename ITKRegistrationType::OptimizerType;
-  using ScalesType = typename OptimizerType::ScalesType;
+  using ScalesType = itk::Optimizer::ScalesType;
 
   /** Typedefs for images of determinants of spatial Jacobian matrices, and images of spatial Jacobian matrices */
   using SpatialJacobianDeterminantImageType = itk::Image<float, FixedImageDimension>;

--- a/Core/Kernel/elxElastixMain.cxx
+++ b/Core/Kernel/elxElastixMain.cxx
@@ -213,9 +213,7 @@ ElastixMain::RunWithInitialTransformParameterMaps(const ArgumentMapType &       
                                                   const ParameterMapType &              inputMap,
                                                   const std::vector<ParameterMapType> & initialTransformParameterMaps)
 {
-  Configuration & configuration = Deref(MainBase::GetConfiguration());
-
-  if (configuration.Initialize(argmap, inputMap) != 0)
+  if (Deref(MainBase::GetConfiguration()).Initialize(argmap, inputMap) != 0)
   {
     log::error("ERROR: Something went wrong during initialization of the configuration object.");
   }

--- a/Core/Kernel/elxMainBase.cxx
+++ b/Core/Kernel/elxMainBase.cxx
@@ -52,7 +52,7 @@ const ComponentDatabase &
 MainBase::GetComponentDatabase()
 {
   // Improved thread-safety by using C++11 "magic statics".
-  static const auto componentDatabase = [] {
+  static const auto staticComponentDatabase = [] {
     const auto componentDatabase = ComponentDatabase::New();
     const auto componentLoader = ComponentLoader::New();
     componentLoader->SetComponentDatabase(componentDatabase);
@@ -63,7 +63,7 @@ MainBase::GetComponentDatabase()
     }
     return componentDatabase;
   }();
-  return *componentDatabase;
+  return *staticComponentDatabase;
 }
 
 

--- a/Core/Main/GTesting/elxCoreMainGTestUtilities.h
+++ b/Core/Main/GTesting/elxCoreMainGTestUtilities.h
@@ -321,8 +321,8 @@ struct ImageDomain
   ImageDomain() = default;
 
   // Explicit constructor
-  explicit ImageDomain(const SizeType & size)
-    : size(size)
+  explicit ImageDomain(const SizeType & initialSize)
+    : size(initialSize)
   {}
 
   explicit ImageDomain(const ImageBaseType & image)
@@ -334,16 +334,16 @@ struct ImageDomain
   {}
 
   // Constructor, allowing to explicitly specify all the settings of the domain.
-  ImageDomain(const DirectionType & direction,
-              const IndexType &     index,
-              const SizeType &      size,
-              const SpacingType &   spacing,
-              const PointType &     origin)
-    : direction(direction)
-    , index(index)
-    , size(size)
-    , spacing(spacing)
-    , origin(origin)
+  ImageDomain(const DirectionType & initialDirection,
+              const IndexType &     initialIndex,
+              const SizeType &      initialSize,
+              const SpacingType &   initialSpacing,
+              const PointType &     initialOrigin)
+    : direction(initialDirection)
+    , index(initialIndex)
+    , size(initialSize)
+    , spacing(initialSpacing)
+    , origin(initialOrigin)
   {}
 
   // Puts the domain settings into the specified image.

--- a/Core/Main/GTesting/elxCoreMainGTestUtilities.h
+++ b/Core/Main/GTesting/elxCoreMainGTestUtilities.h
@@ -162,9 +162,9 @@ FillImageRegion(itk::Image<TPixel, VImageDimension> & image,
 inline std::vector<double>
 ConvertStringsToVectorOfDouble(const std::vector<std::string> & strings)
 {
-  std::vector<double> result(strings.size());
+  std::vector<double> vectorOfDouble(strings.size());
 
-  std::transform(strings.cbegin(), strings.cend(), result.begin(), [](const std::string & str) {
+  std::transform(strings.cbegin(), strings.cend(), vectorOfDouble.begin(), [](const std::string & str) {
     std::size_t index{};
     const auto  result = std::stod(str, &index);
 
@@ -173,7 +173,7 @@ ConvertStringsToVectorOfDouble(const std::vector<std::string> & strings)
     return result;
   });
 
-  return result;
+  return vectorOfDouble;
 }
 
 

--- a/Core/Main/GTesting/itkElastixRegistrationMethodGTest.cxx
+++ b/Core/Main/GTesting/itkElastixRegistrationMethodGTest.cxx
@@ -1179,8 +1179,6 @@ GTEST_TEST(itkElastixRegistrationMethod, SetInitialTransformParameterObject)
 
   for (const unsigned int numberOfRegistrationParameterMaps : { 1, 2, 3 })
   {
-    using ParameterMapVectorType = elx::ParameterObject::ParameterMapVectorType;
-
     // Specify multiple (one or more) registration parameter maps.
     registrationParameterObject.SetParameterMaps(
       ParameterMapVectorType(numberOfRegistrationParameterMaps, registrationParameterMap));


### PR DESCRIPTION
Enabled and addressed `-wshadow` warnings, triggered by comments by Bradley Lowekamp (@blowekamp) from https://github.com/SimpleITK/SimpleITK/pull/2104#issuecomment-2075030813

The warnings are addressed by choosing more specific (more distinguishing) identifiers, removing unnecessary types and variables, reducing the scope of variables, and using modern C++ enum classes.  