### PR TITLE
Fix warnings from "itkPCAMetric.h" and "itkPCAMetric.hxx"

### DIFF
--- a/Components/Metrics/PCAMetric/itkPCAMetric.h
+++ b/Components/Metrics/PCAMetric/itkPCAMetric.h
@@ -112,31 +112,31 @@ public:
   itkStaticConstMacro(MovingImageDimension, unsigned int, MovingImageType::ImageDimension);
 
   /** Get the value for single valued optimizers. */
-  virtual MeasureType
-  GetValue(const TransformParametersType & parameters) const;
+  MeasureType
+  GetValue(const TransformParametersType & parameters) const override;
 
   /** Get the derivatives of the match measure. */
-  virtual void
-  GetDerivative(const TransformParametersType & parameters, DerivativeType & derivative) const;
+  void
+  GetDerivative(const TransformParametersType & parameters, DerivativeType & derivative) const override;
 
   /** Get value and derivatives for multiple valued optimizers. */
-  virtual void
+  void
   GetValueAndDerivative(const TransformParametersType & parameters,
                         MeasureType &                   Value,
-                        DerivativeType &                Derivative) const;
+                        DerivativeType &                Derivative) const override;
 
   /** Initialize the Metric by making sure that all the components
    *  are present and plugged together correctly.
    * \li Call the superclass' implementation.   */
 
-  virtual void
-  Initialize();
+  void
+  Initialize() override;
 
 protected:
   PCAMetric();
   virtual ~PCAMetric() {}
   void
-  PrintSelf(std::ostream & os, Indent indent) const;
+  PrintSelf(std::ostream & os, Indent indent) const override;
 
   /** Protected Typedefs ******************/
 
@@ -159,7 +159,7 @@ protected:
   void
   EvaluateTransformJacobianInnerProduct(const TransformJacobianType &     jacobian,
                                         const MovingImageDerivativeType & movingImageDerivative,
-                                        DerivativeType &                  imageJacobian) const;
+                                        DerivativeType &                  imageJacobian) const override;
 
   mutable vnl_vector<double> m_firstEigenVector{};
   mutable vnl_vector<double> m_secondEigenVector{};

--- a/Components/Metrics/PCAMetric/itkPCAMetric.h
+++ b/Components/Metrics/PCAMetric/itkPCAMetric.h
@@ -92,6 +92,7 @@ public:
   using typename Superclass::MovingImageMaskPointer;
   using typename Superclass::MeasureType;
   using typename Superclass::DerivativeType;
+  using typename Superclass::DerivativeValueType;
   using typename Superclass::ParametersType;
   using typename Superclass::FixedImagePixelType;
   using typename Superclass::MovingImageRegionType;

--- a/Components/Metrics/PCAMetric/itkPCAMetric.hxx
+++ b/Components/Metrics/PCAMetric/itkPCAMetric.hxx
@@ -218,8 +218,8 @@ PCAMetric<TFixedImage, TMovingImage>::GetValue(const TransformParametersType & p
     FixedImagePointType fixedPoint = fixedImageSample.m_ImageCoordinates;
 
     /** Transform sampled point to voxel coordinates. */
-    FixedImageContinuousIndexType voxelCoord;
-    this->GetFixedImage()->TransformPhysicalPointToContinuousIndex(fixedPoint, voxelCoord);
+    FixedImageContinuousIndexType voxelCoord =
+      this->GetFixedImage()->template TransformPhysicalPointToContinuousIndex<CoordinateRepresentationType>(fixedPoint);
 
     unsigned int numSamplesOk = 0;
 
@@ -457,8 +457,8 @@ PCAMetric<TFixedImage, TMovingImage>::GetValueAndDerivative(const TransformParam
     FixedImagePointType fixedPoint = fixedImageSample.m_ImageCoordinates;
 
     /** Transform sampled point to voxel coordinates. */
-    FixedImageContinuousIndexType voxelCoord;
-    this->GetFixedImage()->TransformPhysicalPointToContinuousIndex(fixedPoint, voxelCoord);
+    FixedImageContinuousIndexType voxelCoord =
+      this->GetFixedImage()->template TransformPhysicalPointToContinuousIndex<CoordinateRepresentationType>(fixedPoint);
 
     const unsigned int G = lastDimPositions.size();
     unsigned int       numSamplesOk = 0;
@@ -662,8 +662,8 @@ PCAMetric<TFixedImage, TMovingImage>::GetValueAndDerivative(const TransformParam
     ++startSamplesOK;
 
     /** Transform sampled point to voxel coordinates. */
-    FixedImageContinuousIndexType voxelCoord;
-    this->GetFixedImage()->TransformPhysicalPointToContinuousIndex(fixedPoint, voxelCoord);
+    FixedImageContinuousIndexType voxelCoord =
+      this->GetFixedImage()->template TransformPhysicalPointToContinuousIndex<CoordinateRepresentationType>(fixedPoint);
 
     const unsigned int G = lastDimPositions.size();
 

--- a/Components/Metrics/PCAMetric/itkPCAMetric.hxx
+++ b/Components/Metrics/PCAMetric/itkPCAMetric.hxx
@@ -272,9 +272,9 @@ PCAMetric<TFixedImage, TMovingImage>::GetValue(const TransformParametersType & p
   /** Calculate mean of from columns */
   vnl_vector<RealType> mean(G);
   mean.fill(RealType{});
-  for (int i = 0; i < N; ++i)
+  for (unsigned int i = 0; i < N; ++i)
   {
-    for (int j = 0; j < G; ++j)
+    for (unsigned int j = 0; j < G; ++j)
     {
       mean(j) += A(i, j);
     }
@@ -284,9 +284,9 @@ PCAMetric<TFixedImage, TMovingImage>::GetValue(const TransformParametersType & p
   MatrixType Amm(N, G);
   Amm.fill(RealType{});
 
-  for (int i = 0; i < N; ++i)
+  for (unsigned int i = 0; i < N; ++i)
   {
-    for (int j = 0; j < G; ++j)
+    for (unsigned int j = 0; j < G; ++j)
     {
       Amm(i, j) = A(i, j) - mean(j);
     }
@@ -312,7 +312,7 @@ PCAMetric<TFixedImage, TMovingImage>::GetValue(const TransformParametersType & p
   /** Calculate variance of columns */
   vnl_vector<RealType> var(G);
   var.fill(RealType{});
-  for (int j = 0; j < G; ++j)
+  for (unsigned int j = 0; j < G; ++j)
   {
     var(j) = C(j, j);
   }
@@ -320,12 +320,12 @@ PCAMetric<TFixedImage, TMovingImage>::GetValue(const TransformParametersType & p
 
   MatrixType S(G, G);
   S.fill(RealType{});
-  for (int j = 0; j < G; ++j)
+  for (unsigned int j = 0; j < G; ++j)
   {
     S(j, j) = 1.0 / sqrt(var(j));
   }
 
-  for (int j = 0; j < G; ++j)
+  for (unsigned int j = 0; j < G; ++j)
   {
     C(j, j) -= varNoise;
   }
@@ -513,9 +513,9 @@ PCAMetric<TFixedImage, TMovingImage>::GetValueAndDerivative(const TransformParam
   /** Calculate mean of from columns */
   vnl_vector<RealType> mean(G);
   mean.fill(RealType{});
-  for (int i = 0; i < N; ++i)
+  for (unsigned int i = 0; i < N; ++i)
   {
-    for (int j = 0; j < G; ++j)
+    for (unsigned int j = 0; j < G; ++j)
     {
       mean(j) += A(i, j);
     }
@@ -525,9 +525,9 @@ PCAMetric<TFixedImage, TMovingImage>::GetValueAndDerivative(const TransformParam
   /** Calculate standard deviation from columns */
   MatrixType Amm(N, G);
   Amm.fill(RealType{});
-  for (int i = 0; i < N; ++i)
+  for (unsigned int i = 0; i < N; ++i)
   {
-    for (int j = 0; j < G; ++j)
+    for (unsigned int j = 0; j < G; ++j)
     {
       Amm(i, j) = A(i, j) - mean(j);
     }
@@ -550,7 +550,7 @@ PCAMetric<TFixedImage, TMovingImage>::GetValueAndDerivative(const TransformParam
   /** Calculate standard deviation from columns */
   vnl_vector<RealType> var(G);
   var.fill(RealType{});
-  for (int j = 0; j < G; ++j)
+  for (unsigned int j = 0; j < G; ++j)
   {
     var(j) = C(j, j);
   }
@@ -558,12 +558,12 @@ PCAMetric<TFixedImage, TMovingImage>::GetValueAndDerivative(const TransformParam
 
   vnl_diag_matrix<RealType> S(G);
   S.fill(RealType{});
-  for (int j = 0; j < G; ++j)
+  for (unsigned int j = 0; j < G; ++j)
   {
     S(j, j) = 1.0 / sqrt(var(j));
   }
 
-  for (int j = 0; j < G; ++j)
+  for (unsigned int j = 0; j < G; ++j)
   {
     C(j, j) -= varNoise;
   }

--- a/Components/Metrics/PCAMetric/itkPCAMetric.hxx
+++ b/Components/Metrics/PCAMetric/itkPCAMetric.hxx
@@ -508,26 +508,28 @@ PCAMetric<TFixedImage, TMovingImage>::GetValueAndDerivative(const TransformParam
 
   MatrixType A(datablock.extract(N, realNumLastDimPositions));
 
-  /** Calculate mean of from columns */
-  vnl_vector<RealType> mean(realNumLastDimPositions);
-  mean.fill(RealType{});
-  for (unsigned int i = 0; i < N; ++i)
-  {
-    for (unsigned int j = 0; j < realNumLastDimPositions; ++j)
-    {
-      mean(j) += A(i, j);
-    }
-  }
-  mean /= RealType(N);
-
   /** Calculate standard deviation from columns */
   MatrixType Amm(N, realNumLastDimPositions);
   Amm.fill(RealType{});
-  for (unsigned int i = 0; i < N; ++i)
   {
-    for (unsigned int j = 0; j < realNumLastDimPositions; ++j)
+    /** Calculate mean of from columns */
+    vnl_vector<RealType> mean(realNumLastDimPositions);
+    mean.fill(RealType{});
+    for (unsigned int i = 0; i < N; ++i)
     {
-      Amm(i, j) = A(i, j) - mean(j);
+      for (unsigned int j = 0; j < realNumLastDimPositions; ++j)
+      {
+        mean(j) += A(i, j);
+      }
+    }
+    mean /= RealType(N);
+
+    for (unsigned int i = 0; i < N; ++i)
+    {
+      for (unsigned int j = 0; j < realNumLastDimPositions; ++j)
+      {
+        Amm(i, j) = A(i, j) - mean(j);
+      }
     }
   }
 

--- a/Components/Metrics/PCAMetric/itkPCAMetric.hxx
+++ b/Components/Metrics/PCAMetric/itkPCAMetric.hxx
@@ -152,7 +152,6 @@ PCAMetric<TFixedImage, TMovingImage>::GetValue(const TransformParametersType & p
 
   if (UseGetValueAndDerivative)
   {
-    using DerivativeValueType = typename DerivativeType::ValueType;
     const unsigned int P = this->GetNumberOfParameters();
     MeasureType        dummymeasure{};
     DerivativeType     dummyderivative = DerivativeType(P);
@@ -392,8 +391,7 @@ PCAMetric<TFixedImage, TMovingImage>::GetValueAndDerivative(const TransformParam
                                                             DerivativeType &                derivative) const
 {
   itkDebugMacro("GetValueAndDerivative( " << parameters << " ) ");
-  /** Define derivative and Jacobian types. */
-  using DerivativeValueType = typename DerivativeType::ValueType;
+  /** Define Jacobian type. */
   using TransformJacobianValueType = typename TransformJacobianType::ValueType;
 
   /** Initialize some variables */


### PR DESCRIPTION
Note that "itkPCAMetric.h" and "itkPCAMetric.hxx" appear superseded by "itkPCAMetric_F_multithreaded.h" and "itkPCAMetric_F_multithreaded.hxx", respectively.