### PR TITLE
STYLE: Remove `this->MakeOutput(0)` calls from constructors

### DIFF
--- a/Common/ImageSamplers/itkImageSamplerBase.hxx
+++ b/Common/ImageSamplers/itkImageSamplerBase.hxx
@@ -405,11 +405,8 @@ template <class TInputImage>
 ImageSamplerBase<TInputImage>::ImageSamplerBase()
 {
   this->ProcessObject::SetNumberOfRequiredInputs(1);
-
-  OutputVectorContainerPointer output = dynamic_cast<OutputVectorContainerType *>(this->MakeOutput(0).GetPointer());
-
   this->ProcessObject::SetNumberOfRequiredOutputs(1);
-  this->ProcessObject::SetNthOutput(0, output.GetPointer());
+  this->ProcessObject::SetNthOutput(0, OutputVectorContainerType::New().GetPointer());
 
 } // end Constructor
 

--- a/Common/ImageSamplers/itkVectorContainerSource.hxx
+++ b/Common/ImageSamplers/itkVectorContainerSource.hxx
@@ -30,12 +30,8 @@ namespace itk
 template <class TOutputVectorContainer>
 VectorContainerSource<TOutputVectorContainer>::VectorContainerSource()
 {
-  // Create the output. We use static_cast<> here because we know the default
-  // output must be of type TOutputVectorContainer
-  OutputVectorContainerPointer output = static_cast<TOutputVectorContainer *>(this->MakeOutput(0).GetPointer());
-
   this->ProcessObject::SetNumberOfRequiredOutputs(1);
-  this->ProcessObject::SetNthOutput(0, output.GetPointer());
+  this->ProcessObject::SetNthOutput(0, TOutputVectorContainer::New().GetPointer());
 
   this->m_GenerateDataRegion = 0;
   this->m_GenerateDataNumberOfRegions = 0;

--- a/Common/itkMultiResolutionImageRegistrationMethod2.hxx
+++ b/Common/itkMultiResolutionImageRegistrationMethod2.hxx
@@ -79,9 +79,7 @@ MultiResolutionImageRegistrationMethod2<TFixedImage, TMovingImage>::MultiResolut
   this->m_InitialTransformParametersOfNextLevel.Fill(0.0f);
   this->m_LastTransformParameters.Fill(0.0f);
 
-  TransformOutputPointer transformDecorator = static_cast<TransformOutputType *>(this->MakeOutput(0).GetPointer());
-
-  this->ProcessObject::SetNthOutput(0, transformDecorator.GetPointer());
+  this->ProcessObject::SetNthOutput(0, TransformOutputType::New().GetPointer());
 
 } // end Constructor
 


### PR DESCRIPTION
Analogue to ITK pull request https://github.com/InsightSoftwareConsortium/ITK/pull/4654

Following C++ Core Guidelines, February 15, 2024, "Don’t call virtual functions in constructors and destructors", https://isocpp.github.io/CppCoreGuidelines/CppCoreGuidelines#Rc-ctor-virtual