### PR TITLE
Metrics: Remove local `testPtr4` variables from `BeforeEachResolution()` member functions, rename `testPtr1`, `testPtr2`, and `testPtr3` 

### DIFF
--- a/Components/Metrics/PCAMetric/elxPCAMetric.hxx
+++ b/Components/Metrics/PCAMetric/elxPCAMetric.hxx
@@ -116,9 +116,7 @@ PCAMetric<TElastix>::BeforeEachResolution()
         if (testPtr3->GetNumberOfSubTransforms() > 0)
         {
           /** Check if subtransform is a B-spline transform. */
-          const ReducedDimensionBSplineTransformBaseType * testPtr4 =
-            dynamic_cast<const ReducedDimensionBSplineTransformBaseType *>(testPtr3->GetSubTransform(0).GetPointer());
-          if (testPtr4)
+          if (dynamic_cast<ReducedDimensionBSplineTransformBaseType *>(testPtr3->GetSubTransform(0).GetPointer()))
           {
             FixedImageSizeType gridSize;
             gridSize.Fill(testPtr3->GetNumberOfSubTransforms());

--- a/Components/Metrics/PCAMetric/elxPCAMetric.hxx
+++ b/Components/Metrics/PCAMetric/elxPCAMetric.hxx
@@ -107,19 +107,19 @@ PCAMetric<TElastix>::BeforeEachResolution()
     else
     {
       /** Check for stack transform. */
-      StackTransformType * testPtr3 = dynamic_cast<StackTransformType *>(testPtr1->GetModifiableCurrentTransform());
-      if (testPtr3)
+      const auto stackTransform = dynamic_cast<StackTransformType *>(testPtr1->GetModifiableCurrentTransform());
+      if (stackTransform)
       {
         /** Set itk member variable. */
         this->SetTransformIsStackTransform(true);
 
-        if (testPtr3->GetNumberOfSubTransforms() > 0)
+        if (stackTransform->GetNumberOfSubTransforms() > 0)
         {
           /** Check if subtransform is a B-spline transform. */
-          if (dynamic_cast<ReducedDimensionBSplineTransformBaseType *>(testPtr3->GetSubTransform(0).GetPointer()))
+          if (dynamic_cast<ReducedDimensionBSplineTransformBaseType *>(stackTransform->GetSubTransform(0).GetPointer()))
           {
             FixedImageSizeType gridSize;
-            gridSize.Fill(testPtr3->GetNumberOfSubTransforms());
+            gridSize.Fill(stackTransform->GetNumberOfSubTransforms());
             this->SetGridSize(gridSize);
           }
         }

--- a/Components/Metrics/PCAMetric/elxPCAMetric.hxx
+++ b/Components/Metrics/PCAMetric/elxPCAMetric.hxx
@@ -94,11 +94,13 @@ PCAMetric<TElastix>::BeforeEachResolution()
   }
 
   /** Check if this transform is a B-spline transform. */
-  CombinationTransformType * testPtr1 = BaseComponent::AsITKBaseType(this->GetElastix()->GetElxTransformBase());
-  if (testPtr1)
+  CombinationTransformType * combinationTransform =
+    BaseComponent::AsITKBaseType(this->GetElastix()->GetElxTransformBase());
+  if (combinationTransform)
   {
     /** Check for B-spline transform. */
-    const auto bsplineTransform = dynamic_cast<const BSplineTransformBaseType *>(testPtr1->GetCurrentTransform());
+    const auto bsplineTransform =
+      dynamic_cast<const BSplineTransformBaseType *>(combinationTransform->GetCurrentTransform());
     if (bsplineTransform)
     {
       this->SetGridSize(bsplineTransform->GetGridRegion().GetSize());
@@ -106,7 +108,8 @@ PCAMetric<TElastix>::BeforeEachResolution()
     else
     {
       /** Check for stack transform. */
-      const auto stackTransform = dynamic_cast<StackTransformType *>(testPtr1->GetModifiableCurrentTransform());
+      const auto stackTransform =
+        dynamic_cast<StackTransformType *>(combinationTransform->GetModifiableCurrentTransform());
       if (stackTransform)
       {
         /** Set itk member variable. */

--- a/Components/Metrics/PCAMetric/elxPCAMetric.hxx
+++ b/Components/Metrics/PCAMetric/elxPCAMetric.hxx
@@ -98,11 +98,10 @@ PCAMetric<TElastix>::BeforeEachResolution()
   if (testPtr1)
   {
     /** Check for B-spline transform. */
-    const BSplineTransformBaseType * testPtr2 =
-      dynamic_cast<const BSplineTransformBaseType *>(testPtr1->GetCurrentTransform());
-    if (testPtr2)
+    const auto bsplineTransform = dynamic_cast<const BSplineTransformBaseType *>(testPtr1->GetCurrentTransform());
+    if (bsplineTransform)
     {
-      this->SetGridSize(testPtr2->GetGridRegion().GetSize());
+      this->SetGridSize(bsplineTransform->GetGridRegion().GetSize());
     }
     else
     {

--- a/Components/Metrics/PCAMetric2/elxPCAMetric2.hxx
+++ b/Components/Metrics/PCAMetric2/elxPCAMetric2.hxx
@@ -89,12 +89,13 @@ PCAMetric2<TElastix>::BeforeEachResolution()
   }
 
   /** Check if this transform is a B-spline transform. */
-  CombinationTransformType * testPtr1 =
-    dynamic_cast<CombinationTransformType *>(this->GetElastix()->GetElxTransformBase());
-  if (testPtr1)
+  CombinationTransformType * combinationTransform =
+    BaseComponent::AsITKBaseType(this->GetElastix()->GetElxTransformBase());
+  if (combinationTransform)
   {
     /** Check for B-spline transform. */
-    const auto bsplineTransform = dynamic_cast<const BSplineTransformBaseType *>(testPtr1->GetCurrentTransform());
+    const auto bsplineTransform =
+      dynamic_cast<const BSplineTransformBaseType *>(combinationTransform->GetCurrentTransform());
     if (bsplineTransform)
     {
       this->SetGridSize(bsplineTransform->GetGridRegion().GetSize());
@@ -102,7 +103,8 @@ PCAMetric2<TElastix>::BeforeEachResolution()
     else
     {
       /** Check for stack transform. */
-      const auto stackTransform = dynamic_cast<StackTransformType *>(testPtr1->GetModifiableCurrentTransform());
+      const auto stackTransform =
+        dynamic_cast<StackTransformType *>(combinationTransform->GetModifiableCurrentTransform());
       if (stackTransform)
       {
         /** Set itk member variable. */

--- a/Components/Metrics/PCAMetric2/elxPCAMetric2.hxx
+++ b/Components/Metrics/PCAMetric2/elxPCAMetric2.hxx
@@ -94,11 +94,10 @@ PCAMetric2<TElastix>::BeforeEachResolution()
   if (testPtr1)
   {
     /** Check for B-spline transform. */
-    const BSplineTransformBaseType * testPtr2 =
-      dynamic_cast<const BSplineTransformBaseType *>(testPtr1->GetCurrentTransform());
-    if (testPtr2)
+    const auto bsplineTransform = dynamic_cast<const BSplineTransformBaseType *>(testPtr1->GetCurrentTransform());
+    if (bsplineTransform)
     {
-      this->SetGridSize(testPtr2->GetGridRegion().GetSize());
+      this->SetGridSize(bsplineTransform->GetGridRegion().GetSize());
     }
     else
     {

--- a/Components/Metrics/PCAMetric2/elxPCAMetric2.hxx
+++ b/Components/Metrics/PCAMetric2/elxPCAMetric2.hxx
@@ -103,19 +103,19 @@ PCAMetric2<TElastix>::BeforeEachResolution()
     else
     {
       /** Check for stack transform. */
-      StackTransformType * testPtr3 = dynamic_cast<StackTransformType *>(testPtr1->GetModifiableCurrentTransform());
-      if (testPtr3)
+      const auto stackTransform = dynamic_cast<StackTransformType *>(testPtr1->GetModifiableCurrentTransform());
+      if (stackTransform)
       {
         /** Set itk member variable. */
         this->SetTransformIsStackTransform(true);
 
-        if (testPtr3->GetNumberOfSubTransforms() > 0)
+        if (stackTransform->GetNumberOfSubTransforms() > 0)
         {
           /** Check if subtransform is a B-spline transform. */
-          if (dynamic_cast<ReducedDimensionBSplineTransformBaseType *>(testPtr3->GetSubTransform(0).GetPointer()))
+          if (dynamic_cast<ReducedDimensionBSplineTransformBaseType *>(stackTransform->GetSubTransform(0).GetPointer()))
           {
             FixedImageSizeType gridSize;
-            gridSize.Fill(testPtr3->GetNumberOfSubTransforms());
+            gridSize.Fill(stackTransform->GetNumberOfSubTransforms());
             this->SetGridSize(gridSize);
           }
         }

--- a/Components/Metrics/PCAMetric2/elxPCAMetric2.hxx
+++ b/Components/Metrics/PCAMetric2/elxPCAMetric2.hxx
@@ -112,9 +112,7 @@ PCAMetric2<TElastix>::BeforeEachResolution()
         if (testPtr3->GetNumberOfSubTransforms() > 0)
         {
           /** Check if subtransform is a B-spline transform. */
-          const ReducedDimensionBSplineTransformBaseType * testPtr4 =
-            dynamic_cast<const ReducedDimensionBSplineTransformBaseType *>(testPtr3->GetSubTransform(0).GetPointer());
-          if (testPtr4)
+          if (dynamic_cast<ReducedDimensionBSplineTransformBaseType *>(testPtr3->GetSubTransform(0).GetPointer()))
           {
             FixedImageSizeType gridSize;
             gridSize.Fill(testPtr3->GetNumberOfSubTransforms());

--- a/Components/Metrics/SumOfPairwiseCorrelationsMetric/elxSumOfPairwiseCorrelationCoefficientsMetric.hxx
+++ b/Components/Metrics/SumOfPairwiseCorrelationsMetric/elxSumOfPairwiseCorrelationCoefficientsMetric.hxx
@@ -94,11 +94,10 @@ SumOfPairwiseCorrelationCoefficientsMetric<TElastix>::BeforeEachResolution()
   if (testPtr1)
   {
     /** Check for B-spline transform. */
-    const BSplineTransformBaseType * testPtr2 =
-      dynamic_cast<const BSplineTransformBaseType *>(testPtr1->GetCurrentTransform());
-    if (testPtr2)
+    const auto bsplineTransform = dynamic_cast<const BSplineTransformBaseType *>(testPtr1->GetCurrentTransform());
+    if (bsplineTransform)
     {
-      this->SetGridSize(testPtr2->GetGridRegion().GetSize());
+      this->SetGridSize(bsplineTransform->GetGridRegion().GetSize());
     }
     else
     {

--- a/Components/Metrics/SumOfPairwiseCorrelationsMetric/elxSumOfPairwiseCorrelationCoefficientsMetric.hxx
+++ b/Components/Metrics/SumOfPairwiseCorrelationsMetric/elxSumOfPairwiseCorrelationCoefficientsMetric.hxx
@@ -90,11 +90,13 @@ SumOfPairwiseCorrelationCoefficientsMetric<TElastix>::BeforeEachResolution()
   }
 
   /** Check if this transform is a B-spline transform. */
-  CombinationTransformType * testPtr1 = BaseComponent::AsITKBaseType(this->GetElastix()->GetElxTransformBase());
-  if (testPtr1)
+  CombinationTransformType * combinationTransform =
+    BaseComponent::AsITKBaseType(this->GetElastix()->GetElxTransformBase());
+  if (combinationTransform)
   {
     /** Check for B-spline transform. */
-    const auto bsplineTransform = dynamic_cast<const BSplineTransformBaseType *>(testPtr1->GetCurrentTransform());
+    const auto bsplineTransform =
+      dynamic_cast<const BSplineTransformBaseType *>(combinationTransform->GetCurrentTransform());
     if (bsplineTransform)
     {
       this->SetGridSize(bsplineTransform->GetGridRegion().GetSize());
@@ -102,7 +104,8 @@ SumOfPairwiseCorrelationCoefficientsMetric<TElastix>::BeforeEachResolution()
     else
     {
       /** Check for stack transform. */
-      const auto stackTransform = dynamic_cast<StackTransformType *>(testPtr1->GetModifiableCurrentTransform());
+      const auto stackTransform =
+        dynamic_cast<StackTransformType *>(combinationTransform->GetModifiableCurrentTransform());
       if (stackTransform)
       {
         /** Set itk member variable. */

--- a/Components/Metrics/SumOfPairwiseCorrelationsMetric/elxSumOfPairwiseCorrelationCoefficientsMetric.hxx
+++ b/Components/Metrics/SumOfPairwiseCorrelationsMetric/elxSumOfPairwiseCorrelationCoefficientsMetric.hxx
@@ -103,19 +103,19 @@ SumOfPairwiseCorrelationCoefficientsMetric<TElastix>::BeforeEachResolution()
     else
     {
       /** Check for stack transform. */
-      StackTransformType * testPtr3 = dynamic_cast<StackTransformType *>(testPtr1->GetModifiableCurrentTransform());
-      if (testPtr3)
+      const auto stackTransform = dynamic_cast<StackTransformType *>(testPtr1->GetModifiableCurrentTransform());
+      if (stackTransform)
       {
         /** Set itk member variable. */
         this->SetTransformIsStackTransform(true);
 
-        if (testPtr3->GetNumberOfSubTransforms() > 0)
+        if (stackTransform->GetNumberOfSubTransforms() > 0)
         {
           /** Check if subtransform is a B-spline transform. */
-          if (dynamic_cast<ReducedDimensionBSplineTransformBaseType *>(testPtr3->GetSubTransform(0).GetPointer()))
+          if (dynamic_cast<ReducedDimensionBSplineTransformBaseType *>(stackTransform->GetSubTransform(0).GetPointer()))
           {
             FixedImageSizeType gridSize;
-            gridSize.Fill(testPtr3->GetNumberOfSubTransforms());
+            gridSize.Fill(stackTransform->GetNumberOfSubTransforms());
             this->SetGridSize(gridSize);
           }
         }

--- a/Components/Metrics/SumOfPairwiseCorrelationsMetric/elxSumOfPairwiseCorrelationCoefficientsMetric.hxx
+++ b/Components/Metrics/SumOfPairwiseCorrelationsMetric/elxSumOfPairwiseCorrelationCoefficientsMetric.hxx
@@ -112,9 +112,7 @@ SumOfPairwiseCorrelationCoefficientsMetric<TElastix>::BeforeEachResolution()
         if (testPtr3->GetNumberOfSubTransforms() > 0)
         {
           /** Check if subtransform is a B-spline transform. */
-          ReducedDimensionBSplineTransformBaseType * testPtr4 =
-            dynamic_cast<ReducedDimensionBSplineTransformBaseType *>(testPtr3->GetSubTransform(0).GetPointer());
-          if (testPtr4)
+          if (dynamic_cast<ReducedDimensionBSplineTransformBaseType *>(testPtr3->GetSubTransform(0).GetPointer()))
           {
             FixedImageSizeType gridSize;
             gridSize.Fill(testPtr3->GetNumberOfSubTransforms());

--- a/Components/Metrics/VarianceOverLastDimension/elxVarianceOverLastDimensionMetric.hxx
+++ b/Components/Metrics/VarianceOverLastDimension/elxVarianceOverLastDimensionMetric.hxx
@@ -142,9 +142,7 @@ VarianceOverLastDimensionMetric<TElastix>::BeforeEachResolution()
         if (testPtr3->GetNumberOfSubTransforms() > 0)
         {
           /** Check if subtransform is a B-spline transform. */
-          ReducedDimensionBSplineTransformBaseType * testPtr4 =
-            dynamic_cast<ReducedDimensionBSplineTransformBaseType *>(testPtr3->GetSubTransform(0).GetPointer());
-          if (testPtr4)
+          if (dynamic_cast<ReducedDimensionBSplineTransformBaseType *>(testPtr3->GetSubTransform(0).GetPointer()))
           {
             FixedImageSizeType gridSize;
             gridSize.Fill(testPtr3->GetNumberOfSubTransforms());

--- a/Components/Metrics/VarianceOverLastDimension/elxVarianceOverLastDimensionMetric.hxx
+++ b/Components/Metrics/VarianceOverLastDimension/elxVarianceOverLastDimensionMetric.hxx
@@ -120,11 +120,13 @@ VarianceOverLastDimensionMetric<TElastix>::BeforeEachResolution()
   this->SetReducedDimensionIndex(reducedDimensionIndex);
 
   /** Check if this transform is a B-spline transform. */
-  CombinationTransformType * testPtr1 = BaseComponent::AsITKBaseType(this->GetElastix()->GetElxTransformBase());
-  if (testPtr1)
+  CombinationTransformType * combinationTransform =
+    BaseComponent::AsITKBaseType(this->GetElastix()->GetElxTransformBase());
+  if (combinationTransform)
   {
     /** Check for B-spline transform. */
-    const auto bsplineTransform = dynamic_cast<const BSplineTransformBaseType *>(testPtr1->GetCurrentTransform());
+    const auto bsplineTransform =
+      dynamic_cast<const BSplineTransformBaseType *>(combinationTransform->GetCurrentTransform());
     if (bsplineTransform)
     {
       this->SetGridSize(bsplineTransform->GetGridRegion().GetSize());
@@ -132,7 +134,8 @@ VarianceOverLastDimensionMetric<TElastix>::BeforeEachResolution()
     else
     {
       /** Check for stack transform. */
-      const auto stackTransform = dynamic_cast<StackTransformType *>(testPtr1->GetModifiableCurrentTransform());
+      const auto stackTransform =
+        dynamic_cast<StackTransformType *>(combinationTransform->GetModifiableCurrentTransform());
       if (stackTransform)
       {
         /** Set itk member variable. */

--- a/Components/Metrics/VarianceOverLastDimension/elxVarianceOverLastDimensionMetric.hxx
+++ b/Components/Metrics/VarianceOverLastDimension/elxVarianceOverLastDimensionMetric.hxx
@@ -133,19 +133,19 @@ VarianceOverLastDimensionMetric<TElastix>::BeforeEachResolution()
     else
     {
       /** Check for stack transform. */
-      StackTransformType * testPtr3 = dynamic_cast<StackTransformType *>(testPtr1->GetModifiableCurrentTransform());
-      if (testPtr3)
+      const auto stackTransform = dynamic_cast<StackTransformType *>(testPtr1->GetModifiableCurrentTransform());
+      if (stackTransform)
       {
         /** Set itk member variable. */
         this->SetTransformIsStackTransform(true);
 
-        if (testPtr3->GetNumberOfSubTransforms() > 0)
+        if (stackTransform->GetNumberOfSubTransforms() > 0)
         {
           /** Check if subtransform is a B-spline transform. */
-          if (dynamic_cast<ReducedDimensionBSplineTransformBaseType *>(testPtr3->GetSubTransform(0).GetPointer()))
+          if (dynamic_cast<ReducedDimensionBSplineTransformBaseType *>(stackTransform->GetSubTransform(0).GetPointer()))
           {
             FixedImageSizeType gridSize;
-            gridSize.Fill(testPtr3->GetNumberOfSubTransforms());
+            gridSize.Fill(stackTransform->GetNumberOfSubTransforms());
             this->SetGridSize(gridSize);
           }
         }

--- a/Components/Metrics/VarianceOverLastDimension/elxVarianceOverLastDimensionMetric.hxx
+++ b/Components/Metrics/VarianceOverLastDimension/elxVarianceOverLastDimensionMetric.hxx
@@ -124,11 +124,10 @@ VarianceOverLastDimensionMetric<TElastix>::BeforeEachResolution()
   if (testPtr1)
   {
     /** Check for B-spline transform. */
-    const BSplineTransformBaseType * testPtr2 =
-      dynamic_cast<const BSplineTransformBaseType *>(testPtr1->GetCurrentTransform());
-    if (testPtr2)
+    const auto bsplineTransform = dynamic_cast<const BSplineTransformBaseType *>(testPtr1->GetCurrentTransform());
+    if (bsplineTransform)
     {
-      this->SetGridSize(testPtr2->GetGridRegion().GetSize());
+      this->SetGridSize(bsplineTransform->GetGridRegion().GetSize());
     }
     else
     {


### PR DESCRIPTION
Aims to improve code readability of those `BeforeEachResolution()` member functions 