### PR TITLE
STYLE: ParabolicMorphology compute numberOfRows only for one dimension

### DIFF
--- a/Common/itkParabolicErodeDilateImageFilter.hxx
+++ b/Common/itkParabolicErodeDilateImageFilter.hxx
@@ -198,28 +198,21 @@ ParabolicErodeDilateImageFilter<TInputImage, doDilate, TOutputImage>::ThreadedGe
   ThreadIdType                  threadId)
 {
   // compute the number of rows first, so we can setup a progress reporter
-  typename std::vector<unsigned int> NumberOfRows;
-  InputSizeType                      size = outputRegionForThread.GetSize();
+  unsigned int  numberOfRows = 1;
+  InputSizeType size = outputRegionForThread.GetSize();
 
-  for (unsigned int i = 0; i < InputImageDimension; ++i)
+  for (unsigned int d = 0; d < InputImageDimension; ++d)
   {
-    NumberOfRows.push_back(1);
-    for (unsigned int d = 0; d < InputImageDimension; ++d)
+    if (d != m_CurrentDimension)
     {
-      if (d != i)
-      {
-        NumberOfRows[i] *= size[d];
-      }
+      numberOfRows *= size[d];
     }
   }
+
   float progressPerDimension = 1.0 / ImageDimension;
 
-  ProgressReporter progress(this,
-                            threadId,
-                            NumberOfRows[m_CurrentDimension],
-                            30,
-                            m_CurrentDimension * progressPerDimension,
-                            progressPerDimension);
+  ProgressReporter progress(
+    this, threadId, numberOfRows, 30, m_CurrentDimension * progressPerDimension, progressPerDimension);
 
   using InputConstIteratorType = ImageLinearConstIteratorWithIndex<TInputImage>;
   using OutputIteratorType = ImageLinearIteratorWithIndex<TOutputImage>;


### PR DESCRIPTION
ParabolicErodeDilateImageFilter should not compute the number of rows for _all_ dimensions, only just for its `m_CurrentDimension`.