### PR TITLE
STYLE: Add const overloads to MultiResolution Get member functions

### DIFF
--- a/Components/Registrations/MultiMetricMultiResolutionRegistration/itkMultiMetricMultiResolutionImageRegistrationMethod.h
+++ b/Components/Registrations/MultiMetricMultiResolutionRegistration/itkMultiMetricMultiResolutionImageRegistrationMethod.h
@@ -223,6 +223,13 @@ public:
   {
     return this->GetInterpolator(0);
   }
+
+  const InterpolatorType *
+  GetInterpolator() const override
+  {
+    return this->GetInterpolator(0);
+  }
+
   elxOverrideSimpleSetMacro(Interpolator, InterpolatorType *);
   itkSetNumberOfMacro(Interpolator);
   itkGetNumberOfMacro(Interpolator);
@@ -239,6 +246,13 @@ public:
   {
     return this->GetFixedImagePyramid(0);
   }
+
+  const FixedImagePyramidType *
+  GetFixedImagePyramid() const override
+  {
+    return this->GetFixedImagePyramid(0);
+  }
+
   elxOverrideSimpleSetMacro(FixedImagePyramid, FixedImagePyramidType *);
   itkSetNumberOfMacro(FixedImagePyramid);
   itkGetNumberOfMacro(FixedImagePyramid);
@@ -255,6 +269,13 @@ public:
   {
     return this->GetMovingImagePyramid(0);
   }
+
+  const MovingImagePyramidType *
+  GetMovingImagePyramid() const override
+  {
+    return this->GetMovingImagePyramid(0);
+  }
+
   elxOverrideSimpleSetMacro(MovingImagePyramid, MovingImagePyramidType *);
   itkSetNumberOfMacro(MovingImagePyramid);
   itkGetNumberOfMacro(MovingImagePyramid);

--- a/Components/Registrations/MultiResolutionRegistrationWithFeatures/itkMultiInputMultiResolutionImageRegistrationMethodBase.h
+++ b/Components/Registrations/MultiResolutionRegistrationWithFeatures/itkMultiInputMultiResolutionImageRegistrationMethodBase.h
@@ -181,6 +181,13 @@ public:
   {
     return this->GetFixedImagePyramid(0);
   }
+
+  const FixedImagePyramidType *
+  GetFixedImagePyramid() const override
+  {
+    return this->GetFixedImagePyramid(0);
+  }
+
   elxOverrideSimpleSetMacro(FixedImagePyramid, FixedImagePyramidType *);
   itkSetNumberOfMacro(FixedImagePyramid);
   itkGetNumberOfMacro(FixedImagePyramid);
@@ -213,6 +220,13 @@ public:
   {
     return this->GetMovingImagePyramid(0);
   }
+
+  const MovingImagePyramidType *
+  GetMovingImagePyramid() const override
+  {
+    return this->GetMovingImagePyramid(0);
+  }
+
   elxOverrideSimpleSetMacro(MovingImagePyramid, MovingImagePyramidType *);
   itkSetNumberOfMacro(MovingImagePyramid);
   itkGetNumberOfMacro(MovingImagePyramid);
@@ -229,6 +243,13 @@ public:
   {
     return this->GetInterpolator(0);
   }
+
+  const InterpolatorType *
+  GetInterpolator() const override
+  {
+    return this->GetInterpolator(0);
+  }
+
   elxOverrideSimpleSetMacro(Interpolator, InterpolatorType *);
   itkSetNumberOfMacro(Interpolator);
   itkGetNumberOfMacro(Interpolator);


### PR DESCRIPTION
Aims to fix warnings like (macos-12/clang):

> warning: 'itk::MultiMetricMultiResolutionImageRegistrationMethod::GetFixedImagePyramid' hides overloaded virtual function [-Woverloaded-virtual]