### PR TITLE
COMP: Remove the name of unused parameter 'eps' from KNN/ANN library

### DIFF
--- a/Components/Metrics/KNNGraphAlphaMutualInformation/KNN/ann_1.1/src/brute.cpp
+++ b/Components/Metrics/KNNGraphAlphaMutualInformation/KNN/ann_1.1/src/brute.cpp
@@ -83,7 +83,7 @@ int ANNbruteForce::annkFRSearch(		// approx fixed-radius kNN search
 	int					k,				// number of near neighbors to return
 	ANNidxArray			nn_idx,			// nearest neighbor array (returned)
 	ANNdistArray		dd,				// dist to near neighbors (returned)
-	double				eps)			// error bound
+	double)			// error bound (ignored)
 {
 	ANNmin_k mk(k);						// construct a k-limited priority queue
 	int i;


### PR DESCRIPTION
Addressed -Wunused-parameter warnings from GCC.

- Follow-up to pull request https://github.com/SuperElastix/elastix/pull/1127 commit 0f7c398d2eb05d276cacb27419364ef68cc01aa9