### PR TITLE
Replace vnl `fill(RealType{})` calls with use of zero-filling constructors.

### DIFF
--- a/Components/Metrics/PCAMetric/itkPCAMetric.hxx
+++ b/Components/Metrics/PCAMetric/itkPCAMetric.hxx
@@ -260,8 +260,7 @@ PCAMetric<TFixedImage, TMovingImage>::GetValue(const TransformParametersType & p
   MatrixType         A(datablock.extract(N, G));
 
   /** Calculate mean of from columns */
-  vnl_vector<RealType> mean(G);
-  mean.fill(RealType{});
+  vnl_vector<RealType> mean(G, RealType{});
   for (unsigned int i = 0; i < N; ++i)
   {
     for (unsigned int j = 0; j < G; ++j)
@@ -299,8 +298,7 @@ PCAMetric<TFixedImage, TMovingImage>::GetValue(const TransformParametersType & p
   // std::cout << "varNoise: " << varNoise << std::endl;
 
   /** Calculate variance of columns */
-  vnl_vector<RealType> var(G);
-  var.fill(RealType{});
+  vnl_vector<RealType> var(G, RealType{});
   for (unsigned int j = 0; j < G; ++j)
   {
     var(j) = C(j, j);
@@ -497,8 +495,7 @@ PCAMetric<TFixedImage, TMovingImage>::GetValueAndDerivative(const TransformParam
   MatrixType Amm(N, realNumLastDimPositions, vnl_matrix_null);
   {
     /** Calculate mean of from columns */
-    vnl_vector<RealType> mean(realNumLastDimPositions);
-    mean.fill(RealType{});
+    vnl_vector<RealType> mean(realNumLastDimPositions, RealType{});
     for (unsigned int i = 0; i < N; ++i)
     {
       for (unsigned int j = 0; j < realNumLastDimPositions; ++j)
@@ -532,8 +529,7 @@ PCAMetric<TFixedImage, TMovingImage>::GetValueAndDerivative(const TransformParam
   }
 
   /** Calculate standard deviation from columns */
-  vnl_vector<RealType> var(realNumLastDimPositions);
-  var.fill(RealType{});
+  vnl_vector<RealType> var(realNumLastDimPositions, RealType{});
   for (unsigned int j = 0; j < realNumLastDimPositions; ++j)
   {
     var(j) = C(j, j);

--- a/Components/Metrics/PCAMetric/itkPCAMetric.hxx
+++ b/Components/Metrics/PCAMetric/itkPCAMetric.hxx
@@ -180,7 +180,7 @@ PCAMetric<TFixedImage, TMovingImage>::GetValue(const TransformParametersType & p
 
   /** The rows of the ImageSampleMatrix contain the samples of the images of the stack */
   unsigned int NumberOfSamples = sampleContainer->Size();
-  MatrixType   datablock(NumberOfSamples, realNumLastDimPositions);
+  MatrixType   datablock(NumberOfSamples, realNumLastDimPositions, vnl_matrix_null);
 
   /** Vector containing last dimension positions to use: initialize on all positions when random sampling turned off. */
   std::vector<int> lastDimPositions;
@@ -201,9 +201,6 @@ PCAMetric<TFixedImage, TMovingImage>::GetValue(const TransformParametersType & p
 
   /** Initialize dummy loop variable */
   unsigned int pixelIndex = 0;
-
-  /** Initialize image sample matrix . */
-  datablock.fill(RealType{});
 
   for (const auto & fixedImageSample : *sampleContainer)
   {
@@ -274,8 +271,7 @@ PCAMetric<TFixedImage, TMovingImage>::GetValue(const TransformParametersType & p
   }
   mean /= RealType(N);
 
-  MatrixType Amm(N, G);
-  Amm.fill(RealType{});
+  MatrixType Amm(N, G, vnl_matrix_null);
 
   for (unsigned int i = 0; i < N; ++i)
   {
@@ -311,8 +307,8 @@ PCAMetric<TFixedImage, TMovingImage>::GetValue(const TransformParametersType & p
   }
   var -= varNoise;
 
-  MatrixType S(G, G);
-  S.fill(RealType{});
+  MatrixType S(G, G, vnl_matrix_null);
+
   for (unsigned int j = 0; j < G; ++j)
   {
     S(j, j) = 1.0 / sqrt(var(j));
@@ -418,13 +414,10 @@ PCAMetric<TFixedImage, TMovingImage>::GetValueAndDerivative(const TransformParam
                                                  : lastDimSize;
   /** The rows of the ImageSampleMatrix contain the samples of the images of the stack */
   unsigned int NumberOfSamples = sampleContainer->Size();
-  MatrixType   datablock(NumberOfSamples, realNumLastDimPositions);
+  MatrixType   datablock(NumberOfSamples, realNumLastDimPositions, vnl_matrix_null);
 
   /** Initialize dummy loop variables */
   unsigned int pixelIndex = 0;
-
-  /** Initialize image sample matrix . */
-  datablock.fill(RealType{});
 
   /** Determine random last dimension positions if needed. */
   /** Vector containing last dimension positions to use: initialize on all positions when random sampling turned off. */
@@ -501,8 +494,7 @@ PCAMetric<TFixedImage, TMovingImage>::GetValueAndDerivative(const TransformParam
   MatrixType A(datablock.extract(N, realNumLastDimPositions));
 
   /** Calculate standard deviation from columns */
-  MatrixType Amm(N, realNumLastDimPositions);
-  Amm.fill(RealType{});
+  MatrixType Amm(N, realNumLastDimPositions, vnl_matrix_null);
   {
     /** Calculate mean of from columns */
     vnl_vector<RealType> mean(realNumLastDimPositions);

--- a/Components/Metrics/PCAMetric/itkPCAMetric.hxx
+++ b/Components/Metrics/PCAMetric/itkPCAMetric.hxx
@@ -536,8 +536,7 @@ PCAMetric<TFixedImage, TMovingImage>::GetValueAndDerivative(const TransformParam
   }
   var -= varNoise;
 
-  vnl_diag_matrix<RealType> S(realNumLastDimPositions);
-  S.fill(RealType{});
+  vnl_diag_matrix<RealType> S(realNumLastDimPositions, RealType{});
   for (unsigned int j = 0; j < realNumLastDimPositions; ++j)
   {
     S(j, j) = 1.0 / sqrt(var(j));

--- a/Components/Metrics/PCAMetric/itkPCAMetric_F_multithreaded.hxx
+++ b/Components/Metrics/PCAMetric/itkPCAMetric_F_multithreaded.hxx
@@ -168,13 +168,10 @@ PCAMetric<TFixedImage, TMovingImage>::GetValue(const TransformParametersType & p
 
   /** The rows of the ImageSampleMatrix contain the samples of the images of the stack */
   const unsigned int numberOfSamples = sampleContainer->Size();
-  MatrixType         datablock(numberOfSamples, this->m_G);
+  MatrixType         datablock(numberOfSamples, this->m_G, vnl_matrix_null);
 
   /** Initialize dummy loop variable */
   unsigned int pixelIndex = 0;
-
-  /** Initialize image sample matrix . */
-  datablock.fill(RealType{});
 
   for (const auto & fixedImageSample : *sampleContainer)
   {
@@ -230,8 +227,7 @@ PCAMetric<TFixedImage, TMovingImage>::GetValue(const TransformParametersType & p
   this->CheckNumberOfSamples(numberOfSamples, this->m_NumberOfPixelsCounted);
   MatrixType A(datablock.extract(this->m_NumberOfPixelsCounted, this->m_G));
 
-  MatrixType Amm(this->m_NumberOfPixelsCounted, this->m_G);
-  Amm.fill(RealType{});
+  MatrixType Amm(this->m_NumberOfPixelsCounted, this->m_G, vnl_matrix_null);
   {
     /** Calculate mean of from columns */
     vnl_vector<RealType> mean(this->m_G);
@@ -344,13 +340,10 @@ PCAMetric<TFixedImage, TMovingImage>::GetValueAndDerivativeSingleThreaded(const 
 
   /** The rows of the ImageSampleMatrix contain the samples of the images of the stack */
   const unsigned int numberOfSamples = sampleContainer->Size();
-  MatrixType         datablock(numberOfSamples, this->m_G);
+  MatrixType         datablock(numberOfSamples, this->m_G, vnl_matrix_null);
 
   /** Initialize dummy loop variables */
   unsigned int pixelIndex = 0;
-
-  /** Initialize image sample matrix . */
-  datablock.fill(RealType{});
 
   for (const auto & fixedImageSample : *sampleContainer)
   {
@@ -409,8 +402,7 @@ PCAMetric<TFixedImage, TMovingImage>::GetValueAndDerivativeSingleThreaded(const 
   MatrixType A(datablock.extract(this->m_NumberOfPixelsCounted, this->m_G));
 
   /** Calculate standard deviation from columns */
-  MatrixType Amm(this->m_NumberOfPixelsCounted, this->m_G);
-  Amm.fill(RealType{});
+  MatrixType Amm(this->m_NumberOfPixelsCounted, this->m_G, vnl_matrix_null);
   {
     /** Calculate mean of from columns */
     vnl_vector<RealType> mean(this->m_G);
@@ -779,8 +771,7 @@ PCAMetric<TFixedImage, TMovingImage>::AfterThreadedGetSamples(MeasureType & valu
   }
 
   /** Calculate standard deviation from columns */
-  MatrixType Amm(this->m_NumberOfPixelsCounted, this->m_G);
-  Amm.fill(RealType{});
+  MatrixType Amm(this->m_NumberOfPixelsCounted, this->m_G, vnl_matrix_null);
   {
     /** Calculate mean of from columns */
     vnl_vector<RealType> mean(this->m_G);

--- a/Components/Metrics/PCAMetric/itkPCAMetric_F_multithreaded.hxx
+++ b/Components/Metrics/PCAMetric/itkPCAMetric_F_multithreaded.hxx
@@ -253,8 +253,7 @@ PCAMetric<TFixedImage, TMovingImage>::GetValue(const TransformParametersType & p
   MatrixType C(Amm.transpose() * Amm);
   C /= static_cast<RealType>(RealType(this->m_NumberOfPixelsCounted) - 1.0);
 
-  vnl_diag_matrix<RealType> S(this->m_G);
-  S.fill(RealType{});
+  vnl_diag_matrix<RealType> S(this->m_G, RealType{});
   for (unsigned int j = 0; j < this->m_G; ++j)
   {
     S(j, j) = 1.0 / sqrt(C(j, j));
@@ -428,8 +427,7 @@ PCAMetric<TFixedImage, TMovingImage>::GetValueAndDerivativeSingleThreaded(const 
   MatrixType C(Atmm * Amm);
   C /= static_cast<RealType>(RealType(this->m_NumberOfPixelsCounted) - 1.0);
 
-  vnl_diag_matrix<RealType> S(this->m_G);
-  S.fill(RealType{});
+  vnl_diag_matrix<RealType> S(this->m_G, RealType{});
   for (unsigned int j = 0; j < this->m_G; ++j)
   {
     S(j, j) = 1.0 / sqrt(C(j, j));
@@ -461,10 +459,7 @@ PCAMetric<TFixedImage, TMovingImage>::GetValueAndDerivativeSingleThreaded(const 
   std::vector<NonZeroJacobianIndicesType> nzjis(this->m_G, NonZeroJacobianIndicesType());
 
   /** Sub components of metric derivative */
-  vnl_diag_matrix<DerivativeValueType> dSdmu_part1(this->m_G);
-
-  /** initialize */
-  dSdmu_part1.fill(DerivativeValueType{});
+  vnl_diag_matrix<DerivativeValueType> dSdmu_part1(this->m_G, DerivativeValueType{});
 
   for (unsigned int d = 0; d < this->m_G; ++d)
   {
@@ -796,8 +791,7 @@ PCAMetric<TFixedImage, TMovingImage>::AfterThreadedGetSamples(MeasureType & valu
   MatrixType C(this->m_Atmm * Amm);
   C /= static_cast<RealType>(RealType(this->m_NumberOfPixelsCounted) - 1.0);
 
-  vnl_diag_matrix<RealType> S(this->m_G);
-  S.fill(RealType{});
+  vnl_diag_matrix<RealType> S(this->m_G, RealType{});
   for (unsigned int j = 0; j < this->m_G; ++j)
   {
     S(j, j) = 1.0 / sqrt(C(j, j));

--- a/Components/Metrics/PCAMetric/itkPCAMetric_F_multithreaded.hxx
+++ b/Components/Metrics/PCAMetric/itkPCAMetric_F_multithreaded.hxx
@@ -230,8 +230,7 @@ PCAMetric<TFixedImage, TMovingImage>::GetValue(const TransformParametersType & p
   MatrixType Amm(this->m_NumberOfPixelsCounted, this->m_G, vnl_matrix_null);
   {
     /** Calculate mean of from columns */
-    vnl_vector<RealType> mean(this->m_G);
-    mean.fill(RealType{});
+    vnl_vector<RealType> mean(this->m_G, RealType{});
     for (unsigned int i = 0; i < this->m_NumberOfPixelsCounted; ++i)
     {
       for (unsigned int j = 0; j < this->m_G; ++j)
@@ -405,8 +404,7 @@ PCAMetric<TFixedImage, TMovingImage>::GetValueAndDerivativeSingleThreaded(const 
   MatrixType Amm(this->m_NumberOfPixelsCounted, this->m_G, vnl_matrix_null);
   {
     /** Calculate mean of from columns */
-    vnl_vector<RealType> mean(this->m_G);
-    mean.fill(RealType{});
+    vnl_vector<RealType> mean(this->m_G, RealType{});
     for (unsigned int i = 0; i < this->m_NumberOfPixelsCounted; ++i)
     {
       for (unsigned int j = 0; j < this->m_G; ++j)
@@ -774,8 +772,7 @@ PCAMetric<TFixedImage, TMovingImage>::AfterThreadedGetSamples(MeasureType & valu
   MatrixType Amm(this->m_NumberOfPixelsCounted, this->m_G, vnl_matrix_null);
   {
     /** Calculate mean of from columns */
-    vnl_vector<RealType> mean(this->m_G);
-    mean.fill(RealType{});
+    vnl_vector<RealType> mean(this->m_G, RealType{});
     for (unsigned int i = 0; i < this->m_NumberOfPixelsCounted; ++i)
     {
       for (unsigned int j = 0; j < this->m_G; ++j)

--- a/Components/Metrics/PCAMetric2/itkPCAMetric2.hxx
+++ b/Components/Metrics/PCAMetric2/itkPCAMetric2.hxx
@@ -454,8 +454,7 @@ PCAMetric2<TFixedImage, TMovingImage>::GetValueAndDerivative(const TransformPara
   MatrixType C(Atmm * Amm);
   C /= static_cast<RealType>(RealType(N) - 1.0);
 
-  vnl_diag_matrix<RealType> S(G);
-  S.fill(RealType{});
+  vnl_diag_matrix<RealType> S(G, RealType{});
   for (unsigned int j = 0; j < G; ++j)
   {
     S(j, j) = 1.0 / sqrt(C(j, j));

--- a/Components/Metrics/PCAMetric2/itkPCAMetric2.hxx
+++ b/Components/Metrics/PCAMetric2/itkPCAMetric2.hxx
@@ -164,7 +164,7 @@ PCAMetric2<TFixedImage, TMovingImage>::GetValue(const TransformParametersType & 
 
   /** The rows of the ImageSampleMatrix contain the samples of the images of the stack */
   const unsigned int numberOfSamples = sampleContainer->Size();
-  MatrixType         datablock(numberOfSamples, G);
+  MatrixType         datablock(numberOfSamples, G, vnl_matrix_null);
 
   /** Vector containing last dimension positions to use: initialize on all positions when random sampling turned off. */
   std::vector<int> lastDimPositions;
@@ -177,9 +177,6 @@ PCAMetric2<TFixedImage, TMovingImage>::GetValue(const TransformParametersType & 
 
   /** Initialize dummy loop variable */
   unsigned int pixelIndex = 0;
-
-  /** Initialize image sample matrix . */
-  datablock.fill(RealType{});
 
   for (const auto & fixedImageSample : *sampleContainer)
   {
@@ -236,8 +233,7 @@ PCAMetric2<TFixedImage, TMovingImage>::GetValue(const TransformParametersType & 
   const unsigned int N = this->m_NumberOfPixelsCounted;
   MatrixType         A(datablock.extract(N, G));
 
-  MatrixType Amm(N, G);
-  Amm.fill(RealType{});
+  MatrixType Amm(N, G, vnl_matrix_null);
   {
     /** Calculate mean of from columns */
     vnl_vector<RealType> mean(G);
@@ -264,8 +260,8 @@ PCAMetric2<TFixedImage, TMovingImage>::GetValue(const TransformParametersType & 
   MatrixType C(Amm.transpose() * Amm);
   C /= static_cast<RealType>(RealType(N) - 1.0);
 
-  MatrixType S(G, G);
-  S.fill(RealType{});
+  MatrixType S(G, G, vnl_matrix_null);
+
   for (unsigned int j = 0; j < G; ++j)
   {
     S(j, j) = 1.0 / sqrt(C(j, j));
@@ -361,13 +357,10 @@ PCAMetric2<TFixedImage, TMovingImage>::GetValueAndDerivative(const TransformPara
 
   /** The rows of the ImageSampleMatrix contain the samples of the images of the stack */
   const unsigned int numberOfSamples = sampleContainer->Size();
-  MatrixType         datablock(numberOfSamples, G);
+  MatrixType         datablock(numberOfSamples, G, vnl_matrix_null);
 
   /** Initialize dummy loop variables */
   unsigned int pixelIndex = 0;
-
-  /** Initialize image sample matrix . */
-  datablock.fill(RealType{});
 
   /** Determine random last dimension positions if needed. */
   /** Vector containing last dimension positions to use: initialize on all positions when random sampling turned off. */
@@ -435,8 +428,7 @@ PCAMetric2<TFixedImage, TMovingImage>::GetValueAndDerivative(const TransformPara
   MatrixType A(datablock.extract(N, G));
 
   /** Calculate standard deviation of columns */
-  MatrixType Amm(N, G);
-  Amm.fill(RealType{});
+  MatrixType Amm(N, G, vnl_matrix_null);
   {
     /** Calculate mean of columns */
     vnl_vector<RealType> mean(G);

--- a/Components/Metrics/PCAMetric2/itkPCAMetric2.hxx
+++ b/Components/Metrics/PCAMetric2/itkPCAMetric2.hxx
@@ -236,8 +236,7 @@ PCAMetric2<TFixedImage, TMovingImage>::GetValue(const TransformParametersType & 
   MatrixType Amm(N, G, vnl_matrix_null);
   {
     /** Calculate mean of from columns */
-    vnl_vector<RealType> mean(G);
-    mean.fill(RealType{});
+    vnl_vector<RealType> mean(G, RealType{});
     for (unsigned int i = 0; i < N; ++i)
     {
       for (unsigned int j = 0; j < G; ++j)
@@ -431,8 +430,7 @@ PCAMetric2<TFixedImage, TMovingImage>::GetValueAndDerivative(const TransformPara
   MatrixType Amm(N, G, vnl_matrix_null);
   {
     /** Calculate mean of columns */
-    vnl_vector<RealType> mean(G);
-    mean.fill(RealType{});
+    vnl_vector<RealType> mean(G, RealType{});
     for (unsigned int i = 0; i < N; ++i)
     {
       for (unsigned int j = 0; j < G; ++j)

--- a/Components/Metrics/SumOfPairwiseCorrelationsMetric/itkSumOfPairwiseCorrelationCoefficientsMetric.hxx
+++ b/Components/Metrics/SumOfPairwiseCorrelationsMetric/itkSumOfPairwiseCorrelationCoefficientsMetric.hxx
@@ -210,8 +210,7 @@ SumOfPairwiseCorrelationCoefficientsMetric<TFixedImage, TMovingImage>::GetValue(
   MatrixType Amm(N, G, vnl_matrix_null);
   {
     /** Calculate mean of from columns */
-    vnl_vector<RealType> mean(G);
-    mean.fill(RealType{});
+    vnl_vector<RealType> mean(G, RealType{});
     for (unsigned int i = 0; i < N; ++i)
     {
       for (unsigned int j = 0; j < G; ++j)
@@ -378,8 +377,7 @@ SumOfPairwiseCorrelationCoefficientsMetric<TFixedImage, TMovingImage>::GetValueA
   MatrixType Amm(N, G, vnl_matrix_null);
   {
     /** Calculate mean of from columns */
-    vnl_vector<RealType> mean(G);
-    mean.fill(RealType{});
+    vnl_vector<RealType> mean(G, RealType{});
     for (unsigned int i = 0; i < N; ++i)
     {
       for (unsigned int j = 0; j < G; ++j)

--- a/Components/Metrics/SumOfPairwiseCorrelationsMetric/itkSumOfPairwiseCorrelationCoefficientsMetric.hxx
+++ b/Components/Metrics/SumOfPairwiseCorrelationsMetric/itkSumOfPairwiseCorrelationCoefficientsMetric.hxx
@@ -146,13 +146,10 @@ SumOfPairwiseCorrelationCoefficientsMetric<TFixedImage, TMovingImage>::GetValue(
 
   /** The rows of the ImageSampleMatrix contain the samples of the images of the stack */
   unsigned int NumberOfSamples = sampleContainer->Size();
-  MatrixType   datablock(NumberOfSamples, G);
+  MatrixType   datablock(NumberOfSamples, G, vnl_matrix_null);
 
   /** Initialize dummy loop variable */
   unsigned int pixelIndex = 0;
-
-  /** Initialize image sample matrix . */
-  datablock.fill(RealType{});
 
   for (const auto & fixedImageSample : *sampleContainer)
   {
@@ -210,8 +207,7 @@ SumOfPairwiseCorrelationCoefficientsMetric<TFixedImage, TMovingImage>::GetValue(
 
   MatrixType A(datablock.extract(N, G));
 
-  MatrixType Amm(N, G);
-  Amm.fill(RealType{});
+  MatrixType Amm(N, G, vnl_matrix_null);
   {
     /** Calculate mean of from columns */
     vnl_vector<RealType> mean(G);
@@ -316,13 +312,10 @@ SumOfPairwiseCorrelationCoefficientsMetric<TFixedImage, TMovingImage>::GetValueA
 
   /** The rows of the ImageSampleMatrix contain the samples of the images of the stack */
   unsigned int NumberOfSamples = sampleContainer->Size();
-  MatrixType   datablock(NumberOfSamples, G);
+  MatrixType   datablock(NumberOfSamples, G, vnl_matrix_null);
 
   /** Initialize dummy loop variables */
   unsigned int pixelIndex = 0;
-
-  /** Initialize image sample matrix . */
-  datablock.fill(0.0);
 
   for (const auto & fixedImageSample : *sampleContainer)
   {
@@ -382,8 +375,7 @@ SumOfPairwiseCorrelationCoefficientsMetric<TFixedImage, TMovingImage>::GetValueA
 
   MatrixType A(datablock.extract(N, G));
 
-  MatrixType Amm(N, G);
-  Amm.fill(RealType{});
+  MatrixType Amm(N, G, vnl_matrix_null);
   {
     /** Calculate mean of from columns */
     vnl_vector<RealType> mean(G);

--- a/Components/Metrics/SumOfPairwiseCorrelationsMetric/itkSumOfPairwiseCorrelationCoefficientsMetric.hxx
+++ b/Components/Metrics/SumOfPairwiseCorrelationsMetric/itkSumOfPairwiseCorrelationCoefficientsMetric.hxx
@@ -234,8 +234,7 @@ SumOfPairwiseCorrelationCoefficientsMetric<TFixedImage, TMovingImage>::GetValue(
   MatrixType C(Atmm * Amm);
   C /= static_cast<RealType>(RealType(N) - 1.0);
 
-  vnl_diag_matrix<RealType> S(G);
-  S.fill(RealType{});
+  vnl_diag_matrix<RealType> S(G, RealType{});
   for (unsigned int j = 0; j < G; ++j)
   {
     S(j, j) = 1.0 / sqrt(C(j, j));
@@ -401,8 +400,7 @@ SumOfPairwiseCorrelationCoefficientsMetric<TFixedImage, TMovingImage>::GetValueA
   MatrixType C(Atmm * Amm);
   C /= static_cast<RealType>(RealType(N) - 1.0);
 
-  vnl_diag_matrix<RealType> S(G);
-  S.fill(RealType{});
+  vnl_diag_matrix<RealType> S(G, RealType{});
   for (unsigned int j = 0; j < G; ++j)
   {
     S(j, j) = 1.0 / sqrt(C(j, j));
@@ -418,10 +416,7 @@ SumOfPairwiseCorrelationCoefficientsMetric<TFixedImage, TMovingImage>::GetValueA
   DerivativeType dMTdmu;
 
   /** Sub components of metric derivative */
-  vnl_diag_matrix<DerivativeValueType> dSdmu_part1(G);
-
-  /** initialize */
-  dSdmu_part1.fill(DerivativeValueType{});
+  vnl_diag_matrix<DerivativeValueType> dSdmu_part1(G, DerivativeValueType{});
 
   for (unsigned int d = 0; d < G; ++d)
   {


### PR DESCRIPTION
It appears preferable to properly zero-fill those objects during their construction.