### PR TITLE
STYLE: Set GridSize, TransformIsStackTransform in `BeforeRegistration()`

### DIFF
--- a/Components/Metrics/PCAMetric/elxPCAMetric.h
+++ b/Components/Metrics/PCAMetric/elxPCAMetric.h
@@ -154,6 +154,9 @@ public:
   void
   Initialize() override;
 
+  void
+  BeforeRegistration() override;
+
   /**
    * Do some things before each resolution:
    * \li Set CheckNumberOfSamples setting

--- a/Components/Metrics/PCAMetric2/elxPCAMetric2.h
+++ b/Components/Metrics/PCAMetric2/elxPCAMetric2.h
@@ -155,6 +155,9 @@ public:
   void
   Initialize() override;
 
+  void
+  BeforeRegistration() override;
+
   /**
    * Do some things before each resolution:
    * \li Set CheckNumberOfSamples setting

--- a/Components/Metrics/PCAMetric2/elxPCAMetric2.hxx
+++ b/Components/Metrics/PCAMetric2/elxPCAMetric2.hxx
@@ -55,6 +55,43 @@ PCAMetric2<TElastix>::Initialize()
 
 
 /**
+ * ***************** BeforeRegistration ***********************
+ */
+
+template <class TElastix>
+void
+PCAMetric2<TElastix>::BeforeRegistration()
+{
+  /** Check if this elastix object has a transform. (If so, it must be a combination transform.) */
+  if (CombinationTransformType * const combinationTransform{
+        BaseComponent::AsITKBaseType(this->GetElastix()->GetElxTransformBase()) })
+  {
+    auto * const currentTransform = combinationTransform->GetModifiableCurrentTransform();
+
+    /** Check for B-spline transform. */
+    if (const auto bsplineTransform = dynamic_cast<BSplineTransformBaseType *>(currentTransform))
+    {
+      this->SetGridSize(bsplineTransform->GetGridRegion().GetSize());
+    }
+    else
+    {
+      /** Check for stack transform. */
+      if (const auto stackTransform = dynamic_cast<StackTransformType *>(currentTransform))
+      {
+        /** Set itk member variable. */
+        this->SetTransformIsStackTransform(true);
+
+        // Return early, now that the current transform is a stack transform.
+        return;
+      }
+    }
+  }
+  // If the current transform would have been a stack transform, the function would have returned earlier.
+  this->SetTransformIsStackTransform(false);
+}
+
+
+/**
  * ***************** BeforeEachResolution ***********************
  */
 
@@ -102,33 +139,6 @@ PCAMetric2<TElastix>::BeforeEachResolution()
     this->SetMovingImageDerivativeScales(movingImageDerivativeScales);
     log::info(std::ostringstream{} << "Multiplying moving image derivatives by: " << movingImageDerivativeScales);
   }
-
-  /** Check if this elastix object has a transform. (If so, it must be a combination transform.) */
-  if (CombinationTransformType * const combinationTransform{
-        BaseComponent::AsITKBaseType(this->GetElastix()->GetElxTransformBase()) })
-  {
-    auto * const currentTransform = combinationTransform->GetModifiableCurrentTransform();
-
-    /** Check for B-spline transform. */
-    if (const auto bsplineTransform = dynamic_cast<BSplineTransformBaseType *>(currentTransform))
-    {
-      this->SetGridSize(bsplineTransform->GetGridRegion().GetSize());
-    }
-    else
-    {
-      /** Check for stack transform. */
-      if (const auto stackTransform = dynamic_cast<StackTransformType *>(currentTransform))
-      {
-        /** Set itk member variable. */
-        this->SetTransformIsStackTransform(true);
-
-        // Return early, now that the current transform is a stack transform.
-        return;
-      }
-    }
-  }
-  // If the current transform would have been a stack transform, the function would have returned earlier.
-  this->SetTransformIsStackTransform(false);
 
 } // end BeforeEachResolution()
 

--- a/Components/Metrics/SumOfPairwiseCorrelationsMetric/elxSumOfPairwiseCorrelationCoefficientsMetric.h
+++ b/Components/Metrics/SumOfPairwiseCorrelationsMetric/elxSumOfPairwiseCorrelationCoefficientsMetric.h
@@ -155,6 +155,9 @@ public:
   void
   Initialize() override;
 
+  void
+  BeforeRegistration() override;
+
   /**
    * Do some things before each resolution:
    * \li Set CheckNumberOfSamples setting

--- a/Components/Metrics/SumOfPairwiseCorrelationsMetric/elxSumOfPairwiseCorrelationCoefficientsMetric.hxx
+++ b/Components/Metrics/SumOfPairwiseCorrelationsMetric/elxSumOfPairwiseCorrelationCoefficientsMetric.hxx
@@ -56,6 +56,43 @@ SumOfPairwiseCorrelationCoefficientsMetric<TElastix>::Initialize()
 
 
 /**
+ * ***************** BeforeRegistration ***********************
+ */
+
+template <class TElastix>
+void
+SumOfPairwiseCorrelationCoefficientsMetric<TElastix>::BeforeRegistration()
+{
+  /** Check if this elastix object has a transform. (If so, it must be a combination transform.) */
+  if (CombinationTransformType * const combinationTransform{
+        BaseComponent::AsITKBaseType(this->GetElastix()->GetElxTransformBase()) })
+  {
+    auto * const currentTransform = combinationTransform->GetModifiableCurrentTransform();
+
+    /** Check for B-spline transform. */
+    if (const auto bsplineTransform = dynamic_cast<BSplineTransformBaseType *>(currentTransform))
+    {
+      this->SetGridSize(bsplineTransform->GetGridRegion().GetSize());
+    }
+    else
+    {
+      /** Check for stack transform. */
+      if (const auto stackTransform = dynamic_cast<StackTransformType *>(currentTransform))
+      {
+        /** Set itk member variable. */
+        this->SetTransformIsStackTransform(true);
+
+        // Return early, now that the current transform is a stack transform.
+        return;
+      }
+    }
+  }
+  // If the current transform would have been a stack transform, the function would have returned earlier.
+  this->SetTransformIsStackTransform(false);
+}
+
+
+/**
  * ***************** BeforeEachResolution ***********************
  */
 
@@ -103,33 +140,6 @@ SumOfPairwiseCorrelationCoefficientsMetric<TElastix>::BeforeEachResolution()
     this->SetMovingImageDerivativeScales(movingImageDerivativeScales);
     log::info(std::ostringstream{} << "Multiplying moving image derivatives by: " << movingImageDerivativeScales);
   }
-
-  /** Check if this elastix object has a transform. (If so, it must be a combination transform.) */
-  if (CombinationTransformType * const combinationTransform{
-        BaseComponent::AsITKBaseType(this->GetElastix()->GetElxTransformBase()) })
-  {
-    auto * const currentTransform = combinationTransform->GetModifiableCurrentTransform();
-
-    /** Check for B-spline transform. */
-    if (const auto bsplineTransform = dynamic_cast<BSplineTransformBaseType *>(currentTransform))
-    {
-      this->SetGridSize(bsplineTransform->GetGridRegion().GetSize());
-    }
-    else
-    {
-      /** Check for stack transform. */
-      if (const auto stackTransform = dynamic_cast<StackTransformType *>(currentTransform))
-      {
-        /** Set itk member variable. */
-        this->SetTransformIsStackTransform(true);
-
-        // Return early, now that the current transform is a stack transform.
-        return;
-      }
-    }
-  }
-  // If the current transform would have been a stack transform, the function would have returned earlier.
-  this->SetTransformIsStackTransform(false);
 
   log::info("end BeforeEachResolution");
 

--- a/Components/Metrics/VarianceOverLastDimension/elxVarianceOverLastDimensionMetric.hxx
+++ b/Components/Metrics/VarianceOverLastDimension/elxVarianceOverLastDimensionMetric.hxx
@@ -88,6 +88,33 @@ VarianceOverLastDimensionMetric<TElastix>::BeforeRegistration()
                       << "       [ 0 0 1 ]");
   }
 
+  /** Check if this elastix object has a transform. (If so, it must be a combination transform.) */
+  if (CombinationTransformType * const combinationTransform{
+        BaseComponent::AsITKBaseType(this->GetElastix()->GetElxTransformBase()) })
+  {
+    auto * const currentTransform = combinationTransform->GetModifiableCurrentTransform();
+
+    /** Check for B-spline transform. */
+    if (const auto bsplineTransform = dynamic_cast<BSplineTransformBaseType *>(currentTransform))
+    {
+      this->SetGridSize(bsplineTransform->GetGridRegion().GetSize());
+    }
+    else
+    {
+      /** Check for stack transform. */
+      if (const auto stackTransform = dynamic_cast<StackTransformType *>(currentTransform))
+      {
+        /** Set itk member variable. */
+        this->SetTransformIsStackTransform(true);
+
+        // Return early, now that the current transform is a stack transform.
+        return;
+      }
+    }
+  }
+  // If the current transform would have been a stack transform, the function would have returned earlier.
+  this->SetTransformIsStackTransform(false);
+
 } // end BeforeRegistration()
 
 
@@ -132,33 +159,6 @@ VarianceOverLastDimensionMetric<TElastix>::BeforeEachResolution()
   unsigned int reducedDimensionIndex = 0;
   configuration.ReadParameter(reducedDimensionIndex, "ReducedDimensionIndex", componentLabel, 0, 0);
   this->SetReducedDimensionIndex(reducedDimensionIndex);
-
-  /** Check if this elastix object has a transform. (If so, it must be a combination transform.) */
-  if (CombinationTransformType * const combinationTransform{
-        BaseComponent::AsITKBaseType(this->GetElastix()->GetElxTransformBase()) })
-  {
-    auto * const currentTransform = combinationTransform->GetModifiableCurrentTransform();
-
-    /** Check for B-spline transform. */
-    if (const auto bsplineTransform = dynamic_cast<BSplineTransformBaseType *>(currentTransform))
-    {
-      this->SetGridSize(bsplineTransform->GetGridRegion().GetSize());
-    }
-    else
-    {
-      /** Check for stack transform. */
-      if (const auto stackTransform = dynamic_cast<StackTransformType *>(currentTransform))
-      {
-        /** Set itk member variable. */
-        this->SetTransformIsStackTransform(true);
-
-        // Return early, now that the current transform is a stack transform.
-        return;
-      }
-    }
-  }
-  // If the current transform would have been a stack transform, the function would have returned earlier.
-  this->SetTransformIsStackTransform(false);
 
 } // end BeforeEachResolution()
 


### PR DESCRIPTION
Instead of setting them in `BeforeEachResolution()`. These properties always have the same value for each resolution of a registration.

Discussed with Marius (@mstaring) and Stefan (@stefanklein).