### PR TITLE
ENH: Add support ComputeZYX parameter to EulerStackTransform (for 3D)

### DIFF
--- a/Common/GTesting/elxTransformIOGTest.cxx
+++ b/Common/GTesting/elxTransformIOGTest.cxx
@@ -455,10 +455,16 @@ struct WithDimension
       { { "DeformationFieldFileName", { expectedDeformationFieldFileName } },
         { "DeformationFieldInterpolationOrder", { expectedZero } } });
     WithElastixTransform<EulerStackTransform>::Test_CreateTransformParameterMap_for_default_transform(
-      { { "CenterOfRotationPoint", ParameterValuesType(NDimension - 1, expectedZero) },
-        { "NumberOfSubTransforms", { expectedZero } },
-        { "StackOrigin", { expectedZero } },
-        { "StackSpacing", { expectedOne } } });
+      (NDimension == 4)
+        ? ParameterMapType{ { "CenterOfRotationPoint", ParameterValuesType(NDimension - 1, expectedZero) },
+                            { "ComputeZYX", { expectedFalse } },
+                            { "NumberOfSubTransforms", { expectedZero } },
+                            { "StackOrigin", { expectedZero } },
+                            { "StackSpacing", { expectedOne } } }
+        : ParameterMapType{ { "CenterOfRotationPoint", ParameterValuesType(NDimension - 1, expectedZero) },
+                            { "NumberOfSubTransforms", { expectedZero } },
+                            { "StackOrigin", { expectedZero } },
+                            { "StackSpacing", { expectedOne } } });
 
     WithElastixTransform<EulerTransformElastix>::Test_CreateTransformParameterMap_for_default_transform(
       (NDimension == 3)

--- a/Common/GTesting/elxTransformIOGTest.cxx
+++ b/Common/GTesting/elxTransformIOGTest.cxx
@@ -812,6 +812,7 @@ GTEST_TEST(Transform, CreateTransformParameterMapForDefaultTransform)
 {
   WithDimension<2>::Test_CreateTransformParameterMap_for_default_transform();
   WithDimension<3>::Test_CreateTransformParameterMap_for_default_transform();
+  WithDimension<4>::Test_CreateTransformParameterMap_for_default_transform();
 }
 
 


### PR DESCRIPTION
Supports specifying parameter `(ComputeZYX "true")`, when the transform is "EulerStackTransform" and the image stack is 4D (meaning that the images are 3D).

Triggered by a question from Laurens Beljaards.