### PR TITLE
STYLE: Replace `if (ParametersDimension ...)` clauses with static_assert

### DIFF
--- a/Common/Transforms/itkAdvancedEuler3DTransform.hxx
+++ b/Common/Transforms/itkAdvancedEuler3DTransform.hxx
@@ -274,11 +274,7 @@ template <class TScalarType>
 void
 AdvancedEuler3DTransform<TScalarType>::PrecomputeJacobianOfSpatialJacobian()
 {
-  if (ParametersDimension < 6)
-  {
-    /** Some subclass has a different number of parameters */
-    return;
-  }
+  static_assert(ParametersDimension >= 6);
 
   /** The Jacobian of spatial Jacobian is constant over inputspace, so is precomputed */
   JacobianOfSpatialJacobianType & jsj = this->m_JacobianOfSpatialJacobian;

--- a/Common/Transforms/itkAdvancedRigid2DTransform.hxx
+++ b/Common/Transforms/itkAdvancedRigid2DTransform.hxx
@@ -260,13 +260,14 @@ AdvancedRigid2DTransform<TScalarType>::PrecomputeJacobianOfSpatialJacobian()
   const double                    sa = std::sin(m_Angle);
   JacobianOfSpatialJacobianType & jsj = this->m_JacobianOfSpatialJacobian;
   jsj.resize(ParametersDimension);
-  if (ParametersDimension > 1)
-  {
-    jsj[0](0, 0) = -sa;
-    jsj[0](0, 1) = -ca;
-    jsj[0](1, 0) = ca;
-    jsj[0](1, 1) = -sa;
-  }
+
+  static_assert(ParametersDimension > 1);
+
+  jsj[0](0, 0) = -sa;
+  jsj[0](0, 1) = -ca;
+  jsj[0](1, 0) = ca;
+  jsj[0](1, 1) = -sa;
+
   for (unsigned int par = 1; par < ParametersDimension; ++par)
   {
     jsj[par].Fill(0.0);

--- a/Common/Transforms/itkAdvancedSimilarity2DTransform.hxx
+++ b/Common/Transforms/itkAdvancedSimilarity2DTransform.hxx
@@ -261,19 +261,20 @@ AdvancedSimilarity2DTransform<TScalarType>::PrecomputeJacobianOfSpatialJacobian(
   double                          sa = std::sin(angle);
   JacobianOfSpatialJacobianType & jsj = this->m_JacobianOfSpatialJacobian;
   jsj.resize(ParametersDimension);
-  if (ParametersDimension > 1)
-  {
-    jsj[0](0, 0) = ca;
-    jsj[0](0, 1) = -sa;
-    jsj[0](1, 0) = sa;
-    jsj[0](1, 1) = ca;
-    ca *= this->m_Scale;
-    sa *= this->m_Scale;
-    jsj[1](0, 0) = -sa;
-    jsj[1](0, 1) = -ca;
-    jsj[1](1, 0) = ca;
-    jsj[1](1, 1) = -sa;
-  }
+
+  static_assert(ParametersDimension > 1);
+
+  jsj[0](0, 0) = ca;
+  jsj[0](0, 1) = -sa;
+  jsj[0](1, 0) = sa;
+  jsj[0](1, 1) = ca;
+  ca *= this->m_Scale;
+  sa *= this->m_Scale;
+  jsj[1](0, 0) = -sa;
+  jsj[1](0, 1) = -ca;
+  jsj[1](1, 0) = ca;
+  jsj[1](1, 1) = -sa;
+
   for (unsigned int par = 2; par < ParametersDimension; ++par)
   {
     jsj[par].Fill(0.0);

--- a/Common/Transforms/itkAdvancedSimilarity3DTransform.hxx
+++ b/Common/Transforms/itkAdvancedSimilarity3DTransform.hxx
@@ -287,10 +287,7 @@ template <class TScalarType>
 void
 AdvancedSimilarity3DTransform<TScalarType>::PrecomputeJacobianOfSpatialJacobian()
 {
-  if (ParametersDimension < 7)
-  {
-    return;
-  }
+  static_assert(ParametersDimension >= 7);
 
   /** The Jacobian of spatial Jacobian remains constant, so is precomputed */
   JacobianOfSpatialJacobianType & jsj = this->m_JacobianOfSpatialJacobian;

--- a/Components/Transforms/AffineDTITransform/itkAffineDTI2DTransform.hxx
+++ b/Components/Transforms/AffineDTITransform/itkAffineDTI2DTransform.hxx
@@ -231,11 +231,7 @@ template <class TScalarType>
 void
 AffineDTI2DTransform<TScalarType>::PrecomputeJacobianOfSpatialJacobian()
 {
-  if (ParametersDimension < 7)
-  {
-    /** Some subclass has a different number of parameters */
-    return;
-  }
+  static_assert(ParametersDimension >= 7);
 
   /** The Jacobian of spatial Jacobian is constant over input space, so is precomputed */
   JacobianOfSpatialJacobianType & jsj = this->m_JacobianOfSpatialJacobian;

--- a/Components/Transforms/AffineDTITransform/itkAffineDTI3DTransform.hxx
+++ b/Components/Transforms/AffineDTITransform/itkAffineDTI3DTransform.hxx
@@ -314,11 +314,7 @@ template <class TScalarType>
 void
 AffineDTI3DTransform<TScalarType>::PrecomputeJacobianOfSpatialJacobian()
 {
-  if (ParametersDimension < 12)
-  {
-    /** Some subclass has a different number of parameters */
-    return;
-  }
+  static_assert(ParametersDimension >= 12);
 
   /** The Jacobian of spatial Jacobian is constant over inputspace, so is precomputed */
   JacobianOfSpatialJacobianType & jsj = this->m_JacobianOfSpatialJacobian;


### PR DESCRIPTION
`ParametersDimension` is always specified at compile time by the transform type itself.

This commit might improve run-time performance.