### PR TITLE
COMP: Remove unused parameter `mu` from ComputeJacobiTypePreconditioner

### DIFF
--- a/Common/itkComputePreconditionerUsingDisplacementDistribution.h
+++ b/Common/itkComputePreconditionerUsingDisplacementDistribution.h
@@ -103,8 +103,8 @@ public:
   virtual void
   Compute(const ParametersType & mu, double & maxJJ, ParametersType & preconditioner);
 
-  virtual void
-  ComputeJacobiTypePreconditioner(const ParametersType & mu, double & maxJJ, ParametersType & preconditioner);
+  void
+  ComputeJacobiTypePreconditioner(double & maxJJ, ParametersType & preconditioner);
 
   /** Interpolate the preconditioner, for the non-visited entries. */
   virtual void

--- a/Common/itkComputePreconditionerUsingDisplacementDistribution.hxx
+++ b/Common/itkComputePreconditionerUsingDisplacementDistribution.hxx
@@ -544,9 +544,8 @@ ComputePreconditionerUsingDisplacementDistribution<TFixedImage, TTransform>::Com
 template <class TFixedImage, class TTransform>
 void
 ComputePreconditionerUsingDisplacementDistribution<TFixedImage, TTransform>::ComputeJacobiTypePreconditioner(
-  const ParametersType & mu,
-  double &               maxJJ,
-  ParametersType &       preconditioner)
+  double &         maxJJ,
+  ParametersType & preconditioner)
 {
   /** Initialize. */
   maxJJ = 0.0;

--- a/Components/Optimizers/AdaGrad/elxAdaGrad.hxx
+++ b/Components/Optimizers/AdaGrad/elxAdaGrad.hxx
@@ -594,7 +594,7 @@ AdaGrad<TElastix>::AutomaticPreconditionerEstimation()
 
   if( JacobiType )
   {
-    preconditionerEstimator->ComputeJacobiTypePreconditioner( this->GetScaledCurrentPosition(),
+    preconditionerEstimator->ComputeJacobiTypePreconditioner(
       maxJJ, this->m_PreconditionVector );
   }
   else

--- a/Components/Optimizers/PreconditionedStochasticGradientDescent/elxPreconditionedStochasticGradientDescent.hxx
+++ b/Components/Optimizers/PreconditionedStochasticGradientDescent/elxPreconditionedStochasticGradientDescent.hxx
@@ -593,8 +593,7 @@ PreconditionedStochasticGradientDescent<TElastix>::AutomaticPreconditionerEstima
 
   if (useJacobiType)
   {
-    preconditionerEstimator->ComputeJacobiTypePreconditioner(
-      this->GetScaledCurrentPosition(), maxJJ, this->m_PreconditionVector);
+    preconditionerEstimator->ComputeJacobiTypePreconditioner(maxJJ, this->m_PreconditionVector);
   }
   else
   {


### PR DESCRIPTION
Fixed GCC warning -Wunused-parameter.

ComputeJacobiTypePreconditioner was introduced with commit 70829754af29b92cb34be5997cda8216eaf6be8c "ENH: merging performance into develop branch", 7 Mar 2019. With that initial commit, the `mu` parameter of this member function was already unused.

Also removed the `virtual` keyword from the  member function declaration. This member function did not have any override anyway. Following C++ Core Guidelines, May 11, 2024 "Don’t make a function `virtual` without reason", http://isocpp.github.io/CppCoreGuidelines/CppCoreGuidelines#Rh-virtual