### PR TITLE
Fix MSVC /W4 warnings, "warning C4389: '==': signed/unsigned mismatch"

### DIFF
--- a/Common/itkParabolicErodeDilateImageFilter.hxx
+++ b/Common/itkParabolicErodeDilateImageFilter.hxx
@@ -103,7 +103,7 @@ ParabolicErodeDilateImageFilter<TInputImage, doDilate, TOutputImage>::SplitReque
     splitIndex[splitAxis] += i * valuesPerThread;
     splitSize[splitAxis] = valuesPerThread;
   }
-  if (i == maxThreadIdUsed)
+  if (static_cast<intmax_t>(i) == maxThreadIdUsed)
   {
     splitIndex[splitAxis] += i * valuesPerThread;
     // last thread needs to process the "rest" dimension being split

--- a/Core/Install/elxConversion.h
+++ b/Core/Install/elxConversion.h
@@ -190,7 +190,8 @@ public:
       const auto decimalPointPos = str.find_first_of('.');
       const bool hasDecimalPointAndTrailingZeros =
         (decimalPointPos != std::string::npos) &&
-        (std::count(str.cbegin() + decimalPointPos + 1, str.cend(), '0') == (str.size() - decimalPointPos - 1));
+        (static_cast<std::uintmax_t>(std::count(str.cbegin() + decimalPointPos + 1, str.cend(), '0')) ==
+         (str.size() - decimalPointPos - 1));
       return std::istringstream(
         hasDecimalPointAndTrailingZeros ? std::string(str.cbegin(), str.cbegin() + decimalPointPos) : str);
     }();


### PR DESCRIPTION
Fixed by casting the left side of the `==` to the largest available integer type of the same "signedness" as the right side. 