### PR TITLE
BUG: Fix ParabolicErodeDilateImageFilter progress memory leak, use stack

### DIFF
--- a/Common/itkParabolicErodeDilateImageFilter.hxx
+++ b/Common/itkParabolicErodeDilateImageFilter.hxx
@@ -214,12 +214,12 @@ ParabolicErodeDilateImageFilter<TInputImage, doDilate, TOutputImage>::ThreadedGe
   }
   float progressPerDimension = 1.0 / ImageDimension;
 
-  ProgressReporter * progress = new ProgressReporter(this,
-                                                     threadId,
-                                                     NumberOfRows[m_CurrentDimension],
-                                                     30,
-                                                     m_CurrentDimension * progressPerDimension,
-                                                     progressPerDimension);
+  ProgressReporter progress(this,
+                            threadId,
+                            NumberOfRows[m_CurrentDimension],
+                            30,
+                            m_CurrentDimension * progressPerDimension,
+                            progressPerDimension);
 
   using InputConstIteratorType = ImageLinearConstIteratorWithIndex<TInputImage>;
   using OutputIteratorType = ImageLinearIteratorWithIndex<TOutputImage>;
@@ -263,7 +263,7 @@ ParabolicErodeDilateImageFilter<TInputImage, doDilate, TOutputImage>::ThreadedGe
       doOneDimension<InputConstIteratorType, OutputIteratorType, RealType, OutputPixelType, doDilate>(
         inputIterator,
         outputIterator,
-        *progress,
+        progress,
         LineLength,
         0,
         this->m_MagnitudeSign,
@@ -301,7 +301,7 @@ ParabolicErodeDilateImageFilter<TInputImage, doDilate, TOutputImage>::ThreadedGe
       doOneDimension<OutputConstIteratorType, OutputIteratorType, RealType, OutputPixelType, doDilate>(
         inputIteratorStage2,
         outputIterator,
-        *progress,
+        progress,
         LineLength,
         m_CurrentDimension,
         this->m_MagnitudeSign,


### PR DESCRIPTION
Declaring `ProgressReporter` on the stack (instead of on the heap) may benefit run-time performance. But moreover, it fixes a memory leak.

- Corresponds with pull request https://github.com/richardbeare/parabolicMorphology/pull/11 "BUG: Fix memory leaks by moving `progress` from the heap to the stack"