### PR TITLE
COMP: Upgrade Azure Pipelines CI yml file from macOS-11 to macOS-12

### DIFF
--- a/Testing/CI/Azure/ci.yml
+++ b/Testing/CI/Azure/ci.yml
@@ -135,7 +135,7 @@ jobs:
 - job: macOS
   timeoutInMinutes: 0
   pool:
-    vmImage: 'macOS-11'
+    vmImage: 'macOS-12'
   strategy:
     matrix:
       ITKv5:


### PR DESCRIPTION
Addressing errors at dev.azure.com saying:

> ##[error]This is a scheduled macOS-11 brownout. The macOS-11 environment is deprecated and will be removed on June 28th, 2024.