### PR TITLE
Enable and address  `-Wunused-parameter` warnings from both GCC and clang

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -85,6 +85,7 @@ else()
   add_compile_options(
     -Woverloaded-virtual
     -Wshadow
+    -Wunused-parameter
     )
 endif()
 

--- a/Common/CostFunctions/itkAdvancedImageToImageMetric.h
+++ b/Common/CostFunctions/itkAdvancedImageToImageMetric.h
@@ -388,13 +388,11 @@ protected:
   /** Multi-threaded metric computation. */
 
   /** Multi-threaded version of GetValue(). */
-  virtual void
-  ThreadedGetValue(ThreadIdType threadID) const
-  {}
+  virtual void ThreadedGetValue(ThreadIdType) const {}
 
   /** Finalize multi-threaded metric computation. */
   virtual void
-  AfterThreadedGetValue(MeasureType & value) const
+  AfterThreadedGetValue(MeasureType &) const
   {}
 
   /** GetValue threader callback function. */
@@ -406,13 +404,11 @@ protected:
   LaunchGetValueThreaderCallback() const;
 
   /** Multi-threaded version of GetValueAndDerivative(). */
-  virtual void
-  ThreadedGetValueAndDerivative(ThreadIdType threadID) const
-  {}
+  virtual void ThreadedGetValueAndDerivative(ThreadIdType) const {}
 
   /** Finalize multi-threaded metric computation. */
   virtual void
-  AfterThreadedGetValueAndDerivative(MeasureType & value, DerivativeType & derivative) const
+  AfterThreadedGetValueAndDerivative(MeasureType &, DerivativeType &) const
   {}
 
   /** GetValueAndDerivative threader callback function. */

--- a/Common/GTesting/elxGTestUtilities.h
+++ b/Common/GTesting/elxGTestUtilities.h
@@ -142,7 +142,7 @@ InitializeMetric(
   metric.SetFixedImage(&fixedImage);
   metric.SetTransform(&advancedTransform);
   metric.SetInterpolator(&interpolator);
-  metric.SetFixedImageRegion(fixedImage.GetBufferedRegion());
+  metric.SetFixedImageRegion(fixedImageRegion);
   metric.Initialize();
 }
 

--- a/Common/Transforms/itkAdvancedCombinationTransform.hxx
+++ b/Common/Transforms/itkAdvancedCombinationTransform.hxx
@@ -677,8 +677,8 @@ AdvancedCombinationTransform<TScalarType, NDimensions>::TransformPointNoInitialT
 
 template <typename TScalarType, unsigned int NDimensions>
 auto
-AdvancedCombinationTransform<TScalarType, NDimensions>::TransformPointNoCurrentTransform(
-  const InputPointType & point) const -> OutputPointType
+AdvancedCombinationTransform<TScalarType, NDimensions>::TransformPointNoCurrentTransform(const InputPointType &) const
+  -> OutputPointType
 {
   /** Throw an exception. */
   itkExceptionMacro(<< NoCurrentTransformSet);
@@ -812,10 +812,10 @@ AdvancedCombinationTransform<TScalarType, NDimensions>::EvaluateJacobianWithImag
 template <typename TScalarType, unsigned int NDimensions>
 void
 AdvancedCombinationTransform<TScalarType, NDimensions>::EvaluateJacobianWithImageGradientProductNoCurrentTransform(
-  const InputPointType &          inputPoint,
-  const MovingImageGradientType & movingImageGradient,
-  DerivativeType &                imageJacobian,
-  NonZeroJacobianIndicesType &    nonZeroJacobianIndices) const
+  const InputPointType &,
+  const MovingImageGradientType &,
+  DerivativeType &,
+  NonZeroJacobianIndicesType &) const
 {
   /** Throw an exception. */
   itkExceptionMacro(<< NoCurrentTransformSet);

--- a/Common/Transforms/itkRecursiveBSplineTransformImplementation.h
+++ b/Common/Transforms/itkRecursiveBSplineTransformImplementation.h
@@ -368,8 +368,8 @@ public:
   static void
   TransformPoint(TScalar * const               opp,
                  const TScalar * const * const mu,
-                 const OffsetValueType * const gridOffsetTable,
-                 const double * const          weights1D)
+                 const OffsetValueType * const itkNotUsed(gridOffsetTable),
+                 const double * const          itkNotUsed(weights1D))
   {
     for (unsigned int j = 0; j < OutputDimension; ++j)
     {
@@ -380,7 +380,7 @@ public:
 
   /** GetJacobian recursive implementation. */
   static void
-  GetJacobian(TScalar *& jacobians, const double * const weights1D, const double value)
+  GetJacobian(TScalar *& jacobians, const double * const itkNotUsed(weights1D), const double value)
   {
     unsigned long offset = 0;
     for (unsigned int j = 0; j < OutputDimension; ++j)
@@ -396,7 +396,7 @@ public:
   static void
   EvaluateJacobianWithImageGradientProduct(TScalar *&                      imageJacobian,
                                            const InternalFloatType * const movingImageGradient,
-                                           const double * const            weights1D,
+                                           const double * const            itkNotUsed(weights1D),
                                            const double                    value)
   {
     for (unsigned int j = 0; j < OutputDimension; ++j)
@@ -412,7 +412,7 @@ public:
   ComputeNonZeroJacobianIndices(unsigned long *&              nzji,
                                 const unsigned long           parametersPerDim,
                                 const unsigned long           currentIndex,
-                                const OffsetValueType * const gridOffsetTable)
+                                const OffsetValueType * const itkNotUsed(gridOffsetTable))
   {
     for (unsigned int j = 0; j < OutputDimension; ++j)
     {
@@ -426,9 +426,9 @@ public:
   static void
   GetSpatialJacobian(InternalFloatType * const     sj,
                      const TScalar * const * const mu,
-                     const OffsetValueType * const gridOffsetTable,
-                     const double * const          weights1D,  // normal B-spline weights
-                     const double * const          derivativeWeights1D) // 1st derivative of B-spline
+                     const OffsetValueType * const itkNotUsed(gridOffsetTable),
+                     const double * const          itkNotUsed(weights1D),  // normal B-spline weights
+                     const double * const          itkNotUsed(derivativeWeights1D)) // 1st derivative of B-spline
   {
     for (unsigned int j = 0; j < OutputDimension; ++j)
     {
@@ -441,10 +441,10 @@ public:
   static void
   GetSpatialHessian(InternalFloatType * const     sh,
                     const TScalar * const * const mu,
-                    const OffsetValueType * const gridOffsetTable,
-                    const double * const          weights1D,           // normal B-spline weights
-                    const double * const          derivativeWeights1D, // 1st derivative of B-spline
-                    const double * const          hessianWeights1D)             // 2nd derivative of B-spline
+                    const OffsetValueType * const itkNotUsed(gridOffsetTable),
+                    const double * const          itkNotUsed(weights1D),           // normal B-spline weights
+                    const double * const          itkNotUsed(derivativeWeights1D), // 1st derivative of B-spline
+                    const double * const          itkNotUsed(hessianWeights1D))             // 2nd derivative of B-spline
   {
     for (unsigned int j = 0; j < OutputDimension; ++j)
     {
@@ -455,10 +455,10 @@ public:
 
   /** GetJacobianOfSpatialJacobian recursive implementation. */
   static void
-  GetJacobianOfSpatialJacobian(InternalFloatType *&            jsj_out,
-                               const double * const            weights1D,           // normal B-spline weights
-                               const double * const            derivativeWeights1D, // 1st derivative of B-spline
-                               const double * const            directionCosines,
+  GetJacobianOfSpatialJacobian(InternalFloatType *& jsj_out,
+                               const double * const itkNotUsed(weights1D),           // normal B-spline weights
+                               const double * const itkNotUsed(derivativeWeights1D), // 1st derivative of B-spline
+                               const double * const directionCosines,
                                const InternalFloatType * const jsj)
   {
     /** Copy the correct elements to the output.
@@ -494,11 +494,11 @@ public:
 
   /** GetJacobianOfSpatialHessian recursive implementation. */
   static void
-  GetJacobianOfSpatialHessian(InternalFloatType *&            jsh_out,
-                              const double * const            weights1D,           // normal B-spline weights
-                              const double * const            derivativeWeights1D, // 1st derivative of B-spline
-                              const double * const            hessianWeights1D,    // 2nd derivative of B-spline
-                              const double * const            directionCosines,
+  GetJacobianOfSpatialHessian(InternalFloatType *& jsh_out,
+                              const double * const itkNotUsed(weights1D),           // normal B-spline weights
+                              const double * const itkNotUsed(derivativeWeights1D), // 1st derivative of B-spline
+                              const double * const itkNotUsed(hessianWeights1D),    // 2nd derivative of B-spline
+                              const double * const directionCosines,
                               const InternalFloatType * const jsh)
   {
     double jsh_tmp[OutputDimension * OutputDimension];

--- a/Common/elxSupportedImageDimensions.h
+++ b/Common/elxSupportedImageDimensions.h
@@ -62,10 +62,10 @@ SupportsFixedDimension()
 template <unsigned VDimension = minSupportedImageDimension>
 struct FixedImageDimensionSupport
 {
-  // Adds those dimensions from the specified `dimensionSequence` that are supported.
+  // Adds those dimensions from the specified sequence that are supported.
   template <std::size_t... VIndex>
   static constexpr auto
-  AddSupportedDimensions(std::index_sequence<VIndex...> dimensionSequence)
+  AddSupportedDimensions(std::index_sequence<VIndex...>)
   {
     using AddDimensionIfSupported = std::conditional_t<SupportsFixedDimension<VDimension>(),
                                                        std::index_sequence<VDimension, VIndex...>,

--- a/Common/itkAdvancedLinearInterpolateImageFunction.h
+++ b/Common/itkAdvancedLinearInterpolateImageFunction.h
@@ -157,9 +157,7 @@ private:
 
   /** Method to compute both the value and the derivative. Generic. */
   void
-  EvaluateValueAndDerivativeUnOptimized(const ContinuousIndexType & x,
-                                        OutputType &                value,
-                                        CovariantVectorType &       deriv) const
+  EvaluateValueAndDerivativeUnOptimized(const ContinuousIndexType &, OutputType &, CovariantVectorType &) const
   {
     itkExceptionMacro("ERROR: EvaluateValueAndDerivativeAtContinuousIndex() is not implemented for this dimension ("
                       << ImageDimension << ").");

--- a/Common/itkComputePreconditionerUsingDisplacementDistribution.hxx
+++ b/Common/itkComputePreconditionerUsingDisplacementDistribution.hxx
@@ -55,10 +55,10 @@ ComputePreconditionerUsingDisplacementDistribution<TFixedImage,
 
 template <class TFixedImage, class TTransform>
 void
-ComputePreconditionerUsingDisplacementDistribution<TFixedImage, TTransform>::Compute(const ParametersType & mu,
-                                                                                     double &               jacg,
-                                                                                     double &               maxJJ,
-                                                                                     std::string            methods)
+ComputePreconditionerUsingDisplacementDistribution<TFixedImage, TTransform>::Compute(const ParametersType &,
+                                                                                     double &,
+                                                                                     double &,
+                                                                                     std::string)
 {
   itkExceptionMacro("ERROR: do not call");
 } // end Compute()

--- a/Components/Optimizers/QuasiNewtonLBFGS/itkQuasiNewtonLBFGSOptimizer.h
+++ b/Components/Optimizers/QuasiNewtonLBFGS/itkQuasiNewtonLBFGSOptimizer.h
@@ -139,7 +139,7 @@ protected:
 
   // \todo: should be implemented
   void
-  PrintSelf(std::ostream & os, Indent indent) const override
+  PrintSelf(std::ostream &, Indent) const override
   {}
 
   DerivativeType    m_CurrentGradient{};

--- a/Components/Transforms/DeformationFieldTransform/itkDeformationFieldInterpolatingTransform.h
+++ b/Components/Transforms/DeformationFieldTransform/itkDeformationFieldInterpolatingTransform.h
@@ -182,61 +182,59 @@ public:
 
   /** Must be provided. */
   void
-  GetJacobian(const InputPointType &       inputPoint,
-              JacobianType &               j,
-              NonZeroJacobianIndicesType & nonZeroJacobianIndices) const override
+  GetJacobian(const InputPointType &, JacobianType &, NonZeroJacobianIndicesType &) const override
   {
     itkExceptionMacro("Not implemented for DeformationFieldInterpolatingTransform");
   }
 
 
   void
-  GetSpatialJacobian(const InputPointType & inputPoint, SpatialJacobianType & sj) const override
+  GetSpatialJacobian(const InputPointType &, SpatialJacobianType &) const override
   {
     itkExceptionMacro("Not implemented for DeformationFieldInterpolatingTransform");
   }
 
 
   void
-  GetSpatialHessian(const InputPointType & inputPoint, SpatialHessianType & sh) const override
+  GetSpatialHessian(const InputPointType &, SpatialHessianType &) const override
   {
     itkExceptionMacro("Not implemented for DeformationFieldInterpolatingTransform");
   }
 
 
   void
-  GetJacobianOfSpatialJacobian(const InputPointType &          inputPoint,
-                               JacobianOfSpatialJacobianType & jsj,
-                               NonZeroJacobianIndicesType &    nonZeroJacobianIndices) const override
+  GetJacobianOfSpatialJacobian(const InputPointType &,
+                               JacobianOfSpatialJacobianType &,
+                               NonZeroJacobianIndicesType &) const override
   {
     itkExceptionMacro("Not implemented for DeformationFieldInterpolatingTransform");
   }
 
 
   void
-  GetJacobianOfSpatialJacobian(const InputPointType &          inputPoint,
-                               SpatialJacobianType &           sj,
-                               JacobianOfSpatialJacobianType & jsj,
-                               NonZeroJacobianIndicesType &    nonZeroJacobianIndices) const override
+  GetJacobianOfSpatialJacobian(const InputPointType &,
+                               SpatialJacobianType &,
+                               JacobianOfSpatialJacobianType &,
+                               NonZeroJacobianIndicesType &) const override
   {
     itkExceptionMacro("Not implemented for DeformationFieldInterpolatingTransform");
   }
 
 
   void
-  GetJacobianOfSpatialHessian(const InputPointType &         inputPoint,
-                              JacobianOfSpatialHessianType & jsh,
-                              NonZeroJacobianIndicesType &   nonZeroJacobianIndices) const override
+  GetJacobianOfSpatialHessian(const InputPointType &,
+                              JacobianOfSpatialHessianType &,
+                              NonZeroJacobianIndicesType &) const override
   {
     itkExceptionMacro("Not implemented for DeformationFieldInterpolatingTransform");
   }
 
 
   void
-  GetJacobianOfSpatialHessian(const InputPointType &         inputPoint,
-                              SpatialHessianType &           sh,
-                              JacobianOfSpatialHessianType & jsh,
-                              NonZeroJacobianIndicesType &   nonZeroJacobianIndices) const override
+  GetJacobianOfSpatialHessian(const InputPointType &,
+                              SpatialHessianType &,
+                              JacobianOfSpatialHessianType &,
+                              NonZeroJacobianIndicesType &) const override
   {
     itkExceptionMacro("Not implemented for DeformationFieldInterpolatingTransform");
   }

--- a/Components/Transforms/ExternalTransform/elxAdvancedTransformAdapter.h
+++ b/Components/Transforms/ExternalTransform/elxAdvancedTransformAdapter.h
@@ -89,7 +89,7 @@ public:
 
   /** Set the fixed parameters. Not implemented for this transform. */
   void
-  SetFixedParameters(const ParametersType & fixedParameters) override
+  SetFixedParameters(const ParametersType &) override
   {
     itkExceptionMacro(<< unimplementedOverrideMessage);
   }

--- a/Components/Transforms/MultiBSplineTransformWithNormal/itkMultiBSplineDeformableTransformWithNormal.h
+++ b/Components/Transforms/MultiBSplineTransformWithNormal/itkMultiBSplineDeformableTransformWithNormal.h
@@ -397,9 +397,9 @@ public:
   GetSpatialHessian(const InputPointType & inputPoint, SpatialHessianType & sh) const override;
 
   void
-  GetJacobianOfSpatialHessian(const InputPointType &         inputPoint,
-                              JacobianOfSpatialHessianType & jsh,
-                              NonZeroJacobianIndicesType &   nonZeroJacobianIndices) const override
+  GetJacobianOfSpatialHessian(const InputPointType &,
+                              JacobianOfSpatialHessianType &,
+                              NonZeroJacobianIndicesType &) const override
   {
     itkExceptionMacro("ERROR: GetJacobianOfSpatialHessian() not yet implemented in the "
                       "MultiBSplineDeformableTransformWithNormal class.");

--- a/Components/Transforms/MultiBSplineTransformWithNormal/itkMultiBSplineDeformableTransformWithNormal.hxx
+++ b/Components/Transforms/MultiBSplineTransformWithNormal/itkMultiBSplineDeformableTransformWithNormal.hxx
@@ -865,9 +865,9 @@ MultiBSplineDeformableTransformWithNormal<TScalarType, NDimensions, VSplineOrder
 template <class TScalarType, unsigned int NDimensions, unsigned int VSplineOrder>
 void
 MultiBSplineDeformableTransformWithNormal<TScalarType, NDimensions, VSplineOrder>::GetJacobianOfSpatialJacobian(
-  const InputPointType &          inputPoint,
-  JacobianOfSpatialJacobianType & jsj,
-  NonZeroJacobianIndicesType &    nonZeroJacobianIndices) const
+  const InputPointType &,
+  JacobianOfSpatialJacobianType &,
+  NonZeroJacobianIndicesType &) const
 {
   itkExceptionMacro("ERROR: GetJacobianOfSpatialJacobian() not yet implemented in the "
                     "MultiBSplineDeformableTransformWithNormal class.");

--- a/Components/Transforms/SplineKernelTransform/itkKernelTransform2.h
+++ b/Components/Transforms/SplineKernelTransform/itkKernelTransform2.h
@@ -303,52 +303,52 @@ public:
 
   /** Must be provided. */
   void
-  GetSpatialJacobian(const InputPointType & inputPoint, SpatialJacobianType & sj) const override
+  GetSpatialJacobian(const InputPointType &, SpatialJacobianType &) const override
   {
     itkExceptionMacro("Not implemented for KernelTransform2");
   }
 
 
   void
-  GetSpatialHessian(const InputPointType & inputPoint, SpatialHessianType & sh) const override
+  GetSpatialHessian(const InputPointType &, SpatialHessianType &) const override
   {
     itkExceptionMacro("Not implemented for KernelTransform2");
   }
 
 
   void
-  GetJacobianOfSpatialJacobian(const InputPointType &          inputPoint,
-                               JacobianOfSpatialJacobianType & jsj,
-                               NonZeroJacobianIndicesType &    nonZeroJacobianIndices) const override
+  GetJacobianOfSpatialJacobian(const InputPointType &,
+                               JacobianOfSpatialJacobianType &,
+                               NonZeroJacobianIndicesType &) const override
   {
     itkExceptionMacro("Not implemented for KernelTransform2");
   }
 
 
   void
-  GetJacobianOfSpatialJacobian(const InputPointType &          inputPoint,
-                               SpatialJacobianType &           sj,
-                               JacobianOfSpatialJacobianType & jsj,
-                               NonZeroJacobianIndicesType &    nonZeroJacobianIndices) const override
+  GetJacobianOfSpatialJacobian(const InputPointType &,
+                               SpatialJacobianType &,
+                               JacobianOfSpatialJacobianType &,
+                               NonZeroJacobianIndicesType &) const override
   {
     itkExceptionMacro("Not implemented for KernelTransform2");
   }
 
 
   void
-  GetJacobianOfSpatialHessian(const InputPointType &         inputPoint,
-                              JacobianOfSpatialHessianType & jsh,
-                              NonZeroJacobianIndicesType &   nonZeroJacobianIndices) const override
+  GetJacobianOfSpatialHessian(const InputPointType &,
+                              JacobianOfSpatialHessianType &,
+                              NonZeroJacobianIndicesType &) const override
   {
     itkExceptionMacro("Not implemented for KernelTransform2");
   }
 
 
   void
-  GetJacobianOfSpatialHessian(const InputPointType &         inputPoint,
-                              SpatialHessianType &           sh,
-                              JacobianOfSpatialHessianType & jsh,
-                              NonZeroJacobianIndicesType &   nonZeroJacobianIndices) const override
+  GetJacobianOfSpatialHessian(const InputPointType &,
+                              SpatialHessianType &,
+                              JacobianOfSpatialHessianType &,
+                              NonZeroJacobianIndicesType &) const override
   {
     itkExceptionMacro("Not implemented for KernelTransform2");
   }

--- a/Components/Transforms/WeightedCombinationTransform/itkWeightedCombinationTransform.h
+++ b/Components/Transforms/WeightedCombinationTransform/itkWeightedCombinationTransform.h
@@ -185,52 +185,52 @@ public:
 
   /** Must be provided. */
   void
-  GetSpatialJacobian(const InputPointType & inputPoint, SpatialJacobianType & sj) const override
+  GetSpatialJacobian(const InputPointType &, SpatialJacobianType &) const override
   {
     itkExceptionMacro("Not implemented for WeightedCombinationTransform");
   }
 
 
   void
-  GetSpatialHessian(const InputPointType & inputPoint, SpatialHessianType & sh) const override
+  GetSpatialHessian(const InputPointType &, SpatialHessianType &) const override
   {
     itkExceptionMacro("Not implemented for WeightedCombinationTransform");
   }
 
 
   void
-  GetJacobianOfSpatialJacobian(const InputPointType &          inputPoint,
-                               JacobianOfSpatialJacobianType & jsj,
-                               NonZeroJacobianIndicesType &    nonZeroJacobianIndices) const override
+  GetJacobianOfSpatialJacobian(const InputPointType &,
+                               JacobianOfSpatialJacobianType &,
+                               NonZeroJacobianIndicesType &) const override
   {
     itkExceptionMacro("Not implemented for WeightedCombinationTransform");
   }
 
 
   void
-  GetJacobianOfSpatialJacobian(const InputPointType &          inputPoint,
-                               SpatialJacobianType &           sj,
-                               JacobianOfSpatialJacobianType & jsj,
-                               NonZeroJacobianIndicesType &    nonZeroJacobianIndices) const override
+  GetJacobianOfSpatialJacobian(const InputPointType &,
+                               SpatialJacobianType &,
+                               JacobianOfSpatialJacobianType &,
+                               NonZeroJacobianIndicesType &) const override
   {
     itkExceptionMacro("Not implemented for WeightedCombinationTransform");
   }
 
 
   void
-  GetJacobianOfSpatialHessian(const InputPointType &         inputPoint,
-                              JacobianOfSpatialHessianType & jsh,
-                              NonZeroJacobianIndicesType &   nonZeroJacobianIndices) const override
+  GetJacobianOfSpatialHessian(const InputPointType &,
+                              JacobianOfSpatialHessianType &,
+                              NonZeroJacobianIndicesType &) const override
   {
     itkExceptionMacro("Not implemented for WeightedCombinationTransform");
   }
 
 
   void
-  GetJacobianOfSpatialHessian(const InputPointType &         inputPoint,
-                              SpatialHessianType &           sh,
-                              JacobianOfSpatialHessianType & jsh,
-                              NonZeroJacobianIndicesType &   nonZeroJacobianIndices) const override
+  GetJacobianOfSpatialHessian(const InputPointType &,
+                              SpatialHessianType &,
+                              JacobianOfSpatialHessianType &,
+                              NonZeroJacobianIndicesType &) const override
   {
     itkExceptionMacro("Not implemented for WeightedCombinationTransform");
   }


### PR DESCRIPTION
Suggested by Bradley Lowekamp (@blowekamp) at https://github.com/SimpleITK/SimpleITK/pull/2104#issuecomment-2075743756, as part of "Update elastix to April 19 2024 hash"

The warnings are addressed, either by removing those parameter names (if they were not really informative), by using the `itkNotUsed(x)` macro (in RecursiveBSplineTransformImplementation), of by actually using the specific parameter (specifically in GTestUtilities::InitializeMetric).

Follow-up to:
- pull request #1115
- pull request #1122
