### PR TITLE
COMP: Remove ITK_DISALLOW_COPY_AND_MOVE from UserData struct's

### DIFF
--- a/Common/ImageSamplers/itkImageFullSampler.h
+++ b/Common/ImageSamplers/itkImageFullSampler.h
@@ -123,8 +123,6 @@ private:
 
   struct UserData
   {
-    ITK_DISALLOW_COPY_AND_MOVE(UserData);
-
     const InputImageType & InputImage;
     const MaskType * const Mask{};
     std::vector<WorkUnit>  WorkUnits{};

--- a/Common/ImageSamplers/itkImageGridSampler.h
+++ b/Common/ImageSamplers/itkImageGridSampler.h
@@ -166,8 +166,6 @@ private:
 
   struct UserData
   {
-    ITK_DISALLOW_COPY_AND_MOVE(UserData);
-
     const InputImageType &      InputImage;
     const MaskType * const      Mask{};
     const SampleGridSpacingType GridSpacing{};

--- a/Common/ImageSamplers/itkImageRandomCoordinateSampler.h
+++ b/Common/ImageSamplers/itkImageRandomCoordinateSampler.h
@@ -148,8 +148,6 @@ protected:
 private:
   struct UserData
   {
-    ITK_DISALLOW_COPY_AND_MOVE(UserData);
-
     const std::vector<InputImageContinuousIndexType> & m_RandomCoordinates;
     const InputImageType &                             m_InputImage;
     const InterpolatorType &                           m_Interpolator;

--- a/Common/ImageSamplers/itkImageRandomSampler.h
+++ b/Common/ImageSamplers/itkImageRandomSampler.h
@@ -89,8 +89,6 @@ protected:
 private:
   struct UserData
   {
-    ITK_DISALLOW_COPY_AND_MOVE(UserData);
-
     const std::vector<double> &    m_RandomNumberList;
     const InputImageType &         m_InputImage;
     InputImageIndexType            m_RegionIndex{};

--- a/Common/ImageSamplers/itkImageRandomSamplerSparseMask.h
+++ b/Common/ImageSamplers/itkImageRandomSamplerSparseMask.h
@@ -100,7 +100,7 @@ protected:
 private:
   struct UserData
   {
-    ITK_DISALLOW_COPY_AND_MOVE(UserData);
+    //ITK_DISALLOW_COPY_AND_MOVE(UserData);
 
     const std::vector<ImageSampleType> & m_AllValidSamples;
     const std::vector<size_t> &          m_RandomIndices;


### PR DESCRIPTION
On GCC 12.2.2 (Debian):

/home/matt/src/elastix/Common/ImageSamplers/itkImageGridSampler.hxx: In instantiation of ‘static void itk::ImageGridSampler<TInputImage>::MultiThreadedGenerateData(itk::MultiThreaderBase&, itk::ThreadIdType, const TInputImage&, const MaskType*, const typename Superclass::InputImageRegionType&, const SampleGridSpacingType&, std::vector<typename itk::ImageSamplerBase<TInputImage>::ImageSampleType>&) [with TInputImage = itk::Image<short int, 4>; itk::ThreadIdType = unsigned int; MaskType = itk::ImageMaskSpatialObject<4, unsigned char>; typename Superclass::InputImageRegionType = itk::ImageRegion<4>; Superclass = itk::ImageSamplerBase<itk::Image<short int, 4> >; SampleGridSpacingType = itk::Offset<4>; typename itk::ImageSamplerBase<TInputImage>::ImageSampleType = itk::ImageSample<itk::Image<short int, 4> >]’:
/home/matt/src/elastix/Common/ImageSamplers/itkImageGridSampler.hxx:277:30:   required from ‘void itk::ImageGridSampler<TInputImage>::GenerateData() [with TInputImage = itk::Image<short int, 4>]’
/home/matt/src/elastix/Common/ImageSamplers/itkImageGridSampler.hxx:253:1:   required from here
/home/matt/src/elastix/Common/ImageSamplers/itkImageGridSampler.hxx:212:12: error: no matching function for call to ‘itk::ImageGridSampler<itk::Image<short int, 4> >::UserData::UserData(<brace-enclosed initializer list>)’
  212 |   UserData userData{ inputImage,
      |            ^~~~~~~~
/home/matt/src/elastix/Common/ImageSamplers/itkImageGridSampler.h:169:32: note: candidate: ‘itk::ImageGridSampler<TInputImage>::UserData::UserData(itk::ImageGridSampler<TInputImage>::UserData&&) [with TInputImage = itk::Image<short int, 4>]’ (deleted)
  169 |     ITK_DISALLOW_COPY_AND_MOVE(UserData);
      |                                ^~~~~~~~
/home/matt/src/ITK/Modules/Core/Common/include/itkMacro.h:397:3: note: in definition of macro ‘ITK_DISALLOW_COPY_AND_MOVE’
  397 |   TypeName(TypeName &&) = delete;                  \
      |   ^~~~~~~~
/home/matt/src/elastix/Common/ImageSamplers/itkImageGridSampler.h:169:32: note:   candidate expects 1 argument, 4 provided
  169 |     ITK_DISALLOW_COPY_AND_MOVE(UserData);
      |                                ^~~~~~~~
/home/matt/src/ITK/Modules/Core/Common/include/itkMacro.h:397:3: note: in definition of macro ‘ITK_DISALLOW_COPY_AND_MOVE’
  397 |   TypeName(TypeName &&) = delete;                  \
      |   ^~~~~~~~
/home/matt/src/elastix/Common/ImageSamplers/itkImageGridSampler.h:169:32: note: candidate: ‘itk::ImageGridSampler<TInputImage>::UserData::UserData(const itk::ImageGridSampler<TInputImage>::UserData&) [with TInputImage = itk::Image<short int, 4>]’ (deleted)
  169 |     ITK_DISALLOW_COPY_AND_MOVE(UserData);
      |                                ^~~~~~~~
/home/matt/src/ITK/Modules/Core/Common/include/itkMacro.h:395:3: note: in definition of macro ‘ITK_DISALLOW_COPY_AND_MOVE’
  395 |   TypeName(const TypeName &) = delete;             \
      |   ^~~~~~~~
/home/matt/src/elastix/Common/ImageSamplers/itkImageGridSampler.h:169:32: note:   candidate expects 1 argument, 4 provided
  169 |     ITK_DISALLOW_COPY_AND_MOVE(UserData);
      |                                ^~~~~~~~
/home/matt/src/ITK/Modules/Core/Common/include/itkMacro.h:395:3: note: in definition of macro ‘ITK_DISALLOW_COPY_AND_MOVE’
  395 |   TypeName(const TypeName &) = delete;             \
      |   ^~~~~~~~
