### PR TITLE
COMP: Remove unused function ComputeDistributionTermsUsingSearchDir

### DIFF
--- a/Common/itkComputePreconditionerUsingDisplacementDistribution.h
+++ b/Common/itkComputePreconditionerUsingDisplacementDistribution.h
@@ -92,12 +92,6 @@ public:
   Compute(const ParametersType & mu, double & jacg, double & maxJJ, std::string method) override;
 
   /** The main function that performs the computation.
-   * DO NOT USE.
-   */
-  virtual void
-  ComputeDistributionTermsUsingSearchDir(const ParametersType & mu, double & jacg, double & maxJJ, std::string methods);
-
-  /** The main function that performs the computation.
    * B-spline specific thing we tried. Can be removed later.
    */
   void

--- a/Common/itkComputePreconditionerUsingDisplacementDistribution.hxx
+++ b/Common/itkComputePreconditionerUsingDisplacementDistribution.hxx
@@ -65,22 +65,6 @@ ComputePreconditionerUsingDisplacementDistribution<TFixedImage, TTransform>::Com
 
 
 /**
- * ************************* ComputeDistributionTermsUsingSearchDir ************************
- */
-
-template <class TFixedImage, class TTransform>
-void
-ComputePreconditionerUsingDisplacementDistribution<TFixedImage, TTransform>::ComputeDistributionTermsUsingSearchDir(
-  const ParametersType & mu,
-  double &               jacg,
-  double &               maxJJ,
-  std::string            methods)
-{
-  itkExceptionMacro("ERROR: do not call");
-} // end ComputeDistributionTermsUsingSearchDir()
-
-
-/**
  * ************************* ComputeForBSplineOnly ************************
  */
 


### PR DESCRIPTION
This ComputePreconditionerUsingDisplacementDistribution member function is protected, it is never overridden and never called. And it just throws an exception.

It caused warnings from GCC, like:

> warning: unused parameter 'mu' [-Wunused-parameter]

The member function was introduced with commit 70829754af29b92cb34be5997cda8216eaf6be8c "ENH: merging performance into develop branch", 7 Mar 2019.

----

Just checked: ITK does not have a function named "ComputePreconditionerUsingDisplacementDistribution" either.