### PR TITLE
STYLE: Remove unused jacjjacj variable from ComputeUsingSearchDirection

### DIFF
--- a/Common/itkComputeDisplacementDistribution.hxx
+++ b/Common/itkComputeDisplacementDistribution.hxx
@@ -519,7 +519,6 @@ ComputeDisplacementDistribution<TFixedImage, TTransform>::ComputeUsingSearchDire
   Jgg.Fill(0.0);
   std::vector<double> JGG_k;
   double              globalDeformation = 0.0;
-  JacobianType        jacjjacj(outdim, outdim);
 
   samplenr = 0;
   for (const auto & sample : *sampleContainer)


### PR DESCRIPTION
The unused local `jacjjacj` variable appears to be introduced with commit e9de4b1281a07d2fdbaa96db865f3c7aaaf4e5d2 "ENH: manual syncing with the performance branch", 25 May 2016.

In other cases, such a variable is (post-)initialized by `vnl_fastops::ABt(jacjjacj, jacj, jacj)`, but in this case, it was left uninitialized.