### PR TITLE
DOC: Replace relative link to manual in elastix website with GitHub link

### DIFF
--- a/dox/doxygen/MainPage.dox.in
+++ b/dox/doxygen/MainPage.dox.in
@@ -25,6 +25,6 @@
  *
  * \section manual Manual
  *
- * <p>We have a manual! Download it <a href="../download/elastix-@ELASTIX_VERSION@-manual.pdf" onClick="javascript: pageTracker._trackPageview('../download/elastix-@ELASTIX_VERSION@-manual');">here</a>.</p>
+ * <p>We have a manual! Download it <a href="https://github.com/SuperElastix/elastix/releases/download/@ELASTIX_VERSION@/elastix-@ELASTIX_VERSION@-manual.pdf" onClick="javascript: pageTracker._trackPageview('https://github.com/SuperElastix/elastix/releases/download/@ELASTIX_VERSION@/elastix-@ELASTIX_VERSION@-manual');">here</a>.</p>
  *
  */


### PR DESCRIPTION
Allows to just place the next manual at one location (at github.com/SuperElastix/elastix/releases/download).

Discussed with Marius (@mstaring) and Stefan (@stefanklein), by mail.