### PR TITLE
BUG: Let `elx::ConjugateGradientFRPR` override ITK's FRPROptimizer

### DIFF
--- a/Components/Optimizers/ConjugateGradientFRPR/elxConjugateGradientFRPR.h
+++ b/Components/Optimizers/ConjugateGradientFRPR/elxConjugateGradientFRPR.h
@@ -167,8 +167,8 @@ protected:
    * This implementation calls the Superclass' implementation and caches
    * the computed derivative's magnitude. Besides, it invokes the
    * SelectNewSamples method. */
-  virtual void
-  GetValueAndDerivative(ParametersType p, double * val, ParametersType * xi);
+  void
+  GetValueAndDerivative(ParametersType & p, double * val, ParametersType * xi) override;
 
   /** The LineBracket routine from NRC. Uses current origin and line direction
    * (from SetLine) to find a triple of points (ax, bx, cx) that bracket the
@@ -206,8 +206,8 @@ protected:
    * store the line search direction's (xi) magnitude and call the superclass'
    * implementation.
    */
-  virtual void
-  LineOptimize(ParametersType * p, ParametersType xi, double * val);
+  void
+  LineOptimize(ParametersType * p, ParametersType & xi, double * val) override;
 
 private:
   elxOverrideGetSelfMacro;

--- a/Components/Optimizers/ConjugateGradientFRPR/elxConjugateGradientFRPR.hxx
+++ b/Components/Optimizers/ConjugateGradientFRPR/elxConjugateGradientFRPR.hxx
@@ -283,7 +283,7 @@ ConjugateGradientFRPR<TElastix>::SetInitialPosition(const ParametersType & param
 
 template <class TElastix>
 void
-ConjugateGradientFRPR<TElastix>::GetValueAndDerivative(ParametersType p, double * val, ParametersType * xi)
+ConjugateGradientFRPR<TElastix>::GetValueAndDerivative(ParametersType & p, double * val, ParametersType * xi)
 {
   /** This implementation forces the metric to select new samples
    * (if the user asked for this), calls the Superclass'
@@ -361,7 +361,7 @@ ConjugateGradientFRPR<TElastix>::BracketedLineOptimize(double   ax,
  */
 template <class TElastix>
 void
-ConjugateGradientFRPR<TElastix>::LineOptimize(ParametersType * p, ParametersType xi, double * val)
+ConjugateGradientFRPR<TElastix>::LineOptimize(ParametersType * p, ParametersType & xi, double * val)
 {
   this->m_CurrentSearchDirectionMagnitude = xi.magnitude();
   this->Superclass1::LineOptimize(p, xi, val);


### PR DESCRIPTION
`elx::ConjugateGradientFRPR` member functions GetValueAndDerivative and LineOptimize did originally override the corresponding virtual member functions of ITK's FRPROptimizer. This property was broken by a change in the signature of those ITK member functions: ITK commit https://github.com/InsightSoftwareConsortium/ITK/commit/a088a95fca4e0f94ef661cdc43a6bec26ad687a9, "PERF: Changed to pass by reference for faster performance", 2008-04-23

This commit restores those "overrides", by adjusting the signature of the `elx::ConjugateGradientFRPR` member functions, in accordance with those ITK member functions.

Bug found by macos-12/clang compiler warnings, like:

> warning: 'elastix::ConjugateGradientFRPR::GetValueAndDerivative' hides overloaded virtual function [-Woverloaded-virtual]

Note: These two `elx::ConjugateGradientFRPR` member functions don't seem to be tested at the CI, currently.