### PR TITLE
Let SampleRandom, ImageRandomSamplerSparseMask, ComputeDisplacementDistribution call `std::vector::reserve`

### DIFF
--- a/Common/ImageSamplers/itkImageRandomSamplerSparseMask.hxx
+++ b/Common/ImageSamplers/itkImageRandomSamplerSparseMask.hxx
@@ -97,7 +97,9 @@ ImageRandomSamplerSparseMask<TInputImage>::GenerateData()
   }
 
   /** Take random samples from the allValidSamples-container. */
-  for (unsigned int i = 0; i < this->GetNumberOfSamples(); ++i)
+  sampleVector.reserve(Superclass::m_NumberOfSamples);
+
+  for (unsigned int i = 0; i < Superclass::m_NumberOfSamples; ++i)
   {
     unsigned long randomIndex = this->m_RandomGenerator->GetIntegerVariate(numberOfValidSamples - 1);
     sampleVector.push_back(allValidSamples.ElementAt(randomIndex));

--- a/Common/itkComputeDisplacementDistribution.hxx
+++ b/Common/itkComputeDisplacementDistribution.hxx
@@ -143,10 +143,13 @@ ComputeDisplacementDistribution<TFixedImage, TTransform>::ComputeSingleThreaded(
    */
   DerivativeType Jgg(outdim);
   Jgg.Fill(0.0);
+
   std::vector<double> JGG_k;
-  double              globalDeformation = 0.0;
-  const double        sqrt2 = std::sqrt(static_cast<double>(2.0));
-  JacobianType        jacjjacj(outdim, outdim);
+  JGG_k.reserve(nrofsamples);
+
+  double       globalDeformation = 0.0;
+  const double sqrt2 = std::sqrt(static_cast<double>(2.0));
+  JacobianType jacjjacj(outdim, outdim);
 
   samplenr = 0;
   for (const auto & sample : *sampleContainer)
@@ -511,8 +514,11 @@ ComputeDisplacementDistribution<TFixedImage, TTransform>::ComputeUsingSearchDire
    */
   DerivativeType Jgg(outdim);
   Jgg.Fill(0.0);
+
   std::vector<double> JGG_k;
-  double              globalDeformation = 0.0;
+  JGG_k.reserve(nrofsamples);
+
+  double globalDeformation = 0.0;
 
   samplenr = 0;
   for (const auto & sample : *sampleContainer)

--- a/Components/Metrics/PCAMetric2/itkPCAMetric2.hxx
+++ b/Components/Metrics/PCAMetric2/itkPCAMetric2.hxx
@@ -84,6 +84,7 @@ PCAMetric2<TFixedImage, TMovingImage>::SampleRandom(const int n, const int m, st
 {
   /** Empty list of last dimension positions. */
   numbers.clear();
+  numbers.reserve(m_NumAdditionalSamplesFixed + n);
 
   /** Initialize random number generator. */
   Statistics::MersenneTwisterRandomVariateGenerator::Pointer randomGenerator =

--- a/Components/Metrics/SumOfPairwiseCorrelationsMetric/itkSumOfPairwiseCorrelationCoefficientsMetric.hxx
+++ b/Components/Metrics/SumOfPairwiseCorrelationsMetric/itkSumOfPairwiseCorrelationCoefficientsMetric.hxx
@@ -77,6 +77,7 @@ SumOfPairwiseCorrelationCoefficientsMetric<TFixedImage, TMovingImage>::SampleRan
 {
   /** Empty list of last dimension positions. */
   numbers.clear();
+  numbers.reserve(m_NumAdditionalSamplesFixed + n);
 
   /** Initialize random number generator. */
   Statistics::MersenneTwisterRandomVariateGenerator::Pointer randomGenerator =

--- a/Components/Metrics/VarianceOverLastDimension/itkVarianceOverLastDimensionImageMetric.hxx
+++ b/Components/Metrics/VarianceOverLastDimension/itkVarianceOverLastDimensionImageMetric.hxx
@@ -129,6 +129,7 @@ VarianceOverLastDimensionImageMetric<TFixedImage, TMovingImage>::SampleRandom(co
 {
   /** Empty list of last dimension positions. */
   numbers.clear();
+  numbers.reserve(m_NumAdditionalSamplesFixed + n);
 
   /** Initialize random number generator. */
   Statistics::MersenneTwisterRandomVariateGenerator::Pointer randomGenerator =


### PR DESCRIPTION
Avoided unnecessary memory relocations. 