### PR TITLE
COMP: Remove unused parameter from StatisticalShapePointPenalty

### DIFF
--- a/Components/Metrics/StatisticalShapePenalty/itkStatisticalShapePointPenalty.h
+++ b/Components/Metrics/StatisticalShapePenalty/itkStatisticalShapePointPenalty.h
@@ -209,7 +209,6 @@ private:
   CalculateDerivative(DerivativeType &      derivative,
                       const MeasureType &   value,
                       const VnlVectorType & differenceVector,
-                      const VnlVectorType & centerrotated,
                       const VnlVectorType & eigrot,
                       const unsigned int    shapeLength) const;
 

--- a/Components/Metrics/StatisticalShapePenalty/itkStatisticalShapePointPenalty.hxx
+++ b/Components/Metrics/StatisticalShapePenalty/itkStatisticalShapePointPenalty.hxx
@@ -528,7 +528,7 @@ StatisticalShapePointPenalty<TFixedPointSet, TMovingPointSet>::GetValueAndDeriva
 
   if (value != 0.0)
   {
-    this->CalculateDerivative(derivative, value, differenceVector, centerrotated, eigrot, shapeLength);
+    this->CalculateDerivative(derivative, value, differenceVector, eigrot, shapeLength);
   }
   else
   {
@@ -861,7 +861,6 @@ StatisticalShapePointPenalty<TFixedPointSet, TMovingPointSet>::CalculateDerivati
   DerivativeType &      derivative,
   const MeasureType &   value,
   const VnlVectorType & differenceVector,
-  const VnlVectorType & centerrotated,
   const VnlVectorType & eigrot,
   const unsigned int    shapeLength) const
 {


### PR DESCRIPTION
Removed the unused `centerrotated` parameter from the private member function StatisticalShapePointPenalty::CalculateDerivative

CalculateDerivative already had an unused `centerrotated` parameter with the initial commit 0d330fbb1926ce7e03449d9892ece72ce9401768, Floris Berendsen, 13 May 2013 "ENH: -Add the StatisticalShapePenalty metric module"

Fixed GCC -Wunused-parameter warnings.