### PR TITLE
PERF: Replace PlatformMultiThreader with MultiThreaderBase

### DIFF
--- a/Common/CostFunctions/itkAdvancedImageToImageMetric.h
+++ b/Common/CostFunctions/itkAdvancedImageToImageMetric.h
@@ -35,8 +35,6 @@
 #include "itkAdvancedBSplineDeformableTransform.h"
 #include "itkAdvancedCombinationTransform.h"
 
-#include "itkPlatformMultiThreader.h"
-
 #include <cassert>
 #include <memory> // For unique_ptr.
 #include <typeinfo>
@@ -168,9 +166,8 @@ public:
   using BSplineOrder2TransformPointer = typename BSplineOrder2TransformType::Pointer;
   using BSplineOrder3TransformPointer = typename BSplineOrder3TransformType::Pointer;
 
-  /** Typedefs for multi-threading. */
-  using ThreaderType = itk::PlatformMultiThreader;
-  using ThreadInfoType = typename ThreaderType::WorkUnitInfo;
+  /** Typedef for multi-threading. */
+  using ThreadInfoType = MultiThreaderBase::WorkUnitInfo;
 
   /** Public methods ********************/
 

--- a/Common/CostFunctions/itkParzenWindowHistogramImageToImageMetric.h
+++ b/Common/CostFunctions/itkParzenWindowHistogramImageToImageMetric.h
@@ -126,7 +126,6 @@ public:
   using typename Superclass::FixedImageLimiterOutputType;
   using typename Superclass::MovingImageLimiterOutputType;
   using typename Superclass::MovingImageDerivativeScalesType;
-  using typename Superclass::ThreaderType;
   using typename Superclass::ThreadInfoType;
 
   /** The fixed image dimension. */

--- a/Common/CostFunctions/itkTransformPenaltyTerm.h
+++ b/Common/CostFunctions/itkTransformPenaltyTerm.h
@@ -90,7 +90,6 @@ public:
   using typename Superclass::FixedImagePixelType;
   using typename Superclass::ImageSampleContainerType;
   using typename Superclass::ImageSampleContainerPointer;
-  using typename Superclass::ThreaderType;
   using typename Superclass::ThreadInfoType;
 
   /** Typedef's for the B-spline transform. */

--- a/Common/Transforms/itkAdvancedImageMomentsCalculator.h
+++ b/Common/Transforms/itkAdvancedImageMomentsCalculator.h
@@ -30,7 +30,7 @@
 #include <vnl/vnl_matrix_fixed.h>
 #include <vnl/vnl_diag_matrix.h>
 
-#include "itkPlatformMultiThreader.h"
+#include "itkMultiThreaderBase.h"
 
 #include <vector>
 
@@ -256,9 +256,8 @@ protected:
   void
   PrintSelf(std::ostream & os, Indent indent) const override;
 
-  /** Typedefs for multi-threading. */
-  using ThreaderType = itk::PlatformMultiThreader;
-  using ThreadInfoType = ThreaderType::WorkUnitInfo;
+  /** Typedef for multi-threading. */
+  using ThreadInfoType = MultiThreaderBase::WorkUnitInfo;
 
   /** Launch MultiThread Compute. */
   void
@@ -308,7 +307,7 @@ private:
   void
   operator=(const Self &);
 
-  ThreaderType::Pointer m_Threader{};
+  MultiThreaderBase::Pointer m_Threader{};
 
   mutable MultiThreaderParameterType m_ThreaderParameters{};
 

--- a/Common/Transforms/itkAdvancedImageMomentsCalculator.hxx
+++ b/Common/Transforms/itkAdvancedImageMomentsCalculator.hxx
@@ -46,7 +46,7 @@ AdvancedImageMomentsCalculator<TImage>::AdvancedImageMomentsCalculator()
 
   /** Threading related variables. */
   this->m_UseMultiThread = true;
-  this->m_Threader = ThreaderType::New();
+  this->m_Threader = MultiThreaderBase::New();
 
   /** Initialize the m_ThreaderParameters. */
   this->m_ThreaderParameters.st_Self = this;

--- a/Common/itkComputeDisplacementDistribution.h
+++ b/Common/itkComputeDisplacementDistribution.h
@@ -24,7 +24,7 @@
 #include "itkImageRandomSamplerBase.h"
 #include "itkImageRandomCoordinateSampler.h"
 #include "itkImageFullSampler.h"
-#include "itkPlatformMultiThreader.h"
+#include "itkMultiThreaderBase.h"
 
 #include <vector>
 
@@ -138,9 +138,8 @@ protected:
   ComputeDisplacementDistribution();
   ~ComputeDisplacementDistribution() override = default;
 
-  /** Typedefs for multi-threading. */
-  using ThreaderType = itk::PlatformMultiThreader;
-  using ThreadInfoType = ThreaderType::WorkUnitInfo;
+  /** Typedef for multi-threading. */
+  using ThreadInfoType = MultiThreaderBase::WorkUnitInfo;
 
   typename FixedImageType::ConstPointer   m_FixedImage{};
   FixedImageRegionType                    m_FixedImageRegion{};
@@ -150,7 +149,7 @@ protected:
   SizeValueType                           m_NumberOfJacobianMeasurements{};
   DerivativeType                          m_ExactGradient{};
   SizeValueType                           m_NumberOfParameters{};
-  ThreaderType::Pointer                   m_Threader{};
+  MultiThreaderBase::Pointer              m_Threader{};
 
   using FixedImageIndexType = typename FixedImageType::IndexType;
   using FixedImagePointType = typename FixedImageType::PointType;

--- a/Common/itkComputeDisplacementDistribution.hxx
+++ b/Common/itkComputeDisplacementDistribution.hxx
@@ -53,7 +53,7 @@ ComputeDisplacementDistribution<TFixedImage, TTransform>::ComputeDisplacementDis
 
   /** Threading related variables. */
   this->m_UseMultiThread = true;
-  this->m_Threader = ThreaderType::New();
+  this->m_Threader = MultiThreaderBase::New();
 
   /** Initialize the m_ThreaderParameters. */
   this->m_ThreaderParameters.st_Self = this;

--- a/Components/Metrics/AdvancedKappaStatistic/itkAdvancedKappaStatisticImageToImageMetric.h
+++ b/Components/Metrics/AdvancedKappaStatistic/itkAdvancedKappaStatisticImageToImageMetric.h
@@ -112,7 +112,6 @@ public:
   using typename Superclass::FixedImageLimiterOutputType;
   using typename Superclass::MovingImageLimiterOutputType;
   using typename Superclass::MovingImageDerivativeScalesType;
-  using typename Superclass::ThreaderType;
   using typename Superclass::ThreadInfoType;
 
   /** The fixed image dimension. */

--- a/Components/Metrics/AdvancedMattesMutualInformation/itkParzenWindowMutualInformationImageToImageMetric.h
+++ b/Components/Metrics/AdvancedMattesMutualInformation/itkParzenWindowMutualInformationImageToImageMetric.h
@@ -130,7 +130,6 @@ public:
   using typename Superclass::FixedImageLimiterOutputType;
   using typename Superclass::MovingImageLimiterOutputType;
   using typename Superclass::MovingImageDerivativeScalesType;
-  using typename Superclass::ThreaderType;
   using typename Superclass::ThreadInfoType;
 
   /** The fixed image dimension. */

--- a/Components/Metrics/AdvancedMeanSquares/itkAdvancedMeanSquaresImageToImageMetric.h
+++ b/Components/Metrics/AdvancedMeanSquares/itkAdvancedMeanSquaresImageToImageMetric.h
@@ -107,7 +107,6 @@ public:
   using typename Superclass::FixedImageLimiterOutputType;
   using typename Superclass::MovingImageLimiterOutputType;
   using typename Superclass::MovingImageDerivativeScalesType;
-  using typename Superclass::ThreaderType;
   using typename Superclass::ThreadInfoType;
 
   /** The fixed image dimension. */

--- a/Components/Metrics/AdvancedNormalizedCorrelation/itkAdvancedNormalizedCorrelationImageToImageMetric.h
+++ b/Components/Metrics/AdvancedNormalizedCorrelation/itkAdvancedNormalizedCorrelationImageToImageMetric.h
@@ -146,7 +146,6 @@ public:
   using typename Superclass::FixedImageLimiterOutputType;
   using typename Superclass::MovingImageLimiterOutputType;
   using typename Superclass::MovingImageDerivativeScalesType;
-  using typename Superclass::ThreaderType;
   using typename Superclass::ThreadInfoType;
 
   /** The fixed image dimension. */

--- a/Components/Metrics/BendingEnergyPenalty/itkTransformBendingEnergyPenaltyTerm.h
+++ b/Components/Metrics/BendingEnergyPenalty/itkTransformBendingEnergyPenaltyTerm.h
@@ -99,7 +99,6 @@ public:
   using typename Superclass::ImageSampleContainerType;
   using typename Superclass::ImageSampleContainerPointer;
   using typename Superclass::ScalarType;
-  using typename Superclass::ThreaderType;
   using typename Superclass::ThreadInfoType;
 
   /** Typedef's for the B-spline transform. */

--- a/Components/Metrics/PCAMetric/itkPCAMetric_F_multithreaded.h
+++ b/Components/Metrics/PCAMetric/itkPCAMetric_F_multithreaded.h
@@ -93,7 +93,6 @@ public:
   using typename Superclass::MovingImageLimiterOutputType;
   using typename Superclass::MovingImageDerivativeScalesType;
   using typename Superclass::DerivativeValueType;
-  using typename Superclass::ThreaderType;
   using typename Superclass::ThreadInfoType;
 
   using MatrixType = vnl_matrix<RealType>;

--- a/Components/Metrics/PCAMetric/itkPCAMetric_F_multithreaded.hxx
+++ b/Components/Metrics/PCAMetric/itkPCAMetric_F_multithreaded.hxx
@@ -882,7 +882,7 @@ PCAMetric<TFixedImage, TMovingImage>::LaunchGetSamplesThreaderCallback() const
 {
   /** Setup local threader. */
   // \todo: is a global threader better performance-wise? check
-  auto local_threader = ThreaderType::New();
+  auto local_threader = MultiThreaderBase::New();
   local_threader->SetNumberOfWorkUnits(Self::GetNumberOfWorkUnits());
   local_threader->SetSingleMethodAndExecute(
     this->GetSamplesThreaderCallback,
@@ -1084,7 +1084,7 @@ PCAMetric<TFixedImage, TMovingImage>::LaunchComputeDerivativeThreaderCallback() 
 {
   /** Setup local threader and launch. */
   // \todo: is a global threader better performance-wise? check
-  auto local_threader = ThreaderType::New();
+  auto local_threader = MultiThreaderBase::New();
   local_threader->SetNumberOfWorkUnits(Self::GetNumberOfWorkUnits());
   local_threader->SetSingleMethodAndExecute(
     this->ComputeDerivativeThreaderCallback,

--- a/Components/Optimizers/AdaptiveStochasticLBFGS/elxAdaptiveStochasticLBFGS.h
+++ b/Components/Optimizers/AdaptiveStochasticLBFGS/elxAdaptiveStochasticLBFGS.h
@@ -26,7 +26,7 @@
 #include "itkMersenneTwisterRandomVariateGenerator.h"
 #include "itkComputeJacobianTerms.h"
 #include "itkComputeDisplacementDistribution.h"
-#include "itkPlatformMultiThreader.h"
+#include "itkMultiThreaderBase.h"
 #include "itkImageRandomSampler.h"
 #include "itkLineSearchOptimizer.h"
 #include "itkMoreThuenteLineSearchOptimizer.h"

--- a/Components/Optimizers/AdaptiveStochasticVarianceReducedGradient/elxAdaptiveStochasticVarianceReducedGradient.h
+++ b/Components/Optimizers/AdaptiveStochasticVarianceReducedGradient/elxAdaptiveStochasticVarianceReducedGradient.h
@@ -26,7 +26,7 @@
 #include "itkMersenneTwisterRandomVariateGenerator.h"
 #include "itkComputeJacobianTerms.h"
 #include "itkComputeDisplacementDistribution.h"
-#include "itkPlatformMultiThreader.h"
+#include "itkMultiThreaderBase.h"
 #include "itkImageRandomSampler.h"
 namespace elastix
 {

--- a/Components/Optimizers/AdaptiveStochasticVarianceReducedGradient/itkStochasticVarianceReducedGradientDescentOptimizer.cxx
+++ b/Components/Optimizers/AdaptiveStochasticVarianceReducedGradient/itkStochasticVarianceReducedGradientDescentOptimizer.cxx
@@ -289,7 +289,7 @@ StochasticVarianceReducedGradientDescentOptimizer::AdvanceOneStep()
     temp.t_Optimizer = this;
 
     /** Call multi-threaded AdvanceOneStep(). */
-    auto local_threader = ThreaderType::New();
+    auto local_threader = MultiThreaderBase::New();
     local_threader->SetNumberOfWorkUnits(this->m_Threader->GetNumberOfWorkUnits());
     local_threader->SetSingleMethodAndExecute(AdvanceOneStepThreaderCallback, &temp);
   }

--- a/Components/Optimizers/AdaptiveStochasticVarianceReducedGradient/itkStochasticVarianceReducedGradientDescentOptimizer.h
+++ b/Components/Optimizers/AdaptiveStochasticVarianceReducedGradient/itkStochasticVarianceReducedGradientDescentOptimizer.h
@@ -19,7 +19,7 @@
 #define itkStochasticVarianceReducedGradientDescentOptimizer_h
 
 #include "itkScaledSingleValuedNonLinearOptimizer.h"
-#include "itkPlatformMultiThreader.h"
+#include "itkMultiThreaderBase.h"
 
 namespace itk
 {
@@ -176,9 +176,8 @@ protected:
   void
   PrintSelf(std::ostream & os, Indent indent) const override;
 
-  /** Typedefs for multi-threading. */
-  using ThreaderType = itk::PlatformMultiThreader;
-  using ThreadInfoType = ThreaderType::WorkUnitInfo;
+  /** Typedef for multi-threading. */
+  using ThreadInfoType = MultiThreaderBase::WorkUnitInfo;
 
   // made protected so subclass can access
   double         m_Value{ 0.0 };
@@ -191,8 +190,8 @@ protected:
   StopConditionType m_StopCondition{ MaximumNumberOfIterations };
   DerivativeType    m_PreviousGradient{};
   // DerivativeType                m_PrePreviousGradient;
-  ParametersType        m_PreviousPosition{};
-  ThreaderType::Pointer m_Threader{ ThreaderType::New() };
+  ParametersType             m_PreviousPosition{};
+  MultiThreaderBase::Pointer m_Threader{ MultiThreaderBase::New() };
 
   bool          m_Stop{ false };
   unsigned long m_NumberOfIterations{ 100 };

--- a/Components/Optimizers/StandardStochasticGradientDescent/itkStochasticGradientDescentOptimizer.cxx
+++ b/Components/Optimizers/StandardStochasticGradientDescent/itkStochasticGradientDescentOptimizer.cxx
@@ -288,7 +288,7 @@ StochasticGradientDescentOptimizer::AdvanceOneStep()
     temp.t_Optimizer = this;
 
     /** Call multi-threaded AdvanceOneStep(). */
-    auto local_threader = ThreaderType::New();
+    auto local_threader = MultiThreaderBase::New();
     local_threader->SetNumberOfWorkUnits(this->m_Threader->GetNumberOfWorkUnits());
     local_threader->SetSingleMethodAndExecute(AdvanceOneStepThreaderCallback, &temp);
   }

--- a/Components/Optimizers/StandardStochasticGradientDescent/itkStochasticGradientDescentOptimizer.h
+++ b/Components/Optimizers/StandardStochasticGradientDescent/itkStochasticGradientDescentOptimizer.h
@@ -19,7 +19,7 @@
 #define itkStochasticGradientDescentOptimizer_h
 
 #include "itkScaledSingleValuedNonLinearOptimizer.h"
-#include "itkPlatformMultiThreader.h"
+#include "itkMultiThreaderBase.h"
 
 namespace itk
 {
@@ -177,23 +177,22 @@ protected:
   void
   PrintSelf(std::ostream & os, Indent indent) const override;
 
-  /** Typedefs for multi-threading. */
-  using ThreaderType = itk::PlatformMultiThreader;
-  using ThreadInfoType = ThreaderType::WorkUnitInfo;
+  /** Typedef for multi-threading. */
+  using ThreadInfoType = MultiThreaderBase::WorkUnitInfo;
 
   // made protected so subclass can access
-  double                m_Value{ 0.0 };
-  DerivativeType        m_Gradient{};
-  ParametersType        m_SearchDir{};
-  ParametersType        m_PreviousSearchDir{};
-  ParametersType        m_PrePreviousSearchDir{};
-  ParametersType        m_MeanSearchDir{};
-  double                m_LearningRate{ 1.0 };
-  StopConditionType     m_StopCondition{ MaximumNumberOfIterations };
-  DerivativeType        m_PreviousGradient{};
-  DerivativeType        m_PrePreviousGradient{};
-  ParametersType        m_PreviousPosition{};
-  ThreaderType::Pointer m_Threader{ ThreaderType::New() };
+  double                     m_Value{ 0.0 };
+  DerivativeType             m_Gradient{};
+  ParametersType             m_SearchDir{};
+  ParametersType             m_PreviousSearchDir{};
+  ParametersType             m_PrePreviousSearchDir{};
+  ParametersType             m_MeanSearchDir{};
+  double                     m_LearningRate{ 1.0 };
+  StopConditionType          m_StopCondition{ MaximumNumberOfIterations };
+  DerivativeType             m_PreviousGradient{};
+  DerivativeType             m_PrePreviousGradient{};
+  ParametersType             m_PreviousPosition{};
+  MultiThreaderBase::Pointer m_Threader{ MultiThreaderBase::New() };
 
   bool          m_Stop{ false };
   unsigned long m_NumberOfIterations{ 100 };

--- a/Components/Registrations/MultiMetricMultiResolutionRegistration/itkCombinationImageToImageMetric.h
+++ b/Components/Registrations/MultiMetricMultiResolutionRegistration/itkCombinationImageToImageMetric.h
@@ -150,8 +150,7 @@ public:
                                                               CoordinateRepresentationType>>;
   using PointSetMetricType = SingleValuedPointSetToPointSetMetric<FixedPointSetType, MovingPointSetType>;
 
-  /** Typedefs for multi-threading. */
-  using typename Superclass::ThreaderType;
+  /** Typedef for multi-threading. */
   using typename Superclass::ThreadInfoType;
 
   /**

--- a/Core/Kernel/elxMainBase.cxx
+++ b/Core/Kernel/elxMainBase.cxx
@@ -28,7 +28,7 @@
 #include "elxComponentLoader.h"
 
 #include "elxMacro.h"
-#include "itkPlatformMultiThreader.h"
+#include "itkMultiThreaderBase.h"
 
 #ifdef ELASTIX_USE_OPENCL
 #  include "itkOpenCLContext.h"

--- a/Testing/itkAccumulateDerivativesParallellizationTest.cxx
+++ b/Testing/itkAccumulateDerivativesParallellizationTest.cxx
@@ -28,7 +28,7 @@
 #include "itkTimeProbesCollectorBase.h"
 
 // Multi-threading using ITK threads
-#include "itkPlatformMultiThreader.h"
+#include "itkMultiThreaderBase.h"
 
 // Multi-threading using OpenMP
 #ifdef ELASTIX_USE_OPENMP
@@ -59,13 +59,13 @@ public:
   unsigned long                       m_NumberOfParameters;
   mutable std::vector<DerivativeType> m_ThreaderDerivatives;
 
-  using ThreaderType = itk::PlatformMultiThreader;
-  using ThreadInfoType = ThreaderType::WorkUnitInfo;
-  ThreaderType::Pointer m_Threader;
-  DerivativeValueType   m_NormalSum;
-  ThreadIdType          m_NumberOfThreads;
-  bool                  m_UseOpenMP;
-  bool                  m_UseMultiThreaded;
+  using ThreadInfoType = itk::MultiThreaderBase::WorkUnitInfo;
+
+  itk::MultiThreaderBase::Pointer m_Threader;
+  DerivativeValueType             m_NormalSum;
+  ThreadIdType                    m_NumberOfThreads;
+  bool                            m_UseOpenMP;
+  bool                            m_UseMultiThreaded;
 
   struct MultiThreaderParameterType
   {
@@ -85,7 +85,7 @@ public:
     this->m_ThreaderMetricParameters.st_NormalizationFactor = 0.0;
 
     this->m_NumberOfParameters = 0;
-    this->m_Threader = ThreaderType::New();
+    this->m_Threader = itk::MultiThreaderBase::New();
     this->m_NumberOfThreads = this->m_Threader->GetNumberOfWorkUnits();
     this->m_UseOpenMP = false;
     this->m_UseMultiThreaded = false;

--- a/Testing/itkAdvanceOneStepParallellizationTest.cxx
+++ b/Testing/itkAdvanceOneStepParallellizationTest.cxx
@@ -27,7 +27,7 @@
 #include "itkTimeProbesCollectorBase.h"
 
 // Multi-threading using ITK threads
-#include "itkPlatformMultiThreader.h"
+#include "itkMultiThreaderBase.h"
 
 // Multi-threading using OpenMP
 #ifdef ELASTIX_USE_OPENMP
@@ -72,12 +72,11 @@ public:
   ParametersType     m_Gradient;
   InternalScalarType m_LearningRate;
 
-  using ThreaderType = itk::PlatformMultiThreader;
-  using ThreadInfoType = ThreaderType::WorkUnitInfo;
-  ThreaderType::Pointer m_Threader;
-  bool                  m_UseOpenMP;
-  bool                  m_UseEigen;
-  bool                  m_UseMultiThreaded;
+  using ThreadInfoType = itk::MultiThreaderBase::WorkUnitInfo;
+  itk::MultiThreaderBase::Pointer m_Threader;
+  bool                            m_UseOpenMP;
+  bool                            m_UseEigen;
+  bool                            m_UseMultiThreaded;
 
   struct MultiThreaderParameterType
   {
@@ -89,7 +88,7 @@ public:
   {
     this->m_NumberOfParameters = 0;
     this->m_LearningRate = 0.0;
-    this->m_Threader = ThreaderType::New();
+    this->m_Threader = itk::MultiThreaderBase::New();
     this->m_Threader->SetNumberOfWorkUnits(8);
     this->m_UseOpenMP = false;
     this->m_UseEigen = false;


### PR DESCRIPTION
MultiThreaderBase typically uses a thread pool, by default. As set by `itk::MultiThreaderBase::GetGlobalDefaultThreaderPrivate()`: https://github.com/InsightSoftwareConsortium/ITK/blob/v5.4.0/Modules/Core/Common/src/itkMultiThreaderBase.cxx#L164

See also: "Platform multi-threader should be avoided, as it introduces the biggest overhead". https://github.com/InsightSoftwareConsortium/ITK/blob/v5.4.0/Modules/Core/Common/include/itkMultiThreaderBase.h#L199-L200