### PR TITLE
COMP: Remove unused parameter "spaceDim" from Similarity constructors

### DIFF
--- a/Common/Transforms/itkAdvancedRigid2DTransform.h
+++ b/Common/Transforms/itkAdvancedRigid2DTransform.h
@@ -190,7 +190,7 @@ public:
 
 protected:
   AdvancedRigid2DTransform();
-  AdvancedRigid2DTransform(unsigned int outputSpaceDimension, unsigned int parametersDimension);
+  explicit AdvancedRigid2DTransform(unsigned int parametersDimension);
   ~AdvancedRigid2DTransform() override = default;
 
   /**

--- a/Common/Transforms/itkAdvancedRigid2DTransform.hxx
+++ b/Common/Transforms/itkAdvancedRigid2DTransform.hxx
@@ -51,8 +51,7 @@ AdvancedRigid2DTransform<TScalarType>::AdvancedRigid2DTransform()
 
 // Constructor with arguments
 template <class TScalarType>
-AdvancedRigid2DTransform<TScalarType>::AdvancedRigid2DTransform(unsigned int spaceDimension,
-                                                                unsigned int parametersDimension)
+AdvancedRigid2DTransform<TScalarType>::AdvancedRigid2DTransform(unsigned int parametersDimension)
   : Superclass(parametersDimension)
 {
   m_Angle = TScalarType{};

--- a/Common/Transforms/itkAdvancedSimilarity2DTransform.hxx
+++ b/Common/Transforms/itkAdvancedSimilarity2DTransform.hxx
@@ -42,7 +42,7 @@ namespace itk
 // Constructor with default arguments
 template <class TScalarType>
 AdvancedSimilarity2DTransform<TScalarType>::AdvancedSimilarity2DTransform()
-  : Superclass(OutputSpaceDimension, ParametersDimension)
+  : Superclass(ParametersDimension)
 {
   m_Scale = 1.0f;
   this->PrecomputeJacobianOfSpatialJacobian();

--- a/Common/Transforms/itkAdvancedSimilarity3DTransform.hxx
+++ b/Common/Transforms/itkAdvancedSimilarity3DTransform.hxx
@@ -43,7 +43,7 @@ namespace itk
 // Constructor with default arguments
 template <class TScalarType>
 AdvancedSimilarity3DTransform<TScalarType>::AdvancedSimilarity3DTransform()
-  : Superclass(OutputSpaceDimension, ParametersDimension)
+  : Superclass(ParametersDimension)
 {
   m_Scale = 1.0;
   this->PrecomputeJacobianOfSpatialJacobian();

--- a/Common/Transforms/itkAdvancedVersorRigid3DTransform.h
+++ b/Common/Transforms/itkAdvancedVersorRigid3DTransform.h
@@ -130,7 +130,7 @@ public:
   GetJacobian(const InputPointType &, JacobianType &, NonZeroJacobianIndicesType &) const override;
 
 protected:
-  AdvancedVersorRigid3DTransform(unsigned int outputSpaceDim, unsigned int paramDim);
+  explicit AdvancedVersorRigid3DTransform(unsigned int paramDim);
   AdvancedVersorRigid3DTransform(const MatrixType & matrix, const OutputVectorType & offset);
   AdvancedVersorRigid3DTransform();
   ~AdvancedVersorRigid3DTransform() override = default;

--- a/Common/Transforms/itkAdvancedVersorRigid3DTransform.hxx
+++ b/Common/Transforms/itkAdvancedVersorRigid3DTransform.hxx
@@ -46,8 +46,7 @@ AdvancedVersorRigid3DTransform<TScalarType>::AdvancedVersorRigid3DTransform()
 
 // Constructor with arguments
 template <class TScalarType>
-AdvancedVersorRigid3DTransform<TScalarType>::AdvancedVersorRigid3DTransform(unsigned int outputSpaceDim,
-                                                                            unsigned int paramDim)
+AdvancedVersorRigid3DTransform<TScalarType>::AdvancedVersorRigid3DTransform(unsigned int paramDim)
   : Superclass(paramDim)
 {}
 


### PR DESCRIPTION
Removed the unused "output space dimension" parameter from the constructors of Similarity transform base classes, AdvancedRigid2DTransform and AdvancedVersorRigid3DTransform.

Fixed GCC warnings, like:
> warning: unused parameter 'outputSpaceDim' [-Wunused-parameter]