### PR TITLE
STYLE: Do not set GridSize when TransformIsStackTransform, in Metrics

### DIFF
--- a/Components/Metrics/PCAMetric/elxPCAMetric.hxx
+++ b/Components/Metrics/PCAMetric/elxPCAMetric.hxx
@@ -112,15 +112,6 @@ PCAMetric<TElastix>::BeforeEachResolution()
         /** Set itk member variable. */
         this->SetTransformIsStackTransform(true);
 
-        if (const unsigned int numberOfSubTransforms{ stackTransform->GetNumberOfSubTransforms() };
-            numberOfSubTransforms > 0)
-        {
-          /** Check if subtransform is a B-spline transform. */
-          if (dynamic_cast<ReducedDimensionBSplineTransformBaseType *>(stackTransform->GetSubTransform(0).GetPointer()))
-          {
-            this->SetGridSize(FixedImageSizeType::Filled(numberOfSubTransforms));
-          }
-        }
         // Return early, now that the current transform is a stack transform.
         return;
       }

--- a/Components/Metrics/PCAMetric2/elxPCAMetric2.hxx
+++ b/Components/Metrics/PCAMetric2/elxPCAMetric2.hxx
@@ -107,15 +107,6 @@ PCAMetric2<TElastix>::BeforeEachResolution()
         /** Set itk member variable. */
         this->SetTransformIsStackTransform(true);
 
-        if (const unsigned int numberOfSubTransforms{ stackTransform->GetNumberOfSubTransforms() };
-            numberOfSubTransforms > 0)
-        {
-          /** Check if subtransform is a B-spline transform. */
-          if (dynamic_cast<ReducedDimensionBSplineTransformBaseType *>(stackTransform->GetSubTransform(0).GetPointer()))
-          {
-            this->SetGridSize(FixedImageSizeType::Filled(numberOfSubTransforms));
-          }
-        }
         // Return early, now that the current transform is a stack transform.
         return;
       }

--- a/Components/Metrics/SumOfPairwiseCorrelationsMetric/elxSumOfPairwiseCorrelationCoefficientsMetric.hxx
+++ b/Components/Metrics/SumOfPairwiseCorrelationsMetric/elxSumOfPairwiseCorrelationCoefficientsMetric.hxx
@@ -108,15 +108,6 @@ SumOfPairwiseCorrelationCoefficientsMetric<TElastix>::BeforeEachResolution()
         /** Set itk member variable. */
         this->SetTransformIsStackTransform(true);
 
-        if (const unsigned int numberOfSubTransforms{ stackTransform->GetNumberOfSubTransforms() };
-            numberOfSubTransforms > 0)
-        {
-          /** Check if subtransform is a B-spline transform. */
-          if (dynamic_cast<ReducedDimensionBSplineTransformBaseType *>(stackTransform->GetSubTransform(0).GetPointer()))
-          {
-            this->SetGridSize(FixedImageSizeType::Filled(numberOfSubTransforms));
-          }
-        }
         // Return early, now that the current transform is a stack transform.
         return;
       }

--- a/Components/Metrics/VarianceOverLastDimension/elxVarianceOverLastDimensionMetric.hxx
+++ b/Components/Metrics/VarianceOverLastDimension/elxVarianceOverLastDimensionMetric.hxx
@@ -138,15 +138,6 @@ VarianceOverLastDimensionMetric<TElastix>::BeforeEachResolution()
         /** Set itk member variable. */
         this->SetTransformIsStackTransform(true);
 
-        if (const unsigned int numberOfSubTransforms{ stackTransform->GetNumberOfSubTransforms() };
-            numberOfSubTransforms > 0)
-        {
-          /** Check if subtransform is a B-spline transform. */
-          if (dynamic_cast<ReducedDimensionBSplineTransformBaseType *>(stackTransform->GetSubTransform(0).GetPointer()))
-          {
-            this->SetGridSize(FixedImageSizeType::Filled(numberOfSubTransforms));
-          }
-        }
         // Return early, now that the current transform is a stack transform.
         return;
       }


### PR DESCRIPTION
The GridSize is only relevant when the transform is _not_ a stack transform!

----

@stefanklein This looks strange to me: each of those three metrics _fill_ their GridSize with numberOfSubTransforms. So for 3D, the grid size would then become numberOfSubTransforms x numberOfSubTransforms x numberOfSubTransforms. But they do so, specifically when the transform is a stack transform. And they do so from the very first commit, by Wyke (@whuizinga) 764490d5e37de792fea4340fc11850bfd067318d, Nov 24, 2015. Looking at elxPCAMetric.hxx: 

https://github.com/SuperElastix/elastix/blob/764490d5e37de792fea4340fc11850bfd067318d/src/Components/Metrics/PCAMetric/elxPCAMetric.hxx#L115-L132

But they only seem to _use_ their GridSize (or at least `m_GridSize[lastDim]`) when the transform is _not_ a stack transform, Looking at itkPCAMetric.hxx: 

https://github.com/SuperElastix/elastix/blob/764490d5e37de792fea4340fc11850bfd067318d/src/Components/Metrics/PCAMetric/itkPCAMetric.hxx#L795-L803

So do you agree that when the transform is a stack transform, the GridSize does _not_ need to be filled? (As proposed by this pull request.)