### PR TITLE
STYLE: Add constexpr to `if (Dimension ...)` statements

### DIFF
--- a/Common/OpenCL/Filters/itkGPUResampleImageFilter.hxx
+++ b/Common/OpenCL/Filters/itkGPUResampleImageFilter.hxx
@@ -443,7 +443,7 @@ GPUResampleImageFilter<TInputImage, TOutputImage, TInterpolatorPrecisionType, TT
   // have to be computed based on the remaining global GPU memory.
   // Splitting is not used for low-dimensional images.
   unsigned int requestedNumberOfSplits = this->m_RequestedNumberOfSplits;
-  if (InputImageDimension < 3)
+  if constexpr (InputImageDimension < 3)
   {
     requestedNumberOfSplits = 1;
   }

--- a/Common/OpenCL/ITKimprovements/itkOpenCLKernelToImageBridge.hxx
+++ b/Common/OpenCL/ITKimprovements/itkOpenCLKernelToImageBridge.hxx
@@ -327,7 +327,7 @@ OpenCLKernelToImageBridge<TImage>::SetDirection(OpenCLKernel &                  
                                                 const cl_uint                             argumentIndex,
                                                 const typename ImageType::DirectionType & direction)
 {
-  if (ImageDimension > 3 || ImageDimension < 1)
+  if constexpr (ImageDimension > 3 || ImageDimension < 1)
   {
     itkGenericExceptionMacro("OpenCLKernelToImageBridge::SetDirection"
                              " supports only 1D/2D/3D images.");
@@ -343,7 +343,7 @@ OpenCLKernelToImageBridge<TImage>::SetSize(OpenCLKernel &                       
                                            const cl_uint                        argumentIndex,
                                            const typename ImageType::SizeType & size)
 {
-  if (ImageDimension > 3 || ImageDimension < 1)
+  if constexpr (ImageDimension > 3 || ImageDimension < 1)
   {
     itkGenericExceptionMacro("OpenCLKernelToImageBridge::SetSize"
                              " supports only 1D/2D/3D images.");
@@ -359,7 +359,7 @@ itk::OpenCLKernelToImageBridge<TImage>::SetOrigin(OpenCLKernel &                
                                                   const cl_uint                         argumentIndex,
                                                   const typename ImageType::PointType & origin)
 {
-  if (ImageDimension > 3 || ImageDimension < 1)
+  if constexpr (ImageDimension > 3 || ImageDimension < 1)
   {
     itkGenericExceptionMacro("OpenCLKernelToImageBridge::SetOrigin"
                              " supports only 1D/2D/3D images.");

--- a/Common/Transforms/itkAdvancedBSplineDeformableTransform.hxx
+++ b/Common/Transforms/itkAdvancedBSplineDeformableTransform.hxx
@@ -1189,7 +1189,7 @@ AdvancedBSplineDeformableTransform<TScalarType, NDimensions, VSplineOrder>::Comp
     globalStartNum += supportRegion.GetIndex()[dim] * this->m_GridOffsetTable[dim];
   }
 
-  if (SpaceDimension == 2)
+  if constexpr (SpaceDimension == 2)
   {
     /** Initialize some helper variables. */
     const unsigned int  sx = supportRegion.GetSize()[0];
@@ -1212,7 +1212,7 @@ AdvancedBSplineDeformableTransform<TScalarType, NDimensions, VSplineOrder>::Comp
       globalParNum += diffxy;
     }
   } // end if SpaceDimension == 2
-  else if (SpaceDimension == 3)
+  else if constexpr (SpaceDimension == 3)
   {
     /** Initialize some helper variables. */
     const unsigned int  sx = supportRegion.GetSize()[0];

--- a/Common/Transforms/itkRecursiveBSplineTransformImplementation.h
+++ b/Common/Transforms/itkRecursiveBSplineTransformImplementation.h
@@ -510,12 +510,12 @@ public:
      * For dimensions 2 and 3 optimized code (loop unrolling) is provided. Smart compilers may
      * not need that.
      */
-    if (OutputDimension == 3)
+    if constexpr (OutputDimension == 3)
     {
       const double tmp[] = { jsh[9], jsh[8], jsh[7], jsh[8], jsh[5], jsh[4], jsh[7], jsh[4], jsh[2] };
       FastBitwiseCopy(jsh_tmp, tmp);
     }
-    else if (OutputDimension == 2)
+    else if constexpr (OutputDimension == 2)
     {
       const double tmp[] = { jsh[5], jsh[4], jsh[4], jsh[2] };
       FastBitwiseCopy(jsh_tmp, tmp);

--- a/Components/FixedImagePyramids/OpenCLFixedGenericPyramid/elxOpenCLFixedGenericPyramid.hxx
+++ b/Components/FixedImagePyramids/OpenCLFixedGenericPyramid/elxOpenCLFixedGenericPyramid.hxx
@@ -52,7 +52,7 @@ OpenCLFixedGenericPyramid<TElastix>::OpenCLFixedGenericPyramid()
   // it is not beneficial to create pyramids for 2D images with OpenCL.
   // There are also small extra overhead and potential problems may appear.
   // To avoid it, we simply run it on CPU for 2D images.
-  if (ImageDimension <= 2)
+  if constexpr (ImageDimension <= 2)
   {
     log::warn(
       std::ostringstream{} << "WARNING: Creating the fixed pyramid with OpenCL for 2D images is not beneficial.\n"

--- a/Components/Metrics/DistancePreservingRigidityPenalty/itkDistancePreservingRigidityPenaltyTerm.hxx
+++ b/Components/Metrics/DistancePreservingRigidityPenalty/itkDistancePreservingRigidityPenaltyTerm.hxx
@@ -203,7 +203,7 @@ DistancePreservingRigidityPenaltyTerm<TFixedImage, TScalarType>::GetValue(const 
   unsigned int pixelValue, pixelValueNeighbor;
 
   /** Penalty term computation */
-  if (MovingImageDimension == 3)
+  if constexpr (MovingImageDimension == 3)
   {
     for (pgi.GoToBegin(), ni.GoToBegin(); !pgi.IsAtEnd(); ++pgi, ++ni)
     {
@@ -364,7 +364,7 @@ DistancePreservingRigidityPenaltyTerm<TFixedImage, TScalarType>::GetValueAndDeri
 
   unsigned int pixelValue, pixelValueNeighbor;
 
-  if (MovingImageDimension == 3)
+  if constexpr (MovingImageDimension == 3)
   {
     for (pgi.GoToBegin(), ni.GoToBegin(); !pgi.IsAtEnd(); ++pgi, ++ni)
     {

--- a/Components/Metrics/MissingStructurePenalty/elxMissingStructurePenalty.hxx
+++ b/Components/Metrics/MissingStructurePenalty/elxMissingStructurePenalty.hxx
@@ -509,7 +509,7 @@ the sequence of points to form a 2d connected polydata contour.
   // MeshType::PointsContainer * meshpointset = dynamic_cast<MeshType::PointsContainer *>(inputpointvec);
 
   /** FB: make connected mesh (polygon) for data that is 2d by assuming the sequence of points being connected**/
-  if (FixedImageDimension == 2)
+  if constexpr (FixedImageDimension == 2)
   {
     using CellAutoPointer = typename MeshType::CellType::CellAutoPointer;
     using LineType = itk::LineCell<typename MeshType::CellType>;

--- a/Components/Metrics/PolydataDummyPenalty/elxPolydataDummyPenalty.hxx
+++ b/Components/Metrics/PolydataDummyPenalty/elxPolydataDummyPenalty.hxx
@@ -480,7 +480,7 @@ PolydataDummyPenalty<TElastix>::ReadTransformixPoints(const std::string &       
   mesh->SetPoints(inputPointSet->GetPoints());
 
   /** Floris: make connected mesh (polygon) if data is 2d by assuming the sequence of points being connected**/
-  if (FixedImageDimension == 2)
+  if constexpr (FixedImageDimension == 2)
   {
     using CellAutoPointer = typename MeshType::CellType::CellAutoPointer;
     using LineType = itk::LineCell<typename MeshType::CellType>;

--- a/Components/Metrics/RigidityPenalty/itkTransformRigidityPenaltyTerm.hxx
+++ b/Components/Metrics/RigidityPenalty/itkTransformRigidityPenaltyTerm.hxx
@@ -477,7 +477,7 @@ TransformRigidityPenaltyTerm<TFixedImage, TScalarType>::GetValue(const Parameter
   this->m_BSplineTransform->SetParameters(parameters);
 
   /** Sanity check. */
-  if (ImageDimension != 2 && ImageDimension != 3)
+  if constexpr (ImageDimension != 2 && ImageDimension != 3)
   {
     itkExceptionMacro("ERROR: This filter is only implemented for dimension 2 and 3.");
   }
@@ -541,7 +541,7 @@ TransformRigidityPenaltyTerm<TFixedImage, TScalarType>::GetValue(const Parameter
     ui_FD[i] = CoefficientImageType::New();
     ui_FE[i] = CoefficientImageType::New();
     ui_FG[i] = CoefficientImageType::New();
-    if (ImageDimension == 3)
+    if constexpr (ImageDimension == 3)
     {
       ui_FC[i] = CoefficientImageType::New();
       ui_FF[i] = CoefficientImageType::New();
@@ -557,7 +557,7 @@ TransformRigidityPenaltyTerm<TFixedImage, TScalarType>::GetValue(const Parameter
     this->Create1DOperator(Operators_D[i], "FD_xi", i + 1, spacing);
     this->Create1DOperator(Operators_E[i], "FE_xi", i + 1, spacing);
     this->Create1DOperator(Operators_G[i], "FG_xi", i + 1, spacing);
-    if (ImageDimension == 3)
+    if constexpr (ImageDimension == 3)
     {
       this->Create1DOperator(Operators_C[i], "FC_xi", i + 1, spacing);
       this->Create1DOperator(Operators_F[i], "FF_xi", i + 1, spacing);
@@ -579,7 +579,7 @@ TransformRigidityPenaltyTerm<TFixedImage, TScalarType>::GetValue(const Parameter
     ui_FD[i] = this->FilterSeparable(inputImages[i], Operators_D);
     ui_FE[i] = this->FilterSeparable(inputImages[i], Operators_E);
     ui_FG[i] = this->FilterSeparable(inputImages[i], Operators_G);
-    if (ImageDimension == 3)
+    if constexpr (ImageDimension == 3)
     {
       ui_FC[i] = this->FilterSeparable(inputImages[i], Operators_C);
       ui_FF[i] = this->FilterSeparable(inputImages[i], Operators_F);
@@ -607,7 +607,7 @@ TransformRigidityPenaltyTerm<TFixedImage, TScalarType>::GetValue(const Parameter
     itD[i] = CoefficientImageIteratorType(ui_FD[i], ui_FD[i]->GetLargestPossibleRegion());
     itE[i] = CoefficientImageIteratorType(ui_FE[i], ui_FE[i]->GetLargestPossibleRegion());
     itG[i] = CoefficientImageIteratorType(ui_FG[i], ui_FG[i]->GetLargestPossibleRegion());
-    if (ImageDimension == 3)
+    if constexpr (ImageDimension == 3)
     {
       itC[i] = CoefficientImageIteratorType(ui_FC[i], ui_FC[i]->GetLargestPossibleRegion());
       itF[i] = CoefficientImageIteratorType(ui_FF[i], ui_FF[i]->GetLargestPossibleRegion());
@@ -620,7 +620,7 @@ TransformRigidityPenaltyTerm<TFixedImage, TScalarType>::GetValue(const Parameter
     itD[i].GoToBegin();
     itE[i].GoToBegin();
     itG[i].GoToBegin();
-    if (ImageDimension == 3)
+    if constexpr (ImageDimension == 3)
     {
       itC[i].GoToBegin();
       itF[i].GoToBegin();
@@ -650,7 +650,7 @@ TransformRigidityPenaltyTerm<TFixedImage, TScalarType>::GetValue(const Parameter
       mu2_A = itA[1].Get();
       mu1_B = itB[0].Get();
       mu2_B = itB[1].Get();
-      if (ImageDimension == 3)
+      if constexpr (ImageDimension == 3)
       {
         mu3_A = itA[2].Get();
         mu3_B = itB[2].Get();
@@ -659,14 +659,14 @@ TransformRigidityPenaltyTerm<TFixedImage, TScalarType>::GetValue(const Parameter
         mu3_C = itC[2].Get();
       }
 
-      if (ImageDimension == 2)
+      if constexpr (ImageDimension == 2)
       {
         this->m_OrthonormalityConditionValue +=
           it_RCI.Get() * (std::pow(+(1.0 + mu1_A) * (1.0 + mu1_A) + mu2_A * mu2_A - 1.0, 2.0) +
                           std::pow(+mu1_B * mu1_B + (1.0 + mu2_B) * (1.0 + mu2_B) - 1.0, 2.0) +
                           std::pow(+(1.0 + mu1_A) * mu1_B + mu2_A * (1.0 + mu2_B), 2.0));
       }
-      else if (ImageDimension == 3)
+      else if constexpr (ImageDimension == 3)
       {
         this->m_OrthonormalityConditionValue +=
           it_RCI.Get() * (std::pow(+(1.0 + mu1_A) * (1.0 + mu1_A) + mu2_A * mu2_A + mu3_A * mu3_A - 1.0, 2.0) +
@@ -682,7 +682,7 @@ TransformRigidityPenaltyTerm<TFixedImage, TScalarType>::GetValue(const Parameter
       {
         ++itA[i];
         ++itB[i];
-        if (ImageDimension == 3)
+        if constexpr (ImageDimension == 3)
         {
           ++itC[i];
         }
@@ -702,7 +702,7 @@ TransformRigidityPenaltyTerm<TFixedImage, TScalarType>::GetValue(const Parameter
   {
     itA[i].GoToBegin();
     itB[i].GoToBegin();
-    if (ImageDimension == 3)
+    if constexpr (ImageDimension == 3)
     {
       itC[i].GoToBegin();
     }
@@ -721,7 +721,7 @@ TransformRigidityPenaltyTerm<TFixedImage, TScalarType>::GetValue(const Parameter
       mu2_A = itA[1].Get();
       mu1_B = itB[0].Get();
       mu2_B = itB[1].Get();
-      if (ImageDimension == 3)
+      if constexpr (ImageDimension == 3)
       {
         mu3_A = itA[2].Get();
         mu3_B = itB[2].Get();
@@ -730,12 +730,12 @@ TransformRigidityPenaltyTerm<TFixedImage, TScalarType>::GetValue(const Parameter
         mu3_C = itC[2].Get();
       }
 
-      if (ImageDimension == 2)
+      if constexpr (ImageDimension == 2)
       {
         this->m_PropernessConditionValue +=
           it_RCI.Get() * (std::pow(+(1.0 + mu1_A) * (1.0 + mu2_B) - mu2_A * mu1_B - 1.0, 2.0));
       }
-      else if (ImageDimension == 3)
+      else if constexpr (ImageDimension == 3)
       {
         this->m_PropernessConditionValue +=
           it_RCI.Get() * (std::pow(-mu1_C * (1.0 + mu2_B) * mu3_A + mu1_B * mu2_C * mu3_A + mu1_C * mu2_A * mu3_B -
@@ -749,7 +749,7 @@ TransformRigidityPenaltyTerm<TFixedImage, TScalarType>::GetValue(const Parameter
       {
         ++itA[i];
         ++itB[i];
-        if (ImageDimension == 3)
+        if constexpr (ImageDimension == 3)
         {
           ++itC[i];
         }
@@ -777,7 +777,7 @@ TransformRigidityPenaltyTerm<TFixedImage, TScalarType>::GetValue(const Parameter
       {
         this->m_LinearityConditionValue +=
           it_RCI.Get() * (+itD[i].Get() * itD[i].Get() + itE[i].Get() * itE[i].Get() + itG[i].Get() * itG[i].Get());
-        if (ImageDimension == 3)
+        if constexpr (ImageDimension == 3)
         {
           this->m_LinearityConditionValue +=
             it_RCI.Get() * (+itF[i].Get() * itF[i].Get() + itH[i].Get() * itH[i].Get() + itI[i].Get() * itI[i].Get());
@@ -790,7 +790,7 @@ TransformRigidityPenaltyTerm<TFixedImage, TScalarType>::GetValue(const Parameter
         ++itD[i];
         ++itE[i];
         ++itG[i];
-        if (ImageDimension == 3)
+        if constexpr (ImageDimension == 3)
         {
           ++itF[i];
           ++itH[i];
@@ -920,7 +920,7 @@ TransformRigidityPenaltyTerm<TFixedImage, TScalarType>::GetValueAndDerivative(co
   this->BeforeThreadedGetValueAndDerivative(parameters);
 
   /** Sanity check. */
-  if (ImageDimension != 2 && ImageDimension != 3)
+  if constexpr (ImageDimension != 2 && ImageDimension != 3)
   {
     itkExceptionMacro("ERROR: This filter is only implemented for dimension 2 and 3.");
   }
@@ -984,7 +984,7 @@ TransformRigidityPenaltyTerm<TFixedImage, TScalarType>::GetValueAndDerivative(co
     ui_FD[i] = CoefficientImageType::New();
     ui_FE[i] = CoefficientImageType::New();
     ui_FG[i] = CoefficientImageType::New();
-    if (ImageDimension == 3)
+    if constexpr (ImageDimension == 3)
     {
       ui_FC[i] = CoefficientImageType::New();
       ui_FF[i] = CoefficientImageType::New();
@@ -1000,7 +1000,7 @@ TransformRigidityPenaltyTerm<TFixedImage, TScalarType>::GetValueAndDerivative(co
     this->Create1DOperator(Operators_D[i], "FD_xi", i + 1, spacing);
     this->Create1DOperator(Operators_E[i], "FE_xi", i + 1, spacing);
     this->Create1DOperator(Operators_G[i], "FG_xi", i + 1, spacing);
-    if (ImageDimension == 3)
+    if constexpr (ImageDimension == 3)
     {
       this->Create1DOperator(Operators_C[i], "FC_xi", i + 1, spacing);
       this->Create1DOperator(Operators_F[i], "FF_xi", i + 1, spacing);
@@ -1022,7 +1022,7 @@ TransformRigidityPenaltyTerm<TFixedImage, TScalarType>::GetValueAndDerivative(co
     ui_FD[i] = this->FilterSeparable(inputImages[i], Operators_D);
     ui_FE[i] = this->FilterSeparable(inputImages[i], Operators_E);
     ui_FG[i] = this->FilterSeparable(inputImages[i], Operators_G);
-    if (ImageDimension == 3)
+    if constexpr (ImageDimension == 3)
     {
       ui_FC[i] = this->FilterSeparable(inputImages[i], Operators_C);
       ui_FF[i] = this->FilterSeparable(inputImages[i], Operators_F);
@@ -1050,7 +1050,7 @@ TransformRigidityPenaltyTerm<TFixedImage, TScalarType>::GetValueAndDerivative(co
     itD[i] = CoefficientImageIteratorType(ui_FD[i], ui_FD[i]->GetLargestPossibleRegion());
     itE[i] = CoefficientImageIteratorType(ui_FE[i], ui_FE[i]->GetLargestPossibleRegion());
     itG[i] = CoefficientImageIteratorType(ui_FG[i], ui_FG[i]->GetLargestPossibleRegion());
-    if (ImageDimension == 3)
+    if constexpr (ImageDimension == 3)
     {
       itC[i] = CoefficientImageIteratorType(ui_FC[i], ui_FC[i]->GetLargestPossibleRegion());
       itF[i] = CoefficientImageIteratorType(ui_FF[i], ui_FF[i]->GetLargestPossibleRegion());
@@ -1063,7 +1063,7 @@ TransformRigidityPenaltyTerm<TFixedImage, TScalarType>::GetValueAndDerivative(co
     itD[i].GoToBegin();
     itE[i].GoToBegin();
     itG[i].GoToBegin();
-    if (ImageDimension == 3)
+    if constexpr (ImageDimension == 3)
     {
       itC[i].GoToBegin();
       itF[i].GoToBegin();
@@ -1148,7 +1148,7 @@ TransformRigidityPenaltyTerm<TFixedImage, TScalarType>::GetValueAndDerivative(co
       mu2_A = itA[1].Get();
       mu1_B = itB[0].Get();
       mu2_B = itB[1].Get();
-      if (ImageDimension == 3)
+      if constexpr (ImageDimension == 3)
       {
         mu3_A = itA[2].Get();
         mu3_B = itB[2].Get();
@@ -1156,7 +1156,7 @@ TransformRigidityPenaltyTerm<TFixedImage, TScalarType>::GetValueAndDerivative(co
         mu2_C = itC[1].Get();
         mu3_C = itC[2].Get();
       }
-      if (ImageDimension == 2)
+      if constexpr (ImageDimension == 2)
       {
         /** Calculate the value of the orthonormality condition. */
         this->m_OrthonormalityConditionValue +=
@@ -1182,7 +1182,7 @@ TransformRigidityPenaltyTerm<TFixedImage, TScalarType>::GetValueAndDerivative(co
                   2.0 * (1.0 + mu2_B);
         itOCp[1][1].Set(2.0 * valueOC);
       } // end if dim == 2
-      else if (ImageDimension == 3)
+      else if constexpr (ImageDimension == 3)
       {
         /** Calculate the value of the orthonormality condition. */
         this->m_OrthonormalityConditionValue +=
@@ -1254,7 +1254,7 @@ TransformRigidityPenaltyTerm<TFixedImage, TScalarType>::GetValueAndDerivative(co
       {
         ++itA[i];
         ++itB[i];
-        if (ImageDimension == 3)
+        if constexpr (ImageDimension == 3)
         {
           ++itC[i];
         }
@@ -1278,7 +1278,7 @@ TransformRigidityPenaltyTerm<TFixedImage, TScalarType>::GetValueAndDerivative(co
   {
     itA[i].GoToBegin();
     itB[i].GoToBegin();
-    if (ImageDimension == 3)
+    if constexpr (ImageDimension == 3)
     {
       itC[i].GoToBegin();
     }
@@ -1298,7 +1298,7 @@ TransformRigidityPenaltyTerm<TFixedImage, TScalarType>::GetValueAndDerivative(co
       mu2_A = itA[1].Get();
       mu1_B = itB[0].Get();
       mu2_B = itB[1].Get();
-      if (ImageDimension == 3)
+      if constexpr (ImageDimension == 3)
       {
         mu3_A = itA[2].Get();
         mu3_B = itB[2].Get();
@@ -1306,7 +1306,7 @@ TransformRigidityPenaltyTerm<TFixedImage, TScalarType>::GetValueAndDerivative(co
         mu2_C = itC[1].Get();
         mu3_C = itC[2].Get();
       }
-      if (ImageDimension == 2)
+      if constexpr (ImageDimension == 2)
       {
         /** Calculate the value of the properness condition. */
         this->m_PropernessConditionValue +=
@@ -1325,7 +1325,7 @@ TransformRigidityPenaltyTerm<TFixedImage, TScalarType>::GetValueAndDerivative(co
         valuePC = -(1.0 + mu1_A) + (1.0 + mu1_A) * (1.0 + mu1_A) * (1.0 + mu2_B) - mu1_B * (1.0 + mu1_A) * mu2_A;
         itPCp[1][1].Set(2.0 * valuePC);
       } // end if dim == 2
-      else if (ImageDimension == 3)
+      else if constexpr (ImageDimension == 3)
       {
         /** Calculate the value of the properness condition. */
         this->m_PropernessConditionValue +=
@@ -1435,7 +1435,7 @@ TransformRigidityPenaltyTerm<TFixedImage, TScalarType>::GetValueAndDerivative(co
       {
         ++itA[i];
         ++itB[i];
-        if (ImageDimension == 3)
+        if constexpr (ImageDimension == 3)
         {
           ++itC[i];
         }
@@ -1467,7 +1467,7 @@ TransformRigidityPenaltyTerm<TFixedImage, TScalarType>::GetValueAndDerivative(co
         /** Calculate the value of the linearity condition. */
         this->m_LinearityConditionValue +=
           it_RCI.Get() * (+itD[i].Get() * itD[i].Get() + itE[i].Get() * itE[i].Get() + itG[i].Get() * itG[i].Get());
-        if (ImageDimension == 3)
+        if constexpr (ImageDimension == 3)
         {
           this->m_LinearityConditionValue +=
             it_RCI.Get() * (+itF[i].Get() * itF[i].Get() + itH[i].Get() * itH[i].Get() + itI[i].Get() * itI[i].Get());
@@ -1475,7 +1475,7 @@ TransformRigidityPenaltyTerm<TFixedImage, TScalarType>::GetValueAndDerivative(co
       } // end loop over i
 
       /** Calculate the derivative of the linearity condition. */
-      if (ImageDimension == 2)
+      if constexpr (ImageDimension == 2)
       {
         itLCp[0][0].Set(2.0 * itD[0].Get());
         itLCp[0][1].Set(2.0 * itE[0].Get());
@@ -1484,7 +1484,7 @@ TransformRigidityPenaltyTerm<TFixedImage, TScalarType>::GetValueAndDerivative(co
         itLCp[1][1].Set(2.0 * itE[1].Get());
         itLCp[1][2].Set(2.0 * itG[1].Get());
       } // end if dim == 2
-      else if (ImageDimension == 3)
+      else if constexpr (ImageDimension == 3)
       {
         itLCp[0][0].Set(2.0 * itD[0].Get());
         itLCp[0][1].Set(2.0 * itE[0].Get());
@@ -1512,7 +1512,7 @@ TransformRigidityPenaltyTerm<TFixedImage, TScalarType>::GetValueAndDerivative(co
         ++itD[i];
         ++itE[i];
         ++itG[i];
-        if (ImageDimension == 3)
+        if constexpr (ImageDimension == 3)
         {
           ++itF[i];
           ++itH[i];
@@ -1633,7 +1633,7 @@ TransformRigidityPenaltyTerm<TFixedImage, TScalarType>::GetValueAndDerivative(co
     Operator_I;
   this->CreateNDOperator(Operator_A, "FA", spacing);
   this->CreateNDOperator(Operator_B, "FB", spacing);
-  if (ImageDimension == 3)
+  if constexpr (ImageDimension == 3)
   {
     this->CreateNDOperator(Operator_C, "FC", spacing);
   }
@@ -1643,7 +1643,7 @@ TransformRigidityPenaltyTerm<TFixedImage, TScalarType>::GetValueAndDerivative(co
     this->CreateNDOperator(Operator_D, "FD", spacing);
     this->CreateNDOperator(Operator_E, "FE", spacing);
     this->CreateNDOperator(Operator_G, "FG", spacing);
-    if (ImageDimension == 3)
+    if constexpr (ImageDimension == 3)
     {
       this->CreateNDOperator(Operator_F, "FF", spacing);
       this->CreateNDOperator(Operator_H, "FH", spacing);
@@ -1677,7 +1677,7 @@ TransformRigidityPenaltyTerm<TFixedImage, TScalarType>::GetValueAndDerivative(co
           tmp[i] += Operator_B.GetElement(k)   // FB *
                     * nitOCp[i][1].GetPixel(k) // subpart[ i ][ 1 ]
                     * nit_RCI.GetPixel(k);     // c(k)
-          if (ImageDimension == 3)
+          if constexpr (ImageDimension == 3)
           {
             tmp[i] += Operator_C.GetElement(k)   // FC *
                       * nitOCp[i][2].GetPixel(k) // subpart[ i ][ 2 ]
@@ -1730,7 +1730,7 @@ TransformRigidityPenaltyTerm<TFixedImage, TScalarType>::GetValueAndDerivative(co
           tmp[i] += Operator_B.GetElement(k)   // FB *
                     * nitPCp[i][1].GetPixel(k) // subpart[ i ][ 1 ]
                     * nit_RCI.GetPixel(k);     // c(k)
-          if (ImageDimension == 3)
+          if constexpr (ImageDimension == 3)
           {
             tmp[i] += Operator_C.GetElement(k)   // FC *
                       * nitPCp[i][2].GetPixel(k) // subpart[ i ][ 2 ]
@@ -1785,7 +1785,7 @@ TransformRigidityPenaltyTerm<TFixedImage, TScalarType>::GetValueAndDerivative(co
           tmp[i] += Operator_G.GetElement(k)   // FG *
                     * nitLCp[i][2].GetPixel(k) // subpart[ i ][ 1 ]
                     * nit_RCI.GetPixel(k);     // c(k)
-          if (ImageDimension == 3)
+          if constexpr (ImageDimension == 3)
           {
             tmp[i] += Operator_F.GetElement(k)   // FF *
                       * nitLCp[i][3].GetPixel(k) // subpart[ i ][ 1 ]
@@ -2218,7 +2218,7 @@ TransformRigidityPenaltyTerm<TFixedImage, TScalarType>::CreateNDOperator(
    */
   if (WhichF == "FA")
   {
-    if (ImageDimension == 2)
+    if constexpr (ImageDimension == 2)
     {
       F[0] = 1.0 / 12.0 / s[0];
       F[1] = 0.0;
@@ -2230,7 +2230,7 @@ TransformRigidityPenaltyTerm<TFixedImage, TScalarType>::CreateNDOperator(
       F[7] = 0.0;
       F[8] = -1.0 / 12.0 / s[0];
     }
-    else if (ImageDimension == 3)
+    else if constexpr (ImageDimension == 3)
     {
       /** Fill the operator. First slice. */
       F[0] = 1.0 / 72.0 / s[0];
@@ -2266,7 +2266,7 @@ TransformRigidityPenaltyTerm<TFixedImage, TScalarType>::CreateNDOperator(
   }
   else if (WhichF == "FB")
   {
-    if (ImageDimension == 2)
+    if constexpr (ImageDimension == 2)
     {
       F[0] = 1.0 / 12.0 / s[1];
       F[1] = 1.0 / 3.0 / s[1];
@@ -2278,7 +2278,7 @@ TransformRigidityPenaltyTerm<TFixedImage, TScalarType>::CreateNDOperator(
       F[7] = -1.0 / 3.0 / s[1];
       F[8] = -1.0 / 12.0 / s[1];
     }
-    else if (ImageDimension == 3)
+    else if constexpr (ImageDimension == 3)
     {
       /** Fill the operator. First slice. */
       F[0] = 1.0 / 72.0 / s[1];
@@ -2314,12 +2314,12 @@ TransformRigidityPenaltyTerm<TFixedImage, TScalarType>::CreateNDOperator(
   }
   else if (WhichF == "FC")
   {
-    if (ImageDimension == 2)
+    if constexpr (ImageDimension == 2)
     {
       /** Not appropriate. Throw an exception. */
       itkExceptionMacro("This type of operator (FC) is not appropriate in 2D.");
     }
-    else if (ImageDimension == 3)
+    else if constexpr (ImageDimension == 3)
     {
       /** Fill the operator. First slice. */
       F[0] = 1.0 / 72.0 / s[2];
@@ -2355,7 +2355,7 @@ TransformRigidityPenaltyTerm<TFixedImage, TScalarType>::CreateNDOperator(
   }
   else if (WhichF == "FD")
   {
-    if (ImageDimension == 2)
+    if constexpr (ImageDimension == 2)
     {
       double sp = s[0] * s[0];
       F[0] = 1.0 / 12.0 / sp;
@@ -2368,7 +2368,7 @@ TransformRigidityPenaltyTerm<TFixedImage, TScalarType>::CreateNDOperator(
       F[7] = -1.0 / 6.0 / sp;
       F[8] = 1.0 / 12.0 / sp;
     }
-    else if (ImageDimension == 3)
+    else if constexpr (ImageDimension == 3)
     {
       double sp = s[0] * s[0];
       /** Fill the operator. First slice. */
@@ -2405,7 +2405,7 @@ TransformRigidityPenaltyTerm<TFixedImage, TScalarType>::CreateNDOperator(
   }
   else if (WhichF == "FE")
   {
-    if (ImageDimension == 2)
+    if constexpr (ImageDimension == 2)
     {
       double sp = s[1] * s[1];
       F[0] = 1.0 / 12.0 / sp;
@@ -2418,7 +2418,7 @@ TransformRigidityPenaltyTerm<TFixedImage, TScalarType>::CreateNDOperator(
       F[7] = 1.0 / 3.0 / sp;
       F[8] = 1.0 / 12.0 / sp;
     }
-    else if (ImageDimension == 3)
+    else if constexpr (ImageDimension == 3)
     {
       double sp = s[1] * s[1];
       /** Fill the operator. First slice. */
@@ -2455,12 +2455,12 @@ TransformRigidityPenaltyTerm<TFixedImage, TScalarType>::CreateNDOperator(
   }
   else if (WhichF == "FF")
   {
-    if (ImageDimension == 2)
+    if constexpr (ImageDimension == 2)
     {
       /** Not appropriate. Throw an exception. */
       itkExceptionMacro("This type of operator (FF) is not appropriate in 2D.");
     }
-    else if (ImageDimension == 3)
+    else if constexpr (ImageDimension == 3)
     {
       double sp = s[2] * s[2];
       /** Fill the operator. First slice. */
@@ -2497,7 +2497,7 @@ TransformRigidityPenaltyTerm<TFixedImage, TScalarType>::CreateNDOperator(
   }
   else if (WhichF == "FG")
   {
-    if (ImageDimension == 2)
+    if constexpr (ImageDimension == 2)
     {
       double sp = s[0] * s[1];
       F[0] = 1.0 / 4.0 / sp;
@@ -2510,7 +2510,7 @@ TransformRigidityPenaltyTerm<TFixedImage, TScalarType>::CreateNDOperator(
       F[7] = 0.0;
       F[8] = 1.0 / 4.0 / sp;
     }
-    else if (ImageDimension == 3)
+    else if constexpr (ImageDimension == 3)
     {
       double sp = s[0] * s[1];
       /** Fill the operator. First slice. */
@@ -2547,12 +2547,12 @@ TransformRigidityPenaltyTerm<TFixedImage, TScalarType>::CreateNDOperator(
   }
   else if (WhichF == "FH")
   {
-    if (ImageDimension == 2)
+    if constexpr (ImageDimension == 2)
     {
       /** Not appropriate. Throw an exception. */
       itkExceptionMacro("This type of operator (FH) is not appropriate in 2D.");
     }
-    else if (ImageDimension == 3)
+    else if constexpr (ImageDimension == 3)
     {
       double sp = s[0] * s[2];
       /** Fill the operator. First slice. */
@@ -2589,12 +2589,12 @@ TransformRigidityPenaltyTerm<TFixedImage, TScalarType>::CreateNDOperator(
   }
   else if (WhichF == "FI")
   {
-    if (ImageDimension == 2)
+    if constexpr (ImageDimension == 2)
     {
       /** Not appropriate. Throw an exception. */
       itkExceptionMacro("This type of operator (FI) is not appropriate in 2D.");
     }
-    else if (ImageDimension == 3)
+    else if constexpr (ImageDimension == 3)
     {
       double sp = s[1] * s[2];
       /** Fill the operator. First slice. */

--- a/Components/MovingImagePyramids/OpenCLMovingGenericPyramid/elxOpenCLMovingGenericPyramid.hxx
+++ b/Components/MovingImagePyramids/OpenCLMovingGenericPyramid/elxOpenCLMovingGenericPyramid.hxx
@@ -52,7 +52,7 @@ OpenCLMovingGenericPyramid<TElastix>::OpenCLMovingGenericPyramid()
   // it is not beneficial to create pyramids for 2D images with OpenCL.
   // There are also small extra overhead and potential problems may appear.
   // To avoid it, we simply run it on CPU for 2D images.
-  if (ImageDimension <= 2)
+  if constexpr (ImageDimension <= 2)
   {
     log::warn(
       std::ostringstream{} << "WARNING: Creating the moving pyramid with OpenCL for 2D images is not beneficial.\n"

--- a/Components/Transforms/AdvancedAffineTransform/elxAdvancedAffineTransform.hxx
+++ b/Components/Transforms/AdvancedAffineTransform/elxAdvancedAffineTransform.hxx
@@ -264,7 +264,7 @@ AdvancedAffineTransformElastix<TElastix>::InitializeTransform()
     }
     else if (method == "GeometryTop")
     {
-      if (SpaceDimension < 3)
+      if constexpr (SpaceDimension < 3)
       {
         /** Check if dimension is 3D or higher. **/
         itkExceptionMacro("ERROR: The GeometryTop intialization method does not make sense for 2D images. Use only "

--- a/Components/Transforms/AdvancedAffineTransform/itkCenteredTransformInitializer2.hxx
+++ b/Components/Transforms/AdvancedAffineTransform/itkCenteredTransformInitializer2.hxx
@@ -211,13 +211,13 @@ CenteredTransformInitializer2<TTransform, TFixedImage, TMovingImage>::Initialize
         {
           fixedCorners[index][0] = fixedRegion.GetIndex()[0] + x * fixedRegion.GetSize()[0];
           fixedCorners[index][1] = fixedRegion.GetIndex()[1] + y * fixedRegion.GetSize()[1];
-          if (InputSpaceDimension > 2)
+          if constexpr (InputSpaceDimension > 2)
           {
             fixedCorners[index][2] = fixedRegion.GetIndex()[2] + z * fixedRegion.GetSize()[2];
           }
           movingCorners[index][0] = movingRegion.GetIndex()[0] + x * movingRegion.GetSize()[0];
           movingCorners[index][1] = movingRegion.GetIndex()[1] + y * movingRegion.GetSize()[1];
-          if (InputSpaceDimension > 2)
+          if constexpr (InputSpaceDimension > 2)
           {
             movingCorners[index][2] = movingRegion.GetIndex()[2] + z * movingRegion.GetSize()[2];
           }

--- a/Components/Transforms/AffineDTITransform/elxAffineDTITransform.hxx
+++ b/Components/Transforms/AffineDTITransform/elxAffineDTITransform.hxx
@@ -44,7 +44,7 @@ template <class TElastix>
 void
 AffineDTITransformElastix<TElastix>::BeforeRegistration()
 {
-  if (SpaceDimension != 2 && SpaceDimension != 3)
+  if constexpr (SpaceDimension != 2 && SpaceDimension != 3)
   {
     itkExceptionMacro("AffineDTI transform only works for 2D or 3D images!");
   }

--- a/Components/Transforms/EulerTransform/elxEulerTransform.hxx
+++ b/Components/Transforms/EulerTransform/elxEulerTransform.hxx
@@ -84,7 +84,7 @@ EulerTransformElastix<TElastix>::ReadFromFile()
     this->m_EulerTransform->SetCenter(centerOfRotationPoint);
 
     /** Read the ComputeZYX. */
-    if (SpaceDimension == 3)
+    if constexpr (SpaceDimension == 3)
     {
       std::string computeZYX = "false";
       this->m_Configuration->ReadParameter(computeZYX, "ComputeZYX", 0);
@@ -116,7 +116,7 @@ EulerTransformElastix<TElastix>::CreateDerivedTransformParameterMap() const -> P
                                    Conversion::ToVectorOfStrings(m_EulerTransform->GetCenter()) } };
 
   /** Write the ComputeZYX to file. */
-  if (SpaceDimension == 3)
+  if constexpr (SpaceDimension == 3)
   {
     parameterMap["ComputeZYX"] = { Conversion::ToString(m_EulerTransform->GetComputeZYX()) };
   }
@@ -334,7 +334,7 @@ EulerTransformElastix<TElastix>::SetScales()
      * If the Dimension is 2, only the first parameter represent a rotation.
      */
     unsigned int RotationPart = 3;
-    if (SpaceDimension == 2)
+    if constexpr (SpaceDimension == 2)
     {
       RotationPart = 1;
     }

--- a/Components/Transforms/SimilarityTransform/elxSimilarityTransform.hxx
+++ b/Components/Transforms/SimilarityTransform/elxSimilarityTransform.hxx
@@ -298,12 +298,12 @@ SimilarityTransformElastix<TElastix>::SetScales()
      */
 
     /** Create the scales and set to default values. */
-    if (SpaceDimension == 2)
+    if constexpr (SpaceDimension == 2)
     {
       newscales[0] = 10000.0;
       newscales[1] = 100000.0;
     }
-    else if (SpaceDimension == 3)
+    else if constexpr (SpaceDimension == 3)
     {
       newscales[6] = 10000.0;
       for (unsigned int i = 0; i < 3; ++i)

--- a/Components/Transforms/SplineKernelTransform/elxSplineKernelTransform.hxx
+++ b/Components/Transforms/SplineKernelTransform/elxSplineKernelTransform.hxx
@@ -52,7 +52,7 @@ SplineKernelTransform<TElastix>::SetKernelType(const std::string & kernelType)
    * appropriate for 2D and the normal for 3D
    * \todo: understand why
    */
-  if (SpaceDimension == 2)
+  if constexpr (SpaceDimension == 2)
   {
     /** only one variant for 2D possible: */
     this->m_KernelTransform = TPRKernelTransformType::New();

--- a/Testing/itkAdvancedLinearInterpolatorTest.cxx
+++ b/Testing/itkAdvancedLinearInterpolatorTest.cxx
@@ -76,12 +76,12 @@ TestInterpolators()
 
   /** Make sure to test for non-identity direction cosines. */
   DirectionType direction{};
-  if (Dimension == 2)
+  if constexpr (Dimension == 2)
   {
     direction[0][1] = -1.0;
     direction[1][0] = 1.0;
   }
-  else if (Dimension == 3)
+  else if constexpr (Dimension == 3)
   {
     direction[0][2] = -1.0;
     direction[1][1] = 1.0;
@@ -123,7 +123,7 @@ TestInterpolators()
   /** Test some points. */
   const unsigned int count = 12;
   double             darray1[12][Dimension];
-  if (Dimension == 2)
+  if constexpr (Dimension == 2)
   {
     double darray2[12][2] = { { 0.1, 0.2 }, { 3.4, 5.8 }, { 4.0, 6.0 }, { 2.1, 8.0 },  { -0.1, -0.1 }, { 0.0, 0.0 },
                               { 1.3, 1.0 }, { 2.0, 5.7 }, { 9.5, 9.1 }, { 2.0, -0.1 }, { -0.1, 2.0 },  { 12.7, 15.3 } };
@@ -135,7 +135,7 @@ TestInterpolators()
       }
     }
   }
-  else if (Dimension == 3)
+  else if constexpr (Dimension == 3)
   {
     // double darray2[count][3] =
     //{ { 0.0, 0.0, 0.0}, { 0.1, 0.0, 0.0}, { 0.2, 0.0, 0.0} }; // x, y=z=0, works

--- a/Testing/itkGPUResampleImageFilterTest.cxx
+++ b/Testing/itkGPUResampleImageFilterTest.cxx
@@ -183,7 +183,7 @@ DefineAffineParameters(typename AffineTransformType::ParametersType & parameters
   // Setup parameters
   parameters.SetSize(Dimension * Dimension + Dimension);
   unsigned int par = 0;
-  if (Dimension == 2)
+  if constexpr (Dimension == 2)
   {
     const double matrix[] = {
       0.9, 0.1, // matrix part
@@ -196,7 +196,7 @@ DefineAffineParameters(typename AffineTransformType::ParametersType & parameters
       parameters[par++] = matrix[i];
     }
   }
-  else if (Dimension == 3)
+  else if constexpr (Dimension == 3)
   {
     const double matrix[] = {
       1.0,    -0.045, 0.02,  // matrix part
@@ -283,13 +283,13 @@ DefineEulerParameters(const std::size_t transformIndex, typename EulerTransformT
   const double angle = (double)transformIndex * -0.05;
 
   std::size_t par = 0;
-  if (Dimension == 2)
+  if constexpr (Dimension == 2)
   {
     // See implementation of Rigid2DTransform::SetParameters()
     parameters[0] = angle;
     ++par;
   }
-  else if (Dimension == 3)
+  else if constexpr (Dimension == 3)
   {
     // See implementation of Rigid3DTransform::SetParameters()
     for (std::size_t i = 0; i < 3; ++i)
@@ -323,13 +323,13 @@ DefineSimilarityParameters(const std::size_t                                  tr
   const double scale = ((double)transformIndex + 1.0) * 0.05 + 1.0;
   const double angle = (double)transformIndex * -0.06;
 
-  if (Dimension == 2)
+  if constexpr (Dimension == 2)
   {
     // See implementation of Similarity2DTransform::SetParameters()
     parameters[0] = scale;
     parameters[1] = angle;
   }
-  else if (Dimension == 3)
+  else if constexpr (Dimension == 3)
   {
     // See implementation of Similarity3DTransform::SetParameters()
     for (std::size_t i = 0; i < Dimension; ++i)

--- a/Testing/itkMevisDicomTiffImageIOTest.cxx
+++ b/Testing/itkMevisDicomTiffImageIOTest.cxx
@@ -67,7 +67,7 @@ testMevis()
     direction[i][i] = 1.0; // default, will be changed below
   }
   // 4th dimension origin/spacing are lost using dcm/tiff format!
-  if (Dimension == 4)
+  if constexpr (Dimension == 4)
   {
     // default values
     spacing[3] = 1.0;
@@ -75,7 +75,7 @@ testMevis()
   }
 
   // Difficult direction cosines:
-  if (Dimension == 2)
+  if constexpr (Dimension == 2)
   {
     // Test flips
     direction[0][0] = 1;
@@ -83,7 +83,7 @@ testMevis()
     direction[1][0] = 0;
     direction[1][1] = -1;
   }
-  else if (Dimension == 3)
+  else if constexpr (Dimension == 3)
   {
     // Test axis permutations
     // RM: won't work, because dicom always assume right hand
@@ -105,7 +105,7 @@ testMevis()
     direction[2][1] = 1;
     direction[2][2] = 0;
   }
-  else if (Dimension == 4)
+  else if constexpr (Dimension == 4)
   {
     // Test 4D. RM: also make sure it is a right hand coordinate system
     direction[0][0] = 1;


### PR DESCRIPTION
Ensures that the `if` is evaluated at compile-time. Might (slightly) improve compile-time or run-time performance.

Cases found by the regular expression ` if \(\w*Dimension `.