### PR TITLE
COMP: Remove unused parameter `image` StatisticalShapePenalty::ReadShape

### DIFF
--- a/Components/Metrics/StatisticalShapePenalty/elxStatisticalShapePenalty.h
+++ b/Components/Metrics/StatisticalShapePenalty/elxStatisticalShapePenalty.h
@@ -160,9 +160,7 @@ public:
                 const typename ImageType::ConstPointer image);
 
   unsigned int
-  ReadShape(const std::string &                    ShapeFileName,
-            typename PointSetType::Pointer &       pointSet,
-            const typename ImageType::ConstPointer image);
+  ReadShape(const std::string & ShapeFileName, typename PointSetType::Pointer & pointSet);
 
   /** Overwrite to silence warning. */
   void

--- a/Components/Metrics/StatisticalShapePenalty/elxStatisticalShapePenalty.hxx
+++ b/Components/Metrics/StatisticalShapePenalty/elxStatisticalShapePenalty.hxx
@@ -69,10 +69,9 @@ StatisticalShapePenalty<TElastix>::BeforeRegistration()
   this->SetShapeModelCalculation(shapeModelCalculation);
 
   /** Read and set the fixed pointset. */
-  std::string                            fixedName = this->GetConfiguration()->GetCommandLineArgument("-fp");
-  typename PointSetType::Pointer         fixedPointSet; // default-constructed (null)
-  const typename ImageType::ConstPointer fixedImage = this->GetElastix()->GetFixedImage();
-  const unsigned int                     nrOfFixedPoints = this->ReadShape(fixedName, fixedPointSet, fixedImage);
+  std::string                    fixedName = this->GetConfiguration()->GetCommandLineArgument("-fp");
+  typename PointSetType::Pointer fixedPointSet; // default-constructed (null)
+  const unsigned int             nrOfFixedPoints = this->ReadShape(fixedName, fixedPointSet);
   this->SetFixedPointSet(fixedPointSet);
 
   // itkCombinationImageToImageMetric.hxx checks if metric base class is ImageMetricType or PointSetMetricType.
@@ -348,9 +347,8 @@ StatisticalShapePenalty<TElastix>::ReadLandmarks(const std::string &            
 
 template <class TElastix>
 unsigned int
-StatisticalShapePenalty<TElastix>::ReadShape(const std::string &                    ShapeFileName,
-                                             typename PointSetType::Pointer &       pointSet,
-                                             const typename ImageType::ConstPointer image)
+StatisticalShapePenalty<TElastix>::ReadShape(const std::string &              ShapeFileName,
+                                             typename PointSetType::Pointer & pointSet)
 {
   /** Typedef's. \todo test DummyIPPPixelType=bool. */
   using DummyIPPPixelType = double;


### PR DESCRIPTION
Fixed GCC warning -Wunused-parameter.

ReadShape was introduced with commit 0d330fbb1926ce7e03449d9892ece72ce9401768, Floris Berendsen, 13 May 2013, "-ENH: -Add the StatisticalShapePenalty metric module." With this initial commit, the parameter was already unused.