### PR TITLE
STYLE: Use `auto` more extensively, by clang-tidy `modernize-use-auto`

### DIFF
--- a/Common/CostFunctions/itkAdvancedImageToImageMetric.hxx
+++ b/Common/CostFunctions/itkAdvancedImageToImageMetric.hxx
@@ -356,12 +356,12 @@ void
 AdvancedImageToImageMetric<TFixedImage, TMovingImage>::CheckForBSplineTransform() const
 {
   /** Check if this transform is a combo transform. */
-  CombinationTransformType * testPtr_combo = dynamic_cast<CombinationTransformType *>(m_AdvancedTransform.GetPointer());
+  auto * testPtr_combo = dynamic_cast<CombinationTransformType *>(m_AdvancedTransform.GetPointer());
 
   /** Check if this transform is a B-spline transform. */
-  BSplineOrder1TransformType * testPtr_1 = dynamic_cast<BSplineOrder1TransformType *>(m_AdvancedTransform.GetPointer());
-  BSplineOrder2TransformType * testPtr_2 = dynamic_cast<BSplineOrder2TransformType *>(m_AdvancedTransform.GetPointer());
-  BSplineOrder3TransformType * testPtr_3 = dynamic_cast<BSplineOrder3TransformType *>(m_AdvancedTransform.GetPointer());
+  auto * testPtr_1 = dynamic_cast<BSplineOrder1TransformType *>(m_AdvancedTransform.GetPointer());
+  auto * testPtr_2 = dynamic_cast<BSplineOrder2TransformType *>(m_AdvancedTransform.GetPointer());
+  auto * testPtr_3 = dynamic_cast<BSplineOrder3TransformType *>(m_AdvancedTransform.GetPointer());
 
   bool transformIsBSpline = false;
   if (testPtr_1 || testPtr_2 || testPtr_3)
@@ -371,12 +371,9 @@ AdvancedImageToImageMetric<TFixedImage, TMovingImage>::CheckForBSplineTransform(
   else if (testPtr_combo)
   {
     /** Check if the current transform is a B-spline transform. */
-    const BSplineOrder1TransformType * testPtr_1b =
-      dynamic_cast<const BSplineOrder1TransformType *>(testPtr_combo->GetCurrentTransform());
-    const BSplineOrder2TransformType * testPtr_2b =
-      dynamic_cast<const BSplineOrder2TransformType *>(testPtr_combo->GetCurrentTransform());
-    const BSplineOrder3TransformType * testPtr_3b =
-      dynamic_cast<const BSplineOrder3TransformType *>(testPtr_combo->GetCurrentTransform());
+    const auto * testPtr_1b = dynamic_cast<const BSplineOrder1TransformType *>(testPtr_combo->GetCurrentTransform());
+    const auto * testPtr_2b = dynamic_cast<const BSplineOrder2TransformType *>(testPtr_combo->GetCurrentTransform());
+    const auto * testPtr_3b = dynamic_cast<const BSplineOrder3TransformType *>(testPtr_combo->GetCurrentTransform());
     if (testPtr_1b || testPtr_2b || testPtr_3b)
     {
       transformIsBSpline = true;
@@ -719,7 +716,7 @@ AdvancedImageToImageMetric<TFixedImage, TMovingImage>::AccumulateDerivativesThre
   Self & metric = *(userData.st_Metric);
 
   const unsigned int numPar = metric.GetNumberOfParameters();
-  const unsigned int subSize =
+  const auto         subSize =
     static_cast<unsigned int>(std::ceil(static_cast<double>(numPar) / static_cast<double>(nrOfThreads)));
   const unsigned int jmin = threadID * subSize;
   const unsigned int jmax = std::min((threadID + 1) * subSize, numPar);

--- a/Common/CostFunctions/itkExponentialLimiterFunction.hxx
+++ b/Common/CostFunctions/itkExponentialLimiterFunction.hxx
@@ -56,14 +56,14 @@ auto
 ExponentialLimiterFunction<TInput, NDimension>::Evaluate(const InputType & input) const -> OutputType
 {
   /** Apply a soft limit if the input is larger than the UpperThreshold */
-  const double diffU = static_cast<double>(input - this->m_UpperThreshold);
+  const auto diffU = static_cast<double>(input - this->m_UpperThreshold);
   if (diffU > 1e-10)
   {
     return static_cast<OutputType>(this->m_UTminUB * std::exp(this->m_UTminUBinv * diffU) + this->m_UpperBound);
   }
 
   /** Apply a soft limit if the input is smaller than the LowerThreshold */
-  const double diffL = static_cast<double>(input - this->m_LowerThreshold);
+  const auto diffL = static_cast<double>(input - this->m_LowerThreshold);
   if (diffL < -1e-10)
   {
     return static_cast<OutputType>(this->m_LTminLB * std::exp(this->m_LTminLBinv * diffL) + this->m_LowerBound);
@@ -84,7 +84,7 @@ ExponentialLimiterFunction<TInput, NDimension>::Evaluate(const InputType & input
   -> OutputType
 {
   /** Apply a soft limit if the input is larger than the UpperThreshold */
-  const double diffU = static_cast<double>(input - this->m_UpperThreshold);
+  const auto diffU = static_cast<double>(input - this->m_UpperThreshold);
   if (diffU > 1e-10)
   {
     const double temp = this->m_UTminUB * std::exp(this->m_UTminUBinv * diffU);
@@ -97,7 +97,7 @@ ExponentialLimiterFunction<TInput, NDimension>::Evaluate(const InputType & input
   }
 
   /** Apply a soft limit if the input is smaller than the LowerThreshold */
-  const double diffL = static_cast<double>(input - this->m_LowerThreshold);
+  const auto diffL = static_cast<double>(input - this->m_LowerThreshold);
   if (diffL < -1e-10)
   {
     const double temp = this->m_LTminLB * std::exp(this->m_LTminLBinv * diffL);

--- a/Common/CostFunctions/itkMultiInputImageToImageMetricBase.hxx
+++ b/Common/CostFunctions/itkMultiInputImageToImageMetricBase.hxx
@@ -172,8 +172,7 @@ MultiInputImageToImageMetricBase<TFixedImage, TMovingImage>::CheckForBSplineInte
 
   for (unsigned int i = 0; i < this->m_NumberOfMovingImages; ++i)
   {
-    BSplineInterpolatorType * testPtr =
-      dynamic_cast<BSplineInterpolatorType *>(this->m_InterpolatorVector[i].GetPointer());
+    auto * testPtr = dynamic_cast<BSplineInterpolatorType *>(this->m_InterpolatorVector[i].GetPointer());
 
     if (testPtr)
     {

--- a/Common/CostFunctions/itkParzenWindowHistogramImageToImageMetric.hxx
+++ b/Common/CostFunctions/itkParzenWindowHistogramImageToImageMetric.hxx
@@ -151,7 +151,7 @@ ParzenWindowHistogramImageToImageMetric<TFixedImage, TMovingImage>::InitializeHi
                                    static_cast<double>(this->m_NumberOfFixedHistogramBins - 2 * movingPadding - 1);
 
   /** Compute binsizes. */
-  const double fixedHistogramWidth = static_cast<double>(
+  const auto fixedHistogramWidth = static_cast<double>(
     static_cast<OffsetValueType>(this->m_NumberOfFixedHistogramBins) // requires cast to signed type!
     - 2.0 * fixedPadding - 1.0);
   this->m_FixedImageBinSize =
@@ -162,7 +162,7 @@ ParzenWindowHistogramImageToImageMetric<TFixedImage, TMovingImage>::InitializeHi
   this->m_FixedImageNormalizedMin = (Superclass::m_FixedImageMinLimit - smallNumberFixed) / this->m_FixedImageBinSize -
                                     static_cast<double>(fixedPadding);
 
-  const double movingHistogramWidth = static_cast<double>(
+  const auto movingHistogramWidth = static_cast<double>(
     static_cast<OffsetValueType>(this->m_NumberOfMovingHistogramBins) // requires cast to signed type!
     - 2.0 * movingPadding - 1.0);
   this->m_MovingImageBinSize =
@@ -484,9 +484,9 @@ ParzenWindowHistogramImageToImageMetric<TFixedImage, TMovingImage>::UpdateJointP
     movingImageValue / this->m_MovingImageBinSize - this->m_MovingImageNormalizedMin;
 
   /** The lowest bin numbers affected by this pixel: */
-  const OffsetValueType fixedImageParzenWindowIndex =
+  const auto fixedImageParzenWindowIndex =
     static_cast<OffsetValueType>(std::floor(fixedImageParzenWindowTerm + this->m_FixedParzenTermToIndexOffset));
-  const OffsetValueType movingImageParzenWindowIndex =
+  const auto movingImageParzenWindowIndex =
     static_cast<OffsetValueType>(std::floor(movingImageParzenWindowTerm + this->m_MovingParzenTermToIndexOffset));
 
   /** The Parzen values. */
@@ -539,7 +539,7 @@ ParzenWindowHistogramImageToImageMetric<TFixedImage, TMovingImage>::UpdateJointP
                                *m_DerivativeMovingKernel,
                                derivativeMovingParzenValues.data_block());
 
-    const double et = static_cast<double>(this->m_MovingImageBinSize);
+    const auto et = static_cast<double>(this->m_MovingImageBinSize);
 
     /** Loop over the Parzen window region and increment the values
      * Also update the pdf derivatives.
@@ -616,7 +616,7 @@ ParzenWindowHistogramImageToImageMetric<TFixedImage, TMovingImage>::NormalizeJoi
 {
   using JointPDFIteratorType = ImageScanlineIterator<JointPDFType>;
   JointPDFIteratorType it(pdf, pdf->GetBufferedRegion());
-  const PDFValueType   castfac = static_cast<PDFValueType>(factor);
+  const auto           castfac = static_cast<PDFValueType>(factor);
   while (!it.IsAtEnd())
   {
     while (!it.IsAtEndOfLine())
@@ -764,7 +764,7 @@ ParzenWindowHistogramImageToImageMetric<TFixedImage, TMovingImage>::UpdateJointP
     fixedImageValue / this->m_FixedImageBinSize - this->m_FixedImageNormalizedMin;
 
   /** The lowest bin numbers affected by this pixel: */
-  const OffsetValueType fixedImageParzenWindowIndex =
+  const auto fixedImageParzenWindowIndex =
     static_cast<OffsetValueType>(std::floor(fixedImageParzenWindowTerm + this->m_FixedParzenTermToIndexOffset));
   Self::EvaluateParzenValues(
     fixedImageParzenWindowTerm, fixedImageParzenWindowIndex, *m_FixedKernel, fixedParzenValues.data_block());
@@ -774,7 +774,7 @@ ParzenWindowHistogramImageToImageMetric<TFixedImage, TMovingImage>::UpdateJointP
     /** Determine moving image Parzen window arguments (see eq. 6 of Mattes paper [2]). */
     const double movingImageParzenWindowTerm =
       movingImageValue / this->m_MovingImageBinSize - this->m_MovingImageNormalizedMin;
-    const OffsetValueType movingImageParzenWindowIndex =
+    const auto movingImageParzenWindowIndex =
       static_cast<OffsetValueType>(std::floor(movingImageParzenWindowTerm + this->m_MovingParzenTermToIndexOffset));
     Self::EvaluateParzenValues(
       movingImageParzenWindowTerm, movingImageParzenWindowIndex, *m_MovingKernel, movingParzenValues.data_block());
@@ -795,12 +795,11 @@ ParzenWindowHistogramImageToImageMetric<TFixedImage, TMovingImage>::UpdateJointP
       const double fv_mask = fixedParzenValues[f] * movingMaskValue;
       for (unsigned int m = 0; m < movingParzenValues.GetSize(); ++m)
       {
-        const PDFValueType fv_mask_mv = static_cast<PDFValueType>(fv_mask * movingParzenValues[m]);
+        const auto fv_mask_mv = static_cast<PDFValueType>(fv_mask * movingParzenValues[m]);
         this->m_JointPDF->GetPixel(pdfIndex) += fv_mask_mv;
 
-        unsigned long offset =
-          static_cast<unsigned long>(pdfIndex[0] * this->m_IncrementalJointPDFRight->GetOffsetTable()[1] +
-                                     pdfIndex[1] * this->m_IncrementalJointPDFRight->GetOffsetTable()[2]);
+        auto offset = static_cast<unsigned long>(pdfIndex[0] * this->m_IncrementalJointPDFRight->GetOffsetTable()[1] +
+                                                 pdfIndex[1] * this->m_IncrementalJointPDFRight->GetOffsetTable()[2]);
 
         /** Get the pointer to the element with index [0, pdfIndex[0], pdfIndex[1]]. */
         PDFDerivativeValueType * incRightPtr = incRightBasePtr + offset;
@@ -847,7 +846,7 @@ ParzenWindowHistogramImageToImageMetric<TFixedImage, TMovingImage>::UpdateJointP
       /** Compute Parzen stuff; note: we reuse the movingParzenValues container. */
       const double movr = movingImageValuesRight[i];
       const double movParzenWindowTermRight = movr / this->m_MovingImageBinSize - this->m_MovingImageNormalizedMin;
-      const OffsetValueType movParzenWindowIndexRight =
+      const auto   movParzenWindowIndexRight =
         static_cast<OffsetValueType>(std::floor(movParzenWindowTermRight + this->m_MovingParzenTermToIndexOffset));
       Self::EvaluateParzenValues(
         movParzenWindowTermRight, movParzenWindowIndexRight, *m_MovingKernel, movingParzenValues.data_block());
@@ -863,7 +862,7 @@ ParzenWindowHistogramImageToImageMetric<TFixedImage, TMovingImage>::UpdateJointP
         const double fv_mask = fixedParzenValues[f] * maskr;
         for (unsigned int m = 0; m < movingParzenValues.GetSize(); ++m)
         {
-          const PDFValueType fv_mask_mv = static_cast<PDFValueType>(fv_mask * movingParzenValues[m]);
+          const auto fv_mask_mv = static_cast<PDFValueType>(fv_mask * movingParzenValues[m]);
           this->m_IncrementalJointPDFRight->GetPixel(rindex) += fv_mask_mv;
           ++(rindex[1]);
         } // end for m
@@ -879,7 +878,7 @@ ParzenWindowHistogramImageToImageMetric<TFixedImage, TMovingImage>::UpdateJointP
       /** Compute Parzen stuff; note: we reuse the movingParzenValues container. */
       const double movl = movingImageValuesLeft[i];
       const double movParzenWindowTermLeft = movl / this->m_MovingImageBinSize - this->m_MovingImageNormalizedMin;
-      const OffsetValueType movParzenWindowIndexLeft =
+      const auto   movParzenWindowIndexLeft =
         static_cast<OffsetValueType>(std::floor(movParzenWindowTermLeft + this->m_MovingParzenTermToIndexOffset));
       Self::EvaluateParzenValues(
         movParzenWindowTermLeft, movParzenWindowIndexLeft, *m_MovingKernel, movingParzenValues.data_block());
@@ -895,7 +894,7 @@ ParzenWindowHistogramImageToImageMetric<TFixedImage, TMovingImage>::UpdateJointP
         const double fv_mask = fixedParzenValues[f] * maskl;
         for (unsigned int m = 0; m < movingParzenValues.GetSize(); ++m)
         {
-          const PDFValueType fv_mask_mv = static_cast<PDFValueType>(fv_mask * movingParzenValues[m]);
+          const auto fv_mask_mv = static_cast<PDFValueType>(fv_mask * movingParzenValues[m]);
           this->m_IncrementalJointPDFLeft->GetPixel(lindex) += fv_mask_mv;
           ++(lindex[1]);
         } // end for m
@@ -1053,7 +1052,7 @@ ParzenWindowHistogramImageToImageMetric<TFixedImage, TMovingImage>::ThreadedComp
   const unsigned long         sampleContainerSize = sampleContainer->Size();
 
   /** Get the samples for this thread. */
-  const unsigned long nrOfSamplesPerThreads = static_cast<unsigned long>(
+  const auto nrOfSamplesPerThreads = static_cast<unsigned long>(
     std::ceil(static_cast<double>(sampleContainerSize) / static_cast<double>(Self::GetNumberOfWorkUnits())));
 
   const auto pos_begin = std::min<size_t>(nrOfSamplesPerThreads * threadId, sampleContainerSize);
@@ -1093,7 +1092,7 @@ ParzenWindowHistogramImageToImageMetric<TFixedImage, TMovingImage>::ThreadedComp
       ++numberOfPixelsCounted;
 
       /** Get the fixed image value. */
-      RealType fixedImageValue = static_cast<RealType>(fiter->m_ImageValue);
+      auto fixedImageValue = static_cast<RealType>(fiter->m_ImageValue);
 
       /** Make sure the values fall within the histogram range. */
       fixedImageValue = this->GetFixedImageLimiter()->Evaluate(fixedImageValue);
@@ -1374,8 +1373,8 @@ ParzenWindowHistogramImageToImageMetric<TFixedImage, TMovingImage>::ComputePDFsA
       fixedImageValue = this->GetFixedImageLimiter()->Evaluate(fixedImageValue);
 
       /** Check if the point is inside the moving mask. */
-      bool     sampleOk = this->IsInsideMovingMask(mappedPoint);
-      RealType movingMaskValue = static_cast<RealType>(static_cast<unsigned char>(sampleOk));
+      bool sampleOk = this->IsInsideMovingMask(mappedPoint);
+      auto movingMaskValue = static_cast<RealType>(static_cast<unsigned char>(sampleOk));
 
       /** Compute the moving image value M(T(x)) and check if
        * the point is inside the moving image buffer.
@@ -1434,7 +1433,7 @@ ParzenWindowHistogramImageToImageMetric<TFixedImage, TMovingImage>::ComputePDFsA
 
         /** Compute the moving mask 'value' and moving image value at the right perturbed positions. */
         sampleOk = this->IsInsideMovingMask(mappedPointRight);
-        RealType movingMaskValueRight = static_cast<RealType>(static_cast<unsigned char>(sampleOk));
+        auto movingMaskValueRight = static_cast<RealType>(static_cast<unsigned char>(sampleOk));
         if (sampleOk)
         {
           RealType movingImageValueRight = 0.0;
@@ -1455,7 +1454,7 @@ ParzenWindowHistogramImageToImageMetric<TFixedImage, TMovingImage>::ComputePDFsA
 
         /** Compute the moving mask and moving image value at the left perturbed positions. */
         sampleOk = this->IsInsideMovingMask(mappedPointLeft);
-        RealType movingMaskValueLeft = static_cast<RealType>(static_cast<unsigned char>(sampleOk));
+        auto movingMaskValueLeft = static_cast<RealType>(static_cast<unsigned char>(sampleOk));
         if (sampleOk)
         {
           RealType movingImageValueLeft = 0.0;

--- a/Common/CostFunctions/itkTransformPenaltyTerm.hxx
+++ b/Common/CostFunctions/itkTransformPenaltyTerm.hxx
@@ -39,10 +39,8 @@ TransformPenaltyTerm<TFixedImage, TScalarType>::CheckForBSplineTransform2(BSplin
     return false;
 
   /** We will return the B-spline by reference, but only in case it is a third order B-spline. */
-  BSplineOrder3TransformType * testPtr1 =
-    dynamic_cast<BSplineOrder3TransformType *>(Superclass::m_AdvancedTransform.GetPointer());
-  CombinationTransformType * testPtr2a =
-    dynamic_cast<CombinationTransformType *>(Superclass::m_AdvancedTransform.GetPointer());
+  auto * testPtr1 = dynamic_cast<BSplineOrder3TransformType *>(Superclass::m_AdvancedTransform.GetPointer());
+  auto * testPtr2a = dynamic_cast<CombinationTransformType *>(Superclass::m_AdvancedTransform.GetPointer());
 
   if (testPtr1)
   {
@@ -52,8 +50,7 @@ TransformPenaltyTerm<TFixedImage, TScalarType>::CheckForBSplineTransform2(BSplin
   else if (testPtr2a)
   {
     /** The transform is of type AdvancedCombinationTransform. */
-    BSplineOrder3TransformType * testPtr2b =
-      dynamic_cast<BSplineOrder3TransformType *>((testPtr2a->GetModifiableCurrentTransform()));
+    auto * testPtr2b = dynamic_cast<BSplineOrder3TransformType *>((testPtr2a->GetModifiableCurrentTransform()));
     if (testPtr2b)
     {
       /** The current transform is of type AdvancedBSplineDeformableTransform. */

--- a/Common/ImageSamplers/itkImageGridSampler.hxx
+++ b/Common/ImageSamplers/itkImageGridSampler.hxx
@@ -426,14 +426,14 @@ ImageGridSampler<TInputImage>::SetNumberOfSamples(unsigned long nrofsamples)
 
   /** Get the cropped image region volume in voxels. */
   this->CropInputImageRegion();
-  const double allvoxels = static_cast<double>(this->GetCroppedInputImageRegion().GetNumberOfPixels());
+  const auto allvoxels = static_cast<double>(this->GetCroppedInputImageRegion().GetNumberOfPixels());
 
   /** Compute the fraction in voxels. */
   const double fraction = allvoxels / static_cast<double>(nrofsamples);
 
   /** Compute the grid spacing. */
-  const double indimd = static_cast<double>(InputImageDimension);
-  int          gridSpacing = static_cast<int>( // no unsigned int version of rnd, max
+  const auto indimd = static_cast<double>(InputImageDimension);
+  int        gridSpacing = static_cast<int>( // no unsigned int version of rnd, max
     Math::Round<int64_t>(std::pow(fraction, 1.0 / indimd)));
   gridSpacing = std::max(1, gridSpacing);
 

--- a/Common/ImageSamplers/itkImageRandomSamplerBase.hxx
+++ b/Common/ImageSamplers/itkImageRandomSamplerBase.hxx
@@ -59,7 +59,7 @@ ImageRandomSamplerBase<TInputImage>::GenerateRandomNumberList()
   this->m_RandomNumberList.reserve(this->m_NumberOfSamples);
 
   /** Fill the list with random numbers. */
-  const double numPixels = static_cast<double>(this->GetCroppedInputImageRegion().GetNumberOfPixels());
+  const auto numPixels = static_cast<double>(this->GetCroppedInputImageRegion().GetNumberOfPixels());
   localGenerator->GetVariateWithOpenRange(numPixels - 0.5); // dummy jump
   for (unsigned long i = 0; i < this->m_NumberOfSamples; ++i)
   {

--- a/Common/ImageSamplers/itkImageSamplerBase.hxx
+++ b/Common/ImageSamplers/itkImageSamplerBase.hxx
@@ -325,8 +325,8 @@ ImageSamplerBase<TInputImage>::CropInputImageRegion()
     const PointsContainerType *            cornersWorld = bb->GetPoints();
     auto                                   cornersIndex = PointsContainerType::New();
     cornersIndex->Reserve(cornersWorld->Size());
-    typename PointsContainerType::const_iterator itCW = cornersWorld->begin();
-    typename PointsContainerType::iterator       itCI = cornersIndex->begin();
+    auto itCW = cornersWorld->begin();
+    auto itCI = cornersIndex->begin();
     while (itCW != cornersWorld->end())
     {
       *itCI = inputImage->template TransformPhysicalPointToContinuousIndex<InputImagePointValueType>(*itCW);

--- a/Common/MevisDicomTiff/itkMevisDicomTiffImageIO.cxx
+++ b/Common/MevisDicomTiff/itkMevisDicomTiffImageIO.cxx
@@ -846,13 +846,13 @@ MevisDicomTiffImageIO::Read(void * buffer)
     // buffer pointer is scanline based (one dimensional array)
     // tile is positioned on x,y,z; we read each tile, and fill
     // the corresponding positions in the onedimensional array
-    unsigned char * vol = reinterpret_cast<unsigned char *>(buffer);
+    auto * vol = reinterpret_cast<unsigned char *>(buffer);
 
     const unsigned int tilesize = TIFFTileSize(m_TIFFImage);
     const unsigned int tilerowbytes = TIFFTileRowSize(m_TIFFImage);
     const unsigned int bytespersample = m_BitsPerSample / 8;
 
-    unsigned char * tilebuf = static_cast<unsigned char *>(_TIFFmalloc(tilesize));
+    auto * tilebuf = static_cast<unsigned char *>(_TIFFmalloc(tilesize));
 
     //
     // special cases, if the tilexy is larger than or equal to the image
@@ -1975,8 +1975,8 @@ MevisDicomTiffImageIO ::Write(const void * buffer)
     const unsigned int tilerowbytes = TIFFTileRowSize(m_TIFFImage);
     const unsigned int bytespersample = m_BitsPerSample / 8;
 
-    const unsigned char * vol = reinterpret_cast<const unsigned char *>(buffer);
-    unsigned char *       tilebuf = static_cast<unsigned char *>(_TIFFmalloc(tilesize));
+    const auto * vol = reinterpret_cast<const unsigned char *>(buffer);
+    auto *       tilebuf = static_cast<unsigned char *>(_TIFFmalloc(tilesize));
 
     // is volume direction a multiple of tiledirection?
     const bool mx = (m_Width % m_TileWidth == 0) ? true : false;

--- a/Common/OpenCL/Filters/itkGPUBSplineDecompositionImageFilter.hxx
+++ b/Common/OpenCL/Filters/itkGPUBSplineDecompositionImageFilter.hxx
@@ -157,7 +157,7 @@ GPUBSplineDecompositionImageFilter<TInputImage, TOutputImage>::GPUGenerateData()
   // Solving warning "case label value exceeds maximum value for type"
   // by making a local copy of the input image dimension.
   // switch( InputImageDimension )
-  const unsigned int ImageDim = (unsigned int)(InputImageDimension);
+  const auto ImageDim = (unsigned int)(InputImageDimension);
   switch (ImageDim)
   {
     case 1:

--- a/Common/OpenCL/Filters/itkGPUCompositeTransformBase.hxx
+++ b/Common/OpenCL/Filters/itkGPUCompositeTransformBase.hxx
@@ -43,8 +43,7 @@ GPUCompositeTransformBase<TScalarType, NDimensions>::GetParametersDataManager(co
   }
   else
   {
-    const GPUTransformBase * transformBase =
-      dynamic_cast<const GPUTransformBase *>(this->GetNthTransform(index).GetPointer());
+    const auto * transformBase = dynamic_cast<const GPUTransformBase *>(this->GetNthTransform(index).GetPointer());
 
     if (transformBase)
     {
@@ -188,8 +187,7 @@ GPUCompositeTransformBase<TScalarType, NDimensions>::IsIdentityTransform(const s
 
   // Perform specific check
   using IdentityTransformType = GPUIdentityTransform<ScalarType, NDimensions>;
-  const IdentityTransformType * identity =
-    dynamic_cast<const IdentityTransformType *>(this->GetNthTransform(index).GetPointer());
+  const auto * identity = dynamic_cast<const IdentityTransformType *>(this->GetNthTransform(index).GetPointer());
   if (!identity)
   {
     return false;
@@ -214,7 +212,7 @@ GPUCompositeTransformBase<TScalarType, NDimensions>::IsMatrixOffsetTransform(con
   // Perform specific check
   using MatrixOffsetTransformBaseType =
     GPUMatrixOffsetTransformBase<ScalarType, InputSpaceDimension, OutputSpaceDimension>;
-  const MatrixOffsetTransformBaseType * matrixoffset =
+  const auto * matrixoffset =
     dynamic_cast<const MatrixOffsetTransformBaseType *>(this->GetNthTransform(index).GetPointer());
   if (!matrixoffset)
   {
@@ -239,7 +237,7 @@ GPUCompositeTransformBase<TScalarType, NDimensions>::IsTranslationTransform(cons
 
   // Perform specific check
   using TranslationTransformBaseType = GPUTranslationTransformBase<ScalarType, InputSpaceDimension>;
-  const TranslationTransformBaseType * translation =
+  const auto * translation =
     dynamic_cast<const TranslationTransformBaseType *>(this->GetNthTransform(index).GetPointer());
   if (!translation)
   {
@@ -273,8 +271,7 @@ GPUCompositeTransformBase<TScalarType, NDimensions>::IsIdentityTransform(const s
                                                                          std::string &     source) const
 {
   using IdentityTransformType = GPUIdentityTransform<ScalarType, NDimensions>;
-  const IdentityTransformType * identity =
-    dynamic_cast<const IdentityTransformType *>(this->GetNthTransform(index).GetPointer());
+  const auto * identity = dynamic_cast<const IdentityTransformType *>(this->GetNthTransform(index).GetPointer());
 
   if (!identity)
   {
@@ -283,8 +280,7 @@ GPUCompositeTransformBase<TScalarType, NDimensions>::IsIdentityTransform(const s
 
   if (loadSource)
   {
-    const GPUTransformBase * transformBase =
-      dynamic_cast<const GPUTransformBase *>(this->GetNthTransform(index).GetPointer());
+    const auto * transformBase = dynamic_cast<const GPUTransformBase *>(this->GetNthTransform(index).GetPointer());
     transformBase->GetSourceCode(source);
   }
 
@@ -301,7 +297,7 @@ GPUCompositeTransformBase<TScalarType, NDimensions>::IsMatrixOffsetTransform(con
 {
   using MatrixOffsetTransformBaseType =
     GPUMatrixOffsetTransformBase<ScalarType, InputSpaceDimension, OutputSpaceDimension>;
-  const MatrixOffsetTransformBaseType * matrixoffset =
+  const auto * matrixoffset =
     dynamic_cast<const MatrixOffsetTransformBaseType *>(this->GetNthTransform(index).GetPointer());
 
   if (!matrixoffset)
@@ -311,8 +307,7 @@ GPUCompositeTransformBase<TScalarType, NDimensions>::IsMatrixOffsetTransform(con
 
   if (loadSource)
   {
-    const GPUTransformBase * transformBase =
-      dynamic_cast<const GPUTransformBase *>(this->GetNthTransform(index).GetPointer());
+    const auto * transformBase = dynamic_cast<const GPUTransformBase *>(this->GetNthTransform(index).GetPointer());
     transformBase->GetSourceCode(source);
   }
 
@@ -328,7 +323,7 @@ GPUCompositeTransformBase<TScalarType, NDimensions>::IsTranslationTransform(cons
                                                                             std::string &     source) const
 {
   using TranslationTransformBaseType = GPUTranslationTransformBase<ScalarType, InputSpaceDimension>;
-  const TranslationTransformBaseType * translation =
+  const auto * translation =
     dynamic_cast<const TranslationTransformBaseType *>(this->GetNthTransform(index).GetPointer());
 
   if (!translation)
@@ -338,8 +333,7 @@ GPUCompositeTransformBase<TScalarType, NDimensions>::IsTranslationTransform(cons
 
   if (loadSource)
   {
-    const GPUTransformBase * transformBase =
-      dynamic_cast<const GPUTransformBase *>(this->GetNthTransform(index).GetPointer());
+    const auto * transformBase = dynamic_cast<const GPUTransformBase *>(this->GetNthTransform(index).GetPointer());
     transformBase->GetSourceCode(source);
   }
 
@@ -359,8 +353,7 @@ GPUCompositeTransformBase<TScalarType, NDimensions>::IsBSplineTransform(const st
   {
     if (loadSource)
     {
-      const GPUTransformBase * transformBase =
-        dynamic_cast<const GPUTransformBase *>(this->GetNthTransform(_index).GetPointer());
+      const auto * transformBase = dynamic_cast<const GPUTransformBase *>(this->GetNthTransform(_index).GetPointer());
       transformBase->GetSourceCode(source);
     }
     return true;

--- a/Common/OpenCL/Filters/itkGPURecursiveGaussianImageFilter.hxx
+++ b/Common/OpenCL/Filters/itkGPURecursiveGaussianImageFilter.hxx
@@ -97,7 +97,7 @@ GPURecursiveGaussianImageFilter<TInputImage, TOutputImage>::GPUGenerateData()
 
   const typename GPUOutputImage::SizeType outSize = otPtr->GetLargestPossibleRegion().GetSize();
   const unsigned int                      ln = outSize[this->GetDirection()];
-  const unsigned int                      ImageDim = (unsigned int)(TInputImage::ImageDimension);
+  const auto                              ImageDim = (unsigned int)(TInputImage::ImageDimension);
 
   // Check if GPU filter are able to perform for this image
   if (ln > this->m_DeviceLocalMemorySize)

--- a/Common/OpenCL/Filters/itkGPUResampleImageFilter.hxx
+++ b/Common/OpenCL/Filters/itkGPUResampleImageFilter.hxx
@@ -157,7 +157,7 @@ GPUResampleImageFilter<TInputImage, TOutputImage, TInterpolatorPrecisionType, TT
   CPUSuperclass::SetInterpolator(_arg);
 
   /** Test for a supported GPU interpolator. */
-  const GPUInterpolatorBase * interpolatorBase = dynamic_cast<const GPUInterpolatorBase *>(_arg);
+  const auto * interpolatorBase = dynamic_cast<const GPUInterpolatorBase *>(_arg);
   if (!interpolatorBase)
   {
     itkExceptionMacro("Setting unsupported GPU interpolator to " << _arg);
@@ -165,7 +165,7 @@ GPUResampleImageFilter<TInputImage, TOutputImage, TInterpolatorPrecisionType, TT
   this->m_InterpolatorBase = (GPUInterpolatorBase *)interpolatorBase;
 
   // Test for a GPU B-spline interpolator
-  const GPUBSplineInterpolatorType * GPUBSplineInterpolator = dynamic_cast<const GPUBSplineInterpolatorType *>(_arg);
+  const auto * GPUBSplineInterpolator = dynamic_cast<const GPUBSplineInterpolatorType *>(_arg);
   this->m_InterpolatorIsBSpline = false;
   if (GPUBSplineInterpolator)
   {
@@ -249,7 +249,7 @@ GPUResampleImageFilter<TInputImage, TOutputImage, TInterpolatorPrecisionType, TT
   CPUSuperclass::SetTransform(_arg);
 
   /** Test for a supported GPU transform. */
-  const GPUTransformBase * transformBase = dynamic_cast<const GPUTransformBase *>(_arg);
+  const auto * transformBase = dynamic_cast<const GPUTransformBase *>(_arg);
   if (!transformBase)
   {
     itkExceptionMacro("Setting unsupported GPU transform to " << _arg);
@@ -261,7 +261,7 @@ GPUResampleImageFilter<TInputImage, TOutputImage, TInterpolatorPrecisionType, TT
 
   // Test for a GPU combo transform
   using CompositeTransformType = GPUCompositeTransformBase<InterpolatorPrecisionType, InputImageDimension>;
-  const CompositeTransformType * compositeTransformBase = dynamic_cast<const CompositeTransformType *>(_arg);
+  const auto * compositeTransformBase = dynamic_cast<const CompositeTransformType *>(_arg);
 
   if (compositeTransformBase)
   {
@@ -642,8 +642,7 @@ GPUResampleImageFilter<TInputImage, TOutputImage, TInterpolatorPrecisionType, TT
     if (this->m_TransformIsCombo)
     {
       using CompositeTransformType = GPUCompositeTransformBase<InterpolatorPrecisionType, InputImageDimension>;
-      const CompositeTransformType * compositeTransform =
-        dynamic_cast<const CompositeTransformType *>(this->m_TransformBase);
+      const auto * compositeTransform = dynamic_cast<const CompositeTransformType *>(this->m_TransformBase);
 
       for (int i = compositeTransform->GetNumberOfTransforms() - 1; i >= 0; i--)
       {
@@ -922,8 +921,7 @@ GPUResampleImageFilter<TInputImage, TOutputImage, TInterpolatorPrecisionType, TT
   else
   {
     // Get a handle to the B-spline interpolator.
-    const GPUBSplineInterpolatorType * gpuBSplineInterpolator =
-      dynamic_cast<const GPUBSplineInterpolatorType *>(this->m_InterpolatorBase);
+    const auto * gpuBSplineInterpolator = dynamic_cast<const GPUBSplineInterpolatorType *>(this->m_InterpolatorBase);
 
     // Get a handle to the B-spline interpolator coefficient image.
     GPUBSplineInterpolatorCoefficientImagePointer coefficient = gpuBSplineInterpolator->GetGPUCoefficients();
@@ -973,8 +971,7 @@ GPUResampleImageFilter<TInputImage, TOutputImage, TInterpolatorPrecisionType, TT
 {
   if (this->m_TransformIsCombo)
   {
-    const CompositeTransformBaseType * compositeTransform =
-      dynamic_cast<const CompositeTransformBaseType *>(this->m_TransformBase);
+    const auto * compositeTransform = dynamic_cast<const CompositeTransformBaseType *>(this->m_TransformBase);
 
     if (compositeTransform->IsIdentityTransform(transformIndex))
     {
@@ -1034,7 +1031,7 @@ GPUResampleImageFilter<TInputImage, TOutputImage, TInterpolatorPrecisionType, TT
     return false;
   }
 
-  typename TransformsHandle::const_iterator it = this->m_FilterLoopGPUKernelHandle.find(type);
+  auto it = this->m_FilterLoopGPUKernelHandle.find(type);
   if (it == this->m_FilterLoopGPUKernelHandle.end())
   {
     return false;
@@ -1061,7 +1058,7 @@ GPUResampleImageFilter<TInputImage, TOutputImage, TInterpolatorPrecisionType, TT
     return -1;
   }
 
-  typename TransformsHandle::const_iterator it = this->m_FilterLoopGPUKernelHandle.find(type);
+  auto it = this->m_FilterLoopGPUKernelHandle.find(type);
   if (it == this->m_FilterLoopGPUKernelHandle.end())
   {
     return -1;
@@ -1085,8 +1082,7 @@ GPUResampleImageFilter<TInputImage, TOutputImage, TInterpolatorPrecisionType, TT
 {
   if (this->m_TransformIsCombo)
   {
-    const CompositeTransformBaseType * compositeTransform =
-      dynamic_cast<const CompositeTransformBaseType *>(this->m_TransformBase);
+    const auto * compositeTransform = dynamic_cast<const CompositeTransformBaseType *>(this->m_TransformBase);
 
     if (compositeTransform->IsIdentityTransform(transformIndex))
     {
@@ -1155,7 +1151,7 @@ GPUResampleImageFilter<TInputImage, TOutputImage, TInterpolatorPrecisionType, TT
   if (this->m_TransformIsCombo)
   {
     using CompositeTransformType = GPUCompositeTransformBase<InterpolatorPrecisionType, InputImageDimension>;
-    CompositeTransformType * compositeTransform = dynamic_cast<CompositeTransformType *>(this->m_TransformBase);
+    auto * compositeTransform = dynamic_cast<CompositeTransformType *>(this->m_TransformBase);
 
     GPUBSplineTransformBase =
       dynamic_cast<GPUBSplineBaseTransformType *>(compositeTransform->GetNthTransform(transformIndex).GetPointer());

--- a/Common/OpenCL/Filters/itkGPUShrinkImageFilter.hxx
+++ b/Common/OpenCL/Filters/itkGPUShrinkImageFilter.hxx
@@ -158,7 +158,7 @@ GPUShrinkImageFilter<TInputImage, TOutputImage>::GPUGenerateData()
     shrinkfactors[i] = factorSize[i];
   }
 
-  const unsigned int ImageDim = static_cast<unsigned int>(InputImageDimension);
+  const auto ImageDim = static_cast<unsigned int>(InputImageDimension);
   switch (ImageDim)
   {
     case 1:

--- a/Common/OpenCL/ITKimprovements/itkGPUImageToImageFilter.hxx
+++ b/Common/OpenCL/ITKimprovements/itkGPUImageToImageFilter.hxx
@@ -95,7 +95,7 @@ GPUImageToImageFilter<TInputImage, TOutputImage, TParentImageFilter>::GenerateDa
     using GPUOutputImageType = GPUImage<OutputImagePixelType, OutputImageDimension>;
     for (OutputDataObjectIterator it(this); !it.IsAtEnd(); ++it)
     {
-      GPUOutputImageType * GPUOutput = dynamic_cast<GPUOutputImageType *>(it.GetOutput());
+      auto * GPUOutput = dynamic_cast<GPUOutputImageType *>(it.GetOutput());
       if (GPUOutput)
       {
         GPUOutput->UpdateCPUBuffer();

--- a/Common/OpenCL/ITKimprovements/itkGPUUnaryFunctorImageFilter.hxx
+++ b/Common/OpenCL/ITKimprovements/itkGPUUnaryFunctorImageFilter.hxx
@@ -75,7 +75,7 @@ GPUUnaryFunctorImageFilter<TInputImage, TOutputImage, TFunction, TParentImageFil
   int imgSize[3];
   imgSize[0] = imgSize[1] = imgSize[2] = 1;
 
-  const unsigned int ImageDim = (unsigned int)TInputImage::ImageDimension;
+  const auto ImageDim = (unsigned int)TInputImage::ImageDimension;
 
   for (std::size_t i = 0; i < ImageDim; ++i)
   {

--- a/Common/OpenCL/ITKimprovements/itkOpenCLContext.cxx
+++ b/Common/OpenCL/ITKimprovements/itkOpenCLContext.cxx
@@ -212,7 +212,7 @@ OpenCLContext::Create(const std::list<OpenCLDevice> & devices)
     return false;
   }
   std::vector<cl_device_id> devs;
-  for (std::list<OpenCLDevice>::const_iterator dev = devices.begin(); dev != devices.end(); ++dev)
+  for (auto dev = devices.begin(); dev != devices.end(); ++dev)
   {
     devs.push_back(dev->GetDeviceId());
   }
@@ -495,7 +495,7 @@ OpenCLContext::CreateContext(const std::list<OpenCLDevice> & devices, OpenCLCont
   if (!devices.empty())
   {
     std::vector<cl_device_id> devs;
-    for (std::list<OpenCLDevice>::const_iterator dev = devices.begin(); dev != devices.end(); ++dev)
+    for (auto dev = devices.begin(); dev != devices.end(); ++dev)
 
     {
       devs.push_back(dev->GetDeviceId());

--- a/Common/OpenCL/ITKimprovements/itkOpenCLDevice.cxx
+++ b/Common/OpenCL/ITKimprovements/itkOpenCLDevice.cxx
@@ -730,8 +730,7 @@ OpenCLDevice::GetAllDevices()
   const std::list<itk::OpenCLPlatform> platforms = OpenCLPlatform::GetAllPlatforms();
   std::list<OpenCLDevice>              devices;
 
-  for (std::list<itk::OpenCLPlatform>::const_iterator platform = platforms.begin(); platform != platforms.end();
-       ++platform)
+  for (auto platform = platforms.begin(); platform != platforms.end(); ++platform)
   {
     cl_uint size;
     if (clGetDeviceIDs(platform->GetPlatformId(), CL_DEVICE_TYPE_ALL, 0, 0, &size) != CL_SUCCESS)
@@ -740,7 +739,7 @@ OpenCLDevice::GetAllDevices()
     }
     std::vector<cl_device_id> buffer(size);
     clGetDeviceIDs(platform->GetPlatformId(), CL_DEVICE_TYPE_ALL, size, &buffer[0], &size);
-    for (std::vector<cl_device_id>::iterator device = buffer.begin(); device != buffer.end(); ++device)
+    for (auto device = buffer.begin(); device != buffer.end(); ++device)
     {
       devices.push_back(OpenCLDevice(*device));
     }
@@ -764,7 +763,7 @@ OpenCLDevice::GetDevices(const OpenCLDevice::DeviceType types, const OpenCLPlatf
   {
     platforms.push_back(platform);
   }
-  for (std::list<itk::OpenCLPlatform>::iterator platform = platforms.begin(); platform != platforms.end(); ++platform)
+  for (auto platform = platforms.begin(); platform != platforms.end(); ++platform)
   {
     cl_uint size;
     if (clGetDeviceIDs(platform->GetPlatformId(), cl_device_type(types), 0, 0, &size) != CL_SUCCESS)
@@ -777,7 +776,7 @@ OpenCLDevice::GetDevices(const OpenCLDevice::DeviceType types, const OpenCLPlatf
     }
     std::vector<cl_device_id> buffer(size);
     clGetDeviceIDs(platform->GetPlatformId(), cl_device_type(types), size, &buffer[0], &size);
-    for (std::vector<cl_device_id>::iterator device = buffer.begin(); device != buffer.end(); ++device)
+    for (auto device = buffer.begin(); device != buffer.end(); ++device)
     {
       devices.push_back(OpenCLDevice(*device));
     }
@@ -801,7 +800,7 @@ OpenCLDevice::GetDevices(const OpenCLDevice::DeviceType type, const OpenCLPlatfo
   {
     const std::list<itk::OpenCLDevice> allDevices = itk::OpenCLDevice::GetDevices(type, platform);
     std::list<OpenCLDevice>            devices;
-    for (std::list<itk::OpenCLDevice>::const_iterator dev = allDevices.begin(); dev != allDevices.end(); ++dev)
+    for (auto dev = allDevices.begin(); dev != allDevices.end(); ++dev)
     {
       if ((dev->GetDeviceType() & type) != 0)
       {
@@ -825,7 +824,7 @@ OpenCLDevice::GetMaximumFlopsDevice(const std::list<OpenCLDevice> & devices, con
   // Find the device that has maximum Flops
   int          maxFlops = 0;
   cl_device_id id = 0;
-  for (std::list<OpenCLDevice>::const_iterator device = devices.begin(); device != devices.end(); ++device)
+  for (auto device = devices.begin(); device != devices.end(); ++device)
   {
     int deviceFlops = device->GetComputeUnits() * device->GetClockFrequency();
     if (deviceFlops > maxFlops && (device->GetDeviceType() == type))
@@ -885,7 +884,7 @@ OpenCLDevice::GetMaximumFlopsDevices(const OpenCLDevice::DeviceType type, const 
   using DeviceType = std::pair<std::size_t, cl_device_id>;
   using MaximumFlopsDevicesType = std::set<DeviceType>;
   MaximumFlopsDevicesType maximumFlopsDevices;
-  for (std::list<OpenCLDevice>::const_iterator device = allDevices.begin(); device != allDevices.end(); ++device)
+  for (auto device = allDevices.begin(); device != allDevices.end(); ++device)
   {
     int        deviceFlops = device->GetComputeUnits() * device->GetClockFrequency();
     DeviceType deviceWithFlops(deviceFlops, device->GetDeviceId());
@@ -894,9 +893,7 @@ OpenCLDevice::GetMaximumFlopsDevices(const OpenCLDevice::DeviceType type, const 
 
   // Combine result
   std::list<OpenCLDevice> devices;
-  for (MaximumFlopsDevicesType::const_reverse_iterator rit = maximumFlopsDevices.rbegin();
-       rit != maximumFlopsDevices.rend();
-       ++rit)
+  for (auto rit = maximumFlopsDevices.rbegin(); rit != maximumFlopsDevices.rend(); ++rit)
   {
     OpenCLDevice device(rit->second);
     devices.push_back(device);

--- a/Common/OpenCL/ITKimprovements/itkOpenCLDevice.h
+++ b/Common/OpenCL/ITKimprovements/itkOpenCLDevice.h
@@ -863,7 +863,7 @@ operator<<(std::basic_ostream<charT, traits> & strm, const OpenCLDevice & device
   else
   {
     strm << std::endl;
-    for (std::list<std::string>::const_iterator it = extensions.begin(); it != extensions.end(); ++it)
+    for (auto it = extensions.begin(); it != extensions.end(); ++it)
     {
       strm << indent << indent << "- " << *it << std::endl;
     }

--- a/Common/OpenCL/ITKimprovements/itkOpenCLKernel.cxx
+++ b/Common/OpenCL/ITKimprovements/itkOpenCLKernel.cxx
@@ -584,7 +584,7 @@ OpenCLKernel::SetArg(const cl_uint index, const PointDouble1DType & value)
   }
   else
   {
-    const cl_float values = static_cast<float>(value[0]);
+    const auto values = static_cast<float>(value[0]);
     return this->SetArg(index, values);
   }
 }
@@ -760,7 +760,7 @@ OpenCLKernel::SetArg(const cl_uint index, const VectorDouble1DType & value)
   }
   else
   {
-    const cl_float values = static_cast<float>(value[0]);
+    const auto values = static_cast<float>(value[0]);
     return this->SetArg(index, values);
   }
 }
@@ -936,7 +936,7 @@ OpenCLKernel::SetArg(const cl_uint index, const CovariantVectorDouble1DType & va
   }
   else
   {
-    const cl_float values = static_cast<float>(value[0]);
+    const auto values = static_cast<float>(value[0]);
     return this->SetArg(index, values);
   }
 }
@@ -1103,7 +1103,7 @@ OpenCLKernel::SetArg(const cl_uint index, const MatrixDouble1x1Type & value)
   }
   else
   {
-    const cl_float values = static_cast<float>(value[0][0]);
+    const auto values = static_cast<float>(value[0][0]);
     return this->SetArg(index, values);
   }
 }

--- a/Common/OpenCL/ITKimprovements/itkOpenCLKernelManager.cxx
+++ b/Common/OpenCL/ITKimprovements/itkOpenCLKernelManager.cxx
@@ -390,7 +390,7 @@ OpenCLKernelManager::SetGlobalWorkSizeForAllKernels(const OpenCLSize & size)
     return;
   }
 
-  for (std::vector<OpenCLKernel>::iterator kernel = this->m_Kernels.begin(); kernel != this->m_Kernels.end(); ++kernel)
+  for (auto kernel = this->m_Kernels.begin(); kernel != this->m_Kernels.end(); ++kernel)
   {
     kernel->SetGlobalWorkSize(size);
   }
@@ -406,7 +406,7 @@ OpenCLKernelManager::SetLocalWorkSizeForAllKernels(const OpenCLSize & size)
     return;
   }
 
-  for (std::vector<OpenCLKernel>::iterator kernel = this->m_Kernels.begin(); kernel != this->m_Kernels.end(); ++kernel)
+  for (auto kernel = this->m_Kernels.begin(); kernel != this->m_Kernels.end(); ++kernel)
   {
     kernel->SetLocalWorkSize(size);
   }
@@ -422,7 +422,7 @@ OpenCLKernelManager::SetGlobalWorkOffsetForAllKernels(const OpenCLSize & offset)
     return;
   }
 
-  for (std::vector<OpenCLKernel>::iterator kernel = this->m_Kernels.begin(); kernel != this->m_Kernels.end(); ++kernel)
+  for (auto kernel = this->m_Kernels.begin(); kernel != this->m_Kernels.end(); ++kernel)
   {
     kernel->SetGlobalWorkOffset(offset);
   }

--- a/Common/OpenCL/ITKimprovements/itkOpenCLPlatform.cxx
+++ b/Common/OpenCL/ITKimprovements/itkOpenCLPlatform.cxx
@@ -190,8 +190,7 @@ OpenCLPlatform::GetPlatform(const OpenCLPlatform::VendorType vendor)
 
   cl_platform_id platformID = 0;
 
-  for (std::list<itk::OpenCLPlatform>::const_iterator platform = platforms.begin(); platform != platforms.end();
-       ++platform)
+  for (auto platform = platforms.begin(); platform != platforms.end(); ++platform)
   {
     const std::string vendorName = opencl_simplified(platform->GetVendor());
 

--- a/Common/OpenCL/ITKimprovements/itkOpenCLPlatform.h
+++ b/Common/OpenCL/ITKimprovements/itkOpenCLPlatform.h
@@ -231,7 +231,7 @@ operator<<(std::basic_ostream<charT, traits> & strm, const OpenCLPlatform & plat
   else
   {
     strm << std::endl;
-    for (std::list<std::string>::const_iterator it = extensions.begin(); it != extensions.end(); ++it)
+    for (auto it = extensions.begin(); it != extensions.end(); ++it)
     {
       strm << indent << indent << "- " << *it << std::endl;
     }

--- a/Common/OpenCL/ITKimprovements/itkOpenCLProgram.cxx
+++ b/Common/OpenCL/ITKimprovements/itkOpenCLProgram.cxx
@@ -246,7 +246,7 @@ OpenCLProgram::Build(const std::list<OpenCLDevice> & devices, const std::string 
 {
   std::vector<cl_device_id> devs;
 
-  for (std::list<OpenCLDevice>::const_iterator dev = devices.begin(); dev != devices.end(); ++dev)
+  for (auto dev = devices.begin(); dev != devices.end(); ++dev)
   {
     if (dev->GetDeviceId())
     {
@@ -343,7 +343,7 @@ OpenCLProgram::GetLog() const
 
   // Retrieve the device GetLogs and concatenate them.
   std::string log;
-  for (std::list<itk::OpenCLDevice>::const_iterator dev = devs.begin(); dev != devs.end(); ++dev)
+  for (auto dev = devs.begin(); dev != devs.end(); ++dev)
   {
     std::size_t size = 0;
     if (clGetProgramBuildInfo(this->m_Id, dev->GetDeviceId(), CL_PROGRAM_BUILD_LOG, 0, 0, &size) != CL_SUCCESS || !size)

--- a/Common/OpenCL/itkGPUKernelManagerHelperFunctions.h
+++ b/Common/OpenCL/itkGPUKernelManagerHelperFunctions.h
@@ -76,7 +76,7 @@ SetKernelWithDirection(const typename ImageType::DirectionType & dir,
                        cl_float4 &                               direction2d,
                        cl_float16 &                              direction3d)
 {
-  const unsigned int ImageDim = (unsigned int)(ImageType::ImageDimension);
+  const auto ImageDim = (unsigned int)(ImageType::ImageDimension);
 
   if (ImageDim == 1)
   {
@@ -161,10 +161,10 @@ SetKernelWithITKImage(OpenCLKernelManager::Pointer &      kernelManager,
   // Set ITK image base to the kernelManager
   if (copyImageBase)
   {
-    const unsigned int ImageDim = (unsigned int)(ImageType::ImageDimension);
-    GPUImageBase1D     imageBase1D;
-    GPUImageBase2D     imageBase2D;
-    GPUImageBase3D     imageBase3D;
+    const auto     ImageDim = (unsigned int)(ImageType::ImageDimension);
+    GPUImageBase1D imageBase1D;
+    GPUImageBase2D imageBase2D;
+    GPUImageBase3D imageBase3D;
 
     // Set size
     typename ImageType::RegionType largestPossibleRegion;

--- a/Common/OpenCL/itkOpenCLSetup.cxx
+++ b/Common/OpenCL/itkOpenCLSetup.cxx
@@ -75,7 +75,7 @@ CreateOpenCLContext(std::string & errorMessage, const std::string openCLDeviceTy
   /** Get a list of all OpenCL devices. */
   std::list<itk::OpenCLDevice>       devicesByType;
   const std::list<itk::OpenCLDevice> allDevices = itk::OpenCLDevice::GetAllDevices();
-  for (std::list<itk::OpenCLDevice>::const_iterator device = allDevices.begin(); device != allDevices.end(); ++device)
+  for (auto device = allDevices.begin(); device != allDevices.end(); ++device)
   {
     if ((device->GetDeviceType() & deviceType) != 0)
     {

--- a/Common/ParameterFileParser/itkParameterMapInterface.cxx
+++ b/Common/ParameterFileParser/itkParameterMapInterface.cxx
@@ -162,7 +162,7 @@ ParameterMapInterface::ReadParameter(std::vector<std::string> & parameterValues,
   const ParameterValuesType & vec = this->m_ParameterMap.find(parameterName)->second;
 
   /** Copy all parameters at once. */
-  std::vector<std::string>::const_iterator it = vec.begin();
+  auto it = vec.begin();
   parameterValues.clear();
   parameterValues.assign(it + entry_nr_start, it + entry_nr_end + 1);
 

--- a/Common/ParameterFileParser/itkParameterMapInterface.h
+++ b/Common/ParameterFileParser/itkParameterMapInterface.h
@@ -240,7 +240,7 @@ public:
     if (default_entry_nr >= 0)
     {
       /** Try the default_entry_nr if the entry_nr is not found. */
-      unsigned int uintdefault = static_cast<unsigned int>(default_entry_nr);
+      auto uintdefault = static_cast<unsigned int>(default_entry_nr);
       found |= this->ReadParameter(parameterValue, parameterName, uintdefault, false, dummyString);
       found |= this->ReadParameter(parameterValue, parameterName, entry_nr, false, dummyString);
       found |= this->ReadParameter(parameterValue, fullname, uintdefault, false, dummyString);

--- a/Common/Transforms/itkAdvancedBSplineDeformableTransformBase.hxx
+++ b/Common/Transforms/itkAdvancedBSplineDeformableTransformBase.hxx
@@ -375,7 +375,7 @@ AdvancedBSplineDeformableTransformBase<TScalarType, NDimensions>::WrapAsImages()
    * NOTE: For efficiency, parameters are not copied locally. The parameters
    * are assumed to be maintained by the caller.
    */
-  PixelType *  dataPointer = const_cast<PixelType *>((this->m_InputParametersPointer->data_block()));
+  auto *       dataPointer = const_cast<PixelType *>((this->m_InputParametersPointer->data_block()));
   unsigned int numberOfPixels = this->m_GridRegion.GetNumberOfPixels();
 
   for (unsigned int j = 0; j < SpaceDimension; ++j)

--- a/Common/Transforms/itkAdvancedCombinationTransform.hxx
+++ b/Common/Transforms/itkAdvancedCombinationTransform.hxx
@@ -118,8 +118,8 @@ AdvancedCombinationTransform<TScalarType, NDimensions>::GetNthTransform(SizeValu
     {
       // Perform const_cast, we don't like it, but there is no other option
       // with current ITK4 itk::MultiTransform::GetNthTransform() const design
-      const TransformType * currentTransformCasted = dynamic_cast<const TransformType *>(currentTransform.GetPointer());
-      TransformType *       currentTransformConstCasted = const_cast<TransformType *>(currentTransformCasted);
+      const auto * currentTransformCasted = dynamic_cast<const TransformType *>(currentTransform.GetPointer());
+      auto *       currentTransformConstCasted = const_cast<TransformType *>(currentTransformCasted);
       nthTransform = currentTransformConstCasted;
     }
     else

--- a/Common/Transforms/itkAdvancedImageMomentsCalculator.hxx
+++ b/Common/Transforms/itkAdvancedImageMomentsCalculator.hxx
@@ -272,7 +272,7 @@ AdvancedImageMomentsCalculator<TImage>::ThreadedCompute(ThreadIdType threadId)
   const ThreadIdType  numberOfThreads = this->m_Threader->GetNumberOfWorkUnits();
 
   /** Get the samples for this thread. */
-  const unsigned long nrOfSamplesPerThreads = static_cast<unsigned long>(
+  const auto nrOfSamplesPerThreads = static_cast<unsigned long>(
     std::ceil(static_cast<double>(sampleContainerSize) / static_cast<double>(numberOfThreads)));
 
   const auto pos_begin = std::min<size_t>(nrOfSamplesPerThreads * threadId, sampleContainerSize);

--- a/Common/Transforms/itkGridScheduleComputer.hxx
+++ b/Common/Transforms/itkGridScheduleComputer.hxx
@@ -141,8 +141,7 @@ GridScheduleComputer<TTransformScalarType, VImageDimension>::ComputeBSplineGrid(
       this->m_GridSpacings[res][dim] = gridSpacing;
 
       /** Compute the grid size without the extra grid points at the edges. */
-      const unsigned int bareGridSize =
-        static_cast<unsigned int>(std::ceil(size[dim] * imageSpacing[dim] / gridSpacing));
+      const auto bareGridSize = static_cast<unsigned int>(std::ceil(size[dim] * imageSpacing[dim] / gridSpacing));
 
       /** The number of B-spline grid nodes is the bareGridSize plus the
        * B-spline order more grid nodes. */
@@ -301,7 +300,7 @@ GridScheduleComputer<TTransformScalarType, VImageDimension>::ApplyInitialTransfo
     double oldLength_i = this->m_ImageSpacing[i] * static_cast<double>(this->m_ImageRegion.GetSize()[i] - 1);
 
     /** Compute the length of the bounding box (in mm) for dimension i. */
-    double newLength_i = static_cast<double>(maxPoint[i] - minPoint[i]);
+    auto newLength_i = static_cast<double>(maxPoint[i] - minPoint[i]);
 
     /** Scale the fixedImageSpacing by their ratio. */
     if (oldLength_i > smallnumber)

--- a/Common/Transforms/itkTransformToDeterminantOfSpatialJacobianSource.hxx
+++ b/Common/Transforms/itkTransformToDeterminantOfSpatialJacobianSource.hxx
@@ -244,7 +244,7 @@ TransformToDeterminantOfSpatialJacobianSource<TOutputImage, TTransformPrecisionT
 
     SpatialJacobianType sj;
     this->m_Transform->GetSpatialJacobian(point, sj);
-    const PixelType detjac = static_cast<PixelType>(vnl_det(sj.GetVnlMatrix()));
+    const auto detjac = static_cast<PixelType>(vnl_det(sj.GetVnlMatrix()));
 
     // Set it
     it.Set(detjac);
@@ -275,7 +275,7 @@ TransformToDeterminantOfSpatialJacobianSource<TOutputImage, TTransformPrecisionT
   outputPtr->TransformIndexToPhysicalPoint(index, point);
   SpatialJacobianType sj;
   this->m_Transform->GetSpatialJacobian(point, sj);
-  const PixelType detjac = static_cast<PixelType>(vnl_det(sj.GetVnlMatrix()));
+  const auto detjac = static_cast<PixelType>(vnl_det(sj.GetVnlMatrix()));
 
   outputPtr->FillBuffer(detjac);
 

--- a/Common/Transforms/itkUpsampleBSplineParametersFilter.hxx
+++ b/Common/Transforms/itkUpsampleBSplineParametersFilter.hxx
@@ -75,8 +75,8 @@ UpsampleBSplineParametersFilter<TArray, TImage>::UpsampleParameters(const ArrayT
   parameters_out.SetSize(requiredNumberOfPixels * Dimension);
 
   /** Get the pointer to the data of the input parameters. */
-  PixelType * inputDataPointer = const_cast<PixelType *>(parameters_in.data_block());
-  PixelType * outputDataPointer = const_cast<PixelType *>(parameters_out.data_block());
+  auto * inputDataPointer = const_cast<PixelType *>(parameters_in.data_block());
+  auto * outputDataPointer = const_cast<PixelType *>(parameters_out.data_block());
 
   /** The input parameters are represented as a coefficient image. */
   ImagePointer coeffs_in = ImageType::New();

--- a/Common/itkComputeDisplacementDistribution.hxx
+++ b/Common/itkComputeDisplacementDistribution.hxx
@@ -112,7 +112,7 @@ ComputeDisplacementDistribution<TFixedImage, TTransform>::ComputeSingleThreaded(
   const SizeValueType nrofsamples = sampleContainer->Size();
 
   /** Get the number of parameters. */
-  const unsigned int numberOfParameters = static_cast<unsigned int>(this->m_Transform->GetNumberOfParameters());
+  const auto numberOfParameters = static_cast<unsigned int>(this->m_Transform->GetNumberOfParameters());
 
   /** Get scales vector */
   const ScalesType & scales = this->GetScales();
@@ -198,7 +198,7 @@ ComputeDisplacementDistribution<TFixedImage, TTransform>::ComputeSingleThreaded(
   if (methods == "95percentile")
   {
     /** Compute the 95% percentile of the distribution of JGG_k */
-    unsigned int d = static_cast<unsigned int>(nrofsamples * 0.95);
+    auto d = static_cast<unsigned int>(nrofsamples * 0.95);
     std::sort(JGG_k.begin(), JGG_k.end());
     jacg = (JGG_k[d - 1] + JGG_k[d] + JGG_k[d + 1]) / 3.0;
   }
@@ -333,7 +333,7 @@ ComputeDisplacementDistribution<TFixedImage, TTransform>::ThreadedCompute(Thread
   const ScalesType & scales = this->GetScales();
 
   /** Get the samples for this thread. */
-  const unsigned long nrOfSamplesPerThreads = static_cast<unsigned long>(
+  const auto nrOfSamplesPerThreads = static_cast<unsigned long>(
     std::ceil(static_cast<double>(sampleContainerSize) / static_cast<double>(numberOfThreads)));
 
   const auto pos_begin = std::min<size_t>(nrOfSamplesPerThreads * threadId, sampleContainerSize);
@@ -481,7 +481,7 @@ ComputeDisplacementDistribution<TFixedImage, TTransform>::ComputeUsingSearchDire
   const SizeValueType nrofsamples = sampleContainer->Size();
 
   /** Get the number of parameters. */
-  const unsigned int numberOfParameters = static_cast<unsigned int>(this->m_Transform->GetNumberOfParameters());
+  const auto numberOfParameters = static_cast<unsigned int>(this->m_Transform->GetNumberOfParameters());
 
   /** Get scales vector */
   const ScalesType & scales = this->GetScales();
@@ -555,7 +555,7 @@ ComputeDisplacementDistribution<TFixedImage, TTransform>::ComputeUsingSearchDire
   if (methods == "95percentile")
   {
     /** Compute the 95% percentile of the distribution of JGG_k */
-    unsigned int d = static_cast<unsigned int>(nrofsamples * 0.95);
+    auto d = static_cast<unsigned int>(nrofsamples * 0.95);
     std::sort(JGG_k.begin(), JGG_k.end());
     jacg = (JGG_k[d - 1] + JGG_k[d] + JGG_k[d + 1]) / 3.0;
   }

--- a/Common/itkComputeJacobianTerms.hxx
+++ b/Common/itkComputeJacobianTerms.hxx
@@ -59,10 +59,10 @@ ComputeJacobianTerms<TFixedImage, TTransform>::Compute(double & TrC, double & Tr
   ImageSampleContainerPointer sampleContainer; // default-constructed (null)
   SampleFixedImageForJacobianTerms(sampleContainer);
   const SizeValueType nrofsamples = sampleContainer->Size();
-  const double        n = static_cast<double>(nrofsamples);
+  const auto          n = static_cast<double>(nrofsamples);
 
   /** Get the number of parameters. */
-  const unsigned int numberOfParameters = static_cast<unsigned int>(this->m_Transform->GetNumberOfParameters());
+  const auto numberOfParameters = static_cast<unsigned int>(this->m_Transform->GetNumberOfParameters());
 
   /** Get transform and set current position. */
   typename TransformType::Pointer transform = this->m_Transform;
@@ -166,7 +166,7 @@ ComputeJacobianTerms<TFixedImage, TTransform>::Compute(double & TrC, double & Tr
   std::sort(difHist2.begin(), difHist2.end());
 
   /** Determine the bands that are expected to be most dominant. */
-  DifHist2Type::iterator difHist2It = difHist2.end();
+  auto difHist2It = difHist2.end();
   for (unsigned int b = 0; b < bandcovsize; ++b)
   {
     --difHist2It;

--- a/Common/itkComputePreconditionerUsingDisplacementDistribution.hxx
+++ b/Common/itkComputePreconditionerUsingDisplacementDistribution.hxx
@@ -78,7 +78,7 @@ ComputePreconditionerUsingDisplacementDistribution<TFixedImage, TTransform>::Com
   maxJJ = 0.0;
 
   /** Get the number of parameters. */
-  const unsigned int numberOfParameters = static_cast<unsigned int>(this->m_Transform->GetNumberOfParameters());
+  const auto numberOfParameters = static_cast<unsigned int>(this->m_Transform->GetNumberOfParameters());
 
   // Replace by a general check later.
   bool transformIsBSpline = false;
@@ -304,7 +304,7 @@ ComputePreconditionerUsingDisplacementDistribution<TFixedImage, TTransform>::Com
   maxJJ = 0.0;
 
   /** Get the number of parameters. */
-  const unsigned int numberOfParameters = static_cast<unsigned int>(this->m_Transform->GetNumberOfParameters());
+  const auto numberOfParameters = static_cast<unsigned int>(this->m_Transform->GetNumberOfParameters());
 
   // Replace by a general check later.
   bool transformIsBSpline = false;
@@ -416,7 +416,7 @@ ComputePreconditionerUsingDisplacementDistribution<TFixedImage, TTransform>::Pre
   using PadImageFilterType = ZeroFluxNeumannPadImageFilter<CoefficientImageType, CoefficientImageType>;
   using SmoothingFilterType = SmoothingRecursiveGaussianImageFilter<CoefficientImageType, CoefficientImageType>;
 
-  CombinationTransformType * testPtr_combo = dynamic_cast<CombinationTransformType *>(this->m_Transform.GetPointer());
+  auto * testPtr_combo = dynamic_cast<CombinationTransformType *>(this->m_Transform.GetPointer());
   if (!testPtr_combo)
     return; // throw an error?
   const auto testPtr_bspline = dynamic_cast<const BSplineTransformType *>(testPtr_combo->GetCurrentTransform());

--- a/Common/itkImageFileCastWriter.hxx
+++ b/Common/itkImageFileCastWriter.hxx
@@ -90,8 +90,8 @@ ImageFileCastWriter<TInputImage>::GenerateData()
         this->GetImageIO()->GetComponentTypeAsString(this->GetImageIO()->GetComponentType()) &&
       numberOfComponents == 1)
   {
-    void *             convertedDataBuffer = nullptr;
-    const DataObject * inputAsDataObject = dynamic_cast<const DataObject *>(input);
+    void *       convertedDataBuffer = nullptr;
+    const auto * inputAsDataObject = dynamic_cast<const DataObject *>(input);
 
     /** convert the scalar image to a scalar image with another componenttype
      * The imageIO's PixelType is also changed */

--- a/Common/itkMultiResolutionGaussianSmoothingPyramidImageFilter.hxx
+++ b/Common/itkMultiResolutionGaussianSmoothingPyramidImageFilter.hxx
@@ -250,7 +250,7 @@ MultiResolutionGaussianSmoothingPyramidImageFilter<TInputImage, TOutputImage>::G
   using RegionType = typename OutputImageType::RegionType;
 
   /** \todo: shouldn't this be a dynamic_cast? */
-  TOutputImage * ptr = static_cast<TOutputImage *>(refOutput);
+  auto * ptr = static_cast<TOutputImage *>(refOutput);
   if (!ptr)
   {
     itkExceptionMacro("Could not cast refOutput to TOutputImage*.");
@@ -343,7 +343,7 @@ void
 MultiResolutionGaussianSmoothingPyramidImageFilter<TInputImage, TOutputImage>::EnlargeOutputRequestedRegion(
   DataObject * output)
 {
-  TOutputImage * out = dynamic_cast<TOutputImage *>(output);
+  auto * out = dynamic_cast<TOutputImage *>(output);
 
   if (out)
   {

--- a/Common/itkMultiResolutionImageRegistrationMethod2.hxx
+++ b/Common/itkMultiResolutionImageRegistrationMethod2.hxx
@@ -120,7 +120,7 @@ MultiResolutionImageRegistrationMethod2<TFixedImage, TMovingImage>::Initialize()
   //
   // Connect the transform to the Decorator.
   //
-  TransformOutputType * transformOutput = static_cast<TransformOutputType *>(this->ProcessObject::GetOutput(0));
+  auto * transformOutput = static_cast<TransformOutputType *>(this->ProcessObject::GetOutput(0));
 
   transformOutput->Set(this->m_Transform.GetPointer());
 

--- a/Common/itkParabolicErodeDilateImageFilter.hxx
+++ b/Common/itkParabolicErodeDilateImageFilter.hxx
@@ -145,7 +145,7 @@ template <typename TInputImage, bool doDilate, typename TOutputImage>
 void
 ParabolicErodeDilateImageFilter<TInputImage, doDilate, TOutputImage>::EnlargeOutputRequestedRegion(DataObject * output)
 {
-  TOutputImage * out = dynamic_cast<TOutputImage *>(output);
+  auto * out = dynamic_cast<TOutputImage *>(output);
 
   if (out)
   {

--- a/Components/FixedImagePyramids/OpenCLFixedGenericPyramid/elxOpenCLFixedGenericPyramid.hxx
+++ b/Components/FixedImagePyramids/OpenCLFixedGenericPyramid/elxOpenCLFixedGenericPyramid.hxx
@@ -275,8 +275,7 @@ template <class TElastix>
 void
 OpenCLFixedGenericPyramid<TElastix>::UnregisterFactories()
 {
-  for (std::vector<ObjectFactoryBasePointer>::iterator it = this->m_Factories.begin(); it != this->m_Factories.end();
-       ++it)
+  for (auto it = this->m_Factories.begin(); it != this->m_Factories.end(); ++it)
   {
     itk::ObjectFactoryBase::UnRegisterFactory(*it);
   }

--- a/Components/Metrics/AdvancedKappaStatistic/itkAdvancedKappaStatisticImageToImageMetric.hxx
+++ b/Components/Metrics/AdvancedKappaStatistic/itkAdvancedKappaStatisticImageToImageMetric.hxx
@@ -352,9 +352,9 @@ AdvancedKappaStatisticImageToImageMetric<TFixedImage, TMovingImage>::GetValueAnd
   this->CheckNumberOfSamples(sampleContainer->Size(), Superclass::m_NumberOfPixelsCounted);
 
   /** Compute the final metric value. */
-  std::size_t       areaSum = fixedForegroundArea + movingForegroundArea;
-  const MeasureType intersectionFloat = static_cast<MeasureType>(intersection);
-  const MeasureType areaSumFloat = static_cast<MeasureType>(areaSum);
+  std::size_t areaSum = fixedForegroundArea + movingForegroundArea;
+  const auto  intersectionFloat = static_cast<MeasureType>(intersection);
+  const auto  areaSumFloat = static_cast<MeasureType>(areaSum);
   if (areaSum > 0)
   {
     measure = 1.0 - 2.0 * intersectionFloat / areaSumFloat;
@@ -455,7 +455,7 @@ AdvancedKappaStatisticImageToImageMetric<TFixedImage, TMovingImage>::ThreadedGet
   const unsigned long         sampleContainerSize = sampleContainer->Size();
 
   /** Get the samples for this thread. */
-  const unsigned long nrOfSamplesPerThreads = static_cast<unsigned long>(
+  const auto nrOfSamplesPerThreads = static_cast<unsigned long>(
     std::ceil(static_cast<double>(sampleContainerSize) / static_cast<double>(Self::GetNumberOfWorkUnits())));
 
   const auto pos_begin = std::min<size_t>(nrOfSamplesPerThreads * threadId, sampleContainerSize);
@@ -501,7 +501,7 @@ AdvancedKappaStatisticImageToImageMetric<TFixedImage, TMovingImage>::ThreadedGet
       ++numberOfPixelsCounted;
 
       /** Get the fixed image value. */
-      const RealType fixedImageValue = static_cast<RealType>(fiter->m_ImageValue);
+      const auto fixedImageValue = static_cast<RealType>(fiter->m_ImageValue);
 
 #if 0
       /** Get the TransformJacobian dT/dmu. */
@@ -647,7 +647,7 @@ AdvancedKappaStatisticImageToImageMetric<TFixedImage, TMovingImage>::AccumulateD
   Self & metric = *(userData.st_Metric);
 
   const unsigned int numPar = metric.GetNumberOfParameters();
-  const unsigned int subSize =
+  const auto         subSize =
     static_cast<unsigned int>(std::ceil(static_cast<double>(numPar) / static_cast<double>(nrOfThreads)));
   const unsigned int jmin = threadId * subSize;
   const unsigned int jmax = std::min((threadId + 1) * subSize, numPar);
@@ -815,8 +815,8 @@ AdvancedKappaStatisticImageToImageMetric<TFixedImage, TMovingImage>::ComputeGrad
         /** Get the left, center and right values. */
         minusIndex[i] = currIndex[i] - 1;
         plusIndex[i] = currIndex[i] + 1;
-        const RealType minusVal = static_cast<RealType>(this->m_MovingImage->GetPixel(minusIndex));
-        const RealType plusVal = static_cast<RealType>(this->m_MovingImage->GetPixel(plusIndex));
+        const auto     minusVal = static_cast<RealType>(this->m_MovingImage->GetPixel(minusIndex));
+        const auto     plusVal = static_cast<RealType>(this->m_MovingImage->GetPixel(plusIndex));
         const RealType minusDiff = std::abs(minusVal - this->m_ForegroundValue);
         const RealType plusDiff = std::abs(plusVal - this->m_ForegroundValue);
 

--- a/Components/Metrics/AdvancedMattesMutualInformation/itkParzenWindowMutualInformationImageToImageMetric.hxx
+++ b/Components/Metrics/AdvancedMattesMutualInformation/itkParzenWindowMutualInformationImageToImageMetric.hxx
@@ -438,7 +438,7 @@ ParzenWindowMutualInformationImageToImageMetric<TFixedImage, TMovingImage>::Thre
   const unsigned long         sampleContainerSize = sampleContainer->Size();
 
   /** Get the samples for this thread. */
-  const unsigned long nrOfSamplesPerThreads = static_cast<unsigned long>(
+  const auto nrOfSamplesPerThreads = static_cast<unsigned long>(
     std::ceil(static_cast<double>(sampleContainerSize) / static_cast<double>(Self::GetNumberOfWorkUnits())));
 
   const auto pos_begin = std::min<size_t>(nrOfSamplesPerThreads * threadId, sampleContainerSize);
@@ -475,7 +475,7 @@ ParzenWindowMutualInformationImageToImageMetric<TFixedImage, TMovingImage>::Thre
     if (sampleOk)
     {
       /** Get the fixed image value. */
-      RealType fixedImageValue = static_cast<RealType>(fiter->m_ImageValue);
+      auto fixedImageValue = static_cast<RealType>(fiter->m_ImageValue);
 
       /** Make sure the values fall within the histogram range. */
       fixedImageValue = this->GetFixedImageLimiter()->Evaluate(fixedImageValue);
@@ -737,7 +737,7 @@ ParzenWindowMutualInformationImageToImageMetric<TFixedImage, TMovingImage>::Upda
                                    derivativeMovingParzenValues);
 
   /** Get the moving image bin size. */
-  const double et = static_cast<double>(this->m_MovingImageBinSize);
+  const auto et = static_cast<double>(this->m_MovingImageBinSize);
 
   /** Loop over the Parzen window region and increment sum. */
   PDFValueType sum = 0.0;

--- a/Components/Metrics/AdvancedMeanSquares/itkAdvancedMeanSquaresImageToImageMetric.hxx
+++ b/Components/Metrics/AdvancedMeanSquares/itkAdvancedMeanSquaresImageToImageMetric.hxx
@@ -257,7 +257,7 @@ AdvancedMeanSquaresImageToImageMetric<TFixedImage, TMovingImage>::ThreadedGetVal
   const unsigned long         sampleContainerSize = sampleContainer->Size();
 
   /** Get the samples for this thread. */
-  const unsigned long nrOfSamplesPerThreads = static_cast<unsigned long>(
+  const auto nrOfSamplesPerThreads = static_cast<unsigned long>(
     std::ceil(static_cast<double>(sampleContainerSize) / static_cast<double>(Self::GetNumberOfWorkUnits())));
 
   const auto pos_begin = std::min<size_t>(nrOfSamplesPerThreads * threadId, sampleContainerSize);
@@ -298,7 +298,7 @@ AdvancedMeanSquaresImageToImageMetric<TFixedImage, TMovingImage>::ThreadedGetVal
       ++numberOfPixelsCounted;
 
       /** Get the fixed image value. */
-      const RealType fixedImageValue = static_cast<RealType>(threader_fiter->m_ImageValue);
+      const auto fixedImageValue = static_cast<RealType>(threader_fiter->m_ImageValue);
 
       /** The difference squared. */
       const RealType diff = movingImageValue - fixedImageValue;
@@ -554,7 +554,7 @@ AdvancedMeanSquaresImageToImageMetric<TFixedImage, TMovingImage>::ThreadedGetVal
   const unsigned long         sampleContainerSize = sampleContainer->Size();
 
   /** Get the samples for this thread. */
-  const unsigned long nrOfSamplesPerThreads = static_cast<unsigned long>(
+  const auto nrOfSamplesPerThreads = static_cast<unsigned long>(
     std::ceil(static_cast<double>(sampleContainerSize) / static_cast<double>(Self::GetNumberOfWorkUnits())));
 
   const auto pos_begin = std::min<size_t>(nrOfSamplesPerThreads * threadId, sampleContainerSize);
@@ -597,7 +597,7 @@ AdvancedMeanSquaresImageToImageMetric<TFixedImage, TMovingImage>::ThreadedGetVal
       ++numberOfPixelsCounted;
 
       /** Get the fixed image value. */
-      const RealType fixedImageValue = static_cast<RealType>(threader_fiter->m_ImageValue);
+      const auto fixedImageValue = static_cast<RealType>(threader_fiter->m_ImageValue);
 
 #if 0
       /** Get the TransformJacobian dT/dmu. */

--- a/Components/Metrics/AdvancedNormalizedCorrelation/itkAdvancedNormalizedCorrelationImageToImageMetric.hxx
+++ b/Components/Metrics/AdvancedNormalizedCorrelation/itkAdvancedNormalizedCorrelationImageToImageMetric.hxx
@@ -200,7 +200,7 @@ AdvancedNormalizedCorrelationImageToImageMetric<TFixedImage, TMovingImage>::GetV
       Superclass::m_NumberOfPixelsCounted++;
 
       /** Get the fixed image value. */
-      const RealType fixedImageValue = static_cast<double>(fixedImageSample.m_ImageValue);
+      const auto fixedImageValue = static_cast<double>(fixedImageSample.m_ImageValue);
 
       /** Update some sums needed to calculate NC. */
       sff += fixedImageValue * fixedImageValue;
@@ -217,7 +217,7 @@ AdvancedNormalizedCorrelationImageToImageMetric<TFixedImage, TMovingImage>::GetV
   this->CheckNumberOfSamples(sampleContainer->Size(), Superclass::m_NumberOfPixelsCounted);
 
   /** If NumberOfPixelsCounted > 0, then subtract things from sff, smm and sfm. */
-  const RealType N = static_cast<RealType>(Superclass::m_NumberOfPixelsCounted);
+  const auto N = static_cast<RealType>(Superclass::m_NumberOfPixelsCounted);
   if (Superclass::m_NumberOfPixelsCounted > 0)
   {
     sff -= (sf * sf / N);
@@ -375,7 +375,7 @@ AdvancedNormalizedCorrelationImageToImageMetric<TFixedImage, TMovingImage>::GetV
   /** If NumberOfPixelsCounted > 0, then subtract things from sff, smm, sfm,
    * derivativeF and derivativeM.
    */
-  const RealType N = static_cast<RealType>(Superclass::m_NumberOfPixelsCounted);
+  const auto N = static_cast<RealType>(Superclass::m_NumberOfPixelsCounted);
   if (Superclass::m_NumberOfPixelsCounted > 0)
   {
     sff -= (sf * sf / N);
@@ -479,7 +479,7 @@ AdvancedNormalizedCorrelationImageToImageMetric<TFixedImage, TMovingImage>::Thre
   const unsigned long         sampleContainerSize = sampleContainer->Size();
 
   /** Get the samples for this thread. */
-  const unsigned long nrOfSamplesPerThreads = static_cast<unsigned long>(
+  const auto nrOfSamplesPerThreads = static_cast<unsigned long>(
     std::ceil(static_cast<double>(sampleContainerSize) / static_cast<double>(Self::GetNumberOfWorkUnits())));
 
   const auto pos_begin = std::min<size_t>(nrOfSamplesPerThreads * threadId, sampleContainerSize);
@@ -526,7 +526,7 @@ AdvancedNormalizedCorrelationImageToImageMetric<TFixedImage, TMovingImage>::Thre
       ++numberOfPixelsCounted;
 
       /** Get the fixed image value. */
-      const RealType fixedImageValue = static_cast<RealType>(threader_fiter->m_ImageValue);
+      const auto fixedImageValue = static_cast<RealType>(threader_fiter->m_ImageValue);
 
 #if 0
       /** Get the TransformJacobian dT/dmu. */
@@ -615,7 +615,7 @@ AdvancedNormalizedCorrelationImageToImageMetric<TFixedImage, TMovingImage>::Afte
   }
 
   /** Subtract things from sff, smm and sfm. */
-  const RealType N = static_cast<RealType>(Superclass::m_NumberOfPixelsCounted);
+  const auto N = static_cast<RealType>(Superclass::m_NumberOfPixelsCounted);
   sff -= (sf * sf / N);
   smm -= (sm * sm / N);
   sfm -= (sf * sm / N);
@@ -677,7 +677,7 @@ AdvancedNormalizedCorrelationImageToImageMetric<TFixedImage, TMovingImage>::Accu
   const RealType       invertedDenominator = userData.st_InvertedDenominator;
 
   const unsigned int numPar = metric.GetNumberOfParameters();
-  const unsigned int subSize =
+  const auto         subSize =
     static_cast<unsigned int>(std::ceil(static_cast<double>(numPar) / static_cast<double>(nrOfThreads)));
   const unsigned int jmin = threadId * subSize;
   const unsigned int jmax = std::min((threadId + 1) * subSize, numPar);

--- a/Components/Metrics/BendingEnergyPenalty/itkTransformBendingEnergyPenaltyTerm.hxx
+++ b/Components/Metrics/BendingEnergyPenalty/itkTransformBendingEnergyPenaltyTerm.hxx
@@ -402,7 +402,7 @@ TransformBendingEnergyPenaltyTerm<TFixedImage, TScalarType>::ThreadedGetValueAnd
   const unsigned long         sampleContainerSize = sampleContainer->Size();
 
   /** Get the samples for this thread. */
-  const unsigned long nrOfSamplesPerThreads = static_cast<unsigned long>(
+  const auto nrOfSamplesPerThreads = static_cast<unsigned long>(
     std::ceil(static_cast<double>(sampleContainerSize) / static_cast<double>(Self::GetNumberOfWorkUnits())));
 
   const auto pos_begin = std::min<size_t>(nrOfSamplesPerThreads * threadId, sampleContainerSize);

--- a/Components/Metrics/GradientDifference/itkGradientDifferenceImageToImageMetric2.hxx
+++ b/Components/Metrics/GradientDifference/itkGradientDifferenceImageToImageMetric2.hxx
@@ -77,7 +77,7 @@ GradientDifferenceImageToImageMetric<TFixedImage, TMovingImage>::Initialize()
   }
 
   /** Resampling for 3D->2D */
-  RayCastInterpolatorType * rayCaster = dynamic_cast<RayCastInterpolatorType *>(this->GetInterpolator());
+  auto * rayCaster = dynamic_cast<RayCastInterpolatorType *>(this->GetInterpolator());
   if (rayCaster != nullptr)
   {
     this->m_TransformMovingImageFilter->SetTransform(rayCaster->GetTransform());

--- a/Components/Metrics/KNNGraphAlphaMutualInformation/KNN/ann_1.1/src/ANN.cpp
+++ b/Components/Metrics/KNNGraphAlphaMutualInformation/KNN/ann_1.1/src/ANN.cpp
@@ -109,15 +109,15 @@ void annPrintPt(						// print a point
 
 ANNpoint annAllocPt(int dim, ANNcoord c)		// allocate 1 point
 {
-	ANNpoint p = new ANNcoord[dim];
+	auto p = new ANNcoord[dim];
 	for (int i = 0; i < dim; i++) p[i] = c;
 	return p;
 }
    
 ANNpointArray annAllocPts(int n, int dim)		// allocate n pts in dim
 {
-	ANNpointArray pa = new ANNpoint[n];			// allocate points
-	ANNpoint	  p  = new ANNcoord[n*dim];		// allocate space for coords
+	auto pa = new ANNpoint[n];			// allocate points
+	auto	  p  = new ANNcoord[n*dim];		// allocate space for coords
 	for (int i = 0; i < n; i++) {
 		pa[i] = &(p[i*dim]);
 	}
@@ -139,7 +139,7 @@ void annDeallocPts(ANNpointArray &pa)			// deallocate points
    
 ANNpoint annCopyPt(int dim, ANNpoint source)	// copy point
 {
-	ANNpoint p = new ANNcoord[dim];
+	auto p = new ANNcoord[dim];
 	for (int i = 0; i < dim; i++) p[i] = source[i];
 	return p;
 }

--- a/Components/Metrics/KNNGraphAlphaMutualInformation/KNN/ann_1.1/src/kd_dump.cpp
+++ b/Components/Metrics/KNNGraphAlphaMutualInformation/KNN/ann_1.1/src/kd_dump.cpp
@@ -427,7 +427,7 @@ static ANNkd_ptr annReadTree(
 
 		in >> n_bnds;							// number of bounding sides
 												// allocate bounds array
-		ANNorthHSArray bds = new ANNorthHalfSpace[n_bnds];
+		auto bds = new ANNorthHalfSpace[n_bnds];
 		for (int i = 0; i < n_bnds; i++) {
 			in >> cd >> cv >> sd;				// input bounding halfspace
 												// copy to array

--- a/Components/Metrics/KNNGraphAlphaMutualInformation/KNN/ann_1.1/src/kd_tree.cpp
+++ b/Components/Metrics/KNNGraphAlphaMutualInformation/KNN/ann_1.1/src/kd_tree.cpp
@@ -351,7 +351,7 @@ ANNkd_ptr rkd_tree(				// recursive construction of kd-tree
 		bnd_box.lo[cd] = lv;			// restore bounds
 
 										// create the splitting node
-		ANNkd_split *ptr = new ANNkd_split(cd, cv, lv, hv, lo, hi);
+		auto *ptr = new ANNkd_split(cd, cv, lv, hv, lo, hi);
 
 		return ptr;						// return pointer to this node
 	}

--- a/Components/Metrics/KNNGraphAlphaMutualInformation/KNN/itkANNPriorityTreeSearch.hxx
+++ b/Components/Metrics/KNNGraphAlphaMutualInformation/KNN/itkANNPriorityTreeSearch.hxx
@@ -51,7 +51,7 @@ ANNPriorityTreeSearch<TBinaryTree>::SetBinaryTree(BinaryTreeType * tree)
     if (ps)
     {
       // ANNkDTreeType * testPtr = dynamic_cast<ANNkDTreeType *>( this->m_BinaryTreeAsITKANNType->GetANNTree() );
-      ANNkDTreeType * testPtr = dynamic_cast<ANNkDTreeType *>(ps);
+      auto * testPtr = dynamic_cast<ANNkDTreeType *>(ps);
       if (testPtr)
       {
         if (testPtr != this->m_BinaryTreeAskDTree)

--- a/Components/Metrics/KNNGraphAlphaMutualInformation/KNN/itkBinaryANNTreeSearchBase.hxx
+++ b/Components/Metrics/KNNGraphAlphaMutualInformation/KNN/itkBinaryANNTreeSearchBase.hxx
@@ -45,7 +45,7 @@ BinaryANNTreeSearchBase<TBinaryTree>::SetBinaryTree(BinaryTreeType * tree)
   this->Superclass::SetBinaryTree(tree);
   if (tree)
   {
-    BinaryANNTreeType * testPtr = dynamic_cast<BinaryANNTreeType *>(tree);
+    auto * testPtr = dynamic_cast<BinaryANNTreeType *>(tree);
     if (testPtr)
     {
       if (testPtr != this->m_BinaryTreeAsITKANNType)

--- a/Components/Metrics/KNNGraphAlphaMutualInformation/KNN/itkListSampleCArray.hxx
+++ b/Components/Metrics/KNNGraphAlphaMutualInformation/KNN/itkListSampleCArray.hxx
@@ -207,7 +207,7 @@ void
 ListSampleCArray<TMeasurementVector, TInternalValue>::AllocateInternalContainer(unsigned long size, unsigned int dim)
 {
   this->m_InternalContainer = new InternalDataType[size];
-  InternalDataType p = new InternalValueType[size * dim];
+  auto p = new InternalValueType[size * dim];
   for (unsigned long i = 0; i < size; ++i)
   {
     this->m_InternalContainer[i] = &(p[i * dim]);

--- a/Components/Metrics/NormalizedGradientCorrelation/itkNormalizedGradientCorrelationImageToImageMetric.hxx
+++ b/Components/Metrics/NormalizedGradientCorrelation/itkNormalizedGradientCorrelationImageToImageMetric.hxx
@@ -61,7 +61,7 @@ NormalizedGradientCorrelationImageToImageMetric<TFixedImage, TMovingImage>::Init
   this->ComputeMeanFixedGradient();
 
   /** Resampling for 3D->2D */
-  RayCastInterpolatorType * rayCaster = dynamic_cast<RayCastInterpolatorType *>(this->GetInterpolator());
+  auto * rayCaster = dynamic_cast<RayCastInterpolatorType *>(this->GetInterpolator());
   if (rayCaster != nullptr)
   {
     this->m_TransformMovingImageFilter->SetTransform(rayCaster->GetTransform());

--- a/Components/Metrics/PCAMetric/itkPCAMetric.hxx
+++ b/Components/Metrics/PCAMetric/itkPCAMetric.hxx
@@ -650,7 +650,7 @@ PCAMetric<TFixedImage, TMovingImage>::ThreadedGetSamples(ThreadIdType threadId)
   const unsigned long         sampleContainerSize = sampleContainer->Size();
 
   /** Get the samples for this thread. */
-  const unsigned long nrOfSamplesPerThreads = static_cast<unsigned long>(
+  const auto nrOfSamplesPerThreads = static_cast<unsigned long>(
     std::ceil(static_cast<double>(sampleContainerSize) / static_cast<double>(Self::GetNumberOfWorkUnits())));
 
   const auto pos_begin = std::min<size_t>(nrOfSamplesPerThreads * threadId, sampleContainerSize);

--- a/Components/Metrics/PatternIntensity/itkPatternIntensityImageToImageMetric.hxx
+++ b/Components/Metrics/PatternIntensity/itkPatternIntensityImageToImageMetric.hxx
@@ -42,7 +42,7 @@ PatternIntensityImageToImageMetric<TFixedImage, TMovingImage>::Initialize()
   Superclass::Initialize();
 
   /** Resampling for 3D->2D */
-  RayCastInterpolatorType * rayCaster = dynamic_cast<RayCastInterpolatorType *>(this->GetInterpolator());
+  auto * rayCaster = dynamic_cast<RayCastInterpolatorType *>(this->GetInterpolator());
   if (rayCaster != nullptr)
   {
     this->m_TransformMovingImageFilter->SetTransform(rayCaster->GetTransform());

--- a/Components/Metrics/StatisticalShapePenalty/elxStatisticalShapePenalty.hxx
+++ b/Components/Metrics/StatisticalShapePenalty/elxStatisticalShapePenalty.hxx
@@ -81,9 +81,9 @@ StatisticalShapePenalty<TElastix>::BeforeRegistration()
   // pointset.
 
   /** Read meanVector filename. */
-  std::string                meanVectorName = this->GetConfiguration()->GetCommandLineArgument("-mean");
-  std::ifstream              datafile;
-  vnl_vector<double> * const meanVector = new vnl_vector<double>();
+  std::string   meanVectorName = this->GetConfiguration()->GetCommandLineArgument("-mean");
+  std::ifstream datafile;
+  auto * const  meanVector = new vnl_vector<double>();
   datafile.open(meanVectorName);
   if (datafile.is_open())
   {
@@ -123,7 +123,7 @@ StatisticalShapePenalty<TElastix>::BeforeRegistration()
   /** Read covariance matrix filename. */
   std::string covarianceMatrixName = this->GetConfiguration()->GetCommandLineArgument("-covariance");
 
-  vnl_matrix<double> * const covarianceMatrix = new vnl_matrix<double>();
+  auto * const covarianceMatrix = new vnl_matrix<double>();
 
   datafile.open(covarianceMatrixName);
   if (datafile.is_open())
@@ -142,7 +142,7 @@ StatisticalShapePenalty<TElastix>::BeforeRegistration()
   /** Read eigenvector matrix filename. */
   std::string eigenVectorsName = this->GetConfiguration()->GetCommandLineArgument("-evectors");
 
-  vnl_matrix<double> * const eigenVectors = new vnl_matrix<double>();
+  auto * const eigenVectors = new vnl_matrix<double>();
 
   datafile.open(eigenVectorsName);
   if (datafile.is_open())
@@ -160,8 +160,8 @@ StatisticalShapePenalty<TElastix>::BeforeRegistration()
   this->SetEigenVectors(eigenVectors);
 
   /** Read eigenvalue vector filename. */
-  std::string                eigenValuesName = this->GetConfiguration()->GetCommandLineArgument("-evalues");
-  vnl_vector<double> * const eigenValues = new vnl_vector<double>();
+  std::string  eigenValuesName = this->GetConfiguration()->GetCommandLineArgument("-evalues");
+  auto * const eigenValues = new vnl_vector<double>();
   datafile.open(eigenValuesName);
   if (datafile.is_open())
   {

--- a/Components/Metrics/StatisticalShapePenalty/itkStatisticalShapePointPenalty.hxx
+++ b/Components/Metrics/StatisticalShapePenalty/itkStatisticalShapePointPenalty.hxx
@@ -532,8 +532,8 @@ StatisticalShapePointPenalty<TFixedPointSet, TMovingPointSet>::GetValueAndDeriva
   }
   else
   {
-    typename ProposalDerivativeType::iterator proposalDerivativeIt = this->m_ProposalDerivative->begin();
-    typename ProposalDerivativeType::iterator proposalDerivativeEnd = this->m_ProposalDerivative->end();
+    auto proposalDerivativeIt = this->m_ProposalDerivative->begin();
+    auto proposalDerivativeEnd = this->m_ProposalDerivative->end();
     for (; proposalDerivativeIt != proposalDerivativeEnd; ++proposalDerivativeIt)
     {
       if (*proposalDerivativeIt != nullptr)
@@ -665,8 +665,8 @@ void
 StatisticalShapePointPenalty<TFixedPointSet, TMovingPointSet>::UpdateCentroidAndAlignProposalDerivative(
   const unsigned int shapeLength) const
 {
-  typename ProposalDerivativeType::iterator proposalDerivativeIt = m_ProposalDerivative->begin();
-  typename ProposalDerivativeType::iterator proposalDerivativeEnd = m_ProposalDerivative->end();
+  auto proposalDerivativeIt = m_ProposalDerivative->begin();
+  auto proposalDerivativeEnd = m_ProposalDerivative->end();
   while (proposalDerivativeIt != proposalDerivativeEnd)
   {
     if (*proposalDerivativeIt != nullptr)
@@ -748,8 +748,8 @@ StatisticalShapePointPenalty<TFixedPointSet, TMovingPointSet>::UpdateL2AndNormal
 {
   double & l2norm = this->m_ProposalVector[shapeLength + Self::FixedPointSetDimension];
 
-  typename ProposalDerivativeType::iterator proposalDerivativeIt = this->m_ProposalDerivative->begin();
-  typename ProposalDerivativeType::iterator proposalDerivativeEnd = this->m_ProposalDerivative->end();
+  auto proposalDerivativeIt = this->m_ProposalDerivative->begin();
+  auto proposalDerivativeEnd = this->m_ProposalDerivative->end();
 
   while (proposalDerivativeIt != proposalDerivativeEnd)
   {
@@ -864,8 +864,8 @@ StatisticalShapePointPenalty<TFixedPointSet, TMovingPointSet>::CalculateDerivati
   const VnlVectorType & eigrot,
   const unsigned int    shapeLength) const
 {
-  typename ProposalDerivativeType::iterator proposalDerivativeIt = this->m_ProposalDerivative->begin();
-  typename ProposalDerivativeType::iterator proposalDerivativeEnd = this->m_ProposalDerivative->end();
+  auto proposalDerivativeIt = this->m_ProposalDerivative->begin();
+  auto proposalDerivativeEnd = this->m_ProposalDerivative->end();
 
   typename DerivativeType::iterator derivativeIt = derivative.begin();
 

--- a/Components/Metrics/SumSquaredTissueVolumeDifferenceMetric/itkSumSquaredTissueVolumeDifferenceImageToImageMetric.hxx
+++ b/Components/Metrics/SumSquaredTissueVolumeDifferenceMetric/itkSumSquaredTissueVolumeDifferenceImageToImageMetric.hxx
@@ -109,7 +109,7 @@ SumSquaredTissueVolumeDifferenceImageToImageMetric<TFixedImage, TMovingImage>::G
       Superclass::m_AdvancedTransform->GetSpatialJacobian(fixedPoint, spatialJac);
 
       /** Compute the determinant of the Transform Jacobian |dT/dx|. */
-      const RealType detjac = static_cast<RealType>(vnl_det(spatialJac.GetVnlMatrix()));
+      const auto detjac = static_cast<RealType>(vnl_det(spatialJac.GetVnlMatrix()));
 
       /** Get the fixed image value. */
       const auto fixedImageValue = static_cast<RealType>(fixedImageSample.m_ImageValue);
@@ -203,7 +203,7 @@ SumSquaredTissueVolumeDifferenceImageToImageMetric<TFixedImage, TMovingImage>::T
   const unsigned long         sampleContainerSize = sampleContainer->Size();
 
   /** Get the samples for this thread. */
-  const unsigned long nSamplesPerThread = static_cast<unsigned long>(
+  const auto nSamplesPerThread = static_cast<unsigned long>(
     std::ceil(static_cast<double>(sampleContainerSize) / static_cast<double>(Self::GetNumberOfWorkUnits())));
 
   const auto pos_begin = std::min<size_t>(nSamplesPerThread * threadId, sampleContainerSize);
@@ -240,13 +240,13 @@ SumSquaredTissueVolumeDifferenceImageToImageMetric<TFixedImage, TMovingImage>::T
       ++numberOfPixelsCounted;
 
       /** Get the fixed image value. */
-      const RealType fixedImageValue = static_cast<RealType>(threader_fiter->m_ImageValue);
+      const auto fixedImageValue = static_cast<RealType>(threader_fiter->m_ImageValue);
 
       /** Get the SpatialJacobian dT/dx. */
       Superclass::m_AdvancedTransform->GetSpatialJacobian(fixedPoint, spatialJac);
 
       /** Compute the determinant of the Transform Jacobian |dT/dx|. */
-      const RealType detjac = static_cast<RealType>(vnl_det(spatialJac.GetVnlMatrix()));
+      const auto detjac = static_cast<RealType>(vnl_det(spatialJac.GetVnlMatrix()));
 
       /** The difference squared. */
       const RealType diff = ((fixedImageValue - this->m_AirValue) - detjac * (movingImageValue - this->m_AirValue)) /
@@ -402,7 +402,7 @@ SumSquaredTissueVolumeDifferenceImageToImageMetric<TFixedImage, TMovingImage>::G
       Superclass::m_AdvancedTransform->GetSpatialJacobian(fixedPoint, spatialJac);
 
       /** Compute the determinant of the Transform Jacobian |dT/dx|. */
-      const RealType detjac = static_cast<RealType>(vnl_det(spatialJac.GetVnlMatrix()));
+      const auto detjac = static_cast<RealType>(vnl_det(spatialJac.GetVnlMatrix()));
 
       /** Compute the inverse spatialJacobian. */
       inverseSpatialJacobian = spatialJac.GetInverse();
@@ -511,7 +511,7 @@ SumSquaredTissueVolumeDifferenceImageToImageMetric<TFixedImage, TMovingImage>::T
   const unsigned long         sampleContainerSize = sampleContainer->Size();
 
   /** Get the samples for this thread. */
-  const unsigned long nSamplesPerThread = static_cast<unsigned long>(
+  const auto nSamplesPerThread = static_cast<unsigned long>(
     std::ceil(static_cast<double>(sampleContainerSize) / static_cast<double>(Self::GetNumberOfWorkUnits())));
 
   const auto pos_begin = std::min<size_t>(nSamplesPerThread * threadId, sampleContainerSize);
@@ -550,7 +550,7 @@ SumSquaredTissueVolumeDifferenceImageToImageMetric<TFixedImage, TMovingImage>::T
       ++numberOfPixelsCounted;
 
       /** Get the fixed image value. */
-      const RealType fixedImageValue = static_cast<RealType>(threader_fiter->m_ImageValue);
+      const auto fixedImageValue = static_cast<RealType>(threader_fiter->m_ImageValue);
 
       /** Get the TransformJacobian dT/dmu. */
       this->EvaluateTransformJacobian(fixedPoint, jacobian, nzji);
@@ -562,7 +562,7 @@ SumSquaredTissueVolumeDifferenceImageToImageMetric<TFixedImage, TMovingImage>::T
       Superclass::m_AdvancedTransform->GetSpatialJacobian(fixedPoint, spatialJac);
 
       /** Compute the determinant of the Transform Jacobian |dT/dx|. */
-      const RealType detjac = static_cast<RealType>(vnl_det(spatialJac.GetVnlMatrix()));
+      const auto detjac = static_cast<RealType>(vnl_det(spatialJac.GetVnlMatrix()));
 
       /** Compute the inverse spatialJacobian. */
       inverseSpatialJacobian = spatialJac.GetInverse();
@@ -746,8 +746,8 @@ SumSquaredTissueVolumeDifferenceImageToImageMetric<TFixedImage, TMovingImage>::
 
   jacobianOfSpatialJacobianDeterminant.Fill(0.0);
 
-  JacobianOfSpatialJacobianIteratorType jsjit = jacobianOfSpatialJacobian.begin();
-  DerivativeIteratorType                jsjdit = jacobianOfSpatialJacobianDeterminant.begin();
+  auto                   jsjit = jacobianOfSpatialJacobian.begin();
+  DerivativeIteratorType jsjdit = jacobianOfSpatialJacobianDeterminant.begin();
 
   const unsigned int sizejacobianOfSpatialJacobianDeterminant = jacobianOfSpatialJacobianDeterminant.GetSize();
 

--- a/Components/MovingImagePyramids/OpenCLMovingGenericPyramid/elxOpenCLMovingGenericPyramid.hxx
+++ b/Components/MovingImagePyramids/OpenCLMovingGenericPyramid/elxOpenCLMovingGenericPyramid.hxx
@@ -275,8 +275,7 @@ template <class TElastix>
 void
 OpenCLMovingGenericPyramid<TElastix>::UnregisterFactories()
 {
-  for (std::vector<ObjectFactoryBasePointer>::iterator it = this->m_Factories.begin(); it != this->m_Factories.end();
-       ++it)
+  for (auto it = this->m_Factories.begin(); it != this->m_Factories.end(); ++it)
   {
     itk::ObjectFactoryBase::UnRegisterFactory(*it);
   }

--- a/Components/Optimizers/AdaGrad/elxAdaGrad.hxx
+++ b/Components/Optimizers/AdaGrad/elxAdaGrad.hxx
@@ -105,7 +105,7 @@ void
 AdaGrad<TElastix>::BeforeEachResolution()
 {
   /** Get the current resolution level. */
-  unsigned int level = static_cast<unsigned int>(this->m_Registration->GetAsITKBaseType()->GetCurrentLevel());
+  auto level = static_cast<unsigned int>(this->m_Registration->GetAsITKBaseType()->GetCurrentLevel());
 
   const unsigned int P = this->GetElastix()->GetElxTransformBase()->GetAsITKBaseType()->GetNumberOfParameters();
 
@@ -316,7 +316,7 @@ void
 AdaGrad<TElastix>::AfterEachResolution()
 {
   /** Get the current resolution level. */
-  unsigned int level = static_cast<unsigned int>(this->m_Registration->GetAsITKBaseType()->GetCurrentLevel());
+  auto level = static_cast<unsigned int>(this->m_Registration->GetAsITKBaseType()->GetCurrentLevel());
 
   /**
    * enum StopConditionType {
@@ -514,7 +514,7 @@ AdaGrad<TElastix>::AutomaticPreconditionerEstimation()
   this->GetRegistration()->GetAsITKBaseType()->GetModifiableTransform()->SetParameters(this->GetCurrentPosition());
 
   /** Get the number of parameters. */
-  unsigned int P =
+  auto P =
     static_cast<unsigned int>(this->GetRegistration()->GetAsITKBaseType()->GetTransform()->GetNumberOfParameters());
 
   this->m_SearchDirection = ParametersType(P);
@@ -522,7 +522,7 @@ AdaGrad<TElastix>::AutomaticPreconditionerEstimation()
 
   /** Cast to advanced metric type. */
   using MetricType = typename ElastixType::MetricBaseType::AdvancedMetricType;
-  MetricType * testPtr = dynamic_cast<MetricType *>(this->GetElastix()->GetElxMetricBase()->GetAsITKBaseType());
+  auto * testPtr = dynamic_cast<MetricType *>(this->GetElastix()->GetElxMetricBase()->GetAsITKBaseType());
   if (!testPtr)
   {
     itkExceptionMacro("ERROR: VoxelWiseASGD expects the metric to be of type AdvancedImageToImageMetric!");

--- a/Components/Optimizers/AdaptiveStochasticGradientDescent/elxAdaptiveStochasticGradientDescent.hxx
+++ b/Components/Optimizers/AdaptiveStochasticGradientDescent/elxAdaptiveStochasticGradientDescent.hxx
@@ -97,7 +97,7 @@ void
 AdaptiveStochasticGradientDescent<TElastix>::BeforeEachResolution()
 {
   /** Get the current resolution level. */
-  unsigned int level = static_cast<unsigned int>(this->m_Registration->GetAsITKBaseType()->GetCurrentLevel());
+  auto level = static_cast<unsigned int>(this->m_Registration->GetAsITKBaseType()->GetCurrentLevel());
 
   const unsigned int numberOfParameters =
     this->GetElastix()->GetElxTransformBase()->GetAsITKBaseType()->GetNumberOfParameters();
@@ -296,7 +296,7 @@ void
 AdaptiveStochasticGradientDescent<TElastix>::AfterEachResolution()
 {
   /** Get the current resolution level. */
-  unsigned int level = static_cast<unsigned int>(this->m_Registration->GetAsITKBaseType()->GetCurrentLevel());
+  auto level = static_cast<unsigned int>(this->m_Registration->GetAsITKBaseType()->GetCurrentLevel());
 
   /**
    * enum StopConditionType {
@@ -523,7 +523,7 @@ AdaptiveStochasticGradientDescent<TElastix>::AutomaticParameterEstimationOrigina
 
   /** Cast to advanced metric type. */
   using MetricType = typename ElastixType::MetricBaseType::AdvancedMetricType;
-  MetricType * testPtr = dynamic_cast<MetricType *>(this->GetElastix()->GetElxMetricBase()->GetAsITKBaseType());
+  auto * testPtr = dynamic_cast<MetricType *>(this->GetElastix()->GetElxMetricBase()->GetAsITKBaseType());
   if (!testPtr)
   {
     itkExceptionMacro(
@@ -663,7 +663,7 @@ AdaptiveStochasticGradientDescent<TElastix>::AutomaticParameterEstimationUsingDi
 
   /** Cast to advanced metric type. */
   using MetricType = typename ElastixType::MetricBaseType::AdvancedMetricType;
-  MetricType * testPtr = dynamic_cast<MetricType *>(this->GetElastix()->GetElxMetricBase()->GetAsITKBaseType());
+  auto * testPtr = dynamic_cast<MetricType *>(this->GetElastix()->GetElxMetricBase()->GetAsITKBaseType());
   if (!testPtr)
   {
     itkExceptionMacro(

--- a/Components/Optimizers/AdaptiveStochasticLBFGS/elxAdaptiveStochasticLBFGS.hxx
+++ b/Components/Optimizers/AdaptiveStochasticLBFGS/elxAdaptiveStochasticLBFGS.hxx
@@ -122,7 +122,7 @@ void
 AdaptiveStochasticLBFGS<TElastix>::BeforeEachResolution()
 {
   /** Get the current resolution level. */
-  unsigned int level = static_cast<unsigned int>(this->m_Registration->GetAsITKBaseType()->GetCurrentLevel());
+  auto level = static_cast<unsigned int>(this->m_Registration->GetAsITKBaseType()->GetCurrentLevel());
 
   const unsigned int P = this->GetElastix()->GetElxTransformBase()->GetAsITKBaseType()->GetNumberOfParameters();
 
@@ -367,7 +367,7 @@ void
 AdaptiveStochasticLBFGS<TElastix>::AfterEachResolution()
 {
   /** Get the current resolution level. */
-  unsigned int level = static_cast<unsigned int>(this->m_Registration->GetAsITKBaseType()->GetCurrentLevel());
+  auto level = static_cast<unsigned int>(this->m_Registration->GetAsITKBaseType()->GetCurrentLevel());
 
   /**
    * enum StopConditionType {
@@ -716,7 +716,7 @@ AdaptiveStochasticLBFGS<TElastix>::ResumeOptimization()
         // this->m_SearchLengthScale = this->m_SearchDir.magnitude();
 
         /** Get the current resolution level. */
-        unsigned int level = static_cast<unsigned int>(this->m_Registration->GetAsITKBaseType()->GetCurrentLevel());
+        auto level = static_cast<unsigned int>(this->m_Registration->GetAsITKBaseType()->GetCurrentLevel());
 
         /** Set whether the Search Direction used for adaptive step size mechanism is desired. Default: false */
         bool useSearchDirForAdaptiveStepSize = false;
@@ -923,7 +923,7 @@ AdaptiveStochasticLBFGS<TElastix>::AutomaticParameterEstimationOriginal()
 
   /** Cast to advanced metric type. */
   using MetricType = typename ElastixType::MetricBaseType::AdvancedMetricType;
-  MetricType * testPtr = dynamic_cast<MetricType *>(this->GetElastix()->GetElxMetricBase()->GetAsITKBaseType());
+  auto * testPtr = dynamic_cast<MetricType *>(this->GetElastix()->GetElxMetricBase()->GetAsITKBaseType());
   if (!testPtr)
   {
     itkExceptionMacro("ERROR: AdaptiveStochasticLBFGS expects the metric to be of type AdvancedImageToImageMetric!");
@@ -1062,7 +1062,7 @@ AdaptiveStochasticLBFGS<TElastix>::AutomaticParameterEstimationUsingDisplacement
 
   /** Cast to advanced metric type. */
   using MetricType = typename ElastixType::MetricBaseType::AdvancedMetricType;
-  MetricType * testPtr = dynamic_cast<MetricType *>(this->GetElastix()->GetElxMetricBase()->GetAsITKBaseType());
+  auto * testPtr = dynamic_cast<MetricType *>(this->GetElastix()->GetElxMetricBase()->GetAsITKBaseType());
   if (!testPtr)
   {
     itkExceptionMacro("ERROR: AdaptiveStochasticLBFGS expects the metric to be of type AdvancedImageToImageMetric!");
@@ -1174,7 +1174,7 @@ AdaptiveStochasticLBFGS<TElastix>::AutomaticLBFGSStepsizeEstimation()
 
   /** Cast to advanced metric type. */
   using MetricType = typename ElastixType::MetricBaseType::AdvancedMetricType;
-  MetricType * testPtr = dynamic_cast<MetricType *>(this->GetElastix()->GetElxMetricBase()->GetAsITKBaseType());
+  auto * testPtr = dynamic_cast<MetricType *>(this->GetElastix()->GetElxMetricBase()->GetAsITKBaseType());
   if (!testPtr)
   {
     itkExceptionMacro("ERROR: AdaptiveStochasticLBFGS expects the metric to be of type AdvancedImageToImageMetric!");

--- a/Components/Optimizers/AdaptiveStochasticVarianceReducedGradient/elxAdaptiveStochasticVarianceReducedGradient.hxx
+++ b/Components/Optimizers/AdaptiveStochasticVarianceReducedGradient/elxAdaptiveStochasticVarianceReducedGradient.hxx
@@ -114,7 +114,7 @@ void
 AdaptiveStochasticVarianceReducedGradient<TElastix>::BeforeEachResolution()
 {
   /** Get the current resolution level. */
-  unsigned int level = static_cast<unsigned int>(this->m_Registration->GetAsITKBaseType()->GetCurrentLevel());
+  auto level = static_cast<unsigned int>(this->m_Registration->GetAsITKBaseType()->GetCurrentLevel());
 
   const unsigned int P = this->GetElastix()->GetElxTransformBase()->GetAsITKBaseType()->GetNumberOfParameters();
 
@@ -319,7 +319,7 @@ void
 AdaptiveStochasticVarianceReducedGradient<TElastix>::AfterEachResolution()
 {
   /** Get the current resolution level. */
-  unsigned int level = static_cast<unsigned int>(this->m_Registration->GetAsITKBaseType()->GetCurrentLevel());
+  auto level = static_cast<unsigned int>(this->m_Registration->GetAsITKBaseType()->GetCurrentLevel());
 
   /**
    * enum StopConditionType{
@@ -779,7 +779,7 @@ AdaptiveStochasticVarianceReducedGradient<TElastix>::AutomaticParameterEstimatio
 
   /** Cast to advanced metric type. */
   using MetricType = typename ElastixType::MetricBaseType::AdvancedMetricType;
-  MetricType * testPtr = dynamic_cast<MetricType *>(this->GetElastix()->GetElxMetricBase()->GetAsITKBaseType());
+  auto * testPtr = dynamic_cast<MetricType *>(this->GetElastix()->GetElxMetricBase()->GetAsITKBaseType());
   if (!testPtr)
   {
     itkExceptionMacro("ERROR: AdaptiveStochasticVarianceReducedGradient expects the metric to be of type "
@@ -919,7 +919,7 @@ AdaptiveStochasticVarianceReducedGradient<TElastix>::AutomaticParameterEstimatio
 
   /** Cast to advanced metric type. */
   using MetricType = typename ElastixType::MetricBaseType::AdvancedMetricType;
-  MetricType * testPtr = dynamic_cast<MetricType *>(this->GetElastix()->GetElxMetricBase()->GetAsITKBaseType());
+  auto * testPtr = dynamic_cast<MetricType *>(this->GetElastix()->GetElxMetricBase()->GetAsITKBaseType());
   if (!testPtr)
   {
     itkExceptionMacro("ERROR: AdaptiveStochasticVarianceReducedGradient expects the metric to be of type "

--- a/Components/Optimizers/AdaptiveStochasticVarianceReducedGradient/itkStochasticVarianceReducedGradientDescentOptimizer.cxx
+++ b/Components/Optimizers/AdaptiveStochasticVarianceReducedGradient/itkStochasticVarianceReducedGradientDescentOptimizer.cxx
@@ -248,7 +248,7 @@ StochasticVarianceReducedGradientDescentOptimizer::ThreadedAdvanceOneStep(Thread
 {
   /** Compute the range for this thread. */
   const unsigned int spaceDimension = this->GetScaledCostFunction()->GetNumberOfParameters();
-  const unsigned int subSize = static_cast<unsigned int>(
+  const auto         subSize = static_cast<unsigned int>(
     std::ceil(static_cast<double>(spaceDimension) / static_cast<double>(this->m_Threader->GetNumberOfWorkUnits())));
   const unsigned int jmin = threadId * subSize;
   const unsigned int jmax = std::min((threadId + 1) * subSize, spaceDimension);

--- a/Components/Optimizers/CMAEvolutionStrategy/elxCMAEvolutionStrategy.hxx
+++ b/Components/Optimizers/CMAEvolutionStrategy/elxCMAEvolutionStrategy.hxx
@@ -111,7 +111,7 @@ void
 CMAEvolutionStrategy<TElastix>::BeforeEachResolution()
 {
   /** Get the current resolution level.*/
-  unsigned int level = static_cast<unsigned int>(this->m_Registration->GetAsITKBaseType()->GetCurrentLevel());
+  auto level = static_cast<unsigned int>(this->m_Registration->GetAsITKBaseType()->GetCurrentLevel());
 
   /** Set MaximumNumberOfIterations.*/
   unsigned int maximumNumberOfIterations = 500;

--- a/Components/Optimizers/CMAEvolutionStrategy/itkCMAEvolutionStrategyOptimizer.cxx
+++ b/Components/Optimizers/CMAEvolutionStrategy/itkCMAEvolutionStrategyOptimizer.cxx
@@ -262,11 +262,11 @@ CMAEvolutionStrategyOptimizer::InitializeConstants()
 
   /** Some casts/aliases: */
   const unsigned int N = numberOfParameters;
-  const double       Nd = static_cast<double>(N);
+  const auto         Nd = static_cast<double>(N);
   const unsigned int lambda = this->m_PopulationSize;
-  const double       lambdad = static_cast<double>(lambda);
+  const auto         lambdad = static_cast<double>(lambda);
   const unsigned int mu = this->m_NumberOfParents;
-  const double       mud = static_cast<double>(mu);
+  const auto         mud = static_cast<double>(mu);
 
   /** m_RecombinationWeights */
   this->m_RecombinationWeights.SetSize(mu);
@@ -628,7 +628,7 @@ CMAEvolutionStrategyOptimizer::UpdateHeaviside()
 
   /** Some casts/aliases: */
   const unsigned int N = numberOfParameters;
-  const double       Nd = static_cast<double>(N);
+  const auto         Nd = static_cast<double>(N);
   const double       c_sigma = this->m_ConjugateEvolutionPathConstant;
   const int          nextit = static_cast<int>(this->GetCurrentIteration() + 1);
   const double       chiN = this->m_ExpectationNormNormalDistribution;
@@ -748,7 +748,7 @@ CMAEvolutionStrategyOptimizer::UpdateSigma()
 
   if (this->GetUseDecayingSigma())
   {
-    const double it = static_cast<double>(this->GetCurrentIteration());
+    const auto   it = static_cast<double>(this->GetCurrentIteration());
     const double num = std::pow(this->m_SigmaDecayA + it, this->m_SigmaDecayAlpha);
     const double den = std::pow(this->m_SigmaDecayA + it + 1.0, this->m_SigmaDecayAlpha);
     this->m_CurrentSigma *= num / den;
@@ -979,8 +979,8 @@ CMAEvolutionStrategyOptimizer::FixNumericalErrors()
    * matlabcode: if all( xmean == xmean + 0.1*sigma*B*D(:,i) )
    * B*D(:,i) = i'th column of B times eigenvalue = i'th eigenvector * eigenvalue[i]
    * In the code below: colnr=i-1 (zero-based indexing). */
-  bool               numericalProblemsEncountered2 = false;
-  const unsigned int colnr = static_cast<unsigned int>(nextit % N);
+  bool       numericalProblemsEncountered2 = false;
+  const auto colnr = static_cast<unsigned int>(nextit % N);
   if (this->GetUseCovarianceMatrixAdaptation())
   {
     const double sigDcol = 0.1 * this->m_CurrentSigma * this->m_D[colnr];
@@ -1013,7 +1013,7 @@ CMAEvolutionStrategyOptimizer::FixNumericalErrors()
   /** The indices of the two population members whose cost function will
    * be compared */
   const unsigned int populationMemberA = 0;
-  const unsigned int populationMemberB =
+  const auto         populationMemberB =
     static_cast<unsigned int>(std::ceil(0.1 + static_cast<double>(this->m_PopulationSize) / 4.0));
   /** If they are the same: increase sigma with a magic factor */
   if (this->m_CostFunctionValues[populationMemberA].first == this->m_CostFunctionValues[populationMemberB].first)

--- a/Components/Optimizers/ConjugateGradient/elxConjugateGradient.hxx
+++ b/Components/Optimizers/ConjugateGradient/elxConjugateGradient.hxx
@@ -217,7 +217,7 @@ void
 ConjugateGradient<TElastix>::BeforeEachResolution()
 {
   /** Get the current resolution level.*/
-  unsigned int level = static_cast<unsigned int>(this->m_Registration->GetAsITKBaseType()->GetCurrentLevel());
+  auto level = static_cast<unsigned int>(this->m_Registration->GetAsITKBaseType()->GetCurrentLevel());
 
   /** Set the maximumNumberOfIterations.*/
   unsigned int maximumNumberOfIterations = 100;
@@ -511,8 +511,7 @@ ConjugateGradient<TElastix>::GetLineSearchStopCondition() const
 
   std::string stopcondition;
 
-  LineSearchStopConditionType lineSearchStopCondition =
-    static_cast<LineSearchStopConditionType>(this->m_LineOptimizer->GetStopCondition());
+  auto lineSearchStopCondition = static_cast<LineSearchStopConditionType>(this->m_LineOptimizer->GetStopCondition());
 
   switch (lineSearchStopCondition)
   {

--- a/Components/Optimizers/ConjugateGradientFRPR/elxConjugateGradientFRPR.hxx
+++ b/Components/Optimizers/ConjugateGradientFRPR/elxConjugateGradientFRPR.hxx
@@ -108,7 +108,7 @@ void
 ConjugateGradientFRPR<TElastix>::BeforeEachResolution()
 {
   /** Get the current resolution level.*/
-  unsigned int level = static_cast<unsigned int>(this->m_Registration->GetAsITKBaseType()->GetCurrentLevel());
+  auto level = static_cast<unsigned int>(this->m_Registration->GetAsITKBaseType()->GetCurrentLevel());
 
   /** Set the maximumNumberOfIterations.*/
   unsigned int maximumNumberOfIterations = 100;

--- a/Components/Optimizers/FiniteDifferenceGradientDescent/elxFiniteDifferenceGradientDescent.hxx
+++ b/Components/Optimizers/FiniteDifferenceGradientDescent/elxFiniteDifferenceGradientDescent.hxx
@@ -84,7 +84,7 @@ void
 FiniteDifferenceGradientDescent<TElastix>::BeforeEachResolution()
 {
   /** Get the current resolution level.*/
-  unsigned int level = static_cast<unsigned int>(this->m_Registration->GetAsITKBaseType()->GetCurrentLevel());
+  auto level = static_cast<unsigned int>(this->m_Registration->GetAsITKBaseType()->GetCurrentLevel());
 
   const Configuration & configuration = itk::Deref(Superclass2::GetConfiguration());
 

--- a/Components/Optimizers/FullSearch/elxFullSearchOptimizer.hxx
+++ b/Components/Optimizers/FullSearch/elxFullSearchOptimizer.hxx
@@ -66,7 +66,7 @@ void
 FullSearch<TElastix>::BeforeEachResolution()
 {
   /** Get the current resolution level.*/
-  unsigned int level = static_cast<unsigned int>(this->m_Registration->GetAsITKBaseType()->GetCurrentLevel());
+  auto level = static_cast<unsigned int>(this->m_Registration->GetAsITKBaseType()->GetCurrentLevel());
 
   const Configuration & configuration = itk::Deref(Superclass2::GetConfiguration());
 
@@ -199,7 +199,7 @@ FullSearch<TElastix>::AfterEachIteration()
 
   SearchSpacePointType currentPoint = this->GetCurrentPointInSearchSpace();
   unsigned int         nrOfSSDims = currentPoint.GetSize();
-  NameIteratorType     name_it = this->m_SearchSpaceDimensionNames.begin();
+  auto                 name_it = this->m_SearchSpaceDimensionNames.begin();
 
   for (unsigned int dim = 0; dim < nrOfSSDims; ++dim)
   {
@@ -288,7 +288,7 @@ FullSearch<TElastix>::AfterEachResolution()
   log::info(outputStringStream.str());
 
   /** Remove the columns from IterationInfo. */
-  NameIteratorType name_it = this->m_SearchSpaceDimensionNames.begin();
+  auto name_it = this->m_SearchSpaceDimensionNames.begin();
   for (unsigned int dim = 0; dim < nrOfSSDims; ++dim)
   {
     this->RemoveTargetCellFromIterationInfo(name_it->second.c_str());

--- a/Components/Optimizers/FullSearch/itkFullSearchOptimizer.cxx
+++ b/Components/Optimizers/FullSearch/itkFullSearchOptimizer.cxx
@@ -173,7 +173,7 @@ FullSearchOptimizer::UpdateCurrentPosition()
   itkDebugMacro("Current position updated.");
 
   /** Get the current parameters; const_cast, because we want to adapt it later. */
-  ParametersType & currentPosition = const_cast<ParametersType &>(this->GetCurrentPosition());
+  auto & currentPosition = const_cast<ParametersType &>(this->GetCurrentPosition());
 
   /** Get the dimension and sizes of the searchspace. */
   const unsigned int          searchSpaceDimension = this->GetNumberOfSearchSpaceDimensions();

--- a/Components/Optimizers/Powell/elxPowell.hxx
+++ b/Components/Optimizers/Powell/elxPowell.hxx
@@ -57,7 +57,7 @@ void
 Powell<TElastix>::BeforeEachResolution()
 {
   /** Get the current resolution level.*/
-  unsigned int level = static_cast<unsigned int>(this->m_Registration->GetAsITKBaseType()->GetCurrentLevel());
+  auto level = static_cast<unsigned int>(this->m_Registration->GetAsITKBaseType()->GetCurrentLevel());
 
   /** Set the value tolerance.*/
   double valueTolerance = 1e-8;

--- a/Components/Optimizers/PreconditionedStochasticGradientDescent/elxPreconditionedStochasticGradientDescent.hxx
+++ b/Components/Optimizers/PreconditionedStochasticGradientDescent/elxPreconditionedStochasticGradientDescent.hxx
@@ -105,7 +105,7 @@ void
 PreconditionedStochasticGradientDescent<TElastix>::BeforeEachResolution()
 {
   /** Get the current resolution level. */
-  unsigned int level = static_cast<unsigned int>(this->m_Registration->GetAsITKBaseType()->GetCurrentLevel());
+  auto level = static_cast<unsigned int>(this->m_Registration->GetAsITKBaseType()->GetCurrentLevel());
 
   const unsigned int numberOfParameters =
     this->GetElastix()->GetElxTransformBase()->GetAsITKBaseType()->GetNumberOfParameters();
@@ -321,7 +321,7 @@ void
 PreconditionedStochasticGradientDescent<TElastix>::AfterEachResolution()
 {
   /** Get the current resolution level. */
-  unsigned int level = static_cast<unsigned int>(this->m_Registration->GetAsITKBaseType()->GetCurrentLevel());
+  auto level = static_cast<unsigned int>(this->m_Registration->GetAsITKBaseType()->GetCurrentLevel());
 
   /**
    * enum StopConditionType {
@@ -516,17 +516,17 @@ PreconditionedStochasticGradientDescent<TElastix>::AutomaticPreconditionerEstima
   this->GetRegistration()->GetAsITKBaseType()->GetModifiableTransform()->SetParameters(this->GetCurrentPosition());
 
   /** Get the number of parameters. */
-  unsigned int numberOfParameters =
+  auto numberOfParameters =
     static_cast<unsigned int>(this->GetRegistration()->GetAsITKBaseType()->GetTransform()->GetNumberOfParameters());
 
   this->m_SearchDirection = ParametersType(numberOfParameters);
   this->m_SearchDirection.Fill(0.0); // if the print out is not needed, this could be removed. YQ
   /** Get the current resolution level. */
-  unsigned int level = static_cast<unsigned int>(this->m_Registration->GetAsITKBaseType()->GetCurrentLevel());
+  auto level = static_cast<unsigned int>(this->m_Registration->GetAsITKBaseType()->GetCurrentLevel());
 
   /** Cast to advanced metric type. */
   using MetricType = typename ElastixType::MetricBaseType::AdvancedMetricType;
-  MetricType * testPtr = dynamic_cast<MetricType *>(this->GetElastix()->GetElxMetricBase()->GetAsITKBaseType());
+  auto * testPtr = dynamic_cast<MetricType *>(this->GetElastix()->GetElxMetricBase()->GetAsITKBaseType());
   if (!testPtr)
   {
     itkExceptionMacro(

--- a/Components/Optimizers/QuasiNewtonLBFGS/elxQuasiNewtonLBFGS.hxx
+++ b/Components/Optimizers/QuasiNewtonLBFGS/elxQuasiNewtonLBFGS.hxx
@@ -217,7 +217,7 @@ void
 QuasiNewtonLBFGS<TElastix>::BeforeEachResolution()
 {
   /** Get the current resolution level.*/
-  unsigned int level = static_cast<unsigned int>(this->m_Registration->GetAsITKBaseType()->GetCurrentLevel());
+  auto level = static_cast<unsigned int>(this->m_Registration->GetAsITKBaseType()->GetCurrentLevel());
 
   /** Set the maximumNumberOfIterations.*/
   unsigned int maximumNumberOfIterations = 100;
@@ -499,8 +499,7 @@ QuasiNewtonLBFGS<TElastix>::GetLineSearchStopCondition() const
 
   std::string stopcondition;
 
-  LineSearchStopConditionType lineSearchStopCondition =
-    static_cast<LineSearchStopConditionType>(this->m_LineOptimizer->GetStopCondition());
+  auto lineSearchStopCondition = static_cast<LineSearchStopConditionType>(this->m_LineOptimizer->GetStopCondition());
 
   switch (lineSearchStopCondition)
   {

--- a/Components/Optimizers/RSGDEachParameterApart/elxRSGDEachParameterApart.hxx
+++ b/Components/Optimizers/RSGDEachParameterApart/elxRSGDEachParameterApart.hxx
@@ -57,7 +57,7 @@ void
 RSGDEachParameterApart<TElastix>::BeforeEachResolution()
 {
   /** Get the current resolution level.*/
-  unsigned int level = static_cast<unsigned int>(this->m_Registration->GetAsITKBaseType()->GetCurrentLevel());
+  auto level = static_cast<unsigned int>(this->m_Registration->GetAsITKBaseType()->GetCurrentLevel());
 
   /** Set the Gradient Magnitude Stopping Criterion.*/
   double minGradientMagnitude = 1e-8;

--- a/Components/Optimizers/RegularStepGradientDescent/elxRegularStepGradientDescent.hxx
+++ b/Components/Optimizers/RegularStepGradientDescent/elxRegularStepGradientDescent.hxx
@@ -57,7 +57,7 @@ void
 RegularStepGradientDescent<TElastix>::BeforeEachResolution()
 {
   /** Get the current resolution level.*/
-  unsigned int level = static_cast<unsigned int>(this->m_Registration->GetAsITKBaseType()->GetCurrentLevel());
+  auto level = static_cast<unsigned int>(this->m_Registration->GetAsITKBaseType()->GetCurrentLevel());
 
   /** Set the Gradient Magnitude Stopping Criterion.*/
   double minGradientMagnitude = 1e-8;

--- a/Components/Optimizers/Simplex/elxSimplex.hxx
+++ b/Components/Optimizers/Simplex/elxSimplex.hxx
@@ -57,7 +57,7 @@ void
 Simplex<TElastix>::BeforeEachResolution()
 {
   /** Get the current resolution level.*/
-  unsigned int level = static_cast<unsigned int>(this->m_Registration->GetAsITKBaseType()->GetCurrentLevel());
+  auto level = static_cast<unsigned int>(this->m_Registration->GetAsITKBaseType()->GetCurrentLevel());
 
   /** Set the value tolerance.*/
   double valueTolerance = 1e-8;

--- a/Components/Optimizers/SimultaneousPerturbation/elxSimultaneousPerturbation.hxx
+++ b/Components/Optimizers/SimultaneousPerturbation/elxSimultaneousPerturbation.hxx
@@ -82,7 +82,7 @@ void
 SimultaneousPerturbation<TElastix>::BeforeEachResolution()
 {
   /** Get the current resolution level.*/
-  unsigned int level = static_cast<unsigned int>(this->m_Registration->GetAsITKBaseType()->GetCurrentLevel());
+  auto level = static_cast<unsigned int>(this->m_Registration->GetAsITKBaseType()->GetCurrentLevel());
 
   const Configuration & configuration = itk::Deref(Superclass2::GetConfiguration());
 

--- a/Components/Optimizers/StandardGradientDescent/elxStandardGradientDescent.hxx
+++ b/Components/Optimizers/StandardGradientDescent/elxStandardGradientDescent.hxx
@@ -70,7 +70,7 @@ void
 StandardGradientDescent<TElastix>::BeforeEachResolution()
 {
   /** Get the current resolution level. */
-  unsigned int level = static_cast<unsigned int>(this->m_Registration->GetAsITKBaseType()->GetCurrentLevel());
+  auto level = static_cast<unsigned int>(this->m_Registration->GetAsITKBaseType()->GetCurrentLevel());
 
   const Configuration & configuration = itk::Deref(Superclass2::GetConfiguration());
 

--- a/Components/Optimizers/StandardStochasticGradientDescent/itkStochasticGradientDescentOptimizer.cxx
+++ b/Components/Optimizers/StandardStochasticGradientDescent/itkStochasticGradientDescentOptimizer.cxx
@@ -246,7 +246,7 @@ StochasticGradientDescentOptimizer::ThreadedAdvanceOneStep(ThreadIdType threadId
 {
   /** Compute the range for this thread. */
   const unsigned int spaceDimension = this->GetScaledCostFunction()->GetNumberOfParameters();
-  const unsigned int subSize = static_cast<unsigned int>(
+  const auto         subSize = static_cast<unsigned int>(
     std::ceil(static_cast<double>(spaceDimension) / static_cast<double>(this->m_Threader->GetNumberOfWorkUnits())));
   const unsigned int jmin = threadId * subSize;
   const unsigned int jmax = std::min((threadId + 1) * subSize, spaceDimension);

--- a/Components/Registrations/MultiMetricMultiResolutionRegistration/itkCombinationImageToImageMetric.hxx
+++ b/Components/Registrations/MultiMetricMultiResolutionRegistration/itkCombinationImageToImageMetric.hxx
@@ -189,7 +189,7 @@ CombinationImageToImageMetric<TFixedImage, TMovingImage>::SetFixedImageRegion(co
   {
     this->Superclass::SetFixedImageRegion(_arg);
   }
-  ImageMetricType * testPtr = dynamic_cast<ImageMetricType *>(this->GetMetric(pos));
+  auto * testPtr = dynamic_cast<ImageMetricType *>(this->GetMetric(pos));
   if (testPtr)
   {
     testPtr->SetFixedImageRegion(_arg);
@@ -223,7 +223,7 @@ auto
 CombinationImageToImageMetric<TFixedImage, TMovingImage>::GetFixedImageRegion(unsigned int pos) const
   -> const FixedImageRegionType &
 {
-  const ImageMetricType * testPtr = dynamic_cast<const ImageMetricType *>(this->GetMetric(pos));
+  const auto * testPtr = dynamic_cast<const ImageMetricType *>(this->GetMetric(pos));
   if (testPtr)
   {
     return testPtr->GetFixedImageRegion();
@@ -543,7 +543,7 @@ CombinationImageToImageMetric<TFixedImage, TMovingImage>::GetNumberOfPixelsCount
   unsigned long sum = 0;
   for (unsigned int i = 0; i < this->GetNumberOfMetrics(); ++i)
   {
-    const ImageMetricType * testPtr = dynamic_cast<const ImageMetricType *>(this->GetMetric(i));
+    const auto * testPtr = dynamic_cast<const ImageMetricType *>(this->GetMetric(i));
     if (testPtr)
     {
       sum += testPtr->GetNumberOfPixelsCounted();
@@ -585,8 +585,8 @@ CombinationImageToImageMetric<TFixedImage, TMovingImage>::Initialize()
     {
       itkExceptionMacro("Metric " << i << " has not been set!");
     }
-    ImageMetricType *    testPtr1 = dynamic_cast<ImageMetricType *>(this->GetMetric(i));
-    PointSetMetricType * testPtr2 = dynamic_cast<PointSetMetricType *>(this->GetMetric(i));
+    auto * testPtr1 = dynamic_cast<ImageMetricType *>(this->GetMetric(i));
+    auto * testPtr2 = dynamic_cast<PointSetMetricType *>(this->GetMetric(i));
     if (testPtr1)
     {
       // The NumberOfThreadsPerMetric is changed after Initialize() so we save it before and then
@@ -788,8 +788,8 @@ CombinationImageToImageMetric<TFixedImage, TMovingImage>::GetValueAndDerivative(
    */
   for (unsigned int i = 0; i < this->m_NumberOfMetrics; ++i)
   {
-    ImageMetricType *    testPtr1 = dynamic_cast<ImageMetricType *>(this->GetMetric(i));
-    PointSetMetricType * testPtr2 = dynamic_cast<PointSetMetricType *>(this->GetMetric(i));
+    auto * testPtr1 = dynamic_cast<ImageMetricType *>(this->GetMetric(i));
+    auto * testPtr2 = dynamic_cast<PointSetMetricType *>(this->GetMetric(i));
     if (testPtr1)
     {
       testPtr1->SetUseMetricSingleThreaded(true);

--- a/Components/Registrations/MultiMetricMultiResolutionRegistration/itkMultiMetricMultiResolutionImageRegistrationMethod.hxx
+++ b/Components/Registrations/MultiMetricMultiResolutionRegistration/itkMultiMetricMultiResolutionImageRegistrationMethod.hxx
@@ -123,7 +123,7 @@ template <typename TFixedImage, typename TMovingImage>
 void
 MultiMetricMultiResolutionImageRegistrationMethod<TFixedImage, TMovingImage>::SetMetric(MetricType * _arg)
 {
-  CombinationMetricType * testPtr = dynamic_cast<CombinationMetricType *>(_arg);
+  auto * testPtr = dynamic_cast<CombinationMetricType *>(_arg);
   if (testPtr)
   {
     if (this->m_CombinationMetric != testPtr)
@@ -186,7 +186,7 @@ MultiMetricMultiResolutionImageRegistrationMethod<TFixedImage, TMovingImage>::In
   this->GetModifiableOptimizer()->SetInitialPosition(this->GetInitialTransformParametersOfNextLevel());
 
   /** Connect the transform to the Decorator. */
-  TransformOutputType * transformOutput = static_cast<TransformOutputType *>(this->ProcessObject::GetOutput(0));
+  auto * transformOutput = static_cast<TransformOutputType *>(this->ProcessObject::GetOutput(0));
 
   transformOutput->Set(this->GetTransform());
 

--- a/Components/Registrations/MultiResolutionRegistration/elxMultiResolutionRegistration.hxx
+++ b/Components/Registrations/MultiResolutionRegistration/elxMultiResolutionRegistration.hxx
@@ -124,7 +124,7 @@ MultiResolutionRegistration<TElastix>::SetComponents()
 
   this->SetInterpolator(this->GetElastix()->GetElxInterpolatorBase()->GetAsITKBaseType());
 
-  MetricType * testPtr = dynamic_cast<MetricType *>(this->GetElastix()->GetElxMetricBase()->GetAsITKBaseType());
+  auto * testPtr = dynamic_cast<MetricType *>(this->GetElastix()->GetElxMetricBase()->GetAsITKBaseType());
   if (testPtr)
   {
     this->SetMetric(testPtr);

--- a/Components/Registrations/MultiResolutionRegistrationWithFeatures/elxMultiResolutionRegistrationWithFeatures.hxx
+++ b/Components/Registrations/MultiResolutionRegistrationWithFeatures/elxMultiResolutionRegistrationWithFeatures.hxx
@@ -84,7 +84,7 @@ MultiResolutionRegistrationWithFeatures<TElastix>::GetAndSetComponents()
    */
 
   /** Set the metric. */
-  MetricType * testPtr = dynamic_cast<MetricType *>(this->GetElastix()->GetElxMetricBase()->GetAsITKBaseType());
+  auto * testPtr = dynamic_cast<MetricType *>(this->GetElastix()->GetElxMetricBase()->GetAsITKBaseType());
   if (testPtr)
   {
     this->SetMetric(testPtr);

--- a/Components/Registrations/MultiResolutionRegistrationWithFeatures/itkMultiInputMultiResolutionImageRegistrationMethodBase.hxx
+++ b/Components/Registrations/MultiResolutionRegistrationWithFeatures/itkMultiInputMultiResolutionImageRegistrationMethodBase.hxx
@@ -223,7 +223,7 @@ MultiInputMultiResolutionImageRegistrationMethodBase<TFixedImage, TMovingImage>:
 {
   this->Superclass::SetMetric(_arg);
 
-  MultiInputMetricType * testPointer = dynamic_cast<MultiInputMetricType *>(_arg);
+  auto * testPointer = dynamic_cast<MultiInputMetricType *>(_arg);
   if (testPointer)
   {
     this->m_MultiInputMetric = testPointer;
@@ -292,7 +292,7 @@ MultiInputMultiResolutionImageRegistrationMethodBase<TFixedImage, TMovingImage>:
   this->GetModifiableOptimizer()->SetInitialPosition(this->GetInitialTransformParametersOfNextLevel());
 
   /** Connect the transform to the Decorator. */
-  TransformOutputType * transformOutput = static_cast<TransformOutputType *>(this->ProcessObject::GetOutput(0));
+  auto * transformOutput = static_cast<TransformOutputType *>(this->ProcessObject::GetOutput(0));
 
   transformOutput->Set(this->GetTransform());
 

--- a/Components/Resamplers/OpenCLResampler/elxOpenCLResampler.hxx
+++ b/Components/Resamplers/OpenCLResampler/elxOpenCLResampler.hxx
@@ -87,8 +87,7 @@ OpenCLResampler<TElastix>::SetTransform(const TransformType * _arg)
   if (this->m_ContextCreated && this->m_GPUResamplerCreated)
   {
     // Cast to the AdvancedCombinationTransform
-    const AdvancedCombinationTransformType * advancedCombinationTransform =
-      dynamic_cast<const AdvancedCombinationTransformType *>(_arg);
+    const auto * advancedCombinationTransform = dynamic_cast<const AdvancedCombinationTransformType *>(_arg);
 
     // Set input for the transform copier
     this->m_TransformCopier->SetInputTransform(advancedCombinationTransform);

--- a/Components/Transforms/AdvancedBSplineTransform/elxAdvancedBSplineTransform.hxx
+++ b/Components/Transforms/AdvancedBSplineTransform/elxAdvancedBSplineTransform.hxx
@@ -530,7 +530,7 @@ AdvancedBSplineTransform<TElastix>::SetOptimizerScales(const unsigned int edgeWi
     const unsigned long baseOffset = coeff->ComputeOffset(index);
     for (unsigned int i = 0; i < SpaceDimension; ++i)
     {
-      const unsigned int scalesIndex = static_cast<unsigned int>(baseOffset + i * offset);
+      const auto scalesIndex = static_cast<unsigned int>(baseOffset + i * offset);
       newScales[scalesIndex] = infScale;
     }
     ++cIt;

--- a/Components/Transforms/BSplineDeformableTransformWithDiffusion/elxBSplineTransformWithDiffusion.hxx
+++ b/Components/Transforms/BSplineDeformableTransformWithDiffusion/elxBSplineTransformWithDiffusion.hxx
@@ -722,7 +722,7 @@ BSplineTransformWithDiffusion<TElastix>::IncreaseScale()
   ParametersType latestParameters = this->m_Registration->GetAsITKBaseType()->GetLastTransformParameters();
 
   /** Get the pointer to the data in latestParameters. */
-  PixelType * dataPointer = static_cast<PixelType *>(latestParameters.data_block());
+  auto * dataPointer = static_cast<PixelType *>(latestParameters.data_block());
   /** Get the number of pixels that should go into one coefficient image. */
   unsigned int numberOfPixels = (this->m_BSplineTransform->GetGridRegion()).GetNumberOfPixels();
 
@@ -958,7 +958,7 @@ BSplineTransformWithDiffusion<TElastix>::ReadFromFile()
   /** Convert 'this' to a pointer to a CombinationTransformType and set how
    * to combine the current transform with the initial transform */
   /** Cast to transform grouper. */
-  CombinationTransformType * thisAsGrouper = dynamic_cast<CombinationTransformType *>(this);
+  auto * thisAsGrouper = dynamic_cast<CombinationTransformType *>(this);
   if (thisAsGrouper)
   {
     if (howToCombineTransforms == "Compose")

--- a/Components/Transforms/BSplineStackTransform/elxBSplineStackTransform.hxx
+++ b/Components/Transforms/BSplineStackTransform/elxBSplineStackTransform.hxx
@@ -584,7 +584,7 @@ BSplineStackTransform<TElastix>::SetOptimizerScales(const unsigned int edgeWidth
     const unsigned long baseOffset = coeff->ComputeOffset(index);
     for (unsigned int i = 0; i < SpaceDimension; ++i)
     {
-      const unsigned int scalesIndex = static_cast<unsigned int>(baseOffset + i * offset);
+      const auto scalesIndex = static_cast<unsigned int>(baseOffset + i * offset);
       newScales[scalesIndex] = infScale;
     }
     ++cIt;

--- a/Components/Transforms/MultiBSplineTransformWithNormal/elxMultiBSplineTransformWithNormal.hxx
+++ b/Components/Transforms/MultiBSplineTransformWithNormal/elxMultiBSplineTransformWithNormal.hxx
@@ -668,7 +668,7 @@ MultiBSplineTransformWithNormal<TElastix>::SetOptimizerScales(const unsigned int
     const unsigned long baseOffset = coeff->ComputeOffset(index);
     for (unsigned int i = 0; i < SpaceDimension; ++i)
     {
-      const unsigned int scalesIndex = static_cast<unsigned int>(baseOffset + i * offset);
+      const auto scalesIndex = static_cast<unsigned int>(baseOffset + i * offset);
       newScales[scalesIndex] = infScale;
     }
     ++cIt;

--- a/Components/Transforms/RecursiveBSplineTransform/elxRecursiveBSplineTransform.hxx
+++ b/Components/Transforms/RecursiveBSplineTransform/elxRecursiveBSplineTransform.hxx
@@ -558,7 +558,7 @@ RecursiveBSplineTransform<TElastix>::SetOptimizerScales(const unsigned int edgeW
     const unsigned long baseOffset = coeff->ComputeOffset(index);
     for (unsigned int i = 0; i < SpaceDimension; ++i)
     {
-      const unsigned int scalesIndex = static_cast<unsigned int>(baseOffset + i * offset);
+      const auto scalesIndex = static_cast<unsigned int>(baseOffset + i * offset);
       newScales[scalesIndex] = infScale;
     }
     ++cIt;

--- a/Components/Transforms/WeightedCombinationTransform/elxWeightedCombinationTransform.hxx
+++ b/Components/Transforms/WeightedCombinationTransform/elxWeightedCombinationTransform.hxx
@@ -72,7 +72,7 @@ WeightedCombinationTransformElastix<TElastix>::InitializeTransform()
 
   /** Some helper variables */
   const NumberOfParametersType numberOfParameters = this->GetNumberOfParameters();
-  const double                 Nd = static_cast<double>(numberOfParameters);
+  const auto                   Nd = static_cast<double>(numberOfParameters);
 
   /** Equal weights */
   ParametersType parameters(numberOfParameters);
@@ -243,14 +243,14 @@ WeightedCombinationTransformElastix<TElastix>::LoadSubTransforms()
       if (const itk::Object::Pointer subTransform = creator())
       {
         /** Cast to TransformBase and Call the ReadFromFile method of the elx_subTransform. */
-        if (Superclass2 * elx_subTransform = dynamic_cast<Superclass2 *>(subTransform.GetPointer()))
+        if (auto * elx_subTransform = dynamic_cast<Superclass2 *>(subTransform.GetPointer()))
         {
           elx_subTransform->SetElastix(this->GetElastix());
           elx_subTransform->SetConfiguration(configurationSubTransform);
           elx_subTransform->ReadFromFile();
 
           /** Set in vector of subTransforms. */
-          SubTransformType * testPointer = dynamic_cast<SubTransformType *>(subTransform.GetPointer());
+          auto * testPointer = dynamic_cast<SubTransformType *>(subTransform.GetPointer());
           subTransforms[i] = testPointer;
         }
       }

--- a/Core/ComponentBaseClasses/elxMetricBase.hxx
+++ b/Core/ComponentBaseClasses/elxMetricBase.hxx
@@ -80,7 +80,7 @@ MetricBase<TElastix>::BeforeEachResolutionBase()
   }
 
   /** Cast this to AdvancedMetricType. */
-  AdvancedMetricType * thisAsAdvanced = dynamic_cast<AdvancedMetricType *>(this);
+  auto * thisAsAdvanced = dynamic_cast<AdvancedMetricType *>(this);
 
   /** For advanced metrics several other things can be set. */
   if (thisAsAdvanced != nullptr)
@@ -228,7 +228,7 @@ MetricBase<TElastix>::GetExactValue(const ParametersType & parameters) -> Measur
   }
 
   /** Try to cast the current Sampler to a FullSampler. */
-  ExactMetricImageSamplerType * testPointer = dynamic_cast<ExactMetricImageSamplerType *>(currentSampler.GetPointer());
+  auto * testPointer = dynamic_cast<ExactMetricImageSamplerType *>(currentSampler.GetPointer());
   if (testPointer != nullptr)
   {
     /** GetValue gives us the exact value! */
@@ -271,7 +271,7 @@ bool
 MetricBase<TElastix>::GetAdvancedMetricUseImageSampler() const
 {
   /** Cast this to AdvancedMetricType. */
-  const AdvancedMetricType * thisAsMetricWithSampler = dynamic_cast<const AdvancedMetricType *>(this);
+  const auto * thisAsMetricWithSampler = dynamic_cast<const AdvancedMetricType *>(this);
 
   /** If no AdvancedMetricType, return false. */
   if (thisAsMetricWithSampler == nullptr)
@@ -293,7 +293,7 @@ void
 MetricBase<TElastix>::SetAdvancedMetricImageSampler(ImageSamplerBaseType * sampler)
 {
   /** Cast this to AdvancedMetricType. */
-  AdvancedMetricType * thisAsMetricWithSampler = dynamic_cast<AdvancedMetricType *>(this);
+  auto * thisAsMetricWithSampler = dynamic_cast<AdvancedMetricType *>(this);
 
   /** If no AdvancedMetricType, or if the MetricWithSampler does not
    * utilize the sampler, return.
@@ -322,7 +322,7 @@ auto
 MetricBase<TElastix>::GetAdvancedMetricImageSampler() const -> ImageSamplerBaseType *
 {
   /** Cast this to AdvancedMetricType. */
-  const AdvancedMetricType * thisAsMetricWithSampler = dynamic_cast<const AdvancedMetricType *>(this);
+  const auto * thisAsMetricWithSampler = dynamic_cast<const AdvancedMetricType *>(this);
 
   /** If no AdvancedMetricType, or if the MetricWithSampler does not
    * utilize the sampler, return 0.

--- a/Core/ComponentBaseClasses/elxOptimizerBase.hxx
+++ b/Core/ComponentBaseClasses/elxOptimizerBase.hxx
@@ -88,8 +88,8 @@ OptimizerBase<TElastix>::AfterRegistrationBase()
   }
 
   /** Compute the crc checksum using zlib crc32 function. */
-  const unsigned char * crcInputData = reinterpret_cast<const unsigned char *>(roundedTP.data_block());
-  uLong                 crc = crc32(0L, Z_NULL, 0);
+  const auto * crcInputData = reinterpret_cast<const unsigned char *>(roundedTP.data_block());
+  uLong        crc = crc32(0L, Z_NULL, 0);
   crc = crc32(crc, crcInputData, N * sizeof(ParametersValueType));
 
   log::info(std::ostringstream{} << "\nRegistration result checksum: " << crc);
@@ -201,8 +201,8 @@ OptimizerBase<TElastix>::SetSinusScales(double amplitude, double frequency, unsi
 {
   using ScalesType = typename ITKBaseType::ScalesType;
 
-  const double nrofpar = static_cast<double>(numberOfParameters);
-  ScalesType   scales(numberOfParameters);
+  const auto nrofpar = static_cast<double>(numberOfParameters);
+  ScalesType scales(numberOfParameters);
 
   for (unsigned long i = 0; i < numberOfParameters; ++i)
   {

--- a/Core/Install/elxConversion.cxx
+++ b/Core/Install/elxConversion.cxx
@@ -150,7 +150,7 @@ Conversion::SecondsToDHMS(const double totalSeconds, const unsigned int precisio
   const std::size_t secondsPerDay = 24 * secondsPerHour;
 
   /** Convert total seconds. */
-  std::size_t       iSeconds = static_cast<std::size_t>(totalSeconds);
+  auto              iSeconds = static_cast<std::size_t>(totalSeconds);
   const std::size_t days = iSeconds / secondsPerDay;
 
   iSeconds %= secondsPerDay;

--- a/Core/Main/elastix.h
+++ b/Core/Main/elastix.h
@@ -38,7 +38,7 @@ ConvertSecondsToDHMS(const double totalSeconds, const unsigned int precision = 0
   const std::size_t secondsPerDay = 24 * secondsPerHour;
 
   /** Convert total seconds. */
-  std::size_t       iSeconds = static_cast<std::size_t>(totalSeconds);
+  auto              iSeconds = static_cast<std::size_t>(totalSeconds);
   const std::size_t days = iSeconds / secondsPerDay;
 
   iSeconds %= secondsPerDay;

--- a/Core/Main/elxParameterObject.cxx
+++ b/Core/Main/elxParameterObject.cxx
@@ -517,8 +517,8 @@ ParameterObject::PrintSelf(std::ostream & os, itk::Indent indent) const
   for (unsigned int i = 0; i < m_ParameterMaps.size(); ++i)
   {
     os << "ParameterMap " << i << ": " << std::endl;
-    ParameterMapConstIterator parameterMapIterator = m_ParameterMaps[i].begin();
-    ParameterMapConstIterator parameterMapIteratorEnd = m_ParameterMaps[i].end();
+    auto parameterMapIterator = m_ParameterMaps[i].begin();
+    auto parameterMapIteratorEnd = m_ParameterMaps[i].end();
     while (parameterMapIterator != parameterMapIteratorEnd)
     {
       os << "  (" << parameterMapIterator->first;

--- a/Core/elxProgressCommand.cxx
+++ b/Core/elxProgressCommand.cxx
@@ -124,7 +124,7 @@ ProgressCommand::DisconnectObserver(itk::ProcessObject * filter)
 void
 ProgressCommand::Execute(itk::Object * caller, const itk::EventObject & event)
 {
-  itk::ProcessObject * po = dynamic_cast<itk::ProcessObject *>(caller);
+  auto * po = dynamic_cast<itk::ProcessObject *>(caller);
   if (!po)
   {
     return;
@@ -145,7 +145,7 @@ ProgressCommand::Execute(itk::Object * caller, const itk::EventObject & event)
 void
 ProgressCommand::Execute(const itk::Object * caller, const itk::EventObject & event)
 {
-  const itk::ProcessObject * po = dynamic_cast<const itk::ProcessObject *>(caller);
+  const auto * po = dynamic_cast<const itk::ProcessObject *>(caller);
   if (!po)
   {
     return;
@@ -189,7 +189,7 @@ ProgressCommand::PrintProgress(const float progress) const
 void
 ProgressCommand::UpdateAndPrintProgress(const unsigned long currentVoxelNumber) const
 {
-  const unsigned long frac = static_cast<unsigned long>(m_NumberOfVoxels / m_NumberOfUpdates);
+  const auto frac = static_cast<unsigned long>(m_NumberOfVoxels / m_NumberOfUpdates);
   if (currentVoxelNumber % frac == 0)
   {
     this->PrintProgress(static_cast<float>(currentVoxelNumber) / static_cast<float>(m_NumberOfVoxels));

--- a/Testing/itkAccumulateDerivativesParallellizationTest.cxx
+++ b/Testing/itkAccumulateDerivativesParallellizationTest.cxx
@@ -133,7 +133,7 @@ public:
     Self & metric = *(userData.st_Metric);
 
     const unsigned int numPar = metric.m_NumberOfParameters;
-    const unsigned int subSize =
+    const auto         subSize =
       static_cast<unsigned int>(std::ceil(static_cast<double>(numPar) / static_cast<double>(nrOfThreads)));
     const unsigned int jmin = threadID * subSize;
     const unsigned int jmax = std::min((threadID + 1) * subSize, numPar);

--- a/Testing/itkAdvanceOneStepParallellizationTest.cxx
+++ b/Testing/itkAdvanceOneStepParallellizationTest.cxx
@@ -166,7 +166,7 @@ public:
   {
     /** Compute the range for this thread. */
     const unsigned int spaceDimension = m_NumberOfParameters;
-    const unsigned int subSize = static_cast<unsigned int>(
+    const auto         subSize = static_cast<unsigned int>(
       std::ceil(static_cast<double>(spaceDimension) / static_cast<double>(this->m_Threader->GetNumberOfWorkUnits())));
     const unsigned int jmin = threadId * subSize;
     const unsigned int jmax = std::min((threadId + 1) * subSize, spaceDimension);
@@ -191,7 +191,7 @@ public:
   {
     /** Compute the range for this thread. */
     const unsigned int spaceDimension = m_NumberOfParameters;
-    const unsigned int subSize = static_cast<unsigned int>(
+    const auto         subSize = static_cast<unsigned int>(
       std::ceil(static_cast<double>(spaceDimension) / static_cast<double>(this->m_Threader->GetNumberOfWorkUnits())));
     const unsigned int jmin = threadId * subSize;
     const unsigned int jmax = std::min((threadId + 1) * subSize, spaceDimension);

--- a/Testing/itkAdvancedBSplineDeformableTransformTest.cxx
+++ b/Testing/itkAdvancedBSplineDeformableTransformTest.cxx
@@ -43,7 +43,7 @@ main(int argc, char * argv[])
    * Debug and Release mode.
    */
 #ifndef NDEBUG
-  unsigned int N = static_cast<unsigned int>(1e3);
+  auto N = static_cast<unsigned int>(1e3);
 #else
   unsigned int N = static_cast<unsigned int>(0.5e5);
 #endif

--- a/Testing/itkAdvancedRecursiveBSplineTransformTest.cxx
+++ b/Testing/itkAdvancedRecursiveBSplineTransformTest.cxx
@@ -47,7 +47,7 @@ main(int argc, char * argv[])
    * Debug and Release mode.
    */
 #ifndef NDEBUG
-  unsigned int N = static_cast<unsigned int>(1);
+  auto N = static_cast<unsigned int>(1);
 #else
   unsigned int N = static_cast<unsigned int>(1e5);
 #endif

--- a/Testing/itkBSplineDerivativeKernelFunctionTest.cxx
+++ b/Testing/itkBSplineDerivativeKernelFunctionTest.cxx
@@ -37,7 +37,7 @@ main()
    * fast test results in Release mode.
    * Increase it for real time testing.
    */
-  unsigned int N = static_cast<unsigned int>(1e7);
+  auto         N = static_cast<unsigned int>(1e7);
   const double maxAllowedDistance = 1e-5; // the allowable distance
 
   /** Other typedefs. */

--- a/Testing/itkBSplineInterpolationDerivativeWeightFunctionTest.cxx
+++ b/Testing/itkBSplineInterpolationDerivativeWeightFunctionTest.cxx
@@ -38,7 +38,7 @@ main()
   /** The number of calls to Evaluate(). This number gives reasonably
    * fast test results in Release mode.
    */
-  unsigned int N = static_cast<unsigned int>(1e7);
+  auto N = static_cast<unsigned int>(1e7);
 
   /** Other typedefs. */
   using DerivativeWeightFunctionType =

--- a/Testing/itkBSplineInterpolationSODerivativeWeightFunctionTest.cxx
+++ b/Testing/itkBSplineInterpolationSODerivativeWeightFunctionTest.cxx
@@ -38,7 +38,7 @@ main()
   /** The number of calls to Evaluate(). This number gives reasonably
    * fast test results in Release mode.
    */
-  unsigned int N = static_cast<unsigned int>(1e6);
+  auto N = static_cast<unsigned int>(1e6);
 
   /** Other typedefs. */
   using SODerivativeWeightFunctionType =

--- a/Testing/itkBSplineInterpolationWeightFunctionTest.cxx
+++ b/Testing/itkBSplineInterpolationWeightFunctionTest.cxx
@@ -39,7 +39,7 @@ main()
    * fast test results in Release mode. In 3D half of this number calls are
    * made.
    */
-  unsigned int N = static_cast<unsigned int>(1e6);
+  auto N = static_cast<unsigned int>(1e6);
 
   /** Other typedefs. */
   using WeightFunctionType2D = itk::BSplineInterpolationWeightFunction<CoordinateRepresentationType, 2, SplineOrder>;

--- a/Testing/itkBSplineJacobianGradientPerformanceTest.cxx
+++ b/Testing/itkBSplineJacobianGradientPerformanceTest.cxx
@@ -43,7 +43,7 @@ main(int argc, char * argv[])
    * Debug and Release mode.
    */
 #ifndef NDEBUG
-  unsigned int N = static_cast<unsigned int>(1e3);
+  auto N = static_cast<unsigned int>(1e3);
 #else
   unsigned int N = static_cast<unsigned int>(1e5);
 #endif

--- a/Testing/itkBSplineSODerivativeKernelFunctionTest.cxx
+++ b/Testing/itkBSplineSODerivativeKernelFunctionTest.cxx
@@ -37,7 +37,7 @@ main()
   /** The number of calls to Evaluate(). This number gives reasonably
    * fast test results in Release mode.
    */
-  unsigned int N = static_cast<unsigned int>(1e8);
+  auto N = static_cast<unsigned int>(1e8);
 
   /** Other typedefs. */
   using BSplineSODerivativeKernelType = itk::BSplineSecondOrderDerivativeKernelFunction<SplineOrder>;

--- a/Testing/itkBSplineTransformPointPerformanceTest.cxx
+++ b/Testing/itkBSplineTransformPointPerformanceTest.cxx
@@ -173,7 +173,7 @@ main(int argc, char * argv[])
    * Debug and Release mode.
    */
 #ifndef NDEBUG
-  unsigned int N = static_cast<unsigned int>(1e3);
+  auto N = static_cast<unsigned int>(1e3);
 #else
   unsigned int N = static_cast<unsigned int>(1e5);
 #endif

--- a/Testing/itkCommandLineArgumentParser.cxx
+++ b/Testing/itkCommandLineArgumentParser.cxx
@@ -95,7 +95,7 @@ CommandLineArgumentParser::ArgumentExists(const std::string & key) const
 void
 CommandLineArgumentParser::PrintAllArguments() const
 {
-  ArgumentMapType::const_iterator iter = this->m_ArgumentMap.begin();
+  auto iter = this->m_ArgumentMap.begin();
 
   for (; iter != this->m_ArgumentMap.end(); ++iter)
   {

--- a/Testing/itkGPUBSplineDecompositionImageFilterTest.cxx
+++ b/Testing/itkGPUBSplineDecompositionImageFilterTest.cxx
@@ -193,8 +193,8 @@ main(int argc, char * argv[])
   }
 
   // Compute RMSE
-  double       RMSrelative = 0.0;
-  const double RMSerror =
+  double     RMSrelative = 0.0;
+  const auto RMSerror =
     itk::ComputeRMSE<double, ImageType, ImageType>(cpuFilter->GetOutput(), gpuFilter->GetOutput(), RMSrelative);
   std::cout << " " << RMSerror << std::endl;
 

--- a/Testing/itkGPUCastImageFilterTest.cxx
+++ b/Testing/itkGPUCastImageFilterTest.cxx
@@ -198,8 +198,8 @@ main(int argc, char * argv[])
   }
 
   // Compute RMSE
-  double       RMSrelative = 0.0;
-  const double RMSerror = itk::ComputeRMSE<double, OutputImageType, OutputImageType>(
+  double     RMSrelative = 0.0;
+  const auto RMSerror = itk::ComputeRMSE<double, OutputImageType, OutputImageType>(
     cpuFilter->GetOutput(), gpuFilter->GetOutput(), RMSrelative);
   std::cout << " " << RMSerror << std::endl;
 

--- a/Testing/itkGPUFactoriesTest.cxx
+++ b/Testing/itkGPUFactoriesTest.cxx
@@ -64,7 +64,7 @@ PrintAllRegisteredFactories()
   std::list<itk::ObjectFactoryBase *> factories = itk::ObjectFactoryBase::GetRegisteredFactories();
 
   std::cout << "----- Registered factories -----" << std::endl;
-  for (std::list<itk::ObjectFactoryBase *>::iterator f = factories.begin(); f != factories.end(); ++f)
+  for (auto f = factories.begin(); f != factories.end(); ++f)
   {
     std::cout << "  Factory version: " << (*f)->GetITKSourceVersion() << '\n'
               << "  Factory description: " << (*f)->GetDescription() << std::endl;

--- a/Testing/itkGPUGenericMultiResolutionPyramidImageFilterTest.cxx
+++ b/Testing/itkGPUGenericMultiResolutionPyramidImageFilterTest.cxx
@@ -277,8 +277,8 @@ main(int argc, char * argv[])
   }
 
   // Compute RMSE
-  double       RMSrelative = 0.0;
-  const double RMSerror = itk::ComputeRMSE<double, OutputImageType, OutputImageType>(
+  double     RMSrelative = 0.0;
+  const auto RMSerror = itk::ComputeRMSE<double, OutputImageType, OutputImageType>(
     cpuFilter->GetOutput(numberOfLevels - 1), gpuFilter->GetOutput(numberOfLevels - 1), RMSrelative);
   std::cout << " " << RMSerror << std::endl;
 

--- a/Testing/itkGPURecursiveGaussianImageFilterTest.cxx
+++ b/Testing/itkGPURecursiveGaussianImageFilterTest.cxx
@@ -172,8 +172,8 @@ main(int argc, char * argv[])
   }
 
   // Compute RMSE
-  double       RMSrelative = 0.0;
-  const double RMSerror = itk::ComputeRMSE<double, OutputImageType, OutputImageType>(
+  double     RMSrelative = 0.0;
+  const auto RMSerror = itk::ComputeRMSE<double, OutputImageType, OutputImageType>(
     cpuFilter->GetOutput(), gpuFilter->GetOutput(), RMSrelative);
   std::cout << " " << RMSerror << std::endl;
 
@@ -215,8 +215,8 @@ main(int argc, char * argv[])
               << cputimer.GetMean() / gputimer.GetMean();
 
     // Compute RMSE
-    double       RMSrelative = 0.0;
-    const double RMSerror = itk::ComputeRMSE<double, OutputImageType, OutputImageType>(
+    double     RMSrelative = 0.0;
+    const auto RMSerror = itk::ComputeRMSE<double, OutputImageType, OutputImageType>(
       cpuFilter->GetOutput(), gpuFilter->GetOutput(), RMSrelative);
     std::cout << " " << RMSerror << std::endl;
 

--- a/Testing/itkGPUResampleImageFilterTest.cxx
+++ b/Testing/itkGPUResampleImageFilterTest.cxx
@@ -1061,7 +1061,7 @@ main(int argc, char * argv[])
     else
     {
       // Get CPU AdvancedCombinationTransform
-      const AdvancedCombinationTransformType * CPUAdvancedCombinationTransform =
+      const auto * CPUAdvancedCombinationTransform =
         dynamic_cast<const AdvancedCombinationTransformType *>(cpuTransform.GetPointer());
       if (CPUAdvancedCombinationTransform)
       {
@@ -1143,8 +1143,8 @@ main(int argc, char * argv[])
   }
 
   // Compute RMSE
-  double       RMSrelative = 0.0;
-  const double RMSerror = itk::ComputeRMSE<double, OutputImageType, OutputImageType>(
+  double     RMSrelative = 0.0;
+  const auto RMSerror = itk::ComputeRMSE<double, OutputImageType, OutputImageType>(
     cpuFilter->GetOutput(), gpuFilter->GetOutput(), RMSrelative);
   std::cout << " " << RMSerror << std::endl;
 

--- a/Testing/itkGPUShrinkImageFilterTest.cxx
+++ b/Testing/itkGPUShrinkImageFilterTest.cxx
@@ -208,8 +208,8 @@ main(int argc, char * argv[])
   }
 
   // Compute RMSE
-  double       RMSrelative = 0.0;
-  const double RMSerror =
+  double     RMSrelative = 0.0;
+  const auto RMSerror =
     itk::ComputeRMSE<double, ImageType, ImageType>(cpuFilter->GetOutput(), gpuFilter->GetOutput(), RMSrelative);
   std::cout << " " << RMSerror << std::endl;
 

--- a/Testing/itkGPUSmoothingRecursiveGaussianImageFilterTest.cxx
+++ b/Testing/itkGPUSmoothingRecursiveGaussianImageFilterTest.cxx
@@ -214,8 +214,8 @@ main(int argc, char * argv[])
   }
 
   // Compute RMSE
-  double       RMSrelative = 0.0;
-  const double RMSerror = itk::ComputeRMSE<double, OutputImageType, OutputImageType>(
+  double     RMSrelative = 0.0;
+  const auto RMSerror = itk::ComputeRMSE<double, OutputImageType, OutputImageType>(
     filter->GetOutput(), gpuFilter->GetOutput(), RMSrelative);
   std::cout << " " << RMSerror << std::endl;
 

--- a/Testing/itkOpenCLBufferTest.cxx
+++ b/Testing/itkOpenCLBufferTest.cxx
@@ -25,7 +25,7 @@ template <class type>
 bool
 std_all_of(const std::vector<type> & v, const type value)
 {
-  for (typename std::vector<type>::const_iterator it = v.begin(); it != v.end(); ++it)
+  for (auto it = v.begin(); it != v.end(); ++it)
   {
     if (*it != value)
     {

--- a/Testing/itkOpenCLDeviceTest.cxx
+++ b/Testing/itkOpenCLDeviceTest.cxx
@@ -32,7 +32,7 @@ main()
   // Get all devices
   std::list<itk::OpenCLDevice>       gpus;
   const std::list<itk::OpenCLDevice> devices = itk::OpenCLDevice::GetAllDevices();
-  for (std::list<itk::OpenCLDevice>::const_iterator dev = devices.begin(); dev != devices.end(); ++dev)
+  for (auto dev = devices.begin(); dev != devices.end(); ++dev)
   {
     if ((dev->GetDeviceType() & itk::OpenCLDevice::GPU) != 0)
     {

--- a/Testing/itkOpenCLPlatformTest.cxx
+++ b/Testing/itkOpenCLPlatformTest.cxx
@@ -36,7 +36,7 @@ main()
 
   // Get all platforms and print it
   const std::list<itk::OpenCLPlatform> platforms = itk::OpenCLPlatform::GetAllPlatforms();
-  for (std::list<itk::OpenCLPlatform>::const_iterator it = platforms.begin(); it != platforms.end(); ++it)
+  for (auto it = platforms.begin(); it != platforms.end(); ++it)
   {
     std::cout << *it;
   }

--- a/Testing/itkOpenCLVectorTest.cxx
+++ b/Testing/itkOpenCLVectorTest.cxx
@@ -25,7 +25,7 @@ template <class type>
 bool
 std_all_of(const typename std::vector<type> & v, const type value)
 {
-  for (typename std::vector<type>::const_iterator it = v.begin(); it != v.end(); ++it)
+  for (auto it = v.begin(); it != v.end(); ++it)
   {
     if (*it != value)
     {

--- a/Testing/itkTestHelper.h
+++ b/Testing/itkTestHelper.h
@@ -223,7 +223,7 @@ ComputeRMSE(const CPUImageType * cpuImage, const GPUImageType * gpuImage, TScala
 
   for (cit.GoToBegin(), git.GoToBegin(); !cit.IsAtEnd(); ++cit, ++git)
   {
-    TScalarType cpu = static_cast<TScalarType>(cit.Get());
+    auto        cpu = static_cast<TScalarType>(cit.Get());
     TScalarType err = cpu - static_cast<TScalarType>(git.Get());
     rmse += err * err;
     sumCPUSquared += cpu * cpu;


### PR DESCRIPTION
Ran clang-tidy (LLVM 18.1.8) check `modernize-use-auto`. Aims to improve code readability and maintainability: https://clang.llvm.org/extra/clang-tidy/checks/modernize/use-auto.html

Follows ITK commit https://github.com/InsightSoftwareConsortium/ITK/commit/de713e7ac52f7815a35754de885795ff0a1c4981 "STYLE: Use auto for variable creation", Hans Johnson, February 9, 2018.