### PR TITLE
STYLE: Remove commented out `ITK_DISALLOW_COPY_AND_MOVE` call

### DIFF
--- a/Common/ImageSamplers/itkImageRandomSamplerSparseMask.h
+++ b/Common/ImageSamplers/itkImageRandomSamplerSparseMask.h
@@ -100,8 +100,6 @@ protected:
 private:
   struct UserData
   {
-    //ITK_DISALLOW_COPY_AND_MOVE(UserData);
-
     const std::vector<ImageSampleType> & m_AllValidSamples;
     const std::vector<size_t> &          m_RandomIndices;
     std::vector<ImageSampleType> &       m_Samples;


### PR DESCRIPTION
The line of comment appeared to cause a GitHub Actions CI failure from "test-clang-format / build (push)" (DoozyX/clang-format-lint-action) saying:

    -    //ITK_DISALLOW_COPY_AND_MOVE(UserData);
    +    // ITK_DISALLOW_COPY_AND_MOVE(UserData);

- Follow-up to pull request https://github.com/SuperElastix/elastix/pull/1202 commit 359148b82f8e07a734af86fd4c8c75e4d422d3ed