### PR TITLE
DOC: Replace "elastix.lumc.nl" with "elastix.dev"

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -532,8 +532,8 @@ if(ELASTIX_ENABLE_PACKAGER)
     # Adding information
     set(CPACK_NSIS_DISPLAY_NAME
       "${CPACK_PACKAGE_INSTALL_DIRECTORY} elastix")
-    set(CPACK_NSIS_HELP_LINK "http:\\\\\\\\elastix.lumc.nl")
-    set(CPACK_NSIS_URL_INFO_ABOUT "http:\\\\\\\\elastix.lumc.nl")
+    set(CPACK_NSIS_HELP_LINK "http:\\\\\\\\elastix.dev")
+    set(CPACK_NSIS_URL_INFO_ABOUT "http:\\\\\\\\elastix.dev")
     set(CPACK_NSIS_CONTACT "elastix@bigr.nl")
     set(CPACK_NSIS_PACKAGE_NAME "elastix")
     set(CPACK_NSIS_DISPLAY_NAME "elastix")

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -9,7 +9,7 @@
 
 * Do not open an issue on GitHub for general questions, registration questions, or issues you may have while running `elastix`. _GitHub issues are primarily intended for bug reports and fixes._
 
-* General information about `elastix` can be found on our [wiki](https://github.com/SuperElastix/elastix/wiki) or at the [website](https://elastix.lumc.nl/).
+* General information about `elastix` can be found on our [wiki](https://github.com/SuperElastix/elastix/wiki) or at the [website](https://elastix.dev/).
 
 * [The manual](https://github.com/SuperElastix/elastix/releases/download/5.0.0/elastix-5.0.0-manual.pdf) explains much of the inner workings of image registration.
 

--- a/Common/itkComputeDisplacementDistribution.h
+++ b/Common/itkComputeDisplacementDistribution.h
@@ -40,7 +40,7 @@ namespace itk
  * [1] Y. Qiao, B. van Lew, B.P.F. Lelieveldt and M. Staring
  * "Fast Automatic Step Size Estimation for Gradient Descent Optimization of Image Registration,"
  * IEEE Transactions on Medical Imaging, vol. 35, no. 2, pp. 391 - 403, February 2016.
- * http://elastix.lumc.nl/marius/publications/2016_j_TMIa.php
+ * http://elastix.dev/marius/publications/2016_j_TMIa.php
  *
  */
 

--- a/Common/itkGenericMultiResolutionPyramidImageFilter.h
+++ b/Common/itkGenericMultiResolutionPyramidImageFilter.h
@@ -101,7 +101,7 @@ namespace itk
  * \author Denis P. Shamonin and Marius Staring. Division of Image Processing,
  * Department of Radiology, Leiden, The Netherlands
  *
- * This implementation was taken from elastix (http://elastix.lumc.nl/).
+ * This implementation was taken from elastix (http://elastix.dev/).
  *
  * \note This work was funded by the Netherlands Organisation for
  * Scientific Research (NWO NRG-2010.02 and NWO 639.021.124).

--- a/Components/Optimizers/AdaGrad/elxAdaGrad.h
+++ b/Components/Optimizers/AdaGrad/elxAdaGrad.h
@@ -66,7 +66,7 @@ namespace elastix
  * [3] Y. Qiao, B. van Lew, B.P.F. Lelieveldt and M. Staring
  * "Fast Automatic Step Size Estimation for Gradient Descent Optimization of Image Registration,"
  * IEEE Transactions on Medical Imaging, vol. 35, no. 2, pp. 391 - 403, February 2016.
- * http://elastix.lumc.nl/marius/publications/2016_j_TMIa.php
+ * http://elastix.dev/marius/publications/2016_j_TMIa.php
  *
  * The parameters used in this class are:
  * \parameter Optimizer: Select this optimizer as follows:\n

--- a/Components/Optimizers/AdaptiveStochasticGradientDescent/elxAdaptiveStochasticGradientDescent.h
+++ b/Components/Optimizers/AdaptiveStochasticGradientDescent/elxAdaptiveStochasticGradientDescent.h
@@ -63,7 +63,7 @@ namespace elastix
  * [3] Y. Qiao, B. van Lew, B.P.F. Lelieveldt and M. Staring
  * "Fast Automatic Step Size Estimation for Gradient Descent Optimization of Image Registration,"
  * IEEE Transactions on Medical Imaging, vol. 35, no. 2, pp. 391 - 403, February 2016.
- * http://elastix.lumc.nl/marius/publications/2016_j_TMIa.php
+ * http://elastix.dev/marius/publications/2016_j_TMIa.php
  *
  * The parameters used in this class are:
  * \parameter Optimizer: Select this optimizer as follows:\n

--- a/Core/Kernel/elxElastixBase.cxx
+++ b/Core/Kernel/elxElastixBase.cxx
@@ -361,7 +361,7 @@ ElastixBase::BeforeAllTransformixBase()
   {
     log::warn(std::ostringstream{} << "\nWARNING: From elastix 4.3 it is highly recommended to add\n"
                                    << "the UseDirectionCosines option to your parameter file! See\n"
-                                   << "http://elastix.lumc.nl/whatsnew_04_3.php for more information.\n");
+                                   << "http://elastix.dev/whatsnew_04_3.php for more information.\n");
   }
 
   return returndummy;

--- a/Core/Main/elastix.cxx
+++ b/Core/Main/elastix.cxx
@@ -77,7 +77,7 @@ constexpr const char * elastixHelpText =
   "For a usable parameter-file, see the website.\n\n"
 
   "Need further help? Please check:\n"
-  " * the elastix website: https://elastix.lumc.nl\n"
+  " * the elastix website: https://elastix.dev\n"
   " * the source code repository site: https://github.com/SuperElastix/elastix\n"
   " * the discussion forum: https://groups.google.com/g/elastix-imageregistration";
 

--- a/Core/Main/transformix.cxx
+++ b/Core/Main/transformix.cxx
@@ -72,7 +72,7 @@ constexpr const char * transformixHelpText =
   "run elastix, and inspect the output file \"TransformParameters.0.txt\".\n\n"
 
   "Need further help? Please check:\n"
-  " * the elastix website: https://elastix.lumc.nl\n"
+  " * the elastix website: https://elastix.dev\n"
   " * the source code repository site: https://github.com/SuperElastix/elastix\n"
   " * the discussion forum: https://groups.google.com/g/elastix-imageregistration";
 

--- a/Dockerfile
+++ b/Dockerfile
@@ -3,7 +3,7 @@ FROM ubuntu:20.04
 # Add labels to image
 LABEL documentation="https://github.com/SuperElastix/elastix/wiki"
 LABEL license="Apache License Version 2.0"
-LABEL modelzoo="https://elastix.lumc.nl/modelzoo/"
+LABEL modelzoo="https://elastix.dev/modelzoo/"
 
 # Prepare system packages, libgomp1 is required by elastix
 RUN apt-get update && apt-get -qq install libgomp1 -y

--- a/README.md
+++ b/README.md
@@ -2,10 +2,6 @@
   <img src="https://github.com/SuperElastix/elastix/blob/main/dox/art/elastix_logo_full_small.bmp" alt="elastix logo" title="elastix" align="right" height="80" />
 </a>
 
-# THE WEBSITE IS CURRENTLY DOWN, AND WE ARE WORKING ON A SOLUTION.
-## A zip file with the doxygen documentation can be found [here](https://www.dropbox.com/scl/fi/tftqwu03qdgiieniv6636/doxygen.zip?rlkey=b5qfkejaudnq7y8vmv78e1z60&st=jqssi2dg&dl=0).
-
-
 # elastix image registration toolbox #
 
 [![License](https://img.shields.io/badge/License-Apache%202.0-blue.svg)](https://github.com/SuperElastix/elastix/raw/main/LICENSE)

--- a/README.md
+++ b/README.md
@@ -1,4 +1,4 @@
-<a href="https://elastix.lumc.nl/">
+<a href="https://elastix.dev/">
   <img src="https://github.com/SuperElastix/elastix/blob/main/dox/art/elastix_logo_full_small.bmp" alt="elastix logo" title="elastix" align="right" height="80" />
 </a>
 
@@ -11,7 +11,7 @@
 [![License](https://img.shields.io/badge/License-Apache%202.0-blue.svg)](https://github.com/SuperElastix/elastix/raw/main/LICENSE)
 [![PyPI Version](https://img.shields.io/pypi/v/itk-elastix.svg)](https://pypi.python.org/pypi/itk-elastix)
 [![GitHub Actions](https://github.com/SuperElastix/elastix/workflows/Elastix/badge.svg)](https://github.com/SuperElastix/elastix/actions)
-[![Model Zoo](https://img.shields.io/badge/open-Model%20Zoo-blue.svg)](https://elastix.lumc.nl/modelzoo/)
+[![Model Zoo](https://img.shields.io/badge/open-Model%20Zoo-blue.svg)](https://elastix.dev/modelzoo/)
 [![Docker](https://img.shields.io/badge/open-docker%20image-blueviolet.svg)](https://hub.docker.com/repository/docker/superelastix/elastix)
 
 Welcome to elastix: a toolbox for rigid and nonrigid registration of images.
@@ -24,8 +24,8 @@ Nowadays elastix is accompanied by [ITKElastix](https://github.com/InsightSoftwa
 The lead developers of elastix are [Stefan Klein](https://github.com/stefanklein) and [Marius Staring](https://github.com/mstaring). This software was initially developed at the [Image Sciences Institute](http://www.isi.uu.nl), under supervision of [Josien P.W. Pluim](http://www.isi.uu.nl/People/Josien/). Today, [many](https://github.com/SuperElastix/elastix/graphs/contributors) have contributed to elastix.
 
 If you use this software anywhere we would appreciate if you cite the following articles:
-- S. Klein, M. Staring, K. Murphy, M.A. Viergever, J.P.W. Pluim, "elastix: a toolbox for intensity based medical image registration," IEEE Transactions on Medical Imaging, vol. 29, no. 1, pp. 196 - 205, January 2010. [download](https://elastix.lumc.nl/marius/publications/2010_j_TMI.php) [doi](http://dx.doi.org/10.1109/TMI.2009.2035616)
-- D.P. Shamonin, E.E. Bron, B.P.F. Lelieveldt, M. Smits, S. Klein and M. Staring, "Fast Parallel Image Registration on CPU and GPU for Diagnostic Classification of Alzheimer’s Disease", Frontiers in Neuroinformatics, vol. 7, no. 50, pp. 1-15, January 2014. [download](https://elastix.lumc.nl/marius/publications/2014_j_FNI.php) [doi](http://dx.doi.org/10.3389/fninf.2013.00050)
+- S. Klein, M. Staring, K. Murphy, M.A. Viergever, J.P.W. Pluim, "elastix: a toolbox for intensity based medical image registration," IEEE Transactions on Medical Imaging, vol. 29, no. 1, pp. 196 - 205, January 2010. [download](https://elastix.dev/marius/publications/2010_j_TMI.php) [doi](http://dx.doi.org/10.1109/TMI.2009.2035616)
+- D.P. Shamonin, E.E. Bron, B.P.F. Lelieveldt, M. Smits, S. Klein and M. Staring, "Fast Parallel Image Registration on CPU and GPU for Diagnostic Classification of Alzheimer’s Disease", Frontiers in Neuroinformatics, vol. 7, no. 50, pp. 1-15, January 2014. [download](https://elastix.dev/marius/publications/2014_j_FNI.php) [doi](http://dx.doi.org/10.3389/fninf.2013.00050)
 
 Specific components of elastix are made by many; The relevant citation can be found [here](https://github.com/SuperElastix/elastix/wiki/How-to-cite-elastix-(components)).
 

--- a/Testing/PythonTests/transformix_test.py
+++ b/Testing/PythonTests/transformix_test.py
@@ -34,7 +34,7 @@ OUTPUTPOINTS_FILENAME = "outputpoints.txt"
 
 
 class TransformixTestCase(unittest.TestCase):
-    """Tests transformix from https://elastix.lumc.nl"""
+    """Tests transformix from https://elastix.dev"""
 
     version_string = "5.1.0"
     transformix_exe_file_path = pathlib.Path(os.environ["TRANSFORMIX_EXE"])

--- a/dox/README.txt
+++ b/dox/README.txt
@@ -2,7 +2,7 @@ Welcome to elastix!
 
 This directory contains the documentation of elastix.
 
-doxygen: In this directory we put files that help to generate the doxygen pages in a style that we like. These pages give a lot of information about the setup of elastix, and can be found at http://elastix.lumc.nl/doxygen/index.html.
+doxygen: In this directory we put files that help to generate the doxygen pages in a style that we like. These pages give a lot of information about the setup of elastix, and can be found at http://elastix.dev/doxygen/index.html.
 
 manual: This directory is a submodule that links to the (most recent commit in the) git repository that contains the LaTeX files and the images needed to generate the manual of elastix.
 Be aware that cloning the elastix repository doesn't also clone the submodules. In order to do this the following command should be typed after clone the repo:

--- a/dox/createWebsite
+++ b/dox/createWebsite
@@ -64,7 +64,7 @@ exportdirlinux64="$exportbasedirlinux64/$tag"
 exportdirlinux32grid="$exportbasedirlinux32grid/$tag""linux32"
 svnurl="https://svn.bigr.nl/elastix"
 tempdir="d:/tk/elastixwebsite/$tag"
-websitebase="http://elastix.lumc.nl"
+websitebase="http://elastix.dev"
 copyright="$exportdirwin/src/CopyrightElastix.txt"
 
 

--- a/dox/externalproject/ElastixTranslationExample.cxx
+++ b/dox/externalproject/ElastixTranslationExample.cxx
@@ -36,7 +36,7 @@ main()
 
     std::cout << "Image registation example: estimating the translation between two images of " << imageSizeX << "x"
               << imageSizeY << " pixels\n"
-              << " - Linked to elastix library version " ELASTIX_VERSION_STRING "\n - Web site: https://elastix.lumc.nl"
+              << " - Linked to elastix library version " ELASTIX_VERSION_STRING "\n - Web site: https://elastix.dev"
                  "\n - Source code repository: https://github.com/SuperElastix/elastix"
                  "\n - Discussion forum: https://groups.google.com/g/elastix-imageregistration\n\n";
 


### PR DESCRIPTION
Our new web site is https://elastix.dev/
With a big THANK YOU to our colleague Michèle Huijberts (@mwjhhuijberts)!