### PR TITLE
Remove OpenMP based code, ELASTIX_USE_OPENMP option and OpenMP compiler flags

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -129,23 +129,6 @@ if(ELASTIX_USE_EIGEN)
 endif()
 
 #---------------------------------------------------------------------
-# Find OpenMP
-mark_as_advanced(ELASTIX_USE_OPENMP)
-option(ELASTIX_USE_OPENMP "Use OpenMP to speed up certain computations." ON)
-
-if(ELASTIX_USE_OPENMP)
-  find_package(OpenMP QUIET)
-  if(OPENMP_FOUND)
-    set(CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} ${OpenMP_CXX_FLAGS}")
-    #  set(CMAKE_EXE_LINKER_FLAGS "${CMAKE_EXE_LINKER_FLAGS}
-    #  ${OpenMP_EXE_LINKER_FLAGS}")
-    include_directories(${OpenMP_CXX_INCLUDE_DIRS})
-    link_libraries(${OpenMP_CXX_LIBRARIES})
-    add_definitions(-DELASTIX_USE_OPENMP)
-  endif()
-endif()
-
-#---------------------------------------------------------------------
 # Set single (build-tree) output directories for all executables and libraries.
 # This makes it easier to create an elxUseFile.cmake, that users can
 # include in their programs to borrow elastix functionality.

--- a/Common/CostFunctions/itkAdvancedImageToImageMetric.h
+++ b/Common/CostFunctions/itkAdvancedImageToImageMetric.h
@@ -298,10 +298,6 @@ public:
   void
   Initialize() override;
 
-  /** Set number of threads to use for computations. */
-  void
-  SetNumberOfWorkUnits(ThreadIdType numberOfThreads);
-
   /** Switch the function BeforeThreadedGetValueAndDerivative on or off. */
   itkSetMacro(UseMetricSingleThreaded, bool);
   itkGetConstReferenceMacro(UseMetricSingleThreaded, bool);
@@ -423,7 +419,6 @@ protected:
   /** Variables for multi-threading. */
   bool m_UseMetricSingleThreaded{ true };
   bool m_UseMultiThread{ false };
-  bool m_UseOpenMP{};
 
   /** Helper structs that multi-threads the computation of
    * the metric derivative using ITK threads.

--- a/Common/CostFunctions/itkAdvancedImageToImageMetric.hxx
+++ b/Common/CostFunctions/itkAdvancedImageToImageMetric.hxx
@@ -24,10 +24,6 @@
 #include "itkAdvancedRayCastInterpolateImageFunction.h"
 #include "itkComputeImageExtremaFilter.h"
 
-#ifdef ELASTIX_USE_OPENMP
-#  include <omp.h>
-#endif
-
 #include <algorithm> // For min.
 #include <cassert>
 
@@ -49,39 +45,10 @@ AdvancedImageToImageMetric<TFixedImage, TMovingImage>::AdvancedImageToImageMetri
    */
   this->SetComputeGradient(false);
 
-  /** OpenMP related. Switch to on when available */
-#ifdef ELASTIX_USE_OPENMP
-  m_UseOpenMP = true;
-
-  const int nthreads = static_cast<int>(Self::GetNumberOfWorkUnits());
-  omp_set_num_threads(nthreads);
-#else
-  m_UseOpenMP = false;
-#endif
-
   /** Initialize the m_ThreaderMetricParameters. */
   m_ThreaderMetricParameters.st_Metric = this;
 
 } // end Constructor
-
-
-/**
- * ********************* SetNumberOfWorkUnits ****************************
- */
-
-template <class TFixedImage, class TMovingImage>
-void
-AdvancedImageToImageMetric<TFixedImage, TMovingImage>::SetNumberOfWorkUnits(ThreadIdType numberOfThreads)
-{
-  // Note: This is a workaround for ITK5, which renamed NumberOfThreads
-  // to NumberOfWorkUnits
-  Superclass::SetNumberOfWorkUnits(numberOfThreads);
-
-#ifdef ELASTIX_USE_OPENMP
-  const int nthreads = static_cast<int>(Self::GetNumberOfWorkUnits());
-  omp_set_num_threads(nthreads);
-#endif
-} // end SetNumberOfWorkUnits()
 
 
 /**

--- a/Common/GTesting/elxElastixMainGTest.cxx
+++ b/Common/GTesting/elxElastixMainGTest.cxx
@@ -25,7 +25,7 @@
 // Tests retrieving the component data base and a component creator in parallel.
 GTEST_TEST(ElastixMain, GetComponentDatabaseAndCreatorInParallel)
 {
-#pragma omp parallel for
+  // TODO Make iterations like this run in parallel, for the sake of the test.
   for (auto i = 0; i <= 9; ++i)
   {
     const auto creator = elx::ElastixMain::GetComponentDatabase().GetCreator("Elastix", 1);

--- a/Common/GTesting/itkAdvancedImageToImageMetricGTest.cxx
+++ b/Common/GTesting/itkAdvancedImageToImageMetricGTest.cxx
@@ -66,7 +66,6 @@ public:
       EXPECT_EQ(AdvancedImageToImageMetricType::m_MovingImageMaxLimit, 1);
       EXPECT_EQ(AdvancedImageToImageMetricType::m_UseMetricSingleThreaded, true);
       EXPECT_EQ(AdvancedImageToImageMetricType::m_UseMultiThread, false);
-      EXPECT_EQ(AdvancedImageToImageMetricType::m_UseOpenMP, bool{ AdvancedImageToImageMetricType::m_UseOpenMP });
       EXPECT_EQ(AdvancedImageToImageMetricType::m_ThreaderMetricParameters.st_Metric, this);
       EXPECT_EQ(AdvancedImageToImageMetricType::m_ThreaderMetricParameters.st_DerivativePointer, nullptr);
       EXPECT_EQ(AdvancedImageToImageMetricType::m_ThreaderMetricParameters.st_NormalizationFactor, 0.0);

--- a/Components/Metrics/AdvancedMattesMutualInformation/itkParzenWindowMutualInformationImageToImageMetric.hxx
+++ b/Components/Metrics/AdvancedMattesMutualInformation/itkParzenWindowMutualInformationImageToImageMetric.hxx
@@ -555,42 +555,12 @@ ParzenWindowMutualInformationImageToImageMetric<TFixedImage, TMovingImage>::Afte
   const ThreadIdType numberOfThreads = Self::GetNumberOfWorkUnits();
 
   /** Accumulate derivatives. */
-  // compute single-threadedly
-  if (!Superclass::m_UseMultiThread && false) // force multi-threaded
-  {
-    derivative = Superclass::m_GetValueAndDerivativePerThreadVariables[0].st_Derivative;
-    for (ThreadIdType i = 1; i < numberOfThreads; ++i)
-    {
-      derivative += Superclass::m_GetValueAndDerivativePerThreadVariables[i].st_Derivative;
-    }
-  }
-#ifdef ELASTIX_USE_OPENMP
-  // compute multi-threadedly with openmp
-  else if (false) // Superclass::m_UseOpenMP )
-  {
-    const int spaceDimension = static_cast<int>(this->GetNumberOfParameters());
-
-#  pragma omp parallel for
-    for (int j = 0; j < spaceDimension; ++j)
-    {
-      DerivativeValueType sum = Superclass::m_GetValueAndDerivativePerThreadVariables[0].st_Derivative[j];
-      for (ThreadIdType i = 1; i < numberOfThreads; ++i)
-      {
-        sum += Superclass::m_GetValueAndDerivativePerThreadVariables[i].st_Derivative[j];
-      }
-      derivative[j] = sum;
-    }
-  }
-#endif
   // compute multi-threadedly with itk threads
-  else
-  {
-    Superclass::m_ThreaderMetricParameters.st_DerivativePointer = derivative.begin();
-    Superclass::m_ThreaderMetricParameters.st_NormalizationFactor = 1.0;
+  Superclass::m_ThreaderMetricParameters.st_DerivativePointer = derivative.begin();
+  Superclass::m_ThreaderMetricParameters.st_NormalizationFactor = 1.0;
 
-    this->m_Threader->SetSingleMethodAndExecute(this->AccumulateDerivativesThreaderCallback,
-                                                &(Superclass::m_ThreaderMetricParameters));
-  }
+  this->m_Threader->SetSingleMethodAndExecute(this->AccumulateDerivativesThreaderCallback,
+                                              &(Superclass::m_ThreaderMetricParameters));
 
 } // end AfterThreadedComputeDerivativeLowMemory()
 

--- a/Components/Metrics/AdvancedMeanSquares/elxAdvancedMeanSquaresMetric.hxx
+++ b/Components/Metrics/AdvancedMeanSquares/elxAdvancedMeanSquaresMetric.hxx
@@ -61,13 +61,6 @@ AdvancedMeanSquaresMetric<TElastix>::BeforeEachResolution()
   configuration.ReadParameter(useNormalization, "UseNormalization", BaseComponent::GetComponentLabel(), level, 0);
   this->SetUseNormalization(useNormalization);
 
-  /** Select the use of an OpenMP implementation for GetValueAndDerivative. */
-  std::string useOpenMP = configuration.GetCommandLineArgument("-useOpenMP_SSD");
-  if (useOpenMP == "true")
-  {
-    this->SetUseOpenMP(true);
-  }
-
 } // end BeforeEachResolution()
 
 

--- a/Components/Metrics/AdvancedMeanSquares/itkAdvancedMeanSquaresImageToImageMetric.h
+++ b/Components/Metrics/AdvancedMeanSquares/itkAdvancedMeanSquaresImageToImageMetric.h
@@ -154,13 +154,6 @@ public:
   itkSetMacro(UseNormalization, bool);
   itkGetConstMacro(UseNormalization, bool);
 
-  /** If the compiler supports OpenMP, this flag specifies whether
-   * or not to use it. For this metric we have an OpenMP variant for
-   * GetValueAndDerivative(). It is also used at other places.
-   * Note that MS Visual Studio and gcc support OpenMP.
-   */
-  itkSetMacro(UseOpenMP, bool);
-
 protected:
   AdvancedMeanSquaresImageToImageMetric();
   ~AdvancedMeanSquaresImageToImageMetric() override = default;

--- a/Components/Metrics/BendingEnergyPenalty/itkTransformBendingEnergyPenaltyTerm.hxx
+++ b/Components/Metrics/BendingEnergyPenalty/itkTransformBendingEnergyPenaltyTerm.hxx
@@ -20,10 +20,6 @@
 
 #include "itkTransformBendingEnergyPenaltyTerm.h"
 
-#ifdef ELASTIX_USE_OPENMP
-#  include <omp.h>
-#endif
-
 namespace itk
 {
 
@@ -582,7 +578,7 @@ TransformBendingEnergyPenaltyTerm<TFixedImage, TScalarType>::AfterThreadedGetVal
     derivative /= static_cast<DerivativeValueType>(Superclass::m_NumberOfPixelsCounted);
   }
   // compute multi-threadedly with itk threads
-  else if (!Superclass::m_UseOpenMP || true) // force
+  else
   {
     Superclass::m_ThreaderMetricParameters.st_DerivativePointer = derivative.begin();
     Superclass::m_ThreaderMetricParameters.st_NormalizationFactor =
@@ -591,26 +587,6 @@ TransformBendingEnergyPenaltyTerm<TFixedImage, TScalarType>::AfterThreadedGetVal
     this->m_Threader->SetSingleMethodAndExecute(this->AccumulateDerivativesThreaderCallback,
                                                 &(Superclass::m_ThreaderMetricParameters));
   }
-#ifdef ELASTIX_USE_OPENMP
-  // compute multi-threadedly with openmp
-  else
-  {
-    const DerivativeValueType numPix = static_cast<DerivativeValueType>(Superclass::m_NumberOfPixelsCounted);
-    const int                 nthreads = static_cast<int>(numberOfThreads);
-    omp_set_num_threads(nthreads);
-    const int spaceDimension = static_cast<int>(this->GetNumberOfParameters());
-#  pragma omp parallel for
-    for (int j = 0; j < spaceDimension; ++j)
-    {
-      DerivativeValueType sum{};
-      for (ThreadIdType i = 0; i < numberOfThreads; ++i)
-      {
-        sum += Superclass::m_GetValueAndDerivativePerThreadVariables[i].st_Derivative[j];
-      }
-      derivative[j] = sum / numPix;
-    }
-  }
-#endif
 
 } // end AfterThreadedGetValueAndDerivative()
 

--- a/Components/Metrics/BendingEnergyPenalty/itkTransformBendingEnergyPenaltyTerm.hxx
+++ b/Components/Metrics/BendingEnergyPenalty/itkTransformBendingEnergyPenaltyTerm.hxx
@@ -566,7 +566,6 @@ TransformBendingEnergyPenaltyTerm<TFixedImage, TScalarType>::AfterThreadedGetVal
 
   /** Accumulate derivatives. */
   // it seems that multi-threaded adding is faster than single-threaded
-  // it seems that openmp is faster than itk threads
   // compute single-threadedly
   if (!Superclass::m_UseMultiThread)
   {

--- a/Components/Optimizers/AdaptiveStochasticVarianceReducedGradient/itkStochasticVarianceReducedGradientDescentOptimizer.cxx
+++ b/Components/Optimizers/AdaptiveStochasticVarianceReducedGradient/itkStochasticVarianceReducedGradientDescentOptimizer.cxx
@@ -22,10 +22,6 @@
 #include "itkEventObject.h"
 #include "itkMacro.h"
 
-#ifdef ELASTIX_USE_OPENMP
-#  include <omp.h>
-#endif
-
 #ifdef ELASTIX_USE_EIGEN
 #  include <Eigen/Dense>
 #  include <Eigen/Core>
@@ -204,94 +200,14 @@ StochasticVarianceReducedGradientDescentOptimizer::AdvanceOneStep()
   ParametersType & newPosition = this->m_ScaledCurrentPosition;
 
   /** Advance one step. */
-  // single-threadedly
-  if (!this->m_UseMultiThread || true) // for now force single-threaded since it is fastest most of the times
-  // if( !this->m_UseMultiThread && false ) // force multi-threaded
+  // for now force single-threaded since it is fastest most of the times
+  /** Get a reference to the current position. */
+  const ParametersType & currentPosition = this->GetScaledCurrentPosition();
+
+  /** Update the new position. */
+  for (unsigned int j = 0; j < spaceDimension; ++j)
   {
-    /** Get a reference to the current position. */
-    const ParametersType & currentPosition = this->GetScaledCurrentPosition();
-
-    /** Update the new position. */
-    for (unsigned int j = 0; j < spaceDimension; ++j)
-    {
-      newPosition[j] = currentPosition[j] - this->m_LearningRate * this->m_Gradient[j];
-    }
-  }
-#ifdef ELASTIX_USE_OPENMP
-  else if (this->m_UseOpenMP && !this->m_UseEigen)
-  {
-    /** Get a reference to the current position. */
-    const ParametersType & currentPosition = this->GetScaledCurrentPosition();
-
-    /** Update the new position. */
-    const int nthreads = static_cast<int>(this->m_Threader->GetNumberOfWorkUnits());
-    omp_set_num_threads(nthreads);
-#  pragma omp parallel for
-    for (int j = 0; j < static_cast<int>(spaceDimension); ++j)
-    {
-      newPosition[j] = currentPosition[j] - this->m_LearningRate * this->m_Gradient[j];
-    }
-  }
-#endif
-#ifdef ELASTIX_USE_EIGEN
-  else if (!this->m_UseOpenMP && this->m_UseEigen)
-  {
-    /** Get a reference to the current position. */
-    const ParametersType & currentPosition = this->GetScaledCurrentPosition();
-    const double           learningRate = this->m_LearningRate;
-
-    /** Wrap itk::Arrays into Eigen jackets. */
-    using ParametersTypeEigen = Eigen::VectorXd;
-    Eigen::Map<ParametersTypeEigen>       newPositionE(newPosition.data_block(), spaceDimension);
-    Eigen::Map<const ParametersTypeEigen> currentPositionE(currentPosition.data_block(), spaceDimension);
-    Eigen::Map<ParametersTypeEigen>       gradientE(this->m_Gradient.data_block(), spaceDimension);
-
-    /** Update the new position. */
-    newPositionE = currentPositionE - learningRate * gradientE;
-  }
-#endif
-#if defined(ELASTIX_USE_OPENMP) && defined(ELASTIX_USE_EIGEN)
-  else if (this->m_UseOpenMP && this->m_UseEigen)
-  {
-    /** Get a reference to the current position. */
-    const ParametersType & currentPosition = this->GetScaledCurrentPosition();
-    const double           learningRate = this->m_LearningRate;
-
-    /** Wrap itk::Arrays into Eigen jackets. */
-    using ParametersTypeEigen = Eigen::VectorXd;
-    Eigen::Map<ParametersTypeEigen>       newPositionE(newPosition.data_block(), spaceDimension);
-    Eigen::Map<const ParametersTypeEigen> currentPositionE(currentPosition.data_block(), spaceDimension);
-    Eigen::Map<ParametersTypeEigen>       gradientE(this->m_Gradient.data_block(), spaceDimension);
-
-    /** Update the new position. */
-    const int spaceDim = static_cast<int>(spaceDimension);
-    const int nthreads = static_cast<int>(this->m_Threader->GetNumberOfWorkUnits());
-    omp_set_num_threads(nthreads);
-#  pragma omp parallel for
-    for (int i = 0; i < nthreads; i += 1)
-    {
-      int threadId = omp_get_thread_num();
-      int chunk = (spaceDimension + nthreads - 1) / nthreads;
-      int jmin = threadId * chunk;
-      int jmax = (threadId + 1) * chunk < spaceDim ? (threadId + 1) * chunk : spaceDim;
-      int subSize = jmax - jmin;
-
-      newPositionE.segment(jmin, subSize) =
-        currentPositionE.segment(jmin, subSize) - learningRate * gradientE.segment(jmin, subSize);
-    }
-  }
-#endif
-  else
-  {
-    /** Fill the threader parameter struct with information. */
-    MultiThreaderParameterType temp;
-    temp.t_NewPosition = &newPosition;
-    temp.t_Optimizer = this;
-
-    /** Call multi-threaded AdvanceOneStep(). */
-    auto local_threader = MultiThreaderBase::New();
-    local_threader->SetNumberOfWorkUnits(this->m_Threader->GetNumberOfWorkUnits());
-    local_threader->SetSingleMethodAndExecute(AdvanceOneStepThreaderCallback, &temp);
+    newPosition[j] = currentPosition[j] - this->m_LearningRate * this->m_Gradient[j];
   }
 
   this->InvokeEvent(IterationEvent());

--- a/Components/Optimizers/AdaptiveStochasticVarianceReducedGradient/itkStochasticVarianceReducedGradientDescentOptimizer.h
+++ b/Components/Optimizers/AdaptiveStochasticVarianceReducedGradient/itkStochasticVarianceReducedGradientDescentOptimizer.h
@@ -166,8 +166,6 @@ public:
   }
   // itkGetConstReferenceMacro( NumberOfThreads, ThreadIdType );
   itkSetMacro(UseMultiThread, bool);
-
-  itkSetMacro(UseOpenMP, bool);
   itkSetMacro(UseEigen, bool);
 
 protected:
@@ -209,7 +207,6 @@ private:
     Self *           t_Optimizer;
   };
 
-  bool m_UseOpenMP{ false };
   bool m_UseEigen{ false };
 
   /** The callback function. */

--- a/Components/Optimizers/StandardGradientDescent/itkGradientDescentOptimizer2.cxx
+++ b/Components/Optimizers/StandardGradientDescent/itkGradientDescentOptimizer2.cxx
@@ -31,11 +31,6 @@ namespace itk
  */
 
 GradientDescentOptimizer2 ::GradientDescentOptimizer2()
-  : m_UseOpenMP{
-#ifdef ELASTIX_USE_OPENMP
-    true
-#endif
-  }
 {
   itkDebugMacro("Constructor");
 

--- a/Components/Optimizers/StandardGradientDescent/itkGradientDescentOptimizer2.cxx
+++ b/Components/Optimizers/StandardGradientDescent/itkGradientDescentOptimizer2.cxx
@@ -22,10 +22,6 @@
 #include "itkEventObject.h"
 #include "itkMacro.h"
 
-#ifdef ELASTIX_USE_OPENMP
-#  include <omp.h>
-#endif
-
 
 namespace itk
 {
@@ -194,8 +190,7 @@ GradientDescentOptimizer2 ::AdvanceOneStep()
   ParametersType & newPosition = this->m_ScaledCurrentPosition;
 
   /** Advance one step. */
-#if 1 // force single-threaded since it is fastest most of the times
-      //#ifndef ELASTIX_USE_OPENMP // If no OpenMP detected then use single-threaded code
+  // single-threaded since it is fastest most of the times
   /** Get a reference to the current position. */
   const ParametersType & currentPosition = this->GetScaledCurrentPosition();
 
@@ -204,19 +199,6 @@ GradientDescentOptimizer2 ::AdvanceOneStep()
   {
     newPosition[j] = currentPosition[j] - this->m_LearningRate * this->m_Gradient[j];
   }
-#else // Otherwise use OpenMP
-  /** Get a reference to the current position. */
-  const ParametersType & currentPosition = this->GetScaledCurrentPosition();
-
-  /** Update the new position. */
-  const int nthreads = static_cast<int>(this->m_Threader->GetNumberOfWorkUnits());
-  omp_set_num_threads(nthreads);
-#  pragma omp parallel for
-  for (int j = 0; j < static_cast<int>(spaceDimension); ++j)
-  {
-    newPosition[j] = currentPosition[j] - this->m_LearningRate * this->m_Gradient[j];
-  }
-#endif
 
   this->InvokeEvent(IterationEvent());
 

--- a/Components/Optimizers/StandardGradientDescent/itkGradientDescentOptimizer2.h
+++ b/Components/Optimizers/StandardGradientDescent/itkGradientDescentOptimizer2.h
@@ -136,9 +136,6 @@ public:
   /** Get current search direction */
   itkGetConstReferenceMacro(SearchDirection, DerivativeType);
 
-  /** Set use OpenMP or not. */
-  itkSetMacro(UseOpenMP, bool);
-
 protected:
   GradientDescentOptimizer2();
   ~GradientDescentOptimizer2() override = default;
@@ -156,8 +153,6 @@ private:
   bool          m_Stop{ false };
   unsigned long m_NumberOfIterations{ 100 };
   unsigned long m_CurrentIteration{ 0 };
-
-  bool m_UseOpenMP{};
 };
 
 } // end namespace itk

--- a/Components/Optimizers/StandardStochasticGradientDescent/itkStochasticGradientDescentOptimizer.h
+++ b/Components/Optimizers/StandardStochasticGradientDescent/itkStochasticGradientDescentOptimizer.h
@@ -167,8 +167,6 @@ public:
   }
   // itkGetConstReferenceMacro( NumberOfThreads, ThreadIdType );
   itkSetMacro(UseMultiThread, bool);
-
-  itkSetMacro(UseOpenMP, bool);
   itkSetMacro(UseEigen, bool);
 
 protected:
@@ -210,7 +208,6 @@ private:
     Self *           t_Optimizer;
   };
 
-  bool m_UseOpenMP{ false };
   bool m_UseEigen{ false };
 
   /** The callback function. */

--- a/dox/externalproject/CMakeLists.txt
+++ b/dox/externalproject/CMakeLists.txt
@@ -6,12 +6,6 @@ cmake_minimum_required(VERSION 3.16.3)
 
 find_package(Elastix REQUIRED)
 
-# Elastix might use OpenMP.
-find_package(OpenMP QUIET)
-if(OPENMP_FOUND)
-  set(CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} ${OpenMP_CXX_FLAGS}")
-endif()
-
 # Use the version of ITK from Elastix.
 if ( DEFINED ELASTIX_ITK_DIR)
   set(ITK_DIR "${ELASTIX_ITK_DIR}" CACHE PATH "ITK_DIR from Elastix" FORCE)


### PR DESCRIPTION
Removed unreachable `if` clauses of the form `if (x && false)`, `else` clauses of `if (true)` or `if (x || true)`, and `#else` parts of `#if 1`.

Removed unused `#include <omp.h>` directives.

Removed unreachable code that was specifically for either a single-threaded or a multi-threaded implementation.

----

When reviewing the code, it may help to hide whitespace changes: https://github.com/SuperElastix/elastix/pull/1188/files?w=1