### PR TITLE
PERF: Replace `derivative = DerivativeType(`n`)` with `derivative.set_size(`n`)`

### DIFF
--- a/Components/Metrics/AdvancedKappaStatistic/itkAdvancedKappaStatisticImageToImageMetric.hxx
+++ b/Components/Metrics/AdvancedKappaStatistic/itkAdvancedKappaStatisticImageToImageMetric.hxx
@@ -261,7 +261,7 @@ AdvancedKappaStatisticImageToImageMetric<TFixedImage, TMovingImage>::GetValueAnd
   /** Initialize some variables. */
   Superclass::m_NumberOfPixelsCounted = 0;
   MeasureType measure{};
-  derivative = DerivativeType(this->GetNumberOfParameters());
+  derivative.set_size(this->GetNumberOfParameters());
 
   /** Array that stores dM(x)/dmu, and the sparse jacobian+indices. */
   NonZeroJacobianIndicesType nzji(Superclass::m_AdvancedTransform->GetNumberOfNonZeroJacobianIndices());

--- a/Components/Metrics/AdvancedMattesMutualInformation/itkParzenWindowMutualInformationImageToImageMetric.hxx
+++ b/Components/Metrics/AdvancedMattesMutualInformation/itkParzenWindowMutualInformationImageToImageMetric.hxx
@@ -153,7 +153,7 @@ ParzenWindowMutualInformationImageToImageMetric<TFixedImage, TMovingImage>::GetV
 
   /** Initialize some variables. */
   value = MeasureType{};
-  derivative = DerivativeType(this->GetNumberOfParameters());
+  derivative.set_size(this->GetNumberOfParameters());
   derivative.Fill(0.0);
 
   /** Construct the JointPDF, JointPDFDerivatives, Alpha and its derivatives. */
@@ -824,7 +824,7 @@ ParzenWindowMutualInformationImageToImageMetric<TFixedImage, TMovingImage>::GetV
 {
   /** Initialize some variables. */
   value = MeasureType{};
-  derivative = DerivativeType(this->GetNumberOfParameters());
+  derivative.set_size(this->GetNumberOfParameters());
   derivative.Fill(0.0);
 
   /** Construct the JointPDF, JointPDFDerivatives, Alpha and its derivatives. */

--- a/Components/Metrics/AdvancedMeanSquares/itkAdvancedMeanSquaresImageToImageMetric.hxx
+++ b/Components/Metrics/AdvancedMeanSquares/itkAdvancedMeanSquaresImageToImageMetric.hxx
@@ -397,7 +397,7 @@ AdvancedMeanSquaresImageToImageMetric<TFixedImage, TMovingImage>::GetValueAndDer
   /** Initialize some variables. */
   Superclass::m_NumberOfPixelsCounted = 0;
   MeasureType measure{};
-  derivative = DerivativeType(this->GetNumberOfParameters());
+  derivative.set_size(this->GetNumberOfParameters());
   derivative.Fill(DerivativeValueType{});
 
   /** Array that stores dM(x)/dmu, and the sparse jacobian+indices. */

--- a/Components/Metrics/AdvancedNormalizedCorrelation/itkAdvancedNormalizedCorrelationImageToImageMetric.hxx
+++ b/Components/Metrics/AdvancedNormalizedCorrelation/itkAdvancedNormalizedCorrelationImageToImageMetric.hxx
@@ -284,7 +284,7 @@ AdvancedNormalizedCorrelationImageToImageMetric<TFixedImage, TMovingImage>::GetV
 
   /** Initialize some variables. */
   Superclass::m_NumberOfPixelsCounted = 0;
-  derivative = DerivativeType(this->GetNumberOfParameters());
+  derivative.set_size(this->GetNumberOfParameters());
   derivative.Fill(DerivativeValueType{});
   DerivativeType derivativeF = DerivativeType(this->GetNumberOfParameters());
   derivativeF.Fill(DerivativeValueType{});

--- a/Components/Metrics/BendingEnergyPenalty/itkTransformBendingEnergyPenaltyTerm.hxx
+++ b/Components/Metrics/BendingEnergyPenalty/itkTransformBendingEnergyPenaltyTerm.hxx
@@ -153,7 +153,7 @@ TransformBendingEnergyPenaltyTerm<TFixedImage, TScalarType>::GetValueAndDerivati
   /** Create and initialize some variables. */
   Superclass::m_NumberOfPixelsCounted = 0;
   RealType measure{};
-  derivative = DerivativeType(this->GetNumberOfParameters());
+  derivative.set_size(this->GetNumberOfParameters());
   derivative.Fill(DerivativeValueType{});
 
   SpatialHessianType           spatialHessian;

--- a/Components/Metrics/CorrespondingPointsEuclideanDistanceMetric/itkCorrespondingPointsEuclideanDistancePointMetric.hxx
+++ b/Components/Metrics/CorrespondingPointsEuclideanDistanceMetric/itkCorrespondingPointsEuclideanDistancePointMetric.hxx
@@ -148,7 +148,7 @@ CorrespondingPointsEuclideanDistancePointMetric<TFixedPointSet, TMovingPointSet>
   /** Initialize some variables */
   this->m_NumberOfPointsCounted = 0;
   MeasureType measure{};
-  derivative = DerivativeType(this->GetNumberOfParameters());
+  derivative.set_size(this->GetNumberOfParameters());
   derivative.Fill(DerivativeValueType{});
   NonZeroJacobianIndicesType nzji(this->m_Transform->GetNumberOfNonZeroJacobianIndices());
   TransformJacobianType      jacobian;

--- a/Components/Metrics/DisplacementMagnitudePenalty/itkDisplacementMagnitudePenaltyTerm.hxx
+++ b/Components/Metrics/DisplacementMagnitudePenalty/itkDisplacementMagnitudePenaltyTerm.hxx
@@ -146,7 +146,7 @@ DisplacementMagnitudePenaltyTerm<TFixedImage, TScalarType>::GetValueAndDerivativ
   /** Create and initialize some variables. */
   Superclass::m_NumberOfPixelsCounted = 0;
   RealType measure{};
-  derivative = DerivativeType(this->GetNumberOfParameters());
+  derivative.set_size(this->GetNumberOfParameters());
   derivative.Fill(DerivativeValueType{});
 
   /** Array that stores sparse jacobian+indices. */

--- a/Components/Metrics/DistancePreservingRigidityPenalty/itkDistancePreservingRigidityPenaltyTerm.hxx
+++ b/Components/Metrics/DistancePreservingRigidityPenalty/itkDistancePreservingRigidityPenaltyTerm.hxx
@@ -306,7 +306,7 @@ DistancePreservingRigidityPenaltyTerm<TFixedImage, TScalarType>::GetValueAndDeri
   this->m_RigidityPenaltyTermValue = MeasureType{};
 
   /** Set output values to zero. */
-  derivative = DerivativeType(this->GetNumberOfParameters());
+  derivative.set_size(this->GetNumberOfParameters());
   derivative.Fill(MeasureType{});
 
   this->m_BSplineTransform->SetParameters(parameters);

--- a/Components/Metrics/GradientDifference/itkGradientDifferenceImageToImageMetric2.hxx
+++ b/Components/Metrics/GradientDifference/itkGradientDifferenceImageToImageMetric2.hxx
@@ -457,7 +457,7 @@ GradientDifferenceImageToImageMetric<TFixedImage, TMovingImage>::GetDerivative(
   TransformParametersType testPoint;
   testPoint = parameters;
   const unsigned int numberOfParameters = this->GetNumberOfParameters();
-  derivative = DerivativeType(numberOfParameters);
+  derivative.set_size(numberOfParameters);
 
   for (unsigned int i = 0; i < numberOfParameters; ++i)
   {

--- a/Components/Metrics/KNNGraphAlphaMutualInformation/itkKNNGraphAlphaMutualInformationImageToImageMetric.hxx
+++ b/Components/Metrics/KNNGraphAlphaMutualInformation/itkKNNGraphAlphaMutualInformationImageToImageMetric.hxx
@@ -490,7 +490,7 @@ KNNGraphAlphaMutualInformationImageToImageMetric<TFixedImage, TMovingImage>::Get
 {
   /** Initialize some variables. */
   MeasureType measure{};
-  derivative = DerivativeType(this->GetNumberOfParameters());
+  derivative.set_size(this->GetNumberOfParameters());
   derivative.Fill(DerivativeValueType{});
 
   /** Call non-thread-safe stuff, such as:

--- a/Components/Metrics/MissingStructurePenalty/itkMissingStructurePenalty.hxx
+++ b/Components/Metrics/MissingStructurePenalty/itkMissingStructurePenalty.hxx
@@ -161,7 +161,7 @@ MissingVolumeMeshPenalty<TFixedPointSet, TMovingPointSet>::GetValueAndDerivative
   /** Make sure the transform parameters are up to date. */
   this->SetTransformParameters(parameters);
 
-  derivative = DerivativeType(this->GetNumberOfParameters());
+  derivative.set_size(this->GetNumberOfParameters());
   derivative.Fill(DerivativeValueType{});
 
   NonZeroJacobianIndicesType nzji(this->m_Transform->GetNumberOfNonZeroJacobianIndices());

--- a/Components/Metrics/NormalizedGradientCorrelation/itkNormalizedGradientCorrelationImageToImageMetric.hxx
+++ b/Components/Metrics/NormalizedGradientCorrelation/itkNormalizedGradientCorrelationImageToImageMetric.hxx
@@ -432,7 +432,7 @@ NormalizedGradientCorrelationImageToImageMetric<TFixedImage, TMovingImage>::GetD
   TransformParametersType testPoint;
   testPoint = parameters;
   const unsigned int numberOfParameters = this->GetNumberOfParameters();
-  derivative = DerivativeType(numberOfParameters);
+  derivative.set_size(numberOfParameters);
 
   for (unsigned int i = 0; i < numberOfParameters; ++i)
   {

--- a/Components/Metrics/NormalizedMutualInformation/itkParzenWindowNormalizedMutualInformationImageToImageMetric.hxx
+++ b/Components/Metrics/NormalizedMutualInformation/itkParzenWindowNormalizedMutualInformationImageToImageMetric.hxx
@@ -179,7 +179,7 @@ ParzenWindowNormalizedMutualInformationImageToImageMetric<TFixedImage, TMovingIm
 {
   /** Initialize some variables */
   value = MeasureType{};
-  derivative = DerivativeType(this->GetNumberOfParameters());
+  derivative.set_size(this->GetNumberOfParameters());
   derivative.Fill(0.0);
 
   /** Construct the JointPDF, JointPDFDerivatives, and Alpha. */

--- a/Components/Metrics/PCAMetric/itkPCAMetric.hxx
+++ b/Components/Metrics/PCAMetric/itkPCAMetric.hxx
@@ -385,7 +385,7 @@ PCAMetric<TFixedImage, TMovingImage>::GetValueAndDerivative(const TransformParam
   const unsigned int P = this->GetNumberOfParameters();
   Superclass::m_NumberOfPixelsCounted = 0;
   MeasureType measure{};
-  derivative = DerivativeType(P);
+  derivative.set_size(P);
   derivative.Fill(DerivativeValueType{});
 
   /** Make sure the transform parameters are up to date. */

--- a/Components/Metrics/PCAMetric/itkPCAMetric_F_multithreaded.hxx
+++ b/Components/Metrics/PCAMetric/itkPCAMetric_F_multithreaded.hxx
@@ -314,7 +314,7 @@ PCAMetric<TFixedImage, TMovingImage>::GetValueAndDerivativeSingleThreaded(const 
   /** Initialize some variables */
   Superclass::m_NumberOfPixelsCounted = 0;
   MeasureType measure{};
-  derivative = DerivativeType(this->GetNumberOfParameters());
+  derivative.set_size(this->GetNumberOfParameters());
   derivative.Fill(DerivativeValueType{});
 
   /** Call non-thread-safe stuff, such as:

--- a/Components/Metrics/PCAMetric2/itkPCAMetric2.hxx
+++ b/Components/Metrics/PCAMetric2/itkPCAMetric2.hxx
@@ -335,7 +335,7 @@ PCAMetric2<TFixedImage, TMovingImage>::GetValueAndDerivative(const TransformPara
   const unsigned int numberOfParameters = this->GetNumberOfParameters();
   Superclass::m_NumberOfPixelsCounted = 0;
   MeasureType measure{};
-  derivative = DerivativeType(numberOfParameters);
+  derivative.set_size(numberOfParameters);
   derivative.Fill(DerivativeValueType{});
 
   /** Make sure the transform parameters are up to date. */

--- a/Components/Metrics/PatternIntensity/itkPatternIntensityImageToImageMetric.hxx
+++ b/Components/Metrics/PatternIntensity/itkPatternIntensityImageToImageMetric.hxx
@@ -376,7 +376,7 @@ PatternIntensityImageToImageMetric<TFixedImage, TMovingImage>::GetDerivative(con
   TransformParametersType testPoint;
   testPoint = parameters;
   const unsigned int numberOfParameters = this->GetNumberOfParameters();
-  derivative = DerivativeType(numberOfParameters);
+  derivative.set_size(numberOfParameters);
 
   for (unsigned int i = 0; i < numberOfParameters; ++i)
   {

--- a/Components/Metrics/PolydataDummyPenalty/itkPolydataDummyPenalty.hxx
+++ b/Components/Metrics/PolydataDummyPenalty/itkPolydataDummyPenalty.hxx
@@ -177,7 +177,7 @@ MeshPenalty<TFixedPointSet, TMovingPointSet>::GetValueAndDerivative(const Transf
   /** Make sure the transform parameters are up to date. */
   this->SetTransformParameters(parameters);
 
-  derivative = DerivativeType(this->GetNumberOfParameters());
+  derivative.set_size(this->GetNumberOfParameters());
   derivative.Fill(DerivativeValueType{});
 
   // NonZeroJacobianIndicesType nzji( this->m_Transform->GetNumberOfNonZeroJacobianIndices() );

--- a/Components/Metrics/RigidityPenalty/itkTransformRigidityPenaltyTerm.hxx
+++ b/Components/Metrics/RigidityPenalty/itkTransformRigidityPenaltyTerm.hxx
@@ -901,7 +901,7 @@ TransformRigidityPenaltyTerm<TFixedImage, TScalarType>::GetValueAndDerivative(co
   this->m_PropernessConditionValue = MeasureType{};
 
   /** Set output values to zero. */
-  derivative = DerivativeType(this->GetNumberOfParameters());
+  derivative.set_size(this->GetNumberOfParameters());
   derivative.Fill(MeasureType{});
 
   /** Call non-thread-safe stuff, such as:

--- a/Components/Metrics/StatisticalShapePenalty/itkStatisticalShapePointPenalty.hxx
+++ b/Components/Metrics/StatisticalShapePenalty/itkStatisticalShapePointPenalty.hxx
@@ -456,7 +456,7 @@ StatisticalShapePointPenalty<TFixedPointSet, TMovingPointSet>::GetValueAndDeriva
   /** Initialize some variables */
   // this->m_NumberOfPointsCounted = 0;
   value = MeasureType{};
-  derivative = DerivativeType(this->GetNumberOfParameters());
+  derivative.set_size(this->GetNumberOfParameters());
   derivative.Fill(DerivativeValueType{});
 
   // InputPointType movingPoint;

--- a/Components/Metrics/SumOfPairwiseCorrelationsMetric/itkSumOfPairwiseCorrelationCoefficientsMetric.hxx
+++ b/Components/Metrics/SumOfPairwiseCorrelationsMetric/itkSumOfPairwiseCorrelationCoefficientsMetric.hxx
@@ -289,7 +289,7 @@ SumOfPairwiseCorrelationCoefficientsMetric<TFixedImage, TMovingImage>::GetValueA
   const unsigned int numberOfParameters = this->GetNumberOfParameters();
   Superclass::m_NumberOfPixelsCounted = 0;
   MeasureType measure{};
-  derivative = DerivativeType(numberOfParameters);
+  derivative.set_size(numberOfParameters);
   derivative.Fill(DerivativeValueType{});
 
   /** Make sure the transform parameters are up to date. */

--- a/Components/Metrics/SumSquaredTissueVolumeDifferenceMetric/itkSumSquaredTissueVolumeDifferenceImageToImageMetric.hxx
+++ b/Components/Metrics/SumSquaredTissueVolumeDifferenceMetric/itkSumSquaredTissueVolumeDifferenceImageToImageMetric.hxx
@@ -340,7 +340,7 @@ SumSquaredTissueVolumeDifferenceImageToImageMetric<TFixedImage, TMovingImage>::G
   /** Initialize some variables. */
   Superclass::m_NumberOfPixelsCounted = 0;
   MeasureType measure{};
-  derivative = DerivativeType(this->GetNumberOfParameters());
+  derivative.set_size(this->GetNumberOfParameters());
   derivative.Fill(DerivativeValueType{});
 
   /** Array that stores dM(x)/dmu, and the sparse jacobian+indices. */

--- a/Components/Metrics/VarianceOverLastDimension/itkVarianceOverLastDimensionImageMetric.hxx
+++ b/Components/Metrics/VarianceOverLastDimension/itkVarianceOverLastDimensionImageMetric.hxx
@@ -336,7 +336,7 @@ VarianceOverLastDimensionImageMetric<TFixedImage, TMovingImage>::GetValueAndDeri
   /** Initialize some variables */
   Superclass::m_NumberOfPixelsCounted = 0;
   MeasureType measure{};
-  derivative = DerivativeType(this->GetNumberOfParameters());
+  derivative.set_size(this->GetNumberOfParameters());
   derivative.Fill(DerivativeValueType{});
 
   /** Call non-thread-safe stuff, such as:

--- a/Components/Registrations/MultiMetricMultiResolutionRegistration/itkCombinationImageToImageMetric.hxx
+++ b/Components/Registrations/MultiMetricMultiResolutionRegistration/itkCombinationImageToImageMetric.hxx
@@ -721,7 +721,7 @@ CombinationImageToImageMetric<TFixedImage, TMovingImage>::GetDerivative(const Pa
 {
   /** Initialise. */
   DerivativeType tmpDerivative = DerivativeType(this->GetNumberOfParameters());
-  derivative = DerivativeType(this->GetNumberOfParameters());
+  derivative.set_size(this->GetNumberOfParameters());
   derivative.Fill(MeasureType{});
 
   /** Compute, store and combine all metric derivatives. */


### PR DESCRIPTION
Avoided allocation of an expensive temporary `DerivativeType` object, and reused the existing data buffer of `derivative` (if already had the right size).

----

May improve the run-time performance of many (if not all) metric classes.