### PR TITLE
Specify "fill value" directly with variable declarations and during construction of temporaries

### DIFF
--- a/Common/itkComputePreconditionerUsingDisplacementDistribution.hxx
+++ b/Common/itkComputePreconditionerUsingDisplacementDistribution.hxx
@@ -109,8 +109,7 @@ ComputePreconditionerUsingDisplacementDistribution<TFixedImage, TTransform>::Com
   JacobianType        jacjjacj(outdim, outdim);
   const double        sqrt2 = std::sqrt(static_cast<double>(2.0));
   std::vector<double> localStepSizeSquared(numberOfParameters, 0.0);
-  ParametersType      binCount(numberOfParameters);
-  binCount.Fill(0.0);
+  ParametersType      binCount(numberOfParameters, 0.0);
 
   /** Loop over all voxels in the sample container. */
   for (const auto & sample : *sampleContainer)

--- a/Common/itkMultiResolutionImageRegistrationMethod2.hxx
+++ b/Common/itkMultiResolutionImageRegistrationMethod2.hxx
@@ -71,14 +71,6 @@ MultiResolutionImageRegistrationMethod2<TFixedImage, TMovingImage>::MultiResolut
 
   this->m_Stop = false;
 
-  this->m_InitialTransformParameters = ParametersType(0);
-  this->m_InitialTransformParametersOfNextLevel = ParametersType(0);
-  this->m_LastTransformParameters = ParametersType(0);
-
-  this->m_InitialTransformParameters.Fill(0.0f);
-  this->m_InitialTransformParametersOfNextLevel.Fill(0.0f);
-  this->m_LastTransformParameters.Fill(0.0f);
-
   this->ProcessObject::SetNthOutput(0, TransformOutputType::New().GetPointer());
 
 } // end Constructor

--- a/Components/Interpolators/RayCastInterpolator/elxRayCastInterpolator.hxx
+++ b/Components/Interpolators/RayCastInterpolator/elxRayCastInterpolator.hxx
@@ -60,8 +60,7 @@ RayCastInterpolator<TElastix>::BeforeRegistration()
   this->m_CombinationTransform->SetUseComposition(true);
 
   unsigned int numberofparameters = this->m_Elastix->GetElxTransformBase()->GetAsITKBaseType()->GetNumberOfParameters();
-  TransformParametersType preParameters(numberofparameters);
-  preParameters.Fill(0.0);
+  TransformParametersType preParameters(numberofparameters, 0.0);
 
   for (unsigned int i = 0; i < numberofparameters; ++i)
   {

--- a/Components/Metrics/AdvancedMattesMutualInformation/itkParzenWindowMutualInformationImageToImageMetric.hxx
+++ b/Components/Metrics/AdvancedMattesMutualInformation/itkParzenWindowMutualInformationImageToImageMetric.hxx
@@ -292,8 +292,7 @@ ParzenWindowMutualInformationImageToImageMetric<TFixedImage, TMovingImage>::Comp
   if (this->GetUseJacobianPreconditioning())
   {
     jacobianPreconditioner = DerivativeType(nzji.size());
-    preconditioningDivisor = DerivativeType(this->GetNumberOfParameters());
-    preconditioningDivisor.Fill(0.0);
+    preconditioningDivisor = DerivativeType(this->GetNumberOfParameters(), 0.0);
   }
 
   /** Get a handle to the sample container. */
@@ -431,8 +430,7 @@ ParzenWindowMutualInformationImageToImageMetric<TFixedImage, TMovingImage>::Thre
   if (this->GetUseJacobianPreconditioning())
   {
     jacobianPreconditioner = DerivativeType(nzji.size());
-    preconditioningDivisor = DerivativeType(this->GetNumberOfParameters());
-    preconditioningDivisor.Fill(0.0);
+    preconditioningDivisor = DerivativeType(this->GetNumberOfParameters(), 0.0);
   }
 
   /** Get a handle to the sample container. */

--- a/Components/Optimizers/AdaptiveStochasticGradientDescent/elxAdaptiveStochasticGradientDescent.hxx
+++ b/Components/Optimizers/AdaptiveStochasticGradientDescent/elxAdaptiveStochasticGradientDescent.hxx
@@ -379,8 +379,7 @@ AdaptiveStochasticGradientDescent<TElastix>::StartOptimization()
   const ScalesType & scales = this->GetScales();
   if (scales.GetSize() == this->GetInitialPosition().GetSize())
   {
-    ScalesType unit_scales(scales.GetSize());
-    unit_scales.Fill(1.0);
+    ScalesType unit_scales(scales.GetSize(), 1.0);
     if (scales != unit_scales)
     {
       /** only then: */

--- a/Components/Optimizers/AdaptiveStochasticLBFGS/elxAdaptiveStochasticLBFGS.hxx
+++ b/Components/Optimizers/AdaptiveStochasticLBFGS/elxAdaptiveStochasticLBFGS.hxx
@@ -465,8 +465,7 @@ AdaptiveStochasticLBFGS<TElastix>::StartOptimization()
   const ScalesType & scales = this->GetScales();
   if (scales.GetSize() == this->GetInitialPosition().GetSize())
   {
-    ScalesType unit_scales(scales.GetSize());
-    unit_scales.Fill(1.0);
+    ScalesType unit_scales(scales.GetSize(), 1.0);
     if (scales != unit_scales)
     {
       /** only then: */

--- a/Components/Optimizers/AdaptiveStochasticVarianceReducedGradient/elxAdaptiveStochasticVarianceReducedGradient.hxx
+++ b/Components/Optimizers/AdaptiveStochasticVarianceReducedGradient/elxAdaptiveStochasticVarianceReducedGradient.hxx
@@ -400,8 +400,7 @@ AdaptiveStochasticVarianceReducedGradient<TElastix>::StartOptimization()
   const ScalesType & scales = this->GetScales();
   if (scales.GetSize() == this->GetInitialPosition().GetSize())
   {
-    ScalesType unit_scales(scales.GetSize());
-    unit_scales.Fill(1.0);
+    ScalesType unit_scales(scales.GetSize(), 1.0);
     if (scales != unit_scales)
     {
       /** only then: */

--- a/Components/Optimizers/CMAEvolutionStrategy/elxCMAEvolutionStrategy.hxx
+++ b/Components/Optimizers/CMAEvolutionStrategy/elxCMAEvolutionStrategy.hxx
@@ -40,8 +40,7 @@ CMAEvolutionStrategy<TElastix>::StartOptimization()
   const ScalesType & scales = this->GetScales();
   if (scales.GetSize() == this->GetInitialPosition().GetSize())
   {
-    ScalesType unit_scales(scales.GetSize());
-    unit_scales.Fill(1.0);
+    ScalesType unit_scales(scales.GetSize(), 1.0);
     if (scales != unit_scales)
     {
       /** only then: */

--- a/Components/Optimizers/ConjugateGradient/elxConjugateGradient.hxx
+++ b/Components/Optimizers/ConjugateGradient/elxConjugateGradient.hxx
@@ -92,8 +92,7 @@ ConjugateGradient<TElastix>::StartOptimization()
   const ScalesType & scales = this->GetScales();
   if (scales.GetSize() == this->GetInitialPosition().GetSize())
   {
-    ScalesType unit_scales(scales.GetSize());
-    unit_scales.Fill(1.0);
+    ScalesType unit_scales(scales.GetSize(), 1.0);
     if (scales != unit_scales)
     {
       /** only then: */

--- a/Components/Optimizers/ConjugateGradientFRPR/elxConjugateGradientFRPR.hxx
+++ b/Components/Optimizers/ConjugateGradientFRPR/elxConjugateGradientFRPR.hxx
@@ -267,8 +267,7 @@ ConjugateGradientFRPR<TElastix>::SetInitialPosition(const ParametersType & param
 
   if ((scales.Size()) != paramsize)
   {
-    ScalesType newscales(paramsize);
-    newscales.Fill(1.0);
+    ScalesType newscales(paramsize, 1.0);
     this->SetScales(newscales);
   }
 

--- a/Components/Optimizers/FiniteDifferenceGradientDescent/elxFiniteDifferenceGradientDescent.hxx
+++ b/Components/Optimizers/FiniteDifferenceGradientDescent/elxFiniteDifferenceGradientDescent.hxx
@@ -225,8 +225,7 @@ FiniteDifferenceGradientDescent<TElastix>::StartOptimization()
   const ScalesType & scales = this->GetScales();
   if (scales.GetSize() == this->GetInitialPosition().GetSize())
   {
-    ScalesType unit_scales(scales.GetSize());
-    unit_scales.Fill(1.0);
+    ScalesType unit_scales(scales.GetSize(), 1.0);
     if (scales != unit_scales)
     {
       /** only then: */

--- a/Components/Optimizers/Powell/elxPowell.hxx
+++ b/Components/Optimizers/Powell/elxPowell.hxx
@@ -154,8 +154,7 @@ Powell<TElastix>::SetInitialPosition(const ParametersType & param)
 
   if ((scales.Size()) != paramsize)
   {
-    ScalesType newscales(paramsize);
-    newscales.Fill(1.0);
+    ScalesType newscales(paramsize, 1.0);
     this->SetScales(newscales);
   }
 

--- a/Components/Optimizers/QuasiNewtonLBFGS/elxQuasiNewtonLBFGS.hxx
+++ b/Components/Optimizers/QuasiNewtonLBFGS/elxQuasiNewtonLBFGS.hxx
@@ -92,8 +92,7 @@ QuasiNewtonLBFGS<TElastix>::StartOptimization()
   const ScalesType & scales = this->GetScales();
   if (scales.GetSize() == this->GetInitialPosition().GetSize())
   {
-    ScalesType unit_scales(scales.GetSize());
-    unit_scales.Fill(1.0);
+    ScalesType unit_scales(scales.GetSize(), 1.0);
     if (scales != unit_scales)
     {
       /** only then: */

--- a/Components/Optimizers/RSGDEachParameterApart/elxRSGDEachParameterApart.hxx
+++ b/Components/Optimizers/RSGDEachParameterApart/elxRSGDEachParameterApart.hxx
@@ -202,8 +202,7 @@ RSGDEachParameterApart<TElastix>::SetInitialPosition(const ParametersType & para
 
   if ((scales.Size()) != paramsize)
   {
-    ScalesType newscales(paramsize);
-    newscales.Fill(1.0);
+    ScalesType newscales(paramsize, 1.0);
     this->SetScales(newscales);
   }
 

--- a/Components/Optimizers/RegularStepGradientDescent/elxRegularStepGradientDescent.hxx
+++ b/Components/Optimizers/RegularStepGradientDescent/elxRegularStepGradientDescent.hxx
@@ -193,8 +193,7 @@ RegularStepGradientDescent<TElastix>::SetInitialPosition(const ParametersType & 
 
   if ((scales.Size()) != paramsize)
   {
-    ScalesType newscales(paramsize);
-    newscales.Fill(1.0);
+    ScalesType newscales(paramsize, 1.0);
     this->SetScales(newscales);
   }
 

--- a/Components/Optimizers/Simplex/elxSimplex.hxx
+++ b/Components/Optimizers/Simplex/elxSimplex.hxx
@@ -81,8 +81,7 @@ Simplex<TElastix>::BeforeEachResolution()
   {
     unsigned int numberofparameters =
       this->m_Elastix->GetElxTransformBase()->GetAsITKBaseType()->GetNumberOfParameters();
-    ParametersType initialsimplexdelta(numberofparameters);
-    initialsimplexdelta.Fill(1);
+    ParametersType initialsimplexdelta(numberofparameters, 1);
 
     for (unsigned int i = 0; i < numberofparameters; ++i)
     {
@@ -168,8 +167,7 @@ Simplex<TElastix>::SetInitialPosition(const ParametersType & param)
 
   if ((scales.Size()) != paramsize)
   {
-    ScalesType newscales(paramsize);
-    newscales.Fill(1.0);
+    ScalesType newscales(paramsize, 1.0);
     this->SetScales(newscales);
   }
 

--- a/Components/Optimizers/SimultaneousPerturbation/elxSimultaneousPerturbation.hxx
+++ b/Components/Optimizers/SimultaneousPerturbation/elxSimultaneousPerturbation.hxx
@@ -232,8 +232,7 @@ SimultaneousPerturbation<TElastix>::SetInitialPosition(const ParametersType & pa
 
   if ((scales.Size()) != paramsize)
   {
-    ScalesType newscales(paramsize);
-    newscales.Fill(1.0);
+    ScalesType newscales(paramsize, 1.0);
     this->SetScales(newscales);
   }
 

--- a/Components/Optimizers/StandardGradientDescent/elxStandardGradientDescent.hxx
+++ b/Components/Optimizers/StandardGradientDescent/elxStandardGradientDescent.hxx
@@ -195,8 +195,7 @@ StandardGradientDescent<TElastix>::StartOptimization()
   const ScalesType & scales = this->GetScales();
   if (scales.GetSize() == this->GetInitialPosition().GetSize())
   {
-    ScalesType unit_scales(scales.GetSize());
-    unit_scales.Fill(1.0);
+    ScalesType unit_scales(scales.GetSize(), 1.0);
     if (scales != unit_scales)
     {
       /** only then: */

--- a/Components/ResampleInterpolators/RayCastResampleInterpolator/elxRayCastResampleInterpolator.hxx
+++ b/Components/ResampleInterpolators/RayCastResampleInterpolator/elxRayCastResampleInterpolator.hxx
@@ -39,8 +39,7 @@ RayCastResampleInterpolator<TElastix>::InitializeRayCastInterpolator()
 
   this->m_PreTransform = EulerTransformType::New();
   unsigned int            numberofparameters = this->m_PreTransform->GetNumberOfParameters();
-  TransformParametersType preParameters(numberofparameters);
-  preParameters.Fill(0.0);
+  TransformParametersType preParameters(numberofparameters, 0.0);
 
   for (unsigned int i = 0; i < numberofparameters; ++i)
   {

--- a/Components/Transforms/AdvancedAffineTransform/elxAdvancedAffineTransform.hxx
+++ b/Components/Transforms/AdvancedAffineTransform/elxAdvancedAffineTransform.hxx
@@ -329,8 +329,7 @@ AdvancedAffineTransformElastix<TElastix>::SetScales()
 {
   /** Create the new scales. */
   const NumberOfParametersType numberOfParameters = this->GetNumberOfParameters();
-  ScalesType                   newscales(numberOfParameters);
-  newscales.Fill(1.0);
+  ScalesType                   newscales(numberOfParameters, 1.0);
 
   /** Check if automatic scales estimation is desired. */
   bool automaticScalesEstimation = false;

--- a/Components/Transforms/AdvancedBSplineTransform/elxAdvancedBSplineTransform.hxx
+++ b/Components/Transforms/AdvancedBSplineTransform/elxAdvancedBSplineTransform.hxx
@@ -323,8 +323,7 @@ AdvancedBSplineTransform<TElastix>::InitializeTransform()
   this->m_BSplineTransform->SetGridDirection(gridDirection);
 
   /** Set initial parameters for the first resolution to 0.0. */
-  ParametersType initialParameters(this->GetNumberOfParameters());
-  initialParameters.Fill(0.0);
+  ParametersType initialParameters(this->GetNumberOfParameters(), 0.0);
   this->m_Registration->GetAsITKBaseType()->SetInitialTransformParametersOfNextLevel(initialParameters);
 
 } // end InitializeTransform()

--- a/Components/Transforms/AffineDTITransform/elxAffineDTITransform.hxx
+++ b/Components/Transforms/AffineDTITransform/elxAffineDTITransform.hxx
@@ -275,8 +275,7 @@ AffineDTITransformElastix<TElastix>::SetScales()
 {
   /** Create the new scales. */
   const NumberOfParametersType numberOfParameters = this->GetNumberOfParameters();
-  ScalesType                   newscales(numberOfParameters);
-  newscales.Fill(1.0);
+  ScalesType                   newscales(numberOfParameters, 1.0);
 
   /** Always estimate scales automatically */
   log::info("Scales are estimated automatically.");

--- a/Components/Transforms/AffineLogTransform/elxAffineLogTransform.hxx
+++ b/Components/Transforms/AffineLogTransform/elxAffineLogTransform.hxx
@@ -275,8 +275,7 @@ AffineLogTransformElastix<TElastix>::SetScales()
   log::info("SetScales");
   /** Create the new scales. */
   const NumberOfParametersType numberOfParameters = this->GetNumberOfParameters();
-  ScalesType                   newscales(numberOfParameters);
-  newscales.Fill(1.0);
+  ScalesType                   newscales(numberOfParameters, 1.0);
 
   /** Always estimate scales automatically */
   log::info("Scales are estimated automatically.");

--- a/Components/Transforms/BSplineDeformableTransformWithDiffusion/elxBSplineTransformWithDiffusion.hxx
+++ b/Components/Transforms/BSplineDeformableTransformWithDiffusion/elxBSplineTransformWithDiffusion.hxx
@@ -113,8 +113,7 @@ BSplineTransformWithDiffusion<TElastix>::BeforeRegistration()
   this->m_BSplineTransform->SetGridOrigin(gridorigin);
 
   /** Task 2 - Give the registration an initial parameter-array. */
-  ParametersType dummyInitialParameters(this->GetNumberOfParameters());
-  dummyInitialParameters.Fill(0.0);
+  ParametersType dummyInitialParameters(this->GetNumberOfParameters(), 0.0);
 
   /** Put parameters in the registration. */
   this->m_Registration->GetAsITKBaseType()->SetInitialTransformParameters(dummyInitialParameters);
@@ -664,8 +663,7 @@ BSplineTransformWithDiffusion<TElastix>::SetInitialGrid(bool upsampleGridOption)
   this->m_BSplineTransform->SetGridOrigin(gridorigin);
 
   /** Set initial parameters to 0.0. */
-  ParametersType initialParameters(this->GetNumberOfParameters());
-  initialParameters.Fill(0.0);
+  ParametersType initialParameters(this->GetNumberOfParameters(), 0.0);
   this->m_Registration->GetAsITKBaseType()->SetInitialTransformParametersOfNextLevel(initialParameters);
 
 } // end SetInitialGrid()
@@ -1258,8 +1256,7 @@ BSplineTransformWithDiffusion<TElastix>::DiffuseDeformationField()
   /** ------------- 6: Reset the current transform parameters of the optimizer. ------------- */
 
   /** Create a vector of zeros in order to reset the B-spline transform. */
-  ParametersType dummyParameters(this->GetNumberOfParameters());
-  dummyParameters.Fill(0.0);
+  ParametersType dummyParameters(this->GetNumberOfParameters(), 0.0);
   this->SetParameters(dummyParameters);
 
   /** Reset the optimizer.

--- a/Components/Transforms/BSplineStackTransform/elxBSplineStackTransform.hxx
+++ b/Components/Transforms/BSplineStackTransform/elxBSplineStackTransform.hxx
@@ -360,8 +360,7 @@ BSplineStackTransform<TElastix>::InitializeTransform()
   m_StackTransform->SetAllSubTransforms(*m_DummySubTransform);
 
   /** Set initial parameters for the first resolution to 0.0. */
-  ParametersType initialParameters(this->GetNumberOfParameters());
-  initialParameters.Fill(0.0);
+  ParametersType initialParameters(this->GetNumberOfParameters(), 0.0);
   this->m_Registration->GetAsITKBaseType()->SetInitialTransformParametersOfNextLevel(initialParameters);
 
 } // end InitializeTransform()

--- a/Components/Transforms/EulerTransform/elxEulerTransform.hxx
+++ b/Components/Transforms/EulerTransform/elxEulerTransform.hxx
@@ -290,8 +290,7 @@ EulerTransformElastix<TElastix>::SetScales()
 {
   /** Create the new scales. */
   const NumberOfParametersType numberOfParameters = this->GetNumberOfParameters();
-  ScalesType                   newscales(numberOfParameters);
-  newscales.Fill(1.0);
+  ScalesType                   newscales(numberOfParameters, 1.0);
 
   /** Check if automatic scales estimation is desired. */
   bool automaticScalesEstimation = false;

--- a/Components/Transforms/MultiBSplineTransformWithNormal/elxMultiBSplineTransformWithNormal.hxx
+++ b/Components/Transforms/MultiBSplineTransformWithNormal/elxMultiBSplineTransformWithNormal.hxx
@@ -345,8 +345,7 @@ MultiBSplineTransformWithNormal<TElastix>::InitializeTransform()
   this->m_MultiBSplineTransformWithNormal->UpdateLocalBases();
 
   /** Set initial parameters for the first resolution to 0.0. */
-  ParametersType initialParameters(this->GetNumberOfParameters());
-  initialParameters.Fill(0.0);
+  ParametersType initialParameters(this->GetNumberOfParameters(), 0.0);
   this->m_Registration->GetAsITKBaseType()->SetInitialTransformParametersOfNextLevel(initialParameters);
 
 } // end InitializeTransform()

--- a/Components/Transforms/RecursiveBSplineTransform/elxRecursiveBSplineTransform.hxx
+++ b/Components/Transforms/RecursiveBSplineTransform/elxRecursiveBSplineTransform.hxx
@@ -324,8 +324,7 @@ RecursiveBSplineTransform<TElastix>::InitializeTransform()
   this->m_BSplineTransform->SetGridDirection(gridDirection);
 
   /** Set initial parameters for the first resolution to 0.0. */
-  ParametersType initialParameters(this->GetNumberOfParameters());
-  initialParameters.Fill(0.0);
+  ParametersType initialParameters(this->GetNumberOfParameters(), 0.0);
   this->m_Registration->GetAsITKBaseType()->SetInitialTransformParametersOfNextLevel(initialParameters);
 
 } // end InitializeTransform()

--- a/Components/Transforms/SimilarityTransform/elxSimilarityTransform.hxx
+++ b/Components/Transforms/SimilarityTransform/elxSimilarityTransform.hxx
@@ -275,8 +275,7 @@ SimilarityTransformElastix<TElastix>::SetScales()
 {
   /** Create the new scales. */
   const NumberOfParametersType numberOfParameters = this->GetNumberOfParameters();
-  ScalesType                   newscales(numberOfParameters);
-  newscales.Fill(1.0);
+  ScalesType                   newscales(numberOfParameters, 1.0);
 
   /** Check if automatic scales estimation is desired. */
   bool automaticScalesEstimation = false;

--- a/Components/Transforms/TranslationStackTransform/elxTranslationStackTransform.hxx
+++ b/Components/Transforms/TranslationStackTransform/elxTranslationStackTransform.hxx
@@ -107,8 +107,7 @@ TranslationStackTransform<TElastix>::InitializeTransform()
   m_StackTransform->SetAllSubTransforms(*m_DummySubTransform);
 
   /** Set initial parameters for the first resolution to 0.0. */
-  ParametersType initialParameters(this->GetNumberOfParameters());
-  initialParameters.Fill(0.0);
+  ParametersType initialParameters(this->GetNumberOfParameters(), 0.0);
   this->m_Registration->GetAsITKBaseType()->SetInitialTransformParametersOfNextLevel(initialParameters);
 
 } // end InitializeTransform()

--- a/Components/Transforms/WeightedCombinationTransform/elxWeightedCombinationTransform.hxx
+++ b/Components/Transforms/WeightedCombinationTransform/elxWeightedCombinationTransform.hxx
@@ -140,8 +140,7 @@ WeightedCombinationTransformElastix<TElastix>::SetScales()
 {
   /** Create the new scales. */
   const NumberOfParametersType numberOfParameters = this->GetNumberOfParameters();
-  ScalesType                   newscales(numberOfParameters);
-  newscales.Fill(1.0);
+  ScalesType                   newscales(numberOfParameters, 1.0);
 
   /** Check if automatic scales estimation is desired. */
   bool automaticScalesEstimation = false;


### PR DESCRIPTION
Removed some more unnecessary `Fill` calls.