### PR TITLE
BUG: Do `SetTransformIsStackTransform(false)` in BeforeEachResolution()

### DIFF
--- a/Components/Metrics/PCAMetric/elxPCAMetric.hxx
+++ b/Components/Metrics/PCAMetric/elxPCAMetric.hxx
@@ -121,9 +121,14 @@ PCAMetric<TElastix>::BeforeEachResolution()
             this->SetGridSize(FixedImageSizeType::Filled(numberOfSubTransforms));
           }
         }
+        // Return early, now that the current transform is a stack transform.
+        return;
       }
     }
   }
+  // If the current transform would have been a stack transform, the function would have returned earlier.
+  this->SetTransformIsStackTransform(false);
+
   log::info("end BeforeEachResolution");
 
 } // end BeforeEachResolution()

--- a/Components/Metrics/PCAMetric2/elxPCAMetric2.hxx
+++ b/Components/Metrics/PCAMetric2/elxPCAMetric2.hxx
@@ -116,9 +116,13 @@ PCAMetric2<TElastix>::BeforeEachResolution()
             this->SetGridSize(FixedImageSizeType::Filled(numberOfSubTransforms));
           }
         }
+        // Return early, now that the current transform is a stack transform.
+        return;
       }
     }
   }
+  // If the current transform would have been a stack transform, the function would have returned earlier.
+  this->SetTransformIsStackTransform(false);
 
 } // end BeforeEachResolution()
 

--- a/Components/Metrics/SumOfPairwiseCorrelationsMetric/elxSumOfPairwiseCorrelationCoefficientsMetric.hxx
+++ b/Components/Metrics/SumOfPairwiseCorrelationsMetric/elxSumOfPairwiseCorrelationCoefficientsMetric.hxx
@@ -117,9 +117,14 @@ SumOfPairwiseCorrelationCoefficientsMetric<TElastix>::BeforeEachResolution()
             this->SetGridSize(FixedImageSizeType::Filled(numberOfSubTransforms));
           }
         }
+        // Return early, now that the current transform is a stack transform.
+        return;
       }
     }
   }
+  // If the current transform would have been a stack transform, the function would have returned earlier.
+  this->SetTransformIsStackTransform(false);
+
   log::info("end BeforeEachResolution");
 
 } // end BeforeEachResolution()

--- a/Components/Metrics/VarianceOverLastDimension/elxVarianceOverLastDimensionMetric.hxx
+++ b/Components/Metrics/VarianceOverLastDimension/elxVarianceOverLastDimensionMetric.hxx
@@ -147,9 +147,13 @@ VarianceOverLastDimensionMetric<TElastix>::BeforeEachResolution()
             this->SetGridSize(FixedImageSizeType::Filled(numberOfSubTransforms));
           }
         }
+        // Return early, now that the current transform is a stack transform.
+        return;
       }
     }
   }
+  // If the current transform would have been a stack transform, the function would have returned earlier.
+  this->SetTransformIsStackTransform(false);
 
 } // end BeforeEachResolution()
 


### PR DESCRIPTION
Whenever BeforeEachResolution() detects that there is _no_ stack transform as current transform, let it set TransformIsStackTransform = false, just like it sets TransformIsStackTransform = true when the current transform _is_ a stack transform.

----

- @stefanklein Do you agree that this would be a useful commit? Or would it be unnecessary? (TransformIsStackTransform is now already initialized to false during the construction of all four metrics, with pull request #1163. So I wonder if it's useful to then reset this property with each BeforeEachResolution() call.)