### PR TITLE
COMP: Remove the names of unused parameters from KNN/ANN library

### DIFF
--- a/Components/Metrics/KNNGraphAlphaMutualInformation/KNN/ann_1.1/src/brute.cpp
+++ b/Components/Metrics/KNNGraphAlphaMutualInformation/KNN/ann_1.1/src/brute.cpp
@@ -56,7 +56,7 @@ void ANNbruteForce::annkSearch(			// approx k near neighbor search
 	int					k,				// number of near neighbors to return
 	ANNidxArray			nn_idx,			// nearest neighbor indices (returned)
 	ANNdistArray		dd,				// dist to near neighbors (returned)
-	double				eps)			// error bound (ignored)
+	double)			// error bound (ignored)
 {
 	ANNmin_k mk(k);						// construct a k-limited priority queue
 	int i;

--- a/Components/Metrics/KNNGraphAlphaMutualInformation/KNN/ann_1.1/src/kd_fix_rad_search.cpp
+++ b/Components/Metrics/KNNGraphAlphaMutualInformation/KNN/ann_1.1/src/kd_fix_rad_search.cpp
@@ -145,7 +145,7 @@ void ANNkd_split::ann_FR_search(ANNdist box_dist)
 //		some fine tuning to replace indexing by pointer operations.
 //----------------------------------------------------------------------
 
-void ANNkd_leaf::ann_FR_search(ANNdist box_dist)
+void ANNkd_leaf::ann_FR_search(ANNdist)
 {
 	ANNdist dist;				// distance to data point
 	ANNcoord* pp;				// data coordinate pointer

--- a/Components/Metrics/KNNGraphAlphaMutualInformation/KNN/ann_1.1/src/kd_pr_search.cpp
+++ b/Components/Metrics/KNNGraphAlphaMutualInformation/KNN/ann_1.1/src/kd_pr_search.cpp
@@ -178,7 +178,7 @@ void ANNkd_split::ann_pri_search(ANNdist box_dist)
 //		This is virtually identical to the ann_search for standard search.
 //----------------------------------------------------------------------
 
-void ANNkd_leaf::ann_pri_search(ANNdist box_dist)
+void ANNkd_leaf::ann_pri_search(ANNdist)
 {
 	ANNdist dist;				// distance to data point
 	ANNcoord* pp;				// data coordinate pointer

--- a/Components/Metrics/KNNGraphAlphaMutualInformation/KNN/ann_1.1/src/kd_search.cpp
+++ b/Components/Metrics/KNNGraphAlphaMutualInformation/KNN/ann_1.1/src/kd_search.cpp
@@ -169,7 +169,7 @@ void ANNkd_split::ann_search(ANNdist box_dist)
 //		some fine tuning to replace indexing by pointer operations.
 //----------------------------------------------------------------------
 
-void ANNkd_leaf::ann_search(ANNdist box_dist)
+void ANNkd_leaf::ann_search(ANNdist)
 {
 	ANNdist dist;				// distance to data point
 	ANNcoord* pp;				// data coordinate pointer

--- a/Components/Metrics/KNNGraphAlphaMutualInformation/KNN/ann_1.1/src/kd_split.cpp
+++ b/Components/Metrics/KNNGraphAlphaMutualInformation/KNN/ann_1.1/src/kd_split.cpp
@@ -44,7 +44,7 @@ const double FS_ASPECT_RATIO = 3.0;		// maximum allowed aspect ratio
 void kd_split(
 	ANNpointArray		pa,				// point array (permuted on return)
 	ANNidxArray			pidx,			// point indices
-	const ANNorthRect	&bnds,			// bounding rectangle for cell
+	const ANNorthRect	&,			// bounding rectangle for cell
 	int					n,				// number of points
 	int					dim,			// dimension of space
 	int					&cut_dim,		// cutting dimension (returned)


### PR DESCRIPTION
Addressed -Wunused-parameter warnings from GCC.