### PR TITLE
DOC: Document elastix parameter `UseMultiThreadingForMetrics`

### DIFF
--- a/Core/ComponentBaseClasses/elxMetricBase.h
+++ b/Core/ComponentBaseClasses/elxMetricBase.h
@@ -63,6 +63,11 @@ namespace elastix
  *    CheckNumberOfSamples. \n
  *    example: <tt>(RequiredRatioOfValidSamples 0.1)</tt> \n
  *    The default is 0.25.
+ * \parameter UseMultiThreadingForMetrics: Flag that can set to "true" or "false".
+ *    If "true" the metric may use multi-threading (at least if multi-threading is implemented for the selected
+ *    metric). If "false", it will run single-threaded. This flag will not affect the output of the metric.\n
+ *    example: <tt>(UseMultiThreadingForMetrics "false")</tt> \n
+ *    Default is "true".
  *
  * \ingroup Metrics
  * \ingroup ComponentBaseClasses


### PR DESCRIPTION
This parameter was introduced by commit 1790625ca346e8cadc693cd27b5d9b5aca6c872d "ENH: make multi-threading option first class citizen", 2015-10-28.