### PR TITLE
STYLE: Let signature of `MakeOutput` member functions match with ITK

### DIFF
--- a/Common/ImageSamplers/itkImageSamplerBase.h
+++ b/Common/ImageSamplers/itkImageSamplerBase.h
@@ -89,7 +89,7 @@ public:
 
   /** Create a valid output. */
   DataObject::Pointer
-  MakeOutput(unsigned int idx) override;
+  MakeOutput(ProcessObject::DataObjectPointerArraySizeType idx) override;
 
   /** Set the input image of this process object.  */
   void

--- a/Common/ImageSamplers/itkImageSamplerBase.hxx
+++ b/Common/ImageSamplers/itkImageSamplerBase.hxx
@@ -420,7 +420,7 @@ ImageSamplerBase<TInputImage>::ImageSamplerBase()
 
 template <class TInputImage>
 DataObject::Pointer
-ImageSamplerBase<TInputImage>::MakeOutput(unsigned int itkNotUsed(idx))
+ImageSamplerBase<TInputImage>::MakeOutput(ProcessObject::DataObjectPointerArraySizeType itkNotUsed(idx))
 {
   OutputVectorContainerPointer outputVectorContainer = OutputVectorContainerType::New();
   return outputVectorContainer.GetPointer();

--- a/Common/ImageSamplers/itkVectorContainerSource.h
+++ b/Common/ImageSamplers/itkVectorContainerSource.h
@@ -68,8 +68,8 @@ public:
   GraftNthOutput(unsigned int idx, DataObject * output);
 
   /** Make a DataObject of the correct type to used as the specified output. */
-  virtual DataObjectPointer
-  MakeOutput(unsigned int idx);
+  DataObjectPointer
+  MakeOutput(ProcessObject::DataObjectPointerArraySizeType idx) override;
 
 protected:
   /** The constructor. */

--- a/Common/ImageSamplers/itkVectorContainerSource.hxx
+++ b/Common/ImageSamplers/itkVectorContainerSource.hxx
@@ -49,7 +49,8 @@ VectorContainerSource<TOutputVectorContainer>::VectorContainerSource()
 
 template <class TOutputVectorContainer>
 auto
-VectorContainerSource<TOutputVectorContainer>::MakeOutput(unsigned int itkNotUsed(idx)) -> DataObjectPointer
+VectorContainerSource<TOutputVectorContainer>::MakeOutput(ProcessObject::DataObjectPointerArraySizeType itkNotUsed(idx))
+  -> DataObjectPointer
 {
   return static_cast<DataObject *>(TOutputVectorContainer::New().GetPointer());
 } // end MakeOutput()

--- a/Common/itkMultiResolutionImageRegistrationMethod2.h
+++ b/Common/itkMultiResolutionImageRegistrationMethod2.h
@@ -233,8 +233,8 @@ public:
   /** Make a DataObject of the correct type to be used as the specified
    * output.
    */
-  virtual DataObjectPointer
-  MakeOutput(unsigned int idx);
+  DataObjectPointer
+  MakeOutput(ProcessObject::DataObjectPointerArraySizeType idx) override;
 
   /** Method to return the latest modified time of this object or
    * any of its cached ivars.

--- a/Common/itkMultiResolutionImageRegistrationMethod2.hxx
+++ b/Common/itkMultiResolutionImageRegistrationMethod2.hxx
@@ -458,7 +458,8 @@ MultiResolutionImageRegistrationMethod2<TFixedImage, TMovingImage>::GetOutput() 
 
 template <typename TFixedImage, typename TMovingImage>
 DataObject::Pointer
-MultiResolutionImageRegistrationMethod2<TFixedImage, TMovingImage>::MakeOutput(unsigned int output)
+MultiResolutionImageRegistrationMethod2<TFixedImage, TMovingImage>::MakeOutput(
+  ProcessObject::DataObjectPointerArraySizeType output)
 {
   if (output > 0)
   {


### PR DESCRIPTION
Fixed the parameter type of the `MakeOutput` member functions of ImageSamplerBase, VectorContainerSource, and MultiResolutionImageRegistrationMethod2, to ensure that they properly override ITK's `ProcessObject::MakeOutput(DataObjectPointerArraySizeType)`. Following ITK commit https://github.com/InsightSoftwareConsortium/ITK/commit/b066b3663548acbc200b6781a5f4a56a5737add0 "COMP: Fix VisualStudio warning int possible loss of data.",  Matt McCormick, 2011-11-17, by using `DataObjectPointerArraySizeType`.