### PR TITLE
Enable and address `-woverloaded-virtual` warnings from GCC or clang

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -83,6 +83,7 @@ if (MSVC)
   add_compile_options(/W3)
 else()
   add_compile_options(
+    -Woverloaded-virtual
     -Wshadow
     )
 endif()

--- a/Common/CostFunctions/itkAdvancedImageToImageMetric.h
+++ b/Common/CostFunctions/itkAdvancedImageToImageMetric.h
@@ -606,6 +606,9 @@ protected:
     itkExceptionMacro("Intentionally left unimplemented!");
   }
 
+  // Protected using-declaration, to avoid `-Woverloaded-virtual` warnings from GCC (GCC 11.4) or clang (macos-12).
+  using Superclass::SetTransform;
+
 private:
   template <typename... TOptionalThreadId>
   bool
@@ -633,7 +636,6 @@ private:
   MovingImageDerivativeScalesType m_MovingImageDerivativeScales{ MovingImageDerivativeScalesType::Filled(1.0) };
 
   // Private using-declarations, to avoid `-Woverloaded-virtual` warnings from GCC (GCC 11.4) or clang (macos-12).
-  using Superclass::SetTransform;
   using Superclass::TransformPoint;
 
   struct DummyMask

--- a/Common/CostFunctions/itkAdvancedImageToImageMetric.h
+++ b/Common/CostFunctions/itkAdvancedImageToImageMetric.h
@@ -574,6 +574,31 @@ protected:
   double m_FixedLimitRangeRatio{ 0.01 };
   double m_MovingLimitRangeRatio{ 0.01 };
 
+  // Prevent accidentally calling SetFixedImageMask or SetMovingImageMask through the ITK ImageToImageMetric interface.
+  void
+  SetFixedImageMask(typename Superclass::FixedImageMaskType *) final
+  {
+    itkExceptionMacro("Intentionally left unimplemented!");
+  }
+
+  void
+  SetFixedImageMask(const typename Superclass::FixedImageMaskType *) final
+  {
+    itkExceptionMacro("Intentionally left unimplemented!");
+  }
+
+  void
+  SetMovingImageMask(typename Superclass::MovingImageMaskType *) final
+  {
+    itkExceptionMacro("Intentionally left unimplemented!");
+  }
+
+  void
+  SetMovingImageMask(const typename Superclass::MovingImageMaskType *) final
+  {
+    itkExceptionMacro("Intentionally left unimplemented!");
+  }
+
 private:
   template <typename... TOptionalThreadId>
   bool
@@ -603,32 +628,6 @@ private:
   // Private using-declarations, to avoid `-Woverloaded-virtual` warnings from GCC (GCC 11.4) or clang (macos-12).
   using Superclass::SetTransform;
   using Superclass::TransformPoint;
-
-  // Prevent accidentally calling SetFixedImageMask or SetMovingImageMask through the ITK ImageToImageMetric interface.
-  void
-  SetFixedImageMask(typename Superclass::FixedImageMaskType *) final
-  {
-    itkExceptionMacro("Intentionally left unimplemented!");
-  }
-
-  void
-  SetFixedImageMask(const typename Superclass::FixedImageMaskType *) final
-  {
-    itkExceptionMacro("Intentionally left unimplemented!");
-  }
-
-  void
-  SetMovingImageMask(typename Superclass::MovingImageMaskType *) final
-  {
-    itkExceptionMacro("Intentionally left unimplemented!");
-  }
-
-  void
-  SetMovingImageMask(const typename Superclass::MovingImageMaskType *) final
-  {
-    itkExceptionMacro("Intentionally left unimplemented!");
-  }
-
 
   struct DummyMask
   {};

--- a/Common/CostFunctions/itkAdvancedImageToImageMetric.h
+++ b/Common/CostFunctions/itkAdvancedImageToImageMetric.h
@@ -600,6 +600,10 @@ private:
 
   MovingImageDerivativeScalesType m_MovingImageDerivativeScales{ MovingImageDerivativeScalesType::Filled(1.0) };
 
+  // Private using-declarations, to avoid `-Woverloaded-virtual` warnings from GCC (GCC 11.4) or clang (macos-12).
+  using Superclass::SetTransform;
+  using Superclass::TransformPoint;
+
   // Prevent accidentally calling SetFixedImageMask or SetMovingImageMask through the ITK ImageToImageMetric interface.
   void
   SetFixedImageMask(typename Superclass::FixedImageMaskType *) final

--- a/Common/CostFunctions/itkAdvancedImageToImageMetric.h
+++ b/Common/CostFunctions/itkAdvancedImageToImageMetric.h
@@ -218,6 +218,13 @@ public:
 
 
   /** Get the advanced transform. */
+  AdvancedTransformType *
+  GetTransform() override
+  {
+    return m_AdvancedTransform.GetPointer();
+  }
+
+  /** Get the advanced transform. Const overload. */
   const AdvancedTransformType *
   GetTransform() const override
   {

--- a/Common/CostFunctions/itkMultiInputImageToImageMetricBase.h
+++ b/Common/CostFunctions/itkMultiInputImageToImageMetricBase.h
@@ -291,6 +291,13 @@ public:
 
   /** Get the first interpolator. */
   InterpolatorType *
+  GetInterpolator() override
+  {
+    return this->GetInterpolator(0);
+  }
+
+  /** Get the first interpolator. Const overload. */
+  const InterpolatorType *
   GetInterpolator() const override
   {
     return this->GetInterpolator(0);

--- a/Common/CostFunctions/itkMultiInputImageToImageMetricBase.h
+++ b/Common/CostFunctions/itkMultiInputImageToImageMetricBase.h
@@ -399,6 +399,10 @@ protected:
   BSplineInterpolatorVectorType m_BSplineInterpolatorVector{};
 
 private:
+  // Private using-declarations, to avoid `-Woverloaded-virtual` warnings from GCC (GCC 11.4) or clang (macos-12).
+  using Superclass::SetFixedImageMask;
+  using Superclass::SetMovingImageMask;
+
   /// Avoids accidentally calling `this->FastEvaluateMovingImageValueAndDerivative(mappedPoint, ..., threadId)`, when
   /// `*this` is derived from `MultiInputImageToImageMetricBase`. (The non-virtual member function
   /// `AdvancedImageToImageMetric::FastEvaluateMovingImageValueAndDerivative` does not entirely replace the

--- a/Common/ImageSamplers/itkImageSamplerBase.h
+++ b/Common/ImageSamplers/itkImageSamplerBase.h
@@ -254,6 +254,10 @@ protected:
   bool m_UseMultiThread{ true };
 
 private:
+  // Private using-declarations, to avoid `-Woverloaded-virtual` warnings from GCC (GCC 11.4) or clang (macos-12).
+  using ProcessObject::MakeOutput;
+  using ProcessObject::SetInput;
+
   /** Member variables. */
   MaskConstPointer           m_Mask{ nullptr };
   MaskVectorType             m_MaskVector{};

--- a/Common/ImageSamplers/itkVectorContainerSource.h
+++ b/Common/ImageSamplers/itkVectorContainerSource.h
@@ -72,6 +72,9 @@ public:
   MakeOutput(ProcessObject::DataObjectPointerArraySizeType idx) override;
 
 protected:
+  // Protected using-declaration, to avoid `-Woverloaded-virtual` warnings from GCC (GCC 11.4) or clang (macos-12).
+  using ProcessObject::MakeOutput;
+
   /** The constructor. */
   VectorContainerSource();
   /** The destructor. */

--- a/Common/Transforms/itkAdvancedBSplineDeformableTransformBase.h
+++ b/Common/Transforms/itkAdvancedBSplineDeformableTransformBase.h
@@ -361,6 +361,10 @@ protected:
 private:
   const unsigned m_SplineOrder{};
 
+  // Private using-declarations, to avoid `-Woverloaded-virtual` warnings from GCC (GCC 11.4) or clang (macos-12).
+  using Superclass::TransformVector;
+  using Superclass::TransformCovariantVector;
+
 protected:
   /** Array of images representing the B-spline coefficients
    *  in each dimension.

--- a/Common/Transforms/itkAdvancedCombinationTransform.h
+++ b/Common/Transforms/itkAdvancedCombinationTransform.h
@@ -546,6 +546,10 @@ protected:
                                                 NonZeroJacobianIndicesType &   nonZeroJacobianIndices) const;
 
 private:
+  // Private using-declarations, to avoid `-Woverloaded-virtual` warnings from GCC (GCC 11.4).
+  using Superclass::TransformCovariantVector;
+  using Superclass::TransformVector;
+
   /** Exception text. */
   static constexpr const char * NoCurrentTransformSet = "No current transform set in the AdvancedCombinationTransform";
 

--- a/Common/Transforms/itkAdvancedIdentityTransform.h
+++ b/Common/Transforms/itkAdvancedIdentityTransform.h
@@ -327,6 +327,10 @@ protected:
   ~AdvancedIdentityTransform() override = default;
 
 private:
+  // Private using-declarations, to avoid `-Woverloaded-virtual` warnings from GCC (GCC 11.4).
+  using Superclass::TransformVector;
+  using Superclass::TransformCovariantVector;
+
   JacobianType                  m_LocalJacobian{};
   SpatialJacobianType           m_SpatialJacobian{};
   SpatialHessianType            m_SpatialHessian{};

--- a/Common/Transforms/itkAdvancedMatrixOffsetTransformBase.h
+++ b/Common/Transforms/itkAdvancedMatrixOffsetTransformBase.h
@@ -432,6 +432,10 @@ protected:
   JacobianOfSpatialHessianType  m_JacobianOfSpatialHessian{};
 
 private:
+  // Private using-declarations, to avoid `-Woverloaded-virtual` warnings from GCC (GCC 11.4).
+  using Superclass::TransformCovariantVector;
+  using Superclass::TransformVector;
+
   AdvancedMatrixOffsetTransformBase(const Self & other);
   const Self &
   operator=(const Self &);

--- a/Common/Transforms/itkAdvancedTranslationTransform.h
+++ b/Common/Transforms/itkAdvancedTranslationTransform.h
@@ -251,6 +251,10 @@ protected:
   PrintSelf(std::ostream & os, Indent indent) const override;
 
 private:
+  // Private using-declarations, to avoid `-Woverloaded-virtual` warnings from GCC (GCC 11.4).
+  using Superclass::TransformCovariantVector;
+  using Superclass::TransformVector;
+
   OutputVectorType m_Offset{}; // Offset of the transformation
 
   // The Jacobian of this transform is constant. Therefore it can be shared among all the threads.

--- a/Common/Transforms/itkCyclicBSplineDeformableTransform.h
+++ b/Common/Transforms/itkCyclicBSplineDeformableTransform.h
@@ -134,6 +134,10 @@ protected:
               const RegionType & inRegion,
               RegionType &       outRegion1,
               RegionType &       outRegion2) const;
+
+private:
+  // Private using-declaration, to avoid `-Woverloaded-virtual` warnings from GCC (GCC 11.4) or clang (macos-12).
+  using Superclass::GetJacobian;
 };
 
 } // namespace itk

--- a/Common/Transforms/itkStackTransform.h
+++ b/Common/Transforms/itkStackTransform.h
@@ -304,6 +304,10 @@ protected:
   }
 
 private:
+  // Private using-declarations, to avoid `-Woverloaded-virtual` warnings from GCC (GCC 11.4).
+  using Superclass::TransformCovariantVector;
+  using Superclass::TransformVector;
+
   /** Each override of this pure virtual member function should create a subtransform for the specific (derived) stack
    * transform type. For example, for an `TranslationStackTransform` it should create an `AdvancedTranslationTransform`,
    * and for an `EulerStackTransform` it should create an `EulerTransform`. */

--- a/Common/itkMultiResolutionImageRegistrationMethod2.h
+++ b/Common/itkMultiResolutionImageRegistrationMethod2.h
@@ -281,6 +281,9 @@ protected:
   bool           m_Stop{};
 
 private:
+  // Private using-declarations, to avoid `-Woverloaded-virtual` warnings from GCC (GCC 11.4).
+  using ProcessObject::MakeOutput;
+
   /** Member variables. */
   MetricPointer          m_Metric{};
   OptimizerType::Pointer m_Optimizer{};

--- a/Components/Registrations/MultiMetricMultiResolutionRegistration/itkCombinationImageToImageMetric.h
+++ b/Components/Registrations/MultiMetricMultiResolutionRegistration/itkCombinationImageToImageMetric.h
@@ -471,6 +471,7 @@ private:
   // Private using-declarations, to avoid `-Woverloaded-virtual` warnings from GCC (GCC 11.4) or clang (macos-12).
   using Superclass::SetFixedImageMask;
   using Superclass::SetMovingImageMask;
+  using Superclass::SetTransform;
 
   /** Initialize some multi-threading related parameters.
    * Overrides function in AdvancedImageToImageMetric, because

--- a/Components/Registrations/MultiMetricMultiResolutionRegistration/itkCombinationImageToImageMetric.h
+++ b/Components/Registrations/MultiMetricMultiResolutionRegistration/itkCombinationImageToImageMetric.h
@@ -255,7 +255,15 @@ public:
   virtual const TransformType *
   GetTransform(unsigned int pos) const;
 
-  /** Return Transform 0 */
+  /** Get the first transform. */
+  TransformType *
+  GetTransform() override
+  {
+    const auto metric = dynamic_cast<ImageMetricType *>(this->GetMetric(0));
+    return metric ? metric->GetTransform() : nullptr;
+  }
+
+  /** Get the first transform. Const overload. */
   const TransformType *
   GetTransform() const override
   {
@@ -277,7 +285,15 @@ public:
   virtual const InterpolatorType *
   GetInterpolator(unsigned int pos) const;
 
-  /** Return Interpolator 0 */
+  /** Get the first interpolator. */
+  InterpolatorType *
+  GetInterpolator() override
+  {
+    const auto metric = dynamic_cast<ImageMetricType *>(this->GetMetric(0));
+    return metric ? metric->GetInterpolator() : nullptr;
+  }
+
+  /** Get the first interpolator. Const overload. */
   const InterpolatorType *
   GetInterpolator() const override
   {

--- a/Components/Registrations/MultiMetricMultiResolutionRegistration/itkCombinationImageToImageMetric.h
+++ b/Components/Registrations/MultiMetricMultiResolutionRegistration/itkCombinationImageToImageMetric.h
@@ -452,6 +452,10 @@ protected:
   DerivativeType       m_NullDerivative{};
 
 private:
+  // Private using-declarations, to avoid `-Woverloaded-virtual` warnings from GCC (GCC 11.4) or clang (macos-12).
+  using Superclass::SetFixedImageMask;
+  using Superclass::SetMovingImageMask;
+
   /** Initialize some multi-threading related parameters.
    * Overrides function in AdvancedImageToImageMetric, because
    * here we use other parameters.

--- a/Components/Transforms/DeformationFieldTransform/itkDeformationFieldInterpolatingTransform.h
+++ b/Components/Transforms/DeformationFieldTransform/itkDeformationFieldInterpolatingTransform.h
@@ -257,6 +257,11 @@ protected:
   DeformationFieldPointer             m_DeformationField{};
   DeformationFieldPointer             m_ZeroDeformationField{};
   DeformationFieldInterpolatorPointer m_DeformationFieldInterpolator{};
+
+private:
+  // Private using-declarations, to avoid `-Woverloaded-virtual` warnings from GCC (GCC 11.4).
+  using Superclass::TransformCovariantVector;
+  using Superclass::TransformVector;
 };
 
 } // namespace itk

--- a/Components/Transforms/ExternalTransform/elxAdvancedTransformAdapter.h
+++ b/Components/Transforms/ExternalTransform/elxAdvancedTransformAdapter.h
@@ -222,6 +222,10 @@ protected:
   }
 
 private:
+  // Private using-declarations, to avoid `-Woverloaded-virtual` warnings from GCC (GCC 11.4).
+  using Superclass::TransformCovariantVector;
+  using Superclass::TransformVector;
+
   static constexpr const char * unimplementedOverrideMessage = "Not implemented for AdvancedTransformAdapter";
 
   itk::SmartPointer<TransformType> m_ExternalTransform{};

--- a/Components/Transforms/MultiBSplineTransformWithNormal/itkMultiBSplineDeformableTransformWithNormal.h
+++ b/Components/Transforms/MultiBSplineTransformWithNormal/itkMultiBSplineDeformableTransformWithNormal.h
@@ -502,6 +502,10 @@ protected:
   ImageBasePointer                             m_LocalBases{};
 
 private:
+  // Private using-declarations, to avoid `-Woverloaded-virtual` warnings from GCC (GCC 11.4).
+  using Superclass::TransformCovariantVector;
+  using Superclass::TransformVector;
+
   /** The number of weights. */
   static constexpr unsigned NumberOfWeights = TransformType::NumberOfWeights;
 

--- a/Components/Transforms/SplineKernelTransform/itkKernelTransform2.h
+++ b/Components/Transforms/SplineKernelTransform/itkKernelTransform2.h
@@ -533,6 +533,10 @@ protected:
   bool m_FastComputationPossible{};
 
 private:
+  // Private using-declarations, to avoid `-Woverloaded-virtual` warnings from GCC (GCC 11.4).
+  using Superclass::TransformCovariantVector;
+  using Superclass::TransformVector;
+
   TScalarType m_PoissonRatio{};
 
   /** Using SVD or QR decomposition. */

--- a/Components/Transforms/WeightedCombinationTransform/itkWeightedCombinationTransform.h
+++ b/Components/Transforms/WeightedCombinationTransform/itkWeightedCombinationTransform.h
@@ -247,6 +247,10 @@ protected:
   NonZeroJacobianIndicesType m_NonZeroJacobianIndices{};
 
 private:
+  // Private using-declarations, to avoid `-Woverloaded-virtual` warnings from GCC (GCC 11.4).
+  using Superclass::TransformCovariantVector;
+  using Superclass::TransformVector;
+
   bool m_NormalizeWeights{};
 };
 


### PR DESCRIPTION
Addressed those warnings, mostly from macos-12/clang.

Note that these warnings do sometimes help to find actual (potential) bugs, like:
- pull request #1120
- pull request #1118
- pull request #1123

Follow-up to:
-  pull request #1115