### PR TITLE
STYLE: Remove unnecessary `#include <omp.h>` directives

### DIFF
--- a/Components/Metrics/AdvancedMattesMutualInformation/itkParzenWindowMutualInformationImageToImageMetric.hxx
+++ b/Components/Metrics/AdvancedMattesMutualInformation/itkParzenWindowMutualInformationImageToImageMetric.hxx
@@ -27,10 +27,6 @@
 #include <vnl/vnl_inverse.h>
 #include <vnl/vnl_det.h>
 
-#ifdef ELASTIX_USE_OPENMP
-#  include <omp.h>
-#endif
-
 #include <cassert>
 
 namespace itk

--- a/Components/Metrics/PCAMetric/itkPCAMetric.hxx
+++ b/Components/Metrics/PCAMetric/itkPCAMetric.hxx
@@ -30,10 +30,6 @@
 #include <numeric>
 #include <fstream>
 
-#ifdef ELASTIX_USE_OPENMP
-#  include <omp.h>
-#endif
-
 namespace itk
 {
 /**

--- a/Components/Optimizers/AdaGrad/elxAdaGrad.hxx
+++ b/Components/Optimizers/AdaGrad/elxAdaGrad.hxx
@@ -31,10 +31,6 @@
 #include "itkAdvancedImageToImageMetric.h"
 #include "itkTimeProbe.h"
 
-#ifdef ELASTIX_USE_OPENMP
-#  include <omp.h>
-#endif
-
 namespace elastix
 {
 

--- a/Components/Optimizers/AdaptiveStochasticLBFGS/elxAdaptiveStochasticLBFGS.hxx
+++ b/Components/Optimizers/AdaptiveStochasticLBFGS/elxAdaptiveStochasticLBFGS.hxx
@@ -33,10 +33,6 @@
 #include "itkEventObject.h"
 #include "itkMacro.h"
 
-#ifdef ELASTIX_USE_OPENMP
-#  include <omp.h>
-#endif
-
 #ifdef ELASTIX_USE_EIGEN
 #  include <Eigen/Dense>
 #  include <Eigen/Core>

--- a/Components/Optimizers/AdaptiveStochasticVarianceReducedGradient/elxAdaptiveStochasticVarianceReducedGradient.hxx
+++ b/Components/Optimizers/AdaptiveStochasticVarianceReducedGradient/elxAdaptiveStochasticVarianceReducedGradient.hxx
@@ -33,10 +33,6 @@
 #include "itkEventObject.h"
 #include "itkMacro.h"
 
-#ifdef ELASTIX_USE_OPENMP
-#  include <omp.h>
-#endif
-
 #ifdef ELASTIX_USE_EIGEN
 #  include <Eigen/Dense>
 #  include <Eigen/Core>

--- a/Components/Optimizers/PreconditionedStochasticGradientDescent/elxPreconditionedStochasticGradientDescent.hxx
+++ b/Components/Optimizers/PreconditionedStochasticGradientDescent/elxPreconditionedStochasticGradientDescent.hxx
@@ -31,10 +31,6 @@
 #include "itkAdvancedImageToImageMetric.h"
 #include "itkTimeProbe.h"
 
-#ifdef ELASTIX_USE_OPENMP
-#  include <omp.h>
-#endif
-
 namespace elastix
 {
 


### PR DESCRIPTION
Removed `#include <omp.h>` from components that do not use OpenMP