### PR TITLE
Remove GoToBegin() calls after iterator construction, move iterator variable declarations into init-statement of `for`

### DIFF
--- a/Common/CostFunctions/itkParzenWindowHistogramImageToImageMetric.hxx
+++ b/Common/CostFunctions/itkParzenWindowHistogramImageToImageMetric.hxx
@@ -710,10 +710,6 @@ ParzenWindowHistogramImageToImageMetric<TFixedImage, TMovingImage>::ComputeIncre
   IncMargIteratorType fixincit(fixedIncrementalMarginalPDF, fixedIncrementalMarginalPDF->GetLargestPossibleRegion());
   IncMargIteratorType movincit(movingIncrementalMarginalPDF, movingIncrementalMarginalPDF->GetLargestPossibleRegion());
 
-  incit.GoToBegin();
-  fixincit.GoToBegin();
-  movincit.GoToBegin();
-
   const auto numberOfParameters = this->GetNumberOfParameters();
 
   /** Loop over the incremental pdf and update the incremental marginal pdfs. */

--- a/Common/Transforms/itkBSplineInterpolationWeightFunctionBase.hxx
+++ b/Common/Transforms/itkBSplineInterpolationWeightFunctionBase.hxx
@@ -56,7 +56,6 @@ BSplineInterpolationWeightFunctionBase<TCoordRep, VSpaceDimension, VSplineOrder>
 
   /** Create an iterator over the image. */
   ImageRegionConstIteratorWithIndex<CharImageType> it(tempImage, tempImage->GetBufferedRegion());
-  it.GoToBegin();
 
   /** Fill the OffsetToIndexTable. */
   this->m_OffsetToIndexTable.set_size(NumberOfWeights, SpaceDimension);

--- a/Common/Transforms/itkTransformToDeterminantOfSpatialJacobianSource.hxx
+++ b/Common/Transforms/itkTransformToDeterminantOfSpatialJacobianSource.hxx
@@ -229,7 +229,6 @@ TransformToDeterminantOfSpatialJacobianSource<TOutputImage, TTransformPrecisionT
   // Create an iterator that will walk the output region for this thread.
   using OutputIteratorType = ImageRegionIteratorWithIndex<TOutputImage>;
   OutputIteratorType it(outputPtr, outputRegionForThread);
-  it.GoToBegin();
 
   // pixel coordinates
   PointType point;

--- a/Common/Transforms/itkTransformToSpatialJacobianSource.hxx
+++ b/Common/Transforms/itkTransformToSpatialJacobianSource.hxx
@@ -218,7 +218,6 @@ TransformToSpatialJacobianSource<TOutputImage, TTransformPrecisionType>::Nonline
   // Create an iterator that will walk the output region for this thread.
   using OutputIteratorType = ImageRegionIteratorWithIndex<TOutputImage>;
   OutputIteratorType it(outputPtr, outputRegionForThread);
-  it.GoToBegin();
 
   // pixel coordinates
   PointType point;

--- a/Common/itkMultiOrderBSplineDecompositionImageFilter.hxx
+++ b/Common/itkMultiOrderBSplineDecompositionImageFilter.hxx
@@ -330,8 +330,6 @@ MultiOrderBSplineDecompositionImageFilter<TInputImage, TOutputImage>::CopyImageT
   InputIterator  inIt(this->GetInput(), this->GetInput()->GetBufferedRegion());
   OutputIterator outIt(this->GetOutput(), this->GetOutput()->GetBufferedRegion());
 
-  inIt.GoToBegin();
-  outIt.GoToBegin();
   while (!outIt.IsAtEnd())
   {
     outIt.Set(static_cast<OutputPixelType>(inIt.Get()));

--- a/Components/Metrics/AdvancedKappaStatistic/itkAdvancedKappaStatisticImageToImageMetric.hxx
+++ b/Components/Metrics/AdvancedKappaStatistic/itkAdvancedKappaStatisticImageToImageMetric.hxx
@@ -789,8 +789,6 @@ AdvancedKappaStatisticImageToImageMetric<TFixedImage, TMovingImage>::ComputeGrad
   /** Create and reset iterators. */
   GradientIteratorType git(tempGradientImage, tempGradientImage->GetBufferedRegion());
   MovingIteratorType   mit(this->m_MovingImage, this->m_MovingImage->GetBufferedRegion());
-  git.GoToBegin();
-  mit.GoToBegin();
 
   /** Some temporary variables. */
   typename MovingImageType::IndexType   minusIndex, plusIndex, currIndex;

--- a/Components/Metrics/AdvancedMattesMutualInformation/itkParzenWindowMutualInformationImageToImageMetric.hxx
+++ b/Components/Metrics/AdvancedMattesMutualInformation/itkParzenWindowMutualInformationImageToImageMetric.hxx
@@ -818,14 +818,11 @@ ParzenWindowMutualInformationImageToImageMetric<TFixedImage, TMovingImage>::GetV
   using DerivativeConstIteratorType = typename DerivativeType::const_iterator;
 
   JointPDFIteratorType jointPDFit(this->m_JointPDF, this->m_JointPDF->GetLargestPossibleRegion());
-  jointPDFit.GoToBegin();
 
   IncrementalJointPDFIteratorType jointIncPDFRightit(this->m_IncrementalJointPDFRight,
                                                      this->m_IncrementalJointPDFRight->GetLargestPossibleRegion());
   IncrementalJointPDFIteratorType jointIncPDFLeftit(this->m_IncrementalJointPDFLeft,
                                                     this->m_IncrementalJointPDFLeft->GetLargestPossibleRegion());
-  jointIncPDFRightit.GoToBegin();
-  jointIncPDFLeftit.GoToBegin();
 
   MarginalPDFIteratorType       fixedPDFit = this->m_FixedImageMarginalPDF.begin();
   const MarginalPDFIteratorType fixedPDFend = this->m_FixedImageMarginalPDF.end();
@@ -840,10 +837,6 @@ ParzenWindowMutualInformationImageToImageMetric<TFixedImage, TMovingImage>::GetV
     this->m_FixedIncrementalMarginalPDFLeft, this->m_FixedIncrementalMarginalPDFLeft->GetLargestPossibleRegion());
   IncrementalMarginalPDFIteratorType movingIncPDFLeftit(
     this->m_MovingIncrementalMarginalPDFLeft, this->m_MovingIncrementalMarginalPDFLeft->GetLargestPossibleRegion());
-  fixedIncPDFRightit.GoToBegin();
-  movingIncPDFRightit.GoToBegin();
-  fixedIncPDFLeftit.GoToBegin();
-  movingIncPDFLeftit.GoToBegin();
 
   DerivativeIteratorType       derivit = derivative.begin();
   const DerivativeIteratorType derivbegin = derivative.begin();

--- a/Components/Metrics/DistancePreservingRigidityPenalty/itkDistancePreservingRigidityPenaltyTerm.hxx
+++ b/Components/Metrics/DistancePreservingRigidityPenalty/itkDistancePreservingRigidityPenaltyTerm.hxx
@@ -176,8 +176,6 @@ DistancePreservingRigidityPenaltyTerm<TFixedImage, TScalarType>::GetValue(const 
   using PenaltyGridIteratorType = itk::ImageRegionConstIteratorWithIndex<PenaltyGridImageType>;
   PenaltyGridImageRegionType penaltyGridImageRegion = this->m_PenaltyGridImage->GetBufferedRegion();
 
-  PenaltyGridIteratorType pgi(this->m_PenaltyGridImage, penaltyGridImageRegion);
-
   typename PenaltyGridImageType::IndexType penaltyGridIndex, neighborPenaltyGridIndex;
   typename PenaltyGridImageType::PointType penaltyGridPoint, neighborPenaltyGridPoint, xn, xf;
 
@@ -200,7 +198,7 @@ DistancePreservingRigidityPenaltyTerm<TFixedImage, TScalarType>::GetValue(const 
   /** Penalty term computation */
   if constexpr (MovingImageDimension == 3)
   {
-    for (; !pgi.IsAtEnd(); ++pgi, ++ni)
+    for (PenaltyGridIteratorType pgi(this->m_PenaltyGridImage, penaltyGridImageRegion); !pgi.IsAtEnd(); ++pgi, ++ni)
     {
       penaltyGridIndex = pgi.GetIndex();
 
@@ -329,7 +327,6 @@ DistancePreservingRigidityPenaltyTerm<TFixedImage, TScalarType>::GetValueAndDeri
 
   using PenaltyGridIteratorType = itk::ImageRegionConstIteratorWithIndex<PenaltyGridImageType>;
   PenaltyGridImageRegionType penaltyGridImageRegion = this->m_PenaltyGridImage->GetBufferedRegion();
-  PenaltyGridIteratorType    pgi(this->m_PenaltyGridImage, penaltyGridImageRegion);
 
   // neighborhood iterator
   using NeighborhoodIteratorType = itk::ConstNeighborhoodIterator<PenaltyGridImageType>;
@@ -361,7 +358,7 @@ DistancePreservingRigidityPenaltyTerm<TFixedImage, TScalarType>::GetValueAndDeri
 
   if constexpr (MovingImageDimension == 3)
   {
-    for (; !pgi.IsAtEnd(); ++pgi, ++ni)
+    for (PenaltyGridIteratorType pgi(this->m_PenaltyGridImage, penaltyGridImageRegion); !pgi.IsAtEnd(); ++pgi, ++ni)
     {
       penaltyGridIndex = pgi.GetIndex();
 

--- a/Components/Metrics/DistancePreservingRigidityPenalty/itkDistancePreservingRigidityPenaltyTerm.hxx
+++ b/Components/Metrics/DistancePreservingRigidityPenalty/itkDistancePreservingRigidityPenaltyTerm.hxx
@@ -134,8 +134,6 @@ DistancePreservingRigidityPenaltyTerm<TFixedImage, TScalarType>::Initialize()
 
   unsigned int PixelValue;
 
-  ki.GoToBegin();
-
   while (!ki.IsAtEnd())
   {
     penaltyGridIndex = ki.GetIndex();
@@ -202,7 +200,7 @@ DistancePreservingRigidityPenaltyTerm<TFixedImage, TScalarType>::GetValue(const 
   /** Penalty term computation */
   if constexpr (MovingImageDimension == 3)
   {
-    for (pgi.GoToBegin(), ni.GoToBegin(); !pgi.IsAtEnd(); ++pgi, ++ni)
+    for (; !pgi.IsAtEnd(); ++pgi, ++ni)
     {
       penaltyGridIndex = pgi.GetIndex();
 
@@ -363,7 +361,7 @@ DistancePreservingRigidityPenaltyTerm<TFixedImage, TScalarType>::GetValueAndDeri
 
   if constexpr (MovingImageDimension == 3)
   {
-    for (pgi.GoToBegin(), ni.GoToBegin(); !pgi.IsAtEnd(); ++pgi, ++ni)
+    for (; !pgi.IsAtEnd(); ++pgi, ++ni)
     {
       penaltyGridIndex = pgi.GetIndex();
 

--- a/Components/Metrics/NormalizedGradientCorrelation/itkNormalizedGradientCorrelationImageToImageMetric.hxx
+++ b/Components/Metrics/NormalizedGradientCorrelation/itkNormalizedGradientCorrelationImageToImageMetric.hxx
@@ -131,9 +131,6 @@ NormalizedGradientCorrelationImageToImageMetric<TFixedImage, TMovingImage>::Comp
   FixedIteratorType fixedIteratorx(this->m_FixedSobelFilters[0]->GetOutput(), this->GetFixedImageRegion());
   FixedIteratorType fixedIteratory(this->m_FixedSobelFilters[1]->GetOutput(), this->GetFixedImageRegion());
 
-  fixedIteratorx.GoToBegin();
-  fixedIteratory.GoToBegin();
-
   bool                   sampleOK = false;
   FixedGradientPixelType fixedGradient[FixedImageDimension];
   for (int i = 0; i < FixedImageDimension; ++i)
@@ -204,9 +201,6 @@ NormalizedGradientCorrelationImageToImageMetric<TFixedImage, TMovingImage>::Comp
 
   MovedIteratorType movedIteratorx(this->m_MovedSobelFilters[0]->GetOutput(), this->GetFixedImageRegion());
   MovedIteratorType movedIteratory(this->m_MovedSobelFilters[1]->GetOutput(), this->GetFixedImageRegion());
-
-  movedIteratorx.GoToBegin();
-  movedIteratory.GoToBegin();
 
   bool sampleOK = false;
 
@@ -297,16 +291,10 @@ NormalizedGradientCorrelationImageToImageMetric<TFixedImage, TMovingImage>::Comp
   FixedIteratorType fixedIteratorx(this->m_FixedSobelFilters[0]->GetOutput(), this->GetFixedImageRegion());
   FixedIteratorType fixedIteratory(this->m_FixedSobelFilters[1]->GetOutput(), this->GetFixedImageRegion());
 
-  fixedIteratorx.GoToBegin();
-  fixedIteratory.GoToBegin();
-
   using MovedIteratorType = itk::ImageRegionConstIteratorWithIndex<MovedGradientImageType>;
 
   MovedIteratorType movedIteratorx(this->m_MovedSobelFilters[0]->GetOutput(), this->GetFixedImageRegion());
   MovedIteratorType movedIteratory(this->m_MovedSobelFilters[1]->GetOutput(), this->GetFixedImageRegion());
-
-  movedIteratorx.GoToBegin();
-  movedIteratory.GoToBegin();
 
   Superclass::m_NumberOfPixelsCounted = 0;
   bool sampleOK = false;

--- a/Components/Metrics/PatternIntensity/itkPatternIntensityImageToImageMetric.hxx
+++ b/Components/Metrics/PatternIntensity/itkPatternIntensityImageToImageMetric.hxx
@@ -131,7 +131,6 @@ PatternIntensityImageToImageMetric<TFixedImage, TMovingImage>::ComputePIFixed() 
   using FixedImageTypeIteratorType = itk::ImageRegionConstIteratorWithIndex<FixedImageType>;
 
   FixedImageTypeIteratorType fixedImageIt(this->m_FixedImage, iterationRegion);
-  fixedImageIt.GoToBegin();
 
   neighboriterationRegion.SetSize(neighborIterationSize);
 
@@ -172,7 +171,6 @@ PatternIntensityImageToImageMetric<TFixedImage, TMovingImage>::ComputePIFixed() 
 
       neighboriterationRegion.SetIndex(neighborIndex);
       FixedImageTypeIteratorType neighborIt(this->m_FixedImage, neighboriterationRegion);
-      neighborIt.GoToBegin();
 
       while (!neighborIt.IsAtEnd())
       {
@@ -243,7 +241,6 @@ PatternIntensityImageToImageMetric<TFixedImage, TMovingImage>::ComputePIDiff(con
 
   using DifferenceImageIteratorType = itk::ImageRegionConstIteratorWithIndex<TransformedMovingImageType>;
   DifferenceImageIteratorType differenceImageIt(this->m_DifferenceImageFilter->GetOutput(), iterationRegion);
-  differenceImageIt.GoToBegin();
 
   neighboriterationRegion.SetSize(neighborIterationSize);
 
@@ -283,7 +280,6 @@ PatternIntensityImageToImageMetric<TFixedImage, TMovingImage>::ComputePIDiff(con
 
       neighboriterationRegion.SetIndex(neighborIndex);
       DifferenceImageIteratorType neighborIt(this->m_DifferenceImageFilter->GetOutput(), neighboriterationRegion);
-      neighborIt.GoToBegin();
 
       while (!neighborIt.IsAtEnd())
       {

--- a/Components/Metrics/RigidityPenalty/itkTransformRigidityPenaltyTerm.hxx
+++ b/Components/Metrics/RigidityPenalty/itkTransformRigidityPenaltyTerm.hxx
@@ -341,7 +341,6 @@ TransformRigidityPenaltyTerm<TFixedImage, TScalarType>::FillRigidityCoefficientI
   /** Create and reset an iterator over m_RigidityCoefficientImage. */
   RigidityImageIteratorType it(this->m_RigidityCoefficientImage,
                                this->m_RigidityCoefficientImage->GetLargestPossibleRegion());
-  it.GoToBegin();
 
   /** Fill m_RigidityCoefficientImage. */
   RigidityPixelType      fixedValue, movingValue, in;
@@ -500,8 +499,7 @@ TransformRigidityPenaltyTerm<TFixedImage, TScalarType>::GetValue(const Parameter
   /** Create iterator over the rigidity coeficient image. */
   CoefficientImageIteratorType it_RCI(this->m_RigidityCoefficientImage,
                                       this->m_RigidityCoefficientImage->GetLargestPossibleRegion());
-  it_RCI.GoToBegin();
-  ScalarType rigidityCoefficientSum{};
+  ScalarType                   rigidityCoefficientSum{};
 
   /** Add the rigidity coefficients together. */
   while (!it_RCI.IsAtEnd())
@@ -613,19 +611,6 @@ TransformRigidityPenaltyTerm<TFixedImage, TScalarType>::GetValue(const Parameter
       itF[i] = CoefficientImageIteratorType(ui_FF[i], ui_FF[i]->GetLargestPossibleRegion());
       itH[i] = CoefficientImageIteratorType(ui_FH[i], ui_FH[i]->GetLargestPossibleRegion());
       itI[i] = CoefficientImageIteratorType(ui_FI[i], ui_FI[i]->GetLargestPossibleRegion());
-    }
-    /** Reset iterators. */
-    itA[i].GoToBegin();
-    itB[i].GoToBegin();
-    itD[i].GoToBegin();
-    itE[i].GoToBegin();
-    itG[i].GoToBegin();
-    if constexpr (ImageDimension == 3)
-    {
-      itC[i].GoToBegin();
-      itF[i].GoToBegin();
-      itH[i].GoToBegin();
-      itI[i].GoToBegin();
     }
   }
 
@@ -943,8 +928,7 @@ TransformRigidityPenaltyTerm<TFixedImage, TScalarType>::GetValueAndDerivative(co
   /** Create iterator over the rigidity coeficient image. */
   CoefficientImageIteratorType it_RCI(this->m_RigidityCoefficientImage,
                                       this->m_RigidityCoefficientImage->GetLargestPossibleRegion());
-  it_RCI.GoToBegin();
-  ScalarType rigidityCoefficientSum{};
+  ScalarType                   rigidityCoefficientSum{};
 
   /** Add the rigidity coefficients together. */
   while (!it_RCI.IsAtEnd())
@@ -1057,19 +1041,6 @@ TransformRigidityPenaltyTerm<TFixedImage, TScalarType>::GetValueAndDerivative(co
       itH[i] = CoefficientImageIteratorType(ui_FH[i], ui_FH[i]->GetLargestPossibleRegion());
       itI[i] = CoefficientImageIteratorType(ui_FI[i], ui_FI[i]->GetLargestPossibleRegion());
     }
-    /** Reset iterators. */
-    itA[i].GoToBegin();
-    itB[i].GoToBegin();
-    itD[i].GoToBegin();
-    itE[i].GoToBegin();
-    itG[i].GoToBegin();
-    if constexpr (ImageDimension == 3)
-    {
-      itC[i].GoToBegin();
-      itF[i].GoToBegin();
-      itH[i].GoToBegin();
-      itI[i].GoToBegin();
-    }
   }
 
   /** Create orthonormality and properness parts. */
@@ -1116,14 +1087,11 @@ TransformRigidityPenaltyTerm<TFixedImage, TScalarType>::GetValueAndDerivative(co
     for (unsigned int j = 0; j < ImageDimension; ++j)
     {
       itOCp[i][j] = CoefficientImageIteratorType(OCparts[i][j], OCparts[i][j]->GetLargestPossibleRegion());
-      itOCp[i][j].GoToBegin();
       itPCp[i][j] = CoefficientImageIteratorType(PCparts[i][j], PCparts[i][j]->GetLargestPossibleRegion());
-      itPCp[i][j].GoToBegin();
     }
     for (unsigned int j = 0; j < NofLParts; ++j)
     {
       itLCp[i][j] = CoefficientImageIteratorType(LCparts[i][j], LCparts[i][j]->GetLargestPossibleRegion());
-      itLCp[i][j].GoToBegin();
     }
   }
 
@@ -1597,14 +1565,11 @@ TransformRigidityPenaltyTerm<TFixedImage, TScalarType>::GetValueAndDerivative(co
     for (unsigned int j = 0; j < ImageDimension; ++j)
     {
       nitOCp[i][j] = NeighborhoodIteratorType(radius, OCparts[i][j], OCparts[i][j]->GetLargestPossibleRegion());
-      nitOCp[i][j].GoToBegin();
       nitPCp[i][j] = NeighborhoodIteratorType(radius, PCparts[i][j], PCparts[i][j]->GetLargestPossibleRegion());
-      nitPCp[i][j].GoToBegin();
     }
     for (unsigned int j = 0; j < NofLParts; ++j)
     {
       nitLCp[i][j] = NeighborhoodIteratorType(radius, LCparts[i][j], LCparts[i][j]->GetLargestPossibleRegion());
-      nitLCp[i][j].GoToBegin();
     }
   }
 
@@ -1615,17 +1580,13 @@ TransformRigidityPenaltyTerm<TFixedImage, TScalarType>::GetValueAndDerivative(co
   for (unsigned int i = 0; i < ImageDimension; ++i)
   {
     itOCpf[i] = CoefficientImageIteratorType(OCpartsF[i], OCpartsF[i]->GetLargestPossibleRegion());
-    itOCpf[i].GoToBegin();
     itPCpf[i] = CoefficientImageIteratorType(PCpartsF[i], PCpartsF[i]->GetLargestPossibleRegion());
-    itPCpf[i].GoToBegin();
     itLCpf[i] = CoefficientImageIteratorType(LCpartsF[i], LCpartsF[i]->GetLargestPossibleRegion());
-    itLCpf[i].GoToBegin();
   }
 
   /** Create a neigborhood iterator over the rigidity image. */
   NeighborhoodIteratorType nit_RCI(
     radius, this->m_RigidityCoefficientImage, this->m_RigidityCoefficientImage->GetLargestPossibleRegion());
-  nit_RCI.GoToBegin();
   unsigned int neighborhoodSize = nit_RCI.Size();
 
   /** Create ND operators. */
@@ -1835,7 +1796,6 @@ TransformRigidityPenaltyTerm<TFixedImage, TScalarType>::GetValueAndDerivative(co
   for (unsigned int i = 0; i < ImageDimension; ++i)
   {
     itDIs[i] = CoefficientImageIteratorType(derivativeImages[i], derivativeImages[i]->GetLargestPossibleRegion());
-    itDIs[i].GoToBegin();
     itOCpf[i].GoToBegin();
     itPCpf[i].GoToBegin();
     itLCpf[i].GoToBegin();

--- a/Components/Transforms/MultiBSplineTransformWithNormal/itkMultiBSplineDeformableTransformWithNormal.hxx
+++ b/Components/Transforms/MultiBSplineTransformWithNormal/itkMultiBSplineDeformableTransformWithNormal.hxx
@@ -212,7 +212,7 @@ struct UpdateLocalBases_impl<TScalarType, 2>
     vinterp->SetInputImage(normals);
 
     ImageRegionIterator<ImageBaseType> it(bases, bases->GetLargestPossibleRegion());
-    for (it.GoToBegin(); !it.IsAtEnd(); ++it)
+    for (; !it.IsAtEnd(); ++it)
     {
       BaseType                          b;
       typename ImageBaseType::PointType p;
@@ -272,7 +272,7 @@ struct UpdateLocalBases_impl<TScalarType, 3>
     vinterp->SetInputImage(normals);
 
     ImageRegionIterator<ImageBaseType> it(bases, bases->GetLargestPossibleRegion());
-    for (it.GoToBegin(); !it.IsAtEnd(); ++it)
+    for (; !it.IsAtEnd(); ++it)
     {
       BaseType                          b;
       typename ImageBaseType::PointType p;

--- a/Components/Transforms/MultiBSplineTransformWithNormal/itkMultiBSplineDeformableTransformWithNormal.hxx
+++ b/Components/Transforms/MultiBSplineTransformWithNormal/itkMultiBSplineDeformableTransformWithNormal.hxx
@@ -211,8 +211,7 @@ struct UpdateLocalBases_impl<TScalarType, 2>
     ImageVectorInterpolatorPointer vinterp = ImageVectorInterpolator::New();
     vinterp->SetInputImage(normals);
 
-    ImageRegionIterator<ImageBaseType> it(bases, bases->GetLargestPossibleRegion());
-    for (; !it.IsAtEnd(); ++it)
+    for (ImageRegionIterator<ImageBaseType> it(bases, bases->GetLargestPossibleRegion()); !it.IsAtEnd(); ++it)
     {
       BaseType                          b;
       typename ImageBaseType::PointType p;
@@ -271,8 +270,7 @@ struct UpdateLocalBases_impl<TScalarType, 3>
     ImageVectorInterpolatorPointer vinterp = ImageVectorInterpolator::New();
     vinterp->SetInputImage(normals);
 
-    ImageRegionIterator<ImageBaseType> it(bases, bases->GetLargestPossibleRegion());
-    for (; !it.IsAtEnd(); ++it)
+    for (ImageRegionIterator<ImageBaseType> it(bases, bases->GetLargestPossibleRegion()); !it.IsAtEnd(); ++it)
     {
       BaseType                          b;
       typename ImageBaseType::PointType p;

--- a/Testing/elxComputeOverlap.cxx
+++ b/Testing/elxComputeOverlap.cxx
@@ -123,7 +123,7 @@ main(int argc, char ** argv)
 
   /** Determine size of first object. */
   long long sumA = 0;
-  for (iteratorA.GoToBegin(); !iteratorA.IsAtEnd(); ++iteratorA)
+  for (; !iteratorA.IsAtEnd(); ++iteratorA)
   {
     if (iteratorA.Value())
     {
@@ -134,7 +134,7 @@ main(int argc, char ** argv)
 
   /** Determine size of second object. */
   long long sumB = 0;
-  for (iteratorB.GoToBegin(); !iteratorB.IsAtEnd(); ++iteratorB)
+  for (; !iteratorB.IsAtEnd(); ++iteratorB)
   {
     if (iteratorB.Value())
     {
@@ -145,7 +145,7 @@ main(int argc, char ** argv)
 
   /** Determine size of cross-section. */
   long long sumC = 0;
-  for (iteratorC.GoToBegin(); !iteratorC.IsAtEnd(); ++iteratorC)
+  for (; !iteratorC.IsAtEnd(); ++iteratorC)
   {
     if (iteratorC.Value())
     {

--- a/Testing/elxComputeOverlap.cxx
+++ b/Testing/elxComputeOverlap.cxx
@@ -116,14 +116,11 @@ main(int argc, char ** argv)
 
   /** Now calculate the L1-norms. */
 
-  /** Create iterators. */
-  IteratorType iteratorA(ANDFilter->GetInput(1), ANDFilter->GetInput(1)->GetLargestPossibleRegion());
-  IteratorType iteratorB(ANDFilter->GetInput(0), ANDFilter->GetInput(0)->GetLargestPossibleRegion());
-  IteratorType iteratorC(ANDFilter->GetOutput(), ANDFilter->GetOutput()->GetLargestPossibleRegion());
-
   /** Determine size of first object. */
   long long sumA = 0;
-  for (; !iteratorA.IsAtEnd(); ++iteratorA)
+  for (IteratorType iteratorA(ANDFilter->GetInput(1), ANDFilter->GetInput(1)->GetLargestPossibleRegion());
+       !iteratorA.IsAtEnd();
+       ++iteratorA)
   {
     if (iteratorA.Value())
     {
@@ -134,7 +131,9 @@ main(int argc, char ** argv)
 
   /** Determine size of second object. */
   long long sumB = 0;
-  for (; !iteratorB.IsAtEnd(); ++iteratorB)
+  for (IteratorType iteratorB(ANDFilter->GetInput(0), ANDFilter->GetInput(0)->GetLargestPossibleRegion());
+       !iteratorB.IsAtEnd();
+       ++iteratorB)
   {
     if (iteratorB.Value())
     {
@@ -145,7 +144,9 @@ main(int argc, char ** argv)
 
   /** Determine size of cross-section. */
   long long sumC = 0;
-  for (; !iteratorC.IsAtEnd(); ++iteratorC)
+  for (IteratorType iteratorC(ANDFilter->GetOutput(), ANDFilter->GetOutput()->GetLargestPossibleRegion());
+       !iteratorC.IsAtEnd();
+       ++iteratorC)
   {
     if (iteratorC.Value())
     {

--- a/Testing/itkAdvancedLinearInterpolatorTest.cxx
+++ b/Testing/itkAdvancedLinearInterpolatorTest.cxx
@@ -97,7 +97,6 @@ TestInterpolators()
 
   // loop over image and fill with random values
   IteratorType it(image, image->GetLargestPossibleRegion());
-  it.GoToBegin();
 
   while (!it.IsAtEnd())
   {

--- a/Testing/itkMevisDicomTiffImageIOTest.cxx
+++ b/Testing/itkMevisDicomTiffImageIOTest.cxx
@@ -149,7 +149,7 @@ testMevis()
 
   PixelType     pixval = 0;
   unsigned long pixnr = 0;
-  for (it.GoToBegin(); !it.IsAtEnd(); ++it)
+  for (; !it.IsAtEnd(); ++it)
   {
     pixval = static_cast<PixelType>(itk::Math::Floor<double>(pixnr * factor));
     it.Set(pixval);

--- a/Testing/itkMevisDicomTiffImageIOTest.cxx
+++ b/Testing/itkMevisDicomTiffImageIOTest.cxx
@@ -143,13 +143,12 @@ testMevis()
     return 1;
   }
 
-  IteratorType  it(inputImage, inputImage->GetLargestPossibleRegion());
   unsigned long nrPixels = inputImage->GetLargestPossibleRegion().GetNumberOfPixels();
   double        factor = itk::NumericTraits<PixelType>::max() / static_cast<double>(nrPixels);
 
   PixelType     pixval = 0;
   unsigned long pixnr = 0;
-  for (; !it.IsAtEnd(); ++it)
+  for (IteratorType it(inputImage, inputImage->GetLargestPossibleRegion()); !it.IsAtEnd(); ++it)
   {
     pixval = static_cast<PixelType>(itk::Math::Floor<double>(pixnr * factor));
     it.Set(pixval);


### PR DESCRIPTION
It is unnecessary to call GoToBegin() on an ITK iterator when it has just been constructed, by `Iterator(image, region)`. Such a function call just takes compile-time and run-time.

- Supported by ITK pull request https://github.com/InsightSoftwareConsortium/ITK/pull/4815