### PR TITLE
COMP: Remove EvaluateInverseSpatialJacobian from SumSquaredTissue metric

### DIFF
--- a/Components/Metrics/SumSquaredTissueVolumeDifferenceMetric/itkSumSquaredTissueVolumeDifferenceImageToImageMetric.h
+++ b/Components/Metrics/SumSquaredTissueVolumeDifferenceMetric/itkSumSquaredTissueVolumeDifferenceImageToImageMetric.h
@@ -199,17 +199,6 @@ protected:
                                 MeasureType &                      measure,
                                 DerivativeType &                   deriv) const;
 
-  /** Compute the inverse SpatialJacobian to support calculation of the metric gradient.
-   * Note that this function does not calculate the true inverse, but instead calculates
-   * the inverse SpatialJacobian multiplied by the determinant of the SpatialJacobian, to
-   * avoid redundant use of the determinant.
-   * This function returns false if the SpatialJacobianDeterminant is zero.
-   */
-  bool
-  EvaluateInverseSpatialJacobian(const SpatialJacobianType & spatialJacobian,
-                                 const RealType              spatialJacobianDeterminant,
-                                 SpatialJacobianType &       inverseSpatialJacobian) const;
-
   /** Compute the dot product of the inverse SpatialJacobian with the
    * Jacobian of SpatialJacobian.  The results are stored in
    * jacobianOfSpatialJacobianDeterminant, which has a length equal to

--- a/Components/Metrics/SumSquaredTissueVolumeDifferenceMetric/itkSumSquaredTissueVolumeDifferenceImageToImageMetric.hxx
+++ b/Components/Metrics/SumSquaredTissueVolumeDifferenceMetric/itkSumSquaredTissueVolumeDifferenceImageToImageMetric.hxx
@@ -765,25 +765,6 @@ SumSquaredTissueVolumeDifferenceImageToImageMetric<TFixedImage, TMovingImage>::U
 
 
 /**
- * *************** EvaluateInverseSpatialJacobian **************************
- */
-
-template <class TFixedImage, class TMovingImage>
-bool
-SumSquaredTissueVolumeDifferenceImageToImageMetric<TFixedImage, TMovingImage>::EvaluateInverseSpatialJacobian(
-  const SpatialJacobianType & spatialJacobian,
-  const RealType              spatialJacobianDeterminant,
-  SpatialJacobianType &       inverseSpatialJacobian) const
-{
-  inverseSpatialJacobian.Fill(0.0);
-  inverseSpatialJacobian = spatialJacobian.GetInverse();
-
-  return true;
-
-} // end EvaluateInverseSpatialJacobian()
-
-
-/**
  * ********** EvaluateJacobianOfSpatialJacobianDeterminantInnerProduct ******
  */
 


### PR DESCRIPTION
SumSquaredTissueVolumeDifferenceImageToImageMetric::EvaluateInverseSpatialJacobian is a protected non-virtual member function that was unused, and caused warnings, saying:

> warning: unused parameter 'spatialJacobianDeterminant' [-Wunused-parameter]

The member function was already unused with the initial commit of SumSquaredTissueVolumeDifferenceImageToImageMetric: commit c68b557b070a55d2849f2ecf90ddb9d62111d754, Geoffrey Hugo, 15 Dec 2016, "ADD: New metric SumSquaredTissueVolumeDifferenceMetric, a mass-preserving similarity term".