### PR TITLE
BUG: Call `SetGlobalDefaultNumberOfThreads` when processing "-threads"

### DIFF
--- a/Core/Kernel/elxMainBase.cxx
+++ b/Core/Kernel/elxMainBase.cxx
@@ -302,6 +302,11 @@ MainBase::SetMaximumNumberOfThreads() const
   {
     const int maximumNumberOfThreads = atoi(maximumNumberOfThreadsString.c_str());
     itk::MultiThreaderBase::SetGlobalMaximumNumberOfThreads(maximumNumberOfThreads);
+
+    // The following statement (getting and setting GlobalDefaultNumberOfThreads) may look redundant, but it's not
+    // (using ITK 5.4.0)! The Set function ensures that GlobalDefaultNumberOfThreads <= GlobalMaximumNumberOfThreads.
+    // (GlobalDefaultNumberOfThreads is important, as ITK uses this number when constructing the ThreadPool.)
+    itk::MultiThreaderBase::SetGlobalDefaultNumberOfThreads(itk::MultiThreaderBase::GetGlobalDefaultNumberOfThreads());
   }
 } // end SetMaximumNumberOfThreads()
 


### PR DESCRIPTION
It appears that `SetGlobalMaximumNumberOfThreads` may not affect the size of ITK's ThreadPool. The ThreadPool only uses "GlobalDefaultNumberOfThreads".

- Related to ITK issue https://github.com/InsightSoftwareConsortium/ITK/issues/4773 "GlobalDefaultNumberOfThreads should not be greater than GlobalMaximumNumberOfThreads"

----

@Svdvoort This should at least partially address the multi-threading issues you reported