### PR TITLE
BUG: SumOfPairwiseCorrelationCoefficientsMetric TransformIsStack `false`

### DIFF
--- a/Components/Metrics/SumOfPairwiseCorrelationsMetric/itkSumOfPairwiseCorrelationCoefficientsMetric.h
+++ b/Components/Metrics/SumOfPairwiseCorrelationsMetric/itkSumOfPairwiseCorrelationCoefficientsMetric.h
@@ -167,7 +167,7 @@ private:
   FixedImageSizeType m_GridSize{};
 
   /** Bool to indicate if the transform used is a stacktransform. Set by elx files. */
-  bool m_TransformIsStackTransform{ true };
+  bool m_TransformIsStackTransform{ false };
 };
 
 } // end namespace itk


### PR DESCRIPTION
Initialized `SumOfPairwiseCorrelationCoefficientsMetric::TransformIsStackTransform` to false. Otherwise it would always be true.

Other metrics (PCAMetric, PCAMetric2, VarianceOverLastDimension) have a similar TransformIsStackTransform property, but those are initialized to false, during the construction of those metrics.

 - Addresses issue https://github.com/SuperElastix/elastix/issues/1159 "SumOfPairwiseCorrelationCoefficientsMetric m_TransformIsStackTransform always true?!?"