### PR TITLE
COMP: Add `(void)` casts to `inputPixelTypeHolder` parameters of GTests

### DIFF
--- a/Core/Main/GTesting/itkElastixRegistrationMethodGTest.cxx
+++ b/Core/Main/GTesting/itkElastixRegistrationMethodGTest.cxx
@@ -2258,6 +2258,7 @@ GTEST_TEST(itkElastixRegistrationMethod, CheckZeroFilledMovingImageWithRandomDom
 GTEST_TEST(itkElastixRegistrationMethod, CheckMinimumMovingImageUsingAnyInternalPixelType)
 {
   const auto check = [](const auto inputPixelTypeHolder) {
+    (void)inputPixelTypeHolder;
     elx::ForEachSupportedImageType([](const auto elxTypedef) {
       using ElxTypedef = decltype(elxTypedef);
       using InputPixelType = typename decltype(inputPixelTypeHolder)::Type;
@@ -2311,6 +2312,7 @@ GTEST_TEST(itkElastixRegistrationMethod, CheckZeroFilledMovingImageWithRandomDom
   std::mt19937 randomNumberEngine{};
 
   const auto check = [&randomNumberEngine](const auto inputPixelTypeHolder) {
+    (void)inputPixelTypeHolder;
     elx::ForEachSupportedImageType([&randomNumberEngine](const auto elxTypedef) {
       using ElxTypedef = decltype(elxTypedef);
       using InputPixelType = typename decltype(inputPixelTypeHolder)::Type;

--- a/Core/Main/GTesting/itkTransformixFilterGTest.cxx
+++ b/Core/Main/GTesting/itkTransformixFilterGTest.cxx
@@ -1414,6 +1414,7 @@ GTEST_TEST(itkTransformixFilter, CheckZeroFilledMovingImageWithRandomDomainHavin
 GTEST_TEST(itkTransformixFilter, CheckMinimumMovingImageUsingAnyInternalPixelType)
 {
   const auto check = [](const auto inputPixelTypeHolder) {
+    (void)inputPixelTypeHolder;
     elx::ForEachSupportedImageType([](const auto elxTypedef) {
       using ElxTypedef = decltype(elxTypedef);
       using InputPixelType = typename decltype(inputPixelTypeHolder)::Type;
@@ -1454,6 +1455,7 @@ GTEST_TEST(itkTransformixFilter, CheckZeroFilledMovingImageWithRandomDomainUsing
   std::mt19937 randomNumberEngine{};
 
   const auto check = [&randomNumberEngine](const auto inputPixelTypeHolder) {
+    (void)inputPixelTypeHolder;
     elx::ForEachSupportedImageType([&randomNumberEngine](const auto elxTypedef) {
       using ElxTypedef = decltype(elxTypedef);
       using InputPixelType = typename decltype(inputPixelTypeHolder)::Type;


### PR DESCRIPTION
Fixes MSVC /W4 warnings, saying:
> warning C4100: 'inputPixelTypeHolder': unreferenced formal parameter

Note that `[[maybe_unused]]` cannot be used in these case, because of a compiler bug in MSVC 2022, which would produce:
> error C2187: syntax error: 'attribute specifier' was unexpected here

This error occurs with an `auto` parameter of a lambda, when the capture list `[]` is empty.