### PR TITLE
DOC: Fix documentation about order of matrix elements Rigid3DTransform

### DIFF
--- a/Common/Transforms/itkAdvancedRigid3DTransform.h
+++ b/Common/Transforms/itkAdvancedRigid3DTransform.h
@@ -52,7 +52,7 @@ namespace itk
  * methods or in serialized form using SetParameters() and SetFixedParameters().
  *
  * The serialization of the optimizable parameters is an array of 12 elements.
- * The first 9 parameters represents the rotation matrix in column-major order
+ * The first 9 parameters represents the rotation matrix in row-major order
  * (where the column index varies the fastest). The last 3 parameters defines
  * the translation in each dimension.
  *
@@ -114,7 +114,7 @@ public:
   /** Set the transformation from a container of parameters
    * This is typically used by optimizers.
    * There are 12 parameters. The first 9 represents the rotation
-   * matrix is column-major order and the last 3 represents the translation.
+   * matrix is row-major order and the last 3 represents the translation.
    *
    * \warning The rotation matrix must be orthogonal to within a specified tolerance,
    * else an exception is thrown.


### PR DESCRIPTION
Replaced "column-major order" with "row-major order", which is the correct term in this case.

Following ITK commit https://github.com/InsightSoftwareConsortium/ITK/commit/a2eccee89a115c5c198a41cb0648f3368fc21eae "STYLE: Fixed documentation about the parameters of AffineTransform and Rigid3DTransform. The first parameters are the matrix elements in row-major order an not column-major", Tom Vercauteren, 17 Jun 2009