### PR TITLE
Replace `itk::ImageBase<Dimension>::GetImageDimension()` calls

### DIFF
--- a/Common/Transforms/itkCyclicBSplineDeformableTransform.hxx
+++ b/Common/Transforms/itkCyclicBSplineDeformableTransform.hxx
@@ -40,7 +40,7 @@ CyclicBSplineDeformableTransform<TScalarType, NDimensions, VSplineOrder>::SetGri
   Superclass::SetGridRegion(region);
 
   /** Check if last dimension of supportregion < last dimension of grid. */
-  const int lastDim = this->m_GridRegion.GetImageDimension() - 1;
+  const int lastDim = NDimensions - 1;
   const int lastDimSize = this->m_GridRegion.GetSize(lastDim);
 
   // The support size is the same for all dimensions.
@@ -97,7 +97,7 @@ CyclicBSplineDeformableTransform<TScalarType, NDimensions, VSplineOrder>::SplitR
   SizeType size2{};
 
   /** Get last dimension information. */
-  const unsigned int lastDim = imageRegion.GetImageDimension() - 1;
+  const unsigned int lastDim = NDimensions - 1;
   const unsigned int lastDimSize = imageRegion.GetSize(lastDim);
   const unsigned int supportLastDimSize = inRegion.GetSize(lastDim);
 

--- a/Common/itkNDImageTemplate.hxx
+++ b/Common/itkNDImageTemplate.hxx
@@ -209,7 +209,7 @@ template <class TPixel, unsigned int VDimension>
 unsigned int
 NDImageTemplate<TPixel, VDimension>::ImageDimension()
 {
-  return this->m_Image->GetImageDimension();
+  return VDimension;
 }
 
 
@@ -217,7 +217,7 @@ template <class TPixel, unsigned int VDimension>
 unsigned int
 NDImageTemplate<TPixel, VDimension>::GetImageDimension()
 {
-  return this->m_Image->GetImageDimension();
+  return VDimension;
 }
 
 

--- a/Common/itkParabolicErodeDilateImageFilter.hxx
+++ b/Common/itkParabolicErodeDilateImageFilter.hxx
@@ -81,7 +81,7 @@ ParabolicErodeDilateImageFilter<TInputImage, doDilate, TOutputImage>::SplitReque
 
   // split on the outermost dimension available
   // and avoid the current dimension
-  splitAxis = outputPtr->GetImageDimension() - 1;
+  splitAxis = OutputImageDimension - 1;
   while (requestedRegionSize[splitAxis] == 1 || splitAxis == (int)m_CurrentDimension)
   {
     --splitAxis;
@@ -174,7 +174,6 @@ ParabolicErodeDilateImageFilter<TInputImage, doDilate, TOutputImage>::GenerateDa
   typename TInputImage::ConstPointer inputImage(this->GetInput());
   typename TOutputImage::Pointer     outputImage(this->GetOutput());
 
-  // const unsigned int imageDimension = inputImage->GetImageDimension();
   outputImage->SetBufferedRegion(outputImage->GetRequestedRegion());
   outputImage->Allocate();
   // Set up the multithreaded processing

--- a/Components/Interpolators/RayCastInterpolator/elxRayCastInterpolator.hxx
+++ b/Components/Interpolators/RayCastInterpolator/elxRayCastInterpolator.hxx
@@ -33,12 +33,12 @@ int
 RayCastInterpolator<TElastix>::BeforeAll()
 {
   // Check if 2D-3D
-  if (this->m_Elastix->GetFixedImage()->GetImageDimension() != 3)
+  if (TElastix::FixedDimension != 3)
   {
     itkExceptionMacro("The RayCastInterpolator expects the fixed image to be 3D.");
     return 1;
   }
-  if (this->m_Elastix->GetMovingImage()->GetImageDimension() != 3)
+  if (TElastix::MovingDimension != 3)
   {
     itkExceptionMacro("The RayCastInterpolator expects the moving image to be 3D.");
     return 1;
@@ -83,7 +83,7 @@ RayCastInterpolator<TElastix>::BeforeRegistration()
   PointType focalPoint;
   focalPoint.Fill(0.);
 
-  for (unsigned int i = 0; i < this->m_Elastix->GetFixedImage()->GetImageDimension(); ++i)
+  for (unsigned int i = 0; i < TElastix::FixedDimension; ++i)
   {
     bool ret = this->GetConfiguration()->ReadParameter(focalPoint[i], "FocalPoint", this->GetComponentLabel(), i, 0);
     if (!ret)

--- a/Components/Interpolators/RayCastInterpolator/elxRayCastInterpolator.hxx
+++ b/Components/Interpolators/RayCastInterpolator/elxRayCastInterpolator.hxx
@@ -33,12 +33,12 @@ int
 RayCastInterpolator<TElastix>::BeforeAll()
 {
   // Check if 2D-3D
-  if (TElastix::FixedDimension != 3)
+  if constexpr (TElastix::FixedDimension != 3)
   {
     itkExceptionMacro("The RayCastInterpolator expects the fixed image to be 3D.");
     return 1;
   }
-  if (TElastix::MovingDimension != 3)
+  if constexpr (TElastix::MovingDimension != 3)
   {
     itkExceptionMacro("The RayCastInterpolator expects the moving image to be 3D.");
     return 1;

--- a/Components/Metrics/GradientDifference/elxGradientDifferenceMetric.hxx
+++ b/Components/Metrics/GradientDifference/elxGradientDifferenceMetric.hxx
@@ -51,11 +51,11 @@ void
 GradientDifferenceMetric<TElastix>::BeforeRegistration()
 {
 
-  if (TElastix::FixedDimension != 3)
+  if constexpr (TElastix::FixedDimension != 3)
   {
     itkExceptionMacro("FixedImage must be 3D");
   }
-  if (TElastix::FixedDimension == 3)
+  if constexpr (TElastix::FixedDimension == 3)
   {
     if (this->m_Elastix->GetFixedImage()->GetLargestPossibleRegion().GetSize()[2] != 1)
     {

--- a/Components/Metrics/GradientDifference/elxGradientDifferenceMetric.hxx
+++ b/Components/Metrics/GradientDifference/elxGradientDifferenceMetric.hxx
@@ -51,11 +51,11 @@ void
 GradientDifferenceMetric<TElastix>::BeforeRegistration()
 {
 
-  if (this->m_Elastix->GetFixedImage()->GetImageDimension() != 3)
+  if (TElastix::FixedDimension != 3)
   {
     itkExceptionMacro("FixedImage must be 3D");
   }
-  if (this->m_Elastix->GetFixedImage()->GetImageDimension() == 3)
+  if (TElastix::FixedDimension == 3)
   {
     if (this->m_Elastix->GetFixedImage()->GetLargestPossibleRegion().GetSize()[2] != 1)
     {

--- a/Components/Metrics/NormalizedGradientCorrelation/elxNormalizedGradientCorrelationMetric.hxx
+++ b/Components/Metrics/NormalizedGradientCorrelation/elxNormalizedGradientCorrelationMetric.hxx
@@ -50,11 +50,11 @@ template <class TElastix>
 void
 NormalizedGradientCorrelationMetric<TElastix>::BeforeRegistration()
 {
-  if (this->m_Elastix->GetFixedImage()->GetImageDimension() != 3)
+  if (TElastix::FixedDimension != 3)
   {
     itkExceptionMacro("FixedImage must be 3D");
   }
-  if (this->m_Elastix->GetFixedImage()->GetImageDimension() == 3)
+  if (TElastix::FixedDimension == 3)
   {
     if (this->m_Elastix->GetFixedImage()->GetLargestPossibleRegion().GetSize()[2] != 1)
     {

--- a/Components/Metrics/NormalizedGradientCorrelation/elxNormalizedGradientCorrelationMetric.hxx
+++ b/Components/Metrics/NormalizedGradientCorrelation/elxNormalizedGradientCorrelationMetric.hxx
@@ -50,11 +50,11 @@ template <class TElastix>
 void
 NormalizedGradientCorrelationMetric<TElastix>::BeforeRegistration()
 {
-  if (TElastix::FixedDimension != 3)
+  if constexpr (TElastix::FixedDimension != 3)
   {
     itkExceptionMacro("FixedImage must be 3D");
   }
-  if (TElastix::FixedDimension == 3)
+  if constexpr (TElastix::FixedDimension == 3)
   {
     if (this->m_Elastix->GetFixedImage()->GetLargestPossibleRegion().GetSize()[2] != 1)
     {

--- a/Components/Metrics/PCAMetric/itkPCAMetric.hxx
+++ b/Components/Metrics/PCAMetric/itkPCAMetric.hxx
@@ -56,7 +56,7 @@ PCAMetric<TFixedImage, TMovingImage>::Initialize()
   Superclass::Initialize();
 
   /** Retrieve slowest varying dimension and its size. */
-  const unsigned int lastDim = this->GetFixedImage()->GetImageDimension() - 1;
+  const unsigned int lastDim = FixedImageDimension - 1;
   const unsigned int lastDimSize = this->GetFixedImage()->GetLargestPossibleRegion().GetSize(lastDim);
 
   /** Check num last samples. */
@@ -167,7 +167,7 @@ PCAMetric<TFixedImage, TMovingImage>::GetValue(const TransformParametersType & p
   ImageSampleContainerPointer sampleContainer = this->GetImageSampler()->GetOutput();
 
   /** Retrieve slowest varying dimension and its size. */
-  const unsigned int lastDim = this->GetFixedImage()->GetImageDimension() - 1;
+  const unsigned int lastDim = FixedImageDimension - 1;
   const unsigned int lastDimSize = this->GetFixedImage()->GetLargestPossibleRegion().GetSize(lastDim);
   const unsigned int numLastDimSamples = this->m_NumSamplesLastDimension;
 
@@ -396,7 +396,7 @@ PCAMetric<TFixedImage, TMovingImage>::GetValueAndDerivative(const TransformParam
   ImageSampleContainerPointer sampleContainer = this->GetImageSampler()->GetOutput();
 
   /** Retrieve slowest varying dimension and its size. */
-  const unsigned int lastDim = this->GetFixedImage()->GetImageDimension() - 1;
+  const unsigned int lastDim = FixedImageDimension - 1;
   const unsigned int lastDimSize = this->GetFixedImage()->GetLargestPossibleRegion().GetSize(lastDim);
   const unsigned int numLastDimSamples = this->m_NumSamplesLastDimension;
 
@@ -747,11 +747,10 @@ PCAMetric<TFixedImage, TMovingImage>::GetValueAndDerivative(const TransformParam
        * per dimension xyz.
        */
       const unsigned int lastDimGridSize = m_GridSize[lastDim];
-      const unsigned int numParametersPerDimension =
-        this->GetNumberOfParameters() / this->GetMovingImage()->GetImageDimension();
+      const unsigned int numParametersPerDimension = this->GetNumberOfParameters() / MovingImageDimension;
       const unsigned int numControlPointsPerDimension = numParametersPerDimension / lastDimGridSize;
       DerivativeType     mean(numControlPointsPerDimension);
-      for (unsigned int d = 0; d < this->GetMovingImage()->GetImageDimension(); ++d)
+      for (unsigned int d = 0; d < MovingImageDimension; ++d)
       {
         /** Compute mean per dimension. */
         mean.Fill(0.0);

--- a/Components/Metrics/PCAMetric/itkPCAMetric_F_multithreaded.hxx
+++ b/Components/Metrics/PCAMetric/itkPCAMetric_F_multithreaded.hxx
@@ -64,7 +64,7 @@ PCAMetric<TFixedImage, TMovingImage>::Initialize()
   Superclass::Initialize();
 
   /** Retrieve slowest varying dimension and its size. */
-  m_LastDimIndex = this->GetFixedImage()->GetImageDimension() - 1;
+  m_LastDimIndex = FixedImageDimension - 1;
   m_G = this->GetFixedImage()->GetLargestPossibleRegion().GetSize(m_LastDimIndex);
 
   if (m_NumEigenValues > m_G)
@@ -534,11 +534,10 @@ PCAMetric<TFixedImage, TMovingImage>::GetValueAndDerivativeSingleThreaded(const 
        * per dimension xyz.
        */
       const unsigned int lastDimGridSize = m_GridSize[m_LastDimIndex];
-      const unsigned int numParametersPerDimension =
-        this->GetNumberOfParameters() / this->GetMovingImage()->GetImageDimension();
+      const unsigned int numParametersPerDimension = this->GetNumberOfParameters() / MovingImageDimension;
       const unsigned int numControlPointsPerDimension = numParametersPerDimension / lastDimGridSize;
       DerivativeType     mean(numControlPointsPerDimension);
-      for (unsigned int d = 0; d < this->GetMovingImage()->GetImageDimension(); ++d)
+      for (unsigned int d = 0; d < MovingImageDimension; ++d)
       {
         /** Compute mean per dimension. */
         mean.Fill(0.0);
@@ -968,11 +967,10 @@ PCAMetric<TFixedImage, TMovingImage>::AfterThreadedComputeDerivative(DerivativeT
        * per dimension xyz.
        */
       const unsigned int lastDimGridSize = m_GridSize[m_LastDimIndex];
-      const unsigned int numParametersPerDimension =
-        this->GetNumberOfParameters() / this->GetMovingImage()->GetImageDimension();
+      const unsigned int numParametersPerDimension = this->GetNumberOfParameters() / MovingImageDimension;
       const unsigned int numControlPointsPerDimension = numParametersPerDimension / lastDimGridSize;
       DerivativeType     mean(numControlPointsPerDimension);
-      for (unsigned int d = 0; d < this->GetMovingImage()->GetImageDimension(); ++d)
+      for (unsigned int d = 0; d < MovingImageDimension; ++d)
       {
         /** Compute mean per dimension. */
         mean.Fill(0.0);

--- a/Components/Metrics/PCAMetric2/itkPCAMetric2.hxx
+++ b/Components/Metrics/PCAMetric2/itkPCAMetric2.hxx
@@ -56,7 +56,7 @@ PCAMetric2<TFixedImage, TMovingImage>::Initialize()
   Superclass::Initialize();
 
   /** Retrieve slowest varying dimension and its size. */
-  // const unsigned int lastDim = this->GetFixedImage()->GetImageDimension() - 1;
+  // const unsigned int lastDim = FixedImageDimension - 1;
   // const unsigned int G = this->GetFixedImage()->GetLargestPossibleRegion().GetSize( lastDim );
 
 } // end Initialize()
@@ -157,7 +157,7 @@ PCAMetric2<TFixedImage, TMovingImage>::GetValue(const TransformParametersType & 
   ImageSampleContainerPointer sampleContainer = this->GetImageSampler()->GetOutput();
 
   /** Retrieve slowest varying dimension and its size. */
-  const unsigned int lastDim = this->GetFixedImage()->GetImageDimension() - 1;
+  const unsigned int lastDim = FixedImageDimension - 1;
   const unsigned int G = this->GetFixedImage()->GetLargestPossibleRegion().GetSize(lastDim);
 
   using MatrixType = vnl_matrix<RealType>;
@@ -346,7 +346,7 @@ PCAMetric2<TFixedImage, TMovingImage>::GetValueAndDerivative(const TransformPara
   ImageSampleContainerPointer sampleContainer = this->GetImageSampler()->GetOutput();
 
   /** Retrieve slowest varying dimension and its size. */
-  const unsigned int lastDim = this->GetFixedImage()->GetImageDimension() - 1;
+  const unsigned int lastDim = FixedImageDimension - 1;
   const unsigned int G = this->GetFixedImage()->GetLargestPossibleRegion().GetSize(lastDim);
 
   using MatrixType = vnl_matrix<RealType>;
@@ -567,11 +567,10 @@ PCAMetric2<TFixedImage, TMovingImage>::GetValueAndDerivative(const TransformPara
        * per dimension xyz.
        */
       const unsigned int lastDimGridSize = m_GridSize[lastDim];
-      const unsigned int numParametersPerDimension =
-        this->GetNumberOfParameters() / this->GetMovingImage()->GetImageDimension();
+      const unsigned int numParametersPerDimension = this->GetNumberOfParameters() / MovingImageDimension;
       const unsigned int numControlPointsPerDimension = numParametersPerDimension / lastDimGridSize;
       DerivativeType     mean(numControlPointsPerDimension);
-      for (unsigned int d = 0; d < this->GetMovingImage()->GetImageDimension(); ++d)
+      for (unsigned int d = 0; d < MovingImageDimension; ++d)
       {
         /** Compute mean per dimension. */
         mean.Fill(0.0);

--- a/Components/Metrics/PatternIntensity/elxPatternIntensityMetric.hxx
+++ b/Components/Metrics/PatternIntensity/elxPatternIntensityMetric.hxx
@@ -50,11 +50,11 @@ template <class TElastix>
 void
 PatternIntensityMetric<TElastix>::BeforeRegistration()
 {
-  if (TElastix::FixedDimension != 3)
+  if constexpr (TElastix::FixedDimension != 3)
   {
     itkExceptionMacro("FixedImage must be 3D");
   }
-  if (TElastix::FixedDimension == 3)
+  if constexpr (TElastix::FixedDimension == 3)
   {
     if (this->m_Elastix->GetFixedImage()->GetLargestPossibleRegion().GetSize()[2] != 1)
     {

--- a/Components/Metrics/PatternIntensity/elxPatternIntensityMetric.hxx
+++ b/Components/Metrics/PatternIntensity/elxPatternIntensityMetric.hxx
@@ -50,11 +50,11 @@ template <class TElastix>
 void
 PatternIntensityMetric<TElastix>::BeforeRegistration()
 {
-  if (this->m_Elastix->GetFixedImage()->GetImageDimension() != 3)
+  if (TElastix::FixedDimension != 3)
   {
     itkExceptionMacro("FixedImage must be 3D");
   }
-  if (this->m_Elastix->GetFixedImage()->GetImageDimension() == 3)
+  if (TElastix::FixedDimension == 3)
   {
     if (this->m_Elastix->GetFixedImage()->GetLargestPossibleRegion().GetSize()[2] != 1)
     {

--- a/Components/Metrics/SumOfPairwiseCorrelationsMetric/itkSumOfPairwiseCorrelationCoefficientsMetric.hxx
+++ b/Components/Metrics/SumOfPairwiseCorrelationsMetric/itkSumOfPairwiseCorrelationCoefficientsMetric.hxx
@@ -139,7 +139,7 @@ SumOfPairwiseCorrelationCoefficientsMetric<TFixedImage, TMovingImage>::GetValue(
   ImageSampleContainerPointer sampleContainer = this->GetImageSampler()->GetOutput();
 
   /** Retrieve slowest varying dimension and its size. */
-  const unsigned int lastDim = this->GetFixedImage()->GetImageDimension() - 1;
+  const unsigned int lastDim = FixedImageDimension - 1;
   const unsigned int G = this->GetFixedImage()->GetLargestPossibleRegion().GetSize(lastDim);
 
   using MatrixType = vnl_matrix<RealType>;
@@ -300,7 +300,7 @@ SumOfPairwiseCorrelationCoefficientsMetric<TFixedImage, TMovingImage>::GetValueA
   ImageSampleContainerPointer sampleContainer = this->GetImageSampler()->GetOutput();
 
   /** Retrieve slowest varying dimension and its size. */
-  const unsigned int lastDim = this->GetFixedImage()->GetImageDimension() - 1;
+  const unsigned int lastDim = FixedImageDimension - 1;
   const unsigned int G = this->GetFixedImage()->GetLargestPossibleRegion().GetSize(lastDim);
 
   using MatrixType = vnl_matrix<RealType>;
@@ -490,11 +490,10 @@ SumOfPairwiseCorrelationCoefficientsMetric<TFixedImage, TMovingImage>::GetValueA
        * per dimension xyz.
        */
       const unsigned int lastDimGridSize = m_GridSize[lastDim];
-      const unsigned int numParametersPerDimension =
-        this->GetNumberOfParameters() / this->GetMovingImage()->GetImageDimension();
+      const unsigned int numParametersPerDimension = this->GetNumberOfParameters() / MovingImageDimension;
       const unsigned int numControlPointsPerDimension = numParametersPerDimension / lastDimGridSize;
       DerivativeType     mean(numControlPointsPerDimension);
-      for (unsigned int d = 0; d < this->GetMovingImage()->GetImageDimension(); ++d)
+      for (unsigned int d = 0; d < MovingImageDimension; ++d)
       {
         /** Compute mean per dimension. */
         mean.Fill(0.0);

--- a/Components/Metrics/VarianceOverLastDimension/itkVarianceOverLastDimensionImageMetric.hxx
+++ b/Components/Metrics/VarianceOverLastDimension/itkVarianceOverLastDimensionImageMetric.hxx
@@ -52,7 +52,7 @@ VarianceOverLastDimensionImageMetric<TFixedImage, TMovingImage>::Initialize()
   Superclass::Initialize();
 
   /** Retrieve slowest varying dimension and its size. */
-  const unsigned int lastDim = this->GetFixedImage()->GetImageDimension() - 1;
+  const unsigned int lastDim = FixedImageDimension - 1;
   const unsigned int lastDimSize = this->GetFixedImage()->GetLargestPossibleRegion().GetSize(lastDim);
 
   /** Check num last samples. */
@@ -203,7 +203,7 @@ VarianceOverLastDimensionImageMetric<TFixedImage, TMovingImage>::GetValue(
   ImageSampleContainerPointer sampleContainer = this->GetImageSampler()->GetOutput();
 
   /** Retrieve slowest varying dimension and its size. */
-  const unsigned int lastDim = this->GetFixedImage()->GetImageDimension() - 1;
+  const unsigned int lastDim = FixedImageDimension - 1;
   const unsigned int lastDimSize = this->GetFixedImage()->GetLargestPossibleRegion().GetSize(lastDim);
   const unsigned int numLastDimSamples = m_NumSamplesLastDimension;
 
@@ -358,7 +358,7 @@ VarianceOverLastDimensionImageMetric<TFixedImage, TMovingImage>::GetValueAndDeri
   ImageSampleContainerPointer sampleContainer = this->GetImageSampler()->GetOutput();
 
   /** Retrieve slowest varying dimension and its size. */
-  const unsigned int lastDim = this->GetFixedImage()->GetImageDimension() - 1;
+  const unsigned int lastDim = FixedImageDimension - 1;
   const unsigned int lastDimSize = this->GetFixedImage()->GetLargestPossibleRegion().GetSize(lastDim);
 
   /** Vector containing last dimension positions to use:
@@ -499,11 +499,10 @@ VarianceOverLastDimensionImageMetric<TFixedImage, TMovingImage>::GetValueAndDeri
        * per dimension xyz.
        */
       const unsigned int lastDimGridSize = m_GridSize[lastDim];
-      const unsigned int numParametersPerDimension =
-        this->GetNumberOfParameters() / this->GetMovingImage()->GetImageDimension();
+      const unsigned int numParametersPerDimension = this->GetNumberOfParameters() / MovingImageDimension;
       const unsigned int numControlPointsPerDimension = numParametersPerDimension / lastDimGridSize;
       DerivativeType     mean(numControlPointsPerDimension);
-      for (unsigned int d = 0; d < this->GetMovingImage()->GetImageDimension(); ++d)
+      for (unsigned int d = 0; d < MovingImageDimension; ++d)
       {
         /** Compute mean per dimension. */
         mean.Fill(0.0);

--- a/Components/ResampleInterpolators/RayCastResampleInterpolator/elxRayCastResampleInterpolator.hxx
+++ b/Components/ResampleInterpolators/RayCastResampleInterpolator/elxRayCastResampleInterpolator.hxx
@@ -98,12 +98,12 @@ RayCastResampleInterpolator<TElastix>::BeforeAll()
 {
 
   // Check if 2D-3D
-  if (TElastix::FixedDimension != 3)
+  if constexpr (TElastix::FixedDimension != 3)
   {
     itkExceptionMacro("The RayCastInterpolator expects the fixed image to be 3D.");
     return 1;
   }
-  if (TElastix::MovingDimension != 3)
+  if constexpr (TElastix::MovingDimension != 3)
   {
     itkExceptionMacro("The RayCastInterpolator expects the moving image to be 3D.");
     return 1;

--- a/Components/ResampleInterpolators/RayCastResampleInterpolator/elxRayCastResampleInterpolator.hxx
+++ b/Components/ResampleInterpolators/RayCastResampleInterpolator/elxRayCastResampleInterpolator.hxx
@@ -55,7 +55,7 @@ RayCastResampleInterpolator<TElastix>::InitializeRayCastInterpolator()
   typename EulerTransformType::InputPointType centerofrotation;
   centerofrotation.Fill(0.0);
 
-  for (unsigned int i = 0; i < this->m_Elastix->GetMovingImage()->GetImageDimension(); ++i)
+  for (unsigned int i = 0; i < TElastix::MovingDimension; ++i)
   {
     this->GetConfiguration()->ReadParameter(
       centerofrotation[i], "CenterOfRotationPoint", this->GetComponentLabel(), i, 0);
@@ -70,7 +70,7 @@ RayCastResampleInterpolator<TElastix>::InitializeRayCastInterpolator()
 
   PointType focalPoint{};
 
-  for (unsigned int i = 0; i < this->m_Elastix->GetFixedImage()->GetImageDimension(); ++i)
+  for (unsigned int i = 0; i < TElastix::FixedDimension; ++i)
   {
     bool ret = this->GetConfiguration()->ReadParameter(focalPoint[i], "FocalPoint", this->GetComponentLabel(), i, 0);
     if (!ret)
@@ -98,12 +98,12 @@ RayCastResampleInterpolator<TElastix>::BeforeAll()
 {
 
   // Check if 2D-3D
-  if (this->m_Elastix->GetFixedImage()->GetImageDimension() != 3)
+  if (TElastix::FixedDimension != 3)
   {
     itkExceptionMacro("The RayCastInterpolator expects the fixed image to be 3D.");
     return 1;
   }
-  if (this->m_Elastix->GetMovingImage()->GetImageDimension() != 3)
+  if (TElastix::MovingDimension != 3)
   {
     itkExceptionMacro("The RayCastInterpolator expects the moving image to be 3D.");
     return 1;


### PR DESCRIPTION
It appears unnecessary to estimate the image dimensionality at run-time, as it is usually already known at compile-time. This pull request might yield some performance improvement.