### PR TITLE
PERF: Replace `x = DerivativeType(n)` with `x.set_size(n)`

### DIFF
--- a/Common/itkComputeDisplacementDistribution.hxx
+++ b/Common/itkComputeDisplacementDistribution.hxx
@@ -119,7 +119,7 @@ ComputeDisplacementDistribution<TFixedImage, TTransform>::ComputeSingleThreaded(
   this->m_ScaledCostFunction->SetScales(scales);
 
   /** Get the exact gradient. */
-  this->m_ExactGradient = DerivativeType(numberOfParameters);
+  this->m_ExactGradient.set_size(numberOfParameters);
   this->m_ExactGradient.Fill(0.0);
   this->GetScaledDerivative(mu, this->m_ExactGradient);
 
@@ -268,7 +268,7 @@ ComputeDisplacementDistribution<TFixedImage, TTransform>::BeforeThreadedCompute(
   this->m_ScaledCostFunction->SetScales(scales);
 
   /** Get the exact gradient. */
-  this->m_ExactGradient = DerivativeType(this->m_NumberOfParameters);
+  this->m_ExactGradient.set_size(this->m_NumberOfParameters);
   this->m_ExactGradient.Fill(0.0);
   this->GetScaledDerivative(mu, this->m_ExactGradient);
 

--- a/Components/Optimizers/AdaptiveStochasticLBFGS/elxAdaptiveStochasticLBFGS.hxx
+++ b/Components/Optimizers/AdaptiveStochasticLBFGS/elxAdaptiveStochasticLBFGS.hxx
@@ -610,9 +610,9 @@ AdaptiveStochasticLBFGS<TElastix>::ResumeOptimization()
 
   SizeValueType spaceDimension = this->GetScaledCostFunction()->GetNumberOfParameters();
 
-  this->m_Gradient = DerivativeType(spaceDimension); // check this
+  this->m_Gradient.set_size(spaceDimension); // check this
   this->m_Gradient.fill(0);
-  this->m_SearchDir = DerivativeType(spaceDimension); // check this
+  this->m_SearchDir.set_size(spaceDimension); // check this
   this->m_SearchDir.fill(0);
   DerivativeType meanCurrentCurvatureGradient(spaceDimension);
   DerivativeType previousCurvatureGradient(spaceDimension);

--- a/Components/Optimizers/AdaptiveStochasticVarianceReducedGradient/elxAdaptiveStochasticVarianceReducedGradient.hxx
+++ b/Components/Optimizers/AdaptiveStochasticVarianceReducedGradient/elxAdaptiveStochasticVarianceReducedGradient.hxx
@@ -496,8 +496,8 @@ AdaptiveStochasticVarianceReducedGradient<TElastix>::ResumeOptimization()
 
   SizeValueType spaceDimension = this->GetScaledCostFunction()->GetNumberOfParameters();
 
-  this->m_Gradient = DerivativeType(spaceDimension); // check this
-  this->m_MeanGradient = DerivativeType(spaceDimension);
+  this->m_Gradient.set_size(spaceDimension); // check this
+  this->m_MeanGradient.set_size(spaceDimension);
   DerivativeType localCurrentGradient(spaceDimension);
   DerivativeType localPreviousGradient(spaceDimension);
 

--- a/Components/Optimizers/AdaptiveStochasticVarianceReducedGradient/itkStochasticVarianceReducedGradientDescentOptimizer.cxx
+++ b/Components/Optimizers/AdaptiveStochasticVarianceReducedGradient/itkStochasticVarianceReducedGradientDescentOptimizer.cxx
@@ -107,7 +107,7 @@ StochasticVarianceReducedGradientDescentOptimizer::ResumeOptimization()
   this->m_PreviousPosition = this->GetPreviousPosition();
 
   const unsigned int spaceDimension = this->GetScaledCostFunction()->GetNumberOfParameters();
-  this->m_Gradient = DerivativeType(spaceDimension); // check this
+  this->m_Gradient.set_size(spaceDimension); // check this
 
   DerivativeType currentPositionGradient;
   DerivativeType previousPositionGradient;

--- a/Components/Optimizers/FiniteDifferenceGradientDescent/itkFiniteDifferenceGradientDescentOptimizer.cxx
+++ b/Components/Optimizers/FiniteDifferenceGradientDescent/itkFiniteDifferenceGradientDescentOptimizer.cxx
@@ -120,7 +120,7 @@ FiniteDifferenceGradientDescentOptimizer::ResumeOptimization()
 
     /** Initialisation.*/
     ck = this->Compute_c(m_CurrentIteration);
-    this->m_Gradient = DerivativeType(spaceDimension);
+    this->m_Gradient.set_size(spaceDimension);
     param = this->GetScaledCurrentPosition();
 
     /** Compute the current value, if desired by interested users */

--- a/Components/Optimizers/RSGDEachParameterApart/itkRSGDEachParameterApartBaseOptimizer.cxx
+++ b/Components/Optimizers/RSGDEachParameterApart/itkRSGDEachParameterApartBaseOptimizer.cxx
@@ -46,9 +46,9 @@ RSGDEachParameterApartBaseOptimizer::StartOptimization()
 
   const unsigned int spaceDimension = m_CostFunction->GetNumberOfParameters();
 
-  m_Gradient = DerivativeType(spaceDimension);
-  m_PreviousGradient = DerivativeType(spaceDimension);
-  m_CurrentStepLengths = DerivativeType(spaceDimension);
+  m_Gradient.set_size(spaceDimension);
+  m_PreviousGradient.set_size(spaceDimension);
+  m_CurrentStepLengths.set_size(spaceDimension);
   m_Gradient.Fill(0.0f);
   m_PreviousGradient.Fill(0.0f);
   m_CurrentStepLengths.Fill(m_MaximumStepLength);

--- a/Components/Optimizers/StandardGradientDescent/itkGradientDescentOptimizer2.cxx
+++ b/Components/Optimizers/StandardGradientDescent/itkGradientDescentOptimizer2.cxx
@@ -95,7 +95,7 @@ GradientDescentOptimizer2 ::ResumeOptimization()
   InvokeEvent(StartEvent());
 
   const unsigned int spaceDimension = this->GetScaledCostFunction()->GetNumberOfParameters();
-  this->m_Gradient = DerivativeType(spaceDimension); // check this
+  this->m_Gradient.set_size(spaceDimension); // check this
 
   while (!this->m_Stop)
   {

--- a/Components/Optimizers/StandardStochasticGradientDescent/itkStochasticGradientDescentOptimizer.cxx
+++ b/Components/Optimizers/StandardStochasticGradientDescent/itkStochasticGradientDescentOptimizer.cxx
@@ -106,7 +106,7 @@ StochasticGradientDescentOptimizer::ResumeOptimization()
   this->m_PreviousPosition = this->GetPreviousPosition();
 
   const unsigned int spaceDimension = this->GetScaledCostFunction()->GetNumberOfParameters();
-  this->m_Gradient = DerivativeType(spaceDimension); // check this
+  this->m_Gradient.set_size(spaceDimension); // check this
 
   DerivativeType currentPositionGradient;
   DerivativeType previousPositionGradient;


### PR DESCRIPTION
Avoided allocation of a possibly expensive temporary `DerivativeType` object, and reused the existing data buffer of the existing `DerivativeType` object (if already had the right size).

- Follow-up to pull request #1175 commit c5a04519f34feb13c4af8fa06979a1d48cfc4e87 "PERF: Replace derivative = DerivativeType(n) with derivative.set_size(n)"