### PR TITLE
STYLE: Use "typename" for template parameters

### DIFF
--- a/Common/CostFunctions/itkAdvancedImageToImageMetric.h
+++ b/Common/CostFunctions/itkAdvancedImageToImageMetric.h
@@ -78,7 +78,7 @@ namespace itk
  *
  */
 
-template <class TFixedImage, class TMovingImage>
+template <typename TFixedImage, typename TMovingImage>
 class ITK_TEMPLATE_EXPORT AdvancedImageToImageMetric : public ImageToImageMetric<TFixedImage, TMovingImage>
 {
 public:

--- a/Common/CostFunctions/itkAdvancedImageToImageMetric.hxx
+++ b/Common/CostFunctions/itkAdvancedImageToImageMetric.hxx
@@ -34,7 +34,7 @@ namespace itk
  * ********************* Constructor ****************************
  */
 
-template <class TFixedImage, class TMovingImage>
+template <typename TFixedImage, typename TMovingImage>
 AdvancedImageToImageMetric<TFixedImage, TMovingImage>::AdvancedImageToImageMetric()
 {
   /** Don't use the default gradient image as implemented by ITK.
@@ -55,7 +55,7 @@ AdvancedImageToImageMetric<TFixedImage, TMovingImage>::AdvancedImageToImageMetri
  * ********************* Initialize ****************************
  */
 
-template <class TFixedImage, class TMovingImage>
+template <typename TFixedImage, typename TMovingImage>
 void
 AdvancedImageToImageMetric<TFixedImage, TMovingImage>::Initialize()
 {
@@ -99,7 +99,7 @@ AdvancedImageToImageMetric<TFixedImage, TMovingImage>::Initialize()
  * ********************* InitializeThreadingParameters ****************************
  */
 
-template <class TFixedImage, class TMovingImage>
+template <typename TFixedImage, typename TMovingImage>
 void
 AdvancedImageToImageMetric<TFixedImage, TMovingImage>::InitializeThreadingParameters() const
 {
@@ -138,7 +138,7 @@ AdvancedImageToImageMetric<TFixedImage, TMovingImage>::InitializeThreadingParame
  * ****************** InitializeLimiters *****************************
  */
 
-template <class TFixedImage, class TMovingImage>
+template <typename TFixedImage, typename TMovingImage>
 void
 AdvancedImageToImageMetric<TFixedImage, TMovingImage>::InitializeLimiters()
 {
@@ -207,7 +207,7 @@ AdvancedImageToImageMetric<TFixedImage, TMovingImage>::InitializeLimiters()
  * ********************* InitializeImageSampler ****************************
  */
 
-template <class TFixedImage, class TMovingImage>
+template <typename TFixedImage, typename TMovingImage>
 void
 AdvancedImageToImageMetric<TFixedImage, TMovingImage>::InitializeImageSampler()
 {
@@ -232,7 +232,7 @@ AdvancedImageToImageMetric<TFixedImage, TMovingImage>::InitializeImageSampler()
  * ****************** CheckForBSplineInterpolator **********************
  */
 
-template <class TFixedImage, class TMovingImage>
+template <typename TFixedImage, typename TMovingImage>
 void
 AdvancedImageToImageMetric<TFixedImage, TMovingImage>::CheckForBSplineInterpolator()
 {
@@ -328,7 +328,7 @@ AdvancedImageToImageMetric<TFixedImage, TMovingImage>::CheckForBSplineInterpolat
  * ****************** CheckForAdvancedTransform **********************
  */
 
-template <class TFixedImage, class TMovingImage>
+template <typename TFixedImage, typename TMovingImage>
 void
 AdvancedImageToImageMetric<TFixedImage, TMovingImage>::CheckForAdvancedTransform()
 {
@@ -351,7 +351,7 @@ AdvancedImageToImageMetric<TFixedImage, TMovingImage>::CheckForAdvancedTransform
  * ****************** CheckForBSplineTransform **********************
  */
 
-template <class TFixedImage, class TMovingImage>
+template <typename TFixedImage, typename TMovingImage>
 void
 AdvancedImageToImageMetric<TFixedImage, TMovingImage>::CheckForBSplineTransform() const
 {
@@ -390,7 +390,7 @@ AdvancedImageToImageMetric<TFixedImage, TMovingImage>::CheckForBSplineTransform(
  * ******************* EvaluateMovingImageValueAndDerivativeWithOptionalThreadId ******************
  */
 
-template <class TFixedImage, class TMovingImage>
+template <typename TFixedImage, typename TMovingImage>
 template <typename... TOptionalThreadId>
 bool
 AdvancedImageToImageMetric<TFixedImage, TMovingImage>::EvaluateMovingImageValueAndDerivativeWithOptionalThreadId(
@@ -502,7 +502,7 @@ AdvancedImageToImageMetric<TFixedImage, TMovingImage>::EvaluateMovingImageValueA
  * *************** EvaluateTransformJacobianInnerProduct ****************
  */
 
-template <class TFixedImage, class TMovingImage>
+template <typename TFixedImage, typename TMovingImage>
 void
 AdvancedImageToImageMetric<TFixedImage, TMovingImage>::EvaluateTransformJacobianInnerProduct(
   const TransformJacobianType &     jacobian,
@@ -544,7 +544,7 @@ AdvancedImageToImageMetric<TFixedImage, TMovingImage>::EvaluateTransformJacobian
  * ********************** TransformPoint ************************
  */
 
-template <class TFixedImage, class TMovingImage>
+template <typename TFixedImage, typename TMovingImage>
 auto
 AdvancedImageToImageMetric<TFixedImage, TMovingImage>::TransformPoint(const FixedImagePointType & fixedImagePoint) const
   -> MovingImagePointType
@@ -558,7 +558,7 @@ AdvancedImageToImageMetric<TFixedImage, TMovingImage>::TransformPoint(const Fixe
  * *************** EvaluateTransformJacobian ****************
  */
 
-template <class TFixedImage, class TMovingImage>
+template <typename TFixedImage, typename TMovingImage>
 bool
 AdvancedImageToImageMetric<TFixedImage, TMovingImage>::EvaluateTransformJacobian(
   const FixedImagePointType &  fixedImagePoint,
@@ -579,7 +579,7 @@ AdvancedImageToImageMetric<TFixedImage, TMovingImage>::EvaluateTransformJacobian
  * ************************** IsInsideMovingMask *************************
  */
 
-template <class TFixedImage, class TMovingImage>
+template <typename TFixedImage, typename TMovingImage>
 bool
 AdvancedImageToImageMetric<TFixedImage, TMovingImage>::IsInsideMovingMask(const MovingImagePointType & point) const
 {
@@ -599,7 +599,7 @@ AdvancedImageToImageMetric<TFixedImage, TMovingImage>::IsInsideMovingMask(const 
  * *********************** BeforeThreadedGetValueAndDerivative ***********************
  */
 
-template <class TFixedImage, class TMovingImage>
+template <typename TFixedImage, typename TMovingImage>
 void
 AdvancedImageToImageMetric<TFixedImage, TMovingImage>::BeforeThreadedGetValueAndDerivative(
   const TransformParametersType & parameters) const
@@ -621,7 +621,7 @@ AdvancedImageToImageMetric<TFixedImage, TMovingImage>::BeforeThreadedGetValueAnd
  * **************** GetValueThreaderCallback *******
  */
 
-template <class TFixedImage, class TMovingImage>
+template <typename TFixedImage, typename TMovingImage>
 ITK_THREAD_RETURN_TYPE
 AdvancedImageToImageMetric<TFixedImage, TMovingImage>::GetValueThreaderCallback(void * arg)
 {
@@ -646,7 +646,7 @@ AdvancedImageToImageMetric<TFixedImage, TMovingImage>::GetValueThreaderCallback(
  * *********************** LaunchGetValueThreaderCallback***************
  */
 
-template <class TFixedImage, class TMovingImage>
+template <typename TFixedImage, typename TMovingImage>
 void
 AdvancedImageToImageMetric<TFixedImage, TMovingImage>::LaunchGetValueThreaderCallback() const
 {
@@ -660,7 +660,7 @@ AdvancedImageToImageMetric<TFixedImage, TMovingImage>::LaunchGetValueThreaderCal
  * **************** GetValueAndDerivativeThreaderCallback *******
  */
 
-template <class TFixedImage, class TMovingImage>
+template <typename TFixedImage, typename TMovingImage>
 ITK_THREAD_RETURN_FUNCTION_CALL_CONVENTION
 AdvancedImageToImageMetric<TFixedImage, TMovingImage>::GetValueAndDerivativeThreaderCallback(void * arg)
 {
@@ -685,7 +685,7 @@ AdvancedImageToImageMetric<TFixedImage, TMovingImage>::GetValueAndDerivativeThre
  * *********************** LaunchGetValueAndDerivativeThreaderCallback***************
  */
 
-template <class TFixedImage, class TMovingImage>
+template <typename TFixedImage, typename TMovingImage>
 void
 AdvancedImageToImageMetric<TFixedImage, TMovingImage>::LaunchGetValueAndDerivativeThreaderCallback() const
 {
@@ -700,7 +700,7 @@ AdvancedImageToImageMetric<TFixedImage, TMovingImage>::LaunchGetValueAndDerivati
  *********** AccumulateDerivativesThreaderCallback *************
  */
 
-template <class TFixedImage, class TMovingImage>
+template <typename TFixedImage, typename TMovingImage>
 ITK_THREAD_RETURN_FUNCTION_CALL_CONVENTION
 AdvancedImageToImageMetric<TFixedImage, TMovingImage>::AccumulateDerivativesThreaderCallback(void * arg)
 {
@@ -747,7 +747,7 @@ AdvancedImageToImageMetric<TFixedImage, TMovingImage>::AccumulateDerivativesThre
  * *********************** CheckNumberOfSamples ***********************
  */
 
-template <class TFixedImage, class TMovingImage>
+template <typename TFixedImage, typename TMovingImage>
 void
 AdvancedImageToImageMetric<TFixedImage, TMovingImage>::CheckNumberOfSamples(unsigned long wanted,
                                                                             unsigned long found) const
@@ -765,7 +765,7 @@ AdvancedImageToImageMetric<TFixedImage, TMovingImage>::CheckNumberOfSamples(unsi
  * ********************* PrintSelf ****************************
  */
 
-template <class TFixedImage, class TMovingImage>
+template <typename TFixedImage, typename TMovingImage>
 void
 AdvancedImageToImageMetric<TFixedImage, TMovingImage>::PrintSelf(std::ostream & os, Indent indent) const
 {

--- a/Common/CostFunctions/itkExponentialLimiterFunction.h
+++ b/Common/CostFunctions/itkExponentialLimiterFunction.h
@@ -39,7 +39,7 @@ namespace itk
  * \sa LimiterFunctionBase, HardLimiterFunction
  *
  */
-template <class TInput, unsigned int NDimension>
+template <typename TInput, unsigned int NDimension>
 class ITK_TEMPLATE_EXPORT ExponentialLimiterFunction : public LimiterFunctionBase<TInput, NDimension>
 {
 public:

--- a/Common/CostFunctions/itkExponentialLimiterFunction.hxx
+++ b/Common/CostFunctions/itkExponentialLimiterFunction.hxx
@@ -28,7 +28,7 @@ namespace itk
  * *************** Constructor ********************
  */
 
-template <class TInput, unsigned int NDimension>
+template <typename TInput, unsigned int NDimension>
 ExponentialLimiterFunction<TInput, NDimension>::ExponentialLimiterFunction()
 {
   this->ComputeLimiterSettings();
@@ -39,7 +39,7 @@ ExponentialLimiterFunction<TInput, NDimension>::ExponentialLimiterFunction()
  * **************** Initialize ***********************
  */
 
-template <class TInput, unsigned int NDimension>
+template <typename TInput, unsigned int NDimension>
 void
 ExponentialLimiterFunction<TInput, NDimension>::Initialize()
 {
@@ -51,7 +51,7 @@ ExponentialLimiterFunction<TInput, NDimension>::Initialize()
  * ******************** Evaluate ***********************
  */
 
-template <class TInput, unsigned int NDimension>
+template <typename TInput, unsigned int NDimension>
 auto
 ExponentialLimiterFunction<TInput, NDimension>::Evaluate(const InputType & input) const -> OutputType
 {
@@ -78,7 +78,7 @@ ExponentialLimiterFunction<TInput, NDimension>::Evaluate(const InputType & input
  * *********************** Evaluate *************************
  */
 
-template <class TInput, unsigned int NDimension>
+template <typename TInput, unsigned int NDimension>
 auto
 ExponentialLimiterFunction<TInput, NDimension>::Evaluate(const InputType & input, DerivativeType & derivative) const
   -> OutputType
@@ -118,7 +118,7 @@ ExponentialLimiterFunction<TInput, NDimension>::Evaluate(const InputType & input
  * ******************** ComputeLimiterSettings ********************
  */
 
-template <class TInput, unsigned int NDimension>
+template <typename TInput, unsigned int NDimension>
 void
 ExponentialLimiterFunction<TInput, NDimension>::ComputeLimiterSettings()
 {

--- a/Common/CostFunctions/itkHardLimiterFunction.h
+++ b/Common/CostFunctions/itkHardLimiterFunction.h
@@ -35,7 +35,7 @@ namespace itk
  * \sa LimiterFunctionBase, ExponentialLimiterFunction
  *
  */
-template <class TInput, unsigned int NDimension>
+template <typename TInput, unsigned int NDimension>
 class ITK_TEMPLATE_EXPORT HardLimiterFunction : public LimiterFunctionBase<TInput, NDimension>
 {
 public:

--- a/Common/CostFunctions/itkHardLimiterFunction.hxx
+++ b/Common/CostFunctions/itkHardLimiterFunction.hxx
@@ -24,7 +24,7 @@
 namespace itk
 {
 
-template <class TInput, unsigned int NDimension>
+template <typename TInput, unsigned int NDimension>
 auto
 HardLimiterFunction<TInput, NDimension>::Evaluate(const InputType & input) const -> OutputType
 {
@@ -33,7 +33,7 @@ HardLimiterFunction<TInput, NDimension>::Evaluate(const InputType & input) const
 } // end Evaluate()
 
 
-template <class TInput, unsigned int NDimension>
+template <typename TInput, unsigned int NDimension>
 auto
 HardLimiterFunction<TInput, NDimension>::Evaluate(const InputType & input, DerivativeType & derivative) const
   -> OutputType

--- a/Common/CostFunctions/itkImageToImageMetricWithFeatures.h
+++ b/Common/CostFunctions/itkImageToImageMetricWithFeatures.h
@@ -34,10 +34,10 @@ namespace itk
  *
  */
 
-template <class TFixedImage,
-          class TMovingImage,
-          class TFixedFeatureImage = TFixedImage,
-          class TMovingFeatureImage = TMovingImage>
+template <typename TFixedImage,
+          typename TMovingImage,
+          typename TFixedFeatureImage = TFixedImage,
+          typename TMovingFeatureImage = TMovingImage>
 class ITK_TEMPLATE_EXPORT ImageToImageMetricWithFeatures : public AdvancedImageToImageMetric<TFixedImage, TMovingImage>
 {
 public:

--- a/Common/CostFunctions/itkImageToImageMetricWithFeatures.hxx
+++ b/Common/CostFunctions/itkImageToImageMetricWithFeatures.hxx
@@ -27,7 +27,7 @@ namespace itk
  * ********************* Initialize *****************************
  */
 
-template <class TFixedImage, class TMovingImage, class TFixedFeatureImage, class TMovingFeatureImage>
+template <typename TFixedImage, typename TMovingImage, typename TFixedFeatureImage, typename TMovingFeatureImage>
 void
 ImageToImageMetricWithFeatures<TFixedImage, TMovingImage, TFixedFeatureImage, TMovingFeatureImage>::Initialize()
 {
@@ -78,7 +78,7 @@ ImageToImageMetricWithFeatures<TFixedImage, TMovingImage, TFixedFeatureImage, TM
  * ********************* SetNumberOfFixedFeatureImages ****************************
  */
 
-template <class TFixedImage, class TMovingImage, class TFixedFeatureImage, class TMovingFeatureImage>
+template <typename TFixedImage, typename TMovingImage, typename TFixedFeatureImage, typename TMovingFeatureImage>
 void
 ImageToImageMetricWithFeatures<TFixedImage, TMovingImage, TFixedFeatureImage, TMovingFeatureImage>::
   SetNumberOfFixedFeatureImages(unsigned int arg)
@@ -98,7 +98,7 @@ ImageToImageMetricWithFeatures<TFixedImage, TMovingImage, TFixedFeatureImage, TM
  * ********************* SetFixedFeatureImage ****************************
  */
 
-template <class TFixedImage, class TMovingImage, class TFixedFeatureImage, class TMovingFeatureImage>
+template <typename TFixedImage, typename TMovingImage, typename TFixedFeatureImage, typename TMovingFeatureImage>
 void
 ImageToImageMetricWithFeatures<TFixedImage, TMovingImage, TFixedFeatureImage, TMovingFeatureImage>::
   SetFixedFeatureImage(unsigned int i, FixedFeatureImageType * im)
@@ -126,7 +126,7 @@ ImageToImageMetricWithFeatures<TFixedImage, TMovingImage, TFixedFeatureImage, TM
  * ********************* GetFixedFeatureImage ****************************
  */
 
-template <class TFixedImage, class TMovingImage, class TFixedFeatureImage, class TMovingFeatureImage>
+template <typename TFixedImage, typename TMovingImage, typename TFixedFeatureImage, typename TMovingFeatureImage>
 const typename ImageToImageMetricWithFeatures<TFixedImage, TMovingImage, TFixedFeatureImage, TMovingFeatureImage>::
   FixedFeatureImageType *
   ImageToImageMetricWithFeatures<TFixedImage, TMovingImage, TFixedFeatureImage, TMovingFeatureImage>::
@@ -139,7 +139,7 @@ const typename ImageToImageMetricWithFeatures<TFixedImage, TMovingImage, TFixedF
  * ********************* SetFixedFeatureInterpolator ****************************
  */
 
-template <class TFixedImage, class TMovingImage, class TFixedFeatureImage, class TMovingFeatureImage>
+template <typename TFixedImage, typename TMovingImage, typename TFixedFeatureImage, typename TMovingFeatureImage>
 void
 ImageToImageMetricWithFeatures<TFixedImage, TMovingImage, TFixedFeatureImage, TMovingFeatureImage>::
   SetFixedFeatureInterpolator(unsigned int i, FixedFeatureInterpolatorType * interpolator)
@@ -167,7 +167,7 @@ ImageToImageMetricWithFeatures<TFixedImage, TMovingImage, TFixedFeatureImage, TM
  * ********************* GetFixedFeatureInterpolator ****************************
  */
 
-template <class TFixedImage, class TMovingImage, class TFixedFeatureImage, class TMovingFeatureImage>
+template <typename TFixedImage, typename TMovingImage, typename TFixedFeatureImage, typename TMovingFeatureImage>
 const typename ImageToImageMetricWithFeatures<TFixedImage, TMovingImage, TFixedFeatureImage, TMovingFeatureImage>::
   FixedFeatureInterpolatorType *
   ImageToImageMetricWithFeatures<TFixedImage, TMovingImage, TFixedFeatureImage, TMovingFeatureImage>::
@@ -180,7 +180,7 @@ const typename ImageToImageMetricWithFeatures<TFixedImage, TMovingImage, TFixedF
  * ********************* SetNumberOfMovingFeatureImages ****************************
  */
 
-template <class TFixedImage, class TMovingImage, class TFixedFeatureImage, class TMovingFeatureImage>
+template <typename TFixedImage, typename TMovingImage, typename TFixedFeatureImage, typename TMovingFeatureImage>
 void
 ImageToImageMetricWithFeatures<TFixedImage, TMovingImage, TFixedFeatureImage, TMovingFeatureImage>::
   SetNumberOfMovingFeatureImages(unsigned int arg)
@@ -200,7 +200,7 @@ ImageToImageMetricWithFeatures<TFixedImage, TMovingImage, TFixedFeatureImage, TM
  * ********************* SetMovingFeatureImage ****************************
  */
 
-template <class TFixedImage, class TMovingImage, class TFixedFeatureImage, class TMovingFeatureImage>
+template <typename TFixedImage, typename TMovingImage, typename TFixedFeatureImage, typename TMovingFeatureImage>
 void
 ImageToImageMetricWithFeatures<TFixedImage, TMovingImage, TFixedFeatureImage, TMovingFeatureImage>::
   SetMovingFeatureImage(unsigned int i, MovingFeatureImageType * im)
@@ -228,7 +228,7 @@ ImageToImageMetricWithFeatures<TFixedImage, TMovingImage, TFixedFeatureImage, TM
  * ********************* GetMovingFeatureImage ****************************
  */
 
-template <class TFixedImage, class TMovingImage, class TFixedFeatureImage, class TMovingFeatureImage>
+template <typename TFixedImage, typename TMovingImage, typename TFixedFeatureImage, typename TMovingFeatureImage>
 const typename ImageToImageMetricWithFeatures<TFixedImage, TMovingImage, TFixedFeatureImage, TMovingFeatureImage>::
   MovingFeatureImageType *
   ImageToImageMetricWithFeatures<TFixedImage, TMovingImage, TFixedFeatureImage, TMovingFeatureImage>::
@@ -241,7 +241,7 @@ const typename ImageToImageMetricWithFeatures<TFixedImage, TMovingImage, TFixedF
  * ********************* SetMovingFeatureInterpolator ****************************
  */
 
-template <class TFixedImage, class TMovingImage, class TFixedFeatureImage, class TMovingFeatureImage>
+template <typename TFixedImage, typename TMovingImage, typename TFixedFeatureImage, typename TMovingFeatureImage>
 void
 ImageToImageMetricWithFeatures<TFixedImage, TMovingImage, TFixedFeatureImage, TMovingFeatureImage>::
   SetMovingFeatureInterpolator(unsigned int i, MovingFeatureInterpolatorType * interpolator)
@@ -269,7 +269,7 @@ ImageToImageMetricWithFeatures<TFixedImage, TMovingImage, TFixedFeatureImage, TM
  * ********************* GetMovingFeatureInterpolator ****************************
  */
 
-template <class TFixedImage, class TMovingImage, class TFixedFeatureImage, class TMovingFeatureImage>
+template <typename TFixedImage, typename TMovingImage, typename TFixedFeatureImage, typename TMovingFeatureImage>
 const typename ImageToImageMetricWithFeatures<TFixedImage, TMovingImage, TFixedFeatureImage, TMovingFeatureImage>::
   MovingFeatureInterpolatorType *
   ImageToImageMetricWithFeatures<TFixedImage, TMovingImage, TFixedFeatureImage, TMovingFeatureImage>::
@@ -282,7 +282,7 @@ const typename ImageToImageMetricWithFeatures<TFixedImage, TMovingImage, TFixedF
  * ****************** CheckForBSplineFeatureInterpolators **********************
  */
 
-template <class TFixedImage, class TMovingImage, class TFixedFeatureImage, class TMovingFeatureImage>
+template <typename TFixedImage, typename TMovingImage, typename TFixedFeatureImage, typename TMovingFeatureImage>
 void
 ImageToImageMetricWithFeatures<TFixedImage, TMovingImage, TFixedFeatureImage, TMovingFeatureImage>::
   CheckForBSplineFeatureInterpolators()
@@ -318,7 +318,7 @@ ImageToImageMetricWithFeatures<TFixedImage, TMovingImage, TFixedFeatureImage, TM
  * ********************* PrintSelf ****************************
  */
 
-template <class TFixedImage, class TMovingImage, class TFixedFeatureImage, class TMovingFeatureImage>
+template <typename TFixedImage, typename TMovingImage, typename TFixedFeatureImage, typename TMovingFeatureImage>
 void
 ImageToImageMetricWithFeatures<TFixedImage, TMovingImage, TFixedFeatureImage, TMovingFeatureImage>::PrintSelf(
   std::ostream & os,

--- a/Common/CostFunctions/itkLimiterFunctionBase.h
+++ b/Common/CostFunctions/itkLimiterFunctionBase.h
@@ -46,7 +46,7 @@ namespace itk
  * \ingroup Functions
  *
  */
-template <class TInput, unsigned int NDimension>
+template <typename TInput, unsigned int NDimension>
 class ITK_TEMPLATE_EXPORT LimiterFunctionBase : public FunctionBase<TInput, typename NumericTraits<TInput>::RealType>
 {
 public:

--- a/Common/CostFunctions/itkMultiInputImageToImageMetricBase.h
+++ b/Common/CostFunctions/itkMultiInputImageToImageMetricBase.h
@@ -45,7 +45,7 @@ namespace itk
  *
  */
 
-template <class TFixedImage, class TMovingImage>
+template <typename TFixedImage, typename TMovingImage>
 class ITK_TEMPLATE_EXPORT MultiInputImageToImageMetricBase
   : public AdvancedImageToImageMetric<TFixedImage, TMovingImage>
 {

--- a/Common/CostFunctions/itkMultiInputImageToImageMetricBase.hxx
+++ b/Common/CostFunctions/itkMultiInputImageToImageMetricBase.hxx
@@ -29,7 +29,7 @@
 
 /** Macro for setting objects. */
 #define itkImplementationSetObjectMacro(_name, _type)                                                                  \
-  template <class TFixedImage, class TMovingImage>                                                                     \
+  template <typename TFixedImage, typename TMovingImage>                                                               \
   void MultiInputImageToImageMetricBase<TFixedImage, TMovingImage>::Set##_name(_type * _arg, unsigned int pos)         \
   {                                                                                                                    \
     if (this->m_##_name##Vector.size() < pos + 1)                                                                      \
@@ -50,7 +50,7 @@
 
 /** Macro for setting objects. */
 #define itkImplementationSetObjectMacro2(_name, _type)                                                                 \
-  template <class TFixedImage, class TMovingImage>                                                                     \
+  template <typename TFixedImage, typename TMovingImage>                                                               \
   void MultiInputImageToImageMetricBase<TFixedImage, TMovingImage>::Set##_name(_type * _arg, unsigned int pos)         \
   {                                                                                                                    \
     if (this->m_##_name##Vector.size() < pos + 1)                                                                      \
@@ -67,7 +67,7 @@
 
 /** Macro for getting objects. */
 #define itkImplementationGetObjectMacro(_name, _type)                                                                  \
-  template <class TFixedImage, class TMovingImage>                                                                     \
+  template <typename TFixedImage, typename TMovingImage>                                                               \
   auto MultiInputImageToImageMetricBase<TFixedImage, TMovingImage>::Get##_name(unsigned int pos) const->_type *        \
   {                                                                                                                    \
     if (this->m_##_name##Vector.size() < pos + 1)                                                                      \
@@ -79,7 +79,7 @@
 
 /** Macro for getting const objects. */
 #define itkImplementationGetConstObjectMacro(_name, _type)                                                             \
-  template <class TFixedImage, class TMovingImage>                                                                     \
+  template <typename TFixedImage, typename TMovingImage>                                                               \
   auto MultiInputImageToImageMetricBase<TFixedImage, TMovingImage>::Get##_name(unsigned int pos) const->const _type *  \
   {                                                                                                                    \
     if (this->m_##_name##Vector.size() < pos + 1)                                                                      \
@@ -113,7 +113,7 @@ itkImplementationGetObjectMacro(FixedImageInterpolator, FixedImageInterpolatorTy
  * ************************ SetFixedImageRegion *************************
  */
 
-template <class TFixedImage, class TMovingImage>
+template <typename TFixedImage, typename TMovingImage>
 void
 MultiInputImageToImageMetricBase<TFixedImage, TMovingImage>::SetFixedImageRegion(const FixedImageRegionType _arg,
                                                                                  unsigned int               pos)
@@ -140,7 +140,7 @@ MultiInputImageToImageMetricBase<TFixedImage, TMovingImage>::SetFixedImageRegion
  * ************************ GetFixedImageRegion *************************
  */
 
-template <class TFixedImage, class TMovingImage>
+template <typename TFixedImage, typename TMovingImage>
 auto
 MultiInputImageToImageMetricBase<TFixedImage, TMovingImage>::GetFixedImageRegion(unsigned int pos) const
   -> const FixedImageRegionType &
@@ -159,7 +159,7 @@ MultiInputImageToImageMetricBase<TFixedImage, TMovingImage>::GetFixedImageRegion
  * ****************** CheckForBSplineInterpolators **********************
  */
 
-template <class TFixedImage, class TMovingImage>
+template <typename TFixedImage, typename TMovingImage>
 void
 MultiInputImageToImageMetricBase<TFixedImage, TMovingImage>::CheckForBSplineInterpolators()
 {
@@ -194,7 +194,7 @@ MultiInputImageToImageMetricBase<TFixedImage, TMovingImage>::CheckForBSplineInte
  * ****************** Initialize **********************
  */
 
-template <class TFixedImage, class TMovingImage>
+template <typename TFixedImage, typename TMovingImage>
 void
 MultiInputImageToImageMetricBase<TFixedImage, TMovingImage>::Initialize()
 {
@@ -223,7 +223,7 @@ MultiInputImageToImageMetricBase<TFixedImage, TMovingImage>::Initialize()
  * ********************* InitializeImageSampler ****************************
  */
 
-template <class TFixedImage, class TMovingImage>
+template <typename TFixedImage, typename TMovingImage>
 void
 MultiInputImageToImageMetricBase<TFixedImage, TMovingImage>::InitializeImageSampler()
 {
@@ -261,7 +261,7 @@ MultiInputImageToImageMetricBase<TFixedImage, TMovingImage>::InitializeImageSamp
  * ******************* EvaluateMovingImageValueAndDerivative ******************
  */
 
-template <class TFixedImage, class TMovingImage>
+template <typename TFixedImage, typename TMovingImage>
 bool
 MultiInputImageToImageMetricBase<TFixedImage, TMovingImage>::EvaluateMovingImageValueAndDerivative(
   const MovingImagePointType & mappedPoint,
@@ -291,7 +291,7 @@ MultiInputImageToImageMetricBase<TFixedImage, TMovingImage>::EvaluateMovingImage
  * ************************ IsInsideMovingMask *************************
  */
 
-template <class TFixedImage, class TMovingImage>
+template <typename TFixedImage, typename TMovingImage>
 bool
 MultiInputImageToImageMetricBase<TFixedImage, TMovingImage>::IsInsideMovingMask(
   const MovingImagePointType & mappedPoint) const

--- a/Common/CostFunctions/itkParzenWindowHistogramImageToImageMetric.h
+++ b/Common/CostFunctions/itkParzenWindowHistogramImageToImageMetric.h
@@ -71,7 +71,7 @@ namespace itk
  * \ingroup Metrics
  */
 
-template <class TFixedImage, class TMovingImage>
+template <typename TFixedImage, typename TMovingImage>
 class ITK_TEMPLATE_EXPORT ParzenWindowHistogramImageToImageMetric
   : public AdvancedImageToImageMetric<TFixedImage, TMovingImage>
 {

--- a/Common/CostFunctions/itkParzenWindowHistogramImageToImageMetric.hxx
+++ b/Common/CostFunctions/itkParzenWindowHistogramImageToImageMetric.hxx
@@ -34,7 +34,7 @@ namespace itk
  * ********************* Constructor ****************************
  */
 
-template <class TFixedImage, class TMovingImage>
+template <typename TFixedImage, typename TMovingImage>
 ParzenWindowHistogramImageToImageMetric<TFixedImage, TMovingImage>::ParzenWindowHistogramImageToImageMetric()
 {
   this->SetUseImageSampler(true);
@@ -51,7 +51,7 @@ ParzenWindowHistogramImageToImageMetric<TFixedImage, TMovingImage>::ParzenWindow
  * ********************* PrintSelf ******************************
  */
 
-template <class TFixedImage, class TMovingImage>
+template <typename TFixedImage, typename TMovingImage>
 void
 ParzenWindowHistogramImageToImageMetric<TFixedImage, TMovingImage>::PrintSelf(std::ostream & os, Indent indent) const
 {
@@ -84,7 +84,7 @@ ParzenWindowHistogramImageToImageMetric<TFixedImage, TMovingImage>::PrintSelf(st
  * ********************* Initialize *****************************
  */
 
-template <class TFixedImage, class TMovingImage>
+template <typename TFixedImage, typename TMovingImage>
 void
 ParzenWindowHistogramImageToImageMetric<TFixedImage, TMovingImage>::Initialize()
 {
@@ -118,7 +118,7 @@ ParzenWindowHistogramImageToImageMetric<TFixedImage, TMovingImage>::Initialize()
  * ****************** InitializeHistograms *****************************
  */
 
-template <class TFixedImage, class TMovingImage>
+template <typename TFixedImage, typename TMovingImage>
 void
 ParzenWindowHistogramImageToImageMetric<TFixedImage, TMovingImage>::InitializeHistograms()
 {
@@ -284,7 +284,7 @@ ParzenWindowHistogramImageToImageMetric<TFixedImage, TMovingImage>::InitializeHi
  * ****************** InitializeKernels *****************************
  */
 
-template <class TFixedImage, class TMovingImage>
+template <typename TFixedImage, typename TMovingImage>
 void
 ParzenWindowHistogramImageToImageMetric<TFixedImage, TMovingImage>::InitializeKernels()
 {
@@ -363,7 +363,7 @@ ParzenWindowHistogramImageToImageMetric<TFixedImage, TMovingImage>::InitializeKe
  * ********************* InitializeThreadingParameters ****************************
  */
 
-template <class TFixedImage, class TMovingImage>
+template <typename TFixedImage, typename TMovingImage>
 void
 ParzenWindowHistogramImageToImageMetric<TFixedImage, TMovingImage>::InitializeThreadingParameters() const
 {
@@ -410,7 +410,7 @@ ParzenWindowHistogramImageToImageMetric<TFixedImage, TMovingImage>::InitializeTh
  * ******************** GetDerivative ***************************
  */
 
-template <class TFixedImage, class TMovingImage>
+template <typename TFixedImage, typename TMovingImage>
 void
 ParzenWindowHistogramImageToImageMetric<TFixedImage, TMovingImage>::GetDerivative(const ParametersType & parameters,
                                                                                   DerivativeType & derivative) const
@@ -428,7 +428,7 @@ ParzenWindowHistogramImageToImageMetric<TFixedImage, TMovingImage>::GetDerivativ
  * ******************** GetValueAndDerivative ***************************
  */
 
-template <class TFixedImage, class TMovingImage>
+template <typename TFixedImage, typename TMovingImage>
 void
 ParzenWindowHistogramImageToImageMetric<TFixedImage, TMovingImage>::GetValueAndDerivative(
   const ParametersType & parameters,
@@ -450,7 +450,7 @@ ParzenWindowHistogramImageToImageMetric<TFixedImage, TMovingImage>::GetValueAndD
  * ********************** EvaluateParzenValues ***************
  */
 
-template <class TFixedImage, class TMovingImage>
+template <typename TFixedImage, typename TMovingImage>
 void
 ParzenWindowHistogramImageToImageMetric<TFixedImage, TMovingImage>::EvaluateParzenValues(
   double                     parzenWindowTerm,
@@ -466,7 +466,7 @@ ParzenWindowHistogramImageToImageMetric<TFixedImage, TMovingImage>::EvaluateParz
  * ********************** UpdateJointPDFAndDerivatives ***************
  */
 
-template <class TFixedImage, class TMovingImage>
+template <typename TFixedImage, typename TMovingImage>
 void
 ParzenWindowHistogramImageToImageMetric<TFixedImage, TMovingImage>::UpdateJointPDFAndDerivatives(
   const RealType                     fixedImageValue,
@@ -565,7 +565,7 @@ ParzenWindowHistogramImageToImageMetric<TFixedImage, TMovingImage>::UpdateJointP
  * *************** UpdateJointPDFDerivatives ***************************
  */
 
-template <class TFixedImage, class TMovingImage>
+template <typename TFixedImage, typename TMovingImage>
 void
 ParzenWindowHistogramImageToImageMetric<TFixedImage, TMovingImage>::UpdateJointPDFDerivatives(
   const JointPDFIndexType &          pdfIndex,
@@ -609,7 +609,7 @@ ParzenWindowHistogramImageToImageMetric<TFixedImage, TMovingImage>::UpdateJointP
  * *********************** NormalizeJointPDF ***********************
  */
 
-template <class TFixedImage, class TMovingImage>
+template <typename TFixedImage, typename TMovingImage>
 void
 ParzenWindowHistogramImageToImageMetric<TFixedImage, TMovingImage>::NormalizeJointPDF(JointPDFType * pdf,
                                                                                       const double   factor) const
@@ -634,7 +634,7 @@ ParzenWindowHistogramImageToImageMetric<TFixedImage, TMovingImage>::NormalizeJoi
  * *********************** NormalizeJointPDFDerivatives ***********************
  */
 
-template <class TFixedImage, class TMovingImage>
+template <typename TFixedImage, typename TMovingImage>
 void
 ParzenWindowHistogramImageToImageMetric<TFixedImage, TMovingImage>::NormalizeJointPDFDerivatives(
   JointPDFDerivativesType * pdf,
@@ -660,7 +660,7 @@ ParzenWindowHistogramImageToImageMetric<TFixedImage, TMovingImage>::NormalizeJoi
  * ************************ ComputeMarginalPDF ***********************
  */
 
-template <class TFixedImage, class TMovingImage>
+template <typename TFixedImage, typename TMovingImage>
 void
 ParzenWindowHistogramImageToImageMetric<TFixedImage, TMovingImage>::ComputeMarginalPDF(
   const JointPDFType * itkNotUsed(jointPDF),
@@ -693,7 +693,7 @@ ParzenWindowHistogramImageToImageMetric<TFixedImage, TMovingImage>::ComputeMargi
  * ******************** ComputeIncrementalMarginalPDFs *******************
  */
 
-template <class TFixedImage, class TMovingImage>
+template <typename TFixedImage, typename TMovingImage>
 void
 ParzenWindowHistogramImageToImageMetric<TFixedImage, TMovingImage>::ComputeIncrementalMarginalPDFs(
   const JointPDFDerivativesType * incrementalPDF,
@@ -739,7 +739,7 @@ ParzenWindowHistogramImageToImageMetric<TFixedImage, TMovingImage>::ComputeIncre
  * ******************* UpdateJointPDFAndIncrementalPDFs *******************
  */
 
-template <class TFixedImage, class TMovingImage>
+template <typename TFixedImage, typename TMovingImage>
 void
 ParzenWindowHistogramImageToImageMetric<TFixedImage, TMovingImage>::UpdateJointPDFAndIncrementalPDFs(
   RealType                           fixedImageValue,
@@ -917,7 +917,7 @@ ParzenWindowHistogramImageToImageMetric<TFixedImage, TMovingImage>::UpdateJointP
  * ************************ ComputePDFsSingleThreaded **************************
  */
 
-template <class TFixedImage, class TMovingImage>
+template <typename TFixedImage, typename TMovingImage>
 void
 ParzenWindowHistogramImageToImageMetric<TFixedImage, TMovingImage>::ComputePDFsSingleThreaded(
   const ParametersType & parameters) const
@@ -997,7 +997,7 @@ ParzenWindowHistogramImageToImageMetric<TFixedImage, TMovingImage>::ComputePDFsS
  * ************************ ComputePDFs **************************
  */
 
-template <class TFixedImage, class TMovingImage>
+template <typename TFixedImage, typename TMovingImage>
 void
 ParzenWindowHistogramImageToImageMetric<TFixedImage, TMovingImage>::ComputePDFs(const ParametersType & parameters) const
 {
@@ -1035,7 +1035,7 @@ ParzenWindowHistogramImageToImageMetric<TFixedImage, TMovingImage>::ComputePDFs(
  * ******************* ThreadedComputePDFs *******************
  */
 
-template <class TFixedImage, class TMovingImage>
+template <typename TFixedImage, typename TMovingImage>
 void
 ParzenWindowHistogramImageToImageMetric<TFixedImage, TMovingImage>::ThreadedComputePDFs(ThreadIdType threadId)
 {
@@ -1114,7 +1114,7 @@ ParzenWindowHistogramImageToImageMetric<TFixedImage, TMovingImage>::ThreadedComp
  * ******************* AfterThreadedComputePDFs *******************
  */
 
-template <class TFixedImage, class TMovingImage>
+template <typename TFixedImage, typename TMovingImage>
 void
 ParzenWindowHistogramImageToImageMetric<TFixedImage, TMovingImage>::AfterThreadedComputePDFs() const
 {
@@ -1175,7 +1175,7 @@ ParzenWindowHistogramImageToImageMetric<TFixedImage, TMovingImage>::AfterThreade
  * **************** ComputePDFsThreaderCallback *******
  */
 
-template <class TFixedImage, class TMovingImage>
+template <typename TFixedImage, typename TMovingImage>
 ITK_THREAD_RETURN_FUNCTION_CALL_CONVENTION
 ParzenWindowHistogramImageToImageMetric<TFixedImage, TMovingImage>::ComputePDFsThreaderCallback(void * arg)
 {
@@ -1197,7 +1197,7 @@ ParzenWindowHistogramImageToImageMetric<TFixedImage, TMovingImage>::ComputePDFsT
  * *********************** LaunchComputePDFsThreaderCallback***************
  */
 
-template <class TFixedImage, class TMovingImage>
+template <typename TFixedImage, typename TMovingImage>
 void
 ParzenWindowHistogramImageToImageMetric<TFixedImage, TMovingImage>::LaunchComputePDFsThreaderCallback() const
 {
@@ -1213,7 +1213,7 @@ ParzenWindowHistogramImageToImageMetric<TFixedImage, TMovingImage>::LaunchComput
  * ************************ ComputePDFsAndPDFDerivatives *******************
  */
 
-template <class TFixedImage, class TMovingImage>
+template <typename TFixedImage, typename TMovingImage>
 void
 ParzenWindowHistogramImageToImageMetric<TFixedImage, TMovingImage>::ComputePDFsAndPDFDerivatives(
   const ParametersType & parameters) const
@@ -1311,7 +1311,7 @@ ParzenWindowHistogramImageToImageMetric<TFixedImage, TMovingImage>::ComputePDFsA
  * ************************ ComputePDFsAndIncrementalPDFs *******************
  */
 
-template <class TFixedImage, class TMovingImage>
+template <typename TFixedImage, typename TMovingImage>
 void
 ParzenWindowHistogramImageToImageMetric<TFixedImage, TMovingImage>::ComputePDFsAndIncrementalPDFs(
   const ParametersType & parameters) const

--- a/Common/CostFunctions/itkSingleValuedPointSetToPointSetMetric.h
+++ b/Common/CostFunctions/itkSingleValuedPointSetToPointSetMetric.h
@@ -57,7 +57,7 @@ namespace itk
  *
  */
 
-template <class TFixedPointSet, class TMovingPointSet>
+template <typename TFixedPointSet, typename TMovingPointSet>
 class ITK_TEMPLATE_EXPORT SingleValuedPointSetToPointSetMetric : public SingleValuedCostFunction
 {
 public:

--- a/Common/CostFunctions/itkSingleValuedPointSetToPointSetMetric.hxx
+++ b/Common/CostFunctions/itkSingleValuedPointSetToPointSetMetric.hxx
@@ -42,7 +42,7 @@ namespace itk
  * ******************* SetTransformParameters ***********************
  */
 
-template <class TFixedPointSet, class TMovingPointSet>
+template <typename TFixedPointSet, typename TMovingPointSet>
 void
 SingleValuedPointSetToPointSetMetric<TFixedPointSet, TMovingPointSet>::SetTransformParameters(
   const ParametersType & parameters) const
@@ -60,7 +60,7 @@ SingleValuedPointSetToPointSetMetric<TFixedPointSet, TMovingPointSet>::SetTransf
  * ******************* Initialize ***********************
  */
 
-template <class TFixedPointSet, class TMovingPointSet>
+template <typename TFixedPointSet, typename TMovingPointSet>
 void
 SingleValuedPointSetToPointSetMetric<TFixedPointSet, TMovingPointSet>::Initialize()
 {
@@ -92,7 +92,7 @@ SingleValuedPointSetToPointSetMetric<TFixedPointSet, TMovingPointSet>::Initializ
  * *********************** BeforeThreadedGetValueAndDerivative ***********************
  */
 
-template <class TFixedPointSet, class TMovingPointSet>
+template <typename TFixedPointSet, typename TMovingPointSet>
 void
 SingleValuedPointSetToPointSetMetric<TFixedPointSet, TMovingPointSet>::BeforeThreadedGetValueAndDerivative(
   const TransformParametersType & parameters) const
@@ -110,7 +110,7 @@ SingleValuedPointSetToPointSetMetric<TFixedPointSet, TMovingPointSet>::BeforeThr
  * ******************* PrintSelf ***********************
  */
 
-template <class TFixedPointSet, class TMovingPointSet>
+template <typename TFixedPointSet, typename TMovingPointSet>
 void
 SingleValuedPointSetToPointSetMetric<TFixedPointSet, TMovingPointSet>::PrintSelf(std::ostream & os, Indent indent) const
 {

--- a/Common/CostFunctions/itkTransformPenaltyTerm.h
+++ b/Common/CostFunctions/itkTransformPenaltyTerm.h
@@ -41,7 +41,7 @@ namespace itk
  * \ingroup Metrics
  */
 
-template <class TFixedImage, class TScalarType = double>
+template <typename TFixedImage, typename TScalarType = double>
 class ITK_TEMPLATE_EXPORT TransformPenaltyTerm : public AdvancedImageToImageMetric<TFixedImage, TFixedImage>
 {
 public:

--- a/Common/CostFunctions/itkTransformPenaltyTerm.hxx
+++ b/Common/CostFunctions/itkTransformPenaltyTerm.hxx
@@ -27,7 +27,7 @@ namespace itk
  * ****************** CheckForBSplineTransform *******************************
  */
 
-template <class TFixedImage, class TScalarType>
+template <typename TFixedImage, typename TScalarType>
 bool
 TransformPenaltyTerm<TFixedImage, TScalarType>::CheckForBSplineTransform2(BSplineOrder3TransformPointer & bspline) const
 {

--- a/Common/ImageSamplers/itkImageFullSampler.h
+++ b/Common/ImageSamplers/itkImageFullSampler.h
@@ -34,7 +34,7 @@ namespace itk
  * \ingroup ImageSamplers
  */
 
-template <class TInputImage>
+template <typename TInputImage>
 class ITK_TEMPLATE_EXPORT ImageFullSampler : public ImageSamplerBase<TInputImage>
 {
 public:

--- a/Common/ImageSamplers/itkImageFullSampler.hxx
+++ b/Common/ImageSamplers/itkImageFullSampler.hxx
@@ -33,7 +33,7 @@ namespace itk
  * ******************* GenerateWorkUnits *******************
  */
 
-template <class TInputImage>
+template <typename TInputImage>
 auto
 ImageFullSampler<TInputImage>::GenerateWorkUnits(const ThreadIdType             numberOfWorkUnits,
                                                  const InputImageRegionType &   croppedInputImageRegion,
@@ -63,7 +63,7 @@ ImageFullSampler<TInputImage>::GenerateWorkUnits(const ThreadIdType             
  * ******************* SingleThreadedGenerateData *******************
  */
 
-template <class TInputImage>
+template <typename TInputImage>
 void
 ImageFullSampler<TInputImage>::SingleThreadedGenerateData(const TInputImage &            inputImage,
                                                           const MaskType * const         mask,
@@ -97,7 +97,7 @@ ImageFullSampler<TInputImage>::SingleThreadedGenerateData(const TInputImage &   
  * ******************* MultiThreadedGenerateData *******************
  */
 
-template <class TInputImage>
+template <typename TInputImage>
 void
 ImageFullSampler<TInputImage>::MultiThreadedGenerateData(MultiThreaderBase &            multiThreader,
                                                          const ThreadIdType             numberOfWorkUnits,
@@ -146,7 +146,7 @@ ImageFullSampler<TInputImage>::MultiThreadedGenerateData(MultiThreaderBase &    
  * ******************* GenerateData *******************
  */
 
-template <class TInputImage>
+template <typename TInputImage>
 void
 ImageFullSampler<TInputImage>::GenerateData()
 {
@@ -187,7 +187,7 @@ ImageFullSampler<TInputImage>::GenerateData()
 } // end GenerateData()
 
 
-template <class TInputImage>
+template <typename TInputImage>
 template <elastix::MaskCondition VMaskCondition>
 ITK_THREAD_RETURN_FUNCTION_CALL_CONVENTION
 ImageFullSampler<TInputImage>::ThreaderCallback(void * const arg)
@@ -205,7 +205,7 @@ ImageFullSampler<TInputImage>::ThreaderCallback(void * const arg)
 }
 
 
-template <class TInputImage>
+template <typename TInputImage>
 template <elastix::MaskCondition VMaskCondition>
 void
 ImageFullSampler<TInputImage>::GenerateDataForWorkUnit(WorkUnit &             workUnit,

--- a/Common/ImageSamplers/itkImageGridSampler.h
+++ b/Common/ImageSamplers/itkImageGridSampler.h
@@ -41,7 +41,7 @@ namespace itk
  * \ingroup ImageSamplers
  */
 
-template <class TInputImage>
+template <typename TInputImage>
 class ITK_TEMPLATE_EXPORT ImageGridSampler : public ImageSamplerBase<TInputImage>
 {
 public:

--- a/Common/ImageSamplers/itkImageGridSampler.hxx
+++ b/Common/ImageSamplers/itkImageGridSampler.hxx
@@ -33,7 +33,7 @@ namespace itk
  * ******************* SetSampleGridSpacing *******************
  */
 
-template <class TInputImage>
+template <typename TInputImage>
 void
 ImageGridSampler<TInputImage>::SetSampleGridSpacing(const SampleGridSpacingType & arg)
 {
@@ -50,7 +50,7 @@ ImageGridSampler<TInputImage>::SetSampleGridSpacing(const SampleGridSpacingType 
  * ******************* DetermineGridIndexAndSize *******************
  */
 
-template <class TInputImage>
+template <typename TInputImage>
 auto
 ImageGridSampler<TInputImage>::DetermineGridIndexAndSize(const InputImageRegionType &  croppedInputImageRegion,
                                                          const SampleGridSpacingType & gridSpacing)
@@ -77,7 +77,7 @@ ImageGridSampler<TInputImage>::DetermineGridIndexAndSize(const InputImageRegionT
  * ******************* GenerateWorkUnits *******************
  */
 
-template <class TInputImage>
+template <typename TInputImage>
 auto
 ImageGridSampler<TInputImage>::GenerateWorkUnits(const ThreadIdType             numberOfWorkUnits,
                                                  const InputImageRegionType &   croppedInputImageRegion,
@@ -154,7 +154,7 @@ ImageGridSampler<TInputImage>::GenerateWorkUnits(const ThreadIdType             
  * ******************* SingleThreadedGenerateData *******************
  */
 
-template <class TInputImage>
+template <typename TInputImage>
 void
 ImageGridSampler<TInputImage>::SingleThreadedGenerateData(const TInputImage &            inputImage,
                                                           const MaskType * const         mask,
@@ -193,7 +193,7 @@ ImageGridSampler<TInputImage>::SingleThreadedGenerateData(const TInputImage &   
  * ******************* MultiThreadedGenerateData *******************
  */
 
-template <class TInputImage>
+template <typename TInputImage>
 void
 ImageGridSampler<TInputImage>::MultiThreadedGenerateData(MultiThreaderBase &            multiThreader,
                                                          const ThreadIdType             numberOfWorkUnits,
@@ -248,7 +248,7 @@ ImageGridSampler<TInputImage>::MultiThreadedGenerateData(MultiThreaderBase &    
  * ******************* GenerateData *******************
  */
 
-template <class TInputImage>
+template <typename TInputImage>
 void
 ImageGridSampler<TInputImage>::GenerateData()
 {
@@ -293,7 +293,7 @@ ImageGridSampler<TInputImage>::GenerateData()
 } // end GenerateData()
 
 
-template <class TInputImage>
+template <typename TInputImage>
 template <elastix::MaskCondition VMaskCondition>
 ITK_THREAD_RETURN_FUNCTION_CALL_CONVENTION
 ImageGridSampler<TInputImage>::ThreaderCallback(void * const arg)
@@ -315,7 +315,7 @@ ImageGridSampler<TInputImage>::ThreaderCallback(void * const arg)
 }
 
 
-template <class TInputImage>
+template <typename TInputImage>
 template <elastix::MaskCondition VMaskCondition>
 void
 ImageGridSampler<TInputImage>::GenerateDataForWorkUnit(WorkUnit &                    workUnit,
@@ -395,7 +395,7 @@ ImageGridSampler<TInputImage>::GenerateDataForWorkUnit(WorkUnit &               
  * ******************* SetNumberOfSamples *******************
  */
 
-template <class TInputImage>
+template <typename TInputImage>
 void
 ImageGridSampler<TInputImage>::SetNumberOfSamples(unsigned long nrofsamples)
 {
@@ -456,7 +456,7 @@ ImageGridSampler<TInputImage>::SetNumberOfSamples(unsigned long nrofsamples)
  * ******************* PrintSelf *******************
  */
 
-template <class TInputImage>
+template <typename TInputImage>
 void
 ImageGridSampler<TInputImage>::PrintSelf(std::ostream & os, Indent indent) const
 {

--- a/Common/ImageSamplers/itkImageRandomCoordinateSampler.h
+++ b/Common/ImageSamplers/itkImageRandomCoordinateSampler.h
@@ -36,7 +36,7 @@ namespace itk
  * \ingroup ImageSamplers
  */
 
-template <class TInputImage>
+template <typename TInputImage>
 class ITK_TEMPLATE_EXPORT ImageRandomCoordinateSampler : public ImageRandomSamplerBase<TInputImage>
 {
 public:

--- a/Common/ImageSamplers/itkImageRandomCoordinateSampler.hxx
+++ b/Common/ImageSamplers/itkImageRandomCoordinateSampler.hxx
@@ -30,7 +30,7 @@ namespace itk
  * ******************* GenerateData *******************
  */
 
-template <class TInputImage>
+template <typename TInputImage>
 void
 ImageRandomCoordinateSampler<TInputImage>::GenerateData()
 {
@@ -150,7 +150,7 @@ ImageRandomCoordinateSampler<TInputImage>::GenerateData()
  * ******************* ThreaderCallback *******************
  */
 
-template <class TInputImage>
+template <typename TInputImage>
 ITK_THREAD_RETURN_FUNCTION_CALL_CONVENTION
 ImageRandomCoordinateSampler<TInputImage>::ThreaderCallback(void * const arg)
 {
@@ -200,7 +200,7 @@ ImageRandomCoordinateSampler<TInputImage>::ThreaderCallback(void * const arg)
  * ******************* GenerateRandomCoordinate *******************
  */
 
-template <class TInputImage>
+template <typename TInputImage>
 void
 ImageRandomCoordinateSampler<TInputImage>::GenerateRandomCoordinate(
   const InputImageContinuousIndexType & smallestContIndex,
@@ -219,7 +219,7 @@ ImageRandomCoordinateSampler<TInputImage>::GenerateRandomCoordinate(
  * ******************* GenerateSampleRegion *******************
  */
 
-template <class TInputImage>
+template <typename TInputImage>
 void
 ImageRandomCoordinateSampler<TInputImage>::GenerateSampleRegion(
   const InputImageContinuousIndexType & smallestImageContIndex,
@@ -261,7 +261,7 @@ ImageRandomCoordinateSampler<TInputImage>::GenerateSampleRegion(
  * ******************* PrintSelf *******************
  */
 
-template <class TInputImage>
+template <typename TInputImage>
 void
 ImageRandomCoordinateSampler<TInputImage>::PrintSelf(std::ostream & os, Indent indent) const
 {

--- a/Common/ImageSamplers/itkImageRandomSampler.h
+++ b/Common/ImageSamplers/itkImageRandomSampler.h
@@ -35,7 +35,7 @@ namespace itk
  * \ingroup ImageSamplers
  */
 
-template <class TInputImage>
+template <typename TInputImage>
 class ITK_TEMPLATE_EXPORT ImageRandomSampler : public ImageRandomSamplerBase<TInputImage>
 {
 public:

--- a/Common/ImageSamplers/itkImageRandomSampler.hxx
+++ b/Common/ImageSamplers/itkImageRandomSampler.hxx
@@ -32,7 +32,7 @@ namespace itk
  * ******************* GenerateData *******************
  */
 
-template <class TInputImage>
+template <typename TInputImage>
 void
 ImageRandomSampler<TInputImage>::GenerateData()
 {
@@ -136,7 +136,7 @@ ImageRandomSampler<TInputImage>::GenerateData()
 } // end GenerateData()
 
 
-template <class TInputImage>
+template <typename TInputImage>
 ITK_THREAD_RETURN_FUNCTION_CALL_CONVENTION
 ImageRandomSampler<TInputImage>::ThreaderCallback(void * const arg)
 {

--- a/Common/ImageSamplers/itkImageRandomSamplerBase.h
+++ b/Common/ImageSamplers/itkImageRandomSamplerBase.h
@@ -34,7 +34,7 @@ namespace itk
  * \ingroup ImageSamplers
  */
 
-template <class TInputImage>
+template <typename TInputImage>
 class ITK_TEMPLATE_EXPORT ImageRandomSamplerBase : public ImageSamplerBase<TInputImage>
 {
 public:

--- a/Common/ImageSamplers/itkImageRandomSamplerBase.hxx
+++ b/Common/ImageSamplers/itkImageRandomSamplerBase.hxx
@@ -30,7 +30,7 @@ namespace itk
  * ******************* Constructor *******************
  */
 
-template <class TInputImage>
+template <typename TInputImage>
 ImageRandomSamplerBase<TInputImage>::ImageRandomSamplerBase()
 {
   this->m_NumberOfSamples = 1000;
@@ -42,7 +42,7 @@ ImageRandomSamplerBase<TInputImage>::ImageRandomSamplerBase()
  * ******************* GenerateRandomNumberList *******************
  */
 
-template <class TInputImage>
+template <typename TInputImage>
 void
 ImageRandomSamplerBase<TInputImage>::GenerateRandomNumberList()
 {
@@ -72,7 +72,7 @@ ImageRandomSamplerBase<TInputImage>::GenerateRandomNumberList()
  * ******************* PrintSelf *******************
  */
 
-template <class TInputImage>
+template <typename TInputImage>
 void
 ImageRandomSamplerBase<TInputImage>::PrintSelf(std::ostream & os, Indent indent) const
 {

--- a/Common/ImageSamplers/itkImageRandomSamplerSparseMask.h
+++ b/Common/ImageSamplers/itkImageRandomSamplerSparseMask.h
@@ -34,7 +34,7 @@ namespace itk
  * \ingroup ImageSamplers
  */
 
-template <class TInputImage>
+template <typename TInputImage>
 class ITK_TEMPLATE_EXPORT ImageRandomSamplerSparseMask : public ImageRandomSamplerBase<TInputImage>
 {
 public:

--- a/Common/ImageSamplers/itkImageRandomSamplerSparseMask.hxx
+++ b/Common/ImageSamplers/itkImageRandomSamplerSparseMask.hxx
@@ -29,7 +29,7 @@ namespace itk
  * ******************* GenerateData *******************
  */
 
-template <class TInputImage>
+template <typename TInputImage>
 void
 ImageRandomSamplerSparseMask<TInputImage>::GenerateData()
 {
@@ -111,7 +111,7 @@ ImageRandomSamplerSparseMask<TInputImage>::GenerateData()
 } // end GenerateData()
 
 
-template <class TInputImage>
+template <typename TInputImage>
 ITK_THREAD_RETURN_FUNCTION_CALL_CONVENTION
 ImageRandomSamplerSparseMask<TInputImage>::ThreaderCallback(void * const arg)
 {
@@ -150,7 +150,7 @@ ImageRandomSamplerSparseMask<TInputImage>::ThreaderCallback(void * const arg)
  * ******************* PrintSelf *******************
  */
 
-template <class TInputImage>
+template <typename TInputImage>
 void
 ImageRandomSamplerSparseMask<TInputImage>::PrintSelf(std::ostream & os, Indent indent) const
 {

--- a/Common/ImageSamplers/itkImageSample.h
+++ b/Common/ImageSamplers/itkImageSample.h
@@ -32,7 +32,7 @@ namespace itk
  * Its constructors, assignment operators, and destructor are implicitly defaulted, following the C++ "Rule of Zero".
  */
 
-template <class TImage>
+template <typename TImage>
 class ITK_TEMPLATE_EXPORT ImageSample
 {
 public:

--- a/Common/ImageSamplers/itkImageSamplerBase.h
+++ b/Common/ImageSamplers/itkImageSamplerBase.h
@@ -38,7 +38,7 @@ namespace itk
  * \ingroup ImageSamplers
  */
 
-template <class TInputImage>
+template <typename TInputImage>
 class ITK_TEMPLATE_EXPORT ImageSamplerBase
   : public VectorContainerSource<VectorDataContainer<std::size_t, ImageSample<TInputImage>>>
 {

--- a/Common/ImageSamplers/itkImageSamplerBase.hxx
+++ b/Common/ImageSamplers/itkImageSamplerBase.hxx
@@ -32,7 +32,7 @@ namespace itk
  * ******************* SetMask *******************
  */
 
-template <class TInputImage>
+template <typename TInputImage>
 void
 ImageSamplerBase<TInputImage>::SetMask(const MaskType * _arg, unsigned int pos)
 {
@@ -65,7 +65,7 @@ ImageSamplerBase<TInputImage>::SetMask(const MaskType * _arg, unsigned int pos)
  * ******************* GetMask *******************
  */
 
-template <class TInputImage>
+template <typename TInputImage>
 auto
 ImageSamplerBase<TInputImage>::GetMask(unsigned int pos) const -> const MaskType *
 {
@@ -81,7 +81,7 @@ ImageSamplerBase<TInputImage>::GetMask(unsigned int pos) const -> const MaskType
  * ******************* SetNumberOfMasks *******************
  */
 
-template <class TInputImage>
+template <typename TInputImage>
 void
 ImageSamplerBase<TInputImage>::SetNumberOfMasks(const unsigned int _arg)
 {
@@ -99,7 +99,7 @@ ImageSamplerBase<TInputImage>::SetNumberOfMasks(const unsigned int _arg)
  * ******************* SetInputImageRegion *******************
  */
 
-template <class TInputImage>
+template <typename TInputImage>
 void
 ImageSamplerBase<TInputImage>::SetInputImageRegion(const InputImageRegionType _arg, unsigned int pos)
 {
@@ -125,7 +125,7 @@ ImageSamplerBase<TInputImage>::SetInputImageRegion(const InputImageRegionType _a
  * ******************* GetInputImageRegion *******************
  */
 
-template <class TInputImage>
+template <typename TInputImage>
 auto
 ImageSamplerBase<TInputImage>::GetInputImageRegion(unsigned int pos) const -> const InputImageRegionType &
 {
@@ -141,7 +141,7 @@ ImageSamplerBase<TInputImage>::GetInputImageRegion(unsigned int pos) const -> co
  * ******************* SetNumberOfInputImageRegions *******************
  */
 
-template <class TInputImage>
+template <typename TInputImage>
 void
 ImageSamplerBase<TInputImage>::SetNumberOfInputImageRegions(const unsigned int _arg)
 {
@@ -159,7 +159,7 @@ ImageSamplerBase<TInputImage>::SetNumberOfInputImageRegions(const unsigned int _
  * ******************* GenerateInputRequestedRegion *******************
  */
 
-template <class TInputImage>
+template <typename TInputImage>
 void
 ImageSamplerBase<TInputImage>::GenerateInputRequestedRegion()
 {
@@ -216,7 +216,7 @@ ImageSamplerBase<TInputImage>::GenerateInputRequestedRegion()
  * ******************* SelectNewSamplesOnUpdate *******************
  */
 
-template <class TInputImage>
+template <typename TInputImage>
 bool
 ImageSamplerBase<TInputImage>::SelectNewSamplesOnUpdate()
 {
@@ -235,7 +235,7 @@ ImageSamplerBase<TInputImage>::SelectNewSamplesOnUpdate()
  * ******************* IsInsideAllMasks *******************
  */
 
-template <class TInputImage>
+template <typename TInputImage>
 bool
 ImageSamplerBase<TInputImage>::IsInsideAllMasks(const InputImagePointType & point) const
 {
@@ -254,7 +254,7 @@ ImageSamplerBase<TInputImage>::IsInsideAllMasks(const InputImagePointType & poin
  * ******************* UpdateAllMasks *******************
  */
 
-template <class TInputImage>
+template <typename TInputImage>
 void
 ImageSamplerBase<TInputImage>::UpdateAllMasks()
 {
@@ -271,7 +271,7 @@ ImageSamplerBase<TInputImage>::UpdateAllMasks()
  * ******************* CheckInputImageRegions *******************
  */
 
-template <class TInputImage>
+template <typename TInputImage>
 bool
 ImageSamplerBase<TInputImage>::CheckInputImageRegions()
 {
@@ -289,7 +289,7 @@ ImageSamplerBase<TInputImage>::CheckInputImageRegions()
  * ******************* CropInputImageRegion *******************
  */
 
-template <class TInputImage>
+template <typename TInputImage>
 void
 ImageSamplerBase<TInputImage>::CropInputImageRegion()
 {
@@ -371,7 +371,7 @@ ImageSamplerBase<TInputImage>::CropInputImageRegion()
  * ******************* PrintSelf *******************
  */
 
-template <class TInputImage>
+template <typename TInputImage>
 void
 ImageSamplerBase<TInputImage>::PrintSelf(std::ostream & os, Indent indent) const
 {
@@ -401,7 +401,7 @@ ImageSamplerBase<TInputImage>::PrintSelf(std::ostream & os, Indent indent) const
  * ******************* Constructor *******************
  */
 
-template <class TInputImage>
+template <typename TInputImage>
 ImageSamplerBase<TInputImage>::ImageSamplerBase()
 {
   this->ProcessObject::SetNumberOfRequiredInputs(1);
@@ -415,7 +415,7 @@ ImageSamplerBase<TInputImage>::ImageSamplerBase()
  * ******************* MakeOutput *******************
  */
 
-template <class TInputImage>
+template <typename TInputImage>
 DataObject::Pointer
 ImageSamplerBase<TInputImage>::MakeOutput(ProcessObject::DataObjectPointerArraySizeType itkNotUsed(idx))
 {
@@ -428,7 +428,7 @@ ImageSamplerBase<TInputImage>::MakeOutput(ProcessObject::DataObjectPointerArrayS
  * ******************* SetInput *******************
  */
 
-template <class TInputImage>
+template <typename TInputImage>
 void
 ImageSamplerBase<TInputImage>::SetInput(unsigned int idx, const InputImageType * input)
 {
@@ -442,7 +442,7 @@ ImageSamplerBase<TInputImage>::SetInput(unsigned int idx, const InputImageType *
  * ******************* SetInput *******************
  */
 
-template <class TInputImage>
+template <typename TInputImage>
 void
 ImageSamplerBase<TInputImage>::SetInput(const InputImageType * input)
 {
@@ -454,7 +454,7 @@ ImageSamplerBase<TInputImage>::SetInput(const InputImageType * input)
  * ******************* GetInput *******************
  */
 
-template <class TInputImage>
+template <typename TInputImage>
 auto
 ImageSamplerBase<TInputImage>::GetInput() -> const InputImageType *
 {
@@ -465,7 +465,7 @@ ImageSamplerBase<TInputImage>::GetInput() -> const InputImageType *
  * ******************* GetInput *******************
  */
 
-template <class TInputImage>
+template <typename TInputImage>
 auto
 ImageSamplerBase<TInputImage>::GetInput(unsigned int idx) -> const InputImageType *
 {
@@ -476,7 +476,7 @@ ImageSamplerBase<TInputImage>::GetInput(unsigned int idx) -> const InputImageTyp
  * ******************* GetOutput *******************
  */
 
-template <class TInputImage>
+template <typename TInputImage>
 auto
 ImageSamplerBase<TInputImage>::GetOutput() -> OutputVectorContainerType *
 {
@@ -484,7 +484,7 @@ ImageSamplerBase<TInputImage>::GetOutput() -> OutputVectorContainerType *
 } // end GetOutput()
 
 
-template <class TInputImage>
+template <typename TInputImage>
 auto
 ImageSamplerBase<TInputImage>::SplitRegion(const InputImageRegionType & inputRegion,
                                            const size_t                 requestedNumberOfSubregions)

--- a/Common/ImageSamplers/itkMultiInputImageRandomCoordinateSampler.h
+++ b/Common/ImageSamplers/itkMultiInputImageRandomCoordinateSampler.h
@@ -36,7 +36,7 @@ namespace itk
  * \ingroup ImageSamplers
  */
 
-template <class TInputImage>
+template <typename TInputImage>
 class ITK_TEMPLATE_EXPORT MultiInputImageRandomCoordinateSampler : public ImageRandomSamplerBase<TInputImage>
 {
 public:

--- a/Common/ImageSamplers/itkMultiInputImageRandomCoordinateSampler.hxx
+++ b/Common/ImageSamplers/itkMultiInputImageRandomCoordinateSampler.hxx
@@ -30,7 +30,7 @@ namespace itk
  * ******************* GenerateData *******************
  */
 
-template <class TInputImage>
+template <typename TInputImage>
 void
 MultiInputImageRandomCoordinateSampler<TInputImage>::GenerateData()
 {
@@ -128,7 +128,7 @@ MultiInputImageRandomCoordinateSampler<TInputImage>::GenerateData()
  * ******************* GenerateSampleRegion *******************
  */
 
-template <class TInputImage>
+template <typename TInputImage>
 void
 MultiInputImageRandomCoordinateSampler<TInputImage>::GenerateSampleRegion(
   InputImageContinuousIndexType & smallestContIndex,
@@ -225,7 +225,7 @@ MultiInputImageRandomCoordinateSampler<TInputImage>::GenerateSampleRegion(
  * ******************* GenerateRandomCoordinate *******************
  */
 
-template <class TInputImage>
+template <typename TInputImage>
 void
 MultiInputImageRandomCoordinateSampler<TInputImage>::GenerateRandomCoordinate(
   const InputImageContinuousIndexType & smallestContIndex,
@@ -244,7 +244,7 @@ MultiInputImageRandomCoordinateSampler<TInputImage>::GenerateRandomCoordinate(
  * ******************* PrintSelf *******************
  */
 
-template <class TInputImage>
+template <typename TInputImage>
 void
 MultiInputImageRandomCoordinateSampler<TInputImage>::PrintSelf(std::ostream & os, Indent indent) const
 {

--- a/Common/ImageSamplers/itkVectorContainerSource.h
+++ b/Common/ImageSamplers/itkVectorContainerSource.h
@@ -28,7 +28,7 @@ namespace itk
  * \brief A base class for creating an ImageToVectorContainerFilter.
  */
 
-template <class TOutputVectorContainer>
+template <typename TOutputVectorContainer>
 class ITK_TEMPLATE_EXPORT VectorContainerSource : public ProcessObject
 {
 public:

--- a/Common/ImageSamplers/itkVectorContainerSource.hxx
+++ b/Common/ImageSamplers/itkVectorContainerSource.hxx
@@ -27,7 +27,7 @@ namespace itk
  * ******************* Constructor *******************
  */
 
-template <class TOutputVectorContainer>
+template <typename TOutputVectorContainer>
 VectorContainerSource<TOutputVectorContainer>::VectorContainerSource()
 {
   this->ProcessObject::SetNumberOfRequiredOutputs(1);
@@ -43,7 +43,7 @@ VectorContainerSource<TOutputVectorContainer>::VectorContainerSource()
  * ******************* MakeOutput *******************
  */
 
-template <class TOutputVectorContainer>
+template <typename TOutputVectorContainer>
 auto
 VectorContainerSource<TOutputVectorContainer>::MakeOutput(ProcessObject::DataObjectPointerArraySizeType itkNotUsed(idx))
   -> DataObjectPointer
@@ -56,7 +56,7 @@ VectorContainerSource<TOutputVectorContainer>::MakeOutput(ProcessObject::DataObj
  * ******************* GetOutput *******************
  */
 
-template <class TOutputVectorContainer>
+template <typename TOutputVectorContainer>
 auto
 VectorContainerSource<TOutputVectorContainer>::GetOutput() -> OutputVectorContainerType *
 {
@@ -72,7 +72,7 @@ VectorContainerSource<TOutputVectorContainer>::GetOutput() -> OutputVectorContai
  * ******************* GetOutput *******************
  */
 
-template <class TOutputVectorContainer>
+template <typename TOutputVectorContainer>
 auto
 VectorContainerSource<TOutputVectorContainer>::GetOutput(unsigned int idx) -> OutputVectorContainerType *
 {
@@ -83,7 +83,7 @@ VectorContainerSource<TOutputVectorContainer>::GetOutput(unsigned int idx) -> Ou
  * ******************* GraftOutput *******************
  */
 
-template <class TOutputVectorContainer>
+template <typename TOutputVectorContainer>
 void
 VectorContainerSource<TOutputVectorContainer>::GraftOutput(DataObject * graft)
 {
@@ -95,7 +95,7 @@ VectorContainerSource<TOutputVectorContainer>::GraftOutput(DataObject * graft)
  * ******************* GraftNthOutput *******************
  */
 
-template <class TOutputVectorContainer>
+template <typename TOutputVectorContainer>
 void
 VectorContainerSource<TOutputVectorContainer>::GraftNthOutput(unsigned int idx, DataObject * graft)
 {
@@ -126,7 +126,7 @@ VectorContainerSource<TOutputVectorContainer>::GraftNthOutput(unsigned int idx, 
  * ******************* PrintSelf *******************
  */
 
-template <class TOutputVectorContainer>
+template <typename TOutputVectorContainer>
 void
 VectorContainerSource<TOutputVectorContainer>::PrintSelf(std::ostream & os, Indent indent) const
 {

--- a/Common/ParameterFileParser/itkParameterMapInterface.h
+++ b/Common/ParameterFileParser/itkParameterMapInterface.h
@@ -133,7 +133,7 @@ public:
    * 4) -> Throw exception: there is an error in the parameter file
    *
    */
-  template <class T>
+  template <typename T>
   bool
   ReadParameter(T &                 parameterValue,
                 const std::string & parameterName,
@@ -206,7 +206,7 @@ public:
   /** A shorter version of ReadParameter() that does not require the boolean
    * produceWarningMessage. Instead the default value true is used.
    */
-  template <class T>
+  template <typename T>
   bool
   ReadParameter(T &                 parameterValue,
                 const std::string & parameterName,
@@ -222,7 +222,7 @@ public:
    * This function tries to read parameterName, but also prefix+parameterName.
    * Also, multiple entries are tried, entry_nr as well as default_entry_nr.
    */
-  template <class T>
+  template <typename T>
   bool
   ReadParameter(T &                 parameterValue,
                 const std::string & parameterName,
@@ -268,7 +268,7 @@ public:
   /** A shorter version of the extended ReadParameter() that does not require
    * the boolean produceWarningMessage. Instead the default value true is used.
    */
-  template <class T>
+  template <typename T>
   bool
   ReadParameter(T &                 parameterValue,
                 const std::string & parameterName,
@@ -282,7 +282,7 @@ public:
 
 
   /** An extended version that reads all parameters in a range at once. */
-  template <class T>
+  template <typename T>
   bool
   ReadParameter(std::vector<T> &    parameterValues,
                 const std::string & parameterName,

--- a/Common/Transforms/itkAdvancedBSplineDeformableTransform.h
+++ b/Common/Transforms/itkAdvancedBSplineDeformableTransform.h
@@ -45,7 +45,7 @@ namespace itk
 {
 
 // Forward declarations for friendship
-template <class TScalarType, unsigned int NDimensions, unsigned int VSplineOrder>
+template <typename TScalarType, unsigned int NDimensions, unsigned int VSplineOrder>
 class ITK_TEMPLATE_EXPORT MultiBSplineDeformableTransformWithNormal;
 
 /** \class AdvancedBSplineDeformableTransform
@@ -125,8 +125,8 @@ class ITK_TEMPLATE_EXPORT MultiBSplineDeformableTransformWithNormal;
  *
  * \ingroup Transforms
  */
-template <class TScalarType = double,   // Data type for scalars
-          unsigned int NDimensions = 3, // Number of dimensions
+template <typename TScalarType = double, // Data type for scalars
+          unsigned int NDimensions = 3,  // Number of dimensions
           unsigned int VSplineOrder = 3>
 // Spline order
 class ITK_TEMPLATE_EXPORT AdvancedBSplineDeformableTransform

--- a/Common/Transforms/itkAdvancedBSplineDeformableTransform.hxx
+++ b/Common/Transforms/itkAdvancedBSplineDeformableTransform.hxx
@@ -50,7 +50,7 @@ namespace itk
 {
 
 // Constructor with default arguments
-template <class TScalarType, unsigned int NDimensions, unsigned int VSplineOrder>
+template <typename TScalarType, unsigned int NDimensions, unsigned int VSplineOrder>
 AdvancedBSplineDeformableTransform<TScalarType, NDimensions, VSplineOrder>::AdvancedBSplineDeformableTransform()
   : Superclass(VSplineOrder)
 {
@@ -74,7 +74,7 @@ AdvancedBSplineDeformableTransform<TScalarType, NDimensions, VSplineOrder>::Adva
 
 
 // Set the grid region
-template <class TScalarType, unsigned int NDimensions, unsigned int VSplineOrder>
+template <typename TScalarType, unsigned int NDimensions, unsigned int VSplineOrder>
 void
 AdvancedBSplineDeformableTransform<TScalarType, NDimensions, VSplineOrder>::SetGridRegion(const RegionType & region)
 {
@@ -136,7 +136,7 @@ AdvancedBSplineDeformableTransform<TScalarType, NDimensions, VSplineOrder>::SetG
 
 
 // Transform a point
-template <class TScalarType, unsigned int NDimensions, unsigned int VSplineOrder>
+template <typename TScalarType, unsigned int NDimensions, unsigned int VSplineOrder>
 auto
 AdvancedBSplineDeformableTransform<TScalarType, NDimensions, VSplineOrder>::TransformPoint(
   const InputPointType & point) const -> OutputPointType
@@ -214,7 +214,7 @@ AdvancedBSplineDeformableTransform<TScalarType, NDimensions, VSplineOrder>::Tran
  * ********************* GetNumberOfAffectedWeights ****************************
  */
 
-template <class TScalarType, unsigned int NDimensions, unsigned int VSplineOrder>
+template <typename TScalarType, unsigned int NDimensions, unsigned int VSplineOrder>
 unsigned int
 AdvancedBSplineDeformableTransform<TScalarType, NDimensions, VSplineOrder>::GetNumberOfAffectedWeights() const
 {
@@ -226,7 +226,7 @@ AdvancedBSplineDeformableTransform<TScalarType, NDimensions, VSplineOrder>::GetN
  * ********************* GetNumberOfNonZeroJacobianIndices ****************************
  */
 
-template <class TScalarType, unsigned int NDimensions, unsigned int VSplineOrder>
+template <typename TScalarType, unsigned int NDimensions, unsigned int VSplineOrder>
 auto
 AdvancedBSplineDeformableTransform<TScalarType, NDimensions, VSplineOrder>::GetNumberOfNonZeroJacobianIndices() const
   -> NumberOfParametersType
@@ -239,7 +239,7 @@ AdvancedBSplineDeformableTransform<TScalarType, NDimensions, VSplineOrder>::GetN
  * ********************* GetJacobian ****************************
  */
 
-template <class TScalarType, unsigned int NDimensions, unsigned int VSplineOrder>
+template <typename TScalarType, unsigned int NDimensions, unsigned int VSplineOrder>
 void
 AdvancedBSplineDeformableTransform<TScalarType, NDimensions, VSplineOrder>::GetJacobian(
   const InputPointType &       inputPoint,
@@ -310,7 +310,7 @@ AdvancedBSplineDeformableTransform<TScalarType, NDimensions, VSplineOrder>::GetJ
  * ********************* EvaluateJacobianAndImageGradientProduct ****************************
  */
 
-template <class TScalarType, unsigned int NDimensions, unsigned int VSplineOrder>
+template <typename TScalarType, unsigned int NDimensions, unsigned int VSplineOrder>
 void
 AdvancedBSplineDeformableTransform<TScalarType, NDimensions, VSplineOrder>::EvaluateJacobianWithImageGradientProduct(
   const InputPointType &          inputPoint,
@@ -375,7 +375,7 @@ AdvancedBSplineDeformableTransform<TScalarType, NDimensions, VSplineOrder>::Eval
  * ********************* GetSpatialJacobian ****************************
  */
 
-template <class TScalarType, unsigned int NDimensions, unsigned int VSplineOrder>
+template <typename TScalarType, unsigned int NDimensions, unsigned int VSplineOrder>
 void
 AdvancedBSplineDeformableTransform<TScalarType, NDimensions, VSplineOrder>::GetSpatialJacobian(
   const InputPointType & inputPoint,
@@ -471,7 +471,7 @@ AdvancedBSplineDeformableTransform<TScalarType, NDimensions, VSplineOrder>::GetS
  * ********************* GetSpatialHessian ****************************
  */
 
-template <class TScalarType, unsigned int NDimensions, unsigned int VSplineOrder>
+template <typename TScalarType, unsigned int NDimensions, unsigned int VSplineOrder>
 void
 AdvancedBSplineDeformableTransform<TScalarType, NDimensions, VSplineOrder>::GetSpatialHessian(
   const InputPointType & inputPoint,
@@ -579,7 +579,7 @@ AdvancedBSplineDeformableTransform<TScalarType, NDimensions, VSplineOrder>::GetS
  * ********************* GetJacobianOfSpatialJacobian ****************************
  */
 
-template <class TScalarType, unsigned int NDimensions, unsigned int VSplineOrder>
+template <typename TScalarType, unsigned int NDimensions, unsigned int VSplineOrder>
 void
 AdvancedBSplineDeformableTransform<TScalarType, NDimensions, VSplineOrder>::GetJacobianOfSpatialJacobian(
   const InputPointType &          inputPoint,
@@ -671,7 +671,7 @@ AdvancedBSplineDeformableTransform<TScalarType, NDimensions, VSplineOrder>::GetJ
  * ********************* GetJacobianOfSpatialJacobian ****************************
  */
 
-template <class TScalarType, unsigned int NDimensions, unsigned int VSplineOrder>
+template <typename TScalarType, unsigned int NDimensions, unsigned int VSplineOrder>
 void
 AdvancedBSplineDeformableTransform<TScalarType, NDimensions, VSplineOrder>::GetJacobianOfSpatialJacobian(
   const InputPointType &          inputPoint,
@@ -821,7 +821,7 @@ AdvancedBSplineDeformableTransform<TScalarType, NDimensions, VSplineOrder>::GetJ
  * ********************* GetJacobianOfSpatialHessian ****************************
  */
 
-template <class TScalarType, unsigned int NDimensions, unsigned int VSplineOrder>
+template <typename TScalarType, unsigned int NDimensions, unsigned int VSplineOrder>
 void
 AdvancedBSplineDeformableTransform<TScalarType, NDimensions, VSplineOrder>::GetJacobianOfSpatialHessian(
   const InputPointType &         inputPoint,
@@ -931,7 +931,7 @@ AdvancedBSplineDeformableTransform<TScalarType, NDimensions, VSplineOrder>::GetJ
  * ********************* GetJacobianOfSpatialHessian ****************************
  */
 
-template <class TScalarType, unsigned int NDimensions, unsigned int VSplineOrder>
+template <typename TScalarType, unsigned int NDimensions, unsigned int VSplineOrder>
 void
 AdvancedBSplineDeformableTransform<TScalarType, NDimensions, VSplineOrder>::GetJacobianOfSpatialHessian(
   const InputPointType &         inputPoint,
@@ -1121,7 +1121,7 @@ AdvancedBSplineDeformableTransform<TScalarType, NDimensions, VSplineOrder>::GetJ
  * ********************* ComputeNonZeroJacobianIndices ****************************
  */
 
-template <class TScalarType, unsigned int NDimensions, unsigned int VSplineOrder>
+template <typename TScalarType, unsigned int NDimensions, unsigned int VSplineOrder>
 void
 AdvancedBSplineDeformableTransform<TScalarType, NDimensions, VSplineOrder>::ComputeNonZeroJacobianIndices(
   NonZeroJacobianIndicesType & nonZeroJacobianIndices,
@@ -1244,7 +1244,7 @@ AdvancedBSplineDeformableTransform<TScalarType, NDimensions, VSplineOrder>::Comp
  * ********************* PrintSelf ****************************
  */
 
-template <class TScalarType, unsigned int NDimensions, unsigned int VSplineOrder>
+template <typename TScalarType, unsigned int NDimensions, unsigned int VSplineOrder>
 void
 AdvancedBSplineDeformableTransform<TScalarType, NDimensions, VSplineOrder>::PrintSelf(std::ostream & os,
                                                                                       Indent         indent) const

--- a/Common/Transforms/itkAdvancedBSplineDeformableTransformBase.h
+++ b/Common/Transforms/itkAdvancedBSplineDeformableTransformBase.h
@@ -35,7 +35,7 @@ namespace itk
  * different spline orders more convenient in subsequent code.
  *
  */
-template <class TScalarType = double, // Data type for scalars
+template <typename TScalarType = double, // Data type for scalars
           unsigned int NDimensions = 3>
 // Number of dimensions
 class ITK_TEMPLATE_EXPORT AdvancedBSplineDeformableTransformBase

--- a/Common/Transforms/itkAdvancedBSplineDeformableTransformBase.hxx
+++ b/Common/Transforms/itkAdvancedBSplineDeformableTransformBase.hxx
@@ -27,7 +27,7 @@ namespace itk
 {
 
 // Constructor with default arguments
-template <class TScalarType, unsigned int NDimensions>
+template <typename TScalarType, unsigned int NDimensions>
 AdvancedBSplineDeformableTransformBase<TScalarType, NDimensions>::AdvancedBSplineDeformableTransformBase(
   const unsigned splineOrder)
   : Superclass(SpaceDimension)
@@ -84,7 +84,7 @@ AdvancedBSplineDeformableTransformBase<TScalarType, NDimensions>::AdvancedBSplin
 
 
 // Get the number of parameters
-template <class TScalarType, unsigned int NDimensions>
+template <typename TScalarType, unsigned int NDimensions>
 auto
 AdvancedBSplineDeformableTransformBase<TScalarType, NDimensions>::GetNumberOfParameters() const
   -> NumberOfParametersType
@@ -98,7 +98,7 @@ AdvancedBSplineDeformableTransformBase<TScalarType, NDimensions>::GetNumberOfPar
 
 
 // Get the number of parameters per dimension
-template <class TScalarType, unsigned int NDimensions>
+template <typename TScalarType, unsigned int NDimensions>
 auto
 AdvancedBSplineDeformableTransformBase<TScalarType, NDimensions>::GetNumberOfParametersPerDimension() const
   -> NumberOfParametersType
@@ -110,7 +110,7 @@ AdvancedBSplineDeformableTransformBase<TScalarType, NDimensions>::GetNumberOfPar
 
 
 // Set the grid spacing
-template <class TScalarType, unsigned int NDimensions>
+template <typename TScalarType, unsigned int NDimensions>
 void
 AdvancedBSplineDeformableTransformBase<TScalarType, NDimensions>::UpdatePointIndexConversions()
 {
@@ -151,7 +151,7 @@ AdvancedBSplineDeformableTransformBase<TScalarType, NDimensions>::UpdatePointInd
 
 
 //
-template <class TScalarType, unsigned int NDimensions>
+template <typename TScalarType, unsigned int NDimensions>
 void
 AdvancedBSplineDeformableTransformBase<TScalarType, NDimensions>::UpdateGridOffsetTable()
 {
@@ -166,7 +166,7 @@ AdvancedBSplineDeformableTransformBase<TScalarType, NDimensions>::UpdateGridOffs
 
 
 // Set the grid spacing
-template <class TScalarType, unsigned int NDimensions>
+template <typename TScalarType, unsigned int NDimensions>
 void
 AdvancedBSplineDeformableTransformBase<TScalarType, NDimensions>::SetGridSpacing(const SpacingType & spacing)
 {
@@ -188,7 +188,7 @@ AdvancedBSplineDeformableTransformBase<TScalarType, NDimensions>::SetGridSpacing
 
 
 // Set the grid direction
-template <class TScalarType, unsigned int NDimensions>
+template <typename TScalarType, unsigned int NDimensions>
 void
 AdvancedBSplineDeformableTransformBase<TScalarType, NDimensions>::SetGridDirection(const DirectionType & direction)
 {
@@ -210,7 +210,7 @@ AdvancedBSplineDeformableTransformBase<TScalarType, NDimensions>::SetGridDirecti
 
 
 // Set the grid origin
-template <class TScalarType, unsigned int NDimensions>
+template <typename TScalarType, unsigned int NDimensions>
 void
 AdvancedBSplineDeformableTransformBase<TScalarType, NDimensions>::SetGridOrigin(const OriginType & origin)
 {
@@ -230,7 +230,7 @@ AdvancedBSplineDeformableTransformBase<TScalarType, NDimensions>::SetGridOrigin(
 
 
 // Set the parameters
-template <class TScalarType, unsigned int NDimensions>
+template <typename TScalarType, unsigned int NDimensions>
 void
 AdvancedBSplineDeformableTransformBase<TScalarType, NDimensions>::SetIdentity()
 {
@@ -249,7 +249,7 @@ AdvancedBSplineDeformableTransformBase<TScalarType, NDimensions>::SetIdentity()
 
 
 // Set the parameters
-template <class TScalarType, unsigned int NDimensions>
+template <typename TScalarType, unsigned int NDimensions>
 void
 AdvancedBSplineDeformableTransformBase<TScalarType, NDimensions>::SetParameters(const ParametersType & parameters)
 {
@@ -278,7 +278,7 @@ AdvancedBSplineDeformableTransformBase<TScalarType, NDimensions>::SetParameters(
 
 
 // Set the Fixed Parameters
-template <class TScalarType, unsigned int NDimensions>
+template <typename TScalarType, unsigned int NDimensions>
 void
 AdvancedBSplineDeformableTransformBase<TScalarType, NDimensions>::SetFixedParameters(
   const FixedParametersType & passedParameters)
@@ -366,7 +366,7 @@ AdvancedBSplineDeformableTransformBase<TScalarType, NDimensions>::SetFixedParame
 
 
 // Wrap flat parameters as images
-template <class TScalarType, unsigned int NDimensions>
+template <typename TScalarType, unsigned int NDimensions>
 void
 AdvancedBSplineDeformableTransformBase<TScalarType, NDimensions>::WrapAsImages()
 {
@@ -388,7 +388,7 @@ AdvancedBSplineDeformableTransformBase<TScalarType, NDimensions>::WrapAsImages()
 
 
 // Set the parameters by value
-template <class TScalarType, unsigned int NDimensions>
+template <typename TScalarType, unsigned int NDimensions>
 void
 AdvancedBSplineDeformableTransformBase<TScalarType, NDimensions>::SetParametersByValue(
   const ParametersType & parameters)
@@ -415,7 +415,7 @@ AdvancedBSplineDeformableTransformBase<TScalarType, NDimensions>::SetParametersB
 
 
 // Get the parameters
-template <class TScalarType, unsigned int NDimensions>
+template <typename TScalarType, unsigned int NDimensions>
 auto
 AdvancedBSplineDeformableTransformBase<TScalarType, NDimensions>::GetParameters() const -> const ParametersType &
 {
@@ -432,7 +432,7 @@ AdvancedBSplineDeformableTransformBase<TScalarType, NDimensions>::GetParameters(
 }
 
 // Get the parameters
-template <class TScalarType, unsigned int NDimensions>
+template <typename TScalarType, unsigned int NDimensions>
 auto
 AdvancedBSplineDeformableTransformBase<TScalarType, NDimensions>::GetFixedParameters() const
   -> const FixedParametersType &
@@ -463,7 +463,7 @@ AdvancedBSplineDeformableTransformBase<TScalarType, NDimensions>::GetFixedParame
 }
 
 // Set the B-Spline coefficients using input images
-template <class TScalarType, unsigned int NDimensions>
+template <typename TScalarType, unsigned int NDimensions>
 void
 AdvancedBSplineDeformableTransformBase<TScalarType, NDimensions>::SetCoefficientImages(ImagePointer images[])
 {
@@ -488,7 +488,7 @@ AdvancedBSplineDeformableTransformBase<TScalarType, NDimensions>::SetCoefficient
 
 
 // Print self
-template <class TScalarType, unsigned int NDimensions>
+template <typename TScalarType, unsigned int NDimensions>
 void
 AdvancedBSplineDeformableTransformBase<TScalarType, NDimensions>::PrintSelf(std::ostream & os, Indent indent) const
 {
@@ -524,7 +524,7 @@ AdvancedBSplineDeformableTransformBase<TScalarType, NDimensions>::PrintSelf(std:
 
 
 // Transform a point
-template <class TScalarType, unsigned int NDimensions>
+template <typename TScalarType, unsigned int NDimensions>
 bool
 AdvancedBSplineDeformableTransformBase<TScalarType, NDimensions>::InsideValidRegion(
   const ContinuousIndexType & index) const
@@ -545,7 +545,7 @@ AdvancedBSplineDeformableTransformBase<TScalarType, NDimensions>::InsideValidReg
 }
 
 
-template <class TScalarType, unsigned int NDimensions>
+template <typename TScalarType, unsigned int NDimensions>
 auto
 AdvancedBSplineDeformableTransformBase<TScalarType, NDimensions>::TransformPointToContinuousGridIndex(
   const InputPointType & point) const -> ContinuousIndexType

--- a/Common/Transforms/itkAdvancedEuler3DTransform.h
+++ b/Common/Transforms/itkAdvancedEuler3DTransform.h
@@ -59,7 +59,7 @@ namespace itk
  *
  * \ingroup Transforms
  */
-template <class TScalarType = double>
+template <typename TScalarType = double>
 // Data type for scalars (float or double)
 class ITK_TEMPLATE_EXPORT AdvancedEuler3DTransform : public AdvancedRigid3DTransform<TScalarType>
 {

--- a/Common/Transforms/itkAdvancedEuler3DTransform.hxx
+++ b/Common/Transforms/itkAdvancedEuler3DTransform.hxx
@@ -39,7 +39,7 @@ namespace itk
 {
 
 // Default-constructor
-template <class TScalarType>
+template <typename TScalarType>
 AdvancedEuler3DTransform<TScalarType>::AdvancedEuler3DTransform()
   : Superclass(ParametersDimension)
 {
@@ -52,7 +52,7 @@ AdvancedEuler3DTransform<TScalarType>::AdvancedEuler3DTransform()
 
 
 // Set Parameters
-template <class TScalarType>
+template <typename TScalarType>
 void
 AdvancedEuler3DTransform<TScalarType>::SetParameters(const ParametersType & parameters)
 {
@@ -81,7 +81,7 @@ AdvancedEuler3DTransform<TScalarType>::SetParameters(const ParametersType & para
 
 
 // Get Parameters
-template <class TScalarType>
+template <typename TScalarType>
 auto
 AdvancedEuler3DTransform<TScalarType>::GetParameters() const -> const ParametersType &
 {
@@ -96,7 +96,7 @@ AdvancedEuler3DTransform<TScalarType>::GetParameters() const -> const Parameters
 }
 
 
-template <class TScalarType>
+template <typename TScalarType>
 auto
 AdvancedEuler3DTransform<TScalarType>::GetFixedParameters() const -> const FixedParametersType &
 {
@@ -119,7 +119,7 @@ AdvancedEuler3DTransform<TScalarType>::GetFixedParameters() const -> const Fixed
 }
 
 
-template <class TScalarType>
+template <typename TScalarType>
 void
 AdvancedEuler3DTransform<TScalarType>::SetFixedParameters(const FixedParametersType & parameters)
 {
@@ -149,7 +149,7 @@ AdvancedEuler3DTransform<TScalarType>::SetFixedParameters(const FixedParametersT
 
 
 // Set Rotational Part
-template <class TScalarType>
+template <typename TScalarType>
 void
 AdvancedEuler3DTransform<TScalarType>::SetRotation(ScalarType angleX, ScalarType angleY, ScalarType angleZ)
 {
@@ -162,7 +162,7 @@ AdvancedEuler3DTransform<TScalarType>::SetRotation(ScalarType angleX, ScalarType
 
 
 // Compose
-template <class TScalarType>
+template <typename TScalarType>
 void
 AdvancedEuler3DTransform<TScalarType>::SetIdentity()
 {
@@ -175,7 +175,7 @@ AdvancedEuler3DTransform<TScalarType>::SetIdentity()
 
 
 // Compute angles from the rotation matrix
-template <class TScalarType>
+template <typename TScalarType>
 void
 AdvancedEuler3DTransform<TScalarType>::ComputeMatrixParameters()
 {
@@ -227,7 +227,7 @@ AdvancedEuler3DTransform<TScalarType>::ComputeMatrixParameters()
 
 
 // Compute the matrix
-template <class TScalarType>
+template <typename TScalarType>
 void
 AdvancedEuler3DTransform<TScalarType>::ComputeMatrix()
 {
@@ -288,7 +288,7 @@ AdvancedEuler3DTransform<TScalarType>::ComputeMatrix()
 
 
 // Get Jacobian
-template <class TScalarType>
+template <typename TScalarType>
 void
 AdvancedEuler3DTransform<TScalarType>::GetJacobian(const InputPointType &       p,
                                                    JacobianType &               j,
@@ -325,7 +325,7 @@ AdvancedEuler3DTransform<TScalarType>::GetJacobian(const InputPointType &       
 
 
 // Precompute Jacobian of Spatial Jacobian
-template <class TScalarType>
+template <typename TScalarType>
 void
 AdvancedEuler3DTransform<TScalarType>::PrecomputeJacobianOfSpatialJacobian()
 {
@@ -440,7 +440,7 @@ AdvancedEuler3DTransform<TScalarType>::PrecomputeJacobianOfSpatialJacobian()
 }
 
 
-template <class TScalarType>
+template <typename TScalarType>
 void
 AdvancedEuler3DTransform<TScalarType>::SetComputeZYX(const bool flag)
 {
@@ -457,7 +457,7 @@ AdvancedEuler3DTransform<TScalarType>::SetComputeZYX(const bool flag)
 
 
 // Print self
-template <class TScalarType>
+template <typename TScalarType>
 void
 AdvancedEuler3DTransform<TScalarType>::PrintSelf(std::ostream & os, Indent indent) const
 {

--- a/Common/Transforms/itkAdvancedIdentityTransform.h
+++ b/Common/Transforms/itkAdvancedIdentityTransform.h
@@ -68,7 +68,7 @@ namespace itk
  * \ingroup Transforms
  *
  */
-template <class TScalarType, unsigned int NDimensions = 3>
+template <typename TScalarType, unsigned int NDimensions = 3>
 class ITK_TEMPLATE_EXPORT AdvancedIdentityTransform : public AdvancedTransform<TScalarType, NDimensions, NDimensions>
 {
 public:

--- a/Common/Transforms/itkAdvancedMatrixOffsetTransformBase.h
+++ b/Common/Transforms/itkAdvancedMatrixOffsetTransformBase.h
@@ -88,7 +88,7 @@ namespace itk
  *
  */
 
-template <class TScalarType = double,        // Data type for scalars
+template <typename TScalarType = double,     // Data type for scalars
           unsigned int NInputDimensions = 3, // Number of dimensions in the input space
           unsigned int NOutputDimensions = 3>
 // Number of dimensions in the output space

--- a/Common/Transforms/itkAdvancedMatrixOffsetTransformBase.hxx
+++ b/Common/Transforms/itkAdvancedMatrixOffsetTransformBase.hxx
@@ -41,7 +41,7 @@ namespace itk
 {
 
 // Constructor with default arguments
-template <class TScalarType, unsigned int NInputDimensions, unsigned int NOutputDimensions>
+template <typename TScalarType, unsigned int NInputDimensions, unsigned int NOutputDimensions>
 AdvancedMatrixOffsetTransformBase<TScalarType, NInputDimensions, NOutputDimensions>::AdvancedMatrixOffsetTransformBase(
   unsigned int paramDims)
   : Superclass(paramDims)
@@ -56,7 +56,7 @@ AdvancedMatrixOffsetTransformBase<TScalarType, NInputDimensions, NOutputDimensio
 
 
 // Print self
-template <class TScalarType, unsigned int NInputDimensions, unsigned int NOutputDimensions>
+template <typename TScalarType, unsigned int NInputDimensions, unsigned int NOutputDimensions>
 void
 AdvancedMatrixOffsetTransformBase<TScalarType, NInputDimensions, NOutputDimensions>::PrecomputeJacobians(
   unsigned int paramDims)
@@ -112,7 +112,7 @@ AdvancedMatrixOffsetTransformBase<TScalarType, NInputDimensions, NOutputDimensio
 
 
 // Print self
-template <class TScalarType, unsigned int NInputDimensions, unsigned int NOutputDimensions>
+template <typename TScalarType, unsigned int NInputDimensions, unsigned int NOutputDimensions>
 void
 AdvancedMatrixOffsetTransformBase<TScalarType, NInputDimensions, NOutputDimensions>::PrintSelf(std::ostream & os,
                                                                                                Indent indent) const
@@ -151,7 +151,7 @@ AdvancedMatrixOffsetTransformBase<TScalarType, NInputDimensions, NOutputDimensio
 
 
 // Constructor with explicit arguments
-template <class TScalarType, unsigned int NInputDimensions, unsigned int NOutputDimensions>
+template <typename TScalarType, unsigned int NInputDimensions, unsigned int NOutputDimensions>
 void
 AdvancedMatrixOffsetTransformBase<TScalarType, NInputDimensions, NOutputDimensions>::SetIdentity()
 {
@@ -168,7 +168,7 @@ AdvancedMatrixOffsetTransformBase<TScalarType, NInputDimensions, NOutputDimensio
 
 
 // Transform a point
-template <class TScalarType, unsigned int NInputDimensions, unsigned int NOutputDimensions>
+template <typename TScalarType, unsigned int NInputDimensions, unsigned int NOutputDimensions>
 auto
 AdvancedMatrixOffsetTransformBase<TScalarType, NInputDimensions, NOutputDimensions>::TransformPoint(
   const InputPointType & point) const -> OutputPointType
@@ -178,7 +178,7 @@ AdvancedMatrixOffsetTransformBase<TScalarType, NInputDimensions, NOutputDimensio
 
 
 // Transform a vector
-template <class TScalarType, unsigned int NInputDimensions, unsigned int NOutputDimensions>
+template <typename TScalarType, unsigned int NInputDimensions, unsigned int NOutputDimensions>
 auto
 AdvancedMatrixOffsetTransformBase<TScalarType, NInputDimensions, NOutputDimensions>::TransformVector(
   const InputVectorType & vect) const -> OutputVectorType
@@ -188,7 +188,7 @@ AdvancedMatrixOffsetTransformBase<TScalarType, NInputDimensions, NOutputDimensio
 
 
 // Transform a vnl_vector_fixed
-template <class TScalarType, unsigned int NInputDimensions, unsigned int NOutputDimensions>
+template <typename TScalarType, unsigned int NInputDimensions, unsigned int NOutputDimensions>
 auto
 AdvancedMatrixOffsetTransformBase<TScalarType, NInputDimensions, NOutputDimensions>::TransformVector(
   const InputVnlVectorType & vect) const -> OutputVnlVectorType
@@ -198,7 +198,7 @@ AdvancedMatrixOffsetTransformBase<TScalarType, NInputDimensions, NOutputDimensio
 
 
 // Transform a CovariantVector
-template <class TScalarType, unsigned int NInputDimensions, unsigned int NOutputDimensions>
+template <typename TScalarType, unsigned int NInputDimensions, unsigned int NOutputDimensions>
 auto
 AdvancedMatrixOffsetTransformBase<TScalarType, NInputDimensions, NOutputDimensions>::TransformCovariantVector(
   const InputCovariantVectorType & vec) const -> OutputCovariantVectorType
@@ -218,7 +218,7 @@ AdvancedMatrixOffsetTransformBase<TScalarType, NInputDimensions, NOutputDimensio
 
 
 // Recompute the inverse matrix (internal)
-template <class TScalarType, unsigned int NInputDimensions, unsigned int NOutputDimensions>
+template <typename TScalarType, unsigned int NInputDimensions, unsigned int NOutputDimensions>
 auto
 AdvancedMatrixOffsetTransformBase<TScalarType, NInputDimensions, NOutputDimensions>::GetInverseMatrix() const
   -> const InverseMatrixType &
@@ -243,7 +243,7 @@ AdvancedMatrixOffsetTransformBase<TScalarType, NInputDimensions, NOutputDimensio
 
 
 // Get fixed parameters
-template <class TScalarType, unsigned int NInputDimensions, unsigned int NOutputDimensions>
+template <typename TScalarType, unsigned int NInputDimensions, unsigned int NOutputDimensions>
 void
 AdvancedMatrixOffsetTransformBase<TScalarType, NInputDimensions, NOutputDimensions>::SetFixedParameters(
   const FixedParametersType & fp)
@@ -259,7 +259,7 @@ AdvancedMatrixOffsetTransformBase<TScalarType, NInputDimensions, NOutputDimensio
 
 
 /** Get the Fixed Parameters. */
-template <class TScalarType, unsigned int NInputDimensions, unsigned int NOutputDimensions>
+template <typename TScalarType, unsigned int NInputDimensions, unsigned int NOutputDimensions>
 const typename AdvancedMatrixOffsetTransformBase<TScalarType, NInputDimensions, NOutputDimensions>::
   FixedParametersType &
   AdvancedMatrixOffsetTransformBase<TScalarType, NInputDimensions, NOutputDimensions>::GetFixedParameters() const
@@ -273,7 +273,7 @@ const typename AdvancedMatrixOffsetTransformBase<TScalarType, NInputDimensions, 
 }
 
 // Get parameters
-template <class TScalarType, unsigned int NInputDimensions, unsigned int NOutputDimensions>
+template <typename TScalarType, unsigned int NInputDimensions, unsigned int NOutputDimensions>
 auto
 AdvancedMatrixOffsetTransformBase<TScalarType, NInputDimensions, NOutputDimensions>::GetParameters() const
   -> const ParametersType &
@@ -301,7 +301,7 @@ AdvancedMatrixOffsetTransformBase<TScalarType, NInputDimensions, NOutputDimensio
 }
 
 // Set parameters
-template <class TScalarType, unsigned int NInputDimensions, unsigned int NOutputDimensions>
+template <typename TScalarType, unsigned int NInputDimensions, unsigned int NOutputDimensions>
 void
 AdvancedMatrixOffsetTransformBase<TScalarType, NInputDimensions, NOutputDimensions>::SetParameters(
   const ParametersType & parameters)
@@ -348,7 +348,7 @@ AdvancedMatrixOffsetTransformBase<TScalarType, NInputDimensions, NOutputDimensio
 
 
 // Computes offset based on center, matrix, and translation variables
-template <class TScalarType, unsigned int NInputDimensions, unsigned int NOutputDimensions>
+template <typename TScalarType, unsigned int NInputDimensions, unsigned int NOutputDimensions>
 void
 AdvancedMatrixOffsetTransformBase<TScalarType, NInputDimensions, NOutputDimensions>::ComputeOffset()
 {
@@ -369,7 +369,7 @@ AdvancedMatrixOffsetTransformBase<TScalarType, NInputDimensions, NOutputDimensio
 
 
 // Computes translation based on offset, matrix, and center
-template <class TScalarType, unsigned int NInputDimensions, unsigned int NOutputDimensions>
+template <typename TScalarType, unsigned int NInputDimensions, unsigned int NOutputDimensions>
 void
 AdvancedMatrixOffsetTransformBase<TScalarType, NInputDimensions, NOutputDimensions>::ComputeTranslation()
 {
@@ -391,7 +391,7 @@ AdvancedMatrixOffsetTransformBase<TScalarType, NInputDimensions, NOutputDimensio
 
 // Computes matrix - base class does nothing.  In derived classes is
 //    used to convert, for example, versor into a matrix
-template <class TScalarType, unsigned int NInputDimensions, unsigned int NOutputDimensions>
+template <typename TScalarType, unsigned int NInputDimensions, unsigned int NOutputDimensions>
 void
 AdvancedMatrixOffsetTransformBase<TScalarType, NInputDimensions, NOutputDimensions>::ComputeMatrix()
 {
@@ -403,7 +403,7 @@ AdvancedMatrixOffsetTransformBase<TScalarType, NInputDimensions, NOutputDimensio
 
 // Computes parameters - base class does nothing.  In derived classes is
 //    used to convert, for example, matrix into a versor
-template <class TScalarType, unsigned int NInputDimensions, unsigned int NOutputDimensions>
+template <typename TScalarType, unsigned int NInputDimensions, unsigned int NOutputDimensions>
 void
 AdvancedMatrixOffsetTransformBase<TScalarType, NInputDimensions, NOutputDimensions>::ComputeMatrixParameters()
 {
@@ -418,7 +418,7 @@ AdvancedMatrixOffsetTransformBase<TScalarType, NInputDimensions, NOutputDimensio
  * ********************* GetJacobian ****************************
  */
 
-template <class TScalarType, unsigned int NInputDimensions, unsigned int NOutputDimensions>
+template <typename TScalarType, unsigned int NInputDimensions, unsigned int NOutputDimensions>
 void
 AdvancedMatrixOffsetTransformBase<TScalarType, NInputDimensions, NOutputDimensions>::GetJacobian(
   const InputPointType &       p,
@@ -462,7 +462,7 @@ AdvancedMatrixOffsetTransformBase<TScalarType, NInputDimensions, NOutputDimensio
  * ********************* GetSpatialJacobian ****************************
  */
 
-template <class TScalarType, unsigned int NInputDimensions, unsigned int NOutputDimensions>
+template <typename TScalarType, unsigned int NInputDimensions, unsigned int NOutputDimensions>
 void
 AdvancedMatrixOffsetTransformBase<TScalarType, NInputDimensions, NOutputDimensions>::GetSpatialJacobian(
   const InputPointType &,
@@ -477,7 +477,7 @@ AdvancedMatrixOffsetTransformBase<TScalarType, NInputDimensions, NOutputDimensio
  * ********************* GetSpatialHessian ****************************
  */
 
-template <class TScalarType, unsigned int NInputDimensions, unsigned int NOutputDimensions>
+template <typename TScalarType, unsigned int NInputDimensions, unsigned int NOutputDimensions>
 void
 AdvancedMatrixOffsetTransformBase<TScalarType, NInputDimensions, NOutputDimensions>::GetSpatialHessian(
   const InputPointType &,
@@ -493,7 +493,7 @@ AdvancedMatrixOffsetTransformBase<TScalarType, NInputDimensions, NOutputDimensio
  * ********************* GetJacobianOfSpatialJacobian ****************************
  */
 
-template <class TScalarType, unsigned int NInputDimensions, unsigned int NOutputDimensions>
+template <typename TScalarType, unsigned int NInputDimensions, unsigned int NOutputDimensions>
 void
 AdvancedMatrixOffsetTransformBase<TScalarType, NInputDimensions, NOutputDimensions>::GetJacobianOfSpatialJacobian(
   const InputPointType &,
@@ -510,7 +510,7 @@ AdvancedMatrixOffsetTransformBase<TScalarType, NInputDimensions, NOutputDimensio
  * ********************* GetJacobianOfSpatialJacobian ****************************
  */
 
-template <class TScalarType, unsigned int NInputDimensions, unsigned int NOutputDimensions>
+template <typename TScalarType, unsigned int NInputDimensions, unsigned int NOutputDimensions>
 void
 AdvancedMatrixOffsetTransformBase<TScalarType, NInputDimensions, NOutputDimensions>::GetJacobianOfSpatialJacobian(
   const InputPointType &,
@@ -529,7 +529,7 @@ AdvancedMatrixOffsetTransformBase<TScalarType, NInputDimensions, NOutputDimensio
  * ********************* GetJacobianOfSpatialHessian ****************************
  */
 
-template <class TScalarType, unsigned int NInputDimensions, unsigned int NOutputDimensions>
+template <typename TScalarType, unsigned int NInputDimensions, unsigned int NOutputDimensions>
 void
 AdvancedMatrixOffsetTransformBase<TScalarType, NInputDimensions, NOutputDimensions>::GetJacobianOfSpatialHessian(
   const InputPointType &,
@@ -547,7 +547,7 @@ AdvancedMatrixOffsetTransformBase<TScalarType, NInputDimensions, NOutputDimensio
  * ********************* GetJacobianOfSpatialHessian ****************************
  */
 
-template <class TScalarType, unsigned int NInputDimensions, unsigned int NOutputDimensions>
+template <typename TScalarType, unsigned int NInputDimensions, unsigned int NOutputDimensions>
 void
 AdvancedMatrixOffsetTransformBase<TScalarType, NInputDimensions, NOutputDimensions>::GetJacobianOfSpatialHessian(
   const InputPointType &,

--- a/Common/Transforms/itkAdvancedRigid2DTransform.h
+++ b/Common/Transforms/itkAdvancedRigid2DTransform.h
@@ -70,7 +70,7 @@ namespace itk
  *
  * \ingroup Transforms
  */
-template <class TScalarType = double>
+template <typename TScalarType = double>
 // Data type for scalars (float or double)
 class ITK_TEMPLATE_EXPORT AdvancedRigid2DTransform
   : public AdvancedMatrixOffsetTransformBase<TScalarType, 2, 2> // Dimensions of input and output spaces

--- a/Common/Transforms/itkAdvancedRigid2DTransform.hxx
+++ b/Common/Transforms/itkAdvancedRigid2DTransform.hxx
@@ -40,7 +40,7 @@ namespace itk
 {
 
 // Default-constructor
-template <class TScalarType>
+template <typename TScalarType>
 AdvancedRigid2DTransform<TScalarType>::AdvancedRigid2DTransform()
   : Superclass(ParametersDimension)
 {
@@ -50,7 +50,7 @@ AdvancedRigid2DTransform<TScalarType>::AdvancedRigid2DTransform()
 
 
 // Constructor with arguments
-template <class TScalarType>
+template <typename TScalarType>
 AdvancedRigid2DTransform<TScalarType>::AdvancedRigid2DTransform(unsigned int parametersDimension)
   : Superclass(parametersDimension)
 {
@@ -60,7 +60,7 @@ AdvancedRigid2DTransform<TScalarType>::AdvancedRigid2DTransform(unsigned int par
 
 
 // Print self
-template <class TScalarType>
+template <typename TScalarType>
 void
 AdvancedRigid2DTransform<TScalarType>::PrintSelf(std::ostream & os, Indent indent) const
 {
@@ -70,7 +70,7 @@ AdvancedRigid2DTransform<TScalarType>::PrintSelf(std::ostream & os, Indent inden
 
 
 // Set the rotation matrix
-template <class TScalarType>
+template <typename TScalarType>
 void
 AdvancedRigid2DTransform<TScalarType>::SetMatrix(const MatrixType & matrix)
 {
@@ -94,7 +94,7 @@ AdvancedRigid2DTransform<TScalarType>::SetMatrix(const MatrixType & matrix)
 
 
 /** Compute the Angle from the Rotation Matrix */
-template <class TScalarType>
+template <typename TScalarType>
 void
 AdvancedRigid2DTransform<TScalarType>::ComputeMatrixParameters()
 {
@@ -122,7 +122,7 @@ AdvancedRigid2DTransform<TScalarType>::ComputeMatrixParameters()
 
 
 // Reset the transform to an identity transform
-template <class TScalarType>
+template <typename TScalarType>
 void
 AdvancedRigid2DTransform<TScalarType>::SetIdentity()
 {
@@ -134,7 +134,7 @@ AdvancedRigid2DTransform<TScalarType>::SetIdentity()
 
 
 // Set the angle of rotation
-template <class TScalarType>
+template <typename TScalarType>
 void
 AdvancedRigid2DTransform<TScalarType>::SetAngle(TScalarType angle)
 {
@@ -146,7 +146,7 @@ AdvancedRigid2DTransform<TScalarType>::SetAngle(TScalarType angle)
 
 
 // Compute the matrix from the angle
-template <class TScalarType>
+template <typename TScalarType>
 void
 AdvancedRigid2DTransform<TScalarType>::ComputeMatrix()
 {
@@ -165,7 +165,7 @@ AdvancedRigid2DTransform<TScalarType>::ComputeMatrix()
 
 
 // Set Parameters
-template <class TScalarType>
+template <typename TScalarType>
 void
 AdvancedRigid2DTransform<TScalarType>::SetParameters(const ParametersType & parameters)
 {
@@ -195,7 +195,7 @@ AdvancedRigid2DTransform<TScalarType>::SetParameters(const ParametersType & para
 
 
 // Get Parameters
-template <class TScalarType>
+template <typename TScalarType>
 auto
 AdvancedRigid2DTransform<TScalarType>::GetParameters() const -> const ParametersType &
 {
@@ -216,7 +216,7 @@ AdvancedRigid2DTransform<TScalarType>::GetParameters() const -> const Parameters
 }
 
 // Compute transformation Jacobian
-template <class TScalarType>
+template <typename TScalarType>
 void
 AdvancedRigid2DTransform<TScalarType>::GetJacobian(const InputPointType &       p,
                                                    JacobianType &               j,
@@ -251,7 +251,7 @@ AdvancedRigid2DTransform<TScalarType>::GetJacobian(const InputPointType &       
 
 
 // Precompute Jacobian of Spatial Jacobian
-template <class TScalarType>
+template <typename TScalarType>
 void
 AdvancedRigid2DTransform<TScalarType>::PrecomputeJacobianOfSpatialJacobian()
 {

--- a/Common/Transforms/itkAdvancedRigid3DTransform.h
+++ b/Common/Transforms/itkAdvancedRigid3DTransform.h
@@ -61,7 +61,7 @@ namespace itk
  *
  * \ingroup Transforms
  */
-template <class TScalarType = double>
+template <typename TScalarType = double>
 // type for scalars (float or double)
 class ITK_TEMPLATE_EXPORT AdvancedRigid3DTransform : public AdvancedMatrixOffsetTransformBase<TScalarType, 3, 3>
 {

--- a/Common/Transforms/itkAdvancedRigid3DTransform.hxx
+++ b/Common/Transforms/itkAdvancedRigid3DTransform.hxx
@@ -39,20 +39,20 @@ namespace itk
 {
 
 // Constructor with default arguments
-template <class TScalarType>
+template <typename TScalarType>
 AdvancedRigid3DTransform<TScalarType>::AdvancedRigid3DTransform()
   : Superclass(ParametersDimension)
 {}
 
 // Constructor with default arguments
-template <class TScalarType>
+template <typename TScalarType>
 AdvancedRigid3DTransform<TScalarType>::AdvancedRigid3DTransform(unsigned int paramDim)
   : Superclass(paramDim)
 {}
 
 
 // Check if input matrix is orthogonal to within tolerance
-template <class TScalarType>
+template <typename TScalarType>
 bool
 AdvancedRigid3DTransform<TScalarType>::MatrixIsOrthogonal(const MatrixType & matrix, double tolerance)
 {
@@ -68,7 +68,7 @@ AdvancedRigid3DTransform<TScalarType>::MatrixIsOrthogonal(const MatrixType & mat
 
 
 // Directly set the rotation matrix
-template <class TScalarType>
+template <typename TScalarType>
 void
 AdvancedRigid3DTransform<TScalarType>::SetMatrix(const MatrixType & matrix)
 {
@@ -83,7 +83,7 @@ AdvancedRigid3DTransform<TScalarType>::SetMatrix(const MatrixType & matrix)
 
 
 // Set optimizable parameters from array
-template <class TScalarType>
+template <typename TScalarType>
 void
 AdvancedRigid3DTransform<TScalarType>::SetParameters(const ParametersType & parameters)
 {

--- a/Common/Transforms/itkAdvancedSimilarity2DTransform.h
+++ b/Common/Transforms/itkAdvancedSimilarity2DTransform.h
@@ -73,7 +73,7 @@ namespace itk
  *
  * \ingroup Transforms
  */
-template <class TScalarType = double>
+template <typename TScalarType = double>
 // Data type for scalars (float or double)
 class ITK_TEMPLATE_EXPORT AdvancedSimilarity2DTransform : public AdvancedRigid2DTransform<TScalarType>
 {

--- a/Common/Transforms/itkAdvancedSimilarity2DTransform.hxx
+++ b/Common/Transforms/itkAdvancedSimilarity2DTransform.hxx
@@ -40,7 +40,7 @@ namespace itk
 {
 
 // Constructor with default arguments
-template <class TScalarType>
+template <typename TScalarType>
 AdvancedSimilarity2DTransform<TScalarType>::AdvancedSimilarity2DTransform()
   : Superclass(ParametersDimension)
 {
@@ -50,7 +50,7 @@ AdvancedSimilarity2DTransform<TScalarType>::AdvancedSimilarity2DTransform()
 
 
 // Set Parameters
-template <class TScalarType>
+template <typename TScalarType>
 void
 AdvancedSimilarity2DTransform<TScalarType>::SetParameters(const ParametersType & parameters)
 {
@@ -82,7 +82,7 @@ AdvancedSimilarity2DTransform<TScalarType>::SetParameters(const ParametersType &
 
 
 // Get Parameters
-template <class TScalarType>
+template <typename TScalarType>
 auto
 AdvancedSimilarity2DTransform<TScalarType>::GetParameters() const -> const ParametersType &
 {
@@ -104,7 +104,7 @@ AdvancedSimilarity2DTransform<TScalarType>::GetParameters() const -> const Param
 }
 
 // Set Scale Part
-template <class TScalarType>
+template <typename TScalarType>
 void
 AdvancedSimilarity2DTransform<TScalarType>::SetScale(ScaleType scale)
 {
@@ -115,7 +115,7 @@ AdvancedSimilarity2DTransform<TScalarType>::SetScale(ScaleType scale)
 
 
 // Compute the matrix
-template <class TScalarType>
+template <typename TScalarType>
 void
 AdvancedSimilarity2DTransform<TScalarType>::ComputeMatrix()
 {
@@ -140,7 +140,7 @@ AdvancedSimilarity2DTransform<TScalarType>::ComputeMatrix()
 
 
 /** Compute the Angle from the Rotation Matrix */
-template <class TScalarType>
+template <typename TScalarType>
 void
 AdvancedSimilarity2DTransform<TScalarType>::ComputeMatrixParameters()
 {
@@ -163,7 +163,7 @@ AdvancedSimilarity2DTransform<TScalarType>::ComputeMatrixParameters()
 
 
 // Compute the transformation Jacobian
-template <class TScalarType>
+template <typename TScalarType>
 void
 AdvancedSimilarity2DTransform<TScalarType>::GetJacobian(const InputPointType &       p,
                                                         JacobianType &               j,
@@ -205,7 +205,7 @@ AdvancedSimilarity2DTransform<TScalarType>::GetJacobian(const InputPointType &  
 
 
 // Set Identity
-template <class TScalarType>
+template <typename TScalarType>
 void
 AdvancedSimilarity2DTransform<TScalarType>::SetIdentity()
 {
@@ -216,7 +216,7 @@ AdvancedSimilarity2DTransform<TScalarType>::SetIdentity()
 
 
 // Print self
-template <class TScalarType>
+template <typename TScalarType>
 void
 AdvancedSimilarity2DTransform<TScalarType>::PrintSelf(std::ostream & os, Indent indent) const
 {
@@ -226,7 +226,7 @@ AdvancedSimilarity2DTransform<TScalarType>::PrintSelf(std::ostream & os, Indent 
 
 
 // Set the similarity matrix
-template <class TScalarType>
+template <typename TScalarType>
 void
 AdvancedSimilarity2DTransform<TScalarType>::SetMatrix(const MatrixType & matrix)
 {
@@ -251,7 +251,7 @@ AdvancedSimilarity2DTransform<TScalarType>::SetMatrix(const MatrixType & matrix)
 
 
 // Precompute Jacobian of Spatial Jacobian
-template <class TScalarType>
+template <typename TScalarType>
 void
 AdvancedSimilarity2DTransform<TScalarType>::PrecomputeJacobianOfSpatialJacobian()
 {

--- a/Common/Transforms/itkAdvancedSimilarity3DTransform.h
+++ b/Common/Transforms/itkAdvancedSimilarity3DTransform.h
@@ -58,7 +58,7 @@ namespace itk
  *
  * \sa VersorRigid3DTransform
  */
-template <class TScalarType = double>
+template <typename TScalarType = double>
 // Data type for scalars (float or double)
 class ITK_TEMPLATE_EXPORT AdvancedSimilarity3DTransform : public AdvancedVersorRigid3DTransform<TScalarType>
 {

--- a/Common/Transforms/itkAdvancedSimilarity3DTransform.hxx
+++ b/Common/Transforms/itkAdvancedSimilarity3DTransform.hxx
@@ -41,7 +41,7 @@ namespace itk
 {
 
 // Constructor with default arguments
-template <class TScalarType>
+template <typename TScalarType>
 AdvancedSimilarity3DTransform<TScalarType>::AdvancedSimilarity3DTransform()
   : Superclass(ParametersDimension)
 {
@@ -51,21 +51,21 @@ AdvancedSimilarity3DTransform<TScalarType>::AdvancedSimilarity3DTransform()
 
 
 // Constructor with arguments
-template <class TScalarType>
+template <typename TScalarType>
 AdvancedSimilarity3DTransform<TScalarType>::AdvancedSimilarity3DTransform(unsigned int outputSpaceDim,
                                                                           unsigned int paramDim)
   : Superclass(outputSpaceDim, paramDim)
 {}
 
 // Constructor with arguments
-template <class TScalarType>
+template <typename TScalarType>
 AdvancedSimilarity3DTransform<TScalarType>::AdvancedSimilarity3DTransform(const MatrixType &       matrix,
                                                                           const OutputVectorType & offset)
   : Superclass(matrix, offset)
 {}
 
 // Set the scale factor
-template <class TScalarType>
+template <typename TScalarType>
 void
 AdvancedSimilarity3DTransform<TScalarType>::SetScale(ScaleType scale)
 {
@@ -76,7 +76,7 @@ AdvancedSimilarity3DTransform<TScalarType>::SetScale(ScaleType scale)
 
 
 // Directly set the matrix
-template <class TScalarType>
+template <typename TScalarType>
 void
 AdvancedSimilarity3DTransform<TScalarType>::SetMatrix(const MatrixType & matrix)
 {
@@ -124,7 +124,7 @@ AdvancedSimilarity3DTransform<TScalarType>::SetMatrix(const MatrixType & matrix)
 
 
 // Set Parameters
-template <class TScalarType>
+template <typename TScalarType>
 void
 AdvancedSimilarity3DTransform<TScalarType>::SetParameters(const ParametersType & parameters)
 {
@@ -185,7 +185,7 @@ AdvancedSimilarity3DTransform<TScalarType>::SetParameters(const ParametersType &
 // p[6:6} = scaling factor (isotropic)
 //
 
-template <class TScalarType>
+template <typename TScalarType>
 auto
 AdvancedSimilarity3DTransform<TScalarType>::GetParameters() const -> const ParametersType &
 {
@@ -208,7 +208,7 @@ AdvancedSimilarity3DTransform<TScalarType>::GetParameters() const -> const Param
 }
 
 // Set parameters
-template <class TScalarType>
+template <typename TScalarType>
 void
 AdvancedSimilarity3DTransform<TScalarType>::GetJacobian(const InputPointType &       p,
                                                         JacobianType &               j,
@@ -252,7 +252,7 @@ AdvancedSimilarity3DTransform<TScalarType>::GetJacobian(const InputPointType &  
 
 
 // Set the scale factor
-template <class TScalarType>
+template <typename TScalarType>
 void
 AdvancedSimilarity3DTransform<TScalarType>::ComputeMatrix()
 {
@@ -265,7 +265,7 @@ AdvancedSimilarity3DTransform<TScalarType>::ComputeMatrix()
 
 
 /** Compute the matrix */
-template <class TScalarType>
+template <typename TScalarType>
 void
 AdvancedSimilarity3DTransform<TScalarType>::ComputeMatrixParameters()
 {
@@ -283,7 +283,7 @@ AdvancedSimilarity3DTransform<TScalarType>::ComputeMatrixParameters()
 
 
 // Precompute Jacobian of Spatial Jacobian
-template <class TScalarType>
+template <typename TScalarType>
 void
 AdvancedSimilarity3DTransform<TScalarType>::PrecomputeJacobianOfSpatialJacobian()
 {
@@ -360,7 +360,7 @@ AdvancedSimilarity3DTransform<TScalarType>::PrecomputeJacobianOfSpatialJacobian(
 
 
 // Print self
-template <class TScalarType>
+template <typename TScalarType>
 void
 AdvancedSimilarity3DTransform<TScalarType>::PrintSelf(std::ostream & os, Indent indent) const
 {

--- a/Common/Transforms/itkAdvancedTransform.h
+++ b/Common/Transforms/itkAdvancedTransform.h
@@ -79,7 +79,7 @@ namespace itk
  * \ingroup Transforms
  *
  */
-template <class TScalarType, unsigned int NInputDimensions = 3, unsigned int NOutputDimensions = 3>
+template <typename TScalarType, unsigned int NInputDimensions = 3, unsigned int NOutputDimensions = 3>
 class ITK_TEMPLATE_EXPORT AdvancedTransform : public Transform<TScalarType, NInputDimensions, NOutputDimensions>
 {
 public:
@@ -307,7 +307,7 @@ protected:
 namespace ImplementationDetails
 {
 /** Multiplies the input matrix and the input vector. */
-template <class TScalarType, unsigned int VInputVectorSize>
+template <typename TScalarType, unsigned int VInputVectorSize>
 void
 EvaluateInnerProduct(const vnl_matrix<TScalarType> &                        inputMatrix,
                      const CovariantVector<TScalarType, VInputVectorSize> & inputVector,

--- a/Common/Transforms/itkAdvancedTransform.hxx
+++ b/Common/Transforms/itkAdvancedTransform.hxx
@@ -42,7 +42,7 @@ namespace itk
  * ********************* EvaluateJacobianWithImageGradientProduct ****************************
  */
 
-template <class TScalarType, unsigned int NInputDimensions, unsigned int NOutputDimensions>
+template <typename TScalarType, unsigned int NInputDimensions, unsigned int NOutputDimensions>
 void
 AdvancedTransform<TScalarType, NInputDimensions, NOutputDimensions>::EvaluateJacobianWithImageGradientProduct(
   const InputPointType &          inputPoint,
@@ -65,7 +65,7 @@ AdvancedTransform<TScalarType, NInputDimensions, NOutputDimensions>::EvaluateJac
  * ********************* GetNumberOfNonZeroJacobianIndices ****************************
  */
 
-template <class TScalarType, unsigned int NInputDimensions, unsigned int NOutputDimensions>
+template <typename TScalarType, unsigned int NInputDimensions, unsigned int NOutputDimensions>
 auto
 AdvancedTransform<TScalarType, NInputDimensions, NOutputDimensions>::GetNumberOfNonZeroJacobianIndices() const
   -> NumberOfParametersType

--- a/Common/Transforms/itkAdvancedTranslationTransform.h
+++ b/Common/Transforms/itkAdvancedTranslationTransform.h
@@ -48,7 +48,7 @@ namespace itk
  *
  * \ingroup Transforms
  */
-template <class TScalarType = double, // Data type for scalars (float or double)
+template <typename TScalarType = double, // Data type for scalars (float or double)
           unsigned int NDimensions = 3>
 // Number of dimensions
 class ITK_TEMPLATE_EXPORT AdvancedTranslationTransform : public AdvancedTransform<TScalarType, NDimensions, NDimensions>

--- a/Common/Transforms/itkAdvancedTranslationTransform.hxx
+++ b/Common/Transforms/itkAdvancedTranslationTransform.hxx
@@ -41,7 +41,7 @@ namespace itk
 {
 
 // Constructor with default arguments
-template <class TScalarType, unsigned int NDimensions>
+template <typename TScalarType, unsigned int NDimensions>
 AdvancedTranslationTransform<TScalarType, NDimensions>::AdvancedTranslationTransform()
   : Superclass(ParametersDimension)
 {
@@ -55,7 +55,7 @@ AdvancedTranslationTransform<TScalarType, NDimensions>::AdvancedTranslationTrans
 
 
 // Destructor
-template <class TScalarType, unsigned int NDimensions>
+template <typename TScalarType, unsigned int NDimensions>
 AdvancedTranslationTransform<TScalarType, NDimensions>::~AdvancedTranslationTransform()
 {
   return;
@@ -63,7 +63,7 @@ AdvancedTranslationTransform<TScalarType, NDimensions>::~AdvancedTranslationTran
 
 
 // Set the parameters
-template <class TScalarType, unsigned int NDimensions>
+template <typename TScalarType, unsigned int NDimensions>
 void
 AdvancedTranslationTransform<TScalarType, NDimensions>::SetParameters(const ParametersType & parameters)
 {
@@ -84,7 +84,7 @@ AdvancedTranslationTransform<TScalarType, NDimensions>::SetParameters(const Para
 
 
 // Get the parameters
-template <class TScalarType, unsigned int NDimensions>
+template <typename TScalarType, unsigned int NDimensions>
 auto
 AdvancedTranslationTransform<TScalarType, NDimensions>::GetParameters() const -> const ParametersType &
 {
@@ -96,7 +96,7 @@ AdvancedTranslationTransform<TScalarType, NDimensions>::GetParameters() const ->
 }
 
 // Print self
-template <class TScalarType, unsigned int NDimensions>
+template <typename TScalarType, unsigned int NDimensions>
 void
 AdvancedTranslationTransform<TScalarType, NDimensions>::PrintSelf(std::ostream & os, Indent indent) const
 {
@@ -107,7 +107,7 @@ AdvancedTranslationTransform<TScalarType, NDimensions>::PrintSelf(std::ostream &
 
 
 // Transform a point
-template <class TScalarType, unsigned int NDimensions>
+template <typename TScalarType, unsigned int NDimensions>
 auto
 AdvancedTranslationTransform<TScalarType, NDimensions>::TransformPoint(const InputPointType & point) const
   -> OutputPointType
@@ -117,7 +117,7 @@ AdvancedTranslationTransform<TScalarType, NDimensions>::TransformPoint(const Inp
 
 
 // Transform a vector
-template <class TScalarType, unsigned int NDimensions>
+template <typename TScalarType, unsigned int NDimensions>
 auto
 AdvancedTranslationTransform<TScalarType, NDimensions>::TransformVector(const InputVectorType & vect) const
   -> OutputVectorType
@@ -127,7 +127,7 @@ AdvancedTranslationTransform<TScalarType, NDimensions>::TransformVector(const In
 
 
 // Transform a vnl_vector_fixed
-template <class TScalarType, unsigned int NDimensions>
+template <typename TScalarType, unsigned int NDimensions>
 auto
 AdvancedTranslationTransform<TScalarType, NDimensions>::TransformVector(const InputVnlVectorType & vect) const
   -> OutputVnlVectorType
@@ -137,7 +137,7 @@ AdvancedTranslationTransform<TScalarType, NDimensions>::TransformVector(const In
 
 
 // Transform a CovariantVector
-template <class TScalarType, unsigned int NDimensions>
+template <typename TScalarType, unsigned int NDimensions>
 auto
 AdvancedTranslationTransform<TScalarType, NDimensions>::TransformCovariantVector(
   const InputCovariantVectorType & vect) const -> OutputCovariantVectorType
@@ -150,7 +150,7 @@ AdvancedTranslationTransform<TScalarType, NDimensions>::TransformCovariantVector
  * ********************* GetJacobian ****************************
  */
 
-template <class TScalarType, unsigned int NDimensions>
+template <typename TScalarType, unsigned int NDimensions>
 void
 AdvancedTranslationTransform<TScalarType, NDimensions>::GetJacobian(
   const InputPointType &       itkNotUsed(p),
@@ -166,7 +166,7 @@ AdvancedTranslationTransform<TScalarType, NDimensions>::GetJacobian(
  * ********************* GetSpatialJacobian ****************************
  */
 
-template <class TScalarType, unsigned int NDimensions>
+template <typename TScalarType, unsigned int NDimensions>
 void
 AdvancedTranslationTransform<TScalarType, NDimensions>::GetSpatialJacobian(const InputPointType & itkNotUsed(p),
                                                                            SpatialJacobianType &  sj) const
@@ -180,7 +180,7 @@ AdvancedTranslationTransform<TScalarType, NDimensions>::GetSpatialJacobian(const
  * ********************* GetSpatialHessian ****************************
  */
 
-template <class TScalarType, unsigned int NDimensions>
+template <typename TScalarType, unsigned int NDimensions>
 void
 AdvancedTranslationTransform<TScalarType, NDimensions>::GetSpatialHessian(const InputPointType & itkNotUsed(p),
                                                                           SpatialHessianType &   sh) const
@@ -194,7 +194,7 @@ AdvancedTranslationTransform<TScalarType, NDimensions>::GetSpatialHessian(const 
  * ********************* GetJacobianOfSpatialJacobian ****************************
  */
 
-template <class TScalarType, unsigned int NDimensions>
+template <typename TScalarType, unsigned int NDimensions>
 void
 AdvancedTranslationTransform<TScalarType, NDimensions>::GetJacobianOfSpatialJacobian(
   const InputPointType &          itkNotUsed(p),
@@ -210,7 +210,7 @@ AdvancedTranslationTransform<TScalarType, NDimensions>::GetJacobianOfSpatialJaco
  * ********************* GetJacobianOfSpatialJacobian ****************************
  */
 
-template <class TScalarType, unsigned int NDimensions>
+template <typename TScalarType, unsigned int NDimensions>
 void
 AdvancedTranslationTransform<TScalarType, NDimensions>::GetJacobianOfSpatialJacobian(
   const InputPointType &          itkNotUsed(p),
@@ -228,7 +228,7 @@ AdvancedTranslationTransform<TScalarType, NDimensions>::GetJacobianOfSpatialJaco
  * ********************* GetJacobianOfSpatialHessian ****************************
  */
 
-template <class TScalarType, unsigned int NDimensions>
+template <typename TScalarType, unsigned int NDimensions>
 void
 AdvancedTranslationTransform<TScalarType, NDimensions>::GetJacobianOfSpatialHessian(
   const InputPointType &         itkNotUsed(p),
@@ -245,7 +245,7 @@ AdvancedTranslationTransform<TScalarType, NDimensions>::GetJacobianOfSpatialHess
  * ********************* GetJacobianOfSpatialHessian ****************************
  */
 
-template <class TScalarType, unsigned int NDimensions>
+template <typename TScalarType, unsigned int NDimensions>
 void
 AdvancedTranslationTransform<TScalarType, NDimensions>::GetJacobianOfSpatialHessian(
   const InputPointType &         itkNotUsed(p),
@@ -262,7 +262,7 @@ AdvancedTranslationTransform<TScalarType, NDimensions>::GetJacobianOfSpatialHess
 
 
 // Set the parameters for an Identity transform of this class
-template <class TScalarType, unsigned int NDimensions>
+template <typename TScalarType, unsigned int NDimensions>
 void
 AdvancedTranslationTransform<TScalarType, NDimensions>::SetIdentity()
 {

--- a/Common/Transforms/itkAdvancedVersorRigid3DTransform.h
+++ b/Common/Transforms/itkAdvancedVersorRigid3DTransform.h
@@ -59,7 +59,7 @@ namespace itk
  *
  * \ingroup Transforms
  */
-template <class TScalarType = double>
+template <typename TScalarType = double>
 // Data type for scalars (float or double)
 class ITK_TEMPLATE_EXPORT AdvancedVersorRigid3DTransform : public AdvancedVersorTransform<TScalarType>
 {

--- a/Common/Transforms/itkAdvancedVersorRigid3DTransform.hxx
+++ b/Common/Transforms/itkAdvancedVersorRigid3DTransform.hxx
@@ -39,26 +39,26 @@ namespace itk
 {
 
 // Constructor with default arguments
-template <class TScalarType>
+template <typename TScalarType>
 AdvancedVersorRigid3DTransform<TScalarType>::AdvancedVersorRigid3DTransform()
   : Superclass(ParametersDimension)
 {}
 
 // Constructor with arguments
-template <class TScalarType>
+template <typename TScalarType>
 AdvancedVersorRigid3DTransform<TScalarType>::AdvancedVersorRigid3DTransform(unsigned int paramDim)
   : Superclass(paramDim)
 {}
 
 // Constructor with arguments
-template <class TScalarType>
+template <typename TScalarType>
 AdvancedVersorRigid3DTransform<TScalarType>::AdvancedVersorRigid3DTransform(const MatrixType &       matrix,
                                                                             const OutputVectorType & offset)
   : Superclass(matrix, offset)
 {}
 
 // Set Parameters
-template <class TScalarType>
+template <typename TScalarType>
 void
 AdvancedVersorRigid3DTransform<TScalarType>::SetParameters(const ParametersType & parameters)
 {
@@ -117,7 +117,7 @@ AdvancedVersorRigid3DTransform<TScalarType>::SetParameters(const ParametersType 
 // p[3:5} = translation components
 //
 
-template <class TScalarType>
+template <typename TScalarType>
 auto
 AdvancedVersorRigid3DTransform<TScalarType>::GetParameters() const -> const ParametersType &
 {
@@ -138,7 +138,7 @@ AdvancedVersorRigid3DTransform<TScalarType>::GetParameters() const -> const Para
 }
 
 // Set parameters
-template <class TScalarType>
+template <typename TScalarType>
 void
 AdvancedVersorRigid3DTransform<TScalarType>::GetJacobian(const InputPointType &       p,
                                                          JacobianType &               j,

--- a/Common/Transforms/itkAdvancedVersorTransform.h
+++ b/Common/Transforms/itkAdvancedVersorTransform.h
@@ -62,7 +62,7 @@ namespace itk
  * \ingroup Transforms
  *
  **/
-template <class TScalarType = double>
+template <typename TScalarType = double>
 // Data type for scalars (float or double)
 class ITK_TEMPLATE_EXPORT AdvancedVersorTransform : public AdvancedRigid3DTransform<TScalarType>
 {

--- a/Common/Transforms/itkAdvancedVersorTransform.hxx
+++ b/Common/Transforms/itkAdvancedVersorTransform.hxx
@@ -39,7 +39,7 @@ namespace itk
 {
 
 /** Constructor with default arguments */
-template <class TScalarType>
+template <typename TScalarType>
 AdvancedVersorTransform<TScalarType>::AdvancedVersorTransform()
   : Superclass(ParametersDimension)
 {
@@ -48,7 +48,7 @@ AdvancedVersorTransform<TScalarType>::AdvancedVersorTransform()
 
 
 /** Constructor with default arguments */
-template <class TScalarType>
+template <typename TScalarType>
 AdvancedVersorTransform<TScalarType>::AdvancedVersorTransform(unsigned int parametersDimension)
   : Superclass(parametersDimension)
 {
@@ -57,7 +57,7 @@ AdvancedVersorTransform<TScalarType>::AdvancedVersorTransform(unsigned int param
 
 
 /** Constructor with default arguments */
-template <class TScalarType>
+template <typename TScalarType>
 AdvancedVersorTransform<TScalarType>::AdvancedVersorTransform(const MatrixType &       matrix,
                                                               const OutputVectorType & offset)
   : Superclass(matrix, offset)
@@ -67,7 +67,7 @@ AdvancedVersorTransform<TScalarType>::AdvancedVersorTransform(const MatrixType &
 
 
 /** Set Parameters */
-template <class TScalarType>
+template <typename TScalarType>
 void
 AdvancedVersorTransform<TScalarType>::SetParameters(const ParametersType & parameters)
 {
@@ -96,7 +96,7 @@ AdvancedVersorTransform<TScalarType>::SetParameters(const ParametersType & param
 
 
 /** Set Parameters */
-template <class TScalarType>
+template <typename TScalarType>
 auto
 AdvancedVersorTransform<TScalarType>::GetParameters() const -> const ParametersType &
 {
@@ -108,7 +108,7 @@ AdvancedVersorTransform<TScalarType>::GetParameters() const -> const ParametersT
 }
 
 /** Set Rotational Part */
-template <class TScalarType>
+template <typename TScalarType>
 void
 AdvancedVersorTransform<TScalarType>::SetRotation(const VersorType & versor)
 {
@@ -119,7 +119,7 @@ AdvancedVersorTransform<TScalarType>::SetRotation(const VersorType & versor)
 
 
 /** Set Rotational Part */
-template <class TScalarType>
+template <typename TScalarType>
 void
 AdvancedVersorTransform<TScalarType>::SetRotation(const AxisType & axis, AngleType angle)
 {
@@ -130,7 +130,7 @@ AdvancedVersorTransform<TScalarType>::SetRotation(const AxisType & axis, AngleTy
 
 
 /** Set Identity */
-template <class TScalarType>
+template <typename TScalarType>
 void
 AdvancedVersorTransform<TScalarType>::SetIdentity()
 {
@@ -143,7 +143,7 @@ AdvancedVersorTransform<TScalarType>::SetIdentity()
 
 
 /** Compute the matrix */
-template <class TScalarType>
+template <typename TScalarType>
 void
 AdvancedVersorTransform<TScalarType>::ComputeMatrix()
 {
@@ -178,7 +178,7 @@ AdvancedVersorTransform<TScalarType>::ComputeMatrix()
 
 
 /** Compute the matrix */
-template <class TScalarType>
+template <typename TScalarType>
 void
 AdvancedVersorTransform<TScalarType>::ComputeMatrixParameters()
 {
@@ -187,7 +187,7 @@ AdvancedVersorTransform<TScalarType>::ComputeMatrixParameters()
 
 
 /** Get the Jacobian */
-template <class TScalarType>
+template <typename TScalarType>
 void
 AdvancedVersorTransform<TScalarType>::GetJacobian(const InputPointType &       p,
                                                   JacobianType &               j,
@@ -244,7 +244,7 @@ AdvancedVersorTransform<TScalarType>::GetJacobian(const InputPointType &       p
 
 
 /** Print self */
-template <class TScalarType>
+template <typename TScalarType>
 void
 AdvancedVersorTransform<TScalarType>::PrintSelf(std::ostream & os, Indent indent) const
 {

--- a/Common/Transforms/itkBSplineInterpolationDerivativeWeightFunction.h
+++ b/Common/Transforms/itkBSplineInterpolationDerivativeWeightFunction.h
@@ -40,7 +40,7 @@ namespace itk
  * \ingroup Functions ImageInterpolators
  */
 
-template <class TCoordRep = float, unsigned int VSpaceDimension = 2, unsigned int VSplineOrder = 3>
+template <typename TCoordRep = float, unsigned int VSpaceDimension = 2, unsigned int VSplineOrder = 3>
 class ITK_TEMPLATE_EXPORT BSplineInterpolationDerivativeWeightFunction
   : public BSplineInterpolationWeightFunctionBase<TCoordRep, VSpaceDimension, VSplineOrder>
 {

--- a/Common/Transforms/itkBSplineInterpolationDerivativeWeightFunction.hxx
+++ b/Common/Transforms/itkBSplineInterpolationDerivativeWeightFunction.hxx
@@ -27,7 +27,7 @@ namespace itk
  * ****************** Constructor *******************************
  */
 
-template <class TCoordRep, unsigned int VSpaceDimension, unsigned int VSplineOrder>
+template <typename TCoordRep, unsigned int VSpaceDimension, unsigned int VSplineOrder>
 BSplineInterpolationDerivativeWeightFunction<TCoordRep, VSpaceDimension, VSplineOrder>::
   BSplineInterpolationDerivativeWeightFunction()
 {
@@ -41,7 +41,7 @@ BSplineInterpolationDerivativeWeightFunction<TCoordRep, VSpaceDimension, VSpline
  * ******************* SetDerivativeDirection *******************
  */
 
-template <class TCoordRep, unsigned int VSpaceDimension, unsigned int VSplineOrder>
+template <typename TCoordRep, unsigned int VSpaceDimension, unsigned int VSplineOrder>
 void
 BSplineInterpolationDerivativeWeightFunction<TCoordRep, VSpaceDimension, VSplineOrder>::SetDerivativeDirection(
   unsigned int dir)
@@ -63,7 +63,7 @@ BSplineInterpolationDerivativeWeightFunction<TCoordRep, VSpaceDimension, VSpline
  * ******************* PrintSelf *******************
  */
 
-template <class TCoordRep, unsigned int VSpaceDimension, unsigned int VSplineOrder>
+template <typename TCoordRep, unsigned int VSpaceDimension, unsigned int VSplineOrder>
 void
 BSplineInterpolationDerivativeWeightFunction<TCoordRep, VSpaceDimension, VSplineOrder>::PrintSelf(std::ostream & os,
                                                                                                   Indent indent) const
@@ -77,7 +77,7 @@ BSplineInterpolationDerivativeWeightFunction<TCoordRep, VSpaceDimension, VSpline
  * ******************* Compute1DWeights *******************
  */
 
-template <class TCoordRep, unsigned int VSpaceDimension, unsigned int VSplineOrder>
+template <typename TCoordRep, unsigned int VSpaceDimension, unsigned int VSplineOrder>
 void
 BSplineInterpolationDerivativeWeightFunction<TCoordRep, VSpaceDimension, VSplineOrder>::Compute1DWeights(
   const ContinuousIndexType & cindex,

--- a/Common/Transforms/itkBSplineInterpolationSecondOrderDerivativeWeightFunction.h
+++ b/Common/Transforms/itkBSplineInterpolationSecondOrderDerivativeWeightFunction.h
@@ -41,7 +41,7 @@ namespace itk
  * \ingroup Functions ImageInterpolators
  */
 
-template <class TCoordRep = float, unsigned int VSpaceDimension = 2, unsigned int VSplineOrder = 3>
+template <typename TCoordRep = float, unsigned int VSpaceDimension = 2, unsigned int VSplineOrder = 3>
 class ITK_TEMPLATE_EXPORT BSplineInterpolationSecondOrderDerivativeWeightFunction
   : public BSplineInterpolationWeightFunctionBase<TCoordRep, VSpaceDimension, VSplineOrder>
 {

--- a/Common/Transforms/itkBSplineInterpolationSecondOrderDerivativeWeightFunction.hxx
+++ b/Common/Transforms/itkBSplineInterpolationSecondOrderDerivativeWeightFunction.hxx
@@ -30,7 +30,7 @@ namespace itk
  * ****************** Constructor *******************************
  */
 
-template <class TCoordRep, unsigned int VSpaceDimension, unsigned int VSplineOrder>
+template <typename TCoordRep, unsigned int VSpaceDimension, unsigned int VSplineOrder>
 BSplineInterpolationSecondOrderDerivativeWeightFunction<TCoordRep, VSpaceDimension, VSplineOrder>::
   BSplineInterpolationSecondOrderDerivativeWeightFunction()
 {
@@ -45,7 +45,7 @@ BSplineInterpolationSecondOrderDerivativeWeightFunction<TCoordRep, VSpaceDimensi
  * ******************* SetDerivativeDirections *******************
  */
 
-template <class TCoordRep, unsigned int VSpaceDimension, unsigned int VSplineOrder>
+template <typename TCoordRep, unsigned int VSpaceDimension, unsigned int VSplineOrder>
 void
 BSplineInterpolationSecondOrderDerivativeWeightFunction<TCoordRep, VSpaceDimension, VSplineOrder>::
   SetDerivativeDirections(unsigned int dir0, unsigned int dir1)
@@ -73,7 +73,7 @@ BSplineInterpolationSecondOrderDerivativeWeightFunction<TCoordRep, VSpaceDimensi
  * ******************* PrintSelf *******************
  */
 
-template <class TCoordRep, unsigned int VSpaceDimension, unsigned int VSplineOrder>
+template <typename TCoordRep, unsigned int VSpaceDimension, unsigned int VSplineOrder>
 void
 BSplineInterpolationSecondOrderDerivativeWeightFunction<TCoordRep, VSpaceDimension, VSplineOrder>::PrintSelf(
   std::ostream & os,
@@ -92,7 +92,7 @@ BSplineInterpolationSecondOrderDerivativeWeightFunction<TCoordRep, VSpaceDimensi
  * ******************* Compute1DWeights *******************
  */
 
-template <class TCoordRep, unsigned int VSpaceDimension, unsigned int VSplineOrder>
+template <typename TCoordRep, unsigned int VSpaceDimension, unsigned int VSplineOrder>
 void
 BSplineInterpolationSecondOrderDerivativeWeightFunction<TCoordRep, VSpaceDimension, VSplineOrder>::Compute1DWeights(
   const ContinuousIndexType & index,

--- a/Common/Transforms/itkBSplineInterpolationWeightFunction2.h
+++ b/Common/Transforms/itkBSplineInterpolationWeightFunction2.h
@@ -39,7 +39,7 @@ namespace itk
  *
  * \ingroup Functions ImageInterpolators
  */
-template <class TCoordRep = float, unsigned int VSpaceDimension = 2, unsigned int VSplineOrder = 3>
+template <typename TCoordRep = float, unsigned int VSpaceDimension = 2, unsigned int VSplineOrder = 3>
 class ITK_TEMPLATE_EXPORT BSplineInterpolationWeightFunction2
   : public BSplineInterpolationWeightFunctionBase<TCoordRep, VSpaceDimension, VSplineOrder>
 {

--- a/Common/Transforms/itkBSplineInterpolationWeightFunction2.hxx
+++ b/Common/Transforms/itkBSplineInterpolationWeightFunction2.hxx
@@ -27,7 +27,7 @@ namespace itk
  * ******************* Compute1DWeights *******************
  */
 
-template <class TCoordRep, unsigned int VSpaceDimension, unsigned int VSplineOrder>
+template <typename TCoordRep, unsigned int VSpaceDimension, unsigned int VSplineOrder>
 void
 BSplineInterpolationWeightFunction2<TCoordRep, VSpaceDimension, VSplineOrder>::Compute1DWeights(
   const ContinuousIndexType & index,

--- a/Common/Transforms/itkBSplineInterpolationWeightFunctionBase.h
+++ b/Common/Transforms/itkBSplineInterpolationWeightFunctionBase.h
@@ -46,7 +46,7 @@ namespace itk
  *
  * \ingroup Functions ImageInterpolators
  */
-template <class TCoordRep = float, unsigned int VSpaceDimension = 2, unsigned int VSplineOrder = 3>
+template <typename TCoordRep = float, unsigned int VSpaceDimension = 2, unsigned int VSplineOrder = 3>
 class ITK_TEMPLATE_EXPORT BSplineInterpolationWeightFunctionBase
   : public FunctionBase<ContinuousIndex<TCoordRep, VSpaceDimension>,
                         FixedArray<double, Math::UnsignedPower(VSplineOrder + 1, VSpaceDimension)>>

--- a/Common/Transforms/itkBSplineInterpolationWeightFunctionBase.hxx
+++ b/Common/Transforms/itkBSplineInterpolationWeightFunctionBase.hxx
@@ -30,7 +30,7 @@ namespace itk
  * ****************** Constructor *******************************
  */
 
-template <class TCoordRep, unsigned int VSpaceDimension, unsigned int VSplineOrder>
+template <typename TCoordRep, unsigned int VSpaceDimension, unsigned int VSplineOrder>
 BSplineInterpolationWeightFunctionBase<TCoordRep, VSpaceDimension, VSplineOrder>::
   BSplineInterpolationWeightFunctionBase()
 {
@@ -44,7 +44,7 @@ BSplineInterpolationWeightFunctionBase<TCoordRep, VSpaceDimension, VSplineOrder>
  * ******************* InitializeOffsetToIndexTable *******************
  */
 
-template <class TCoordRep, unsigned int VSpaceDimension, unsigned int VSplineOrder>
+template <typename TCoordRep, unsigned int VSpaceDimension, unsigned int VSplineOrder>
 void
 BSplineInterpolationWeightFunctionBase<TCoordRep, VSpaceDimension, VSplineOrder>::InitializeOffsetToIndexTable()
 {
@@ -79,7 +79,7 @@ BSplineInterpolationWeightFunctionBase<TCoordRep, VSpaceDimension, VSplineOrder>
  * ******************* PrintSelf *******************
  */
 
-template <class TCoordRep, unsigned int VSpaceDimension, unsigned int VSplineOrder>
+template <typename TCoordRep, unsigned int VSpaceDimension, unsigned int VSplineOrder>
 void
 BSplineInterpolationWeightFunctionBase<TCoordRep, VSpaceDimension, VSplineOrder>::PrintSelf(std::ostream & os,
                                                                                             Indent         indent) const
@@ -95,7 +95,7 @@ BSplineInterpolationWeightFunctionBase<TCoordRep, VSpaceDimension, VSplineOrder>
  * ******************* ComputeStartIndex *******************
  */
 
-template <class TCoordRep, unsigned int VSpaceDimension, unsigned int VSplineOrder>
+template <typename TCoordRep, unsigned int VSpaceDimension, unsigned int VSplineOrder>
 void
 BSplineInterpolationWeightFunctionBase<TCoordRep, VSpaceDimension, VSplineOrder>::ComputeStartIndex(
   const ContinuousIndexType & cindex,
@@ -115,7 +115,7 @@ BSplineInterpolationWeightFunctionBase<TCoordRep, VSpaceDimension, VSplineOrder>
  * ******************* Evaluate *******************
  */
 
-template <class TCoordRep, unsigned int VSpaceDimension, unsigned int VSplineOrder>
+template <typename TCoordRep, unsigned int VSpaceDimension, unsigned int VSplineOrder>
 auto
 BSplineInterpolationWeightFunctionBase<TCoordRep, VSpaceDimension, VSplineOrder>::Evaluate(
   const ContinuousIndexType & cindex) const -> WeightsType
@@ -137,7 +137,7 @@ BSplineInterpolationWeightFunctionBase<TCoordRep, VSpaceDimension, VSplineOrder>
  * ******************* Evaluate *******************
  */
 
-template <class TCoordRep, unsigned int VSpaceDimension, unsigned int VSplineOrder>
+template <typename TCoordRep, unsigned int VSpaceDimension, unsigned int VSplineOrder>
 void
 BSplineInterpolationWeightFunctionBase<TCoordRep, VSpaceDimension, VSplineOrder>::Evaluate(
   const ContinuousIndexType & cindex,

--- a/Common/Transforms/itkCyclicBSplineDeformableTransform.h
+++ b/Common/Transforms/itkCyclicBSplineDeformableTransform.h
@@ -37,8 +37,8 @@ namespace itk
  *
  * \ingroup Transforms
  */
-template <class TScalarType = double,   // Data type for scalars
-          unsigned int NDimensions = 3, // Number of dimensions
+template <typename TScalarType = double, // Data type for scalars
+          unsigned int NDimensions = 3,  // Number of dimensions
           unsigned int VSplineOrder = 3>
 // Spline order
 class ITK_TEMPLATE_EXPORT CyclicBSplineDeformableTransform

--- a/Common/Transforms/itkCyclicBSplineDeformableTransform.hxx
+++ b/Common/Transforms/itkCyclicBSplineDeformableTransform.hxx
@@ -26,13 +26,13 @@ namespace itk
 {
 
 /** Constructor with default arguments. */
-template <class TScalarType, unsigned int NDimensions, unsigned int VSplineOrder>
+template <typename TScalarType, unsigned int NDimensions, unsigned int VSplineOrder>
 CyclicBSplineDeformableTransform<TScalarType, NDimensions, VSplineOrder>::CyclicBSplineDeformableTransform()
   : Superclass()
 {}
 
 /** Set the grid region. */
-template <class TScalarType, unsigned int NDimensions, unsigned int VSplineOrder>
+template <typename TScalarType, unsigned int NDimensions, unsigned int VSplineOrder>
 void
 CyclicBSplineDeformableTransform<TScalarType, NDimensions, VSplineOrder>::SetGridRegion(const RegionType & region)
 {
@@ -56,7 +56,7 @@ CyclicBSplineDeformableTransform<TScalarType, NDimensions, VSplineOrder>::SetGri
 
 
 /** Check if the point lies inside a valid region. */
-template <class TScalarType, unsigned int NDimensions, unsigned int VSplineOrder>
+template <typename TScalarType, unsigned int NDimensions, unsigned int VSplineOrder>
 bool
 CyclicBSplineDeformableTransform<TScalarType, NDimensions, VSplineOrder>::InsideValidRegion(
   const ContinuousIndexType & index) const
@@ -82,7 +82,7 @@ CyclicBSplineDeformableTransform<TScalarType, NDimensions, VSplineOrder>::Inside
  * 2) The part that reaches from 0 in the last dimension to the end of the
  * inRegion.
  */
-template <class TScalarType, unsigned int NDimensions, unsigned int VSplineOrder>
+template <typename TScalarType, unsigned int NDimensions, unsigned int VSplineOrder>
 void
 CyclicBSplineDeformableTransform<TScalarType, NDimensions, VSplineOrder>::SplitRegion(const RegionType & imageRegion,
                                                                                       const RegionType & inRegion,
@@ -136,7 +136,7 @@ CyclicBSplineDeformableTransform<TScalarType, NDimensions, VSplineOrder>::SplitR
 
 
 // Transform a point
-template <class TScalarType, unsigned int NDimensions, unsigned int VSplineOrder>
+template <typename TScalarType, unsigned int NDimensions, unsigned int VSplineOrder>
 auto
 CyclicBSplineDeformableTransform<TScalarType, NDimensions, VSplineOrder>::TransformPoint(
   const InputPointType & point) const -> OutputPointType
@@ -215,7 +215,7 @@ CyclicBSplineDeformableTransform<TScalarType, NDimensions, VSplineOrder>::Transf
 
 
 /** Compute the Jacobian in one position. */
-template <class TScalarType, unsigned int NDimensions, unsigned int VSplineOrder>
+template <typename TScalarType, unsigned int NDimensions, unsigned int VSplineOrder>
 void
 CyclicBSplineDeformableTransform<TScalarType, NDimensions, VSplineOrder>::GetJacobian(
   const InputPointType &    point,
@@ -272,7 +272,7 @@ CyclicBSplineDeformableTransform<TScalarType, NDimensions, VSplineOrder>::GetJac
  * ********************* GetSpatialJacobian ****************************
  */
 
-template <class TScalarType, unsigned int NDimensions, unsigned int VSplineOrder>
+template <typename TScalarType, unsigned int NDimensions, unsigned int VSplineOrder>
 void
 CyclicBSplineDeformableTransform<TScalarType, NDimensions, VSplineOrder>::GetSpatialJacobian(
   const InputPointType & inputPoint,
@@ -367,7 +367,7 @@ CyclicBSplineDeformableTransform<TScalarType, NDimensions, VSplineOrder>::GetSpa
  * ********************* ComputeNonZeroJacobianIndices ****************************
  */
 
-template <class TScalarType, unsigned int NDimensions, unsigned int VSplineOrder>
+template <typename TScalarType, unsigned int NDimensions, unsigned int VSplineOrder>
 void
 CyclicBSplineDeformableTransform<TScalarType, NDimensions, VSplineOrder>::ComputeNonZeroJacobianIndices(
   NonZeroJacobianIndicesType & nonZeroJacobianIndices,

--- a/Common/Transforms/itkEulerTransform.h
+++ b/Common/Transforms/itkEulerTransform.h
@@ -35,7 +35,7 @@ template <unsigned int Dimension>
 class ITK_TEMPLATE_EXPORT EulerGroup
 {
 public:
-  template <class TScalarType>
+  template <typename TScalarType>
   using TransformAlias = AdvancedMatrixOffsetTransformBase<TScalarType, Dimension, Dimension>;
 };
 
@@ -49,7 +49,7 @@ template <>
 class ITK_TEMPLATE_EXPORT EulerGroup<2>
 {
 public:
-  template <class TScalarType>
+  template <typename TScalarType>
   using TransformAlias = AdvancedRigid2DTransform<TScalarType>;
 };
 
@@ -63,7 +63,7 @@ template <>
 class ITK_TEMPLATE_EXPORT EulerGroup<3>
 {
 public:
-  template <class TScalarType>
+  template <typename TScalarType>
   using TransformAlias = AdvancedEuler3DTransform<TScalarType>;
 };
 
@@ -71,7 +71,7 @@ public:
 /**
  * This alias templates the EulerGroup over its dimension.
  */
-template <class TScalarType, unsigned int Dimension>
+template <typename TScalarType, unsigned int Dimension>
 using EulerGroupTemplate = typename EulerGroup<Dimension>::template TransformAlias<TScalarType>;
 
 
@@ -84,7 +84,7 @@ using EulerGroupTemplate = typename EulerGroup<Dimension>::template TransformAli
  * \ingroup Transforms
  */
 
-template <class TScalarType, unsigned int Dimension>
+template <typename TScalarType, unsigned int Dimension>
 class ITK_TEMPLATE_EXPORT EulerTransform : public EulerGroupTemplate<TScalarType, Dimension>
 {
 public:
@@ -155,7 +155,7 @@ protected:
   ~EulerTransform() override = default;
 };
 
-template <class TScalarType>
+template <typename TScalarType>
 class ITK_TEMPLATE_EXPORT EulerTransform<TScalarType, 3> : public EulerGroupTemplate<TScalarType, 3>
 {
 public:

--- a/Common/Transforms/itkRecursiveBSplineTransform.hxx
+++ b/Common/Transforms/itkRecursiveBSplineTransform.hxx
@@ -89,7 +89,7 @@ RecursiveBSplineTransform<TScalar, NDimensions, VSplineOrder>::TransformPoint(co
  * ********************* GetJacobian ****************************
  */
 
-template <class TScalar, unsigned int NDimensions, unsigned int VSplineOrder>
+template <typename TScalar, unsigned int NDimensions, unsigned int VSplineOrder>
 void
 RecursiveBSplineTransform<TScalar, NDimensions, VSplineOrder>::GetJacobian(
   const InputPointType &       inputPoint,
@@ -146,7 +146,7 @@ RecursiveBSplineTransform<TScalar, NDimensions, VSplineOrder>::GetJacobian(
  * ********************* EvaluateJacobianAndImageGradientProduct ****************************
  */
 
-template <class TScalar, unsigned int NDimensions, unsigned int VSplineOrder>
+template <typename TScalar, unsigned int NDimensions, unsigned int VSplineOrder>
 void
 RecursiveBSplineTransform<TScalar, NDimensions, VSplineOrder>::EvaluateJacobianWithImageGradientProduct(
   const InputPointType &          inputPoint,
@@ -204,7 +204,7 @@ RecursiveBSplineTransform<TScalar, NDimensions, VSplineOrder>::EvaluateJacobianW
  * ********************* GetSpatialJacobian ****************************
  */
 
-template <class TScalar, unsigned int NDimensions, unsigned int VSplineOrder>
+template <typename TScalar, unsigned int NDimensions, unsigned int VSplineOrder>
 void
 RecursiveBSplineTransform<TScalar, NDimensions, VSplineOrder>::GetSpatialJacobian(const InputPointType & inputPoint,
                                                                                   SpatialJacobianType &  sj) const
@@ -279,7 +279,7 @@ RecursiveBSplineTransform<TScalar, NDimensions, VSplineOrder>::GetSpatialJacobia
  * ********************* GetSpatialHessian ****************************
  */
 
-template <class TScalar, unsigned int NDimensions, unsigned int VSplineOrder>
+template <typename TScalar, unsigned int NDimensions, unsigned int VSplineOrder>
 void
 RecursiveBSplineTransform<TScalar, NDimensions, VSplineOrder>::GetSpatialHessian(const InputPointType & inputPoint,
                                                                                  SpatialHessianType &   sh) const
@@ -373,7 +373,7 @@ RecursiveBSplineTransform<TScalar, NDimensions, VSplineOrder>::GetSpatialHessian
  * ********************* GetJacobianOfSpatialJacobian ****************************
  */
 
-template <class TScalar, unsigned int NDimensions, unsigned int VSplineOrder>
+template <typename TScalar, unsigned int NDimensions, unsigned int VSplineOrder>
 void
 RecursiveBSplineTransform<TScalar, NDimensions, VSplineOrder>::GetJacobianOfSpatialJacobian(
   const InputPointType &          inputPoint,
@@ -439,7 +439,7 @@ RecursiveBSplineTransform<TScalar, NDimensions, VSplineOrder>::GetJacobianOfSpat
  * ********************* GetJacobianOfSpatialJacobian ****************************
  */
 
-template <class TScalar, unsigned int NDimensions, unsigned int VSplineOrder>
+template <typename TScalar, unsigned int NDimensions, unsigned int VSplineOrder>
 void
 RecursiveBSplineTransform<TScalar, NDimensions, VSplineOrder>::GetJacobianOfSpatialJacobian(
   const InputPointType &          inputPoint,
@@ -456,7 +456,7 @@ RecursiveBSplineTransform<TScalar, NDimensions, VSplineOrder>::GetJacobianOfSpat
  * ********************* GetJacobianOfSpatialHessian ****************************
  */
 
-template <class TScalar, unsigned int NDimensions, unsigned int VSplineOrder>
+template <typename TScalar, unsigned int NDimensions, unsigned int VSplineOrder>
 void
 RecursiveBSplineTransform<TScalar, NDimensions, VSplineOrder>::GetJacobianOfSpatialHessian(
   const InputPointType &         inputPoint,
@@ -529,7 +529,7 @@ RecursiveBSplineTransform<TScalar, NDimensions, VSplineOrder>::GetJacobianOfSpat
  * ********************* GetJacobianOfSpatialHessian ****************************
  */
 
-template <class TScalar, unsigned int NDimensions, unsigned int VSplineOrder>
+template <typename TScalar, unsigned int NDimensions, unsigned int VSplineOrder>
 void
 RecursiveBSplineTransform<TScalar, NDimensions, VSplineOrder>::GetJacobianOfSpatialHessian(
   const InputPointType &         inputPoint,
@@ -546,7 +546,7 @@ RecursiveBSplineTransform<TScalar, NDimensions, VSplineOrder>::GetJacobianOfSpat
  * ********************* ComputeNonZeroJacobianIndices ****************************
  */
 
-template <class TScalar, unsigned int NDimensions, unsigned int VSplineOrder>
+template <typename TScalar, unsigned int NDimensions, unsigned int VSplineOrder>
 void
 RecursiveBSplineTransform<TScalar, NDimensions, VSplineOrder>::ComputeNonZeroJacobianIndices(
   NonZeroJacobianIndicesType & nonZeroJacobianIndices,

--- a/Common/Transforms/itkRecursiveBSplineTransformImplementation.h
+++ b/Common/Transforms/itkRecursiveBSplineTransformImplementation.h
@@ -42,7 +42,7 @@ namespace itk
  * \ingroup ITKTransform
  */
 
-template <unsigned int OutputDimension, unsigned int SpaceDimension, unsigned int SplineOrder, class TScalar>
+template <unsigned int OutputDimension, unsigned int SpaceDimension, unsigned int SplineOrder, typename TScalar>
 class ITK_TEMPLATE_EXPORT RecursiveBSplineTransformImplementation
 {
 public:
@@ -353,7 +353,7 @@ public:
  * \brief Define the end case for SpaceDimension = 0.
  */
 
-template <unsigned int OutputDimension, unsigned int SplineOrder, class TScalar>
+template <unsigned int OutputDimension, unsigned int SplineOrder, typename TScalar>
 class ITK_TEMPLATE_EXPORT RecursiveBSplineTransformImplementation<OutputDimension, 0, SplineOrder, TScalar>
 {
 public:

--- a/Common/Transforms/itkStackTransform.h
+++ b/Common/Transforms/itkStackTransform.h
@@ -36,7 +36,7 @@ namespace itk
  * \ingroup Transforms
  *
  */
-template <class TScalarType, unsigned int NInputDimensions, unsigned int NOutputDimensions>
+template <typename TScalarType, unsigned int NInputDimensions, unsigned int NOutputDimensions>
 class ITK_TEMPLATE_EXPORT StackTransform : public AdvancedTransform<TScalarType, NInputDimensions, NOutputDimensions>
 {
 public:

--- a/Common/Transforms/itkStackTransform.hxx
+++ b/Common/Transforms/itkStackTransform.hxx
@@ -27,7 +27,7 @@ namespace itk
  * ************************ SetParameters ***********************
  */
 
-template <class TScalarType, unsigned int NInputDimensions, unsigned int NOutputDimensions>
+template <typename TScalarType, unsigned int NInputDimensions, unsigned int NOutputDimensions>
 void
 StackTransform<TScalarType, NInputDimensions, NOutputDimensions>::SetParameters(const ParametersType & param)
 {
@@ -57,7 +57,7 @@ StackTransform<TScalarType, NInputDimensions, NOutputDimensions>::SetParameters(
  * ************************ GetParameters ***********************
  */
 
-template <class TScalarType, unsigned int NInputDimensions, unsigned int NOutputDimensions>
+template <typename TScalarType, unsigned int NInputDimensions, unsigned int NOutputDimensions>
 auto
 StackTransform<TScalarType, NInputDimensions, NOutputDimensions>::GetParameters() const -> const ParametersType &
 {
@@ -84,7 +84,7 @@ StackTransform<TScalarType, NInputDimensions, NOutputDimensions>::GetParameters(
  * ********************* TransformPoint ****************************
  */
 
-template <class TScalarType, unsigned int NInputDimensions, unsigned int NOutputDimensions>
+template <typename TScalarType, unsigned int NInputDimensions, unsigned int NOutputDimensions>
 auto
 StackTransform<TScalarType, NInputDimensions, NOutputDimensions>::TransformPoint(
   const InputPointType & inputPoint) const -> OutputPointType
@@ -121,7 +121,7 @@ StackTransform<TScalarType, NInputDimensions, NOutputDimensions>::TransformPoint
  * ********************* GetJacobian ****************************
  */
 
-template <class TScalarType, unsigned int NInputDimensions, unsigned int NOutputDimensions>
+template <typename TScalarType, unsigned int NInputDimensions, unsigned int NOutputDimensions>
 void
 StackTransform<TScalarType, NInputDimensions, NOutputDimensions>::GetJacobian(const InputPointType &       inputPoint,
                                                                               JacobianType &               jac,
@@ -166,7 +166,7 @@ StackTransform<TScalarType, NInputDimensions, NOutputDimensions>::GetJacobian(co
  * ********************* GetNumberOfNonZeroJacobianIndices ****************************
  */
 
-template <class TScalarType, unsigned int NInputDimensions, unsigned int NOutputDimensions>
+template <typename TScalarType, unsigned int NInputDimensions, unsigned int NOutputDimensions>
 auto
 StackTransform<TScalarType, NInputDimensions, NOutputDimensions>::GetNumberOfNonZeroJacobianIndices() const
   -> NumberOfParametersType

--- a/Common/Transforms/itkTransformToDeterminantOfSpatialJacobianSource.h
+++ b/Common/Transforms/itkTransformToDeterminantOfSpatialJacobianSource.h
@@ -70,7 +70,7 @@ namespace itk
  *
  * \ingroup GeometricTransforms
  */
-template <class TOutputImage, class TTransformPrecisionType = double>
+template <typename TOutputImage, typename TTransformPrecisionType = double>
 class ITK_TEMPLATE_EXPORT TransformToDeterminantOfSpatialJacobianSource : public ImageSource<TOutputImage>
 {
 public:

--- a/Common/Transforms/itkTransformToDeterminantOfSpatialJacobianSource.hxx
+++ b/Common/Transforms/itkTransformToDeterminantOfSpatialJacobianSource.hxx
@@ -46,7 +46,7 @@ namespace itk
 /**
  * Constructor
  */
-template <class TOutputImage, class TTransformPrecisionType>
+template <typename TOutputImage, typename TTransformPrecisionType>
 TransformToDeterminantOfSpatialJacobianSource<TOutputImage,
                                               TTransformPrecisionType>::TransformToDeterminantOfSpatialJacobianSource()
 {
@@ -61,7 +61,7 @@ TransformToDeterminantOfSpatialJacobianSource<TOutputImage,
  *
  * \todo Add details about this class
  */
-template <class TOutputImage, class TTransformPrecisionType>
+template <typename TOutputImage, typename TTransformPrecisionType>
 void
 TransformToDeterminantOfSpatialJacobianSource<TOutputImage, TTransformPrecisionType>::PrintSelf(std::ostream & os,
                                                                                                 Indent indent) const
@@ -80,7 +80,7 @@ TransformToDeterminantOfSpatialJacobianSource<TOutputImage, TTransformPrecisionT
 /**
  * Set the output image size.
  */
-template <class TOutputImage, class TTransformPrecisionType>
+template <typename TOutputImage, typename TTransformPrecisionType>
 void
 TransformToDeterminantOfSpatialJacobianSource<TOutputImage, TTransformPrecisionType>::SetOutputSize(
   const SizeType & size)
@@ -92,7 +92,7 @@ TransformToDeterminantOfSpatialJacobianSource<TOutputImage, TTransformPrecisionT
 /**
  * Get the output image size.
  */
-template <class TOutputImage, class TTransformPrecisionType>
+template <typename TOutputImage, typename TTransformPrecisionType>
 auto
 TransformToDeterminantOfSpatialJacobianSource<TOutputImage, TTransformPrecisionType>::GetOutputSize()
   -> const SizeType &
@@ -103,7 +103,7 @@ TransformToDeterminantOfSpatialJacobianSource<TOutputImage, TTransformPrecisionT
 /**
  * Set the output image index.
  */
-template <class TOutputImage, class TTransformPrecisionType>
+template <typename TOutputImage, typename TTransformPrecisionType>
 void
 TransformToDeterminantOfSpatialJacobianSource<TOutputImage, TTransformPrecisionType>::SetOutputIndex(
   const IndexType & index)
@@ -115,7 +115,7 @@ TransformToDeterminantOfSpatialJacobianSource<TOutputImage, TTransformPrecisionT
 /**
  * Get the output image index.
  */
-template <class TOutputImage, class TTransformPrecisionType>
+template <typename TOutputImage, typename TTransformPrecisionType>
 auto
 TransformToDeterminantOfSpatialJacobianSource<TOutputImage, TTransformPrecisionType>::GetOutputIndex()
   -> const IndexType &
@@ -126,7 +126,7 @@ TransformToDeterminantOfSpatialJacobianSource<TOutputImage, TTransformPrecisionT
 /**
  * Set the output image spacing.
  */
-template <class TOutputImage, class TTransformPrecisionType>
+template <typename TOutputImage, typename TTransformPrecisionType>
 void
 TransformToDeterminantOfSpatialJacobianSource<TOutputImage, TTransformPrecisionType>::SetOutputSpacing(
   const double * spacing)
@@ -140,7 +140,7 @@ TransformToDeterminantOfSpatialJacobianSource<TOutputImage, TTransformPrecisionT
 /**
  * Set the output image origin.
  */
-template <class TOutputImage, class TTransformPrecisionType>
+template <typename TOutputImage, typename TTransformPrecisionType>
 void
 TransformToDeterminantOfSpatialJacobianSource<TOutputImage, TTransformPrecisionType>::SetOutputOrigin(
   const double * origin)
@@ -151,7 +151,7 @@ TransformToDeterminantOfSpatialJacobianSource<TOutputImage, TTransformPrecisionT
 
 
 /** Helper method to set the output parameters based on this image */
-template <class TOutputImage, class TTransformPrecisionType>
+template <typename TOutputImage, typename TTransformPrecisionType>
 void
 TransformToDeterminantOfSpatialJacobianSource<TOutputImage, TTransformPrecisionType>::SetOutputParametersFromImage(
   const ImageBaseType * image)
@@ -174,7 +174,7 @@ TransformToDeterminantOfSpatialJacobianSource<TOutputImage, TTransformPrecisionT
  * InterpolatorType::SetInputImage is not thread-safe and hence
  * has to be set up before ThreadedGenerateData
  */
-template <class TOutputImage, class TTransformPrecisionType>
+template <typename TOutputImage, typename TTransformPrecisionType>
 void
 TransformToDeterminantOfSpatialJacobianSource<TOutputImage, TTransformPrecisionType>::BeforeThreadedGenerateData()
 {
@@ -197,7 +197,7 @@ TransformToDeterminantOfSpatialJacobianSource<TOutputImage, TTransformPrecisionT
 /**
  * ThreadedGenerateData
  */
-template <class TOutputImage, class TTransformPrecisionType>
+template <typename TOutputImage, typename TTransformPrecisionType>
 void
 TransformToDeterminantOfSpatialJacobianSource<TOutputImage, TTransformPrecisionType>::ThreadedGenerateData(
   const OutputImageRegionType & outputRegionForThread,
@@ -217,7 +217,7 @@ TransformToDeterminantOfSpatialJacobianSource<TOutputImage, TTransformPrecisionT
 } // end ThreadedGenerateData()
 
 
-template <class TOutputImage, class TTransformPrecisionType>
+template <typename TOutputImage, typename TTransformPrecisionType>
 void
 TransformToDeterminantOfSpatialJacobianSource<TOutputImage, TTransformPrecisionType>::NonlinearThreadedGenerateData(
   const OutputImageRegionType & outputRegionForThread,
@@ -257,7 +257,7 @@ TransformToDeterminantOfSpatialJacobianSource<TOutputImage, TTransformPrecisionT
 } // end NonlinearThreadedGenerateData()
 
 
-template <class TOutputImage, class TTransformPrecisionType>
+template <typename TOutputImage, typename TTransformPrecisionType>
 void
 TransformToDeterminantOfSpatialJacobianSource<TOutputImage, TTransformPrecisionType>::LinearGenerateData()
 {
@@ -285,7 +285,7 @@ TransformToDeterminantOfSpatialJacobianSource<TOutputImage, TTransformPrecisionT
 /**
  * Inform pipeline of required output region
  */
-template <class TOutputImage, class TTransformPrecisionType>
+template <typename TOutputImage, typename TTransformPrecisionType>
 void
 TransformToDeterminantOfSpatialJacobianSource<TOutputImage, TTransformPrecisionType>::GenerateOutputInformation()
 {
@@ -311,7 +311,7 @@ TransformToDeterminantOfSpatialJacobianSource<TOutputImage, TTransformPrecisionT
 /**
  * Verify if any of the components has been modified.
  */
-template <class TOutputImage, class TTransformPrecisionType>
+template <typename TOutputImage, typename TTransformPrecisionType>
 ModifiedTimeType
 TransformToDeterminantOfSpatialJacobianSource<TOutputImage, TTransformPrecisionType>::GetMTime() const
 {

--- a/Common/Transforms/itkTransformToSpatialJacobianSource.h
+++ b/Common/Transforms/itkTransformToSpatialJacobianSource.h
@@ -63,7 +63,7 @@ namespace itk
  *
  * \ingroup GeometricTransforms
  */
-template <class TOutputImage, class TTransformPrecisionType = double>
+template <typename TOutputImage, typename TTransformPrecisionType = double>
 class ITK_TEMPLATE_EXPORT TransformToSpatialJacobianSource : public ImageSource<TOutputImage>
 {
 public:

--- a/Common/Transforms/itkTransformToSpatialJacobianSource.hxx
+++ b/Common/Transforms/itkTransformToSpatialJacobianSource.hxx
@@ -31,7 +31,7 @@ namespace itk
 /**
  * Constructor
  */
-template <class TOutputImage, class TTransformPrecisionType>
+template <typename TOutputImage, typename TTransformPrecisionType>
 TransformToSpatialJacobianSource<TOutputImage, TTransformPrecisionType>::TransformToSpatialJacobianSource()
 {
   // Check if the output pixel type is valid
@@ -56,7 +56,7 @@ TransformToSpatialJacobianSource<TOutputImage, TTransformPrecisionType>::Transfo
  *
  * \todo Add details about this class
  */
-template <class TOutputImage, class TTransformPrecisionType>
+template <typename TOutputImage, typename TTransformPrecisionType>
 void
 TransformToSpatialJacobianSource<TOutputImage, TTransformPrecisionType>::PrintSelf(std::ostream & os,
                                                                                    Indent         indent) const
@@ -75,7 +75,7 @@ TransformToSpatialJacobianSource<TOutputImage, TTransformPrecisionType>::PrintSe
 /**
  * Set the output image size.
  */
-template <class TOutputImage, class TTransformPrecisionType>
+template <typename TOutputImage, typename TTransformPrecisionType>
 void
 TransformToSpatialJacobianSource<TOutputImage, TTransformPrecisionType>::SetOutputSize(const SizeType & size)
 {
@@ -86,7 +86,7 @@ TransformToSpatialJacobianSource<TOutputImage, TTransformPrecisionType>::SetOutp
 /**
  * Get the output image size.
  */
-template <class TOutputImage, class TTransformPrecisionType>
+template <typename TOutputImage, typename TTransformPrecisionType>
 auto
 TransformToSpatialJacobianSource<TOutputImage, TTransformPrecisionType>::GetOutputSize() -> const SizeType &
 {
@@ -96,7 +96,7 @@ TransformToSpatialJacobianSource<TOutputImage, TTransformPrecisionType>::GetOutp
 /**
  * Set the output image index.
  */
-template <class TOutputImage, class TTransformPrecisionType>
+template <typename TOutputImage, typename TTransformPrecisionType>
 void
 TransformToSpatialJacobianSource<TOutputImage, TTransformPrecisionType>::SetOutputIndex(const IndexType & index)
 {
@@ -107,7 +107,7 @@ TransformToSpatialJacobianSource<TOutputImage, TTransformPrecisionType>::SetOutp
 /**
  * Get the output image index.
  */
-template <class TOutputImage, class TTransformPrecisionType>
+template <typename TOutputImage, typename TTransformPrecisionType>
 auto
 TransformToSpatialJacobianSource<TOutputImage, TTransformPrecisionType>::GetOutputIndex() -> const IndexType &
 {
@@ -117,7 +117,7 @@ TransformToSpatialJacobianSource<TOutputImage, TTransformPrecisionType>::GetOutp
 /**
  * Set the output image spacing.
  */
-template <class TOutputImage, class TTransformPrecisionType>
+template <typename TOutputImage, typename TTransformPrecisionType>
 void
 TransformToSpatialJacobianSource<TOutputImage, TTransformPrecisionType>::SetOutputSpacing(const double * spacing)
 {
@@ -130,7 +130,7 @@ TransformToSpatialJacobianSource<TOutputImage, TTransformPrecisionType>::SetOutp
 /**
  * Set the output image origin.
  */
-template <class TOutputImage, class TTransformPrecisionType>
+template <typename TOutputImage, typename TTransformPrecisionType>
 void
 TransformToSpatialJacobianSource<TOutputImage, TTransformPrecisionType>::SetOutputOrigin(const double * origin)
 {
@@ -140,7 +140,7 @@ TransformToSpatialJacobianSource<TOutputImage, TTransformPrecisionType>::SetOutp
 
 
 /** Helper method to set the output parameters based on this image */
-template <class TOutputImage, class TTransformPrecisionType>
+template <typename TOutputImage, typename TTransformPrecisionType>
 void
 TransformToSpatialJacobianSource<TOutputImage, TTransformPrecisionType>::SetOutputParametersFromImage(
   const ImageBaseType * image)
@@ -163,7 +163,7 @@ TransformToSpatialJacobianSource<TOutputImage, TTransformPrecisionType>::SetOutp
  * InterpolatorType::SetInputImage is not thread-safe and hence
  * has to be set up before ThreadedGenerateData
  */
-template <class TOutputImage, class TTransformPrecisionType>
+template <typename TOutputImage, typename TTransformPrecisionType>
 void
 TransformToSpatialJacobianSource<TOutputImage, TTransformPrecisionType>::BeforeThreadedGenerateData()
 {
@@ -186,7 +186,7 @@ TransformToSpatialJacobianSource<TOutputImage, TTransformPrecisionType>::BeforeT
 /**
  * ThreadedGenerateData
  */
-template <class TOutputImage, class TTransformPrecisionType>
+template <typename TOutputImage, typename TTransformPrecisionType>
 void
 TransformToSpatialJacobianSource<TOutputImage, TTransformPrecisionType>::ThreadedGenerateData(
   const OutputImageRegionType & outputRegionForThread,
@@ -206,7 +206,7 @@ TransformToSpatialJacobianSource<TOutputImage, TTransformPrecisionType>::Threade
 } // end ThreadedGenerateData()
 
 
-template <class TOutputImage, class TTransformPrecisionType>
+template <typename TOutputImage, typename TTransformPrecisionType>
 void
 TransformToSpatialJacobianSource<TOutputImage, TTransformPrecisionType>::NonlinearThreadedGenerateData(
   const OutputImageRegionType & outputRegionForThread,
@@ -251,7 +251,7 @@ TransformToSpatialJacobianSource<TOutputImage, TTransformPrecisionType>::Nonline
 } // end NonlinearThreadedGenerateData()
 
 
-template <class TOutputImage, class TTransformPrecisionType>
+template <typename TOutputImage, typename TTransformPrecisionType>
 void
 TransformToSpatialJacobianSource<TOutputImage, TTransformPrecisionType>::LinearGenerateData()
 {
@@ -284,7 +284,7 @@ TransformToSpatialJacobianSource<TOutputImage, TTransformPrecisionType>::LinearG
 /**
  * Inform pipeline of required output region
  */
-template <class TOutputImage, class TTransformPrecisionType>
+template <typename TOutputImage, typename TTransformPrecisionType>
 void
 TransformToSpatialJacobianSource<TOutputImage, TTransformPrecisionType>::GenerateOutputInformation()
 {
@@ -310,7 +310,7 @@ TransformToSpatialJacobianSource<TOutputImage, TTransformPrecisionType>::Generat
 /**
  * Verify if any of the components has been modified.
  */
-template <class TOutputImage, class TTransformPrecisionType>
+template <typename TOutputImage, typename TTransformPrecisionType>
 ModifiedTimeType
 TransformToSpatialJacobianSource<TOutputImage, TTransformPrecisionType>::GetMTime() const
 {

--- a/Common/Transforms/itkUpsampleBSplineParametersFilter.h
+++ b/Common/Transforms/itkUpsampleBSplineParametersFilter.h
@@ -35,7 +35,7 @@ namespace itk
  *
  */
 
-template <class TArray, class TImage>
+template <typename TArray, typename TImage>
 class ITK_TEMPLATE_EXPORT UpsampleBSplineParametersFilter : public Object
 {
 public:

--- a/Common/Transforms/itkUpsampleBSplineParametersFilter.hxx
+++ b/Common/Transforms/itkUpsampleBSplineParametersFilter.hxx
@@ -31,7 +31,7 @@ namespace itk
  * ******************* Constructor *******************
  */
 
-template <class TArray, class TImage>
+template <typename TArray, typename TImage>
 UpsampleBSplineParametersFilter<TArray, TImage>::UpsampleBSplineParametersFilter()
 {
   this->m_BSplineOrder = 3;
@@ -50,7 +50,7 @@ UpsampleBSplineParametersFilter<TArray, TImage>::UpsampleBSplineParametersFilter
  * ******************* UpsampleParameters *******************
  */
 
-template <class TArray, class TImage>
+template <typename TArray, typename TImage>
 void
 UpsampleBSplineParametersFilter<TArray, TImage>::UpsampleParameters(const ArrayType & parameters_in,
                                                                     ArrayType &       parameters_out)
@@ -154,7 +154,7 @@ UpsampleBSplineParametersFilter<TArray, TImage>::UpsampleParameters(const ArrayT
  * ******************* DoUpsampling *******************
  */
 
-template <class TArray, class TImage>
+template <typename TArray, typename TImage>
 bool
 UpsampleBSplineParametersFilter<TArray, TImage>::DoUpsampling()
 {
@@ -172,7 +172,7 @@ UpsampleBSplineParametersFilter<TArray, TImage>::DoUpsampling()
  * ******************* PrintSelf *******************
  */
 
-template <class TArray, class TImage>
+template <typename TArray, typename TImage>
 void
 UpsampleBSplineParametersFilter<TArray, TImage>::PrintSelf(std::ostream & os, Indent indent) const
 {

--- a/Common/TypeList.h
+++ b/Common/TypeList.h
@@ -208,16 +208,16 @@ struct Length<NullType>
  * error
  *
  */
-template <class TTypeList, unsigned int index>
+template <typename TTypeList, unsigned int index>
 struct TypeAt;
 
-template <class Head, class Tail>
+template <typename Head, typename Tail>
 struct TypeAt<TypeList<Head, Tail>, 0>
 {
   using Type = Head;
 };
 
-template <class Head, class Tail, unsigned int i>
+template <typename Head, typename Tail, unsigned int i>
 struct TypeAt<TypeList<Head, Tail>, i>
 {
   using Type = typename TypeAt<Tail, i - 1>::Type;
@@ -229,7 +229,7 @@ struct TypeAt<NullType, i>
   using Type = NullType;
 };
 
-template <class TTypeList1, class TTypeList2>
+template <typename TTypeList1, typename TTypeList2>
 struct Append;
 /**\class Append
  * \brief Appends a type or a typelist to another
@@ -252,7 +252,7 @@ struct Append;
  *  single type.
  *
  */
-template <class Head, class Tail, class T>
+template <typename Head, typename Tail, typename T>
 struct Append<TypeList<Head, Tail>, T>
 {
   using Type = TypeList<Head, typename Append<Tail, T>::Type>;
@@ -264,22 +264,22 @@ struct Append<NullType, NullType>
 {
   using Type = NullType;
 };
-template <class T>
+template <typename T>
 struct Append<NullType, T>
 {
   using Type = TypeList<T, NullType>;
 };
-template <class T>
+template <typename T>
 struct Append<T, NullType>
 {
   using Type = TypeList<T, NullType>;
 };
-template <class Head, class Tail>
+template <typename Head, typename Tail>
 struct Append<NullType, TypeList<Head, Tail>>
 {
   using Type = TypeList<Head, Tail>;
 };
-template <class Head, class Tail>
+template <typename Head, typename Tail>
 struct Append<TypeList<Head, Tail>, NullType>
 {
   using Type = TypeList<Head, Tail>;
@@ -288,22 +288,22 @@ struct Append<TypeList<Head, Tail>, NullType>
 /**\class Erase
  * \brief
  */
-template <class TList, class T>
+template <typename TList, typename T>
 struct Erase;
 
-template <class T>
+template <typename T>
 struct Erase<NullType, T>
 {
   using Type = NullType;
 };
 
-template <class T, class Tail>
+template <typename T, typename Tail>
 struct Erase<TypeList<T, Tail>, T>
 {
   using Type = Tail;
 };
 
-template <class Head, class Tail, class T>
+template <typename Head, typename Tail, typename T>
 struct Erase<TypeList<Head, Tail>, T>
 {
   using Type = TypeList<Head, typename Erase<Tail, T>::Type>;
@@ -312,19 +312,19 @@ struct Erase<TypeList<Head, Tail>, T>
 /**\class EraseAll
  * \brief
  */
-template <class TList, class T>
+template <typename TList, typename T>
 struct EraseAll;
-template <class T>
+template <typename T>
 struct EraseAll<NullType, T>
 {
   using Type = NullType;
 };
-template <class T, class Tail>
+template <typename T, typename Tail>
 struct EraseAll<TypeList<T, Tail>, T>
 {
   using Type = typename EraseAll<Tail, T>::Type;
 };
-template <class Head, class Tail, class T>
+template <typename Head, typename Tail, typename T>
 struct EraseAll<TypeList<Head, Tail>, T>
 {
   using Type = TypeList<Head, typename EraseAll<Tail, T>::Type>;
@@ -333,7 +333,7 @@ struct EraseAll<TypeList<Head, Tail>, T>
 /**\class NoDuplicates
  * \brief
  */
-template <class TList>
+template <typename TList>
 struct NoDuplicates;
 
 template <>
@@ -342,7 +342,7 @@ struct NoDuplicates<NullType>
   using Type = NullType;
 };
 
-template <class Head, class Tail>
+template <typename Head, typename Tail>
 struct NoDuplicates<TypeList<Head, Tail>>
 {
 private:
@@ -356,22 +356,22 @@ public:
 /**\class Replace
  * \brief
  */
-template <class TList, class T, class U>
+template <typename TList, typename T, typename U>
 struct Replace;
 
-template <class T, class U>
+template <typename T, typename U>
 struct Replace<NullType, T, U>
 {
   using Type = NullType;
 };
 
-template <class T, class Tail, class U>
+template <typename T, typename Tail, typename U>
 struct Replace<TypeList<T, Tail>, T, U>
 {
   using Type = TypeList<U, Tail>;
 };
 
-template <class Head, class Tail, class T, class U>
+template <typename Head, typename Tail, typename T, typename U>
 struct Replace<TypeList<Head, Tail>, T, U>
 {
   using Type = TypeList<Head, typename Replace<Tail, T, U>::Type>;
@@ -380,22 +380,22 @@ struct Replace<TypeList<Head, Tail>, T, U>
 /**\class ReplaceAll
  * \brief
  */
-template <class TList, class T, class U>
+template <typename TList, typename T, typename U>
 struct ReplaceAll;
 
-template <class T, class U>
+template <typename T, typename U>
 struct ReplaceAll<NullType, T, U>
 {
   using Type = NullType;
 };
 
-template <class T, class Tail, class U>
+template <typename T, typename Tail, typename U>
 struct ReplaceAll<TypeList<T, Tail>, T, U>
 {
   using Type = TypeList<U, typename ReplaceAll<Tail, T, U>::Type>;
 };
 
-template <class Head, class Tail, class T, class U>
+template <typename Head, typename Tail, typename T, typename U>
 struct ReplaceAll<TypeList<Head, Tail>, T, U>
 {
   using Type = TypeList<Head, typename ReplaceAll<Tail, T, U>::Type>;
@@ -404,7 +404,7 @@ struct ReplaceAll<TypeList<Head, Tail>, T, U>
 /**\class Reverse
  * \brief
  */
-template <class TList>
+template <typename TList>
 struct Reverse;
 
 template <>
@@ -413,7 +413,7 @@ struct Reverse<NullType>
   using Type = NullType;
 };
 
-template <class Head, class Tail>
+template <typename Head, typename Tail>
 struct Reverse<TypeList<Head, Tail>>
 {
   using Type = typename Append<typename Reverse<Tail>::Type, Head>::Type;
@@ -433,9 +433,9 @@ struct Reverse<TypeList<Head, Tail>>
  * IndexOf<TTypeList, T>::Type
  * returns the position of T in TList, or NullType if T is not found in TList
  */
-template <class TTypeList, class TType>
+template <typename TTypeList, typename TType>
 struct IndexOf;
-template <class TType>
+template <typename TType>
 struct IndexOf<NullType, TType>
 {
   enum
@@ -443,7 +443,7 @@ struct IndexOf<NullType, TType>
     Type = -1
   };
 };
-template <class TType, class TTail>
+template <typename TType, typename TTail>
 struct IndexOf<TypeList<TType, TTail>, TType>
 {
   enum
@@ -451,7 +451,7 @@ struct IndexOf<TypeList<TType, TTail>, TType>
     Type = 0
   };
 };
-template <class Head, class TTail, class TType>
+template <typename Head, typename TTail, typename TType>
 struct IndexOf<TypeList<Head, TTail>, TType>
 {
 private:
@@ -479,9 +479,9 @@ public:
  * HasType<TList, T>::Type
  * evaluates to true if TList contains T, false otherwise.
  */
-template <class TTypeList, class TType>
+template <typename TTypeList, typename TType>
 struct HasType;
-template <class TType>
+template <typename TType>
 struct HasType<NullType, TType>
 {
   enum
@@ -489,7 +489,7 @@ struct HasType<NullType, TType>
     Type = false
   };
 };
-template <class TType, class TTail>
+template <typename TType, typename TTail>
 struct HasType<TypeList<TType, TTail>, TType>
 {
   enum
@@ -497,7 +497,7 @@ struct HasType<TypeList<TType, TTail>, TType>
     Type = true
   };
 };
-template <class Head, class TTail, class TType>
+template <typename Head, typename TTail, typename TType>
 struct HasType<TypeList<Head, TTail>, TType>
 {
   enum
@@ -524,10 +524,10 @@ struct HasType<TypeList<Head, TTail>, TType>
  *
  *
  */
-template <class TTypeList>
+template <typename TTypeList>
 struct Visit
 {
-  template <class Predicate>
+  template <typename Predicate>
   void
   operator()(Predicate & visitor)
   {
@@ -539,7 +539,7 @@ struct Visit
   }
 
 
-  template <class Predicate>
+  template <typename Predicate>
   void
   operator()(const Predicate & visitor)
   {
@@ -554,7 +554,7 @@ struct Visit
 template <>
 struct Visit<NullType>
 {
-  template <class Predicate>
+  template <typename Predicate>
   void
   operator()(const Predicate &)
   {}
@@ -576,10 +576,10 @@ struct Visit<NullType>
  *
  * \endcode
  */
-template <class TTypeList, unsigned int Dimension>
+template <typename TTypeList, unsigned int Dimension>
 struct VisitDimension
 {
-  template <class Predicate>
+  template <typename Predicate>
   void
   operator()(Predicate & visitor)
   {
@@ -591,7 +591,7 @@ struct VisitDimension
   }
 
 
-  template <class Predicate>
+  template <typename Predicate>
   void
   operator()(const Predicate & visitor)
   {
@@ -606,7 +606,7 @@ struct VisitDimension
 template <unsigned int Dimension>
 struct VisitDimension<NullType, Dimension>
 {
-  template <class Predicate>
+  template <typename Predicate>
   void
   operator()(const Predicate &)
   {}
@@ -619,7 +619,7 @@ struct VisitDimension<NullType, Dimension>
  * \code
  * struct Predicate
  * {
- *   template<class TType1, class TType2>
+ *   template<class TType1, typename TType2>
  *     void operator()() const
  *     { std::cout << typeid(TType1).name() << " " << typeid(TType2).name() << std::endl; }
  * };
@@ -767,7 +767,7 @@ struct DualVisitImpl<typelist::NullType, typelist::NullType>
  * \code
  * struct Predicate
  * {
- *   template<class TType1, class TType2, unsigned int Dimension>
+ *   template<class TType1, typename TType2, unsigned int Dimension>
  *     void operator()() const
  *     { std::cout << typeid(TType1).name()
             << " " << typeid(TType2).name() " "

--- a/Common/itkAdvancedLinearInterpolateImageFunction.h
+++ b/Common/itkAdvancedLinearInterpolateImageFunction.h
@@ -59,7 +59,7 @@ namespace itk
  * \wikiexample{ImageProcessing/LinearInterpolateImageFunction,Linearly interpolate a position in an image}
  * \endwiki
  */
-template <class TInputImage, class TCoordRep = double>
+template <typename TInputImage, typename TCoordRep = double>
 class ITK_TEMPLATE_EXPORT AdvancedLinearInterpolateImageFunction
   : public LinearInterpolateImageFunction<TInputImage, TCoordRep>
 {

--- a/Common/itkAdvancedLinearInterpolateImageFunction.hxx
+++ b/Common/itkAdvancedLinearInterpolateImageFunction.hxx
@@ -29,7 +29,7 @@ namespace itk
  * ***************** EvaluateDerivativeAtContinuousIndex ***********************
  */
 
-// template< class TInputImage, class TCoordRep >
+// template< class TInputImage, typename TCoordRep >
 // typename AdvancedLinearInterpolateImageFunction< TInputImage, TCoordRep >
 //::CovariantVectorType
 // AdvancedLinearInterpolateImageFunction< TInputImage, TCoordRep >
@@ -66,7 +66,7 @@ namespace itk
  * ***************** EvaluateValueAndDerivativeOptimized ***********************
  */
 
-template <class TInputImage, class TCoordRep>
+template <typename TInputImage, typename TCoordRep>
 void
 AdvancedLinearInterpolateImageFunction<TInputImage, TCoordRep>::EvaluateValueAndDerivativeOptimized(
   const Dispatch<2> &,
@@ -146,7 +146,7 @@ AdvancedLinearInterpolateImageFunction<TInputImage, TCoordRep>::EvaluateValueAnd
  * ***************** EvaluateValueAndDerivativeOptimized ***********************
  */
 
-template <class TInputImage, class TCoordRep>
+template <typename TInputImage, typename TCoordRep>
 void
 AdvancedLinearInterpolateImageFunction<TInputImage, TCoordRep>::EvaluateValueAndDerivativeOptimized(
   const Dispatch<3> &,

--- a/Common/itkAdvancedRayCastInterpolateImageFunction.h
+++ b/Common/itkAdvancedRayCastInterpolateImageFunction.h
@@ -52,7 +52,7 @@ namespace itk
  *
  * \ingroup ImageFunctions
  */
-template <class TInputImage, class TCoordRep = double>
+template <typename TInputImage, typename TCoordRep = double>
 class ITK_TEMPLATE_EXPORT AdvancedRayCastInterpolateImageFunction
   : public InterpolateImageFunction<TInputImage, TCoordRep>
 {

--- a/Common/itkAdvancedRayCastInterpolateImageFunction.hxx
+++ b/Common/itkAdvancedRayCastInterpolateImageFunction.hxx
@@ -44,7 +44,7 @@ namespace itk
 /** \class Helper class to maintain state when casting a ray.
  *  This helper class keeps the AdvancedRayCastInterpolateImageFunction thread safe.
  */
-template <class TInputImage, class TCoordRep>
+template <typename TInputImage, typename TCoordRep>
 class AdvancedRayCastInterpolateImageFunction<TInputImage, TCoordRep>::RayCastHelper
 {
 public:
@@ -349,7 +349,7 @@ protected:
    Initialise() - Initialise the object
    ----------------------------------------------------------------------- */
 
-template <class TInputImage, class TCoordRep>
+template <typename TInputImage, typename TCoordRep>
 void
 AdvancedRayCastInterpolateImageFunction<TInputImage, TCoordRep>::RayCastHelper::Initialise()
 {
@@ -366,7 +366,7 @@ AdvancedRayCastInterpolateImageFunction<TInputImage, TCoordRep>::RayCastHelper::
    RecordVolumeDimensions() - Record volume dimensions and resolution
    ----------------------------------------------------------------------- */
 
-template <class TInputImage, class TCoordRep>
+template <typename TInputImage, typename TCoordRep>
 void
 AdvancedRayCastInterpolateImageFunction<TInputImage, TCoordRep>::RayCastHelper::RecordVolumeDimensions()
 {
@@ -387,7 +387,7 @@ AdvancedRayCastInterpolateImageFunction<TInputImage, TCoordRep>::RayCastHelper::
    DefineCorners() - Define the corners of the volume
    ----------------------------------------------------------------------- */
 
-template <class TInputImage, class TCoordRep>
+template <typename TInputImage, typename TCoordRep>
 void
 AdvancedRayCastInterpolateImageFunction<TInputImage, TCoordRep>::RayCastHelper::DefineCorners()
 {
@@ -414,7 +414,7 @@ AdvancedRayCastInterpolateImageFunction<TInputImage, TCoordRep>::RayCastHelper::
    CalcPlanesAndCorners() - Calculate the planes and corners of the volume.
    ----------------------------------------------------------------------- */
 
-template <class TInputImage, class TCoordRep>
+template <typename TInputImage, typename TCoordRep>
 void
 AdvancedRayCastInterpolateImageFunction<TInputImage, TCoordRep>::RayCastHelper::CalcPlanesAndCorners()
 {
@@ -505,7 +505,7 @@ AdvancedRayCastInterpolateImageFunction<TInputImage, TCoordRep>::RayCastHelper::
    CalcRayIntercepts() - Calculate the ray intercepts with the volume.
    ----------------------------------------------------------------------- */
 
-template <class TInputImage, class TCoordRep>
+template <typename TInputImage, typename TCoordRep>
 bool
 AdvancedRayCastInterpolateImageFunction<TInputImage, TCoordRep>::RayCastHelper::CalcRayIntercepts()
 {
@@ -732,7 +732,7 @@ AdvancedRayCastInterpolateImageFunction<TInputImage, TCoordRep>::RayCastHelper::
    SetRay() - Set the position and direction of the ray
    ----------------------------------------------------------------------- */
 
-template <class TInputImage, class TCoordRep>
+template <typename TInputImage, typename TCoordRep>
 bool
 AdvancedRayCastInterpolateImageFunction<TInputImage, TCoordRep>::RayCastHelper::SetRay(OutputPointType RayPosn,
                                                                                        DirectionType   RayDirn)
@@ -802,7 +802,7 @@ AdvancedRayCastInterpolateImageFunction<TInputImage, TCoordRep>::RayCastHelper::
    EndPointsInVoxels() - Convert the endpoints to voxels
    ----------------------------------------------------------------------- */
 
-template <class TInputImage, class TCoordRep>
+template <typename TInputImage, typename TCoordRep>
 void
 AdvancedRayCastInterpolateImageFunction<TInputImage, TCoordRep>::RayCastHelper::EndPointsInVoxels()
 {
@@ -820,7 +820,7 @@ AdvancedRayCastInterpolateImageFunction<TInputImage, TCoordRep>::RayCastHelper::
    CalcDirnVector() - Calculate the incremental direction vector in voxels.
    ----------------------------------------------------------------------- */
 
-template <class TInputImage, class TCoordRep>
+template <typename TInputImage, typename TCoordRep>
 void
 AdvancedRayCastInterpolateImageFunction<TInputImage, TCoordRep>::RayCastHelper::CalcDirnVector()
 {
@@ -971,7 +971,7 @@ AdvancedRayCastInterpolateImageFunction<TInputImage, TCoordRep>::RayCastHelper::
    AdjustRayLength() - Ensure that the ray lies within the volume
    ----------------------------------------------------------------------- */
 
-template <class TInputImage, class TCoordRep>
+template <typename TInputImage, typename TCoordRep>
 bool
 AdvancedRayCastInterpolateImageFunction<TInputImage, TCoordRep>::RayCastHelper::AdjustRayLength()
 {
@@ -1062,7 +1062,7 @@ AdvancedRayCastInterpolateImageFunction<TInputImage, TCoordRep>::RayCastHelper::
    Reset() - Reset the iterator to the start of the ray.
    ----------------------------------------------------------------------- */
 
-template <class TInputImage, class TCoordRep>
+template <typename TInputImage, typename TCoordRep>
 void
 AdvancedRayCastInterpolateImageFunction<TInputImage, TCoordRep>::RayCastHelper::Reset()
 {
@@ -1117,7 +1117,7 @@ AdvancedRayCastInterpolateImageFunction<TInputImage, TCoordRep>::RayCastHelper::
    InitialiseVoxelPointers() - Obtain pointers to the first four voxels
    ----------------------------------------------------------------------- */
 
-template <class TInputImage, class TCoordRep>
+template <typename TInputImage, typename TCoordRep>
 void
 AdvancedRayCastInterpolateImageFunction<TInputImage, TCoordRep>::RayCastHelper::InitialiseVoxelPointers()
 {
@@ -1256,7 +1256,7 @@ AdvancedRayCastInterpolateImageFunction<TInputImage, TCoordRep>::RayCastHelper::
    IncrementVoxelPointers() - Increment the voxel pointers
    ----------------------------------------------------------------------- */
 
-template <class TInputImage, class TCoordRep>
+template <typename TInputImage, typename TCoordRep>
 void
 AdvancedRayCastInterpolateImageFunction<TInputImage, TCoordRep>::RayCastHelper::IncrementVoxelPointers()
 {
@@ -1289,7 +1289,7 @@ AdvancedRayCastInterpolateImageFunction<TInputImage, TCoordRep>::RayCastHelper::
    GetCurrentIntensity() - Get the intensity of the current ray point.
    ----------------------------------------------------------------------- */
 
-template <class TInputImage, class TCoordRep>
+template <typename TInputImage, typename TCoordRep>
 double
 AdvancedRayCastInterpolateImageFunction<TInputImage, TCoordRep>::RayCastHelper::GetCurrentIntensity() const
 {
@@ -1344,7 +1344,7 @@ AdvancedRayCastInterpolateImageFunction<TInputImage, TCoordRep>::RayCastHelper::
    IncrementIntensities() - Increment the intensities of the current ray point
    ----------------------------------------------------------------------- */
 
-template <class TInputImage, class TCoordRep>
+template <typename TInputImage, typename TCoordRep>
 void
 AdvancedRayCastInterpolateImageFunction<TInputImage, TCoordRep>::RayCastHelper::IncrementIntensities(double increment)
 {
@@ -1367,7 +1367,7 @@ AdvancedRayCastInterpolateImageFunction<TInputImage, TCoordRep>::RayCastHelper::
    IntegrateAboveThreshold() - Integrate intensities above a threshold.
    ----------------------------------------------------------------------- */
 
-template <class TInputImage, class TCoordRep>
+template <typename TInputImage, typename TCoordRep>
 bool
 AdvancedRayCastInterpolateImageFunction<TInputImage, TCoordRep>::RayCastHelper::IntegrateAboveThreshold(
   double & integral,
@@ -1412,7 +1412,7 @@ AdvancedRayCastInterpolateImageFunction<TInputImage, TCoordRep>::RayCastHelper::
    ZeroState() - Set the default (zero) state of the object
    ----------------------------------------------------------------------- */
 
-template <class TInputImage, class TCoordRep>
+template <typename TInputImage, typename TCoordRep>
 void
 AdvancedRayCastInterpolateImageFunction<TInputImage, TCoordRep>::RayCastHelper::ZeroState()
 {
@@ -1477,7 +1477,7 @@ AdvancedRayCastInterpolateImageFunction<TInputImage, TCoordRep>::RayCastHelper::
    PrintSelf
    ----------------------------------------------------------------------- */
 
-template <class TInputImage, class TCoordRep>
+template <typename TInputImage, typename TCoordRep>
 void
 AdvancedRayCastInterpolateImageFunction<TInputImage, TCoordRep>::PrintSelf(std::ostream & os, Indent indent) const
 {
@@ -1494,7 +1494,7 @@ AdvancedRayCastInterpolateImageFunction<TInputImage, TCoordRep>::PrintSelf(std::
    Evaluate at image index position
    ----------------------------------------------------------------------- */
 
-template <class TInputImage, class TCoordRep>
+template <typename TInputImage, typename TCoordRep>
 auto
 AdvancedRayCastInterpolateImageFunction<TInputImage, TCoordRep>::Evaluate(const PointType & point) const -> OutputType
 {
@@ -1516,7 +1516,7 @@ AdvancedRayCastInterpolateImageFunction<TInputImage, TCoordRep>::Evaluate(const 
 }
 
 
-template <class TInputImage, class TCoordRep>
+template <typename TInputImage, typename TCoordRep>
 auto
 AdvancedRayCastInterpolateImageFunction<TInputImage, TCoordRep>::EvaluateAtContinuousIndex(
   const ContinuousIndexType & index) const -> OutputType

--- a/Common/itkComputeDisplacementDistribution.h
+++ b/Common/itkComputeDisplacementDistribution.h
@@ -44,7 +44,7 @@ namespace itk
  *
  */
 
-template <class TFixedImage, class TTransform>
+template <typename TFixedImage, typename TTransform>
 class ITK_TEMPLATE_EXPORT ComputeDisplacementDistribution : public ScaledSingleValuedNonLinearOptimizer
 {
 public:

--- a/Common/itkComputeDisplacementDistribution.hxx
+++ b/Common/itkComputeDisplacementDistribution.hxx
@@ -41,7 +41,7 @@ namespace itk
  * ************************* Constructor ************************
  */
 
-template <class TFixedImage, class TTransform>
+template <typename TFixedImage, typename TTransform>
 ComputeDisplacementDistribution<TFixedImage, TTransform>::ComputeDisplacementDistribution()
 {
   this->m_FixedImage = nullptr;
@@ -65,7 +65,7 @@ ComputeDisplacementDistribution<TFixedImage, TTransform>::ComputeDisplacementDis
  * ************************* InitializeThreadingParameters ************************
  */
 
-template <class TFixedImage, class TTransform>
+template <typename TFixedImage, typename TTransform>
 void
 ComputeDisplacementDistribution<TFixedImage, TTransform>::InitializeThreadingParameters()
 {
@@ -90,7 +90,7 @@ ComputeDisplacementDistribution<TFixedImage, TTransform>::InitializeThreadingPar
  * ************************* ComputeSingleThreaded ************************
  */
 
-template <class TFixedImage, class TTransform>
+template <typename TFixedImage, typename TTransform>
 void
 ComputeDisplacementDistribution<TFixedImage, TTransform>::ComputeSingleThreaded(const ParametersType & mu,
                                                                                 double &               jacg,
@@ -222,7 +222,7 @@ ComputeDisplacementDistribution<TFixedImage, TTransform>::ComputeSingleThreaded(
  * ************************* Compute ************************
  */
 
-template <class TFixedImage, class TTransform>
+template <typename TFixedImage, typename TTransform>
 void
 ComputeDisplacementDistribution<TFixedImage, TTransform>::Compute(const ParametersType & mu,
                                                                   double &               jacg,
@@ -255,7 +255,7 @@ ComputeDisplacementDistribution<TFixedImage, TTransform>::Compute(const Paramete
  * *********************** BeforeThreadedCompute***************
  */
 
-template <class TFixedImage, class TTransform>
+template <typename TFixedImage, typename TTransform>
 void
 ComputeDisplacementDistribution<TFixedImage, TTransform>::BeforeThreadedCompute(const ParametersType & mu)
 {
@@ -282,7 +282,7 @@ ComputeDisplacementDistribution<TFixedImage, TTransform>::BeforeThreadedCompute(
  * *********************** LaunchComputeThreaderCallback***************
  */
 
-template <class TFixedImage, class TTransform>
+template <typename TFixedImage, typename TTransform>
 void
 ComputeDisplacementDistribution<TFixedImage, TTransform>::LaunchComputeThreaderCallback() const
 {
@@ -296,7 +296,7 @@ ComputeDisplacementDistribution<TFixedImage, TTransform>::LaunchComputeThreaderC
  * ************ ComputeThreaderCallback ****************************
  */
 
-template <class TFixedImage, class TTransform>
+template <typename TFixedImage, typename TTransform>
 ITK_THREAD_RETURN_FUNCTION_CALL_CONVENTION
 ComputeDisplacementDistribution<TFixedImage, TTransform>::ComputeThreaderCallback(void * arg)
 {
@@ -320,7 +320,7 @@ ComputeDisplacementDistribution<TFixedImage, TTransform>::ComputeThreaderCallbac
  * ************************* ThreadedCompute ************************
  */
 
-template <class TFixedImage, class TTransform>
+template <typename TFixedImage, typename TTransform>
 void
 ComputeDisplacementDistribution<TFixedImage, TTransform>::ThreadedCompute(ThreadIdType threadId)
 {
@@ -425,7 +425,7 @@ ComputeDisplacementDistribution<TFixedImage, TTransform>::ThreadedCompute(Thread
  * *********************** AfterThreadedCompute***************
  */
 
-template <class TFixedImage, class TTransform>
+template <typename TFixedImage, typename TTransform>
 void
 ComputeDisplacementDistribution<TFixedImage, TTransform>::AfterThreadedCompute(double & jacg, double & maxJJ)
 {
@@ -459,7 +459,7 @@ ComputeDisplacementDistribution<TFixedImage, TTransform>::AfterThreadedCompute(d
  * ************************* ComputeUsingSearchDirection ************************
  */
 
-template <class TFixedImage, class TTransform>
+template <typename TFixedImage, typename TTransform>
 void
 ComputeDisplacementDistribution<TFixedImage, TTransform>::ComputeUsingSearchDirection(const ParametersType & mu,
                                                                                       double &               jacg,
@@ -578,7 +578,7 @@ ComputeDisplacementDistribution<TFixedImage, TTransform>::ComputeUsingSearchDire
  * ************************* SampleFixedImageForJacobianTerms ************************
  */
 
-template <class TFixedImage, class TTransform>
+template <typename TFixedImage, typename TTransform>
 void
 ComputeDisplacementDistribution<TFixedImage, TTransform>::SampleFixedImageForJacobianTerms(
   ImageSampleContainerPointer & sampleContainer)

--- a/Common/itkComputeJacobianTerms.h
+++ b/Common/itkComputeJacobianTerms.h
@@ -33,7 +33,7 @@ namespace itk
  * Details can be found in the paper.
  */
 
-template <class TFixedImage, class TTransform>
+template <typename TFixedImage, typename TTransform>
 class ITK_TEMPLATE_EXPORT ComputeJacobianTerms : public Object
 {
 public:

--- a/Common/itkComputeJacobianTerms.hxx
+++ b/Common/itkComputeJacobianTerms.hxx
@@ -32,7 +32,7 @@ namespace itk
  * ************************* Compute ************************
  */
 
-template <class TFixedImage, class TTransform>
+template <typename TFixedImage, typename TTransform>
 void
 ComputeJacobianTerms<TFixedImage, TTransform>::Compute(double & TrC, double & TrCC, double & maxJJ, double & maxJCJ)
 {
@@ -475,7 +475,7 @@ ComputeJacobianTerms<TFixedImage, TTransform>::Compute(double & TrC, double & Tr
  * ************************* SampleFixedImageForJacobianTerms ************************
  */
 
-template <class TFixedImage, class TTransform>
+template <typename TFixedImage, typename TTransform>
 void
 ComputeJacobianTerms<TFixedImage, TTransform>::SampleFixedImageForJacobianTerms(
   ImageSampleContainerPointer & sampleContainer)

--- a/Common/itkComputePreconditionerUsingDisplacementDistribution.h
+++ b/Common/itkComputePreconditionerUsingDisplacementDistribution.h
@@ -36,7 +36,7 @@ namespace itk
  * http://dx.doi.org/10.1109/TMI.2015.2476354
  */
 
-template <class TFixedImage, class TTransform>
+template <typename TFixedImage, typename TTransform>
 class ITK_TEMPLATE_EXPORT ComputePreconditionerUsingDisplacementDistribution
   : public ComputeDisplacementDistribution<TFixedImage, TTransform>
 {

--- a/Common/itkComputePreconditionerUsingDisplacementDistribution.hxx
+++ b/Common/itkComputePreconditionerUsingDisplacementDistribution.hxx
@@ -39,7 +39,7 @@ namespace itk
  * ************************* Constructor ************************
  */
 
-template <class TFixedImage, class TTransform>
+template <typename TFixedImage, typename TTransform>
 ComputePreconditionerUsingDisplacementDistribution<TFixedImage,
                                                    TTransform>::ComputePreconditionerUsingDisplacementDistribution()
 {
@@ -53,7 +53,7 @@ ComputePreconditionerUsingDisplacementDistribution<TFixedImage,
  * ************************* Compute ************************
  */
 
-template <class TFixedImage, class TTransform>
+template <typename TFixedImage, typename TTransform>
 void
 ComputePreconditionerUsingDisplacementDistribution<TFixedImage, TTransform>::Compute(const ParametersType &,
                                                                                      double &,
@@ -68,7 +68,7 @@ ComputePreconditionerUsingDisplacementDistribution<TFixedImage, TTransform>::Com
  * ************************* Compute ************************
  */
 
-template <class TFixedImage, class TTransform>
+template <typename TFixedImage, typename TTransform>
 void
 ComputePreconditionerUsingDisplacementDistribution<TFixedImage, TTransform>::Compute(const ParametersType & mu,
                                                                                      double &               maxJJ,
@@ -294,7 +294,7 @@ ComputePreconditionerUsingDisplacementDistribution<TFixedImage, TTransform>::Com
  * ************************* ComputeJacobiTypePreconditioner ************************
  */
 
-template <class TFixedImage, class TTransform>
+template <typename TFixedImage, typename TTransform>
 void
 ComputePreconditionerUsingDisplacementDistribution<TFixedImage, TTransform>::ComputeJacobiTypePreconditioner(
   double &         maxJJ,
@@ -389,7 +389,7 @@ ComputePreconditionerUsingDisplacementDistribution<TFixedImage, TTransform>::Com
  * ************************* PreconditionerInterpolation ************************
  */
 
-template <class TFixedImage, class TTransform>
+template <typename TFixedImage, typename TTransform>
 void
 ComputePreconditionerUsingDisplacementDistribution<TFixedImage, TTransform>::PreconditionerInterpolation(
   ParametersType & preconditioner)

--- a/Common/itkErodeMaskImageFilter.h
+++ b/Common/itkErodeMaskImageFilter.h
@@ -53,7 +53,7 @@ namespace itk
  *
  **/
 
-template <class TImage>
+template <typename TImage>
 class ITK_TEMPLATE_EXPORT ErodeMaskImageFilter : public ImageToImageFilter<TImage, TImage>
 {
 public:

--- a/Common/itkErodeMaskImageFilter.hxx
+++ b/Common/itkErodeMaskImageFilter.hxx
@@ -29,7 +29,7 @@ namespace itk
  * ************* GenerateData *******************
  */
 
-template <class TImage>
+template <typename TImage>
 void
 ErodeMaskImageFilter<TImage>::GenerateData()
 {

--- a/Common/itkGenericMultiResolutionPyramidImageFilter.h
+++ b/Common/itkGenericMultiResolutionPyramidImageFilter.h
@@ -113,7 +113,7 @@ namespace itk
  * \ingroup PyramidImageFilter MultiThreaded Streamed
  * \ingroup ITKRegistrationCommon
  */
-template <class TInputImage, class TOutputImage, class TPrecisionType = double>
+template <typename TInputImage, typename TOutputImage, typename TPrecisionType = double>
 class ITK_TEMPLATE_EXPORT GenericMultiResolutionPyramidImageFilter
   : public MultiResolutionPyramidImageFilter<TInputImage, TOutputImage>
 {

--- a/Common/itkGenericMultiResolutionPyramidImageFilter.hxx
+++ b/Common/itkGenericMultiResolutionPyramidImageFilter.hxx
@@ -30,7 +30,7 @@ namespace itk
  * ******************* Constructor ***********************
  */
 
-template <class TInputImage, class TOutputImage, class TPrecisionType>
+template <typename TInputImage, typename TOutputImage, typename TPrecisionType>
 GenericMultiResolutionPyramidImageFilter<TInputImage, TOutputImage, TPrecisionType>::
   GenericMultiResolutionPyramidImageFilter()
 {
@@ -45,7 +45,7 @@ GenericMultiResolutionPyramidImageFilter<TInputImage, TOutputImage, TPrecisionTy
  * ******************* SetNumberOfLevels ***********************
  */
 
-template <class TInputImage, class TOutputImage, class TPrecisionType>
+template <typename TInputImage, typename TOutputImage, typename TPrecisionType>
 void
 GenericMultiResolutionPyramidImageFilter<TInputImage, TOutputImage, TPrecisionType>::SetNumberOfLevels(unsigned int num)
 {
@@ -66,7 +66,7 @@ GenericMultiResolutionPyramidImageFilter<TInputImage, TOutputImage, TPrecisionTy
  * ******************* SetCurrentLevel ***********************
  */
 
-template <class TInputImage, class TOutputImage, class TPrecisionType>
+template <typename TInputImage, typename TOutputImage, typename TPrecisionType>
 void
 GenericMultiResolutionPyramidImageFilter<TInputImage, TOutputImage, TPrecisionType>::SetCurrentLevel(unsigned int level)
 {
@@ -95,7 +95,7 @@ GenericMultiResolutionPyramidImageFilter<TInputImage, TOutputImage, TPrecisionTy
  * ******************* SetComputeOnlyForCurrentLevel ***********************
  */
 
-template <class TInputImage, class TOutputImage, class TPrecisionType>
+template <typename TInputImage, typename TOutputImage, typename TPrecisionType>
 void
 GenericMultiResolutionPyramidImageFilter<TInputImage, TOutputImage, TPrecisionType>::SetComputeOnlyForCurrentLevel(
   const bool _arg)
@@ -114,7 +114,7 @@ GenericMultiResolutionPyramidImageFilter<TInputImage, TOutputImage, TPrecisionTy
  * ******************* SetSchedule ***********************
  */
 
-template <class TInputImage, class TOutputImage, class TPrecisionType>
+template <typename TInputImage, typename TOutputImage, typename TPrecisionType>
 void
 GenericMultiResolutionPyramidImageFilter<TInputImage, TOutputImage, TPrecisionType>::SetSchedule(
   const ScheduleType & schedule)
@@ -135,7 +135,7 @@ GenericMultiResolutionPyramidImageFilter<TInputImage, TOutputImage, TPrecisionTy
  * ******************* SetRescaleSchedule ***********************
  */
 
-template <class TInputImage, class TOutputImage, class TPrecisionType>
+template <typename TInputImage, typename TOutputImage, typename TPrecisionType>
 void
 GenericMultiResolutionPyramidImageFilter<TInputImage, TOutputImage, TPrecisionType>::SetRescaleSchedule(
   const RescaleScheduleType & schedule)
@@ -153,7 +153,7 @@ GenericMultiResolutionPyramidImageFilter<TInputImage, TOutputImage, TPrecisionTy
  * ******************* SetRescaleScheduleToUnity ***********************
  */
 
-template <class TInputImage, class TOutputImage, class TPrecisionType>
+template <typename TInputImage, typename TOutputImage, typename TPrecisionType>
 void
 GenericMultiResolutionPyramidImageFilter<TInputImage, TOutputImage, TPrecisionType>::SetRescaleScheduleToUnity()
 {
@@ -167,7 +167,7 @@ GenericMultiResolutionPyramidImageFilter<TInputImage, TOutputImage, TPrecisionTy
  * ******************* SetSmoothingSchedule ***********************
  */
 
-template <class TInputImage, class TOutputImage, class TPrecisionType>
+template <typename TInputImage, typename TOutputImage, typename TPrecisionType>
 void
 GenericMultiResolutionPyramidImageFilter<TInputImage, TOutputImage, TPrecisionType>::SetSmoothingSchedule(
   const SmoothingScheduleType & schedule)
@@ -213,7 +213,7 @@ GenericMultiResolutionPyramidImageFilter<TInputImage, TOutputImage, TPrecisionTy
  * ******************* SetSmoothingScheduleToZero ***********************
  */
 
-template <class TInputImage, class TOutputImage, class TPrecisionType>
+template <typename TInputImage, typename TOutputImage, typename TPrecisionType>
 void
 GenericMultiResolutionPyramidImageFilter<TInputImage, TOutputImage, TPrecisionType>::SetSmoothingScheduleToZero()
 {
@@ -225,7 +225,7 @@ GenericMultiResolutionPyramidImageFilter<TInputImage, TOutputImage, TPrecisionTy
  * ******************* GenerateData ***********************
  */
 
-template <class TInputImage, class TOutputImage, class TPrecisionType>
+template <typename TInputImage, typename TOutputImage, typename TPrecisionType>
 void
 GenericMultiResolutionPyramidImageFilter<TInputImage, TOutputImage, TPrecisionType>::GenerateData()
 {
@@ -357,7 +357,7 @@ GenericMultiResolutionPyramidImageFilter<TInputImage, TOutputImage, TPrecisionTy
  * ******************* SetupSmoother ***********************
  */
 
-template <class TInputImage, class TOutputImage, class TPrecisionType>
+template <typename TInputImage, typename TOutputImage, typename TPrecisionType>
 bool
 GenericMultiResolutionPyramidImageFilter<TInputImage, TOutputImage, TPrecisionType>::SetupSmoother(
   const unsigned int               level,
@@ -388,7 +388,7 @@ GenericMultiResolutionPyramidImageFilter<TInputImage, TOutputImage, TPrecisionTy
  * ******************* SetupShrinkerOrResampler ***********************
  */
 
-template <class TInputImage, class TOutputImage, class TPrecisionType>
+template <typename TInputImage, typename TOutputImage, typename TPrecisionType>
 int
 GenericMultiResolutionPyramidImageFilter<TInputImage, TOutputImage, TPrecisionType>::SetupShrinkerOrResampler(
   const unsigned int                                   level,
@@ -432,7 +432,7 @@ GenericMultiResolutionPyramidImageFilter<TInputImage, TOutputImage, TPrecisionTy
  * ******************* DefineShrinkerOrResampler ***********************
  */
 
-template <class TInputImage, class TOutputImage, class TPrecisionType>
+template <typename TInputImage, typename TOutputImage, typename TPrecisionType>
 void
 GenericMultiResolutionPyramidImageFilter<TInputImage, TOutputImage, TPrecisionType>::DefineShrinkerOrResampler(
   const bool                                           sameType,
@@ -567,7 +567,7 @@ GenericMultiResolutionPyramidImageFilter<TInputImage, TOutputImage, TPrecisionTy
  * ******************* GenerateOutputInformation ***********************
  */
 
-template <class TInputImage, class TOutputImage, class TPrecisionType>
+template <typename TInputImage, typename TOutputImage, typename TPrecisionType>
 void
 GenericMultiResolutionPyramidImageFilter<TInputImage, TOutputImage, TPrecisionType>::GenerateOutputInformation()
 {
@@ -587,7 +587,7 @@ GenericMultiResolutionPyramidImageFilter<TInputImage, TOutputImage, TPrecisionTy
  * ******************* GenerateOutputRequestedRegion ***********************
  */
 
-template <class TInputImage, class TOutputImage, class TPrecisionType>
+template <typename TInputImage, typename TOutputImage, typename TPrecisionType>
 void
 GenericMultiResolutionPyramidImageFilter<TInputImage, TOutputImage, TPrecisionType>::GenerateOutputRequestedRegion(
   DataObject * refOutput)
@@ -614,7 +614,7 @@ GenericMultiResolutionPyramidImageFilter<TInputImage, TOutputImage, TPrecisionTy
  * ******************* GenerateInputRequestedRegion ***********************
  */
 
-template <class TInputImage, class TOutputImage, class TPrecisionType>
+template <typename TInputImage, typename TOutputImage, typename TPrecisionType>
 void
 GenericMultiResolutionPyramidImageFilter<TInputImage, TOutputImage, TPrecisionType>::GenerateInputRequestedRegion()
 {
@@ -654,7 +654,7 @@ GenericMultiResolutionPyramidImageFilter<TInputImage, TOutputImage, TPrecisionTy
  * ******************* ReleaseOutputs ***********************
  */
 
-template <class TInputImage, class TOutputImage, class TPrecisionType>
+template <typename TInputImage, typename TOutputImage, typename TPrecisionType>
 void
 GenericMultiResolutionPyramidImageFilter<TInputImage, TOutputImage, TPrecisionType>::ReleaseOutputs()
 {
@@ -673,7 +673,7 @@ GenericMultiResolutionPyramidImageFilter<TInputImage, TOutputImage, TPrecisionTy
  * ******************* ComputeForCurrentLevel ***********************
  */
 
-template <class TInputImage, class TOutputImage, class TPrecisionType>
+template <typename TInputImage, typename TOutputImage, typename TPrecisionType>
 bool
 GenericMultiResolutionPyramidImageFilter<TInputImage, TOutputImage, TPrecisionType>::ComputeForCurrentLevel(
   const unsigned int level) const
@@ -693,7 +693,7 @@ GenericMultiResolutionPyramidImageFilter<TInputImage, TOutputImage, TPrecisionTy
  * ******************* GetDefaultSigma ***********************
  */
 
-template <class TInputImage, class TOutputImage, class TPrecisionType>
+template <typename TInputImage, typename TOutputImage, typename TPrecisionType>
 double
 GenericMultiResolutionPyramidImageFilter<TInputImage, TOutputImage, TPrecisionType>::GetDefaultSigma(
   const unsigned int   level,
@@ -719,7 +719,7 @@ GenericMultiResolutionPyramidImageFilter<TInputImage, TOutputImage, TPrecisionTy
  * ******************* SetSmoothingScheduleToDefault ***********************
  */
 
-template <class TInputImage, class TOutputImage, class TPrecisionType>
+template <typename TInputImage, typename TOutputImage, typename TPrecisionType>
 void
 GenericMultiResolutionPyramidImageFilter<TInputImage, TOutputImage, TPrecisionType>::SetSmoothingScheduleToDefault()
 {
@@ -745,7 +745,7 @@ GenericMultiResolutionPyramidImageFilter<TInputImage, TOutputImage, TPrecisionTy
  * ******************* GetSigma ***********************
  */
 
-template <class TInputImage, class TOutputImage, class TPrecisionType>
+template <typename TInputImage, typename TOutputImage, typename TPrecisionType>
 void
 GenericMultiResolutionPyramidImageFilter<TInputImage, TOutputImage, TPrecisionType>::GetSigma(
   const unsigned int level,
@@ -763,7 +763,7 @@ GenericMultiResolutionPyramidImageFilter<TInputImage, TOutputImage, TPrecisionTy
  * ******************* GetShrinkFactors ***********************
  */
 
-template <class TInputImage, class TOutputImage, class TPrecisionType>
+template <typename TInputImage, typename TOutputImage, typename TPrecisionType>
 void
 GenericMultiResolutionPyramidImageFilter<TInputImage, TOutputImage, TPrecisionType>::GetShrinkFactors(
   const unsigned int       level,
@@ -786,7 +786,7 @@ GenericMultiResolutionPyramidImageFilter<TInputImage, TOutputImage, TPrecisionTy
  * ******************* AreSigmasAllZeros ***********************
  */
 
-template <class TInputImage, class TOutputImage, class TPrecisionType>
+template <typename TInputImage, typename TOutputImage, typename TPrecisionType>
 bool
 GenericMultiResolutionPyramidImageFilter<TInputImage, TOutputImage, TPrecisionType>::AreSigmasAllZeros(
   const SigmaArrayType & sigmaArray) const
@@ -807,7 +807,7 @@ GenericMultiResolutionPyramidImageFilter<TInputImage, TOutputImage, TPrecisionTy
  * ******************* AreRescaleFactorsAllOnes ***********************
  */
 
-template <class TInputImage, class TOutputImage, class TPrecisionType>
+template <typename TInputImage, typename TOutputImage, typename TPrecisionType>
 bool
 GenericMultiResolutionPyramidImageFilter<TInputImage, TOutputImage, TPrecisionType>::AreRescaleFactorsAllOnes(
   const RescaleFactorArrayType & rescaleFactors) const
@@ -829,7 +829,7 @@ GenericMultiResolutionPyramidImageFilter<TInputImage, TOutputImage, TPrecisionTy
  * ******************* IsSmoothingUsed ***********************
  */
 
-template <class TInputImage, class TOutputImage, class TPrecisionType>
+template <typename TInputImage, typename TOutputImage, typename TPrecisionType>
 bool
 GenericMultiResolutionPyramidImageFilter<TInputImage, TOutputImage, TPrecisionType>::IsSmoothingUsed() const
 {
@@ -851,7 +851,7 @@ GenericMultiResolutionPyramidImageFilter<TInputImage, TOutputImage, TPrecisionTy
  * ******************* IsRescaleUsed ***********************
  */
 
-template <class TInputImage, class TOutputImage, class TPrecisionType>
+template <typename TInputImage, typename TOutputImage, typename TPrecisionType>
 bool
 GenericMultiResolutionPyramidImageFilter<TInputImage, TOutputImage, TPrecisionType>::IsRescaleUsed() const
 {
@@ -873,7 +873,7 @@ GenericMultiResolutionPyramidImageFilter<TInputImage, TOutputImage, TPrecisionTy
  * ******************* PrintSelf ***********************
  */
 
-template <class TInputImage, class TOutputImage, class TPrecisionType>
+template <typename TInputImage, typename TOutputImage, typename TPrecisionType>
 void
 GenericMultiResolutionPyramidImageFilter<TInputImage, TOutputImage, TPrecisionType>::PrintSelf(std::ostream & os,
                                                                                                Indent indent) const

--- a/Common/itkImageFileCastWriter.h
+++ b/Common/itkImageFileCastWriter.h
@@ -37,7 +37,7 @@ namespace itk
  * a itk::CastImageFilter (to save memory for example).
  *
  */
-template <class TInputImage>
+template <typename TInputImage>
 class ITK_TEMPLATE_EXPORT ImageFileCastWriter : public ImageFileWriter<TInputImage>
 {
 public:
@@ -86,7 +86,7 @@ private:
    * a pointer to the PixelBuffer. Assumes scalar singlecomponent images
    * The buffer data is valid until this->m_Caster is destroyed or assigned
    * a new caster. The ImageIO's PixelType is also adapted by this function */
-  template <class OutputComponentType>
+  template <typename OutputComponentType>
   void *
   ConvertScalarImage(const DataObject * inputImage)
   {

--- a/Common/itkImageFileCastWriter.hxx
+++ b/Common/itkImageFileCastWriter.hxx
@@ -32,7 +32,7 @@ namespace itk
 {
 
 //---------------------------------------------------------
-template <class TInputImage>
+template <typename TInputImage>
 std::string
 ImageFileCastWriter<TInputImage>::GetDefaultOutputComponentType()
 {
@@ -50,7 +50,7 @@ ImageFileCastWriter<TInputImage>::GetDefaultOutputComponentType()
 
 
 //---------------------------------------------------------
-template <class TInputImage>
+template <typename TInputImage>
 void
 ImageFileCastWriter<TInputImage>::GenerateData()
 {

--- a/Common/itkMeshFileReaderBase.h
+++ b/Common/itkMeshFileReaderBase.h
@@ -33,7 +33,7 @@ namespace itk
  * a mesh or a pointset.
  */
 
-template <class TOutputMesh>
+template <typename TOutputMesh>
 class ITK_TEMPLATE_EXPORT MeshFileReaderBase : public MeshSource<TOutputMesh>
 {
 public:

--- a/Common/itkMeshFileReaderBase.hxx
+++ b/Common/itkMeshFileReaderBase.hxx
@@ -30,7 +30,7 @@ namespace itk
  * ***************GenerateOutputInformation ***********
  */
 
-template <class TOutputMesh>
+template <typename TOutputMesh>
 void
 MeshFileReaderBase<TOutputMesh>::GenerateOutputInformation()
 {
@@ -64,7 +64,7 @@ MeshFileReaderBase<TOutputMesh>::GenerateOutputInformation()
  * *************TestFileExistanceAndReadability ***********
  */
 
-template <class TOutputMesh>
+template <typename TOutputMesh>
 void
 MeshFileReaderBase<TOutputMesh>::TestFileExistanceAndReadability()
 {
@@ -92,7 +92,7 @@ MeshFileReaderBase<TOutputMesh>::TestFileExistanceAndReadability()
  * **************EnlargeOutputRequestedRegion***********
  */
 
-template <class TOutputMesh>
+template <typename TOutputMesh>
 void
 MeshFileReaderBase<TOutputMesh>::EnlargeOutputRequestedRegion(DataObject * output)
 {

--- a/Common/itkMultiOrderBSplineDecompositionImageFilter.h
+++ b/Common/itkMultiOrderBSplineDecompositionImageFilter.h
@@ -77,7 +77,7 @@ namespace itk
  * \ingroup SingleThreaded
  * \ingroup CannotBeStreamed
  */
-template <class TInputImage, class TOutputImage>
+template <typename TInputImage, typename TOutputImage>
 class ITK_TEMPLATE_EXPORT MultiOrderBSplineDecompositionImageFilter
   : public ImageToImageFilter<TInputImage, TOutputImage>
 {

--- a/Common/itkMultiOrderBSplineDecompositionImageFilter.hxx
+++ b/Common/itkMultiOrderBSplineDecompositionImageFilter.hxx
@@ -48,7 +48,7 @@ namespace itk
 /**
  * Constructor
  */
-template <class TInputImage, class TOutputImage>
+template <typename TInputImage, typename TOutputImage>
 MultiOrderBSplineDecompositionImageFilter<TInputImage, TOutputImage>::MultiOrderBSplineDecompositionImageFilter()
 {
   int splineOrder = 3;
@@ -61,7 +61,7 @@ MultiOrderBSplineDecompositionImageFilter<TInputImage, TOutputImage>::MultiOrder
 /**
  * Standard "PrintSelf" method
  */
-template <class TInputImage, class TOutputImage>
+template <typename TInputImage, typename TOutputImage>
 void
 MultiOrderBSplineDecompositionImageFilter<TInputImage, TOutputImage>::PrintSelf(std::ostream & os, Indent indent) const
 {
@@ -79,7 +79,7 @@ MultiOrderBSplineDecompositionImageFilter<TInputImage, TOutputImage>::PrintSelf(
 }
 
 
-template <class TInputImage, class TOutputImage>
+template <typename TInputImage, typename TOutputImage>
 bool
 MultiOrderBSplineDecompositionImageFilter<TInputImage, TOutputImage>::DataToCoefficients1D()
 {
@@ -130,7 +130,7 @@ MultiOrderBSplineDecompositionImageFilter<TInputImage, TOutputImage>::DataToCoef
 }
 
 
-template <class TInputImage, class TOutputImage>
+template <typename TInputImage, typename TOutputImage>
 void
 MultiOrderBSplineDecompositionImageFilter<TInputImage, TOutputImage>::SetSplineOrder(unsigned int order)
 {
@@ -152,7 +152,7 @@ MultiOrderBSplineDecompositionImageFilter<TInputImage, TOutputImage>::SetSplineO
 }
 
 
-template <class TInputImage, class TOutputImage>
+template <typename TInputImage, typename TOutputImage>
 void
 MultiOrderBSplineDecompositionImageFilter<TInputImage, TOutputImage>::SetSplineOrder(unsigned int dimension,
                                                                                      unsigned int order)
@@ -167,7 +167,7 @@ MultiOrderBSplineDecompositionImageFilter<TInputImage, TOutputImage>::SetSplineO
 }
 
 
-template <class TInputImage, class TOutputImage>
+template <typename TInputImage, typename TOutputImage>
 void
 MultiOrderBSplineDecompositionImageFilter<TInputImage, TOutputImage>::SetPoles(unsigned int dimension)
 {
@@ -211,7 +211,7 @@ MultiOrderBSplineDecompositionImageFilter<TInputImage, TOutputImage>::SetPoles(u
 }
 
 
-template <class TInputImage, class TOutputImage>
+template <typename TInputImage, typename TOutputImage>
 void
 MultiOrderBSplineDecompositionImageFilter<TInputImage, TOutputImage>::SetInitialCausalCoefficient(double z)
 {
@@ -257,7 +257,7 @@ MultiOrderBSplineDecompositionImageFilter<TInputImage, TOutputImage>::SetInitial
 }
 
 
-template <class TInputImage, class TOutputImage>
+template <typename TInputImage, typename TOutputImage>
 void
 MultiOrderBSplineDecompositionImageFilter<TInputImage, TOutputImage>::SetInitialAntiCausalCoefficient(double z)
 {
@@ -270,7 +270,7 @@ MultiOrderBSplineDecompositionImageFilter<TInputImage, TOutputImage>::SetInitial
 }
 
 
-template <class TInputImage, class TOutputImage>
+template <typename TInputImage, typename TOutputImage>
 void
 MultiOrderBSplineDecompositionImageFilter<TInputImage, TOutputImage>::DataToCoefficientsND()
 {
@@ -319,7 +319,7 @@ MultiOrderBSplineDecompositionImageFilter<TInputImage, TOutputImage>::DataToCoef
 /**
  * Copy the input image into the output image
  */
-template <class TInputImage, class TOutputImage>
+template <typename TInputImage, typename TOutputImage>
 void
 MultiOrderBSplineDecompositionImageFilter<TInputImage, TOutputImage>::CopyImageToImage()
 {
@@ -342,7 +342,7 @@ MultiOrderBSplineDecompositionImageFilter<TInputImage, TOutputImage>::CopyImageT
 /**
  * Copy the scratch to one line of the output image
  */
-template <class TInputImage, class TOutputImage>
+template <typename TInputImage, typename TOutputImage>
 void
 MultiOrderBSplineDecompositionImageFilter<TInputImage, TOutputImage>::CopyScratchToCoefficients(
   OutputLinearIterator & Iter)
@@ -361,7 +361,7 @@ MultiOrderBSplineDecompositionImageFilter<TInputImage, TOutputImage>::CopyScratc
 /**
  * Copy one line of the output image to the scratch
  */
-template <class TInputImage, class TOutputImage>
+template <typename TInputImage, typename TOutputImage>
 void
 MultiOrderBSplineDecompositionImageFilter<TInputImage, TOutputImage>::CopyCoefficientsToScratch(
   OutputLinearIterator & Iter)
@@ -379,7 +379,7 @@ MultiOrderBSplineDecompositionImageFilter<TInputImage, TOutputImage>::CopyCoeffi
 /**
  * GenerateInputRequestedRegion method.
  */
-template <class TInputImage, class TOutputImage>
+template <typename TInputImage, typename TOutputImage>
 void
 MultiOrderBSplineDecompositionImageFilter<TInputImage, TOutputImage>::GenerateInputRequestedRegion()
 {
@@ -396,7 +396,7 @@ MultiOrderBSplineDecompositionImageFilter<TInputImage, TOutputImage>::GenerateIn
 /**
  * EnlargeOutputRequestedRegion method.
  */
-template <class TInputImage, class TOutputImage>
+template <typename TInputImage, typename TOutputImage>
 void
 MultiOrderBSplineDecompositionImageFilter<TInputImage, TOutputImage>::EnlargeOutputRequestedRegion(DataObject * output)
 {
@@ -415,7 +415,7 @@ MultiOrderBSplineDecompositionImageFilter<TInputImage, TOutputImage>::EnlargeOut
 /**
  * Generate data
  */
-template <class TInputImage, class TOutputImage>
+template <typename TInputImage, typename TOutputImage>
 void
 MultiOrderBSplineDecompositionImageFilter<TInputImage, TOutputImage>::GenerateData()
 {

--- a/Common/itkMultiResolutionGaussianSmoothingPyramidImageFilter.h
+++ b/Common/itkMultiResolutionGaussianSmoothingPyramidImageFilter.h
@@ -119,7 +119,7 @@ namespace itk
  *
  * \ingroup PyramidImageFilter Multithreaded Streamed
  */
-template <class TInputImage, class TOutputImage>
+template <typename TInputImage, typename TOutputImage>
 class ITK_TEMPLATE_EXPORT MultiResolutionGaussianSmoothingPyramidImageFilter
   : public MultiResolutionPyramidImageFilter<TInputImage, TOutputImage>
 {

--- a/Common/itkMultiResolutionGaussianSmoothingPyramidImageFilter.hxx
+++ b/Common/itkMultiResolutionGaussianSmoothingPyramidImageFilter.hxx
@@ -49,7 +49,7 @@ namespace itk
 /*
  * Set the multi-resolution schedule
  */
-template <class TInputImage, class TOutputImage>
+template <typename TInputImage, typename TOutputImage>
 void
 MultiResolutionGaussianSmoothingPyramidImageFilter<TInputImage, TOutputImage>::SetSchedule(
   const ScheduleType & schedule)
@@ -80,7 +80,7 @@ MultiResolutionGaussianSmoothingPyramidImageFilter<TInputImage, TOutputImage>::S
 /*
  * GenerateData for non downward divisible schedules
  */
-template <class TInputImage, class TOutputImage>
+template <typename TInputImage, typename TOutputImage>
 void
 MultiResolutionGaussianSmoothingPyramidImageFilter<TInputImage, TOutputImage>::GenerateData()
 {
@@ -198,7 +198,7 @@ MultiResolutionGaussianSmoothingPyramidImageFilter<TInputImage, TOutputImage>::G
 /*
  * GenerateOutputInformation
  */
-template <class TInputImage, class TOutputImage>
+template <typename TInputImage, typename TOutputImage>
 void
 MultiResolutionGaussianSmoothingPyramidImageFilter<TInputImage, TOutputImage>::GenerateOutputInformation()
 {
@@ -234,7 +234,7 @@ MultiResolutionGaussianSmoothingPyramidImageFilter<TInputImage, TOutputImage>::G
 /*
  * GenerateOutputRequestedRegion
  */
-template <class TInputImage, class TOutputImage>
+template <typename TInputImage, typename TOutputImage>
 void
 MultiResolutionGaussianSmoothingPyramidImageFilter<TInputImage, TOutputImage>::GenerateOutputRequestedRegion(
   DataObject * refOutput)
@@ -309,7 +309,7 @@ MultiResolutionGaussianSmoothingPyramidImageFilter<TInputImage, TOutputImage>::G
 /*
  * GenerateInputRequestedRegion
  */
-template <class TInputImage, class TOutputImage>
+template <typename TInputImage, typename TOutputImage>
 void
 MultiResolutionGaussianSmoothingPyramidImageFilter<TInputImage, TOutputImage>::GenerateInputRequestedRegion()
 {
@@ -338,7 +338,7 @@ MultiResolutionGaussianSmoothingPyramidImageFilter<TInputImage, TOutputImage>::G
  * EnlargeOutputRequestedRegion
  */
 
-template <class TInputImage, class TOutputImage>
+template <typename TInputImage, typename TOutputImage>
 void
 MultiResolutionGaussianSmoothingPyramidImageFilter<TInputImage, TOutputImage>::EnlargeOutputRequestedRegion(
   DataObject * output)

--- a/Common/itkMultiResolutionShrinkPyramidImageFilter.h
+++ b/Common/itkMultiResolutionShrinkPyramidImageFilter.h
@@ -35,7 +35,7 @@ namespace itk
  *
  * \ingroup PyramidImageFilter Multithreaded Streamed
  */
-template <class TInputImage, class TOutputImage>
+template <typename TInputImage, typename TOutputImage>
 class ITK_TEMPLATE_EXPORT MultiResolutionShrinkPyramidImageFilter
   : public MultiResolutionPyramidImageFilter<TInputImage, TOutputImage>
 {

--- a/Common/itkMultiResolutionShrinkPyramidImageFilter.hxx
+++ b/Common/itkMultiResolutionShrinkPyramidImageFilter.hxx
@@ -29,7 +29,7 @@ namespace itk
 /*
  * GenerateData
  */
-template <class TInputImage, class TOutputImage>
+template <typename TInputImage, typename TOutputImage>
 void
 MultiResolutionShrinkPyramidImageFilter<TInputImage, TOutputImage>::GenerateData()
 {
@@ -68,7 +68,7 @@ MultiResolutionShrinkPyramidImageFilter<TInputImage, TOutputImage>::GenerateData
 /**
  * GenerateInputRequestedRegion
  */
-template <class TInputImage, class TOutputImage>
+template <typename TInputImage, typename TOutputImage>
 void
 MultiResolutionShrinkPyramidImageFilter<TInputImage, TOutputImage>::GenerateInputRequestedRegion()
 {

--- a/Common/itkNDImageBase.h
+++ b/Common/itkNDImageBase.h
@@ -54,7 +54,7 @@ namespace itk
  * \ingroup Miscellaneous
  */
 
-template <class TPixel>
+template <typename TPixel>
 class ITK_TEMPLATE_EXPORT NDImageBase : public Object
 {
 public:
@@ -256,7 +256,7 @@ protected:
 namespace itk
 {
 
-template <class TPixel>
+template <typename TPixel>
 auto
 NDImageBase<TPixel>::NewNDImage(unsigned int dim) -> Pointer
 {

--- a/Common/itkNDImageTemplate.h
+++ b/Common/itkNDImageTemplate.h
@@ -41,7 +41,7 @@ namespace itk
  * \ingroup Miscellaneous
  */
 
-template <class TPixel, unsigned int VDimension>
+template <typename TPixel, unsigned int VDimension>
 class ITK_TEMPLATE_EXPORT NDImageTemplate : public NDImageBase<TPixel>
 {
 public:
@@ -234,7 +234,7 @@ protected:
   WriterPointer m_Writer{ nullptr };
   ReaderPointer m_Reader{ nullptr };
 
-  template <class TIn, class TOut>
+  template <typename TIn, typename TOut>
   class ITK_TEMPLATE_EXPORT ConvertToDynamicArray
   {
   public:
@@ -251,7 +251,7 @@ protected:
     }
   };
 
-  template <class TIn, class TOut>
+  template <typename TIn, typename TOut>
   class ITK_TEMPLATE_EXPORT ConvertToStaticArray
   {
   public:

--- a/Common/itkNDImageTemplate.hxx
+++ b/Common/itkNDImageTemplate.hxx
@@ -24,7 +24,7 @@
 namespace itk
 {
 
-template <class TPixel, unsigned int VDimension>
+template <typename TPixel, unsigned int VDimension>
 void
 NDImageTemplate<TPixel, VDimension>::SetRegions(SizeType size)
 {
@@ -32,7 +32,7 @@ NDImageTemplate<TPixel, VDimension>::SetRegions(SizeType size)
 }
 
 
-template <class TPixel, unsigned int VDimension>
+template <typename TPixel, unsigned int VDimension>
 void
 NDImageTemplate<TPixel, VDimension>::SetRequestedRegion(DataObject * data)
 {
@@ -40,7 +40,7 @@ NDImageTemplate<TPixel, VDimension>::SetRequestedRegion(DataObject * data)
 }
 
 
-template <class TPixel, unsigned int VDimension>
+template <typename TPixel, unsigned int VDimension>
 void
 NDImageTemplate<TPixel, VDimension>::Allocate()
 {
@@ -48,7 +48,7 @@ NDImageTemplate<TPixel, VDimension>::Allocate()
 }
 
 
-template <class TPixel, unsigned int VDimension>
+template <typename TPixel, unsigned int VDimension>
 void
 NDImageTemplate<TPixel, VDimension>::Initialize()
 {
@@ -56,7 +56,7 @@ NDImageTemplate<TPixel, VDimension>::Initialize()
 }
 
 
-template <class TPixel, unsigned int VDimension>
+template <typename TPixel, unsigned int VDimension>
 void
 NDImageTemplate<TPixel, VDimension>::FillBuffer(const TPixel & value)
 {
@@ -64,7 +64,7 @@ NDImageTemplate<TPixel, VDimension>::FillBuffer(const TPixel & value)
 }
 
 
-template <class TPixel, unsigned int VDimension>
+template <typename TPixel, unsigned int VDimension>
 void
 NDImageTemplate<TPixel, VDimension>::SetPixel(const IndexType & index, const TPixel & value)
 {
@@ -72,7 +72,7 @@ NDImageTemplate<TPixel, VDimension>::SetPixel(const IndexType & index, const TPi
 }
 
 
-template <class TPixel, unsigned int VDimension>
+template <typename TPixel, unsigned int VDimension>
 const TPixel &
 NDImageTemplate<TPixel, VDimension>::GetPixel(const IndexType & index) const
 {
@@ -80,7 +80,7 @@ NDImageTemplate<TPixel, VDimension>::GetPixel(const IndexType & index) const
 }
 
 
-template <class TPixel, unsigned int VDimension>
+template <typename TPixel, unsigned int VDimension>
 TPixel &
 NDImageTemplate<TPixel, VDimension>::GetPixel(const IndexType & index)
 {
@@ -88,7 +88,7 @@ NDImageTemplate<TPixel, VDimension>::GetPixel(const IndexType & index)
 }
 
 
-template <class TPixel, unsigned int VDimension>
+template <typename TPixel, unsigned int VDimension>
 TPixel *
 NDImageTemplate<TPixel, VDimension>::GetBufferPointer()
 {
@@ -96,7 +96,7 @@ NDImageTemplate<TPixel, VDimension>::GetBufferPointer()
 }
 
 
-template <class TPixel, unsigned int VDimension>
+template <typename TPixel, unsigned int VDimension>
 const TPixel *
 NDImageTemplate<TPixel, VDimension>::GetBufferPointer() const
 {
@@ -104,21 +104,21 @@ NDImageTemplate<TPixel, VDimension>::GetBufferPointer() const
 }
 
 
-template <class TPixel, unsigned int VDimension>
+template <typename TPixel, unsigned int VDimension>
 auto
 NDImageTemplate<TPixel, VDimension>::GetPixelContainer() -> PixelContainer *
 {
   return this->m_Image->GetPixelContainer();
 }
 
-template <class TPixel, unsigned int VDimension>
+template <typename TPixel, unsigned int VDimension>
 auto
 NDImageTemplate<TPixel, VDimension>::GetPixelContainer() const -> const PixelContainer *
 {
   return this->m_Image->GetPixelContainer();
 }
 
-template <class TPixel, unsigned int VDimension>
+template <typename TPixel, unsigned int VDimension>
 void
 NDImageTemplate<TPixel, VDimension>::SetPixelContainer(PixelContainer * container)
 {
@@ -126,7 +126,7 @@ NDImageTemplate<TPixel, VDimension>::SetPixelContainer(PixelContainer * containe
 }
 
 
-template <class TPixel, unsigned int VDimension>
+template <typename TPixel, unsigned int VDimension>
 auto
 NDImageTemplate<TPixel, VDimension>::GetPixelAccessor() -> AccessorType
 {
@@ -134,7 +134,7 @@ NDImageTemplate<TPixel, VDimension>::GetPixelAccessor() -> AccessorType
 }
 
 
-template <class TPixel, unsigned int VDimension>
+template <typename TPixel, unsigned int VDimension>
 auto
 NDImageTemplate<TPixel, VDimension>::GetPixelAccessor() const -> const AccessorType
 {
@@ -142,7 +142,7 @@ NDImageTemplate<TPixel, VDimension>::GetPixelAccessor() const -> const AccessorT
 }
 
 
-template <class TPixel, unsigned int VDimension>
+template <typename TPixel, unsigned int VDimension>
 void
 NDImageTemplate<TPixel, VDimension>::SetSpacing(const SpacingType & spacing)
 {
@@ -150,7 +150,7 @@ NDImageTemplate<TPixel, VDimension>::SetSpacing(const SpacingType & spacing)
 }
 
 
-template <class TPixel, unsigned int VDimension>
+template <typename TPixel, unsigned int VDimension>
 void
 NDImageTemplate<TPixel, VDimension>::SetOrigin(const PointType & origin)
 {
@@ -158,7 +158,7 @@ NDImageTemplate<TPixel, VDimension>::SetOrigin(const PointType & origin)
 }
 
 
-template <class TPixel, unsigned int VDimension>
+template <typename TPixel, unsigned int VDimension>
 auto
 NDImageTemplate<TPixel, VDimension>::GetSpacing() -> SpacingType
 {
@@ -166,7 +166,7 @@ NDImageTemplate<TPixel, VDimension>::GetSpacing() -> SpacingType
 }
 
 
-template <class TPixel, unsigned int VDimension>
+template <typename TPixel, unsigned int VDimension>
 auto
 NDImageTemplate<TPixel, VDimension>::GetOrigin() -> PointType
 {
@@ -174,7 +174,7 @@ NDImageTemplate<TPixel, VDimension>::GetOrigin() -> PointType
 }
 
 
-template <class TPixel, unsigned int VDimension>
+template <typename TPixel, unsigned int VDimension>
 void
 NDImageTemplate<TPixel, VDimension>::CopyInformation(const DataObject * data)
 {
@@ -182,14 +182,14 @@ NDImageTemplate<TPixel, VDimension>::CopyInformation(const DataObject * data)
 }
 
 
-template <class TPixel, unsigned int VDimension>
+template <typename TPixel, unsigned int VDimension>
 auto
 NDImageTemplate<TPixel, VDimension>::GetOffsetTable() const -> const OffsetValueType *
 {
   return this->m_Image->GetOffsetTable();
 }
 
-template <class TPixel, unsigned int VDimension>
+template <typename TPixel, unsigned int VDimension>
 auto
 NDImageTemplate<TPixel, VDimension>::ComputeOffset(const IndexType & ind) const -> OffsetValueType
 {
@@ -197,7 +197,7 @@ NDImageTemplate<TPixel, VDimension>::ComputeOffset(const IndexType & ind) const 
 }
 
 
-template <class TPixel, unsigned int VDimension>
+template <typename TPixel, unsigned int VDimension>
 auto
 NDImageTemplate<TPixel, VDimension>::ComputeIndex(OffsetValueType offset) const -> IndexType
 {
@@ -205,7 +205,7 @@ NDImageTemplate<TPixel, VDimension>::ComputeIndex(OffsetValueType offset) const 
 }
 
 
-template <class TPixel, unsigned int VDimension>
+template <typename TPixel, unsigned int VDimension>
 unsigned int
 NDImageTemplate<TPixel, VDimension>::ImageDimension()
 {
@@ -213,7 +213,7 @@ NDImageTemplate<TPixel, VDimension>::ImageDimension()
 }
 
 
-template <class TPixel, unsigned int VDimension>
+template <typename TPixel, unsigned int VDimension>
 unsigned int
 NDImageTemplate<TPixel, VDimension>::GetImageDimension()
 {
@@ -221,7 +221,7 @@ NDImageTemplate<TPixel, VDimension>::GetImageDimension()
 }
 
 
-template <class TPixel, unsigned int VDimension>
+template <typename TPixel, unsigned int VDimension>
 void
 NDImageTemplate<TPixel, VDimension>::Write()
 {
@@ -233,7 +233,7 @@ NDImageTemplate<TPixel, VDimension>::Write()
 }
 
 
-template <class TPixel, unsigned int VDimension>
+template <typename TPixel, unsigned int VDimension>
 void
 NDImageTemplate<TPixel, VDimension>::Read()
 {
@@ -245,7 +245,7 @@ NDImageTemplate<TPixel, VDimension>::Read()
 }
 
 
-template <class TPixel, unsigned int VDimension>
+template <typename TPixel, unsigned int VDimension>
 void
 NDImageTemplate<TPixel, VDimension>::CreateNewImage()
 {
@@ -253,7 +253,7 @@ NDImageTemplate<TPixel, VDimension>::CreateNewImage()
 }
 
 
-template <class TPixel, unsigned int VDimension>
+template <typename TPixel, unsigned int VDimension>
 void
 NDImageTemplate<TPixel, VDimension>::SetImageIOWriter(ImageIOBase * _arg)
 {
@@ -265,7 +265,7 @@ NDImageTemplate<TPixel, VDimension>::SetImageIOWriter(ImageIOBase * _arg)
 }
 
 
-template <class TPixel, unsigned int VDimension>
+template <typename TPixel, unsigned int VDimension>
 ImageIOBase *
 NDImageTemplate<TPixel, VDimension>::GetImageIOWriter()
 {
@@ -280,7 +280,7 @@ NDImageTemplate<TPixel, VDimension>::GetImageIOWriter()
 }
 
 
-template <class TPixel, unsigned int VDimension>
+template <typename TPixel, unsigned int VDimension>
 void
 NDImageTemplate<TPixel, VDimension>::SetImageIOReader(ImageIOBase * _arg)
 {
@@ -292,7 +292,7 @@ NDImageTemplate<TPixel, VDimension>::SetImageIOReader(ImageIOBase * _arg)
 }
 
 
-template <class TPixel, unsigned int VDimension>
+template <typename TPixel, unsigned int VDimension>
 ImageIOBase *
 NDImageTemplate<TPixel, VDimension>::GetImageIOReader()
 {
@@ -307,7 +307,7 @@ NDImageTemplate<TPixel, VDimension>::GetImageIOReader()
 }
 
 
-template <class TPixel, unsigned int VDimension>
+template <typename TPixel, unsigned int VDimension>
 void
 NDImageTemplate<TPixel, VDimension>::SetOutputFileName(const char * name)
 {
@@ -319,7 +319,7 @@ NDImageTemplate<TPixel, VDimension>::SetOutputFileName(const char * name)
 }
 
 
-template <class TPixel, unsigned int VDimension>
+template <typename TPixel, unsigned int VDimension>
 void
 NDImageTemplate<TPixel, VDimension>::SetInputFileName(const char * name)
 {
@@ -331,7 +331,7 @@ NDImageTemplate<TPixel, VDimension>::SetInputFileName(const char * name)
 }
 
 
-template <class TPixel, unsigned int VDimension>
+template <typename TPixel, unsigned int VDimension>
 const char *
 NDImageTemplate<TPixel, VDimension>::GetOutputFileName()
 {
@@ -346,7 +346,7 @@ NDImageTemplate<TPixel, VDimension>::GetOutputFileName()
 }
 
 
-template <class TPixel, unsigned int VDimension>
+template <typename TPixel, unsigned int VDimension>
 const char *
 NDImageTemplate<TPixel, VDimension>::GetInputFileName()
 {

--- a/Common/itkParabolicMorphUtils.h
+++ b/Common/itkParabolicMorphUtils.h
@@ -23,7 +23,7 @@
 #include "itkProgressReporter.h"
 namespace itk
 {
-template <class LineBufferType, class RealType, class TInputPixel, bool doDilate>
+template <typename LineBufferType, typename RealType, typename TInputPixel, bool doDilate>
 void
 DoLine(LineBufferType & LineBuf, LineBufferType & tmpLineBuf, const RealType magnitude)
 {
@@ -72,7 +72,12 @@ DoLine(LineBufferType & LineBuf, LineBufferType & tmpLineBuf, const RealType mag
 }
 
 
-template <class TInIter, class TOutIter, class RealType, class TInputPixel, class OutputPixelType, bool doDilate>
+template <typename TInIter,
+          typename TOutIter,
+          typename RealType,
+          typename TInputPixel,
+          typename OutputPixelType,
+          bool doDilate>
 void
 doOneDimension(TInIter &          inputIterator,
                TOutIter &         outputIterator,

--- a/Common/itkReducedDimensionBSplineInterpolateImageFunction.h
+++ b/Common/itkReducedDimensionBSplineInterpolateImageFunction.h
@@ -81,7 +81,7 @@ namespace itk
  *
  * \ingroup ImageFunctions
  */
-template <class TImageType, class TCoordRep = double, class TCoefficientType = double>
+template <typename TImageType, typename TCoordRep = double, typename TCoefficientType = double>
 class ITK_TEMPLATE_EXPORT ReducedDimensionBSplineInterpolateImageFunction
   : public InterpolateImageFunction<TImageType, TCoordRep>
 {

--- a/Common/itkReducedDimensionBSplineInterpolateImageFunction.hxx
+++ b/Common/itkReducedDimensionBSplineInterpolateImageFunction.hxx
@@ -51,7 +51,7 @@ namespace itk
 /**
  * Constructor
  */
-template <class TImageType, class TCoordRep, class TCoefficientType>
+template <typename TImageType, typename TCoordRep, typename TCoefficientType>
 ReducedDimensionBSplineInterpolateImageFunction<TImageType, TCoordRep, TCoefficientType>::
   ReducedDimensionBSplineInterpolateImageFunction()
 {
@@ -68,7 +68,7 @@ ReducedDimensionBSplineInterpolateImageFunction<TImageType, TCoordRep, TCoeffici
 /**
  * Standard "PrintSelf" method
  */
-template <class TImageType, class TCoordRep, class TCoefficientType>
+template <typename TImageType, typename TCoordRep, typename TCoefficientType>
 void
 ReducedDimensionBSplineInterpolateImageFunction<TImageType, TCoordRep, TCoefficientType>::PrintSelf(std::ostream & os,
                                                                                                     Indent indent) const
@@ -79,7 +79,7 @@ ReducedDimensionBSplineInterpolateImageFunction<TImageType, TCoordRep, TCoeffici
 }
 
 
-template <class TImageType, class TCoordRep, class TCoefficientType>
+template <typename TImageType, typename TCoordRep, typename TCoefficientType>
 void
 ReducedDimensionBSplineInterpolateImageFunction<TImageType, TCoordRep, TCoefficientType>::SetInputImage(
   const TImageType * inputData)
@@ -109,7 +109,7 @@ ReducedDimensionBSplineInterpolateImageFunction<TImageType, TCoordRep, TCoeffici
 }
 
 
-template <class TImageType, class TCoordRep, class TCoefficientType>
+template <typename TImageType, typename TCoordRep, typename TCoefficientType>
 void
 ReducedDimensionBSplineInterpolateImageFunction<TImageType, TCoordRep, TCoefficientType>::SetSplineOrder(
   unsigned int SplineOrder)
@@ -130,7 +130,7 @@ ReducedDimensionBSplineInterpolateImageFunction<TImageType, TCoordRep, TCoeffici
 }
 
 
-template <class TImageType, class TCoordRep, class TCoefficientType>
+template <typename TImageType, typename TCoordRep, typename TCoefficientType>
 auto
 ReducedDimensionBSplineInterpolateImageFunction<TImageType, TCoordRep, TCoefficientType>::EvaluateAtContinuousIndex(
   const ContinuousIndexType & x) const -> OutputType
@@ -179,7 +179,7 @@ ReducedDimensionBSplineInterpolateImageFunction<TImageType, TCoordRep, TCoeffici
 }
 
 
-template <class TImageType, class TCoordRep, class TCoefficientType>
+template <typename TImageType, typename TCoordRep, typename TCoefficientType>
 auto
 ReducedDimensionBSplineInterpolateImageFunction<TImageType, TCoordRep, TCoefficientType>::
   EvaluateDerivativeAtContinuousIndex(const ContinuousIndexType & x) const -> CovariantVectorType
@@ -248,7 +248,7 @@ ReducedDimensionBSplineInterpolateImageFunction<TImageType, TCoordRep, TCoeffici
 }
 
 
-template <class TImageType, class TCoordRep, class TCoefficientType>
+template <typename TImageType, typename TCoordRep, typename TCoefficientType>
 void
 ReducedDimensionBSplineInterpolateImageFunction<TImageType, TCoordRep, TCoefficientType>::SetInterpolationWeights(
   const ContinuousIndexType & x,
@@ -348,7 +348,7 @@ ReducedDimensionBSplineInterpolateImageFunction<TImageType, TCoordRep, TCoeffici
 }
 
 
-template <class TImageType, class TCoordRep, class TCoefficientType>
+template <typename TImageType, typename TCoordRep, typename TCoefficientType>
 void
 ReducedDimensionBSplineInterpolateImageFunction<TImageType, TCoordRep, TCoefficientType>::SetDerivativeWeights(
   const ContinuousIndexType & x,
@@ -464,7 +464,7 @@ ReducedDimensionBSplineInterpolateImageFunction<TImageType, TCoordRep, TCoeffici
 
 
 // Generates m_PointsToIndex;
-template <class TImageType, class TCoordRep, class TCoefficientType>
+template <typename TImageType, typename TCoordRep, typename TCoefficientType>
 void
 ReducedDimensionBSplineInterpolateImageFunction<TImageType, TCoordRep, TCoefficientType>::GeneratePointsToIndex()
 {
@@ -493,7 +493,7 @@ ReducedDimensionBSplineInterpolateImageFunction<TImageType, TCoordRep, TCoeffici
 }
 
 
-template <class TImageType, class TCoordRep, class TCoefficientType>
+template <typename TImageType, typename TCoordRep, typename TCoefficientType>
 void
 ReducedDimensionBSplineInterpolateImageFunction<TImageType, TCoordRep, TCoefficientType>::DetermineRegionOfSupport(
   vnl_matrix<long> &          evaluateIndex,
@@ -525,7 +525,7 @@ ReducedDimensionBSplineInterpolateImageFunction<TImageType, TCoordRep, TCoeffici
 }
 
 
-template <class TImageType, class TCoordRep, class TCoefficientType>
+template <typename TImageType, typename TCoordRep, typename TCoefficientType>
 void
 ReducedDimensionBSplineInterpolateImageFunction<TImageType, TCoordRep, TCoefficientType>::ApplyMirrorBoundaryConditions(
   vnl_matrix<long> & evaluateIndex,

--- a/Common/itkTransformixInputPointFileReader.h
+++ b/Common/itkTransformixInputPointFileReader.h
@@ -42,7 +42,7 @@ namespace itk
  * should be read.
  **/
 
-template <class TOutputMesh>
+template <typename TOutputMesh>
 class ITK_TEMPLATE_EXPORT TransformixInputPointFileReader : public MeshFileReaderBase<TOutputMesh>
 {
 public:

--- a/Common/itkTransformixInputPointFileReader.hxx
+++ b/Common/itkTransformixInputPointFileReader.hxx
@@ -28,7 +28,7 @@ namespace itk
  * ***************GenerateOutputInformation ***********
  */
 
-template <class TOutputMesh>
+template <typename TOutputMesh>
 void
 TransformixInputPointFileReader<TOutputMesh>::GenerateOutputInformation()
 {
@@ -75,7 +75,7 @@ TransformixInputPointFileReader<TOutputMesh>::GenerateOutputInformation()
  * ***************GenerateData ***********
  */
 
-template <class TOutputMesh>
+template <typename TOutputMesh>
 void
 TransformixInputPointFileReader<TOutputMesh>::GenerateData()
 {

--- a/Components/FixedImagePyramids/FixedGenericPyramid/elxFixedGenericPyramid.h
+++ b/Components/FixedImagePyramids/FixedGenericPyramid/elxFixedGenericPyramid.h
@@ -64,7 +64,7 @@ namespace elastix
  * \ingroup ImagePyramids
  */
 
-template <class TElastix>
+template <typename TElastix>
 class ITK_TEMPLATE_EXPORT FixedGenericPyramid
   : public itk::GenericMultiResolutionPyramidImageFilter<typename FixedImagePyramidBase<TElastix>::InputImageType,
                                                          typename FixedImagePyramidBase<TElastix>::OutputImageType>

--- a/Components/FixedImagePyramids/FixedGenericPyramid/elxFixedGenericPyramid.hxx
+++ b/Components/FixedImagePyramids/FixedGenericPyramid/elxFixedGenericPyramid.hxx
@@ -28,7 +28,7 @@ namespace elastix
  * ******************* SetFixedSchedule ***********************
  */
 
-template <class TElastix>
+template <typename TElastix>
 void
 FixedGenericPyramid<TElastix>::SetFixedSchedule()
 {
@@ -41,7 +41,7 @@ FixedGenericPyramid<TElastix>::SetFixedSchedule()
  * ******************* BeforeEachResolution ***********************
  */
 
-template <class TElastix>
+template <typename TElastix>
 void
 FixedGenericPyramid<TElastix>::BeforeEachResolution()
 {

--- a/Components/FixedImagePyramids/FixedRecursivePyramid/elxFixedRecursivePyramid.h
+++ b/Components/FixedImagePyramids/FixedRecursivePyramid/elxFixedRecursivePyramid.h
@@ -35,7 +35,7 @@ namespace elastix
  * \ingroup ImagePyramids
  */
 
-template <class TElastix>
+template <typename TElastix>
 class ITK_TEMPLATE_EXPORT FixedRecursivePyramid
   : public itk::RecursiveMultiResolutionPyramidImageFilter<typename FixedImagePyramidBase<TElastix>::InputImageType,
                                                            typename FixedImagePyramidBase<TElastix>::OutputImageType>

--- a/Components/FixedImagePyramids/FixedShrinkingPyramid/elxFixedShrinkingPyramid.h
+++ b/Components/FixedImagePyramids/FixedShrinkingPyramid/elxFixedShrinkingPyramid.h
@@ -35,7 +35,7 @@ namespace elastix
  * \ingroup ImagePyramids
  */
 
-template <class TElastix>
+template <typename TElastix>
 class ITK_TEMPLATE_EXPORT FixedShrinkingPyramid
   : public itk::MultiResolutionShrinkPyramidImageFilter<typename FixedImagePyramidBase<TElastix>::InputImageType,
                                                         typename FixedImagePyramidBase<TElastix>::OutputImageType>

--- a/Components/FixedImagePyramids/FixedSmoothingPyramid/elxFixedSmoothingPyramid.h
+++ b/Components/FixedImagePyramids/FixedSmoothingPyramid/elxFixedSmoothingPyramid.h
@@ -35,7 +35,7 @@ namespace elastix
  * \ingroup ImagePyramids
  */
 
-template <class TElastix>
+template <typename TElastix>
 class ITK_TEMPLATE_EXPORT FixedSmoothingPyramid
   : public itk::MultiResolutionGaussianSmoothingPyramidImageFilter<
       typename FixedImagePyramidBase<TElastix>::InputImageType,

--- a/Components/FixedImagePyramids/OpenCLFixedGenericPyramid/elxOpenCLFixedGenericPyramid.h
+++ b/Components/FixedImagePyramids/OpenCLFixedGenericPyramid/elxOpenCLFixedGenericPyramid.h
@@ -44,7 +44,7 @@ namespace elastix
  * \ingroup ImagePyramids
  */
 
-template <class TElastix>
+template <typename TElastix>
 class ITK_TEMPLATE_EXPORT OpenCLFixedGenericPyramid : public FixedGenericPyramid<TElastix>
 {
 public:

--- a/Components/FixedImagePyramids/OpenCLFixedGenericPyramid/elxOpenCLFixedGenericPyramid.hxx
+++ b/Components/FixedImagePyramids/OpenCLFixedGenericPyramid/elxOpenCLFixedGenericPyramid.hxx
@@ -40,7 +40,7 @@ namespace elastix
  * ******************* Constructor ***********************
  */
 
-template <class TElastix>
+template <typename TElastix>
 OpenCLFixedGenericPyramid<TElastix>::OpenCLFixedGenericPyramid()
   : m_GPUPyramidReady(true)
   , m_GPUPyramidCreated(true)
@@ -87,7 +87,7 @@ OpenCLFixedGenericPyramid<TElastix>::OpenCLFixedGenericPyramid()
  * ******************* BeforeGenerateData ***********************
  */
 
-template <class TElastix>
+template <typename TElastix>
 void
 OpenCLFixedGenericPyramid<TElastix>::BeforeGenerateData()
 {
@@ -143,7 +143,7 @@ OpenCLFixedGenericPyramid<TElastix>::BeforeGenerateData()
  * ******************* GenerateData ***********************
  */
 
-template <class TElastix>
+template <typename TElastix>
 void
 OpenCLFixedGenericPyramid<TElastix>::GenerateData()
 {
@@ -221,7 +221,7 @@ OpenCLFixedGenericPyramid<TElastix>::GenerateData()
  * ******************* RegisterFactories ***********************
  */
 
-template <class TElastix>
+template <typename TElastix>
 void
 OpenCLFixedGenericPyramid<TElastix>::RegisterFactories()
 {
@@ -271,7 +271,7 @@ OpenCLFixedGenericPyramid<TElastix>::RegisterFactories()
  * ******************* UnregisterFactories ***********************
  */
 
-template <class TElastix>
+template <typename TElastix>
 void
 OpenCLFixedGenericPyramid<TElastix>::UnregisterFactories()
 {
@@ -287,7 +287,7 @@ OpenCLFixedGenericPyramid<TElastix>::UnregisterFactories()
  * ******************* BeforeRegistration ***********************
  */
 
-template <class TElastix>
+template <typename TElastix>
 void
 OpenCLFixedGenericPyramid<TElastix>::BeforeRegistration()
 {
@@ -302,7 +302,7 @@ OpenCLFixedGenericPyramid<TElastix>::BeforeRegistration()
  * ******************* ReadFromFile  ****************************
  */
 
-template <class TElastix>
+template <typename TElastix>
 void
 OpenCLFixedGenericPyramid<TElastix>::ReadFromFile()
 {
@@ -317,7 +317,7 @@ OpenCLFixedGenericPyramid<TElastix>::ReadFromFile()
  * ************************* SwitchingToCPUAndReport ************************
  */
 
-template <class TElastix>
+template <typename TElastix>
 void
 OpenCLFixedGenericPyramid<TElastix>::SwitchingToCPUAndReport(const bool configError)
 {
@@ -340,7 +340,7 @@ OpenCLFixedGenericPyramid<TElastix>::SwitchingToCPUAndReport(const bool configEr
  * ************************* ReportToLog ************************************
  */
 
-template <class TElastix>
+template <typename TElastix>
 void
 OpenCLFixedGenericPyramid<TElastix>::ReportToLog()
 {

--- a/Components/ImageSamplers/Full/elxFullSampler.h
+++ b/Components/ImageSamplers/Full/elxFullSampler.h
@@ -40,7 +40,7 @@ namespace elastix
  * \ingroup ImageSamplers
  */
 
-template <class TElastix>
+template <typename TElastix>
 class ITK_TEMPLATE_EXPORT FullSampler
   : public itk::ImageFullSampler<typename elx::ImageSamplerBase<TElastix>::InputImageType>
   , public elx::ImageSamplerBase<TElastix>

--- a/Components/ImageSamplers/Grid/elxGridSampler.h
+++ b/Components/ImageSamplers/Grid/elxGridSampler.h
@@ -45,7 +45,7 @@ namespace elastix
  * \ingroup ImageSamplers
  */
 
-template <class TElastix>
+template <typename TElastix>
 class ITK_TEMPLATE_EXPORT GridSampler
   : public itk::ImageGridSampler<typename elx::ImageSamplerBase<TElastix>::InputImageType>
   , public elx::ImageSamplerBase<TElastix>

--- a/Components/ImageSamplers/Grid/elxGridSampler.hxx
+++ b/Components/ImageSamplers/Grid/elxGridSampler.hxx
@@ -29,7 +29,7 @@ namespace elastix
  * ******************* BeforeEachResolution ******************
  */
 
-template <class TElastix>
+template <typename TElastix>
 void
 GridSampler<TElastix>::BeforeEachResolution()
 {

--- a/Components/ImageSamplers/MultInputRandomCoordinate/elxMultiInputRandomCoordinateSampler.h
+++ b/Components/ImageSamplers/MultInputRandomCoordinate/elxMultiInputRandomCoordinateSampler.h
@@ -80,7 +80,7 @@ namespace elastix
  * \sa MultiResolutionRegistrationWithFeatures
  */
 
-template <class TElastix>
+template <typename TElastix>
 class ITK_TEMPLATE_EXPORT MultiInputRandomCoordinateSampler
   : public itk::MultiInputImageRandomCoordinateSampler<typename elx::ImageSamplerBase<TElastix>::InputImageType>
   , public elx::ImageSamplerBase<TElastix>

--- a/Components/ImageSamplers/MultInputRandomCoordinate/elxMultiInputRandomCoordinateSampler.hxx
+++ b/Components/ImageSamplers/MultInputRandomCoordinate/elxMultiInputRandomCoordinateSampler.hxx
@@ -29,7 +29,7 @@ namespace elastix
  * ******************* BeforeEachResolution ******************
  */
 
-template <class TElastix>
+template <typename TElastix>
 void
 MultiInputRandomCoordinateSampler<TElastix>::BeforeEachResolution()
 {

--- a/Components/ImageSamplers/Random/elxRandomSampler.h
+++ b/Components/ImageSamplers/Random/elxRandomSampler.h
@@ -48,7 +48,7 @@ namespace elastix
  * \ingroup ImageSamplers
  */
 
-template <class TElastix>
+template <typename TElastix>
 class ITK_TEMPLATE_EXPORT RandomSampler
   : public itk::ImageRandomSampler<typename elx::ImageSamplerBase<TElastix>::InputImageType>
   , public elx::ImageSamplerBase<TElastix>

--- a/Components/ImageSamplers/Random/elxRandomSampler.hxx
+++ b/Components/ImageSamplers/Random/elxRandomSampler.hxx
@@ -28,7 +28,7 @@ namespace elastix
  * ******************* BeforeEachResolution ******************
  */
 
-template <class TElastix>
+template <typename TElastix>
 void
 RandomSampler<TElastix>::BeforeEachResolution()
 {

--- a/Components/ImageSamplers/RandomCoordinate/elxRandomCoordinateSampler.h
+++ b/Components/ImageSamplers/RandomCoordinate/elxRandomCoordinateSampler.h
@@ -74,7 +74,7 @@ namespace elastix
  * \ingroup ImageSamplers
  */
 
-template <class TElastix>
+template <typename TElastix>
 class ITK_TEMPLATE_EXPORT RandomCoordinateSampler
   : public itk::ImageRandomCoordinateSampler<typename elx::ImageSamplerBase<TElastix>::InputImageType>
   , public elx::ImageSamplerBase<TElastix>

--- a/Components/ImageSamplers/RandomCoordinate/elxRandomCoordinateSampler.hxx
+++ b/Components/ImageSamplers/RandomCoordinate/elxRandomCoordinateSampler.hxx
@@ -29,7 +29,7 @@ namespace elastix
  * ******************* BeforeEachResolution ******************
  */
 
-template <class TElastix>
+template <typename TElastix>
 void
 RandomCoordinateSampler<TElastix>::BeforeEachResolution()
 {

--- a/Components/ImageSamplers/RandomSparseMask/elxRandomSamplerSparseMask.h
+++ b/Components/ImageSamplers/RandomSparseMask/elxRandomSamplerSparseMask.h
@@ -50,7 +50,7 @@ namespace elastix
  * \ingroup ImageSamplers
  */
 
-template <class TElastix>
+template <typename TElastix>
 class ITK_TEMPLATE_EXPORT RandomSamplerSparseMask
   : public itk::ImageRandomSamplerSparseMask<typename elx::ImageSamplerBase<TElastix>::InputImageType>
   , public elx::ImageSamplerBase<TElastix>

--- a/Components/ImageSamplers/RandomSparseMask/elxRandomSamplerSparseMask.hxx
+++ b/Components/ImageSamplers/RandomSparseMask/elxRandomSamplerSparseMask.hxx
@@ -29,7 +29,7 @@ namespace elastix
  * ******************* BeforeEachResolution ******************
  */
 
-template <class TElastix>
+template <typename TElastix>
 void
 RandomSamplerSparseMask<TElastix>::BeforeEachResolution()
 {

--- a/Components/Interpolators/BSplineInterpolator/elxBSplineInterpolator.h
+++ b/Components/Interpolators/BSplineInterpolator/elxBSplineInterpolator.h
@@ -46,7 +46,7 @@ namespace elastix
  * \ingroup Interpolators
  */
 
-template <class TElastix>
+template <typename TElastix>
 class ITK_TEMPLATE_EXPORT BSplineInterpolator
   : public itk::BSplineInterpolateImageFunction<typename InterpolatorBase<TElastix>::InputImageType,
                                                 typename InterpolatorBase<TElastix>::CoordRepType,

--- a/Components/Interpolators/BSplineInterpolator/elxBSplineInterpolator.hxx
+++ b/Components/Interpolators/BSplineInterpolator/elxBSplineInterpolator.hxx
@@ -28,7 +28,7 @@ namespace elastix
  * ***************** BeforeEachResolution ***********************
  */
 
-template <class TElastix>
+template <typename TElastix>
 void
 BSplineInterpolator<TElastix>::BeforeEachResolution()
 {

--- a/Components/Interpolators/BSplineInterpolatorFloat/elxBSplineInterpolatorFloat.h
+++ b/Components/Interpolators/BSplineInterpolatorFloat/elxBSplineInterpolatorFloat.h
@@ -46,7 +46,7 @@ namespace elastix
  * \ingroup Interpolators
  */
 
-template <class TElastix>
+template <typename TElastix>
 class ITK_TEMPLATE_EXPORT BSplineInterpolatorFloat
   : public itk::BSplineInterpolateImageFunction<typename InterpolatorBase<TElastix>::InputImageType,
                                                 typename InterpolatorBase<TElastix>::CoordRepType,

--- a/Components/Interpolators/BSplineInterpolatorFloat/elxBSplineInterpolatorFloat.hxx
+++ b/Components/Interpolators/BSplineInterpolatorFloat/elxBSplineInterpolatorFloat.hxx
@@ -28,7 +28,7 @@ namespace elastix
  * ***************** BeforeEachResolution ***********************
  */
 
-template <class TElastix>
+template <typename TElastix>
 void
 BSplineInterpolatorFloat<TElastix>::BeforeEachResolution()
 {

--- a/Components/Interpolators/LinearInterpolator/elxLinearInterpolator.h
+++ b/Components/Interpolators/LinearInterpolator/elxLinearInterpolator.h
@@ -40,7 +40,7 @@ namespace elastix
  * \ingroup Interpolators
  */
 
-template <class TElastix>
+template <typename TElastix>
 class ITK_TEMPLATE_EXPORT LinearInterpolator
   : public itk::AdvancedLinearInterpolateImageFunction<typename InterpolatorBase<TElastix>::InputImageType,
                                                        typename InterpolatorBase<TElastix>::CoordRepType>

--- a/Components/Interpolators/NearestNeighborInterpolator/elxNearestNeighborInterpolator.h
+++ b/Components/Interpolators/NearestNeighborInterpolator/elxNearestNeighborInterpolator.h
@@ -38,7 +38,7 @@ namespace elastix
  * \ingroup Interpolators
  */
 
-template <class TElastix>
+template <typename TElastix>
 class ITK_TEMPLATE_EXPORT NearestNeighborInterpolator
   : public itk::NearestNeighborInterpolateImageFunction<typename InterpolatorBase<TElastix>::InputImageType,
                                                         typename InterpolatorBase<TElastix>::CoordRepType>

--- a/Components/Interpolators/RayCastInterpolator/elxRayCastInterpolator.h
+++ b/Components/Interpolators/RayCastInterpolator/elxRayCastInterpolator.h
@@ -40,7 +40,7 @@ namespace elastix
  * \ingroup Interpolators
  */
 
-template <class TElastix>
+template <typename TElastix>
 class ITK_TEMPLATE_EXPORT RayCastInterpolator
   : public itk::AdvancedRayCastInterpolateImageFunction<typename InterpolatorBase<TElastix>::InputImageType,
                                                         typename InterpolatorBase<TElastix>::CoordRepType>

--- a/Components/Interpolators/RayCastInterpolator/elxRayCastInterpolator.hxx
+++ b/Components/Interpolators/RayCastInterpolator/elxRayCastInterpolator.hxx
@@ -28,7 +28,7 @@ namespace elastix
  * ***************** BeforeAll *****************
  */
 
-template <class TElastix>
+template <typename TElastix>
 int
 RayCastInterpolator<TElastix>::BeforeAll()
 {
@@ -52,7 +52,7 @@ RayCastInterpolator<TElastix>::BeforeAll()
  * ***************** BeforeRegistration *****************
  */
 
-template <class TElastix>
+template <typename TElastix>
 void
 RayCastInterpolator<TElastix>::BeforeRegistration()
 {
@@ -100,7 +100,7 @@ RayCastInterpolator<TElastix>::BeforeRegistration()
  * ***************** BeforeEachResolution *****************
  */
 
-template <class TElastix>
+template <typename TElastix>
 void
 RayCastInterpolator<TElastix>::BeforeEachResolution()
 {

--- a/Components/Interpolators/ReducedDimensionBSplineInterpolator/elxReducedDimensionBSplineInterpolator.h
+++ b/Components/Interpolators/ReducedDimensionBSplineInterpolator/elxReducedDimensionBSplineInterpolator.h
@@ -44,7 +44,7 @@ namespace elastix
  * \ingroup Interpolators
  */
 
-template <class TElastix>
+template <typename TElastix>
 class ITK_TEMPLATE_EXPORT ReducedDimensionBSplineInterpolator
   : public itk::ReducedDimensionBSplineInterpolateImageFunction<typename InterpolatorBase<TElastix>::InputImageType,
                                                                 typename InterpolatorBase<TElastix>::CoordRepType,

--- a/Components/Interpolators/ReducedDimensionBSplineInterpolator/elxReducedDimensionBSplineInterpolator.hxx
+++ b/Components/Interpolators/ReducedDimensionBSplineInterpolator/elxReducedDimensionBSplineInterpolator.hxx
@@ -28,7 +28,7 @@ namespace elastix
  * ***************** BeforeEachResolution ***********************
  */
 
-template <class TElastix>
+template <typename TElastix>
 void
 ReducedDimensionBSplineInterpolator<TElastix>::BeforeEachResolution()
 {

--- a/Components/Metrics/AdvancedKappaStatistic/elxAdvancedKappaStatisticMetric.h
+++ b/Components/Metrics/AdvancedKappaStatistic/elxAdvancedKappaStatisticMetric.h
@@ -45,7 +45,7 @@ namespace elastix
  *
  */
 
-template <class TElastix>
+template <typename TElastix>
 class ITK_TEMPLATE_EXPORT AdvancedKappaStatisticMetric
   : public itk::AdvancedKappaStatisticImageToImageMetric<typename MetricBase<TElastix>::FixedImageType,
                                                          typename MetricBase<TElastix>::MovingImageType>

--- a/Components/Metrics/AdvancedKappaStatistic/elxAdvancedKappaStatisticMetric.hxx
+++ b/Components/Metrics/AdvancedKappaStatistic/elxAdvancedKappaStatisticMetric.hxx
@@ -30,7 +30,7 @@ namespace elastix
  * ******************* Initialize ***********************
  */
 
-template <class TElastix>
+template <typename TElastix>
 void
 AdvancedKappaStatisticMetric<TElastix>::Initialize()
 {
@@ -48,7 +48,7 @@ AdvancedKappaStatisticMetric<TElastix>::Initialize()
  * ***************** BeforeRegistration ***********************
  */
 
-template <class TElastix>
+template <typename TElastix>
 void
 AdvancedKappaStatisticMetric<TElastix>::BeforeRegistration()
 {

--- a/Components/Metrics/AdvancedKappaStatistic/itkAdvancedKappaStatisticImageToImageMetric.h
+++ b/Components/Metrics/AdvancedKappaStatistic/itkAdvancedKappaStatisticImageToImageMetric.h
@@ -53,7 +53,7 @@ namespace itk
  * \ingroup Metrics
  */
 
-template <class TFixedImage, class TMovingImage>
+template <typename TFixedImage, typename TMovingImage>
 class ITK_TEMPLATE_EXPORT AdvancedKappaStatisticImageToImageMetric
   : public AdvancedImageToImageMetric<TFixedImage, TMovingImage>
 {

--- a/Components/Metrics/AdvancedKappaStatistic/itkAdvancedKappaStatisticImageToImageMetric.hxx
+++ b/Components/Metrics/AdvancedKappaStatistic/itkAdvancedKappaStatisticImageToImageMetric.hxx
@@ -31,7 +31,7 @@ namespace itk
  * ******************* Constructor *******************
  */
 
-template <class TFixedImage, class TMovingImage>
+template <typename TFixedImage, typename TMovingImage>
 AdvancedKappaStatisticImageToImageMetric<TFixedImage, TMovingImage>::AdvancedKappaStatisticImageToImageMetric()
 {
   this->SetComputeGradient(true);
@@ -46,7 +46,7 @@ AdvancedKappaStatisticImageToImageMetric<TFixedImage, TMovingImage>::AdvancedKap
  * ******************* InitializeThreadingParameters *******************
  */
 
-template <class TFixedImage, class TMovingImage>
+template <typename TFixedImage, typename TMovingImage>
 void
 AdvancedKappaStatisticImageToImageMetric<TFixedImage, TMovingImage>::InitializeThreadingParameters() const
 {
@@ -81,7 +81,7 @@ AdvancedKappaStatisticImageToImageMetric<TFixedImage, TMovingImage>::InitializeT
  * ******************* PrintSelf *******************
  */
 
-template <class TFixedImage, class TMovingImage>
+template <typename TFixedImage, typename TMovingImage>
 void
 AdvancedKappaStatisticImageToImageMetric<TFixedImage, TMovingImage>::PrintSelf(std::ostream & os, Indent indent) const
 {
@@ -99,7 +99,7 @@ AdvancedKappaStatisticImageToImageMetric<TFixedImage, TMovingImage>::PrintSelf(s
  * ******************* GetValue *******************
  */
 
-template <class TFixedImage, class TMovingImage>
+template <typename TFixedImage, typename TMovingImage>
 auto
 AdvancedKappaStatisticImageToImageMetric<TFixedImage, TMovingImage>::GetValue(
   const TransformParametersType & parameters) const -> MeasureType
@@ -228,7 +228,7 @@ AdvancedKappaStatisticImageToImageMetric<TFixedImage, TMovingImage>::GetValue(
  * ******************* GetDerivative *******************
  */
 
-template <class TFixedImage, class TMovingImage>
+template <typename TFixedImage, typename TMovingImage>
 void
 AdvancedKappaStatisticImageToImageMetric<TFixedImage, TMovingImage>::GetDerivative(
   const TransformParametersType & parameters,
@@ -249,7 +249,7 @@ AdvancedKappaStatisticImageToImageMetric<TFixedImage, TMovingImage>::GetDerivati
  * ******************* GetValueAndDerivativeSingleThreaded *******************
  */
 
-template <class TFixedImage, class TMovingImage>
+template <typename TFixedImage, typename TMovingImage>
 void
 AdvancedKappaStatisticImageToImageMetric<TFixedImage, TMovingImage>::GetValueAndDerivativeSingleThreaded(
   const TransformParametersType & parameters,
@@ -391,7 +391,7 @@ AdvancedKappaStatisticImageToImageMetric<TFixedImage, TMovingImage>::GetValueAnd
  * ******************* GetValueAndDerivative *******************
  */
 
-template <class TFixedImage, class TMovingImage>
+template <typename TFixedImage, typename TMovingImage>
 void
 AdvancedKappaStatisticImageToImageMetric<TFixedImage, TMovingImage>::GetValueAndDerivative(
   const TransformParametersType & parameters,
@@ -432,7 +432,7 @@ AdvancedKappaStatisticImageToImageMetric<TFixedImage, TMovingImage>::GetValueAnd
  * ******************* ThreadedGetValueAndDerivative *******************
  */
 
-template <class TFixedImage, class TMovingImage>
+template <typename TFixedImage, typename TMovingImage>
 void
 AdvancedKappaStatisticImageToImageMetric<TFixedImage, TMovingImage>::ThreadedGetValueAndDerivative(
   ThreadIdType threadId) const
@@ -544,7 +544,7 @@ AdvancedKappaStatisticImageToImageMetric<TFixedImage, TMovingImage>::ThreadedGet
  * ******************* AfterThreadedGetValueAndDerivative *******************
  */
 
-template <class TFixedImage, class TMovingImage>
+template <typename TFixedImage, typename TMovingImage>
 void
 AdvancedKappaStatisticImageToImageMetric<TFixedImage, TMovingImage>::AfterThreadedGetValueAndDerivative(
   MeasureType &    value,
@@ -631,7 +631,7 @@ AdvancedKappaStatisticImageToImageMetric<TFixedImage, TMovingImage>::AfterThread
  *********** AccumulateDerivativesThreaderCallback *************
  */
 
-template <class TFixedImage, class TMovingImage>
+template <typename TFixedImage, typename TMovingImage>
 ITK_THREAD_RETURN_FUNCTION_CALL_CONVENTION
 AdvancedKappaStatisticImageToImageMetric<TFixedImage, TMovingImage>::AccumulateDerivativesThreaderCallback(void * arg)
 {
@@ -678,7 +678,7 @@ AdvancedKappaStatisticImageToImageMetric<TFixedImage, TMovingImage>::AccumulateD
  * *************** UpdateValueAndDerivativeTerms ***************************
  */
 
-template <class TFixedImage, class TMovingImage>
+template <typename TFixedImage, typename TMovingImage>
 void
 AdvancedKappaStatisticImageToImageMetric<TFixedImage, TMovingImage>::UpdateValueAndDerivativeTerms(
   const RealType                     fixedImageValue,
@@ -773,7 +773,7 @@ AdvancedKappaStatisticImageToImageMetric<TFixedImage, TMovingImage>::UpdateValue
  * *************** ComputeGradient ***************************
  */
 
-template <class TFixedImage, class TMovingImage>
+template <typename TFixedImage, typename TMovingImage>
 void
 AdvancedKappaStatisticImageToImageMetric<TFixedImage, TMovingImage>::ComputeGradient()
 {

--- a/Components/Metrics/AdvancedMattesMutualInformation/elxAdvancedMattesMutualInformationMetric.h
+++ b/Components/Metrics/AdvancedMattesMutualInformation/elxAdvancedMattesMutualInformationMetric.h
@@ -96,7 +96,7 @@ namespace elastix
  * \ingroup Metrics
  */
 
-template <class TElastix>
+template <typename TElastix>
 class ITK_TEMPLATE_EXPORT AdvancedMattesMutualInformationMetric
   : public itk::ParzenWindowMutualInformationImageToImageMetric<typename MetricBase<TElastix>::FixedImageType,
                                                                 typename MetricBase<TElastix>::MovingImageType>

--- a/Components/Metrics/AdvancedMattesMutualInformation/elxAdvancedMattesMutualInformationMetric.hxx
+++ b/Components/Metrics/AdvancedMattesMutualInformation/elxAdvancedMattesMutualInformationMetric.hxx
@@ -34,7 +34,7 @@ namespace elastix
  * ****************** Constructor ***********************
  */
 
-template <class TElastix>
+template <typename TElastix>
 AdvancedMattesMutualInformationMetric<TElastix>::AdvancedMattesMutualInformationMetric()
 {
   this->m_CurrentIteration = 0.0;
@@ -49,7 +49,7 @@ AdvancedMattesMutualInformationMetric<TElastix>::AdvancedMattesMutualInformation
  * ******************* Initialize ***********************
  */
 
-template <class TElastix>
+template <typename TElastix>
 void
 AdvancedMattesMutualInformationMetric<TElastix>::Initialize()
 {
@@ -67,7 +67,7 @@ AdvancedMattesMutualInformationMetric<TElastix>::Initialize()
  * ***************** BeforeEachResolution ***********************
  */
 
-template <class TElastix>
+template <typename TElastix>
 void
 AdvancedMattesMutualInformationMetric<TElastix>::BeforeEachResolution()
 {
@@ -147,7 +147,7 @@ AdvancedMattesMutualInformationMetric<TElastix>::BeforeEachResolution()
  * ***************** AfterEachIteration ***********************
  */
 
-template <class TElastix>
+template <typename TElastix>
 void
 AdvancedMattesMutualInformationMetric<TElastix>::AfterEachIteration()
 {
@@ -163,7 +163,7 @@ AdvancedMattesMutualInformationMetric<TElastix>::AfterEachIteration()
  * ************************** Compute_c *************************
  */
 
-template <class TElastix>
+template <typename TElastix>
 double
 AdvancedMattesMutualInformationMetric<TElastix>::Compute_c(unsigned long k) const
 {

--- a/Components/Metrics/AdvancedMattesMutualInformation/itkParzenWindowMutualInformationImageToImageMetric.h
+++ b/Components/Metrics/AdvancedMattesMutualInformation/itkParzenWindowMutualInformationImageToImageMetric.h
@@ -71,7 +71,7 @@ namespace itk
  * \sa ParzenWindowHistogramImageToImageMetric
  */
 
-template <class TFixedImage, class TMovingImage>
+template <typename TFixedImage, typename TMovingImage>
 class ITK_TEMPLATE_EXPORT ParzenWindowMutualInformationImageToImageMetric
   : public ParzenWindowHistogramImageToImageMetric<TFixedImage, TMovingImage>
 {

--- a/Components/Metrics/AdvancedMattesMutualInformation/itkParzenWindowMutualInformationImageToImageMetric.hxx
+++ b/Components/Metrics/AdvancedMattesMutualInformation/itkParzenWindowMutualInformationImageToImageMetric.hxx
@@ -35,7 +35,7 @@ namespace itk
  * ********************* Constructor ******************************
  */
 
-template <class TFixedImage, class TMovingImage>
+template <typename TFixedImage, typename TMovingImage>
 ParzenWindowMutualInformationImageToImageMetric<TFixedImage,
                                                 TMovingImage>::ParzenWindowMutualInformationImageToImageMetric()
 {
@@ -49,7 +49,7 @@ ParzenWindowMutualInformationImageToImageMetric<TFixedImage,
  * ********************* InitializeHistograms ******************************
  */
 
-template <class TFixedImage, class TMovingImage>
+template <typename TFixedImage, typename TMovingImage>
 void
 ParzenWindowMutualInformationImageToImageMetric<TFixedImage, TMovingImage>::InitializeHistograms()
 {
@@ -69,7 +69,7 @@ ParzenWindowMutualInformationImageToImageMetric<TFixedImage, TMovingImage>::Init
  * ************************** GetValue **************************
  */
 
-template <class TFixedImage, class TMovingImage>
+template <typename TFixedImage, typename TMovingImage>
 auto
 ParzenWindowMutualInformationImageToImageMetric<TFixedImage, TMovingImage>::GetValue(
   const ParametersType & parameters) const -> MeasureType
@@ -133,7 +133,7 @@ ParzenWindowMutualInformationImageToImageMetric<TFixedImage, TMovingImage>::GetV
  * ******************** GetValueAndAnalyticDerivative *******************
  */
 
-template <class TFixedImage, class TMovingImage>
+template <typename TFixedImage, typename TMovingImage>
 void
 ParzenWindowMutualInformationImageToImageMetric<TFixedImage, TMovingImage>::GetValueAndAnalyticDerivative(
   const ParametersType & parameters,
@@ -231,7 +231,7 @@ ParzenWindowMutualInformationImageToImageMetric<TFixedImage, TMovingImage>::GetV
  * ******************** GetValueAndAnalyticDerivativeLowMemory *******************
  */
 
-template <class TFixedImage, class TMovingImage>
+template <typename TFixedImage, typename TMovingImage>
 void
 ParzenWindowMutualInformationImageToImageMetric<TFixedImage, TMovingImage>::GetValueAndAnalyticDerivativeLowMemory(
   const ParametersType & parameters,
@@ -275,7 +275,7 @@ ParzenWindowMutualInformationImageToImageMetric<TFixedImage, TMovingImage>::GetV
  * ******************** ComputeDerivativeLowMemorySingleThreaded *******************
  */
 
-template <class TFixedImage, class TMovingImage>
+template <typename TFixedImage, typename TMovingImage>
 void
 ParzenWindowMutualInformationImageToImageMetric<TFixedImage, TMovingImage>::ComputeDerivativeLowMemorySingleThreaded(
   DerivativeType & derivative) const
@@ -384,7 +384,7 @@ ParzenWindowMutualInformationImageToImageMetric<TFixedImage, TMovingImage>::Comp
  * ******************** ComputeDerivativeLowMemory *******************
  */
 
-template <class TFixedImage, class TMovingImage>
+template <typename TFixedImage, typename TMovingImage>
 void
 ParzenWindowMutualInformationImageToImageMetric<TFixedImage, TMovingImage>::ComputeDerivativeLowMemory(
   DerivativeType & derivative) const
@@ -408,7 +408,7 @@ ParzenWindowMutualInformationImageToImageMetric<TFixedImage, TMovingImage>::Comp
  * ******************* ThreadedComputeDerivativeLowMemory *******************
  */
 
-template <class TFixedImage, class TMovingImage>
+template <typename TFixedImage, typename TMovingImage>
 void
 ParzenWindowMutualInformationImageToImageMetric<TFixedImage, TMovingImage>::ThreadedComputeDerivativeLowMemory(
   ThreadIdType threadId)
@@ -545,7 +545,7 @@ ParzenWindowMutualInformationImageToImageMetric<TFixedImage, TMovingImage>::Thre
  * ******************* AfterThreadedComputeDerivativeLowMemory *******************
  */
 
-template <class TFixedImage, class TMovingImage>
+template <typename TFixedImage, typename TMovingImage>
 void
 ParzenWindowMutualInformationImageToImageMetric<TFixedImage, TMovingImage>::AfterThreadedComputeDerivativeLowMemory(
   DerivativeType & derivative) const
@@ -567,7 +567,7 @@ ParzenWindowMutualInformationImageToImageMetric<TFixedImage, TMovingImage>::Afte
  * **************** ComputeDerivativeLowMemoryThreaderCallback *******
  */
 
-template <class TFixedImage, class TMovingImage>
+template <typename TFixedImage, typename TMovingImage>
 ITK_THREAD_RETURN_FUNCTION_CALL_CONVENTION
 ParzenWindowMutualInformationImageToImageMetric<TFixedImage, TMovingImage>::ComputeDerivativeLowMemoryThreaderCallback(
   void * arg)
@@ -590,7 +590,7 @@ ParzenWindowMutualInformationImageToImageMetric<TFixedImage, TMovingImage>::Comp
  * *********************** LaunchComputeDerivativeLowMemoryThreaderCallback***************
  */
 
-template <class TFixedImage, class TMovingImage>
+template <typename TFixedImage, typename TMovingImage>
 void
 ParzenWindowMutualInformationImageToImageMetric<TFixedImage,
                                                 TMovingImage>::LaunchComputeDerivativeLowMemoryThreaderCallback() const
@@ -607,7 +607,7 @@ ParzenWindowMutualInformationImageToImageMetric<TFixedImage,
  * ******************* ComputeValueAndPRatioArray *******************
  */
 
-template <class TFixedImage, class TMovingImage>
+template <typename TFixedImage, typename TMovingImage>
 void
 ParzenWindowMutualInformationImageToImageMetric<TFixedImage, TMovingImage>::ComputeValueAndPRatioArray(
   double & MI) const
@@ -682,7 +682,7 @@ ParzenWindowMutualInformationImageToImageMetric<TFixedImage, TMovingImage>::Comp
  * ******************* UpdateDerivativeLowMemory *******************
  */
 
-template <class TFixedImage, class TMovingImage>
+template <typename TFixedImage, typename TMovingImage>
 void
 ParzenWindowMutualInformationImageToImageMetric<TFixedImage, TMovingImage>::UpdateDerivativeLowMemory(
   const RealType                     fixedImageValue,
@@ -779,7 +779,7 @@ ParzenWindowMutualInformationImageToImageMetric<TFixedImage, TMovingImage>::Upda
  * ******************** GetValueAndFiniteDifferenceDerivative *******************
  */
 
-template <class TFixedImage, class TMovingImage>
+template <typename TFixedImage, typename TMovingImage>
 void
 ParzenWindowMutualInformationImageToImageMetric<TFixedImage, TMovingImage>::GetValueAndFiniteDifferenceDerivative(
   const ParametersType & parameters,
@@ -967,7 +967,7 @@ ParzenWindowMutualInformationImageToImageMetric<TFixedImage, TMovingImage>::GetV
  * ******************** ComputeJacobianPreconditioner *******************
  */
 
-template <class TFixedImage, class TMovingImage>
+template <typename TFixedImage, typename TMovingImage>
 void
 ParzenWindowMutualInformationImageToImageMetric<TFixedImage, TMovingImage>::ComputeJacobianPreconditioner(
   const TransformJacobianType &      jac,

--- a/Components/Metrics/AdvancedMeanSquares/elxAdvancedMeanSquaresMetric.h
+++ b/Components/Metrics/AdvancedMeanSquares/elxAdvancedMeanSquaresMetric.h
@@ -41,7 +41,7 @@ namespace elastix
  *
  */
 
-template <class TElastix>
+template <typename TElastix>
 class ITK_TEMPLATE_EXPORT AdvancedMeanSquaresMetric
   : public itk::AdvancedMeanSquaresImageToImageMetric<typename MetricBase<TElastix>::FixedImageType,
                                                       typename MetricBase<TElastix>::MovingImageType>

--- a/Components/Metrics/AdvancedMeanSquares/elxAdvancedMeanSquaresMetric.hxx
+++ b/Components/Metrics/AdvancedMeanSquares/elxAdvancedMeanSquaresMetric.hxx
@@ -29,7 +29,7 @@ namespace elastix
  * ******************* Initialize ***********************
  */
 
-template <class TElastix>
+template <typename TElastix>
 void
 AdvancedMeanSquaresMetric<TElastix>::Initialize()
 {
@@ -47,7 +47,7 @@ AdvancedMeanSquaresMetric<TElastix>::Initialize()
  * ***************** BeforeEachResolution ***********************
  */
 
-template <class TElastix>
+template <typename TElastix>
 void
 AdvancedMeanSquaresMetric<TElastix>::BeforeEachResolution()
 {

--- a/Components/Metrics/AdvancedMeanSquares/itkAdvancedMeanSquaresImageToImageMetric.h
+++ b/Components/Metrics/AdvancedMeanSquares/itkAdvancedMeanSquaresImageToImageMetric.h
@@ -48,7 +48,7 @@ namespace itk
  * \ingroup Metrics
  */
 
-template <class TFixedImage, class TMovingImage>
+template <typename TFixedImage, typename TMovingImage>
 class ITK_TEMPLATE_EXPORT AdvancedMeanSquaresImageToImageMetric
   : public AdvancedImageToImageMetric<TFixedImage, TMovingImage>
 {

--- a/Components/Metrics/AdvancedMeanSquares/itkAdvancedMeanSquaresImageToImageMetric.hxx
+++ b/Components/Metrics/AdvancedMeanSquares/itkAdvancedMeanSquaresImageToImageMetric.hxx
@@ -30,7 +30,7 @@ namespace itk
  * ******************* Constructor *******************
  */
 
-template <class TFixedImage, class TMovingImage>
+template <typename TFixedImage, typename TMovingImage>
 AdvancedMeanSquaresImageToImageMetric<TFixedImage, TMovingImage>::AdvancedMeanSquaresImageToImageMetric()
 {
   this->Superclass::SetUseImageSampler(true);
@@ -40,7 +40,7 @@ AdvancedMeanSquaresImageToImageMetric<TFixedImage, TMovingImage>::AdvancedMeanSq
  * ********************* Initialize ****************************
  */
 
-template <class TFixedImage, class TMovingImage>
+template <typename TFixedImage, typename TMovingImage>
 void
 AdvancedMeanSquaresImageToImageMetric<TFixedImage, TMovingImage>::Initialize()
 {
@@ -108,7 +108,7 @@ AdvancedMeanSquaresImageToImageMetric<TFixedImage, TMovingImage>::Initialize()
  * ******************* PrintSelf *******************
  */
 
-template <class TFixedImage, class TMovingImage>
+template <typename TFixedImage, typename TMovingImage>
 void
 AdvancedMeanSquaresImageToImageMetric<TFixedImage, TMovingImage>::PrintSelf(std::ostream & os, Indent indent) const
 {
@@ -123,7 +123,7 @@ AdvancedMeanSquaresImageToImageMetric<TFixedImage, TMovingImage>::PrintSelf(std:
  * ******************* GetValueSingleThreaded *******************
  */
 
-template <class TFixedImage, class TMovingImage>
+template <typename TFixedImage, typename TMovingImage>
 auto
 AdvancedMeanSquaresImageToImageMetric<TFixedImage, TMovingImage>::GetValueSingleThreaded(
   const TransformParametersType & parameters) const -> MeasureType
@@ -207,7 +207,7 @@ AdvancedMeanSquaresImageToImageMetric<TFixedImage, TMovingImage>::GetValueSingle
  * ******************* GetValue *******************
  */
 
-template <class TFixedImage, class TMovingImage>
+template <typename TFixedImage, typename TMovingImage>
 auto
 AdvancedMeanSquaresImageToImageMetric<TFixedImage, TMovingImage>::GetValue(
   const TransformParametersType & parameters) const -> MeasureType
@@ -248,7 +248,7 @@ AdvancedMeanSquaresImageToImageMetric<TFixedImage, TMovingImage>::GetValue(
  * ******************* ThreadedGetValue *******************
  */
 
-template <class TFixedImage, class TMovingImage>
+template <typename TFixedImage, typename TMovingImage>
 void
 AdvancedMeanSquaresImageToImageMetric<TFixedImage, TMovingImage>::ThreadedGetValue(ThreadIdType threadId) const
 {
@@ -319,7 +319,7 @@ AdvancedMeanSquaresImageToImageMetric<TFixedImage, TMovingImage>::ThreadedGetVal
  * ******************* AfterThreadedGetValue *******************
  */
 
-template <class TFixedImage, class TMovingImage>
+template <typename TFixedImage, typename TMovingImage>
 void
 AdvancedMeanSquaresImageToImageMetric<TFixedImage, TMovingImage>::AfterThreadedGetValue(MeasureType & value) const
 {
@@ -360,7 +360,7 @@ AdvancedMeanSquaresImageToImageMetric<TFixedImage, TMovingImage>::AfterThreadedG
  * ******************* GetDerivative *******************
  */
 
-template <class TFixedImage, class TMovingImage>
+template <typename TFixedImage, typename TMovingImage>
 void
 AdvancedMeanSquaresImageToImageMetric<TFixedImage, TMovingImage>::GetDerivative(
   const TransformParametersType & parameters,
@@ -381,7 +381,7 @@ AdvancedMeanSquaresImageToImageMetric<TFixedImage, TMovingImage>::GetDerivative(
  * ******************* GetValueAndDerivativeSingleThreaded *******************
  */
 
-template <class TFixedImage, class TMovingImage>
+template <typename TFixedImage, typename TMovingImage>
 void
 AdvancedMeanSquaresImageToImageMetric<TFixedImage, TMovingImage>::GetValueAndDerivativeSingleThreaded(
   const TransformParametersType & parameters,
@@ -491,7 +491,7 @@ AdvancedMeanSquaresImageToImageMetric<TFixedImage, TMovingImage>::GetValueAndDer
  * ******************* GetValueAndDerivative *******************
  */
 
-template <class TFixedImage, class TMovingImage>
+template <typename TFixedImage, typename TMovingImage>
 void
 AdvancedMeanSquaresImageToImageMetric<TFixedImage, TMovingImage>::GetValueAndDerivative(
   const TransformParametersType & parameters,
@@ -532,7 +532,7 @@ AdvancedMeanSquaresImageToImageMetric<TFixedImage, TMovingImage>::GetValueAndDer
  * ******************* ThreadedGetValueAndDerivative *******************
  */
 
-template <class TFixedImage, class TMovingImage>
+template <typename TFixedImage, typename TMovingImage>
 void
 AdvancedMeanSquaresImageToImageMetric<TFixedImage, TMovingImage>::ThreadedGetValueAndDerivative(
   ThreadIdType threadId) const
@@ -630,7 +630,7 @@ AdvancedMeanSquaresImageToImageMetric<TFixedImage, TMovingImage>::ThreadedGetVal
  * ******************* AfterThreadedGetValueAndDerivative *******************
  */
 
-template <class TFixedImage, class TMovingImage>
+template <typename TFixedImage, typename TMovingImage>
 void
 AdvancedMeanSquaresImageToImageMetric<TFixedImage, TMovingImage>::AfterThreadedGetValueAndDerivative(
   MeasureType &    value,
@@ -681,7 +681,7 @@ AdvancedMeanSquaresImageToImageMetric<TFixedImage, TMovingImage>::AfterThreadedG
  * *************** UpdateValueAndDerivativeTerms ***************************
  */
 
-template <class TFixedImage, class TMovingImage>
+template <typename TFixedImage, typename TMovingImage>
 void
 AdvancedMeanSquaresImageToImageMetric<TFixedImage, TMovingImage>::UpdateValueAndDerivativeTerms(
   const RealType                     fixedImageValue,

--- a/Components/Metrics/AdvancedNormalizedCorrelation/elxAdvancedNormalizedCorrelationMetric.h
+++ b/Components/Metrics/AdvancedNormalizedCorrelation/elxAdvancedNormalizedCorrelationMetric.h
@@ -41,7 +41,7 @@ namespace elastix
  *
  */
 
-template <class TElastix>
+template <typename TElastix>
 class ITK_TEMPLATE_EXPORT AdvancedNormalizedCorrelationMetric
   : public itk::AdvancedNormalizedCorrelationImageToImageMetric<typename MetricBase<TElastix>::FixedImageType,
                                                                 typename MetricBase<TElastix>::MovingImageType>

--- a/Components/Metrics/AdvancedNormalizedCorrelation/elxAdvancedNormalizedCorrelationMetric.hxx
+++ b/Components/Metrics/AdvancedNormalizedCorrelation/elxAdvancedNormalizedCorrelationMetric.hxx
@@ -28,7 +28,7 @@ namespace elastix
  * ***************** BeforeEachResolution ***********************
  */
 
-template <class TElastix>
+template <typename TElastix>
 void
 AdvancedNormalizedCorrelationMetric<TElastix>::BeforeEachResolution()
 {
@@ -62,7 +62,7 @@ AdvancedNormalizedCorrelationMetric<TElastix>::BeforeEachResolution()
  * ******************* Initialize ***********************
  */
 
-template <class TElastix>
+template <typename TElastix>
 void
 AdvancedNormalizedCorrelationMetric<TElastix>::Initialize()
 {

--- a/Components/Metrics/AdvancedNormalizedCorrelation/itkAdvancedNormalizedCorrelationImageToImageMetric.h
+++ b/Components/Metrics/AdvancedNormalizedCorrelation/itkAdvancedNormalizedCorrelationImageToImageMetric.h
@@ -87,7 +87,7 @@ namespace itk
  * \ingroup Metrics
  */
 
-template <class TFixedImage, class TMovingImage>
+template <typename TFixedImage, typename TMovingImage>
 class ITK_TEMPLATE_EXPORT AdvancedNormalizedCorrelationImageToImageMetric
   : public AdvancedImageToImageMetric<TFixedImage, TMovingImage>
 {

--- a/Components/Metrics/AdvancedNormalizedCorrelation/itkAdvancedNormalizedCorrelationImageToImageMetric.hxx
+++ b/Components/Metrics/AdvancedNormalizedCorrelation/itkAdvancedNormalizedCorrelationImageToImageMetric.hxx
@@ -30,7 +30,7 @@ namespace itk
  * ******************* Constructor *******************
  */
 
-template <class TFixedImage, class TMovingImage>
+template <typename TFixedImage, typename TMovingImage>
 AdvancedNormalizedCorrelationImageToImageMetric<TFixedImage,
                                                 TMovingImage>::AdvancedNormalizedCorrelationImageToImageMetric()
 {
@@ -45,7 +45,7 @@ AdvancedNormalizedCorrelationImageToImageMetric<TFixedImage,
  * ******************* InitializeThreadingParameters *******************
  */
 
-template <class TFixedImage, class TMovingImage>
+template <typename TFixedImage, typename TMovingImage>
 void
 AdvancedNormalizedCorrelationImageToImageMetric<TFixedImage, TMovingImage>::InitializeThreadingParameters() const
 {
@@ -86,7 +86,7 @@ AdvancedNormalizedCorrelationImageToImageMetric<TFixedImage, TMovingImage>::Init
  * *************** UpdateDerivativeTerms ***************************
  */
 
-template <class TFixedImage, class TMovingImage>
+template <typename TFixedImage, typename TMovingImage>
 void
 AdvancedNormalizedCorrelationImageToImageMetric<TFixedImage, TMovingImage>::UpdateDerivativeTerms(
   const RealType                     fixedImageValue,
@@ -139,7 +139,7 @@ AdvancedNormalizedCorrelationImageToImageMetric<TFixedImage, TMovingImage>::Upda
  * ******************* GetValue *******************
  */
 
-template <class TFixedImage, class TMovingImage>
+template <typename TFixedImage, typename TMovingImage>
 auto
 AdvancedNormalizedCorrelationImageToImageMetric<TFixedImage, TMovingImage>::GetValue(
   const TransformParametersType & parameters) const -> MeasureType
@@ -248,7 +248,7 @@ AdvancedNormalizedCorrelationImageToImageMetric<TFixedImage, TMovingImage>::GetV
  * ******************* GetDerivative *******************
  */
 
-template <class TFixedImage, class TMovingImage>
+template <typename TFixedImage, typename TMovingImage>
 void
 AdvancedNormalizedCorrelationImageToImageMetric<TFixedImage, TMovingImage>::GetDerivative(
   const TransformParametersType & parameters,
@@ -269,7 +269,7 @@ AdvancedNormalizedCorrelationImageToImageMetric<TFixedImage, TMovingImage>::GetD
  * ******************* GetValueAndDerivativeSingleThreaded *******************
  */
 
-template <class TFixedImage, class TMovingImage>
+template <typename TFixedImage, typename TMovingImage>
 void
 AdvancedNormalizedCorrelationImageToImageMetric<TFixedImage, TMovingImage>::GetValueAndDerivativeSingleThreaded(
   const TransformParametersType & parameters,
@@ -414,7 +414,7 @@ AdvancedNormalizedCorrelationImageToImageMetric<TFixedImage, TMovingImage>::GetV
  * ******************* GetValueAndDerivative *******************
  */
 
-template <class TFixedImage, class TMovingImage>
+template <typename TFixedImage, typename TMovingImage>
 void
 AdvancedNormalizedCorrelationImageToImageMetric<TFixedImage, TMovingImage>::GetValueAndDerivative(
   const TransformParametersType & parameters,
@@ -455,7 +455,7 @@ AdvancedNormalizedCorrelationImageToImageMetric<TFixedImage, TMovingImage>::GetV
  * ******************* ThreadedGetValueAndDerivative *******************
  */
 
-template <class TFixedImage, class TMovingImage>
+template <typename TFixedImage, typename TMovingImage>
 void
 AdvancedNormalizedCorrelationImageToImageMetric<TFixedImage, TMovingImage>::ThreadedGetValueAndDerivative(
   ThreadIdType threadId) const
@@ -571,7 +571,7 @@ AdvancedNormalizedCorrelationImageToImageMetric<TFixedImage, TMovingImage>::Thre
  * ******************* AfterThreadedGetValueAndDerivative *******************
  */
 
-template <class TFixedImage, class TMovingImage>
+template <typename TFixedImage, typename TMovingImage>
 void
 AdvancedNormalizedCorrelationImageToImageMetric<TFixedImage, TMovingImage>::AfterThreadedGetValueAndDerivative(
   MeasureType &    value,
@@ -655,7 +655,7 @@ AdvancedNormalizedCorrelationImageToImageMetric<TFixedImage, TMovingImage>::Afte
  *********** AccumulateDerivativesThreaderCallback *************
  */
 
-template <class TFixedImage, class TMovingImage>
+template <typename TFixedImage, typename TMovingImage>
 ITK_THREAD_RETURN_FUNCTION_CALL_CONVENTION
 AdvancedNormalizedCorrelationImageToImageMetric<TFixedImage, TMovingImage>::AccumulateDerivativesThreaderCallback(
   void * arg)

--- a/Components/Metrics/BendingEnergyPenalty/elxTransformBendingEnergyPenaltyTerm.h
+++ b/Components/Metrics/BendingEnergyPenalty/elxTransformBendingEnergyPenaltyTerm.h
@@ -44,7 +44,7 @@ namespace elastix
  *
  */
 
-template <class TElastix>
+template <typename TElastix>
 class ITK_TEMPLATE_EXPORT TransformBendingEnergyPenalty
   : public itk::TransformBendingEnergyPenaltyTerm<typename MetricBase<TElastix>::FixedImageType, double>
   , public MetricBase<TElastix>

--- a/Components/Metrics/BendingEnergyPenalty/elxTransformBendingEnergyPenaltyTerm.hxx
+++ b/Components/Metrics/BendingEnergyPenalty/elxTransformBendingEnergyPenaltyTerm.hxx
@@ -28,7 +28,7 @@ namespace elastix
  * ******************* Initialize ***********************
  */
 
-template <class TElastix>
+template <typename TElastix>
 void
 TransformBendingEnergyPenalty<TElastix>::Initialize()
 {

--- a/Components/Metrics/BendingEnergyPenalty/itkTransformBendingEnergyPenaltyTerm.h
+++ b/Components/Metrics/BendingEnergyPenalty/itkTransformBendingEnergyPenaltyTerm.h
@@ -46,7 +46,7 @@ namespace itk
  * \ingroup Metrics
  */
 
-template <class TFixedImage, class TScalarType>
+template <typename TFixedImage, typename TScalarType>
 class ITK_TEMPLATE_EXPORT TransformBendingEnergyPenaltyTerm : public TransformPenaltyTerm<TFixedImage, TScalarType>
 {
 public:

--- a/Components/Metrics/BendingEnergyPenalty/itkTransformBendingEnergyPenaltyTerm.hxx
+++ b/Components/Metrics/BendingEnergyPenalty/itkTransformBendingEnergyPenaltyTerm.hxx
@@ -27,7 +27,7 @@ namespace itk
  * ****************** Constructor *******************************
  */
 
-template <class TFixedImage, class TScalarType>
+template <typename TFixedImage, typename TScalarType>
 TransformBendingEnergyPenaltyTerm<TFixedImage, TScalarType>::TransformBendingEnergyPenaltyTerm()
 {
   /** Initialize member variables. */
@@ -42,7 +42,7 @@ TransformBendingEnergyPenaltyTerm<TFixedImage, TScalarType>::TransformBendingEne
  * ****************** GetValue *******************************
  */
 
-template <class TFixedImage, class TScalarType>
+template <typename TFixedImage, typename TScalarType>
 auto
 TransformBendingEnergyPenaltyTerm<TFixedImage, TScalarType>::GetValue(const ParametersType & parameters) const
   -> MeasureType
@@ -123,7 +123,7 @@ TransformBendingEnergyPenaltyTerm<TFixedImage, TScalarType>::GetValue(const Para
  * ******************* GetDerivative *******************
  */
 
-template <class TFixedImage, class TScalarType>
+template <typename TFixedImage, typename TScalarType>
 void
 TransformBendingEnergyPenaltyTerm<TFixedImage, TScalarType>::GetDerivative(const ParametersType & parameters,
                                                                            DerivativeType &       derivative) const
@@ -139,7 +139,7 @@ TransformBendingEnergyPenaltyTerm<TFixedImage, TScalarType>::GetDerivative(const
  * ****************** GetValueAndDerivativeSingleThreaded *******************************
  */
 
-template <class TFixedImage, class TScalarType>
+template <typename TFixedImage, typename TScalarType>
 void
 TransformBendingEnergyPenaltyTerm<TFixedImage, TScalarType>::GetValueAndDerivativeSingleThreaded(
   const ParametersType & parameters,
@@ -325,7 +325,7 @@ TransformBendingEnergyPenaltyTerm<TFixedImage, TScalarType>::GetValueAndDerivati
  * ******************* GetValueAndDerivative *******************
  */
 
-template <class TFixedImage, class TScalarType>
+template <typename TFixedImage, typename TScalarType>
 void
 TransformBendingEnergyPenaltyTerm<TFixedImage, TScalarType>::GetValueAndDerivative(const ParametersType & parameters,
                                                                                    MeasureType &          value,
@@ -365,7 +365,7 @@ TransformBendingEnergyPenaltyTerm<TFixedImage, TScalarType>::GetValueAndDerivati
  * ******************* ThreadedGetValueAndDerivative *******************
  */
 
-template <class TFixedImage, class TScalarType>
+template <typename TFixedImage, typename TScalarType>
 void
 TransformBendingEnergyPenaltyTerm<TFixedImage, TScalarType>::ThreadedGetValueAndDerivative(ThreadIdType threadId) const
 {
@@ -533,7 +533,7 @@ TransformBendingEnergyPenaltyTerm<TFixedImage, TScalarType>::ThreadedGetValueAnd
  * ******************* AfterThreadedGetValueAndDerivative *******************
  */
 
-template <class TFixedImage, class TScalarType>
+template <typename TFixedImage, typename TScalarType>
 void
 TransformBendingEnergyPenaltyTerm<TFixedImage, TScalarType>::AfterThreadedGetValueAndDerivative(
   MeasureType &    value,

--- a/Components/Metrics/CorrespondingPointsEuclideanDistanceMetric/elxCorrespondingPointsEuclideanDistanceMetric.h
+++ b/Components/Metrics/CorrespondingPointsEuclideanDistanceMetric/elxCorrespondingPointsEuclideanDistanceMetric.h
@@ -36,7 +36,7 @@ namespace elastix
  *
  */
 
-template <class TElastix>
+template <typename TElastix>
 class ITK_TEMPLATE_EXPORT CorrespondingPointsEuclideanDistanceMetric
   : public itk::CorrespondingPointsEuclideanDistancePointMetric<typename MetricBase<TElastix>::FixedPointSetType,
                                                                 typename MetricBase<TElastix>::MovingPointSetType>

--- a/Components/Metrics/CorrespondingPointsEuclideanDistanceMetric/elxCorrespondingPointsEuclideanDistanceMetric.hxx
+++ b/Components/Metrics/CorrespondingPointsEuclideanDistanceMetric/elxCorrespondingPointsEuclideanDistanceMetric.hxx
@@ -31,7 +31,7 @@ namespace elastix
  * ******************* Initialize ***********************
  */
 
-template <class TElastix>
+template <typename TElastix>
 void
 CorrespondingPointsEuclideanDistanceMetric<TElastix>::Initialize()
 {
@@ -49,7 +49,7 @@ CorrespondingPointsEuclideanDistanceMetric<TElastix>::Initialize()
  * ***************** BeforeAllBase ***********************
  */
 
-template <class TElastix>
+template <typename TElastix>
 int
 CorrespondingPointsEuclideanDistanceMetric<TElastix>::BeforeAllBase()
 {
@@ -109,7 +109,7 @@ CorrespondingPointsEuclideanDistanceMetric<TElastix>::BeforeAllBase()
  * ***************** BeforeRegistration ***********************
  */
 
-template <class TElastix>
+template <typename TElastix>
 void
 CorrespondingPointsEuclideanDistanceMetric<TElastix>::BeforeRegistration()
 {
@@ -144,7 +144,7 @@ CorrespondingPointsEuclideanDistanceMetric<TElastix>::BeforeRegistration()
  * ***************** ReadLandmarks ***********************
  */
 
-template <class TElastix>
+template <typename TElastix>
 unsigned int
 CorrespondingPointsEuclideanDistanceMetric<TElastix>::ReadLandmarks(const std::string &              landmarkFileName,
                                                                     typename PointSetType::Pointer & pointSet,

--- a/Components/Metrics/CorrespondingPointsEuclideanDistanceMetric/itkCorrespondingPointsEuclideanDistancePointMetric.h
+++ b/Components/Metrics/CorrespondingPointsEuclideanDistanceMetric/itkCorrespondingPointsEuclideanDistancePointMetric.h
@@ -35,7 +35,7 @@ namespace itk
  * \ingroup RegistrationMetrics
  */
 
-template <class TFixedPointSet, class TMovingPointSet>
+template <typename TFixedPointSet, typename TMovingPointSet>
 class ITK_TEMPLATE_EXPORT CorrespondingPointsEuclideanDistancePointMetric
   : public SingleValuedPointSetToPointSetMetric<TFixedPointSet, TMovingPointSet>
 {

--- a/Components/Metrics/CorrespondingPointsEuclideanDistanceMetric/itkCorrespondingPointsEuclideanDistancePointMetric.hxx
+++ b/Components/Metrics/CorrespondingPointsEuclideanDistanceMetric/itkCorrespondingPointsEuclideanDistancePointMetric.hxx
@@ -27,7 +27,7 @@ namespace itk
  * ******************* GetValue *******************
  */
 
-template <class TFixedPointSet, class TMovingPointSet>
+template <typename TFixedPointSet, typename TMovingPointSet>
 auto
 CorrespondingPointsEuclideanDistancePointMetric<TFixedPointSet, TMovingPointSet>::GetValue(
   const TransformParametersType & parameters) const -> MeasureType
@@ -104,7 +104,7 @@ CorrespondingPointsEuclideanDistancePointMetric<TFixedPointSet, TMovingPointSet>
  * ******************* GetDerivative *******************
  */
 
-template <class TFixedPointSet, class TMovingPointSet>
+template <typename TFixedPointSet, typename TMovingPointSet>
 void
 CorrespondingPointsEuclideanDistancePointMetric<TFixedPointSet, TMovingPointSet>::GetDerivative(
   const TransformParametersType & parameters,
@@ -125,7 +125,7 @@ CorrespondingPointsEuclideanDistancePointMetric<TFixedPointSet, TMovingPointSet>
  * ******************* GetValueAndDerivative *******************
  */
 
-template <class TFixedPointSet, class TMovingPointSet>
+template <typename TFixedPointSet, typename TMovingPointSet>
 void
 CorrespondingPointsEuclideanDistancePointMetric<TFixedPointSet, TMovingPointSet>::GetValueAndDerivative(
   const TransformParametersType & parameters,

--- a/Components/Metrics/DisplacementMagnitudePenalty/elxDisplacementMagnitudePenalty.h
+++ b/Components/Metrics/DisplacementMagnitudePenalty/elxDisplacementMagnitudePenalty.h
@@ -41,7 +41,7 @@ namespace elastix
  * \sa DisplacementEnergyPenaltyTerm
  */
 
-template <class TElastix>
+template <typename TElastix>
 class ITK_TEMPLATE_EXPORT DisplacementMagnitudePenalty
   : public itk::DisplacementMagnitudePenaltyTerm<typename MetricBase<TElastix>::FixedImageType, double>
   , public MetricBase<TElastix>

--- a/Components/Metrics/DisplacementMagnitudePenalty/elxDisplacementMagnitudePenalty.hxx
+++ b/Components/Metrics/DisplacementMagnitudePenalty/elxDisplacementMagnitudePenalty.hxx
@@ -28,7 +28,7 @@ namespace elastix
  * ******************* Initialize ***********************
  */
 
-template <class TElastix>
+template <typename TElastix>
 void
 DisplacementMagnitudePenalty<TElastix>::Initialize()
 {

--- a/Components/Metrics/DisplacementMagnitudePenalty/itkDisplacementMagnitudePenaltyTerm.h
+++ b/Components/Metrics/DisplacementMagnitudePenalty/itkDisplacementMagnitudePenaltyTerm.h
@@ -30,7 +30,7 @@ namespace itk
  * \ingroup Metrics
  */
 
-template <class TFixedImage, class TScalarType>
+template <typename TFixedImage, typename TScalarType>
 class ITK_TEMPLATE_EXPORT DisplacementMagnitudePenaltyTerm : public TransformPenaltyTerm<TFixedImage, TScalarType>
 {
 public:

--- a/Components/Metrics/DisplacementMagnitudePenalty/itkDisplacementMagnitudePenaltyTerm.hxx
+++ b/Components/Metrics/DisplacementMagnitudePenalty/itkDisplacementMagnitudePenaltyTerm.hxx
@@ -28,7 +28,7 @@ namespace itk
  * ****************** Constructor *******************************
  */
 
-template <class TFixedImage, class TScalarType>
+template <typename TFixedImage, typename TScalarType>
 DisplacementMagnitudePenaltyTerm<TFixedImage, TScalarType>::DisplacementMagnitudePenaltyTerm()
 {
   /** Initialize member variables. */
@@ -43,7 +43,7 @@ DisplacementMagnitudePenaltyTerm<TFixedImage, TScalarType>::DisplacementMagnitud
  * ****************** PrintSelf *******************************
  *
 
-template< class TFixedImage, class TScalarType >
+template< class TFixedImage, typename TScalarType >
 void
 DisplacementMagnitudePenaltyTerm< TFixedImage, TScalarType >
 ::PrintSelf( std::ostream & os, Indent indent ) const
@@ -60,7 +60,7 @@ DisplacementMagnitudePenaltyTerm< TFixedImage, TScalarType >
  * ****************** GetValue *******************************
  */
 
-template <class TFixedImage, class TScalarType>
+template <typename TFixedImage, typename TScalarType>
 auto
 DisplacementMagnitudePenaltyTerm<TFixedImage, TScalarType>::GetValue(const ParametersType & parameters) const
   -> MeasureType
@@ -119,7 +119,7 @@ DisplacementMagnitudePenaltyTerm<TFixedImage, TScalarType>::GetValue(const Param
  * ******************* GetDerivative *******************
  */
 
-template <class TFixedImage, class TScalarType>
+template <typename TFixedImage, typename TScalarType>
 void
 DisplacementMagnitudePenaltyTerm<TFixedImage, TScalarType>::GetDerivative(const ParametersType & parameters,
                                                                           DerivativeType &       derivative) const
@@ -135,7 +135,7 @@ DisplacementMagnitudePenaltyTerm<TFixedImage, TScalarType>::GetDerivative(const 
  * ****************** GetValueAndDerivative *******************************
  */
 
-template <class TFixedImage, class TScalarType>
+template <typename TFixedImage, typename TScalarType>
 void
 DisplacementMagnitudePenaltyTerm<TFixedImage, TScalarType>::GetValueAndDerivative(const ParametersType & parameters,
                                                                                   MeasureType &          value,

--- a/Components/Metrics/DistancePreservingRigidityPenalty/elxDistancePreservingRigidityPenaltyTerm.h
+++ b/Components/Metrics/DistancePreservingRigidityPenalty/elxDistancePreservingRigidityPenaltyTerm.h
@@ -60,7 +60,7 @@ namespace elastix
  *
  */
 
-template <class TElastix>
+template <typename TElastix>
 class ITK_TEMPLATE_EXPORT DistancePreservingRigidityPenalty
   : public itk::DistancePreservingRigidityPenaltyTerm<typename MetricBase<TElastix>::FixedImageType, double>
   , public MetricBase<TElastix>

--- a/Components/Metrics/DistancePreservingRigidityPenalty/elxDistancePreservingRigidityPenaltyTerm.hxx
+++ b/Components/Metrics/DistancePreservingRigidityPenalty/elxDistancePreservingRigidityPenaltyTerm.hxx
@@ -31,7 +31,7 @@ namespace elastix
  * ******************* BeforeRegistration ***********************
  */
 
-template <class TElastix>
+template <typename TElastix>
 void
 DistancePreservingRigidityPenalty<TElastix>::BeforeRegistration()
 {
@@ -117,7 +117,7 @@ DistancePreservingRigidityPenalty<TElastix>::BeforeRegistration()
  * ******************* Initialize ***********************
  */
 
-template <class TElastix>
+template <typename TElastix>
 void
 DistancePreservingRigidityPenalty<TElastix>::Initialize()
 {

--- a/Components/Metrics/DistancePreservingRigidityPenalty/itkDistancePreservingRigidityPenaltyTerm.h
+++ b/Components/Metrics/DistancePreservingRigidityPenalty/itkDistancePreservingRigidityPenaltyTerm.h
@@ -72,7 +72,7 @@ namespace itk
  *
  */
 
-template <class TFixedImage, class TScalarType>
+template <typename TFixedImage, typename TScalarType>
 class ITK_TEMPLATE_EXPORT DistancePreservingRigidityPenaltyTerm : public TransformPenaltyTerm<TFixedImage, TScalarType>
 {
 public:

--- a/Components/Metrics/DistancePreservingRigidityPenalty/itkDistancePreservingRigidityPenaltyTerm.hxx
+++ b/Components/Metrics/DistancePreservingRigidityPenalty/itkDistancePreservingRigidityPenaltyTerm.hxx
@@ -30,7 +30,7 @@ namespace itk
  * ****************** Constructor *******************************
  */
 
-template <class TFixedImage, class TScalarType>
+template <typename TFixedImage, typename TScalarType>
 DistancePreservingRigidityPenaltyTerm<TFixedImage, TScalarType>::DistancePreservingRigidityPenaltyTerm()
 {
   /** Values. */
@@ -54,7 +54,7 @@ DistancePreservingRigidityPenaltyTerm<TFixedImage, TScalarType>::DistancePreserv
 /**
  * *********************** Initialize *****************************
  */
-template <class TFixedImage, class TScalarType>
+template <typename TFixedImage, typename TScalarType>
 void
 DistancePreservingRigidityPenaltyTerm<TFixedImage, TScalarType>::Initialize()
 {
@@ -155,7 +155,7 @@ DistancePreservingRigidityPenaltyTerm<TFixedImage, TScalarType>::Initialize()
  * *********************** GetValue *****************************
  */
 
-template <class TFixedImage, class TScalarType>
+template <typename TFixedImage, typename TScalarType>
 auto
 DistancePreservingRigidityPenaltyTerm<TFixedImage, TScalarType>::GetValue(const ParametersType & parameters) const
   -> MeasureType
@@ -273,7 +273,7 @@ DistancePreservingRigidityPenaltyTerm<TFixedImage, TScalarType>::GetValue(const 
  * *********************** GetDerivative ************************
  */
 
-template <class TFixedImage, class TScalarType>
+template <typename TFixedImage, typename TScalarType>
 void
 DistancePreservingRigidityPenaltyTerm<TFixedImage, TScalarType>::GetDerivative(const ParametersType & parameters,
                                                                                DerivativeType &       derivative) const
@@ -287,7 +287,7 @@ DistancePreservingRigidityPenaltyTerm<TFixedImage, TScalarType>::GetDerivative(c
  * *********************** GetValueAndDerivative ****************
  */
 
-template <class TFixedImage, class TScalarType>
+template <typename TFixedImage, typename TScalarType>
 void
 DistancePreservingRigidityPenaltyTerm<TFixedImage, TScalarType>::GetValueAndDerivative(
   const ParametersType & parameters,
@@ -503,7 +503,7 @@ DistancePreservingRigidityPenaltyTerm<TFixedImage, TScalarType>::GetValueAndDeri
  * ********************* PrintSelf ******************************
  */
 
-template <class TFixedImage, class TScalarType>
+template <typename TFixedImage, typename TScalarType>
 void
 DistancePreservingRigidityPenaltyTerm<TFixedImage, TScalarType>::PrintSelf(std::ostream & os, Indent indent) const
 {

--- a/Components/Metrics/GradientDifference/elxGradientDifferenceMetric.h
+++ b/Components/Metrics/GradientDifference/elxGradientDifferenceMetric.h
@@ -33,7 +33,7 @@ namespace elastix
  *
  */
 
-template <class TElastix>
+template <typename TElastix>
 class ITK_TEMPLATE_EXPORT GradientDifferenceMetric
   : public itk::GradientDifferenceImageToImageMetric<typename MetricBase<TElastix>::FixedImageType,
                                                      typename MetricBase<TElastix>::MovingImageType>

--- a/Components/Metrics/GradientDifference/elxGradientDifferenceMetric.hxx
+++ b/Components/Metrics/GradientDifference/elxGradientDifferenceMetric.hxx
@@ -28,7 +28,7 @@ namespace elastix
  * ******************* Initialize ***********************
  */
 
-template <class TElastix>
+template <typename TElastix>
 void
 GradientDifferenceMetric<TElastix>::Initialize()
 {
@@ -46,7 +46,7 @@ GradientDifferenceMetric<TElastix>::Initialize()
  * ***************** BeforeRegistration ***********************
  */
 
-template <class TElastix>
+template <typename TElastix>
 void
 GradientDifferenceMetric<TElastix>::BeforeRegistration()
 {
@@ -70,7 +70,7 @@ GradientDifferenceMetric<TElastix>::BeforeRegistration()
  * ***************** BeforeEachResolution ***********************
  */
 
-template <class TElastix>
+template <typename TElastix>
 void
 GradientDifferenceMetric<TElastix>::BeforeEachResolution()
 {

--- a/Components/Metrics/GradientDifference/itkGradientDifferenceImageToImageMetric2.h
+++ b/Components/Metrics/GradientDifference/itkGradientDifferenceImageToImageMetric2.h
@@ -70,7 +70,7 @@ namespace itk
  *
  * \ingroup RegistrationMetrics
  */
-template <class TFixedImage, class TMovingImage>
+template <typename TFixedImage, typename TMovingImage>
 class ITK_TEMPLATE_EXPORT GradientDifferenceImageToImageMetric
   : public AdvancedImageToImageMetric<TFixedImage, TMovingImage>
 {

--- a/Components/Metrics/GradientDifference/itkGradientDifferenceImageToImageMetric2.hxx
+++ b/Components/Metrics/GradientDifference/itkGradientDifferenceImageToImageMetric2.hxx
@@ -52,7 +52,7 @@ namespace itk
  * ********************* Initialize ******************************
  */
 
-template <class TFixedImage, class TMovingImage>
+template <typename TFixedImage, typename TMovingImage>
 void
 GradientDifferenceImageToImageMetric<TFixedImage, TMovingImage>::Initialize()
 {
@@ -128,7 +128,7 @@ GradientDifferenceImageToImageMetric<TFixedImage, TMovingImage>::Initialize()
  * ********************* PrintSelf ******************************
  */
 
-template <class TFixedImage, class TMovingImage>
+template <typename TFixedImage, typename TMovingImage>
 void
 GradientDifferenceImageToImageMetric<TFixedImage, TMovingImage>::PrintSelf(std::ostream & os, Indent indent) const
 {
@@ -141,7 +141,7 @@ GradientDifferenceImageToImageMetric<TFixedImage, TMovingImage>::PrintSelf(std::
  * ******************** ComputeMovedGradientRange ******************************
  */
 
-template <class TFixedImage, class TMovingImage>
+template <typename TFixedImage, typename TMovingImage>
 void
 GradientDifferenceImageToImageMetric<TFixedImage, TMovingImage>::ComputeMovedGradientRange() const
 {
@@ -181,7 +181,7 @@ GradientDifferenceImageToImageMetric<TFixedImage, TMovingImage>::ComputeMovedGra
 /**
  * ******************** ComputeVariance ******************************
  */
-template <class TFixedImage, class TMovingImage>
+template <typename TFixedImage, typename TMovingImage>
 void
 GradientDifferenceImageToImageMetric<TFixedImage, TMovingImage>::ComputeVariance() const
 {
@@ -301,7 +301,7 @@ GradientDifferenceImageToImageMetric<TFixedImage, TMovingImage>::ComputeVariance
  * ******************** ComputeMeasure ******************************
  */
 
-template <class TFixedImage, class TMovingImage>
+template <typename TFixedImage, typename TMovingImage>
 auto
 GradientDifferenceImageToImageMetric<TFixedImage, TMovingImage>::ComputeMeasure(
   const TransformParametersType & parameters,
@@ -409,7 +409,7 @@ GradientDifferenceImageToImageMetric<TFixedImage, TMovingImage>::ComputeMeasure(
  * ******************** GetValue ******************************
  */
 
-template <class TFixedImage, class TMovingImage>
+template <typename TFixedImage, typename TMovingImage>
 auto
 GradientDifferenceImageToImageMetric<TFixedImage, TMovingImage>::GetValue(
   const TransformParametersType & parameters) const -> MeasureType
@@ -448,7 +448,7 @@ GradientDifferenceImageToImageMetric<TFixedImage, TMovingImage>::GetValue(
  * ******************** GetDerivative ******************************
  */
 
-template <class TFixedImage, class TMovingImage>
+template <typename TFixedImage, typename TMovingImage>
 void
 GradientDifferenceImageToImageMetric<TFixedImage, TMovingImage>::GetDerivative(
   const TransformParametersType & parameters,
@@ -476,7 +476,7 @@ GradientDifferenceImageToImageMetric<TFixedImage, TMovingImage>::GetDerivative(
  * ******************** GetValueAndDerivative ******************************
  */
 
-template <class TFixedImage, class TMovingImage>
+template <typename TFixedImage, typename TMovingImage>
 void
 GradientDifferenceImageToImageMetric<TFixedImage, TMovingImage>::GetValueAndDerivative(
   const TransformParametersType & parameters,

--- a/Components/Metrics/KNNGraphAlphaMutualInformation/KNN/itkANNBruteForceTree.h
+++ b/Components/Metrics/KNNGraphAlphaMutualInformation/KNN/itkANNBruteForceTree.h
@@ -32,7 +32,7 @@ namespace itk
  * \ingroup ANNwrap
  */
 
-template <class TListSample>
+template <typename TListSample>
 class ITK_TEMPLATE_EXPORT ANNBruteForceTree : public BinaryANNTreeBase<TListSample>
 {
 public:

--- a/Components/Metrics/KNNGraphAlphaMutualInformation/KNN/itkANNBruteForceTree.hxx
+++ b/Components/Metrics/KNNGraphAlphaMutualInformation/KNN/itkANNBruteForceTree.hxx
@@ -28,7 +28,7 @@ namespace itk
  * ************************ Constructor *************************
  */
 
-template <class TListSample>
+template <typename TListSample>
 ANNBruteForceTree<TListSample>::ANNBruteForceTree()
 {
   this->m_ANNTree = nullptr;
@@ -39,7 +39,7 @@ ANNBruteForceTree<TListSample>::ANNBruteForceTree()
  * ************************ Destructor *************************
  */
 
-template <class TListSample>
+template <typename TListSample>
 ANNBruteForceTree<TListSample>::~ANNBruteForceTree()
 {
   ANNBinaryTreeCreator::DeleteANNBruteForceTree(this->m_ANNTree);
@@ -50,7 +50,7 @@ ANNBruteForceTree<TListSample>::~ANNBruteForceTree()
  * ************************ GenerateTree *************************
  */
 
-template <class TListSample>
+template <typename TListSample>
 void
 ANNBruteForceTree<TListSample>::GenerateTree()
 {

--- a/Components/Metrics/KNNGraphAlphaMutualInformation/KNN/itkANNFixedRadiusTreeSearch.h
+++ b/Components/Metrics/KNNGraphAlphaMutualInformation/KNN/itkANNFixedRadiusTreeSearch.h
@@ -32,7 +32,7 @@ namespace itk
  * \ingroup ANNwrap
  */
 
-template <class TListSample>
+template <typename TListSample>
 class ITK_TEMPLATE_EXPORT ANNFixedRadiusTreeSearch : public BinaryANNTreeSearchBase<TListSample>
 {
 public:

--- a/Components/Metrics/KNNGraphAlphaMutualInformation/KNN/itkANNFixedRadiusTreeSearch.hxx
+++ b/Components/Metrics/KNNGraphAlphaMutualInformation/KNN/itkANNFixedRadiusTreeSearch.hxx
@@ -27,7 +27,7 @@ namespace itk
  * ************************ Constructor *************************
  */
 
-template <class TBinaryTree>
+template <typename TBinaryTree>
 ANNFixedRadiusTreeSearch<TBinaryTree>::ANNFixedRadiusTreeSearch()
 {
   this->m_ErrorBound = 0.0;
@@ -39,7 +39,7 @@ ANNFixedRadiusTreeSearch<TBinaryTree>::ANNFixedRadiusTreeSearch()
  * ************************ Search *************************
  */
 
-template <class TBinaryTree>
+template <typename TBinaryTree>
 void
 ANNFixedRadiusTreeSearch<TBinaryTree>::Search(const MeasurementVectorType & qp,
                                               IndexArrayType &              ind,
@@ -88,7 +88,7 @@ ANNFixedRadiusTreeSearch<TBinaryTree>::Search(const MeasurementVectorType & qp,
  * ************************ Search *************************
  */
 
-template <class TBinaryTree>
+template <typename TBinaryTree>
 void
 ANNFixedRadiusTreeSearch<TBinaryTree>::Search(const MeasurementVectorType & qp,
                                               IndexArrayType &              ind,

--- a/Components/Metrics/KNNGraphAlphaMutualInformation/KNN/itkANNPriorityTreeSearch.h
+++ b/Components/Metrics/KNNGraphAlphaMutualInformation/KNN/itkANNPriorityTreeSearch.h
@@ -32,7 +32,7 @@ namespace itk
  * \ingroup ANNwrap
  */
 
-template <class TListSample>
+template <typename TListSample>
 class ITK_TEMPLATE_EXPORT ANNPriorityTreeSearch : public BinaryANNTreeSearchBase<TListSample>
 {
 public:

--- a/Components/Metrics/KNNGraphAlphaMutualInformation/KNN/itkANNPriorityTreeSearch.hxx
+++ b/Components/Metrics/KNNGraphAlphaMutualInformation/KNN/itkANNPriorityTreeSearch.hxx
@@ -27,7 +27,7 @@ namespace itk
  * ************************ Constructor *************************
  */
 
-template <class TBinaryTree>
+template <typename TBinaryTree>
 ANNPriorityTreeSearch<TBinaryTree>::ANNPriorityTreeSearch()
 {
   this->m_ErrorBound = 0.0;
@@ -40,7 +40,7 @@ ANNPriorityTreeSearch<TBinaryTree>::ANNPriorityTreeSearch()
  *
  */
 
-template <class TBinaryTree>
+template <typename TBinaryTree>
 void
 ANNPriorityTreeSearch<TBinaryTree>::SetBinaryTree(BinaryTreeType * tree)
 {
@@ -84,7 +84,7 @@ ANNPriorityTreeSearch<TBinaryTree>::SetBinaryTree(BinaryTreeType * tree)
  * The error bound eps is ignored.
  */
 
-template <class TBinaryTree>
+template <typename TBinaryTree>
 void
 ANNPriorityTreeSearch<TBinaryTree>::Search(const MeasurementVectorType & qp,
                                            IndexArrayType &              ind,

--- a/Components/Metrics/KNNGraphAlphaMutualInformation/KNN/itkANNStandardTreeSearch.h
+++ b/Components/Metrics/KNNGraphAlphaMutualInformation/KNN/itkANNStandardTreeSearch.h
@@ -32,7 +32,7 @@ namespace itk
  * \ingroup ANNwrap
  */
 
-template <class TListSample>
+template <typename TListSample>
 class ITK_TEMPLATE_EXPORT ANNStandardTreeSearch : public BinaryANNTreeSearchBase<TListSample>
 {
 public:

--- a/Components/Metrics/KNNGraphAlphaMutualInformation/KNN/itkANNStandardTreeSearch.hxx
+++ b/Components/Metrics/KNNGraphAlphaMutualInformation/KNN/itkANNStandardTreeSearch.hxx
@@ -27,7 +27,7 @@ namespace itk
  * ************************ Constructor *************************
  */
 
-template <class TBinaryTree>
+template <typename TBinaryTree>
 ANNStandardTreeSearch<TBinaryTree>::ANNStandardTreeSearch()
 {
   this->m_ErrorBound = 0.0;
@@ -38,7 +38,7 @@ ANNStandardTreeSearch<TBinaryTree>::ANNStandardTreeSearch()
  * ************************ Search *************************
  */
 
-template <class TBinaryTree>
+template <typename TBinaryTree>
 void
 ANNStandardTreeSearch<TBinaryTree>::Search(const MeasurementVectorType & qp,
                                            IndexArrayType &              ind,

--- a/Components/Metrics/KNNGraphAlphaMutualInformation/KNN/itkANNbdTree.h
+++ b/Components/Metrics/KNNGraphAlphaMutualInformation/KNN/itkANNbdTree.h
@@ -32,7 +32,7 @@ namespace itk
  * \ingroup ANNwrap
  */
 
-template <class TListSample>
+template <typename TListSample>
 class ITK_TEMPLATE_EXPORT ANNbdTree : public ANNkDTree<TListSample>
 {
 public:

--- a/Components/Metrics/KNNGraphAlphaMutualInformation/KNN/itkANNbdTree.hxx
+++ b/Components/Metrics/KNNGraphAlphaMutualInformation/KNN/itkANNbdTree.hxx
@@ -27,7 +27,7 @@ namespace itk
  * ************************ Constructor *************************
  */
 
-template <class TListSample>
+template <typename TListSample>
 ANNbdTree<TListSample>::ANNbdTree()
 {
   this->m_ShrinkingRule = ANN_BD_SIMPLE;
@@ -39,7 +39,7 @@ ANNbdTree<TListSample>::ANNbdTree()
  * ************************ SetShrinkingRule *************************
  */
 
-template <class TListSample>
+template <typename TListSample>
 void
 ANNbdTree<TListSample>::SetShrinkingRule(const std::string & rule)
 {
@@ -71,7 +71,7 @@ ANNbdTree<TListSample>::SetShrinkingRule(const std::string & rule)
  * ************************ GetShrinkingRule *************************
  */
 
-template <class TListSample>
+template <typename TListSample>
 std::string
 ANNbdTree<TListSample>::GetShrinkingRule()
 {
@@ -94,7 +94,7 @@ ANNbdTree<TListSample>::GetShrinkingRule()
  * ************************ GenerateTree *************************
  */
 
-template <class TListSample>
+template <typename TListSample>
 void
 ANNbdTree<TListSample>::GenerateTree()
 {
@@ -114,7 +114,7 @@ ANNbdTree<TListSample>::GenerateTree()
  * ************************ PrintSelf *************************
  */
 
-template <class TListSample>
+template <typename TListSample>
 void
 ANNbdTree<TListSample>::PrintSelf(std::ostream & os, Indent indent) const
 {

--- a/Components/Metrics/KNNGraphAlphaMutualInformation/KNN/itkANNkDTree.h
+++ b/Components/Metrics/KNNGraphAlphaMutualInformation/KNN/itkANNkDTree.h
@@ -32,7 +32,7 @@ namespace itk
  * \ingroup ANNwrap
  */
 
-template <class TListSample>
+template <typename TListSample>
 class ITK_TEMPLATE_EXPORT ANNkDTree : public BinaryANNTreeBase<TListSample>
 {
 public:

--- a/Components/Metrics/KNNGraphAlphaMutualInformation/KNN/itkANNkDTree.hxx
+++ b/Components/Metrics/KNNGraphAlphaMutualInformation/KNN/itkANNkDTree.hxx
@@ -28,7 +28,7 @@ namespace itk
  * ************************ Constructor *************************
  */
 
-template <class TListSample>
+template <typename TListSample>
 ANNkDTree<TListSample>::ANNkDTree()
 {
   this->m_ANNTree = nullptr;
@@ -42,7 +42,7 @@ ANNkDTree<TListSample>::ANNkDTree()
  * ************************ Destructor *************************
  */
 
-template <class TListSample>
+template <typename TListSample>
 ANNkDTree<TListSample>::~ANNkDTree()
 {
   ANNBinaryTreeCreator::DeleteANNkDTree(this->m_ANNTree);
@@ -54,7 +54,7 @@ ANNkDTree<TListSample>::~ANNkDTree()
  * ************************ SetSplittingRule *************************
  */
 
-template <class TListSample>
+template <typename TListSample>
 void
 ANNkDTree<TListSample>::SetSplittingRule(const std::string & rule)
 {
@@ -94,7 +94,7 @@ ANNkDTree<TListSample>::SetSplittingRule(const std::string & rule)
  * ************************ GetSplittingRule *************************
  */
 
-template <class TListSample>
+template <typename TListSample>
 std::string
 ANNkDTree<TListSample>::GetSplittingRule()
 {
@@ -121,7 +121,7 @@ ANNkDTree<TListSample>::GetSplittingRule()
  * ************************ GenerateTree *************************
  */
 
-template <class TListSample>
+template <typename TListSample>
 void
 ANNkDTree<TListSample>::GenerateTree()
 {
@@ -141,7 +141,7 @@ ANNkDTree<TListSample>::GenerateTree()
  * ************************ PrintSelf *************************
  */
 
-template <class TListSample>
+template <typename TListSample>
 void
 ANNkDTree<TListSample>::PrintSelf(std::ostream & os, Indent indent) const
 {

--- a/Components/Metrics/KNNGraphAlphaMutualInformation/KNN/itkBinaryANNTreeBase.h
+++ b/Components/Metrics/KNNGraphAlphaMutualInformation/KNN/itkBinaryANNTreeBase.h
@@ -33,7 +33,7 @@ namespace itk
  * \ingroup ANNwrap
  */
 
-template <class TListSample>
+template <typename TListSample>
 class ITK_TEMPLATE_EXPORT BinaryANNTreeBase : public BinaryTreeBase<TListSample>
 {
 public:

--- a/Components/Metrics/KNNGraphAlphaMutualInformation/KNN/itkBinaryANNTreeSearchBase.h
+++ b/Components/Metrics/KNNGraphAlphaMutualInformation/KNN/itkBinaryANNTreeSearchBase.h
@@ -34,7 +34,7 @@ namespace itk
  * \ingroup ANNwrap
  */
 
-template <class TListSample>
+template <typename TListSample>
 class ITK_TEMPLATE_EXPORT BinaryANNTreeSearchBase : public BinaryTreeSearchBase<TListSample>
 {
 public:

--- a/Components/Metrics/KNNGraphAlphaMutualInformation/KNN/itkBinaryANNTreeSearchBase.hxx
+++ b/Components/Metrics/KNNGraphAlphaMutualInformation/KNN/itkBinaryANNTreeSearchBase.hxx
@@ -27,7 +27,7 @@ namespace itk
  * ************************ Constructor *************************
  */
 
-template <class TBinaryTree>
+template <typename TBinaryTree>
 BinaryANNTreeSearchBase<TBinaryTree>::BinaryANNTreeSearchBase()
 {
   this->m_BinaryTreeAsITKANNType = nullptr;
@@ -38,7 +38,7 @@ BinaryANNTreeSearchBase<TBinaryTree>::BinaryANNTreeSearchBase()
  * ************************ SetBinaryTree *************************
  */
 
-template <class TBinaryTree>
+template <typename TBinaryTree>
 void
 BinaryANNTreeSearchBase<TBinaryTree>::SetBinaryTree(BinaryTreeType * tree)
 {

--- a/Components/Metrics/KNNGraphAlphaMutualInformation/KNN/itkBinaryTreeBase.h
+++ b/Components/Metrics/KNNGraphAlphaMutualInformation/KNN/itkBinaryTreeBase.h
@@ -32,7 +32,7 @@ namespace itk
  * \ingroup ANNwrap
  */
 
-template <class TListSample>
+template <typename TListSample>
 class ITK_TEMPLATE_EXPORT BinaryTreeBase : public DataObject
 {
 public:

--- a/Components/Metrics/KNNGraphAlphaMutualInformation/KNN/itkBinaryTreeBase.hxx
+++ b/Components/Metrics/KNNGraphAlphaMutualInformation/KNN/itkBinaryTreeBase.hxx
@@ -27,7 +27,7 @@ namespace itk
  * ************************ Constructor *************************
  */
 
-template <class TListSample>
+template <typename TListSample>
 BinaryTreeBase<TListSample>::BinaryTreeBase()
 {
   this->m_Sample = nullptr;
@@ -38,7 +38,7 @@ BinaryTreeBase<TListSample>::BinaryTreeBase()
  * ************************ GetNumberOfDataPoints *************************
  */
 
-template <class TListSample>
+template <typename TListSample>
 auto
 BinaryTreeBase<TListSample>::GetNumberOfDataPoints() const -> TotalAbsoluteFrequencyType
 {
@@ -55,7 +55,7 @@ BinaryTreeBase<TListSample>::GetNumberOfDataPoints() const -> TotalAbsoluteFrequ
  * ************************ GetActualNumberOfDataPoints *************************
  */
 
-template <class TListSample>
+template <typename TListSample>
 auto
 BinaryTreeBase<TListSample>::GetActualNumberOfDataPoints() const -> TotalAbsoluteFrequencyType
 {
@@ -72,7 +72,7 @@ BinaryTreeBase<TListSample>::GetActualNumberOfDataPoints() const -> TotalAbsolut
  * ************************ GetDataDimension *************************
  */
 
-template <class TListSample>
+template <typename TListSample>
 auto
 BinaryTreeBase<TListSample>::GetDataDimension() const -> MeasurementVectorSizeType
 {
@@ -89,7 +89,7 @@ BinaryTreeBase<TListSample>::GetDataDimension() const -> MeasurementVectorSizeTy
  * ****************** PrintSelf ******************
  */
 
-template <class TListSample>
+template <typename TListSample>
 void
 BinaryTreeBase<TListSample>::PrintSelf(std::ostream & os, Indent indent) const
 {

--- a/Components/Metrics/KNNGraphAlphaMutualInformation/KNN/itkBinaryTreeSearchBase.h
+++ b/Components/Metrics/KNNGraphAlphaMutualInformation/KNN/itkBinaryTreeSearchBase.h
@@ -35,7 +35,7 @@ namespace itk
  * \ingroup ANNwrap
  */
 
-template <class TListSample>
+template <typename TListSample>
 class ITK_TEMPLATE_EXPORT BinaryTreeSearchBase : public Object
 {
 public:

--- a/Components/Metrics/KNNGraphAlphaMutualInformation/KNN/itkBinaryTreeSearchBase.hxx
+++ b/Components/Metrics/KNNGraphAlphaMutualInformation/KNN/itkBinaryTreeSearchBase.hxx
@@ -27,7 +27,7 @@ namespace itk
  * ************************ Constructor *************************
  */
 
-template <class TBinaryTree>
+template <typename TBinaryTree>
 BinaryTreeSearchBase<TBinaryTree>::BinaryTreeSearchBase()
 {
   this->m_BinaryTree = nullptr;
@@ -39,7 +39,7 @@ BinaryTreeSearchBase<TBinaryTree>::BinaryTreeSearchBase()
  * ************************ SetBinaryTree *************************
  */
 
-template <class TBinaryTree>
+template <typename TBinaryTree>
 void
 BinaryTreeSearchBase<TBinaryTree>::SetBinaryTree(BinaryTreeType * tree)
 {
@@ -59,7 +59,7 @@ BinaryTreeSearchBase<TBinaryTree>::SetBinaryTree(BinaryTreeType * tree)
  * ************************ GetBinaryTree *************************
  */
 
-template <class TBinaryTree>
+template <typename TBinaryTree>
 auto
 BinaryTreeSearchBase<TBinaryTree>::GetBinaryTree() const -> const BinaryTreeType *
 {

--- a/Components/Metrics/KNNGraphAlphaMutualInformation/KNN/itkListSampleCArray.h
+++ b/Components/Metrics/KNNGraphAlphaMutualInformation/KNN/itkListSampleCArray.h
@@ -41,7 +41,7 @@ namespace Statistics
  * \ingroup Miscellaneous
  */
 
-template <class TMeasurementVector, class TInternalValue = typename TMeasurementVector::ValueType>
+template <typename TMeasurementVector, typename TInternalValue = typename TMeasurementVector::ValueType>
 class ITK_TEMPLATE_EXPORT ListSampleCArray : public Sample<TMeasurementVector>
 {
 public:

--- a/Components/Metrics/KNNGraphAlphaMutualInformation/KNN/itkListSampleCArray.hxx
+++ b/Components/Metrics/KNNGraphAlphaMutualInformation/KNN/itkListSampleCArray.hxx
@@ -30,7 +30,7 @@ namespace Statistics
  * ************************ Constructor *************************
  */
 
-template <class TMeasurementVector, class TInternalValue>
+template <typename TMeasurementVector, typename TInternalValue>
 ListSampleCArray<TMeasurementVector, TInternalValue>::ListSampleCArray()
 {
   this->m_InternalContainer = nullptr;
@@ -42,7 +42,7 @@ ListSampleCArray<TMeasurementVector, TInternalValue>::ListSampleCArray()
 /**
  * ************************ Destructor *************************
  */
-template <class TMeasurementVector, class TInternalValue>
+template <typename TMeasurementVector, typename TInternalValue>
 ListSampleCArray<TMeasurementVector, TInternalValue>::~ListSampleCArray()
 {
   this->DeallocateInternalContainer();
@@ -53,7 +53,7 @@ ListSampleCArray<TMeasurementVector, TInternalValue>::~ListSampleCArray()
  * ************************ GetMeasurementVector *************************
  */
 
-template <class TMeasurementVector, class TInternalValue>
+template <typename TMeasurementVector, typename TInternalValue>
 void
 ListSampleCArray<TMeasurementVector, TInternalValue>::GetMeasurementVector(InstanceIdentifier      id,
                                                                            MeasurementVectorType & mv) const
@@ -72,7 +72,7 @@ ListSampleCArray<TMeasurementVector, TInternalValue>::GetMeasurementVector(Insta
  * ************************ GetMeasurementVector *************************
  */
 
-template <class TMeasurementVector, class TInternalValue>
+template <typename TMeasurementVector, typename TInternalValue>
 auto
 ListSampleCArray<TMeasurementVector, TInternalValue>::GetMeasurementVector(InstanceIdentifier id) const
   -> const MeasurementVectorType &
@@ -94,7 +94,7 @@ ListSampleCArray<TMeasurementVector, TInternalValue>::GetMeasurementVector(Insta
  * ************************ SetMeasurement *************************
  */
 
-template <class TMeasurementVector, class TInternalValue>
+template <typename TMeasurementVector, typename TInternalValue>
 void
 ListSampleCArray<TMeasurementVector, TInternalValue>::SetMeasurement(InstanceIdentifier      id,
                                                                      unsigned int            dim,
@@ -111,7 +111,7 @@ ListSampleCArray<TMeasurementVector, TInternalValue>::SetMeasurement(InstanceIde
  * ************************ SetMeasurementVector *************************
  */
 
-template <class TMeasurementVector, class TInternalValue>
+template <typename TMeasurementVector, typename TInternalValue>
 void
 ListSampleCArray<TMeasurementVector, TInternalValue>::SetMeasurementVector(InstanceIdentifier            id,
                                                                            const MeasurementVectorType & mv)
@@ -132,7 +132,7 @@ ListSampleCArray<TMeasurementVector, TInternalValue>::SetMeasurementVector(Insta
  * ************************ Resize *************************
  */
 
-template <class TMeasurementVector, class TInternalValue>
+template <typename TMeasurementVector, typename TInternalValue>
 void
 ListSampleCArray<TMeasurementVector, TInternalValue>::Resize(unsigned long size)
 {
@@ -162,7 +162,7 @@ ListSampleCArray<TMeasurementVector, TInternalValue>::Resize(unsigned long size)
  * ************************ SetActualSize *************************
  */
 
-template <class TMeasurementVector, class TInternalValue>
+template <typename TMeasurementVector, typename TInternalValue>
 void
 ListSampleCArray<TMeasurementVector, TInternalValue>::SetActualSize(unsigned long size)
 {
@@ -178,7 +178,7 @@ ListSampleCArray<TMeasurementVector, TInternalValue>::SetActualSize(unsigned lon
  * ************************ GetActualSize *************************
  */
 
-template <class TMeasurementVector, class TInternalValue>
+template <typename TMeasurementVector, typename TInternalValue>
 unsigned long
 ListSampleCArray<TMeasurementVector, TInternalValue>::GetActualSize()
 {
@@ -190,7 +190,7 @@ ListSampleCArray<TMeasurementVector, TInternalValue>::GetActualSize()
  * ************************ Clear *************************
  */
 
-template <class TMeasurementVector, class TInternalValue>
+template <typename TMeasurementVector, typename TInternalValue>
 void
 ListSampleCArray<TMeasurementVector, TInternalValue>::Clear()
 {
@@ -202,7 +202,7 @@ ListSampleCArray<TMeasurementVector, TInternalValue>::Clear()
  * ************************ AllocateInternalContainer *************************
  */
 
-template <class TMeasurementVector, class TInternalValue>
+template <typename TMeasurementVector, typename TInternalValue>
 void
 ListSampleCArray<TMeasurementVector, TInternalValue>::AllocateInternalContainer(unsigned long size, unsigned int dim)
 {
@@ -219,7 +219,7 @@ ListSampleCArray<TMeasurementVector, TInternalValue>::AllocateInternalContainer(
  * ************************ DeallocateInternalContainer *************************
  */
 
-template <class TMeasurementVector, class TInternalValue>
+template <typename TMeasurementVector, typename TInternalValue>
 void
 ListSampleCArray<TMeasurementVector, TInternalValue>::DeallocateInternalContainer()
 {
@@ -236,7 +236,7 @@ ListSampleCArray<TMeasurementVector, TInternalValue>::DeallocateInternalContaine
  * ************************ GetFrequency *************************
  */
 
-template <class TMeasurementVector, class TInternalValue>
+template <typename TMeasurementVector, typename TInternalValue>
 auto
 ListSampleCArray<TMeasurementVector, TInternalValue>::GetFrequency(InstanceIdentifier id) const -> AbsoluteFrequencyType
 {
@@ -255,7 +255,7 @@ ListSampleCArray<TMeasurementVector, TInternalValue>::GetFrequency(InstanceIdent
  * ************************ PrintSelf *************************
  */
 
-template <class TMeasurementVector, class TInternalValue>
+template <typename TMeasurementVector, typename TInternalValue>
 void
 ListSampleCArray<TMeasurementVector, TInternalValue>::PrintSelf(std::ostream & os, Indent indent) const
 {

--- a/Components/Metrics/KNNGraphAlphaMutualInformation/elxKNNGraphAlphaMutualInformationMetric.h
+++ b/Components/Metrics/KNNGraphAlphaMutualInformation/elxKNNGraphAlphaMutualInformationMetric.h
@@ -78,7 +78,7 @@ namespace elastix
  * \ingroup Metrics
  */
 
-template <class TElastix>
+template <typename TElastix>
 class ITK_TEMPLATE_EXPORT KNNGraphAlphaMutualInformationMetric
   : public itk::KNNGraphAlphaMutualInformationImageToImageMetric<typename MetricBase<TElastix>::FixedImageType,
                                                                  typename MetricBase<TElastix>::MovingImageType>

--- a/Components/Metrics/KNNGraphAlphaMutualInformation/elxKNNGraphAlphaMutualInformationMetric.hxx
+++ b/Components/Metrics/KNNGraphAlphaMutualInformation/elxKNNGraphAlphaMutualInformationMetric.hxx
@@ -32,7 +32,7 @@ namespace elastix
  * ******************* Initialize ***********************
  */
 
-template <class TElastix>
+template <typename TElastix>
 void
 KNNGraphAlphaMutualInformationMetric<TElastix>::Initialize()
 {
@@ -50,7 +50,7 @@ KNNGraphAlphaMutualInformationMetric<TElastix>::Initialize()
  * ***************** BeforeRegistration ***********************
  */
 
-template <class TElastix>
+template <typename TElastix>
 void
 KNNGraphAlphaMutualInformationMetric<TElastix>::BeforeRegistration()
 {
@@ -73,7 +73,7 @@ KNNGraphAlphaMutualInformationMetric<TElastix>::BeforeRegistration()
  * ***************** BeforeEachResolution ***********************
  */
 
-template <class TElastix>
+template <typename TElastix>
 void
 KNNGraphAlphaMutualInformationMetric<TElastix>::BeforeEachResolution()
 {

--- a/Components/Metrics/KNNGraphAlphaMutualInformation/itkKNNGraphAlphaMutualInformationImageToImageMetric.h
+++ b/Components/Metrics/KNNGraphAlphaMutualInformation/itkKNNGraphAlphaMutualInformationImageToImageMetric.h
@@ -70,7 +70,7 @@ namespace itk
  * \ingroup RegistrationMetrics
  */
 
-template <class TFixedImage, class TMovingImage>
+template <typename TFixedImage, typename TMovingImage>
 class ITK_TEMPLATE_EXPORT KNNGraphAlphaMutualInformationImageToImageMetric
   : public MultiInputImageToImageMetricBase<TFixedImage, TMovingImage>
 {

--- a/Components/Metrics/KNNGraphAlphaMutualInformation/itkKNNGraphAlphaMutualInformationImageToImageMetric.hxx
+++ b/Components/Metrics/KNNGraphAlphaMutualInformation/itkKNNGraphAlphaMutualInformationImageToImageMetric.hxx
@@ -27,7 +27,7 @@ namespace itk
  * ************************ Constructor *************************
  */
 
-template <class TFixedImage, class TMovingImage>
+template <typename TFixedImage, typename TMovingImage>
 KNNGraphAlphaMutualInformationImageToImageMetric<TFixedImage,
                                                  TMovingImage>::KNNGraphAlphaMutualInformationImageToImageMetric()
 {
@@ -41,7 +41,7 @@ KNNGraphAlphaMutualInformationImageToImageMetric<TFixedImage,
  * ************************ SetANNkDTree *************************
  */
 
-template <class TFixedImage, class TMovingImage>
+template <typename TFixedImage, typename TMovingImage>
 void
 KNNGraphAlphaMutualInformationImageToImageMetric<TFixedImage, TMovingImage>::SetANNkDTree(unsigned int bucketSize,
                                                                                           std::string  splittingRule)
@@ -55,7 +55,7 @@ KNNGraphAlphaMutualInformationImageToImageMetric<TFixedImage, TMovingImage>::Set
  * ************************ SetANNkDTree *************************
  */
 
-template <class TFixedImage, class TMovingImage>
+template <typename TFixedImage, typename TMovingImage>
 void
 KNNGraphAlphaMutualInformationImageToImageMetric<TFixedImage, TMovingImage>::SetANNkDTree(
   unsigned int bucketSize,
@@ -86,7 +86,7 @@ KNNGraphAlphaMutualInformationImageToImageMetric<TFixedImage, TMovingImage>::Set
  * ************************ SetANNbdTree *************************
  */
 
-template <class TFixedImage, class TMovingImage>
+template <typename TFixedImage, typename TMovingImage>
 void
 KNNGraphAlphaMutualInformationImageToImageMetric<TFixedImage, TMovingImage>::SetANNbdTree(unsigned int bucketSize,
                                                                                           std::string  splittingRule,
@@ -102,7 +102,7 @@ KNNGraphAlphaMutualInformationImageToImageMetric<TFixedImage, TMovingImage>::Set
  * ************************ SetANNbdTree *************************
  */
 
-template <class TFixedImage, class TMovingImage>
+template <typename TFixedImage, typename TMovingImage>
 void
 KNNGraphAlphaMutualInformationImageToImageMetric<TFixedImage, TMovingImage>::SetANNbdTree(
   unsigned int bucketSize,
@@ -140,7 +140,7 @@ KNNGraphAlphaMutualInformationImageToImageMetric<TFixedImage, TMovingImage>::Set
  * ************************ SetANNBruteForceTree *************************
  */
 
-template <class TFixedImage, class TMovingImage>
+template <typename TFixedImage, typename TMovingImage>
 void
 KNNGraphAlphaMutualInformationImageToImageMetric<TFixedImage, TMovingImage>::SetANNBruteForceTree()
 {
@@ -155,7 +155,7 @@ KNNGraphAlphaMutualInformationImageToImageMetric<TFixedImage, TMovingImage>::Set
  * ************************ SetANNStandardTreeSearch *************************
  */
 
-template <class TFixedImage, class TMovingImage>
+template <typename TFixedImage, typename TMovingImage>
 void
 KNNGraphAlphaMutualInformationImageToImageMetric<TFixedImage, TMovingImage>::SetANNStandardTreeSearch(
   unsigned int kNearestNeighbors,
@@ -184,7 +184,7 @@ KNNGraphAlphaMutualInformationImageToImageMetric<TFixedImage, TMovingImage>::Set
  * ************************ SetANNFixedRadiusTreeSearch *************************
  */
 
-template <class TFixedImage, class TMovingImage>
+template <typename TFixedImage, typename TMovingImage>
 void
 KNNGraphAlphaMutualInformationImageToImageMetric<TFixedImage, TMovingImage>::SetANNFixedRadiusTreeSearch(
   unsigned int kNearestNeighbors,
@@ -218,7 +218,7 @@ KNNGraphAlphaMutualInformationImageToImageMetric<TFixedImage, TMovingImage>::Set
  * ************************ SetANNPriorityTreeSearch *************************
  */
 
-template <class TFixedImage, class TMovingImage>
+template <typename TFixedImage, typename TMovingImage>
 void
 KNNGraphAlphaMutualInformationImageToImageMetric<TFixedImage, TMovingImage>::SetANNPriorityTreeSearch(
   unsigned int kNearestNeighbors,
@@ -247,7 +247,7 @@ KNNGraphAlphaMutualInformationImageToImageMetric<TFixedImage, TMovingImage>::Set
  * ********************* Initialize *****************************
  */
 
-template <class TFixedImage, class TMovingImage>
+template <typename TFixedImage, typename TMovingImage>
 void
 KNNGraphAlphaMutualInformationImageToImageMetric<TFixedImage, TMovingImage>::Initialize()
 {
@@ -273,7 +273,7 @@ KNNGraphAlphaMutualInformationImageToImageMetric<TFixedImage, TMovingImage>::Ini
  * ************************ GetValue *************************
  */
 
-template <class TFixedImage, class TMovingImage>
+template <typename TFixedImage, typename TMovingImage>
 auto
 KNNGraphAlphaMutualInformationImageToImageMetric<TFixedImage, TMovingImage>::GetValue(
   const TransformParametersType & parameters) const -> MeasureType
@@ -460,7 +460,7 @@ KNNGraphAlphaMutualInformationImageToImageMetric<TFixedImage, TMovingImage>::Get
  * ************************ GetDerivative *************************
  */
 
-template <class TFixedImage, class TMovingImage>
+template <typename TFixedImage, typename TMovingImage>
 void
 KNNGraphAlphaMutualInformationImageToImageMetric<TFixedImage, TMovingImage>::GetDerivative(
   const TransformParametersType & parameters,
@@ -481,7 +481,7 @@ KNNGraphAlphaMutualInformationImageToImageMetric<TFixedImage, TMovingImage>::Get
  * ************************ GetValueAndDerivative *************************
  */
 
-template <class TFixedImage, class TMovingImage>
+template <typename TFixedImage, typename TMovingImage>
 void
 KNNGraphAlphaMutualInformationImageToImageMetric<TFixedImage, TMovingImage>::GetValueAndDerivative(
   const TransformParametersType & parameters,
@@ -717,7 +717,7 @@ KNNGraphAlphaMutualInformationImageToImageMetric<TFixedImage, TMovingImage>::Get
  * ************************ ComputeListSampleValuesAndDerivativePlusJacobian *************************
  */
 
-template <class TFixedImage, class TMovingImage>
+template <typename TFixedImage, typename TMovingImage>
 void
 KNNGraphAlphaMutualInformationImageToImageMetric<TFixedImage, TMovingImage>::
   ComputeListSampleValuesAndDerivativePlusJacobian(const ListSamplePointer &               listSampleFixed,
@@ -879,7 +879,7 @@ KNNGraphAlphaMutualInformationImageToImageMetric<TFixedImage, TMovingImage>::
  * ************************ EvaluateMovingFeatureImageDerivatives *************************
  */
 
-template <class TFixedImage, class TMovingImage>
+template <typename TFixedImage, typename TMovingImage>
 void
 KNNGraphAlphaMutualInformationImageToImageMetric<TFixedImage, TMovingImage>::EvaluateMovingFeatureImageDerivatives(
   const MovingImagePointType & mappedPoint,
@@ -940,7 +940,7 @@ KNNGraphAlphaMutualInformationImageToImageMetric<TFixedImage, TMovingImage>::Eva
  * ************************ UpdateDerivativeOfGammas *************************
  */
 
-template <class TFixedImage, class TMovingImage>
+template <typename TFixedImage, typename TMovingImage>
 void
 KNNGraphAlphaMutualInformationImageToImageMetric<TFixedImage, TMovingImage>::UpdateDerivativeOfGammas(
   const SpatialDerivativeType &      D1sparse,
@@ -1024,7 +1024,7 @@ KNNGraphAlphaMutualInformationImageToImageMetric<TFixedImage, TMovingImage>::Upd
  * ************************ PrintSelf *************************
  */
 
-template <class TFixedImage, class TMovingImage>
+template <typename TFixedImage, typename TMovingImage>
 void
 KNNGraphAlphaMutualInformationImageToImageMetric<TFixedImage, TMovingImage>::PrintSelf(std::ostream & os,
                                                                                        Indent         indent) const

--- a/Components/Metrics/MissingStructurePenalty/elxMissingStructurePenalty.h
+++ b/Components/Metrics/MissingStructurePenalty/elxMissingStructurePenalty.h
@@ -50,7 +50,7 @@ namespace elastix
  * \ingroup RegistrationMetrics
  */
 
-template <class TElastix>
+template <typename TElastix>
 class ITK_TEMPLATE_EXPORT MissingStructurePenalty
   : public itk::MissingVolumeMeshPenalty<typename MetricBase<TElastix>::FixedPointSetType,
                                          typename MetricBase<TElastix>::MovingPointSetType>

--- a/Components/Metrics/MissingStructurePenalty/elxMissingStructurePenalty.hxx
+++ b/Components/Metrics/MissingStructurePenalty/elxMissingStructurePenalty.hxx
@@ -28,7 +28,7 @@ namespace elastix
  * ******************* Constructor *******************
  */
 
-template <class TElastix>
+template <typename TElastix>
 MissingStructurePenalty<TElastix>::MissingStructurePenalty()
 {
   this->m_NumberOfMeshes = 0;
@@ -39,7 +39,7 @@ MissingStructurePenalty<TElastix>::MissingStructurePenalty()
  * ******************* Initialize ***********************
  */
 
-template <class TElastix>
+template <typename TElastix>
 void
 MissingStructurePenalty<TElastix>::Initialize()
 {
@@ -56,7 +56,7 @@ MissingStructurePenalty<TElastix>::Initialize()
  * ***************** BeforeAllBase ***********************
  */
 
-template <class TElastix>
+template <typename TElastix>
 int
 MissingStructurePenalty<TElastix>::BeforeAllBase()
 {
@@ -125,7 +125,7 @@ MissingStructurePenalty<TElastix>::BeforeAllBase()
  * ***************** BeforeRegistration ***********************
  */
 
-template <class TElastix>
+template <typename TElastix>
 void
 MissingStructurePenalty<TElastix>::BeforeRegistration()
 {
@@ -175,7 +175,7 @@ MissingStructurePenalty<TElastix>::BeforeRegistration()
  * ***************** AfterEachIteration ***********************
  */
 
-template <class TElastix>
+template <typename TElastix>
 void
 MissingStructurePenalty<TElastix>::AfterEachIteration()
 {
@@ -228,7 +228,7 @@ MissingStructurePenalty<TElastix>::AfterEachIteration()
  * ***************** AfterEachResolution ***********************
  */
 
-template <class TElastix>
+template <typename TElastix>
 void
 MissingStructurePenalty<TElastix>::AfterEachResolution()
 {
@@ -277,7 +277,7 @@ MissingStructurePenalty<TElastix>::AfterEachResolution()
  * ************** ReadMesh *********************
  */
 
-template <class TElastix>
+template <typename TElastix>
 unsigned int
 MissingStructurePenalty<TElastix>::ReadMesh(const std::string & meshFileName, typename FixedMeshType::Pointer & mesh)
 {
@@ -307,7 +307,7 @@ MissingStructurePenalty<TElastix>::ReadMesh(const std::string & meshFileName, ty
  * ******************* WriteResultMesh ********************
  */
 
-template <class TElastix>
+template <typename TElastix>
 void
 MissingStructurePenalty<TElastix>::WriteResultMesh(const std::string & filename, MeshIdType meshId)
 {
@@ -384,7 +384,7 @@ MissingStructurePenalty<TElastix>::WriteResultMesh(const std::string & filename,
  * ******************* ReadTransformixPoints ********************
  */
 
-template <class TElastix>
+template <typename TElastix>
 unsigned int
 MissingStructurePenalty<TElastix>::ReadTransformixPoints(const std::string &          filename,
                                                          typename MeshType::Pointer & mesh) // const

--- a/Components/Metrics/MissingStructurePenalty/itkMissingStructurePenalty.h
+++ b/Components/Metrics/MissingStructurePenalty/itkMissingStructurePenalty.h
@@ -40,7 +40,7 @@ namespace itk
  * http://stacks.iop.org/0031-9155/59/4033
  * \ingroup RegistrationMetrics
  */
-template <class TFixedPointSet, class TMovingPointSet>
+template <typename TFixedPointSet, typename TMovingPointSet>
 class ITK_TEMPLATE_EXPORT MissingVolumeMeshPenalty
   : public SingleValuedPointSetToPointSetMetric<TFixedPointSet, TMovingPointSet>
 {

--- a/Components/Metrics/MissingStructurePenalty/itkMissingStructurePenalty.hxx
+++ b/Components/Metrics/MissingStructurePenalty/itkMissingStructurePenalty.hxx
@@ -28,7 +28,7 @@ namespace itk
  * ******************* Constructor *******************
  */
 
-template <class TFixedPointSet, class TMovingPointSet>
+template <typename TFixedPointSet, typename TMovingPointSet>
 MissingVolumeMeshPenalty<TFixedPointSet, TMovingPointSet>::MissingVolumeMeshPenalty()
 {
   this->m_MappedMeshContainer = MappedMeshContainerType::New();
@@ -39,7 +39,7 @@ MissingVolumeMeshPenalty<TFixedPointSet, TMovingPointSet>::MissingVolumeMeshPena
  * *********************** Initialize *****************************
  */
 
-template <class TFixedPointSet, class TMovingPointSet>
+template <typename TFixedPointSet, typename TMovingPointSet>
 void
 MissingVolumeMeshPenalty<TFixedPointSet, TMovingPointSet>::Initialize()
 {
@@ -88,7 +88,7 @@ MissingVolumeMeshPenalty<TFixedPointSet, TMovingPointSet>::Initialize()
  * ******************* GetValue *******************
  */
 
-template <class TFixedPointSet, class TMovingPointSet>
+template <typename TFixedPointSet, typename TMovingPointSet>
 auto
 MissingVolumeMeshPenalty<TFixedPointSet, TMovingPointSet>::GetValue(const TransformParametersType & parameters) const
   -> MeasureType
@@ -121,7 +121,7 @@ MissingVolumeMeshPenalty<TFixedPointSet, TMovingPointSet>::GetValue(const Transf
  * ******************* GetDerivative *******************
  */
 
-template <class TFixedPointSet, class TMovingPointSet>
+template <typename TFixedPointSet, typename TMovingPointSet>
 void
 MissingVolumeMeshPenalty<TFixedPointSet, TMovingPointSet>::GetDerivative(const TransformParametersType & parameters,
                                                                          DerivativeType & derivative) const
@@ -141,7 +141,7 @@ MissingVolumeMeshPenalty<TFixedPointSet, TMovingPointSet>::GetDerivative(const T
  * ******************* GetValueAndDerivative *******************
  */
 
-template <class TFixedPointSet, class TMovingPointSet>
+template <typename TFixedPointSet, typename TMovingPointSet>
 void
 MissingVolumeMeshPenalty<TFixedPointSet, TMovingPointSet>::GetValueAndDerivative(
   const TransformParametersType & parameters,
@@ -327,7 +327,7 @@ MissingVolumeMeshPenalty<TFixedPointSet, TMovingPointSet>::GetValueAndDerivative
  * ******************* SubVector *******************
  */
 
-template <class TFixedPointSet, class TMovingPointSet>
+template <typename TFixedPointSet, typename TMovingPointSet>
 void
 MissingVolumeMeshPenalty<TFixedPointSet, TMovingPointSet>::SubVector(const VectorType & fullVector,
                                                                      SubVectorType &    subVector,

--- a/Components/Metrics/MissingStructurePenalty/vnl_adjugate_fixed.h
+++ b/Components/Metrics/MissingStructurePenalty/vnl_adjugate_fixed.h
@@ -32,7 +32,7 @@
 //
 //  \relatesalso vnl_matrix_fixed
 
-template <class T>
+template <typename T>
 vnl_matrix_fixed<T, 1, 1> vnl_adjugate(vnl_matrix_fixed<T, 1, 1> const & m)
 {
   return vnl_matrix_fixed<T, 1, 1>(m(0, 0));
@@ -49,7 +49,7 @@ vnl_matrix_fixed<T, 1, 1> vnl_adjugate(vnl_matrix_fixed<T, 1, 1> const & m)
 //
 //  \relatesalso vnl_matrix_fixed
 
-template <class T>
+template <typename T>
 vnl_matrix_fixed<T, 2, 2> vnl_adjugate(vnl_matrix_fixed<T, 2, 2> const & m)
 {
   T d[4];
@@ -71,7 +71,7 @@ vnl_matrix_fixed<T, 2, 2> vnl_adjugate(vnl_matrix_fixed<T, 2, 2> const & m)
 //
 //  \relatesalso vnl_matrix_fixed
 
-template <class T>
+template <typename T>
 vnl_matrix_fixed<T, 3, 3> vnl_adjugate(vnl_matrix_fixed<T, 3, 3> const & m)
 {
   T d[9];
@@ -98,7 +98,7 @@ vnl_matrix_fixed<T, 3, 3> vnl_adjugate(vnl_matrix_fixed<T, 3, 3> const & m)
 //
 //  \relatesalso vnl_matrix_fixed
 
-template <class T>
+template <typename T>
 vnl_matrix_fixed<T, 4, 4> vnl_adjugate(vnl_matrix_fixed<T, 4, 4> const & m)
 {
   T d[16];
@@ -148,7 +148,7 @@ vnl_matrix_fixed<T, 4, 4> vnl_adjugate(vnl_matrix_fixed<T, 4, 4> const & m)
 //
 //  \relatesalso vnl_matrix
 
-template <class T>
+template <typename T>
 vnl_matrix<T>
 vnl_adjugate_asfixed(vnl_matrix<T> const & m)
 {
@@ -177,7 +177,7 @@ vnl_adjugate_asfixed(vnl_matrix<T> const & m)
 //
 //  \relatesalso vnl_matrix_fixed
 
-template <class T>
+template <typename T>
 vnl_matrix_fixed<T, 1, 1> vnl_cofactor(vnl_matrix_fixed<T, 1, 1> const & m)
 {
   return vnl_matrix_fixed<T, 1, 1>(T(1) / m(0, 0));
@@ -196,7 +196,7 @@ vnl_matrix_fixed<T, 1, 1> vnl_cofactor(vnl_matrix_fixed<T, 1, 1> const & m)
 //
 //  \relatesalso vnl_matrix_fixed
 
-template <class T>
+template <typename T>
 vnl_matrix_fixed<T, 2, 2> vnl_cofactor(vnl_matrix_fixed<T, 2, 2> const & m)
 {
 
@@ -221,7 +221,7 @@ vnl_matrix_fixed<T, 2, 2> vnl_cofactor(vnl_matrix_fixed<T, 2, 2> const & m)
 //
 //  \relatesalso vnl_matrix_fixed
 
-template <class T>
+template <typename T>
 vnl_matrix_fixed<T, 3, 3> vnl_cofactor(vnl_matrix_fixed<T, 3, 3> const & m)
 {
 
@@ -251,7 +251,7 @@ vnl_matrix_fixed<T, 3, 3> vnl_cofactor(vnl_matrix_fixed<T, 3, 3> const & m)
 //
 //  \relatesalso vnl_matrix_fixed
 
-template <class T>
+template <typename T>
 vnl_matrix_fixed<T, 4, 4> vnl_cofactor(vnl_matrix_fixed<T, 4, 4> const & m)
 {
   T d[16];
@@ -303,7 +303,7 @@ vnl_matrix_fixed<T, 4, 4> vnl_cofactor(vnl_matrix_fixed<T, 4, 4> const & m)
 //
 //  \relatesalso vnl_matrix
 
-template <class T>
+template <typename T>
 vnl_matrix<T>
 vnl_cofactor(vnl_matrix<T> const & m)
 {
@@ -320,7 +320,7 @@ vnl_cofactor(vnl_matrix<T> const & m)
 }
 
 
-template <class T>
+template <typename T>
 vnl_vector_fixed<T, 3> vnl_cofactor_row1(vnl_vector_fixed<T, 3> const & row2, vnl_vector_fixed<T, 3> const & row3)
 {
   T d[3];

--- a/Components/Metrics/NormalizedGradientCorrelation/elxNormalizedGradientCorrelationMetric.h
+++ b/Components/Metrics/NormalizedGradientCorrelation/elxNormalizedGradientCorrelationMetric.h
@@ -33,7 +33,7 @@ namespace elastix
  *
  */
 
-template <class TElastix>
+template <typename TElastix>
 class ITK_TEMPLATE_EXPORT NormalizedGradientCorrelationMetric
   : public itk::NormalizedGradientCorrelationImageToImageMetric<typename MetricBase<TElastix>::FixedImageType,
                                                                 typename MetricBase<TElastix>::MovingImageType>

--- a/Components/Metrics/NormalizedGradientCorrelation/elxNormalizedGradientCorrelationMetric.hxx
+++ b/Components/Metrics/NormalizedGradientCorrelation/elxNormalizedGradientCorrelationMetric.hxx
@@ -28,7 +28,7 @@ namespace elastix
  * ******************* Initialize ***********************
  */
 
-template <class TElastix>
+template <typename TElastix>
 void
 NormalizedGradientCorrelationMetric<TElastix>::Initialize()
 {
@@ -46,7 +46,7 @@ NormalizedGradientCorrelationMetric<TElastix>::Initialize()
  * ***************** BeforeRegistration ***********************
  */
 
-template <class TElastix>
+template <typename TElastix>
 void
 NormalizedGradientCorrelationMetric<TElastix>::BeforeRegistration()
 {
@@ -69,7 +69,7 @@ NormalizedGradientCorrelationMetric<TElastix>::BeforeRegistration()
  * ***************** BeforeEachResolution ***********************
  */
 
-template <class TElastix>
+template <typename TElastix>
 void
 NormalizedGradientCorrelationMetric<TElastix>::BeforeEachResolution()
 {

--- a/Components/Metrics/NormalizedGradientCorrelation/itkNormalizedGradientCorrelationImageToImageMetric.h
+++ b/Components/Metrics/NormalizedGradientCorrelation/itkNormalizedGradientCorrelationImageToImageMetric.h
@@ -40,7 +40,7 @@ namespace itk
  *
  */
 
-template <class TFixedImage, class TMovingImage>
+template <typename TFixedImage, typename TMovingImage>
 class ITK_TEMPLATE_EXPORT NormalizedGradientCorrelationImageToImageMetric
   : public AdvancedImageToImageMetric<TFixedImage, TMovingImage>
 {

--- a/Components/Metrics/NormalizedGradientCorrelation/itkNormalizedGradientCorrelationImageToImageMetric.hxx
+++ b/Components/Metrics/NormalizedGradientCorrelation/itkNormalizedGradientCorrelationImageToImageMetric.hxx
@@ -34,7 +34,7 @@ namespace itk
  * ***************** Initialize *****************
  */
 
-template <class TFixedImage, class TMovingImage>
+template <typename TFixedImage, typename TMovingImage>
 void
 NormalizedGradientCorrelationImageToImageMetric<TFixedImage, TMovingImage>::Initialize()
 {
@@ -101,7 +101,7 @@ NormalizedGradientCorrelationImageToImageMetric<TFixedImage, TMovingImage>::Init
  * ***************** PrintSelf *****************
  */
 
-template <class TFixedImage, class TMovingImage>
+template <typename TFixedImage, typename TMovingImage>
 void
 NormalizedGradientCorrelationImageToImageMetric<TFixedImage, TMovingImage>::PrintSelf(std::ostream & os,
                                                                                       Indent         indent) const
@@ -115,7 +115,7 @@ NormalizedGradientCorrelationImageToImageMetric<TFixedImage, TMovingImage>::Prin
  * ***************** ComputeMeanFixedGradient *****************
  */
 
-template <class TFixedImage, class TMovingImage>
+template <typename TFixedImage, typename TMovingImage>
 void
 NormalizedGradientCorrelationImageToImageMetric<TFixedImage, TMovingImage>::ComputeMeanFixedGradient() const
 {
@@ -185,7 +185,7 @@ NormalizedGradientCorrelationImageToImageMetric<TFixedImage, TMovingImage>::Comp
  * ***************** ComputeMeanMovedGradient *****************
  */
 
-template <class TFixedImage, class TMovingImage>
+template <typename TFixedImage, typename TMovingImage>
 void
 NormalizedGradientCorrelationImageToImageMetric<TFixedImage, TMovingImage>::ComputeMeanMovedGradient() const
 {
@@ -258,7 +258,7 @@ NormalizedGradientCorrelationImageToImageMetric<TFixedImage, TMovingImage>::Comp
  * ***************** ComputeMeasure *****************
  */
 
-template <class TFixedImage, class TMovingImage>
+template <typename TFixedImage, typename TMovingImage>
 auto
 NormalizedGradientCorrelationImageToImageMetric<TFixedImage, TMovingImage>::ComputeMeasure(
   const TransformParametersType & parameters) const -> MeasureType
@@ -351,7 +351,7 @@ NormalizedGradientCorrelationImageToImageMetric<TFixedImage, TMovingImage>::Comp
  * ***************** GetValue *****************
  */
 
-template <class TFixedImage, class TMovingImage>
+template <typename TFixedImage, typename TMovingImage>
 auto
 NormalizedGradientCorrelationImageToImageMetric<TFixedImage, TMovingImage>::GetValue(
   const TransformParametersType & parameters) const -> MeasureType
@@ -393,7 +393,7 @@ NormalizedGradientCorrelationImageToImageMetric<TFixedImage, TMovingImage>::GetV
  * ***************** SetTransformParameters *****************
  */
 
-template <class TFixedImage, class TMovingImage>
+template <typename TFixedImage, typename TMovingImage>
 void
 NormalizedGradientCorrelationImageToImageMetric<TFixedImage, TMovingImage>::SetTransformParameters(
   const TransformParametersType & parameters) const
@@ -411,7 +411,7 @@ NormalizedGradientCorrelationImageToImageMetric<TFixedImage, TMovingImage>::SetT
  * ***************** GetDerivative *****************
  */
 
-template <class TFixedImage, class TMovingImage>
+template <typename TFixedImage, typename TMovingImage>
 void
 NormalizedGradientCorrelationImageToImageMetric<TFixedImage, TMovingImage>::GetDerivative(
   const TransformParametersType & parameters,
@@ -439,7 +439,7 @@ NormalizedGradientCorrelationImageToImageMetric<TFixedImage, TMovingImage>::GetD
  * ***************** GetValueAndDerivative *****************
  */
 
-template <class TFixedImage, class TMovingImage>
+template <typename TFixedImage, typename TMovingImage>
 void
 NormalizedGradientCorrelationImageToImageMetric<TFixedImage, TMovingImage>::GetValueAndDerivative(
   const TransformParametersType & parameters,

--- a/Components/Metrics/NormalizedMutualInformation/elxNormalizedMutualInformationMetric.h
+++ b/Components/Metrics/NormalizedMutualInformation/elxNormalizedMutualInformationMetric.h
@@ -69,7 +69,7 @@ namespace elastix
  * \ingroup Metrics
  */
 
-template <class TElastix>
+template <typename TElastix>
 class ITK_TEMPLATE_EXPORT NormalizedMutualInformationMetric
   : public itk::ParzenWindowNormalizedMutualInformationImageToImageMetric<
       typename MetricBase<TElastix>::FixedImageType,

--- a/Components/Metrics/NormalizedMutualInformation/elxNormalizedMutualInformationMetric.hxx
+++ b/Components/Metrics/NormalizedMutualInformation/elxNormalizedMutualInformationMetric.hxx
@@ -33,7 +33,7 @@ namespace elastix
  * ******************* Initialize ***********************
  */
 
-template <class TElastix>
+template <typename TElastix>
 void
 NormalizedMutualInformationMetric<TElastix>::Initialize()
 {
@@ -51,7 +51,7 @@ NormalizedMutualInformationMetric<TElastix>::Initialize()
  * ***************** BeforeEachResolution ***********************
  */
 
-template <class TElastix>
+template <typename TElastix>
 void
 NormalizedMutualInformationMetric<TElastix>::BeforeEachResolution()
 {

--- a/Components/Metrics/NormalizedMutualInformation/itkParzenWindowNormalizedMutualInformationImageToImageMetric.h
+++ b/Components/Metrics/NormalizedMutualInformation/itkParzenWindowNormalizedMutualInformationImageToImageMetric.h
@@ -68,7 +68,7 @@ namespace itk
  * \sa ParzenWindowHistogramImageToImageMetric
  */
 
-template <class TFixedImage, class TMovingImage>
+template <typename TFixedImage, typename TMovingImage>
 class ITK_TEMPLATE_EXPORT ParzenWindowNormalizedMutualInformationImageToImageMetric
   : public ParzenWindowHistogramImageToImageMetric<TFixedImage, TMovingImage>
 {

--- a/Components/Metrics/NormalizedMutualInformation/itkParzenWindowNormalizedMutualInformationImageToImageMetric.hxx
+++ b/Components/Metrics/NormalizedMutualInformation/itkParzenWindowNormalizedMutualInformationImageToImageMetric.hxx
@@ -33,7 +33,7 @@ namespace itk
  * Print out internal information about this class.
  */
 
-template <class TFixedImage, class TMovingImage>
+template <typename TFixedImage, typename TMovingImage>
 void
 ParzenWindowNormalizedMutualInformationImageToImageMetric<TFixedImage, TMovingImage>::PrintSelf(std::ostream & os,
                                                                                                 Indent indent) const
@@ -50,7 +50,7 @@ ParzenWindowNormalizedMutualInformationImageToImageMetric<TFixedImage, TMovingIm
  * ********************** ComputeLogMarginalPDF***********************
  */
 
-template <class TFixedImage, class TMovingImage>
+template <typename TFixedImage, typename TMovingImage>
 void
 ParzenWindowNormalizedMutualInformationImageToImageMetric<TFixedImage, TMovingImage>::ComputeLogMarginalPDF(
   MarginalPDFType & pdf) const
@@ -85,7 +85,7 @@ ParzenWindowNormalizedMutualInformationImageToImageMetric<TFixedImage, TMovingIm
  * Returns the normalized mutual information, so not its negative...
  */
 
-template <class TFixedImage, class TMovingImage>
+template <typename TFixedImage, typename TMovingImage>
 auto
 ParzenWindowNormalizedMutualInformationImageToImageMetric<TFixedImage, TMovingImage>::
   ComputeNormalizedMutualInformation(MeasureType & jointEntropy) const -> MeasureType
@@ -137,7 +137,7 @@ ParzenWindowNormalizedMutualInformationImageToImageMetric<TFixedImage, TMovingIm
  * Get the match Measure.
  */
 
-template <class TFixedImage, class TMovingImage>
+template <typename TFixedImage, typename TMovingImage>
 auto
 ParzenWindowNormalizedMutualInformationImageToImageMetric<TFixedImage, TMovingImage>::GetValue(
   const ParametersType & parameters) const -> MeasureType
@@ -170,7 +170,7 @@ ParzenWindowNormalizedMutualInformationImageToImageMetric<TFixedImage, TMovingIm
  * Get both the Value and the Derivative of the Measure.
  */
 
-template <class TFixedImage, class TMovingImage>
+template <typename TFixedImage, typename TMovingImage>
 void
 ParzenWindowNormalizedMutualInformationImageToImageMetric<TFixedImage, TMovingImage>::GetValueAndDerivative(
   const ParametersType & parameters,

--- a/Components/Metrics/PCAMetric/elxPCAMetric.h
+++ b/Components/Metrics/PCAMetric/elxPCAMetric.h
@@ -61,7 +61,7 @@ namespace elastix
  * \ingroup Metrics
  */
 
-template <class TElastix>
+template <typename TElastix>
 class ITK_TEMPLATE_EXPORT PCAMetric
   : public itk::PCAMetric<typename MetricBase<TElastix>::FixedImageType, typename MetricBase<TElastix>::MovingImageType>
   , public MetricBase<TElastix>

--- a/Components/Metrics/PCAMetric/elxPCAMetric.hxx
+++ b/Components/Metrics/PCAMetric/elxPCAMetric.hxx
@@ -29,7 +29,7 @@ namespace elastix
  * ******************* Initialize ***********************
  */
 
-template <class TElastix>
+template <typename TElastix>
 void
 PCAMetric<TElastix>::Initialize()
 {
@@ -58,7 +58,7 @@ PCAMetric<TElastix>::Initialize()
  * ***************** BeforeRegistration ***********************
  */
 
-template <class TElastix>
+template <typename TElastix>
 void
 PCAMetric<TElastix>::BeforeRegistration()
 {
@@ -95,7 +95,7 @@ PCAMetric<TElastix>::BeforeRegistration()
  * ***************** BeforeEachResolution ***********************
  */
 
-template <class TElastix>
+template <typename TElastix>
 void
 PCAMetric<TElastix>::BeforeEachResolution()
 {

--- a/Components/Metrics/PCAMetric/itkPCAMetric.h
+++ b/Components/Metrics/PCAMetric/itkPCAMetric.h
@@ -28,7 +28,7 @@
 
 namespace itk
 {
-template <class TFixedImage, class TMovingImage>
+template <typename TFixedImage, typename TMovingImage>
 class ITK_TEMPLATE_EXPORT PCAMetric : public AdvancedImageToImageMetric<TFixedImage, TMovingImage>
 {
 public:

--- a/Components/Metrics/PCAMetric/itkPCAMetric.hxx
+++ b/Components/Metrics/PCAMetric/itkPCAMetric.hxx
@@ -36,7 +36,7 @@ namespace itk
  * ******************* Constructor *******************
  */
 
-template <class TFixedImage, class TMovingImage>
+template <typename TFixedImage, typename TMovingImage>
 PCAMetric<TFixedImage, TMovingImage>::PCAMetric()
 {
   this->SetUseImageSampler(true);
@@ -52,7 +52,7 @@ PCAMetric<TFixedImage, TMovingImage>::PCAMetric()
  * ******************* Initialize *******************
  */
 
-template <class TFixedImage, class TMovingImage>
+template <typename TFixedImage, typename TMovingImage>
 void
 PCAMetric<TFixedImage, TMovingImage>::Initialize()
 {
@@ -75,7 +75,7 @@ PCAMetric<TFixedImage, TMovingImage>::Initialize()
  * ******************* PrintSelf *******************
  */
 
-template <class TFixedImage, class TMovingImage>
+template <typename TFixedImage, typename TMovingImage>
 void
 PCAMetric<TFixedImage, TMovingImage>::PrintSelf(std::ostream & os, Indent indent) const
 {
@@ -88,7 +88,7 @@ PCAMetric<TFixedImage, TMovingImage>::PrintSelf(std::ostream & os, Indent indent
  * ********************* InitializeThreadingParameters ****************************
  */
 
-template <class TFixedImage, class TMovingImage>
+template <typename TFixedImage, typename TMovingImage>
 void
 PCAMetric<TFixedImage, TMovingImage>::InitializeThreadingParameters() const
 {
@@ -120,7 +120,7 @@ PCAMetric<TFixedImage, TMovingImage>::InitializeThreadingParameters() const
  * *************** EvaluateTransformJacobianInnerProduct ****************
  */
 
-template <class TFixedImage, class TMovingImage>
+template <typename TFixedImage, typename TMovingImage>
 void
 PCAMetric<TFixedImage, TMovingImage>::EvaluateTransformJacobianInnerProduct(
   const TransformJacobianType &     jacobian,
@@ -134,7 +134,7 @@ PCAMetric<TFixedImage, TMovingImage>::EvaluateTransformJacobianInnerProduct(
  * ******************* GetValue *******************
  */
 
-template <class TFixedImage, class TMovingImage>
+template <typename TFixedImage, typename TMovingImage>
 auto
 PCAMetric<TFixedImage, TMovingImage>::GetValue(const TransformParametersType & parameters) const -> MeasureType
 {
@@ -279,7 +279,7 @@ PCAMetric<TFixedImage, TMovingImage>::GetValue(const TransformParametersType & p
  * ******************* GetDerivative *******************
  */
 
-template <class TFixedImage, class TMovingImage>
+template <typename TFixedImage, typename TMovingImage>
 void
 PCAMetric<TFixedImage, TMovingImage>::GetDerivative(const TransformParametersType & parameters,
                                                     DerivativeType &                derivative) const
@@ -299,7 +299,7 @@ PCAMetric<TFixedImage, TMovingImage>::GetDerivative(const TransformParametersTyp
  * ******************* GetValueAndDerivativeSingleThreaded *******************
  */
 
-template <class TFixedImage, class TMovingImage>
+template <typename TFixedImage, typename TMovingImage>
 void
 PCAMetric<TFixedImage, TMovingImage>::GetValueAndDerivativeSingleThreaded(const TransformParametersType & parameters,
                                                                           MeasureType &                   value,
@@ -593,7 +593,7 @@ PCAMetric<TFixedImage, TMovingImage>::GetValueAndDerivativeSingleThreaded(const 
  * ******************* GetValueAndDerivative *******************
  */
 
-template <class TFixedImage, class TMovingImage>
+template <typename TFixedImage, typename TMovingImage>
 void
 PCAMetric<TFixedImage, TMovingImage>::GetValueAndDerivative(const TransformParametersType & parameters,
                                                             MeasureType &                   value,
@@ -641,7 +641,7 @@ PCAMetric<TFixedImage, TMovingImage>::GetValueAndDerivative(const TransformParam
  * ******************* ThreadedGetSamples *******************
  */
 
-template <class TFixedImage, class TMovingImage>
+template <typename TFixedImage, typename TMovingImage>
 void
 PCAMetric<TFixedImage, TMovingImage>::ThreadedGetSamples(ThreadIdType threadId)
 {
@@ -727,7 +727,7 @@ PCAMetric<TFixedImage, TMovingImage>::ThreadedGetSamples(ThreadIdType threadId)
  * ******************* AfterThreadedGetSamples *******************
  */
 
-template <class TFixedImage, class TMovingImage>
+template <typename TFixedImage, typename TMovingImage>
 void
 PCAMetric<TFixedImage, TMovingImage>::AfterThreadedGetSamples(MeasureType & value) const
 {
@@ -826,7 +826,7 @@ PCAMetric<TFixedImage, TMovingImage>::AfterThreadedGetSamples(MeasureType & valu
  * **************** GetSamplesThreaderCallback *******
  */
 
-template <class TFixedImage, class TMovingImage>
+template <typename TFixedImage, typename TMovingImage>
 ITK_THREAD_RETURN_TYPE
 PCAMetric<TFixedImage, TMovingImage>::GetSamplesThreaderCallback(void * arg)
 {
@@ -848,7 +848,7 @@ PCAMetric<TFixedImage, TMovingImage>::GetSamplesThreaderCallback(void * arg)
  * *********************** LaunchGetSamplesThreaderCallback***************
  */
 
-template <class TFixedImage, class TMovingImage>
+template <typename TFixedImage, typename TMovingImage>
 void
 PCAMetric<TFixedImage, TMovingImage>::LaunchGetSamplesThreaderCallback() const
 {
@@ -867,7 +867,7 @@ PCAMetric<TFixedImage, TMovingImage>::LaunchGetSamplesThreaderCallback() const
  * ******************* ThreadedComputeDerivative *******************
  */
 
-template <class TFixedImage, class TMovingImage>
+template <typename TFixedImage, typename TMovingImage>
 void
 PCAMetric<TFixedImage, TMovingImage>::ThreadedComputeDerivative(ThreadIdType threadId)
 {
@@ -938,7 +938,7 @@ PCAMetric<TFixedImage, TMovingImage>::ThreadedComputeDerivative(ThreadIdType thr
  * ******************* AfterThreadedComputeDerivative *******************
  */
 
-template <class TFixedImage, class TMovingImage>
+template <typename TFixedImage, typename TMovingImage>
 void
 PCAMetric<TFixedImage, TMovingImage>::AfterThreadedComputeDerivative(DerivativeType & derivative) const
 {
@@ -1021,7 +1021,7 @@ PCAMetric<TFixedImage, TMovingImage>::AfterThreadedComputeDerivative(DerivativeT
  * **************** ComputeDerivativeThreaderCallback *******
  */
 
-template <class TFixedImage, class TMovingImage>
+template <typename TFixedImage, typename TMovingImage>
 ITK_THREAD_RETURN_TYPE
 PCAMetric<TFixedImage, TMovingImage>::ComputeDerivativeThreaderCallback(void * arg)
 {
@@ -1043,7 +1043,7 @@ PCAMetric<TFixedImage, TMovingImage>::ComputeDerivativeThreaderCallback(void * a
  * ************** LaunchComputeDerivativeThreaderCallback **********
  */
 
-template <class TFixedImage, class TMovingImage>
+template <typename TFixedImage, typename TMovingImage>
 void
 PCAMetric<TFixedImage, TMovingImage>::LaunchComputeDerivativeThreaderCallback() const
 {

--- a/Components/Metrics/PCAMetric2/elxPCAMetric2.h
+++ b/Components/Metrics/PCAMetric2/elxPCAMetric2.h
@@ -61,7 +61,7 @@ namespace elastix
  * \ingroup Metrics
  */
 
-template <class TElastix>
+template <typename TElastix>
 class ITK_TEMPLATE_EXPORT PCAMetric2
   : public itk::PCAMetric2<typename MetricBase<TElastix>::FixedImageType,
                            typename MetricBase<TElastix>::MovingImageType>

--- a/Components/Metrics/PCAMetric2/elxPCAMetric2.hxx
+++ b/Components/Metrics/PCAMetric2/elxPCAMetric2.hxx
@@ -29,7 +29,7 @@ namespace elastix
  * ******************* Initialize ***********************
  */
 
-template <class TElastix>
+template <typename TElastix>
 void
 PCAMetric2<TElastix>::Initialize()
 {
@@ -58,7 +58,7 @@ PCAMetric2<TElastix>::Initialize()
  * ***************** BeforeRegistration ***********************
  */
 
-template <class TElastix>
+template <typename TElastix>
 void
 PCAMetric2<TElastix>::BeforeRegistration()
 {
@@ -95,7 +95,7 @@ PCAMetric2<TElastix>::BeforeRegistration()
  * ***************** BeforeEachResolution ***********************
  */
 
-template <class TElastix>
+template <typename TElastix>
 void
 PCAMetric2<TElastix>::BeforeEachResolution()
 {

--- a/Components/Metrics/PCAMetric2/itkPCAMetric2.h
+++ b/Components/Metrics/PCAMetric2/itkPCAMetric2.h
@@ -27,7 +27,7 @@
 
 namespace itk
 {
-template <class TFixedImage, class TMovingImage>
+template <typename TFixedImage, typename TMovingImage>
 class ITK_TEMPLATE_EXPORT PCAMetric2 : public AdvancedImageToImageMetric<TFixedImage, TMovingImage>
 {
 public:

--- a/Components/Metrics/PCAMetric2/itkPCAMetric2.hxx
+++ b/Components/Metrics/PCAMetric2/itkPCAMetric2.hxx
@@ -35,7 +35,7 @@ namespace itk
  * ******************* Constructor *******************
  */
 
-template <class TFixedImage, class TMovingImage>
+template <typename TFixedImage, typename TMovingImage>
 PCAMetric2<TFixedImage, TMovingImage>::PCAMetric2()
 {
   this->SetUseImageSampler(true);
@@ -48,7 +48,7 @@ PCAMetric2<TFixedImage, TMovingImage>::PCAMetric2()
  * ******************* Initialize *******************
  */
 
-template <class TFixedImage, class TMovingImage>
+template <typename TFixedImage, typename TMovingImage>
 void
 PCAMetric2<TFixedImage, TMovingImage>::Initialize()
 {
@@ -66,7 +66,7 @@ PCAMetric2<TFixedImage, TMovingImage>::Initialize()
  * ******************* PrintSelf *******************
  */
 
-template <class TFixedImage, class TMovingImage>
+template <typename TFixedImage, typename TMovingImage>
 void
 PCAMetric2<TFixedImage, TMovingImage>::PrintSelf(std::ostream & os, Indent indent) const
 {
@@ -78,7 +78,7 @@ PCAMetric2<TFixedImage, TMovingImage>::PrintSelf(std::ostream & os, Indent inden
  * ******************* SampleRandom *******************
  */
 
-template <class TFixedImage, class TMovingImage>
+template <typename TFixedImage, typename TMovingImage>
 void
 PCAMetric2<TFixedImage, TMovingImage>::SampleRandom(const int n, const int m, std::vector<int> & numbers) const
 {
@@ -113,7 +113,7 @@ PCAMetric2<TFixedImage, TMovingImage>::SampleRandom(const int n, const int m, st
  * *************** EvaluateTransformJacobianInnerProduct ****************
  */
 
-template <class TFixedImage, class TMovingImage>
+template <typename TFixedImage, typename TMovingImage>
 void
 PCAMetric2<TFixedImage, TMovingImage>::EvaluateTransformJacobianInnerProduct(
   const TransformJacobianType &     jacobian,
@@ -128,7 +128,7 @@ PCAMetric2<TFixedImage, TMovingImage>::EvaluateTransformJacobianInnerProduct(
  * ******************* GetValue *******************
  */
 
-template <class TFixedImage, class TMovingImage>
+template <typename TFixedImage, typename TMovingImage>
 auto
 PCAMetric2<TFixedImage, TMovingImage>::GetValue(const TransformParametersType & parameters) const -> MeasureType
 {
@@ -294,7 +294,7 @@ PCAMetric2<TFixedImage, TMovingImage>::GetValue(const TransformParametersType & 
  * ******************* GetDerivative *******************
  */
 
-template <class TFixedImage, class TMovingImage>
+template <typename TFixedImage, typename TMovingImage>
 void
 PCAMetric2<TFixedImage, TMovingImage>::GetDerivative(const TransformParametersType & parameters,
                                                      DerivativeType &                derivative) const
@@ -314,7 +314,7 @@ PCAMetric2<TFixedImage, TMovingImage>::GetDerivative(const TransformParametersTy
  * ******************* GetValueAndDerivative *******************
  */
 
-template <class TFixedImage, class TMovingImage>
+template <typename TFixedImage, typename TMovingImage>
 void
 PCAMetric2<TFixedImage, TMovingImage>::GetValueAndDerivative(const TransformParametersType & parameters,
                                                              MeasureType &                   value,

--- a/Components/Metrics/PatternIntensity/elxPatternIntensityMetric.h
+++ b/Components/Metrics/PatternIntensity/elxPatternIntensityMetric.h
@@ -33,7 +33,7 @@ namespace elastix
  *
  */
 
-template <class TElastix>
+template <typename TElastix>
 class ITK_TEMPLATE_EXPORT PatternIntensityMetric
   : public itk::PatternIntensityImageToImageMetric<typename MetricBase<TElastix>::FixedImageType,
                                                    typename MetricBase<TElastix>::MovingImageType>

--- a/Components/Metrics/PatternIntensity/elxPatternIntensityMetric.hxx
+++ b/Components/Metrics/PatternIntensity/elxPatternIntensityMetric.hxx
@@ -29,7 +29,7 @@ namespace elastix
  * ******************* Initialize ***********************
  */
 
-template <class TElastix>
+template <typename TElastix>
 void
 PatternIntensityMetric<TElastix>::Initialize()
 {
@@ -47,7 +47,7 @@ PatternIntensityMetric<TElastix>::Initialize()
  * ***************** BeforeRegistration ***********************
  */
 
-template <class TElastix>
+template <typename TElastix>
 void
 PatternIntensityMetric<TElastix>::BeforeRegistration()
 {
@@ -70,7 +70,7 @@ PatternIntensityMetric<TElastix>::BeforeRegistration()
  * ***************** BeforeEachResolution ***********************
  */
 
-template <class TElastix>
+template <typename TElastix>
 void
 PatternIntensityMetric<TElastix>::BeforeEachResolution()
 {

--- a/Components/Metrics/PatternIntensity/itkPatternIntensityImageToImageMetric.h
+++ b/Components/Metrics/PatternIntensity/itkPatternIntensityImageToImageMetric.h
@@ -41,7 +41,7 @@ namespace itk
  * \ingroup RegistrationMetrics
  */
 
-template <class TFixedImage, class TMovingImage>
+template <typename TFixedImage, typename TMovingImage>
 class ITK_TEMPLATE_EXPORT PatternIntensityImageToImageMetric
   : public AdvancedImageToImageMetric<TFixedImage, TMovingImage>
 {

--- a/Components/Metrics/PatternIntensity/itkPatternIntensityImageToImageMetric.hxx
+++ b/Components/Metrics/PatternIntensity/itkPatternIntensityImageToImageMetric.hxx
@@ -35,7 +35,7 @@ namespace itk
  * ********************* Initialize ******************************
  */
 
-template <class TFixedImage, class TMovingImage>
+template <typename TFixedImage, typename TMovingImage>
 void
 PatternIntensityImageToImageMetric<TFixedImage, TMovingImage>::Initialize()
 {
@@ -88,7 +88,7 @@ PatternIntensityImageToImageMetric<TFixedImage, TMovingImage>::Initialize()
  * ********************* PrintSelf ******************************
  */
 
-template <class TFixedImage, class TMovingImage>
+template <typename TFixedImage, typename TMovingImage>
 void
 PatternIntensityImageToImageMetric<TFixedImage, TMovingImage>::PrintSelf(std::ostream & os, Indent indent) const
 {
@@ -102,7 +102,7 @@ PatternIntensityImageToImageMetric<TFixedImage, TMovingImage>::PrintSelf(std::os
  * ********************* ComputePIFixed ******************************
  */
 
-template <class TFixedImage, class TMovingImage>
+template <typename TFixedImage, typename TMovingImage>
 auto
 PatternIntensityImageToImageMetric<TFixedImage, TMovingImage>::ComputePIFixed() const -> MeasureType
 {
@@ -193,7 +193,7 @@ PatternIntensityImageToImageMetric<TFixedImage, TMovingImage>::ComputePIFixed() 
  * ********************* ComputePIDiff ******************************
  */
 
-template <class TFixedImage, class TMovingImage>
+template <typename TFixedImage, typename TMovingImage>
 auto
 PatternIntensityImageToImageMetric<TFixedImage, TMovingImage>::ComputePIDiff(const TransformParametersType & parameters,
                                                                              float scalingfactor) const -> MeasureType
@@ -302,7 +302,7 @@ PatternIntensityImageToImageMetric<TFixedImage, TMovingImage>::ComputePIDiff(con
  * ********************* GetValue ******************************
  */
 
-template <class TFixedImage, class TMovingImage>
+template <typename TFixedImage, typename TMovingImage>
 auto
 PatternIntensityImageToImageMetric<TFixedImage, TMovingImage>::GetValue(
   const TransformParametersType & parameters) const -> MeasureType
@@ -364,7 +364,7 @@ PatternIntensityImageToImageMetric<TFixedImage, TMovingImage>::GetValue(
  * ********************* GetDerivative ******************************
  */
 
-template <class TFixedImage, class TMovingImage>
+template <typename TFixedImage, typename TMovingImage>
 void
 PatternIntensityImageToImageMetric<TFixedImage, TMovingImage>::GetDerivative(const TransformParametersType & parameters,
                                                                              DerivativeType & derivative) const
@@ -391,7 +391,7 @@ PatternIntensityImageToImageMetric<TFixedImage, TMovingImage>::GetDerivative(con
  * ********************* GetValueAndDerivative ******************************
  */
 
-template <class TFixedImage, class TMovingImage>
+template <typename TFixedImage, typename TMovingImage>
 void
 PatternIntensityImageToImageMetric<TFixedImage, TMovingImage>::GetValueAndDerivative(
   const TransformParametersType & parameters,

--- a/Components/Metrics/PolydataDummyPenalty/elxPolydataDummyPenalty.h
+++ b/Components/Metrics/PolydataDummyPenalty/elxPolydataDummyPenalty.h
@@ -54,13 +54,13 @@ namespace elastix
 // typedef itk::Mesh<BinaryPixelType,FixedImageDimension> FixedMeshType;
 // typedef itk::Mesh <DummyPixelType, MetricBase<TElastix>::FixedImageDimension>  FixedMeshType; //pixeltype is unused,
 // but necessary for the declaration, so a type with the smallest memory footprint is used.
-//  template <class TElastix >
+//  template <typename TElastix >
 // class PolydataDummyPenalty
 //  : public
 //  itk::MeshPenalty < itk::Mesh<DummyPixelType, MetricBase <TElastix>::FixedImageDimension > >,
 //  public MetricBase<TElastix>
 //
-template <class TElastix>
+template <typename TElastix>
 class ITK_TEMPLATE_EXPORT PolydataDummyPenalty
   : public itk::MeshPenalty<typename MetricBase<TElastix>::FixedPointSetType,
                             typename MetricBase<TElastix>::MovingPointSetType>

--- a/Components/Metrics/PolydataDummyPenalty/elxPolydataDummyPenalty.hxx
+++ b/Components/Metrics/PolydataDummyPenalty/elxPolydataDummyPenalty.hxx
@@ -27,7 +27,7 @@ namespace elastix
  * ******************* Constructor *******************
  */
 
-template <class TElastix>
+template <typename TElastix>
 PolydataDummyPenalty<TElastix>::PolydataDummyPenalty()
 {
   this->m_NumberOfMeshes = 0;
@@ -38,7 +38,7 @@ PolydataDummyPenalty<TElastix>::PolydataDummyPenalty()
  * ******************* Initialize ***********************
  */
 
-template <class TElastix>
+template <typename TElastix>
 void
 PolydataDummyPenalty<TElastix>::Initialize()
 {
@@ -56,7 +56,7 @@ PolydataDummyPenalty<TElastix>::Initialize()
  * ***************** BeforeAllBase ***********************
  */
 
-template <class TElastix>
+template <typename TElastix>
 int
 PolydataDummyPenalty<TElastix>::BeforeAllBase()
 {
@@ -114,7 +114,7 @@ PolydataDummyPenalty<TElastix>::BeforeAllBase()
  * ***************** BeforeRegistration ***********************
  */
 
-template <class TElastix>
+template <typename TElastix>
 void
 PolydataDummyPenalty<TElastix>::BeforeRegistration()
 {
@@ -164,7 +164,7 @@ PolydataDummyPenalty<TElastix>::BeforeRegistration()
  * ***************** AfterEachIteration ***********************
  */
 
-template <class TElastix>
+template <typename TElastix>
 void
 PolydataDummyPenalty<TElastix>::AfterEachIteration()
 {
@@ -217,7 +217,7 @@ PolydataDummyPenalty<TElastix>::AfterEachIteration()
  * ***************** AfterEachResolution ***********************
  */
 
-template <class TElastix>
+template <typename TElastix>
 void
 PolydataDummyPenalty<TElastix>::AfterEachResolution()
 {
@@ -266,7 +266,7 @@ PolydataDummyPenalty<TElastix>::AfterEachResolution()
  * ************** ReadMesh *********************
  */
 
-template <class TElastix>
+template <typename TElastix>
 unsigned int
 PolydataDummyPenalty<TElastix>::ReadMesh(const std::string & meshFileName, typename FixedMeshType::Pointer & mesh)
 {
@@ -298,7 +298,7 @@ PolydataDummyPenalty<TElastix>::ReadMesh(const std::string & meshFileName, typen
  * ******************* WriteResultMesh ********************
  */
 
-template <class TElastix>
+template <typename TElastix>
 void
 PolydataDummyPenalty<TElastix>::WriteResultMesh(const std::string & filename, MeshIdType meshId)
 {
@@ -368,7 +368,7 @@ PolydataDummyPenalty<TElastix>::WriteResultMesh(const std::string & filename, Me
  * ******************* ReadTransformixPoints ********************
  */
 
-template <class TElastix>
+template <typename TElastix>
 unsigned int
 PolydataDummyPenalty<TElastix>::ReadTransformixPoints(const std::string &          filename,
                                                       typename MeshType::Pointer & mesh) // const

--- a/Components/Metrics/PolydataDummyPenalty/itkPolydataDummyPenalty.h
+++ b/Components/Metrics/PolydataDummyPenalty/itkPolydataDummyPenalty.h
@@ -36,7 +36,7 @@ namespace itk
  * \ingroup RegistrationMetrics
  */
 
-template <class TFixedPointSet, class TMovingPointSet>
+template <typename TFixedPointSet, typename TMovingPointSet>
 class ITK_TEMPLATE_EXPORT MeshPenalty : public SingleValuedPointSetToPointSetMetric<TFixedPointSet, TMovingPointSet>
 {
 public:

--- a/Components/Metrics/PolydataDummyPenalty/itkPolydataDummyPenalty.hxx
+++ b/Components/Metrics/PolydataDummyPenalty/itkPolydataDummyPenalty.hxx
@@ -27,7 +27,7 @@ namespace itk
  * ******************* Constructor *******************
  */
 
-template <class TFixedPointSet, class TMovingPointSet>
+template <typename TFixedPointSet, typename TMovingPointSet>
 MeshPenalty<TFixedPointSet, TMovingPointSet>::MeshPenalty()
 {
   this->m_MappedMeshContainer = MappedMeshContainerType::New();
@@ -38,7 +38,7 @@ MeshPenalty<TFixedPointSet, TMovingPointSet>::MeshPenalty()
  * *********************** Initialize *****************************
  */
 
-template <class TFixedPointSet, class TMovingPointSet>
+template <typename TFixedPointSet, typename TMovingPointSet>
 void
 MeshPenalty<TFixedPointSet, TMovingPointSet>::Initialize()
 {
@@ -102,7 +102,7 @@ MeshPenalty<TFixedPointSet, TMovingPointSet>::Initialize()
  * ******************* GetValue *******************
  */
 
-template <class TFixedPointSet, class TMovingPointSet>
+template <typename TFixedPointSet, typename TMovingPointSet>
 auto
 MeshPenalty<TFixedPointSet, TMovingPointSet>::GetValue(const TransformParametersType & parameters) const -> MeasureType
 {
@@ -137,7 +137,7 @@ MeshPenalty<TFixedPointSet, TMovingPointSet>::GetValue(const TransformParameters
  * ******************* GetDerivative *******************
  */
 
-template <class TFixedPointSet, class TMovingPointSet>
+template <typename TFixedPointSet, typename TMovingPointSet>
 void
 MeshPenalty<TFixedPointSet, TMovingPointSet>::GetDerivative(const TransformParametersType & parameters,
                                                             DerivativeType &                derivative) const
@@ -157,7 +157,7 @@ MeshPenalty<TFixedPointSet, TMovingPointSet>::GetDerivative(const TransformParam
  * ******************* GetValueAndDerivative *******************
  */
 
-template <class TFixedPointSet, class TMovingPointSet>
+template <typename TFixedPointSet, typename TMovingPointSet>
 void
 MeshPenalty<TFixedPointSet, TMovingPointSet>::GetValueAndDerivative(const TransformParametersType & parameters,
                                                                     MeasureType &                   value,
@@ -225,7 +225,7 @@ MeshPenalty<TFixedPointSet, TMovingPointSet>::GetValueAndDerivative(const Transf
  * ******************* PrintSelf *******************
  */
 
-template <class TFixedPointSet, class TMovingPointSet>
+template <typename TFixedPointSet, typename TMovingPointSet>
 void
 MeshPenalty<TFixedPointSet, TMovingPointSet>::PrintSelf(std::ostream & os, Indent indent) const
 {

--- a/Components/Metrics/RigidityPenalty/elxTransformRigidityPenaltyTerm.h
+++ b/Components/Metrics/RigidityPenalty/elxTransformRigidityPenaltyTerm.h
@@ -106,7 +106,7 @@ namespace elastix
  *
  */
 
-template <class TElastix>
+template <typename TElastix>
 class ITK_TEMPLATE_EXPORT TransformRigidityPenalty
   : public itk::TransformRigidityPenaltyTerm<typename MetricBase<TElastix>::FixedImageType, double>
   , public MetricBase<TElastix>

--- a/Components/Metrics/RigidityPenalty/elxTransformRigidityPenaltyTerm.hxx
+++ b/Components/Metrics/RigidityPenalty/elxTransformRigidityPenaltyTerm.hxx
@@ -30,7 +30,7 @@ namespace elastix
  * ******************* BeforeRegistration ***********************
  */
 
-template <class TElastix>
+template <typename TElastix>
 void
 TransformRigidityPenalty<TElastix>::BeforeRegistration()
 {
@@ -146,7 +146,7 @@ TransformRigidityPenalty<TElastix>::BeforeRegistration()
  * ******************* Initialize ***********************
  */
 
-template <class TElastix>
+template <typename TElastix>
 void
 TransformRigidityPenalty<TElastix>::Initialize()
 {
@@ -167,7 +167,7 @@ TransformRigidityPenalty<TElastix>::Initialize()
  * ***************** BeforeEachResolution ***********************
  */
 
-template <class TElastix>
+template <typename TElastix>
 void
 TransformRigidityPenalty<TElastix>::BeforeEachResolution()
 {
@@ -247,7 +247,7 @@ TransformRigidityPenalty<TElastix>::BeforeEachResolution()
  * ***************AfterEachIteration ****************************
  */
 
-template <class TElastix>
+template <typename TElastix>
 void
 TransformRigidityPenalty<TElastix>::AfterEachIteration()
 {

--- a/Components/Metrics/RigidityPenalty/itkTransformRigidityPenaltyTerm.h
+++ b/Components/Metrics/RigidityPenalty/itkTransformRigidityPenaltyTerm.h
@@ -67,7 +67,7 @@ namespace itk
  * \ingroup Metrics
  */
 
-template <class TFixedImage, class TScalarType>
+template <typename TFixedImage, typename TScalarType>
 class ITK_TEMPLATE_EXPORT TransformRigidityPenaltyTerm : public TransformPenaltyTerm<TFixedImage, TScalarType>
 {
 public:

--- a/Components/Metrics/RigidityPenalty/itkTransformRigidityPenaltyTerm.hxx
+++ b/Components/Metrics/RigidityPenalty/itkTransformRigidityPenaltyTerm.hxx
@@ -29,7 +29,7 @@ namespace itk
  * ****************** Constructor *******************************
  */
 
-template <class TFixedImage, class TScalarType>
+template <typename TFixedImage, typename TScalarType>
 TransformRigidityPenaltyTerm<TFixedImage, TScalarType>::TransformRigidityPenaltyTerm()
 {
   /** Weights. */
@@ -93,7 +93,7 @@ TransformRigidityPenaltyTerm<TFixedImage, TScalarType>::TransformRigidityPenalty
  * *********************** CheckUseAndCalculationBooleans *****************************
  */
 
-template <class TFixedImage, class TScalarType>
+template <typename TFixedImage, typename TScalarType>
 void
 TransformRigidityPenaltyTerm<TFixedImage, TScalarType>::CheckUseAndCalculationBooleans()
 {
@@ -117,7 +117,7 @@ TransformRigidityPenaltyTerm<TFixedImage, TScalarType>::CheckUseAndCalculationBo
  * *********************** Initialize *****************************
  */
 
-template <class TFixedImage, class TScalarType>
+template <typename TFixedImage, typename TScalarType>
 void
 TransformRigidityPenaltyTerm<TFixedImage, TScalarType>::Initialize()
 {
@@ -171,7 +171,7 @@ TransformRigidityPenaltyTerm<TFixedImage, TScalarType>::Initialize()
  * **************** DilateRigidityImages *****************
  */
 
-template <class TFixedImage, class TScalarType>
+template <typename TFixedImage, typename TScalarType>
 void
 TransformRigidityPenaltyTerm<TFixedImage, TScalarType>::DilateRigidityImages()
 {
@@ -318,7 +318,7 @@ TransformRigidityPenaltyTerm<TFixedImage, TScalarType>::DilateRigidityImages()
  * **************** FillRigidityCoefficientImage *****************
  */
 
-template <class TFixedImage, class TScalarType>
+template <typename TFixedImage, typename TScalarType>
 void
 TransformRigidityPenaltyTerm<TFixedImage, TScalarType>::FillRigidityCoefficientImage(
   const ParametersType & parameters) const
@@ -457,7 +457,7 @@ TransformRigidityPenaltyTerm<TFixedImage, TScalarType>::FillRigidityCoefficientI
  * *********************** GetValue *****************************
  */
 
-template <class TFixedImage, class TScalarType>
+template <typename TFixedImage, typename TScalarType>
 auto
 TransformRigidityPenaltyTerm<TFixedImage, TScalarType>::GetValue(const ParametersType & parameters) const -> MeasureType
 {
@@ -829,7 +829,7 @@ TransformRigidityPenaltyTerm<TFixedImage, TScalarType>::GetValue(const Parameter
  * *********************** GetDerivative ************************
  */
 
-template <class TFixedImage, class TScalarType>
+template <typename TFixedImage, typename TScalarType>
 void
 TransformRigidityPenaltyTerm<TFixedImage, TScalarType>::GetDerivative(const ParametersType & parameters,
                                                                       DerivativeType &       derivative) const
@@ -849,7 +849,7 @@ TransformRigidityPenaltyTerm<TFixedImage, TScalarType>::GetDerivative(const Para
  * *********************** BeforeThreadedGetValueAndDerivative ***********************
  */
 
-template <class TFixedImage, class TScalarType>
+template <typename TFixedImage, typename TScalarType>
 void
 TransformRigidityPenaltyTerm<TFixedImage, TScalarType>::BeforeThreadedGetValueAndDerivative(
   const TransformParametersType & parameters) const
@@ -869,7 +869,7 @@ TransformRigidityPenaltyTerm<TFixedImage, TScalarType>::BeforeThreadedGetValueAn
  * *********************** GetValueAndDerivative ****************
  */
 
-template <class TFixedImage, class TScalarType>
+template <typename TFixedImage, typename TScalarType>
 void
 TransformRigidityPenaltyTerm<TFixedImage, TScalarType>::GetValueAndDerivative(const ParametersType & parameters,
                                                                               MeasureType &          value,
@@ -1873,7 +1873,7 @@ TransformRigidityPenaltyTerm<TFixedImage, TScalarType>::GetValueAndDerivative(co
  * ********************* PrintSelf ******************************
  */
 
-template <class TFixedImage, class TScalarType>
+template <typename TFixedImage, typename TScalarType>
 void
 TransformRigidityPenaltyTerm<TFixedImage, TScalarType>::PrintSelf(std::ostream & os, Indent indent) const
 {
@@ -1908,7 +1908,7 @@ TransformRigidityPenaltyTerm<TFixedImage, TScalarType>::PrintSelf(std::ostream &
  * ************************ Create1DOperator *********************
  */
 
-template <class TFixedImage, class TScalarType>
+template <typename TFixedImage, typename TScalarType>
 void
 TransformRigidityPenaltyTerm<TFixedImage, TScalarType>::Create1DOperator(
   NeighborhoodType &                  F,
@@ -2120,7 +2120,7 @@ TransformRigidityPenaltyTerm<TFixedImage, TScalarType>::Create1DOperator(
  * ************************** FilterSeparable ********************
  */
 
-template <class TFixedImage, class TScalarType>
+template <typename TFixedImage, typename TScalarType>
 auto
 TransformRigidityPenaltyTerm<TFixedImage, TScalarType>::FilterSeparable(
   const CoefficientImageType *          image,
@@ -2154,7 +2154,7 @@ TransformRigidityPenaltyTerm<TFixedImage, TScalarType>::FilterSeparable(
  * ************************ CreateNDOperator *********************
  */
 
-template <class TFixedImage, class TScalarType>
+template <typename TFixedImage, typename TScalarType>
 void
 TransformRigidityPenaltyTerm<TFixedImage, TScalarType>::CreateNDOperator(
   NeighborhoodType &                  F,

--- a/Components/Metrics/StatisticalShapePenalty/elxStatisticalShapePenalty.h
+++ b/Components/Metrics/StatisticalShapePenalty/elxStatisticalShapePenalty.h
@@ -54,7 +54,7 @@ using namespace itk;
  * \ingroup Metrics
  */
 
-template <class TElastix>
+template <typename TElastix>
 class ITK_TEMPLATE_EXPORT StatisticalShapePenalty
   : public StatisticalShapePointPenalty<typename MetricBase<TElastix>::FixedPointSetType,
                                         typename MetricBase<TElastix>::MovingPointSetType>

--- a/Components/Metrics/StatisticalShapePenalty/elxStatisticalShapePenalty.hxx
+++ b/Components/Metrics/StatisticalShapePenalty/elxStatisticalShapePenalty.hxx
@@ -36,7 +36,7 @@ namespace elastix
  * ******************* Initialize ***********************
  */
 
-template <class TElastix>
+template <typename TElastix>
 void
 StatisticalShapePenalty<TElastix>::Initialize()
 {
@@ -54,7 +54,7 @@ StatisticalShapePenalty<TElastix>::Initialize()
  * ***************** BeforeRegistration ***********************
  */
 
-template <class TElastix>
+template <typename TElastix>
 void
 StatisticalShapePenalty<TElastix>::BeforeRegistration()
 {
@@ -183,7 +183,7 @@ StatisticalShapePenalty<TElastix>::BeforeRegistration()
  * ***************** BeforeEachResolution ***********************
  */
 
-template <class TElastix>
+template <typename TElastix>
 void
 StatisticalShapePenalty<TElastix>::BeforeEachResolution()
 {
@@ -268,7 +268,7 @@ StatisticalShapePenalty<TElastix>::BeforeEachResolution()
  * ***************** ReadLandmarks ***********************
  */
 
-template <class TElastix>
+template <typename TElastix>
 unsigned int
 StatisticalShapePenalty<TElastix>::ReadLandmarks(const std::string &                    landmarkFileName,
                                                  typename PointSetType::Pointer &       pointSet,
@@ -345,7 +345,7 @@ StatisticalShapePenalty<TElastix>::ReadLandmarks(const std::string &            
  * ************** TransformPointsSomePointsVTK *********************
  */
 
-template <class TElastix>
+template <typename TElastix>
 unsigned int
 StatisticalShapePenalty<TElastix>::ReadShape(const std::string &              ShapeFileName,
                                              typename PointSetType::Pointer & pointSet)

--- a/Components/Metrics/StatisticalShapePenalty/itkStatisticalShapePointPenalty.h
+++ b/Components/Metrics/StatisticalShapePenalty/itkStatisticalShapePointPenalty.h
@@ -52,7 +52,7 @@ namespace itk
  * \ingroup RegistrationMetrics
  */
 
-template <class TFixedPointSet, class TMovingPointSet>
+template <typename TFixedPointSet, typename TMovingPointSet>
 class ITK_TEMPLATE_EXPORT StatisticalShapePointPenalty
   : public SingleValuedPointSetToPointSetMetric<TFixedPointSet, TMovingPointSet>
 {

--- a/Components/Metrics/StatisticalShapePenalty/itkStatisticalShapePointPenalty.hxx
+++ b/Components/Metrics/StatisticalShapePenalty/itkStatisticalShapePointPenalty.hxx
@@ -27,7 +27,7 @@ namespace itk
  * ******************* Constructor *******************
  */
 
-template <class TFixedPointSet, class TMovingPointSet>
+template <typename TFixedPointSet, typename TMovingPointSet>
 StatisticalShapePointPenalty<TFixedPointSet, TMovingPointSet>::StatisticalShapePointPenalty()
 {
   this->m_MeanVector = nullptr;
@@ -48,7 +48,7 @@ StatisticalShapePointPenalty<TFixedPointSet, TMovingPointSet>::StatisticalShapeP
  * ******************* Destructor *******************
  */
 
-template <class TFixedPointSet, class TMovingPointSet>
+template <typename TFixedPointSet, typename TMovingPointSet>
 StatisticalShapePointPenalty<TFixedPointSet, TMovingPointSet>::~StatisticalShapePointPenalty()
 {
   if (this->m_MeanVector != nullptr)
@@ -94,7 +94,7 @@ StatisticalShapePointPenalty<TFixedPointSet, TMovingPointSet>::~StatisticalShape
  * *********************** Initialize *****************************
  */
 
-template <class TFixedPointSet, class TMovingPointSet>
+template <typename TFixedPointSet, typename TMovingPointSet>
 void
 StatisticalShapePointPenalty<TFixedPointSet, TMovingPointSet>::Initialize()
 {
@@ -341,7 +341,7 @@ StatisticalShapePointPenalty<TFixedPointSet, TMovingPointSet>::Initialize()
  * ******************* GetValue *******************
  */
 
-template <class TFixedPointSet, class TMovingPointSet>
+template <typename TFixedPointSet, typename TMovingPointSet>
 auto
 StatisticalShapePointPenalty<TFixedPointSet, TMovingPointSet>::GetValue(
   const TransformParametersType & parameters) const -> MeasureType
@@ -419,7 +419,7 @@ StatisticalShapePointPenalty<TFixedPointSet, TMovingPointSet>::GetValue(
  * ******************* GetDerivative *******************
  */
 
-template <class TFixedPointSet, class TMovingPointSet>
+template <typename TFixedPointSet, typename TMovingPointSet>
 void
 StatisticalShapePointPenalty<TFixedPointSet, TMovingPointSet>::GetDerivative(const TransformParametersType & parameters,
                                                                              DerivativeType & derivative) const
@@ -439,7 +439,7 @@ StatisticalShapePointPenalty<TFixedPointSet, TMovingPointSet>::GetDerivative(con
  * ******************* GetValueAndDerivative *******************
  */
 
-template <class TFixedPointSet, class TMovingPointSet>
+template <typename TFixedPointSet, typename TMovingPointSet>
 void
 StatisticalShapePointPenalty<TFixedPointSet, TMovingPointSet>::GetValueAndDerivative(
   const TransformParametersType & parameters,
@@ -554,7 +554,7 @@ StatisticalShapePointPenalty<TFixedPointSet, TMovingPointSet>::GetValueAndDeriva
  * ******************* FillProposalVector *******************
  */
 
-template <class TFixedPointSet, class TMovingPointSet>
+template <typename TFixedPointSet, typename TMovingPointSet>
 void
 StatisticalShapePointPenalty<TFixedPointSet, TMovingPointSet>::FillProposalVector(const OutputPointType & fixedPoint,
                                                                                   const unsigned int vertexindex) const
@@ -575,7 +575,7 @@ StatisticalShapePointPenalty<TFixedPointSet, TMovingPointSet>::FillProposalVecto
  * ******************* FillProposalDerivative *******************
  */
 
-template <class TFixedPointSet, class TMovingPointSet>
+template <typename TFixedPointSet, typename TMovingPointSet>
 void
 StatisticalShapePointPenalty<TFixedPointSet, TMovingPointSet>::FillProposalDerivative(
   const OutputPointType & fixedPoint,
@@ -624,7 +624,7 @@ StatisticalShapePointPenalty<TFixedPointSet, TMovingPointSet>::FillProposalDeriv
  * ******************* UpdateCentroidAndAlignProposalVector *******************
  */
 
-template <class TFixedPointSet, class TMovingPointSet>
+template <typename TFixedPointSet, typename TMovingPointSet>
 void
 StatisticalShapePointPenalty<TFixedPointSet, TMovingPointSet>::UpdateCentroidAndAlignProposalVector(
   const unsigned int shapeLength) const
@@ -660,7 +660,7 @@ StatisticalShapePointPenalty<TFixedPointSet, TMovingPointSet>::UpdateCentroidAnd
  * ******************* UpdateCentroidAndAlignProposalDerivative *******************
  */
 
-template <class TFixedPointSet, class TMovingPointSet>
+template <typename TFixedPointSet, typename TMovingPointSet>
 void
 StatisticalShapePointPenalty<TFixedPointSet, TMovingPointSet>::UpdateCentroidAndAlignProposalDerivative(
   const unsigned int shapeLength) const
@@ -698,7 +698,7 @@ StatisticalShapePointPenalty<TFixedPointSet, TMovingPointSet>::UpdateCentroidAnd
  * ******************* UpdateL2 *******************
  */
 
-template <class TFixedPointSet, class TMovingPointSet>
+template <typename TFixedPointSet, typename TMovingPointSet>
 void
 StatisticalShapePointPenalty<TFixedPointSet, TMovingPointSet>::UpdateL2(const unsigned int shapeLength) const
 {
@@ -720,7 +720,7 @@ StatisticalShapePointPenalty<TFixedPointSet, TMovingPointSet>::UpdateL2(const un
  * ******************* NormalizeProposalVector *******************
  */
 
-template <class TFixedPointSet, class TMovingPointSet>
+template <typename TFixedPointSet, typename TMovingPointSet>
 void
 StatisticalShapePointPenalty<TFixedPointSet, TMovingPointSet>::NormalizeProposalVector(
   const unsigned int shapeLength) const
@@ -741,7 +741,7 @@ StatisticalShapePointPenalty<TFixedPointSet, TMovingPointSet>::NormalizeProposal
  * ******************* UpdateL2AndNormalizeProposalDerivative *******************
  */
 
-template <class TFixedPointSet, class TMovingPointSet>
+template <typename TFixedPointSet, typename TMovingPointSet>
 void
 StatisticalShapePointPenalty<TFixedPointSet, TMovingPointSet>::UpdateL2AndNormalizeProposalDerivative(
   const unsigned int shapeLength) const
@@ -782,7 +782,7 @@ StatisticalShapePointPenalty<TFixedPointSet, TMovingPointSet>::UpdateL2AndNormal
  * ******************* CalculateValue *******************
  */
 
-template <class TFixedPointSet, class TMovingPointSet>
+template <typename TFixedPointSet, typename TMovingPointSet>
 void
 StatisticalShapePointPenalty<TFixedPointSet, TMovingPointSet>::CalculateValue(MeasureType &   value,
                                                                               VnlVectorType & differenceVector,
@@ -855,7 +855,7 @@ StatisticalShapePointPenalty<TFixedPointSet, TMovingPointSet>::CalculateValue(Me
  * ******************* CalculateDerivative *******************
  */
 
-template <class TFixedPointSet, class TMovingPointSet>
+template <typename TFixedPointSet, typename TMovingPointSet>
 void
 StatisticalShapePointPenalty<TFixedPointSet, TMovingPointSet>::CalculateDerivative(
   DerivativeType &      derivative,
@@ -952,7 +952,7 @@ StatisticalShapePointPenalty<TFixedPointSet, TMovingPointSet>::CalculateDerivati
  * ******************* CalculateCutOffValue *******************
  */
 
-template <class TFixedPointSet, class TMovingPointSet>
+template <typename TFixedPointSet, typename TMovingPointSet>
 void
 StatisticalShapePointPenalty<TFixedPointSet, TMovingPointSet>::CalculateCutOffValue(MeasureType & value) const
 {
@@ -969,7 +969,7 @@ StatisticalShapePointPenalty<TFixedPointSet, TMovingPointSet>::CalculateCutOffVa
  * ******************* CalculateCutOffDerivative *******************
  */
 
-template <class TFixedPointSet, class TMovingPointSet>
+template <typename TFixedPointSet, typename TMovingPointSet>
 void
 StatisticalShapePointPenalty<TFixedPointSet, TMovingPointSet>::CalculateCutOffDerivative(
   typename DerivativeType::element_type & derivativeElement,
@@ -986,7 +986,7 @@ StatisticalShapePointPenalty<TFixedPointSet, TMovingPointSet>::CalculateCutOffDe
  * ******************* PrintSelf *******************
  */
 
-template <class TFixedPointSet, class TMovingPointSet>
+template <typename TFixedPointSet, typename TMovingPointSet>
 void
 StatisticalShapePointPenalty<TFixedPointSet, TMovingPointSet>::PrintSelf(std::ostream & os, Indent indent) const
 {

--- a/Components/Metrics/SumOfPairwiseCorrelationsMetric/elxSumOfPairwiseCorrelationCoefficientsMetric.h
+++ b/Components/Metrics/SumOfPairwiseCorrelationsMetric/elxSumOfPairwiseCorrelationCoefficientsMetric.h
@@ -61,7 +61,7 @@ namespace elastix
  * \ingroup Metrics
  */
 
-template <class TElastix>
+template <typename TElastix>
 class ITK_TEMPLATE_EXPORT SumOfPairwiseCorrelationCoefficientsMetric
   : public itk::SumOfPairwiseCorrelationCoefficientsMetric<typename MetricBase<TElastix>::FixedImageType,
                                                            typename MetricBase<TElastix>::MovingImageType>

--- a/Components/Metrics/SumOfPairwiseCorrelationsMetric/elxSumOfPairwiseCorrelationCoefficientsMetric.hxx
+++ b/Components/Metrics/SumOfPairwiseCorrelationsMetric/elxSumOfPairwiseCorrelationCoefficientsMetric.hxx
@@ -29,7 +29,7 @@ namespace elastix
  * ******************* Initialize ***********************
  */
 
-template <class TElastix>
+template <typename TElastix>
 void
 SumOfPairwiseCorrelationCoefficientsMetric<TElastix>::Initialize()
 {
@@ -59,7 +59,7 @@ SumOfPairwiseCorrelationCoefficientsMetric<TElastix>::Initialize()
  * ***************** BeforeRegistration ***********************
  */
 
-template <class TElastix>
+template <typename TElastix>
 void
 SumOfPairwiseCorrelationCoefficientsMetric<TElastix>::BeforeRegistration()
 {
@@ -96,7 +96,7 @@ SumOfPairwiseCorrelationCoefficientsMetric<TElastix>::BeforeRegistration()
  * ***************** BeforeEachResolution ***********************
  */
 
-template <class TElastix>
+template <typename TElastix>
 void
 SumOfPairwiseCorrelationCoefficientsMetric<TElastix>::BeforeEachResolution()
 {

--- a/Components/Metrics/SumOfPairwiseCorrelationsMetric/itkSumOfPairwiseCorrelationCoefficientsMetric.h
+++ b/Components/Metrics/SumOfPairwiseCorrelationsMetric/itkSumOfPairwiseCorrelationCoefficientsMetric.h
@@ -27,7 +27,7 @@
 
 namespace itk
 {
-template <class TFixedImage, class TMovingImage>
+template <typename TFixedImage, typename TMovingImage>
 class ITK_TEMPLATE_EXPORT SumOfPairwiseCorrelationCoefficientsMetric
   : public AdvancedImageToImageMetric<TFixedImage, TMovingImage>
 {

--- a/Components/Metrics/SumOfPairwiseCorrelationsMetric/itkSumOfPairwiseCorrelationCoefficientsMetric.hxx
+++ b/Components/Metrics/SumOfPairwiseCorrelationsMetric/itkSumOfPairwiseCorrelationCoefficientsMetric.hxx
@@ -31,7 +31,7 @@ namespace itk
  * ******************* Constructor *******************
  */
 
-template <class TFixedImage, class TMovingImage>
+template <typename TFixedImage, typename TMovingImage>
 SumOfPairwiseCorrelationCoefficientsMetric<TFixedImage, TMovingImage>::SumOfPairwiseCorrelationCoefficientsMetric()
 {
   this->SetUseImageSampler(true);
@@ -44,7 +44,7 @@ SumOfPairwiseCorrelationCoefficientsMetric<TFixedImage, TMovingImage>::SumOfPair
  * ******************* Initialize *******************
  */
 
-template <class TFixedImage, class TMovingImage>
+template <typename TFixedImage, typename TMovingImage>
 void
 SumOfPairwiseCorrelationCoefficientsMetric<TFixedImage, TMovingImage>::Initialize()
 {
@@ -57,7 +57,7 @@ SumOfPairwiseCorrelationCoefficientsMetric<TFixedImage, TMovingImage>::Initializ
  * ******************* PrintSelf *******************
  */
 
-template <class TFixedImage, class TMovingImage>
+template <typename TFixedImage, typename TMovingImage>
 void
 SumOfPairwiseCorrelationCoefficientsMetric<TFixedImage, TMovingImage>::PrintSelf(std::ostream & os, Indent indent) const
 {
@@ -69,7 +69,7 @@ SumOfPairwiseCorrelationCoefficientsMetric<TFixedImage, TMovingImage>::PrintSelf
  * ******************* SampleRandom *******************
  */
 
-template <class TFixedImage, class TMovingImage>
+template <typename TFixedImage, typename TMovingImage>
 void
 SumOfPairwiseCorrelationCoefficientsMetric<TFixedImage, TMovingImage>::SampleRandom(const int          n,
                                                                                     const int          m,
@@ -107,7 +107,7 @@ SumOfPairwiseCorrelationCoefficientsMetric<TFixedImage, TMovingImage>::SampleRan
  * *************** EvaluateTransformJacobianInnerProduct ****************
  */
 
-template <class TFixedImage, class TMovingImage>
+template <typename TFixedImage, typename TMovingImage>
 void
 SumOfPairwiseCorrelationCoefficientsMetric<TFixedImage, TMovingImage>::EvaluateTransformJacobianInnerProduct(
   const TransformJacobianType &     jacobian,
@@ -121,7 +121,7 @@ SumOfPairwiseCorrelationCoefficientsMetric<TFixedImage, TMovingImage>::EvaluateT
  * ******************* GetValue *******************
  */
 
-template <class TFixedImage, class TMovingImage>
+template <typename TFixedImage, typename TMovingImage>
 auto
 SumOfPairwiseCorrelationCoefficientsMetric<TFixedImage, TMovingImage>::GetValue(
   const TransformParametersType & parameters) const -> MeasureType
@@ -255,7 +255,7 @@ SumOfPairwiseCorrelationCoefficientsMetric<TFixedImage, TMovingImage>::GetValue(
  * ******************* GetDerivative *******************
  */
 
-template <class TFixedImage, class TMovingImage>
+template <typename TFixedImage, typename TMovingImage>
 void
 SumOfPairwiseCorrelationCoefficientsMetric<TFixedImage, TMovingImage>::GetDerivative(
   const TransformParametersType & parameters,
@@ -277,7 +277,7 @@ SumOfPairwiseCorrelationCoefficientsMetric<TFixedImage, TMovingImage>::GetDeriva
  * ******************* GetValueAndDerivative *******************
  */
 
-template <class TFixedImage, class TMovingImage>
+template <typename TFixedImage, typename TMovingImage>
 void
 SumOfPairwiseCorrelationCoefficientsMetric<TFixedImage, TMovingImage>::GetValueAndDerivative(
   const TransformParametersType & parameters,

--- a/Components/Metrics/SumSquaredTissueVolumeDifferenceMetric/elxSumSquaredTissueVolumeDifferenceMetric.h
+++ b/Components/Metrics/SumSquaredTissueVolumeDifferenceMetric/elxSumSquaredTissueVolumeDifferenceMetric.h
@@ -46,7 +46,7 @@ namespace elastix
  * \ingroup Metrics
  */
 
-template <class TElastix>
+template <typename TElastix>
 class ITK_TEMPLATE_EXPORT SumSquaredTissueVolumeDifferenceMetric
   : public itk::SumSquaredTissueVolumeDifferenceImageToImageMetric<typename MetricBase<TElastix>::FixedImageType,
                                                                    typename MetricBase<TElastix>::MovingImageType>

--- a/Components/Metrics/SumSquaredTissueVolumeDifferenceMetric/elxSumSquaredTissueVolumeDifferenceMetric.hxx
+++ b/Components/Metrics/SumSquaredTissueVolumeDifferenceMetric/elxSumSquaredTissueVolumeDifferenceMetric.hxx
@@ -29,7 +29,7 @@ namespace elastix
  * ******************* Initialize ***********************
  */
 
-template <class TElastix>
+template <typename TElastix>
 void
 SumSquaredTissueVolumeDifferenceMetric<TElastix>::Initialize()
 {
@@ -47,7 +47,7 @@ SumSquaredTissueVolumeDifferenceMetric<TElastix>::Initialize()
  * ***************** BeforeEachResolution ***********************
  */
 
-template <class TElastix>
+template <typename TElastix>
 void
 SumSquaredTissueVolumeDifferenceMetric<TElastix>::BeforeEachResolution()
 {

--- a/Components/Metrics/SumSquaredTissueVolumeDifferenceMetric/itkSumSquaredTissueVolumeDifferenceImageToImageMetric.h
+++ b/Components/Metrics/SumSquaredTissueVolumeDifferenceMetric/itkSumSquaredTissueVolumeDifferenceImageToImageMetric.h
@@ -57,7 +57,7 @@ namespace itk
  * \ingroup Metrics
  */
 
-template <class TFixedImage, class TMovingImage>
+template <typename TFixedImage, typename TMovingImage>
 class ITK_TEMPLATE_EXPORT SumSquaredTissueVolumeDifferenceImageToImageMetric
   : public AdvancedImageToImageMetric<TFixedImage, TMovingImage>
 {

--- a/Components/Metrics/SumSquaredTissueVolumeDifferenceMetric/itkSumSquaredTissueVolumeDifferenceImageToImageMetric.hxx
+++ b/Components/Metrics/SumSquaredTissueVolumeDifferenceMetric/itkSumSquaredTissueVolumeDifferenceImageToImageMetric.hxx
@@ -28,7 +28,7 @@ namespace itk
  * ******************* Constructor *******************
  */
 
-template <class TFixedImage, class TMovingImage>
+template <typename TFixedImage, typename TMovingImage>
 SumSquaredTissueVolumeDifferenceImageToImageMetric<TFixedImage,
                                                    TMovingImage>::SumSquaredTissueVolumeDifferenceImageToImageMetric()
 {
@@ -42,7 +42,7 @@ SumSquaredTissueVolumeDifferenceImageToImageMetric<TFixedImage,
  * ******************* PrintSelf *******************
  */
 
-template <class TFixedImage, class TMovingImage>
+template <typename TFixedImage, typename TMovingImage>
 void
 SumSquaredTissueVolumeDifferenceImageToImageMetric<TFixedImage, TMovingImage>::PrintSelf(std::ostream & os,
                                                                                          Indent         indent) const
@@ -59,7 +59,7 @@ SumSquaredTissueVolumeDifferenceImageToImageMetric<TFixedImage, TMovingImage>::P
  * ******************* GetValueSingleThreaded *******************
  */
 
-template <class TFixedImage, class TMovingImage>
+template <typename TFixedImage, typename TMovingImage>
 auto
 SumSquaredTissueVolumeDifferenceImageToImageMetric<TFixedImage, TMovingImage>::GetValueSingleThreaded(
   const TransformParametersType & parameters) const -> MeasureType
@@ -144,7 +144,7 @@ SumSquaredTissueVolumeDifferenceImageToImageMetric<TFixedImage, TMovingImage>::G
  * ******************* GetValue *******************
  */
 
-template <class TFixedImage, class TMovingImage>
+template <typename TFixedImage, typename TMovingImage>
 auto
 SumSquaredTissueVolumeDifferenceImageToImageMetric<TFixedImage, TMovingImage>::GetValue(
   const TransformParametersType & parameters) const -> MeasureType
@@ -186,7 +186,7 @@ SumSquaredTissueVolumeDifferenceImageToImageMetric<TFixedImage, TMovingImage>::G
  * ******************* ThreadedGetValue *******************
  */
 
-template <class TFixedImage, class TMovingImage>
+template <typename TFixedImage, typename TMovingImage>
 void
 SumSquaredTissueVolumeDifferenceImageToImageMetric<TFixedImage, TMovingImage>::ThreadedGetValue(
   ThreadIdType threadId) const
@@ -268,7 +268,7 @@ SumSquaredTissueVolumeDifferenceImageToImageMetric<TFixedImage, TMovingImage>::T
  * ******************* AfterThreadedGetValue *******************
  */
 
-template <class TFixedImage, class TMovingImage>
+template <typename TFixedImage, typename TMovingImage>
 void
 SumSquaredTissueVolumeDifferenceImageToImageMetric<TFixedImage, TMovingImage>::AfterThreadedGetValue(
   MeasureType & value) const
@@ -306,7 +306,7 @@ SumSquaredTissueVolumeDifferenceImageToImageMetric<TFixedImage, TMovingImage>::A
  * ******************* GetDerivative *******************
  */
 
-template <class TFixedImage, class TMovingImage>
+template <typename TFixedImage, typename TMovingImage>
 void
 SumSquaredTissueVolumeDifferenceImageToImageMetric<TFixedImage, TMovingImage>::GetDerivative(
   const TransformParametersType & parameters,
@@ -324,7 +324,7 @@ SumSquaredTissueVolumeDifferenceImageToImageMetric<TFixedImage, TMovingImage>::G
 
 
 /** Get value and derivatives single-threaded */
-template <class TFixedImage, class TMovingImage>
+template <typename TFixedImage, typename TMovingImage>
 void
 SumSquaredTissueVolumeDifferenceImageToImageMetric<TFixedImage, TMovingImage>::GetValueAndDerivativeSingleThreaded(
   const TransformParametersType & parameters,
@@ -450,7 +450,7 @@ SumSquaredTissueVolumeDifferenceImageToImageMetric<TFixedImage, TMovingImage>::G
  * ******************* GetValueAndDerivative *******************
  */
 
-template <class TFixedImage, class TMovingImage>
+template <typename TFixedImage, typename TMovingImage>
 void
 SumSquaredTissueVolumeDifferenceImageToImageMetric<TFixedImage, TMovingImage>::GetValueAndDerivative(
   const TransformParametersType & parameters,
@@ -480,7 +480,7 @@ SumSquaredTissueVolumeDifferenceImageToImageMetric<TFixedImage, TMovingImage>::G
  * ******************* ThreadedGetValueAndDerivative *******************
  */
 
-template <class TFixedImage, class TMovingImage>
+template <typename TFixedImage, typename TMovingImage>
 void
 SumSquaredTissueVolumeDifferenceImageToImageMetric<TFixedImage, TMovingImage>::ThreadedGetValueAndDerivative(
   ThreadIdType threadId) const
@@ -599,7 +599,7 @@ SumSquaredTissueVolumeDifferenceImageToImageMetric<TFixedImage, TMovingImage>::T
  * *************** AfterThreadedGetValueAndDerivative ****************
  */
 
-template <class TFixedImage, class TMovingImage>
+template <typename TFixedImage, typename TMovingImage>
 void
 SumSquaredTissueVolumeDifferenceImageToImageMetric<TFixedImage, TMovingImage>::AfterThreadedGetValueAndDerivative(
   MeasureType &    value,
@@ -647,7 +647,7 @@ SumSquaredTissueVolumeDifferenceImageToImageMetric<TFixedImage, TMovingImage>::A
  * *************** EvaluateTransformJacobianInnerProduct ****************
  */
 
-template <class TFixedImage, class TMovingImage>
+template <typename TFixedImage, typename TMovingImage>
 void
 SumSquaredTissueVolumeDifferenceImageToImageMetric<TFixedImage, TMovingImage>::EvaluateTransformJacobianInnerProduct(
   const TransformJacobianType &     jacobian,
@@ -675,7 +675,7 @@ SumSquaredTissueVolumeDifferenceImageToImageMetric<TFixedImage, TMovingImage>::E
  * *************** UpdateValueAndDerivativeTerms ***************************
  */
 
-template <class TFixedImage, class TMovingImage>
+template <typename TFixedImage, typename TMovingImage>
 void
 SumSquaredTissueVolumeDifferenceImageToImageMetric<TFixedImage, TMovingImage>::UpdateValueAndDerivativeTerms(
   const RealType                     fixedImageValue,
@@ -733,7 +733,7 @@ SumSquaredTissueVolumeDifferenceImageToImageMetric<TFixedImage, TMovingImage>::U
  * ********** EvaluateJacobianOfSpatialJacobianDeterminantInnerProduct ******
  */
 
-template <class TFixedImage, class TMovingImage>
+template <typename TFixedImage, typename TMovingImage>
 void
 SumSquaredTissueVolumeDifferenceImageToImageMetric<TFixedImage, TMovingImage>::
   EvaluateJacobianOfSpatialJacobianDeterminantInnerProduct(

--- a/Components/Metrics/VarianceOverLastDimension/elxVarianceOverLastDimensionMetric.h
+++ b/Components/Metrics/VarianceOverLastDimension/elxVarianceOverLastDimensionMetric.h
@@ -65,7 +65,7 @@ namespace elastix
  * \ingroup Metrics
  */
 
-template <class TElastix>
+template <typename TElastix>
 class ITK_TEMPLATE_EXPORT VarianceOverLastDimensionMetric
   : public itk::VarianceOverLastDimensionImageMetric<typename MetricBase<TElastix>::FixedImageType,
                                                      typename MetricBase<TElastix>::MovingImageType>

--- a/Components/Metrics/VarianceOverLastDimension/elxVarianceOverLastDimensionMetric.hxx
+++ b/Components/Metrics/VarianceOverLastDimension/elxVarianceOverLastDimensionMetric.hxx
@@ -29,7 +29,7 @@ namespace elastix
  * ******************* Initialize ***********************
  */
 
-template <class TElastix>
+template <typename TElastix>
 void
 VarianceOverLastDimensionMetric<TElastix>::Initialize()
 {
@@ -58,7 +58,7 @@ VarianceOverLastDimensionMetric<TElastix>::Initialize()
  * ***************** BeforeRegistration ***********************
  */
 
-template <class TElastix>
+template <typename TElastix>
 void
 VarianceOverLastDimensionMetric<TElastix>::BeforeRegistration()
 {
@@ -122,7 +122,7 @@ VarianceOverLastDimensionMetric<TElastix>::BeforeRegistration()
  * ***************** BeforeEachResolution ***********************
  */
 
-template <class TElastix>
+template <typename TElastix>
 void
 VarianceOverLastDimensionMetric<TElastix>::BeforeEachResolution()
 {

--- a/Components/Metrics/VarianceOverLastDimension/itkVarianceOverLastDimensionImageMetric.h
+++ b/Components/Metrics/VarianceOverLastDimension/itkVarianceOverLastDimensionImageMetric.h
@@ -48,7 +48,7 @@ namespace itk
  * \ingroup Metrics
  */
 
-template <class TFixedImage, class TMovingImage>
+template <typename TFixedImage, typename TMovingImage>
 class ITK_TEMPLATE_EXPORT VarianceOverLastDimensionImageMetric
   : public AdvancedImageToImageMetric<TFixedImage, TMovingImage>
 {

--- a/Components/Metrics/VarianceOverLastDimension/itkVarianceOverLastDimensionImageMetric.hxx
+++ b/Components/Metrics/VarianceOverLastDimension/itkVarianceOverLastDimensionImageMetric.hxx
@@ -30,7 +30,7 @@ namespace itk
  * ******************* Constructor *******************
  */
 
-template <class TFixedImage, class TMovingImage>
+template <typename TFixedImage, typename TMovingImage>
 VarianceOverLastDimensionImageMetric<TFixedImage, TMovingImage>::VarianceOverLastDimensionImageMetric()
 {
   this->SetUseImageSampler(true);
@@ -44,7 +44,7 @@ VarianceOverLastDimensionImageMetric<TFixedImage, TMovingImage>::VarianceOverLas
  * ******************* Initialize *******************
  */
 
-template <class TFixedImage, class TMovingImage>
+template <typename TFixedImage, typename TMovingImage>
 void
 VarianceOverLastDimensionImageMetric<TFixedImage, TMovingImage>::Initialize()
 {
@@ -109,7 +109,7 @@ VarianceOverLastDimensionImageMetric<TFixedImage, TMovingImage>::Initialize()
  * ******************* PrintSelf *******************
  */
 
-template <class TFixedImage, class TMovingImage>
+template <typename TFixedImage, typename TMovingImage>
 void
 VarianceOverLastDimensionImageMetric<TFixedImage, TMovingImage>::PrintSelf(std::ostream & os, Indent indent) const
 {
@@ -121,7 +121,7 @@ VarianceOverLastDimensionImageMetric<TFixedImage, TMovingImage>::PrintSelf(std::
  * ******************* SampleRandom *******************
  */
 
-template <class TFixedImage, class TMovingImage>
+template <typename TFixedImage, typename TMovingImage>
 void
 VarianceOverLastDimensionImageMetric<TFixedImage, TMovingImage>::SampleRandom(const int          n,
                                                                               const int          m,
@@ -158,7 +158,7 @@ VarianceOverLastDimensionImageMetric<TFixedImage, TMovingImage>::SampleRandom(co
  * *************** EvaluateTransformJacobianInnerProduct ****************
  */
 
-template <class TFixedImage, class TMovingImage>
+template <typename TFixedImage, typename TMovingImage>
 void
 VarianceOverLastDimensionImageMetric<TFixedImage, TMovingImage>::EvaluateTransformJacobianInnerProduct(
   const TransformJacobianType &     jacobian,
@@ -174,7 +174,7 @@ VarianceOverLastDimensionImageMetric<TFixedImage, TMovingImage>::EvaluateTransfo
  * ******************* GetValue *******************
  */
 
-template <class TFixedImage, class TMovingImage>
+template <typename TFixedImage, typename TMovingImage>
 auto
 VarianceOverLastDimensionImageMetric<TFixedImage, TMovingImage>::GetValue(
   const TransformParametersType & parameters) const -> MeasureType
@@ -306,7 +306,7 @@ VarianceOverLastDimensionImageMetric<TFixedImage, TMovingImage>::GetValue(
  * ******************* GetDerivative *******************
  */
 
-template <class TFixedImage, class TMovingImage>
+template <typename TFixedImage, typename TMovingImage>
 void
 VarianceOverLastDimensionImageMetric<TFixedImage, TMovingImage>::GetDerivative(
   const TransformParametersType & parameters,
@@ -327,7 +327,7 @@ VarianceOverLastDimensionImageMetric<TFixedImage, TMovingImage>::GetDerivative(
  * ******************* GetValueAndDerivative *******************
  */
 
-template <class TFixedImage, class TMovingImage>
+template <typename TFixedImage, typename TMovingImage>
 void
 VarianceOverLastDimensionImageMetric<TFixedImage, TMovingImage>::GetValueAndDerivative(
   const TransformParametersType & parameters,

--- a/Components/MovingImagePyramids/MovingGenericPyramid/elxMovingGenericPyramid.h
+++ b/Components/MovingImagePyramids/MovingGenericPyramid/elxMovingGenericPyramid.h
@@ -64,7 +64,7 @@ namespace elastix
  * \ingroup ImagePyramids
  */
 
-template <class TElastix>
+template <typename TElastix>
 class ITK_TEMPLATE_EXPORT MovingGenericPyramid
   : public itk::GenericMultiResolutionPyramidImageFilter<typename MovingImagePyramidBase<TElastix>::InputImageType,
                                                          typename MovingImagePyramidBase<TElastix>::OutputImageType>

--- a/Components/MovingImagePyramids/MovingGenericPyramid/elxMovingGenericPyramid.hxx
+++ b/Components/MovingImagePyramids/MovingGenericPyramid/elxMovingGenericPyramid.hxx
@@ -28,7 +28,7 @@ namespace elastix
  * ******************* SetMovingSchedule ***********************
  */
 
-template <class TElastix>
+template <typename TElastix>
 void
 MovingGenericPyramid<TElastix>::SetMovingSchedule()
 {
@@ -41,7 +41,7 @@ MovingGenericPyramid<TElastix>::SetMovingSchedule()
  * ******************* BeforeEachResolution ***********************
  */
 
-template <class TElastix>
+template <typename TElastix>
 void
 MovingGenericPyramid<TElastix>::BeforeEachResolution()
 {

--- a/Components/MovingImagePyramids/MovingRecursivePyramid/elxMovingRecursivePyramid.h
+++ b/Components/MovingImagePyramids/MovingRecursivePyramid/elxMovingRecursivePyramid.h
@@ -35,7 +35,7 @@ namespace elastix
  * \ingroup ImagePyramids
  */
 
-template <class TElastix>
+template <typename TElastix>
 class ITK_TEMPLATE_EXPORT MovingRecursivePyramid
   : public itk::RecursiveMultiResolutionPyramidImageFilter<typename MovingImagePyramidBase<TElastix>::InputImageType,
                                                            typename MovingImagePyramidBase<TElastix>::OutputImageType>

--- a/Components/MovingImagePyramids/MovingShrinkingPyramid/elxMovingShrinkingPyramid.h
+++ b/Components/MovingImagePyramids/MovingShrinkingPyramid/elxMovingShrinkingPyramid.h
@@ -35,7 +35,7 @@ namespace elastix
  * \ingroup ImagePyramids
  */
 
-template <class TElastix>
+template <typename TElastix>
 class ITK_TEMPLATE_EXPORT MovingShrinkingPyramid
   : public itk::MultiResolutionShrinkPyramidImageFilter<typename MovingImagePyramidBase<TElastix>::InputImageType,
                                                         typename MovingImagePyramidBase<TElastix>::OutputImageType>

--- a/Components/MovingImagePyramids/MovingSmoothingPyramid/elxMovingSmoothingPyramid.h
+++ b/Components/MovingImagePyramids/MovingSmoothingPyramid/elxMovingSmoothingPyramid.h
@@ -35,7 +35,7 @@ namespace elastix
  * \ingroup ImagePyramids
  */
 
-template <class TElastix>
+template <typename TElastix>
 class ITK_TEMPLATE_EXPORT MovingSmoothingPyramid
   : public itk::MultiResolutionGaussianSmoothingPyramidImageFilter<
       typename MovingImagePyramidBase<TElastix>::InputImageType,

--- a/Components/MovingImagePyramids/OpenCLMovingGenericPyramid/elxOpenCLMovingGenericPyramid.h
+++ b/Components/MovingImagePyramids/OpenCLMovingGenericPyramid/elxOpenCLMovingGenericPyramid.h
@@ -44,7 +44,7 @@ namespace elastix
  * \ingroup ImagePyramids
  */
 
-template <class TElastix>
+template <typename TElastix>
 class ITK_TEMPLATE_EXPORT OpenCLMovingGenericPyramid : public MovingGenericPyramid<TElastix>
 {
 public:

--- a/Components/MovingImagePyramids/OpenCLMovingGenericPyramid/elxOpenCLMovingGenericPyramid.hxx
+++ b/Components/MovingImagePyramids/OpenCLMovingGenericPyramid/elxOpenCLMovingGenericPyramid.hxx
@@ -40,7 +40,7 @@ namespace elastix
  * ******************* Constructor ***********************
  */
 
-template <class TElastix>
+template <typename TElastix>
 OpenCLMovingGenericPyramid<TElastix>::OpenCLMovingGenericPyramid()
   : m_GPUPyramidReady(true)
   , m_GPUPyramidCreated(true)
@@ -87,7 +87,7 @@ OpenCLMovingGenericPyramid<TElastix>::OpenCLMovingGenericPyramid()
  * ******************* BeforeGenerateData ***********************
  */
 
-template <class TElastix>
+template <typename TElastix>
 void
 OpenCLMovingGenericPyramid<TElastix>::BeforeGenerateData()
 {
@@ -143,7 +143,7 @@ OpenCLMovingGenericPyramid<TElastix>::BeforeGenerateData()
  * ******************* GenerateData ***********************
  */
 
-template <class TElastix>
+template <typename TElastix>
 void
 OpenCLMovingGenericPyramid<TElastix>::GenerateData()
 {
@@ -221,7 +221,7 @@ OpenCLMovingGenericPyramid<TElastix>::GenerateData()
  * ******************* RegisterFactories ***********************
  */
 
-template <class TElastix>
+template <typename TElastix>
 void
 OpenCLMovingGenericPyramid<TElastix>::RegisterFactories()
 {
@@ -271,7 +271,7 @@ OpenCLMovingGenericPyramid<TElastix>::RegisterFactories()
  * ******************* UnregisterFactories ***********************
  */
 
-template <class TElastix>
+template <typename TElastix>
 void
 OpenCLMovingGenericPyramid<TElastix>::UnregisterFactories()
 {
@@ -287,7 +287,7 @@ OpenCLMovingGenericPyramid<TElastix>::UnregisterFactories()
  * ******************* BeforeRegistration ***********************
  */
 
-template <class TElastix>
+template <typename TElastix>
 void
 OpenCLMovingGenericPyramid<TElastix>::BeforeRegistration()
 {
@@ -302,7 +302,7 @@ OpenCLMovingGenericPyramid<TElastix>::BeforeRegistration()
  * ******************* ReadFromFile  ****************************
  */
 
-template <class TElastix>
+template <typename TElastix>
 void
 OpenCLMovingGenericPyramid<TElastix>::ReadFromFile()
 {
@@ -317,7 +317,7 @@ OpenCLMovingGenericPyramid<TElastix>::ReadFromFile()
  * ************************* SwitchingToCPUAndReport ************************
  */
 
-template <class TElastix>
+template <typename TElastix>
 void
 OpenCLMovingGenericPyramid<TElastix>::SwitchingToCPUAndReport(const bool configError)
 {
@@ -340,7 +340,7 @@ OpenCLMovingGenericPyramid<TElastix>::SwitchingToCPUAndReport(const bool configE
  * ************************* ReportToLog ************************************
  */
 
-template <class TElastix>
+template <typename TElastix>
 void
 OpenCLMovingGenericPyramid<TElastix>::ReportToLog()
 {

--- a/Components/Optimizers/AdaGrad/elxAdaGrad.h
+++ b/Components/Optimizers/AdaGrad/elxAdaGrad.h
@@ -186,7 +186,7 @@ namespace elastix
  * \ingroup Optimizers
  */
 
-template <class TElastix>
+template <typename TElastix>
 class ITK_TEMPLATE_EXPORT AdaGrad
   : public itk::AdaptiveStepsizeOptimizer
   , public OptimizerBase<TElastix>

--- a/Components/Optimizers/AdaGrad/elxAdaGrad.hxx
+++ b/Components/Optimizers/AdaGrad/elxAdaGrad.hxx
@@ -38,7 +38,7 @@ namespace elastix
  * ********************** Constructor ***********************
  */
 
-template <class TElastix>
+template <typename TElastix>
 AdaGrad<TElastix>::AdaGrad()
 {
   this->m_MaximumNumberOfSamplingAttempts = 0;
@@ -73,7 +73,7 @@ AdaGrad<TElastix>::AdaGrad()
  * ***************** BeforeRegistration ***********************
  */
 
-template <class TElastix>
+template <typename TElastix>
 void
 AdaGrad<TElastix>::BeforeRegistration()
 {
@@ -100,7 +100,7 @@ AdaGrad<TElastix>::BeforeRegistration()
  * ***************** BeforeEachResolution ***********************
  */
 
-template <class TElastix>
+template <typename TElastix>
 void
 AdaGrad<TElastix>::BeforeEachResolution()
 {
@@ -277,7 +277,7 @@ AdaGrad<TElastix>::BeforeEachResolution()
  * ***************** AfterEachIteration *************************
  */
 
-template <class TElastix>
+template <typename TElastix>
 void
 AdaGrad<TElastix>::AfterEachIteration()
 {
@@ -311,7 +311,7 @@ AdaGrad<TElastix>::AfterEachIteration()
  * ***************** AfterEachResolution *************************
  */
 
-template <class TElastix>
+template <typename TElastix>
 void
 AdaGrad<TElastix>::AfterEachResolution()
 {
@@ -371,7 +371,7 @@ AdaGrad<TElastix>::AfterEachResolution()
  * ******************* AfterRegistration ************************
  */
 
-template <class TElastix>
+template <typename TElastix>
 void
 AdaGrad<TElastix>::AfterRegistration()
 {
@@ -390,7 +390,7 @@ AdaGrad<TElastix>::AfterRegistration()
  * ****************** StartOptimization *************************
  */
 
-template <class TElastix>
+template <typename TElastix>
 void
 AdaGrad<TElastix>::StartOptimization()
 {
@@ -407,7 +407,7 @@ AdaGrad<TElastix>::StartOptimization()
  * ********************** AdvanceOneStep **********************
  */
 
-template <class TElastix>
+template <typename TElastix>
 void
 AdaGrad<TElastix>::AdvanceOneStep()
 {
@@ -447,7 +447,7 @@ AdaGrad<TElastix>::AdvanceOneStep()
  * ********************** ResumeOptimization **********************
  */
 
-template <class TElastix>
+template <typename TElastix>
 void
 AdaGrad<TElastix>::ResumeOptimization()
 {
@@ -469,7 +469,7 @@ AdaGrad<TElastix>::ResumeOptimization()
  * ****************** MetricErrorResponse *************************
  */
 
-template <class TElastix>
+template <typename TElastix>
 void
 AdaGrad<TElastix>::MetricErrorResponse(itk::ExceptionObject & err)
 {
@@ -501,7 +501,7 @@ AdaGrad<TElastix>::MetricErrorResponse(itk::ExceptionObject & err)
  * ******************* AutomaticPreconditionerEstimation **********************
  */
 
-template <class TElastix>
+template <typename TElastix>
 void
 AdaGrad<TElastix>::AutomaticPreconditionerEstimation()
 {
@@ -692,7 +692,7 @@ AdaGrad<TElastix>::AutomaticPreconditionerEstimation()
  * ******************** SampleGradients **********************
  */
 
-template <class TElastix>
+template <typename TElastix>
 void
 AdaGrad<TElastix>::SampleGradients(const ParametersType & mu0, double perturbationSigma, double & gg, double & ee)
 {
@@ -884,7 +884,7 @@ AdaGrad<TElastix>::SampleGradients(const ParametersType & mu0, double perturbati
  * *************** GetScaledDerivativeWithExceptionHandling ***************
  */
 
-template <class TElastix>
+template <typename TElastix>
 void
 AdaGrad<TElastix>::GetScaledDerivativeWithExceptionHandling(const ParametersType & parameters,
                                                             DerivativeType &       derivative)
@@ -908,7 +908,7 @@ AdaGrad<TElastix>::GetScaledDerivativeWithExceptionHandling(const ParametersType
  * *************** AddRandomPerturbation ***************
  */
 
-template <class TElastix>
+template <typename TElastix>
 void
 AdaGrad<TElastix>::AddRandomPerturbation(ParametersType & parameters, double sigma)
 {

--- a/Components/Optimizers/AdaptiveStochasticGradientDescent/elxAdaptiveStochasticGradientDescent.h
+++ b/Components/Optimizers/AdaptiveStochasticGradientDescent/elxAdaptiveStochasticGradientDescent.h
@@ -189,7 +189,7 @@ namespace elastix
  * \ingroup Optimizers
  */
 
-template <class TElastix>
+template <typename TElastix>
 class ITK_TEMPLATE_EXPORT AdaptiveStochasticGradientDescent
   : public itk::AdaptiveStochasticGradientDescentOptimizer
   , public OptimizerBase<TElastix>

--- a/Components/Optimizers/AdaptiveStochasticGradientDescent/elxAdaptiveStochasticGradientDescent.hxx
+++ b/Components/Optimizers/AdaptiveStochasticGradientDescent/elxAdaptiveStochasticGradientDescent.hxx
@@ -37,7 +37,7 @@ namespace elastix
  * ********************** Constructor ***********************
  */
 
-template <class TElastix>
+template <typename TElastix>
 AdaptiveStochasticGradientDescent<TElastix>::AdaptiveStochasticGradientDescent()
 {
   this->m_MaximumNumberOfSamplingAttempts = 0;
@@ -67,7 +67,7 @@ AdaptiveStochasticGradientDescent<TElastix>::AdaptiveStochasticGradientDescent()
  * ***************** BeforeRegistration ***********************
  */
 
-template <class TElastix>
+template <typename TElastix>
 void
 AdaptiveStochasticGradientDescent<TElastix>::BeforeRegistration()
 {
@@ -92,7 +92,7 @@ AdaptiveStochasticGradientDescent<TElastix>::BeforeRegistration()
  * ***************** BeforeEachResolution ***********************
  */
 
-template <class TElastix>
+template <typename TElastix>
 void
 AdaptiveStochasticGradientDescent<TElastix>::BeforeEachResolution()
 {
@@ -260,7 +260,7 @@ AdaptiveStochasticGradientDescent<TElastix>::BeforeEachResolution()
  * ***************** AfterEachIteration *************************
  */
 
-template <class TElastix>
+template <typename TElastix>
 void
 AdaptiveStochasticGradientDescent<TElastix>::AfterEachIteration()
 {
@@ -291,7 +291,7 @@ AdaptiveStochasticGradientDescent<TElastix>::AfterEachIteration()
  * ***************** AfterEachResolution *************************
  */
 
-template <class TElastix>
+template <typename TElastix>
 void
 AdaptiveStochasticGradientDescent<TElastix>::AfterEachResolution()
 {
@@ -351,7 +351,7 @@ AdaptiveStochasticGradientDescent<TElastix>::AfterEachResolution()
  * ******************* AfterRegistration ************************
  */
 
-template <class TElastix>
+template <typename TElastix>
 void
 AdaptiveStochasticGradientDescent<TElastix>::AfterRegistration()
 {
@@ -370,7 +370,7 @@ AdaptiveStochasticGradientDescent<TElastix>::AfterRegistration()
  * ****************** StartOptimization *************************
  */
 
-template <class TElastix>
+template <typename TElastix>
 void
 AdaptiveStochasticGradientDescent<TElastix>::StartOptimization()
 {
@@ -398,7 +398,7 @@ AdaptiveStochasticGradientDescent<TElastix>::StartOptimization()
  * ********************** ResumeOptimization **********************
  */
 
-template <class TElastix>
+template <typename TElastix>
 void
 AdaptiveStochasticGradientDescent<TElastix>::ResumeOptimization()
 {
@@ -423,7 +423,7 @@ AdaptiveStochasticGradientDescent<TElastix>::ResumeOptimization()
  * ****************** MetricErrorResponse *************************
  */
 
-template <class TElastix>
+template <typename TElastix>
 void
 AdaptiveStochasticGradientDescent<TElastix>::MetricErrorResponse(itk::ExceptionObject & err)
 {
@@ -455,7 +455,7 @@ AdaptiveStochasticGradientDescent<TElastix>::MetricErrorResponse(itk::ExceptionO
  * ******************* AutomaticParameterEstimation **********************
  */
 
-template <class TElastix>
+template <typename TElastix>
 void
 AdaptiveStochasticGradientDescent<TElastix>::AutomaticParameterEstimation()
 {
@@ -503,7 +503,7 @@ AdaptiveStochasticGradientDescent<TElastix>::AutomaticParameterEstimation()
  * ******************* AutomaticParameterEstimationOriginal **********************
  */
 
-template <class TElastix>
+template <typename TElastix>
 void
 AdaptiveStochasticGradientDescent<TElastix>::AutomaticParameterEstimationOriginal()
 {
@@ -648,7 +648,7 @@ AdaptiveStochasticGradientDescent<TElastix>::AutomaticParameterEstimationOrigina
  * *************** AutomaticParameterEstimationUsingDisplacementDistribution *****
  */
 
-template <class TElastix>
+template <typename TElastix>
 void
 AdaptiveStochasticGradientDescent<TElastix>::AutomaticParameterEstimationUsingDisplacementDistribution()
 {
@@ -762,7 +762,7 @@ AdaptiveStochasticGradientDescent<TElastix>::AutomaticParameterEstimationUsingDi
  * ******************** SampleGradients **********************
  */
 
-template <class TElastix>
+template <typename TElastix>
 void
 AdaptiveStochasticGradientDescent<TElastix>::SampleGradients(const ParametersType & mu0,
                                                              double                 perturbationSigma,
@@ -958,7 +958,7 @@ AdaptiveStochasticGradientDescent<TElastix>::SampleGradients(const ParametersTyp
  * *************** GetScaledDerivativeWithExceptionHandling ***************
  */
 
-template <class TElastix>
+template <typename TElastix>
 void
 AdaptiveStochasticGradientDescent<TElastix>::GetScaledDerivativeWithExceptionHandling(const ParametersType & parameters,
                                                                                       DerivativeType &       derivative)
@@ -982,7 +982,7 @@ AdaptiveStochasticGradientDescent<TElastix>::GetScaledDerivativeWithExceptionHan
  * *************** AddRandomPerturbation ***************
  */
 
-template <class TElastix>
+template <typename TElastix>
 void
 AdaptiveStochasticGradientDescent<TElastix>::AddRandomPerturbation(ParametersType & parameters, double sigma)
 {

--- a/Components/Optimizers/AdaptiveStochasticLBFGS/elxAdaptiveStochasticLBFGS.h
+++ b/Components/Optimizers/AdaptiveStochasticLBFGS/elxAdaptiveStochasticLBFGS.h
@@ -99,7 +99,7 @@ namespace elastix
  * \ingroup Optimizers
  */
 
-template <class TElastix>
+template <typename TElastix>
 class ITK_TEMPLATE_EXPORT AdaptiveStochasticLBFGS
   : public itk::AdaptiveStochasticLBFGSOptimizer
   , public OptimizerBase<TElastix>

--- a/Components/Optimizers/AdaptiveStochasticLBFGS/elxAdaptiveStochasticLBFGS.hxx
+++ b/Components/Optimizers/AdaptiveStochasticLBFGS/elxAdaptiveStochasticLBFGS.hxx
@@ -46,7 +46,7 @@ namespace elastix
  * ********************** Constructor ***********************
  */
 
-template <class TElastix>
+template <typename TElastix>
 AdaptiveStochasticLBFGS<TElastix>::AdaptiveStochasticLBFGS()
 {
   this->m_MaximumNumberOfSamplingAttempts = 0;
@@ -90,7 +90,7 @@ AdaptiveStochasticLBFGS<TElastix>::AdaptiveStochasticLBFGS()
  * ***************** BeforeRegistration ***********************
  */
 
-template <class TElastix>
+template <typename TElastix>
 void
 AdaptiveStochasticLBFGS<TElastix>::BeforeRegistration()
 {
@@ -117,7 +117,7 @@ AdaptiveStochasticLBFGS<TElastix>::BeforeRegistration()
  * ***************** BeforeEachResolution ***********************
  */
 
-template <class TElastix>
+template <typename TElastix>
 void
 AdaptiveStochasticLBFGS<TElastix>::BeforeEachResolution()
 {
@@ -338,7 +338,7 @@ AdaptiveStochasticLBFGS<TElastix>::BeforeEachResolution()
  * ***************** AfterEachIteration *************************
  */
 
-template <class TElastix>
+template <typename TElastix>
 void
 AdaptiveStochasticLBFGS<TElastix>::AfterEachIteration()
 {
@@ -362,7 +362,7 @@ AdaptiveStochasticLBFGS<TElastix>::AfterEachIteration()
  * ***************** AfterEachResolution *************************
  */
 
-template <class TElastix>
+template <typename TElastix>
 void
 AdaptiveStochasticLBFGS<TElastix>::AfterEachResolution()
 {
@@ -431,7 +431,7 @@ AdaptiveStochasticLBFGS<TElastix>::AfterEachResolution()
  * ******************* AfterRegistration ************************
  */
 
-template <class TElastix>
+template <typename TElastix>
 void
 AdaptiveStochasticLBFGS<TElastix>::AfterRegistration()
 {
@@ -451,7 +451,7 @@ AdaptiveStochasticLBFGS<TElastix>::AfterRegistration()
  * ****************** StartOptimization *************************
  */
 
-template <class TElastix>
+template <typename TElastix>
 void
 AdaptiveStochasticLBFGS<TElastix>::StartOptimization()
 {
@@ -509,7 +509,7 @@ AdaptiveStochasticLBFGS<TElastix>::StartOptimization()
  * ********************** LBFGSUpdate **********************
  */
 
-template <class TElastix>
+template <typename TElastix>
 void
 AdaptiveStochasticLBFGS<TElastix>::LBFGSUpdate()
 {
@@ -539,7 +539,7 @@ AdaptiveStochasticLBFGS<TElastix>::LBFGSUpdate()
  * ********************** AdvanceOneStep **********************
  */
 
-template <class TElastix>
+template <typename TElastix>
 void
 AdaptiveStochasticLBFGS<TElastix>::AdvanceOneStep()
 {
@@ -570,7 +570,7 @@ AdaptiveStochasticLBFGS<TElastix>::AdvanceOneStep()
  * ********************** StopOptimization **********************
  */
 
-template <class TElastix>
+template <typename TElastix>
 void
 AdaptiveStochasticLBFGS<TElastix>::StopOptimization()
 {
@@ -585,7 +585,7 @@ AdaptiveStochasticLBFGS<TElastix>::StopOptimization()
  * ********************** ResumeOptimization **********************
  */
 
-template <class TElastix>
+template <typename TElastix>
 void
 AdaptiveStochasticLBFGS<TElastix>::ResumeOptimization()
 {
@@ -821,7 +821,7 @@ AdaptiveStochasticLBFGS<TElastix>::ResumeOptimization()
  * ****************** MetricErrorResponse *************************
  */
 
-template <class TElastix>
+template <typename TElastix>
 void
 AdaptiveStochasticLBFGS<TElastix>::MetricErrorResponse(itk::ExceptionObject & err)
 {
@@ -853,7 +853,7 @@ AdaptiveStochasticLBFGS<TElastix>::MetricErrorResponse(itk::ExceptionObject & er
  * ******************* AutomaticParameterEstimation **********************
  */
 
-template <class TElastix>
+template <typename TElastix>
 void
 AdaptiveStochasticLBFGS<TElastix>::AutomaticParameterEstimation()
 {
@@ -903,7 +903,7 @@ AdaptiveStochasticLBFGS<TElastix>::AutomaticParameterEstimation()
  * ******************* AutomaticParameterEstimationOriginal **********************
  */
 
-template <class TElastix>
+template <typename TElastix>
 void
 AdaptiveStochasticLBFGS<TElastix>::AutomaticParameterEstimationOriginal()
 {
@@ -1047,7 +1047,7 @@ AdaptiveStochasticLBFGS<TElastix>::AutomaticParameterEstimationOriginal()
  * *************** AutomaticParameterEstimationUsingDisplacementDistribution *****
  */
 
-template <class TElastix>
+template <typename TElastix>
 void
 AdaptiveStochasticLBFGS<TElastix>::AutomaticParameterEstimationUsingDisplacementDistribution()
 {
@@ -1161,7 +1161,7 @@ AdaptiveStochasticLBFGS<TElastix>::AutomaticParameterEstimationUsingDisplacement
  * *************** AutomaticLBFGSStepsizeEstimation *****
  */
 
-template <class TElastix>
+template <typename TElastix>
 void
 AdaptiveStochasticLBFGS<TElastix>::AutomaticLBFGSStepsizeEstimation()
 {
@@ -1247,7 +1247,7 @@ AdaptiveStochasticLBFGS<TElastix>::AutomaticLBFGSStepsizeEstimation()
  * ******************** SampleGradients **********************
  */
 
-template <class TElastix>
+template <typename TElastix>
 void
 AdaptiveStochasticLBFGS<TElastix>::SampleGradients(const ParametersType & mu0,
                                                    double                 perturbationSigma,
@@ -1424,7 +1424,7 @@ AdaptiveStochasticLBFGS<TElastix>::SampleGradients(const ParametersType & mu0,
  * *************** GetScaledDerivativeWithExceptionHandling ***************
  */
 
-template <class TElastix>
+template <typename TElastix>
 void
 AdaptiveStochasticLBFGS<TElastix>::GetScaledDerivativeWithExceptionHandling(const ParametersType & parameters,
                                                                             DerivativeType &       derivative)
@@ -1448,7 +1448,7 @@ AdaptiveStochasticLBFGS<TElastix>::GetScaledDerivativeWithExceptionHandling(cons
  * *************** AddRandomPerturbation ***************
  */
 
-template <class TElastix>
+template <typename TElastix>
 void
 AdaptiveStochasticLBFGS<TElastix>::AddRandomPerturbation(ParametersType & parameters, double sigma)
 {
@@ -1465,7 +1465,7 @@ AdaptiveStochasticLBFGS<TElastix>::AddRandomPerturbation(ParametersType & parame
  * ********************* StoreCurrentPoint ************************
  */
 
-template <class TElastix>
+template <typename TElastix>
 void
 AdaptiveStochasticLBFGS<TElastix>::StoreCurrentPoint(const ParametersType & step, const DerivativeType & grad_dif)
 {
@@ -1503,7 +1503,7 @@ AdaptiveStochasticLBFGS<TElastix>::StoreCurrentPoint(const ParametersType & step
  * ********************* ComputeDiagonalMatrix ********************
  */
 
-template <class TElastix>
+template <typename TElastix>
 void
 AdaptiveStochasticLBFGS<TElastix>::ComputeDiagonalMatrix(DiagonalMatrixType & diag_H0)
 {
@@ -1525,7 +1525,7 @@ AdaptiveStochasticLBFGS<TElastix>::ComputeDiagonalMatrix(DiagonalMatrixType & di
  * *********************** ComputeSearchDirection ************************
  */
 
-template <class TElastix>
+template <typename TElastix>
 void
 AdaptiveStochasticLBFGS<TElastix>::ComputeSearchDirection(const DerivativeType & gradient, DerivativeType & searchDir)
 {

--- a/Components/Optimizers/AdaptiveStochasticVarianceReducedGradient/elxAdaptiveStochasticVarianceReducedGradient.h
+++ b/Components/Optimizers/AdaptiveStochasticVarianceReducedGradient/elxAdaptiveStochasticVarianceReducedGradient.h
@@ -189,7 +189,7 @@ namespace elastix
  * \ingroup Optimizers
  */
 
-template <class TElastix>
+template <typename TElastix>
 class ITK_TEMPLATE_EXPORT AdaptiveStochasticVarianceReducedGradient
   : public itk::AdaptiveStochasticVarianceReducedGradientOptimizer
   , public OptimizerBase<TElastix>

--- a/Components/Optimizers/AdaptiveStochasticVarianceReducedGradient/elxAdaptiveStochasticVarianceReducedGradient.hxx
+++ b/Components/Optimizers/AdaptiveStochasticVarianceReducedGradient/elxAdaptiveStochasticVarianceReducedGradient.hxx
@@ -48,7 +48,7 @@ namespace elastix
  * ********************** Constructor ***********************
  */
 
-template <class TElastix>
+template <typename TElastix>
 AdaptiveStochasticVarianceReducedGradient<TElastix>::AdaptiveStochasticVarianceReducedGradient()
 {
   this->m_MaximumNumberOfSamplingAttempts = 0;
@@ -84,7 +84,7 @@ AdaptiveStochasticVarianceReducedGradient<TElastix>::AdaptiveStochasticVarianceR
  * ***************** BeforeRegistration ***********************
  */
 
-template <class TElastix>
+template <typename TElastix>
 void
 AdaptiveStochasticVarianceReducedGradient<TElastix>::BeforeRegistration()
 {
@@ -109,7 +109,7 @@ AdaptiveStochasticVarianceReducedGradient<TElastix>::BeforeRegistration()
  * ***************** BeforeEachResolution ***********************
  */
 
-template <class TElastix>
+template <typename TElastix>
 void
 AdaptiveStochasticVarianceReducedGradient<TElastix>::BeforeEachResolution()
 {
@@ -283,7 +283,7 @@ AdaptiveStochasticVarianceReducedGradient<TElastix>::BeforeEachResolution()
  * ***************** AfterEachIteration *************************
  */
 
-template <class TElastix>
+template <typename TElastix>
 void
 AdaptiveStochasticVarianceReducedGradient<TElastix>::AfterEachIteration()
 {
@@ -314,7 +314,7 @@ AdaptiveStochasticVarianceReducedGradient<TElastix>::AfterEachIteration()
  * ***************** AfterEachResolution *************************
  */
 
-template <class TElastix>
+template <typename TElastix>
 void
 AdaptiveStochasticVarianceReducedGradient<TElastix>::AfterEachResolution()
 {
@@ -371,7 +371,7 @@ AdaptiveStochasticVarianceReducedGradient<TElastix>::AfterEachResolution()
  * ******************* AfterRegistration ************************
  */
 
-template <class TElastix>
+template <typename TElastix>
 void
 AdaptiveStochasticVarianceReducedGradient<TElastix>::AfterRegistration()
 {
@@ -391,7 +391,7 @@ AdaptiveStochasticVarianceReducedGradient<TElastix>::AfterRegistration()
  * ****************** StartOptimization *************************
  */
 
-template <class TElastix>
+template <typename TElastix>
 void
 AdaptiveStochasticVarianceReducedGradient<TElastix>::StartOptimization()
 {
@@ -432,7 +432,7 @@ AdaptiveStochasticVarianceReducedGradient<TElastix>::StartOptimization()
  * ********************** AdvanceOneStep **********************
  */
 
-template <class TElastix>
+template <typename TElastix>
 void
 AdaptiveStochasticVarianceReducedGradient<TElastix>::AdvanceOneStep()
 {
@@ -462,7 +462,7 @@ AdaptiveStochasticVarianceReducedGradient<TElastix>::AdvanceOneStep()
  * ********************** StopOptimization **********************
  */
 
-template <class TElastix>
+template <typename TElastix>
 void
 AdaptiveStochasticVarianceReducedGradient<TElastix>::StopOptimization()
 {
@@ -477,7 +477,7 @@ AdaptiveStochasticVarianceReducedGradient<TElastix>::StopOptimization()
  * ********************** ResumeOptimization **********************
  */
 
-template <class TElastix>
+template <typename TElastix>
 void
 AdaptiveStochasticVarianceReducedGradient<TElastix>::ResumeOptimization()
 {
@@ -677,7 +677,7 @@ AdaptiveStochasticVarianceReducedGradient<TElastix>::ResumeOptimization()
  * ****************** MetricErrorResponse *************************
  */
 
-template <class TElastix>
+template <typename TElastix>
 void
 AdaptiveStochasticVarianceReducedGradient<TElastix>::MetricErrorResponse(itk::ExceptionObject & err)
 {
@@ -709,7 +709,7 @@ AdaptiveStochasticVarianceReducedGradient<TElastix>::MetricErrorResponse(itk::Ex
  * ******************* AutomaticParameterEstimation **********************
  */
 
-template <class TElastix>
+template <typename TElastix>
 void
 AdaptiveStochasticVarianceReducedGradient<TElastix>::AutomaticParameterEstimation()
 {
@@ -759,7 +759,7 @@ AdaptiveStochasticVarianceReducedGradient<TElastix>::AutomaticParameterEstimatio
  * ******************* AutomaticParameterEstimationOriginal **********************
  */
 
-template <class TElastix>
+template <typename TElastix>
 void
 AdaptiveStochasticVarianceReducedGradient<TElastix>::AutomaticParameterEstimationOriginal()
 {
@@ -904,7 +904,7 @@ AdaptiveStochasticVarianceReducedGradient<TElastix>::AutomaticParameterEstimatio
  * *************** AutomaticParameterEstimationUsingDisplacementDistribution *****
  */
 
-template <class TElastix>
+template <typename TElastix>
 void
 AdaptiveStochasticVarianceReducedGradient<TElastix>::AutomaticParameterEstimationUsingDisplacementDistribution()
 {
@@ -1019,7 +1019,7 @@ AdaptiveStochasticVarianceReducedGradient<TElastix>::AutomaticParameterEstimatio
  * ******************** SampleGradients **********************
  */
 
-template <class TElastix>
+template <typename TElastix>
 void
 AdaptiveStochasticVarianceReducedGradient<TElastix>::SampleGradients(const ParametersType & mu0,
                                                                      double                 perturbationSigma,
@@ -1218,7 +1218,7 @@ AdaptiveStochasticVarianceReducedGradient<TElastix>::SampleGradients(const Param
  * *************** GetScaledDerivativeWithExceptionHandling ***************
  */
 
-template <class TElastix>
+template <typename TElastix>
 void
 AdaptiveStochasticVarianceReducedGradient<TElastix>::GetScaledDerivativeWithExceptionHandling(
   const ParametersType & parameters,
@@ -1243,7 +1243,7 @@ AdaptiveStochasticVarianceReducedGradient<TElastix>::GetScaledDerivativeWithExce
  * *************** AddRandomPerturbation ***************
  */
 
-template <class TElastix>
+template <typename TElastix>
 void
 AdaptiveStochasticVarianceReducedGradient<TElastix>::AddRandomPerturbation(ParametersType & parameters, double sigma)
 {

--- a/Components/Optimizers/CMAEvolutionStrategy/elxCMAEvolutionStrategy.h
+++ b/Components/Optimizers/CMAEvolutionStrategy/elxCMAEvolutionStrategy.h
@@ -111,7 +111,7 @@ namespace elastix
  * \ingroup Optimizers
  */
 
-template <class TElastix>
+template <typename TElastix>
 class ITK_TEMPLATE_EXPORT CMAEvolutionStrategy
   : public itk::CMAEvolutionStrategyOptimizer
   , public OptimizerBase<TElastix>

--- a/Components/Optimizers/CMAEvolutionStrategy/elxCMAEvolutionStrategy.hxx
+++ b/Components/Optimizers/CMAEvolutionStrategy/elxCMAEvolutionStrategy.hxx
@@ -31,7 +31,7 @@ namespace elastix
  * ***************** StartOptimization ************************
  */
 
-template <class TElastix>
+template <typename TElastix>
 void
 CMAEvolutionStrategy<TElastix>::StartOptimization()
 {
@@ -58,7 +58,7 @@ CMAEvolutionStrategy<TElastix>::StartOptimization()
  * ***************** InitializeProgressVariables ************************
  */
 
-template <class TElastix>
+template <typename TElastix>
 void
 CMAEvolutionStrategy<TElastix>::InitializeProgressVariables()
 {
@@ -79,7 +79,7 @@ CMAEvolutionStrategy<TElastix>::InitializeProgressVariables()
  * ***************** BeforeRegistration ***********************
  */
 
-template <class TElastix>
+template <typename TElastix>
 void
 CMAEvolutionStrategy<TElastix>::BeforeRegistration()
 {
@@ -106,7 +106,7 @@ CMAEvolutionStrategy<TElastix>::BeforeRegistration()
  * ***************** BeforeEachResolution ***********************
  */
 
-template <class TElastix>
+template <typename TElastix>
 void
 CMAEvolutionStrategy<TElastix>::BeforeEachResolution()
 {
@@ -200,7 +200,7 @@ CMAEvolutionStrategy<TElastix>::BeforeEachResolution()
  * ***************** AfterEachIteration *************************
  */
 
-template <class TElastix>
+template <typename TElastix>
 void
 CMAEvolutionStrategy<TElastix>::AfterEachIteration()
 {
@@ -226,7 +226,7 @@ CMAEvolutionStrategy<TElastix>::AfterEachIteration()
  * ***************** AfterEachResolution *************************
  */
 
-template <class TElastix>
+template <typename TElastix>
 void
 CMAEvolutionStrategy<TElastix>::AfterEachResolution()
 {
@@ -283,7 +283,7 @@ CMAEvolutionStrategy<TElastix>::AfterEachResolution()
  * ******************* AfterRegistration ************************
  */
 
-template <class TElastix>
+template <typename TElastix>
 void
 CMAEvolutionStrategy<TElastix>::AfterRegistration()
 {

--- a/Components/Optimizers/ConjugateGradient/elxConjugateGradient.h
+++ b/Components/Optimizers/ConjugateGradient/elxConjugateGradient.h
@@ -87,7 +87,7 @@ namespace elastix
  * \ingroup Optimizers
  */
 
-template <class TElastix>
+template <typename TElastix>
 class ITK_TEMPLATE_EXPORT ConjugateGradient
   : public itk::GenericConjugateGradientOptimizer
   , public OptimizerBase<TElastix>

--- a/Components/Optimizers/ConjugateGradient/elxConjugateGradient.hxx
+++ b/Components/Optimizers/ConjugateGradient/elxConjugateGradient.hxx
@@ -31,7 +31,7 @@ namespace elastix
  * ********************* Constructor ****************************
  */
 
-template <class TElastix>
+template <typename TElastix>
 ConjugateGradient<TElastix>::ConjugateGradient()
 {
   this->m_LineOptimizer = LineOptimizerType::New();
@@ -54,7 +54,7 @@ ConjugateGradient<TElastix>::ConjugateGradient()
  * ***************** InvokeIterationEvent ************************
  */
 
-template <class TElastix>
+template <typename TElastix>
 void
 ConjugateGradient<TElastix>::InvokeIterationEvent(const itk::EventObject & event)
 {
@@ -81,7 +81,7 @@ ConjugateGradient<TElastix>::InvokeIterationEvent(const itk::EventObject & event
  * ***************** StartOptimization ************************
  */
 
-template <class TElastix>
+template <typename TElastix>
 void
 ConjugateGradient<TElastix>::StartOptimization()
 {
@@ -109,7 +109,7 @@ ConjugateGradient<TElastix>::StartOptimization()
  * ***************** LineSearch ************************
  */
 
-template <class TElastix>
+template <typename TElastix>
 void
 ConjugateGradient<TElastix>::LineSearch(const ParametersType searchDir,
                                         double &             step,
@@ -152,7 +152,7 @@ ConjugateGradient<TElastix>::LineSearch(const ParametersType searchDir,
  * during iterating
  */
 
-template <class TElastix>
+template <typename TElastix>
 std::string
 ConjugateGradient<TElastix>::DeterminePhase() const
 {
@@ -171,7 +171,7 @@ ConjugateGradient<TElastix>::DeterminePhase() const
  * ***************** BeforeRegistration ***********************
  */
 
-template <class TElastix>
+template <typename TElastix>
 void
 ConjugateGradient<TElastix>::BeforeRegistration()
 {
@@ -212,7 +212,7 @@ ConjugateGradient<TElastix>::BeforeRegistration()
  * ***************** BeforeEachResolution ***********************
  */
 
-template <class TElastix>
+template <typename TElastix>
 void
 ConjugateGradient<TElastix>::BeforeEachResolution()
 {
@@ -288,7 +288,7 @@ ConjugateGradient<TElastix>::BeforeEachResolution()
  * ***************** AfterEachIteration *************************
  */
 
-template <class TElastix>
+template <typename TElastix>
 void
 ConjugateGradient<TElastix>::AfterEachIteration()
 {
@@ -380,7 +380,7 @@ ConjugateGradient<TElastix>::AfterEachIteration()
  * ***************** AfterEachResolution *************************
  */
 
-template <class TElastix>
+template <typename TElastix>
 void
 ConjugateGradient<TElastix>::AfterEachResolution()
 {
@@ -445,7 +445,7 @@ ConjugateGradient<TElastix>::AfterEachResolution()
  * ******************* AfterRegistration ************************
  */
 
-template <class TElastix>
+template <typename TElastix>
 void
 ConjugateGradient<TElastix>::AfterRegistration()
 {
@@ -461,7 +461,7 @@ ConjugateGradient<TElastix>::AfterRegistration()
  * *********************** TestConvergence *****************
  */
 
-template <class TElastix>
+template <typename TElastix>
 bool
 ConjugateGradient<TElastix>::TestConvergence(bool firstLineSearchDone)
 {
@@ -489,7 +489,7 @@ ConjugateGradient<TElastix>::TestConvergence(bool firstLineSearchDone)
  * ***************** GetLineSearchStopCondition *****************
  */
 
-template <class TElastix>
+template <typename TElastix>
 std::string
 ConjugateGradient<TElastix>::GetLineSearchStopCondition() const
 {

--- a/Components/Optimizers/ConjugateGradientFRPR/elxConjugateGradientFRPR.h
+++ b/Components/Optimizers/ConjugateGradientFRPR/elxConjugateGradientFRPR.h
@@ -70,7 +70,7 @@ namespace elastix
  * \ingroup Optimizers
  */
 
-template <class TElastix>
+template <typename TElastix>
 class ITK_TEMPLATE_EXPORT ConjugateGradientFRPR
   : public itk::FRPROptimizer
   , public OptimizerBase<TElastix>

--- a/Components/Optimizers/ConjugateGradientFRPR/elxConjugateGradientFRPR.hxx
+++ b/Components/Optimizers/ConjugateGradientFRPR/elxConjugateGradientFRPR.hxx
@@ -32,7 +32,7 @@ namespace elastix
  * ********************* Constructor ****************************
  */
 
-template <class TElastix>
+template <typename TElastix>
 ConjugateGradientFRPR<TElastix>::ConjugateGradientFRPR()
 {
   this->m_LineBracketing = false;
@@ -51,7 +51,7 @@ ConjugateGradientFRPR<TElastix>::ConjugateGradientFRPR()
  * during iterating
  */
 
-template <class TElastix>
+template <typename TElastix>
 const char *
 ConjugateGradientFRPR<TElastix>::DeterminePhase() const
 {
@@ -74,7 +74,7 @@ ConjugateGradientFRPR<TElastix>::DeterminePhase() const
  * ***************** BeforeRegistration ***********************
  */
 
-template <class TElastix>
+template <typename TElastix>
 void
 ConjugateGradientFRPR<TElastix>::BeforeRegistration()
 {
@@ -103,7 +103,7 @@ ConjugateGradientFRPR<TElastix>::BeforeRegistration()
  * ***************** BeforeEachResolution ***********************
  */
 
-template <class TElastix>
+template <typename TElastix>
 void
 ConjugateGradientFRPR<TElastix>::BeforeEachResolution()
 {
@@ -153,7 +153,7 @@ ConjugateGradientFRPR<TElastix>::BeforeEachResolution()
  * ***************** AfterEachIteration *************************
  */
 
-template <class TElastix>
+template <typename TElastix>
 void
 ConjugateGradientFRPR<TElastix>::AfterEachIteration()
 {
@@ -192,7 +192,7 @@ ConjugateGradientFRPR<TElastix>::AfterEachIteration()
  * ***************** AfterEachResolution *************************
  */
 
-template <class TElastix>
+template <typename TElastix>
 void
 ConjugateGradientFRPR<TElastix>::AfterEachResolution()
 {
@@ -233,7 +233,7 @@ ConjugateGradientFRPR<TElastix>::AfterEachResolution()
  * ******************* AfterRegistration ************************
  */
 
-template <class TElastix>
+template <typename TElastix>
 void
 ConjugateGradientFRPR<TElastix>::AfterRegistration()
 {
@@ -249,7 +249,7 @@ ConjugateGradientFRPR<TElastix>::AfterRegistration()
  * ******************* SetInitialPosition ***********************
  */
 
-template <class TElastix>
+template <typename TElastix>
 void
 ConjugateGradientFRPR<TElastix>::SetInitialPosition(const ParametersType & param)
 {
@@ -280,7 +280,7 @@ ConjugateGradientFRPR<TElastix>::SetInitialPosition(const ParametersType & param
  * *************** GetValueAndDerivative ***********************
  */
 
-template <class TElastix>
+template <typename TElastix>
 void
 ConjugateGradientFRPR<TElastix>::GetValueAndDerivative(ParametersType & p, double * val, ParametersType * xi)
 {
@@ -304,7 +304,7 @@ ConjugateGradientFRPR<TElastix>::GetValueAndDerivative(ParametersType & p, doubl
  * *************** LineBracket ****************************
  */
 
-template <class TElastix>
+template <typename TElastix>
 void
 ConjugateGradientFRPR<TElastix>::LineBracket(double *         ax,
                                              double *         bx,
@@ -331,7 +331,7 @@ ConjugateGradientFRPR<TElastix>::LineBracket(double *         ax,
  * *************** BracketedLineOptimize *********************
  */
 
-template <class TElastix>
+template <typename TElastix>
 void
 ConjugateGradientFRPR<TElastix>::BracketedLineOptimize(double           ax,
                                                        double           bx,
@@ -360,7 +360,7 @@ ConjugateGradientFRPR<TElastix>::BracketedLineOptimize(double           ax,
  * store the line search direction's (xi) magnitude and call the superclass'
  * implementation.
  */
-template <class TElastix>
+template <typename TElastix>
 void
 ConjugateGradientFRPR<TElastix>::LineOptimize(ParametersType * p,
                                               ParametersType & xi,

--- a/Components/Optimizers/FiniteDifferenceGradientDescent/elxFiniteDifferenceGradientDescent.h
+++ b/Components/Optimizers/FiniteDifferenceGradientDescent/elxFiniteDifferenceGradientDescent.h
@@ -76,7 +76,7 @@ namespace elastix
  * \sa FiniteDifferenceGradientDescentOptimizer
  */
 
-template <class TElastix>
+template <typename TElastix>
 class ITK_TEMPLATE_EXPORT FiniteDifferenceGradientDescent
   : public itk::FiniteDifferenceGradientDescentOptimizer
   , public OptimizerBase<TElastix>

--- a/Components/Optimizers/FiniteDifferenceGradientDescent/elxFiniteDifferenceGradientDescent.hxx
+++ b/Components/Optimizers/FiniteDifferenceGradientDescent/elxFiniteDifferenceGradientDescent.hxx
@@ -32,7 +32,7 @@ namespace elastix
  * ********************* Constructor ****************************
  */
 
-template <class TElastix>
+template <typename TElastix>
 FiniteDifferenceGradientDescent<TElastix>::FiniteDifferenceGradientDescent()
 {
   this->m_ShowMetricValues = false;
@@ -43,7 +43,7 @@ FiniteDifferenceGradientDescent<TElastix>::FiniteDifferenceGradientDescent()
  * ***************** BeforeRegistration ***********************
  */
 
-template <class TElastix>
+template <typename TElastix>
 void
 FiniteDifferenceGradientDescent<TElastix>::BeforeRegistration()
 {
@@ -79,7 +79,7 @@ FiniteDifferenceGradientDescent<TElastix>::BeforeRegistration()
  * ***************** BeforeEachResolution ***********************
  */
 
-template <class TElastix>
+template <typename TElastix>
 void
 FiniteDifferenceGradientDescent<TElastix>::BeforeEachResolution()
 {
@@ -120,7 +120,7 @@ FiniteDifferenceGradientDescent<TElastix>::BeforeEachResolution()
  * ***************** AfterEachIteration *************************
  */
 
-template <class TElastix>
+template <typename TElastix>
 void
 FiniteDifferenceGradientDescent<TElastix>::AfterEachIteration()
 {
@@ -152,7 +152,7 @@ FiniteDifferenceGradientDescent<TElastix>::AfterEachIteration()
  * ***************** AfterEachResolution *************************
  */
 
-template <class TElastix>
+template <typename TElastix>
 void
 FiniteDifferenceGradientDescent<TElastix>::AfterEachResolution()
 {
@@ -188,7 +188,7 @@ FiniteDifferenceGradientDescent<TElastix>::AfterEachResolution()
  * ******************* AfterRegistration ************************
  */
 
-template <class TElastix>
+template <typename TElastix>
 void
 FiniteDifferenceGradientDescent<TElastix>::AfterRegistration()
 {
@@ -214,7 +214,7 @@ FiniteDifferenceGradientDescent<TElastix>::AfterRegistration()
  * ******************* StartOptimization ***********************
  */
 
-template <class TElastix>
+template <typename TElastix>
 void
 FiniteDifferenceGradientDescent<TElastix>::StartOptimization()
 {

--- a/Components/Optimizers/FullSearch/elxFullSearchOptimizer.h
+++ b/Components/Optimizers/FullSearch/elxFullSearchOptimizer.h
@@ -53,7 +53,7 @@ namespace elastix
  * \sa FullSearchOptimizer
  */
 
-template <class TElastix>
+template <typename TElastix>
 class ITK_TEMPLATE_EXPORT FullSearch
   : public itk::FullSearchOptimizer
   , public OptimizerBase<TElastix>

--- a/Components/Optimizers/FullSearch/elxFullSearchOptimizer.hxx
+++ b/Components/Optimizers/FullSearch/elxFullSearchOptimizer.hxx
@@ -32,7 +32,7 @@ namespace elastix
  * ********************* Constructor ****************************
  */
 
-template <class TElastix>
+template <typename TElastix>
 FullSearch<TElastix>::FullSearch()
 {
   this->m_OptimizationSurface = nullptr;
@@ -44,7 +44,7 @@ FullSearch<TElastix>::FullSearch()
  * ***************** BeforeRegistration ***********************
  */
 
-template <class TElastix>
+template <typename TElastix>
 void
 FullSearch<TElastix>::BeforeRegistration()
 {
@@ -61,7 +61,7 @@ FullSearch<TElastix>::BeforeRegistration()
  * ***************** BeforeEachResolution ***********************
  */
 
-template <class TElastix>
+template <typename TElastix>
 void
 FullSearch<TElastix>::BeforeEachResolution()
 {
@@ -188,7 +188,7 @@ FullSearch<TElastix>::BeforeEachResolution()
  * ***************** AfterEachIteration *************************
  */
 
-template <class TElastix>
+template <typename TElastix>
 void
 FullSearch<TElastix>::AfterEachIteration()
 {
@@ -214,7 +214,7 @@ FullSearch<TElastix>::AfterEachIteration()
  * ***************** AfterEachResolution *************************
  */
 
-template <class TElastix>
+template <typename TElastix>
 void
 FullSearch<TElastix>::AfterEachResolution()
 {
@@ -307,7 +307,7 @@ FullSearch<TElastix>::AfterEachResolution()
 /**
  * ******************* AfterRegistration ************************
  */
-template <class TElastix>
+template <typename TElastix>
 void
 FullSearch<TElastix>::AfterRegistration()
 {
@@ -322,7 +322,7 @@ FullSearch<TElastix>::AfterRegistration()
  * ************ CheckSearchSpaceRangeDefinition *****************
  */
 
-template <class TElastix>
+template <typename TElastix>
 bool
 FullSearch<TElastix>::CheckSearchSpaceRangeDefinition(const std::string & fullFieldName,
                                                       const bool          found,

--- a/Components/Optimizers/Powell/elxPowell.h
+++ b/Components/Optimizers/Powell/elxPowell.h
@@ -37,7 +37,7 @@ namespace elastix
  * \ingroup Optimizers
  */
 
-template <class TElastix>
+template <typename TElastix>
 class ITK_TEMPLATE_EXPORT Powell
   : public itk::PowellOptimizer
   , public OptimizerBase<TElastix>

--- a/Components/Optimizers/Powell/elxPowell.hxx
+++ b/Components/Optimizers/Powell/elxPowell.hxx
@@ -31,7 +31,7 @@ namespace elastix
  * ***************** BeforeRegistration ***********************
  */
 
-template <class TElastix>
+template <typename TElastix>
 void
 Powell<TElastix>::BeforeRegistration()
 {
@@ -52,7 +52,7 @@ Powell<TElastix>::BeforeRegistration()
  * ***************** BeforeEachResolution ***********************
  */
 
-template <class TElastix>
+template <typename TElastix>
 void
 Powell<TElastix>::BeforeEachResolution()
 {
@@ -87,7 +87,7 @@ Powell<TElastix>::BeforeEachResolution()
  * ***************** AfterEachIteration *************************
  */
 
-template <class TElastix>
+template <typename TElastix>
 void
 Powell<TElastix>::AfterEachIteration()
 {
@@ -101,7 +101,7 @@ Powell<TElastix>::AfterEachIteration()
  * ***************** AfterEachResolution *************************
  */
 
-template <class TElastix>
+template <typename TElastix>
 void
 Powell<TElastix>::AfterEachResolution()
 {
@@ -121,7 +121,7 @@ Powell<TElastix>::AfterEachResolution()
  * ******************* AfterRegistration ************************
  */
 
-template <class TElastix>
+template <typename TElastix>
 void
 Powell<TElastix>::AfterRegistration()
 {
@@ -136,7 +136,7 @@ Powell<TElastix>::AfterRegistration()
  * ******************* SetInitialPosition ***********************
  */
 
-template <class TElastix>
+template <typename TElastix>
 void
 Powell<TElastix>::SetInitialPosition(const ParametersType & param)
 {

--- a/Components/Optimizers/PreconditionedStochasticGradientDescent/elxPreconditionedStochasticGradientDescent.h
+++ b/Components/Optimizers/PreconditionedStochasticGradientDescent/elxPreconditionedStochasticGradientDescent.h
@@ -174,7 +174,7 @@ namespace elastix
  * \ingroup Optimizers
  */
 
-template <class TElastix>
+template <typename TElastix>
 class ITK_TEMPLATE_EXPORT PreconditionedStochasticGradientDescent
   : public itk::PreconditionedASGDOptimizer
   , public OptimizerBase<TElastix>

--- a/Components/Optimizers/PreconditionedStochasticGradientDescent/elxPreconditionedStochasticGradientDescent.hxx
+++ b/Components/Optimizers/PreconditionedStochasticGradientDescent/elxPreconditionedStochasticGradientDescent.hxx
@@ -38,7 +38,7 @@ namespace elastix
  * ********************** Constructor ***********************
  */
 
-template <class TElastix>
+template <typename TElastix>
 PreconditionedStochasticGradientDescent<TElastix>::PreconditionedStochasticGradientDescent()
 {
   this->m_MaximumNumberOfSamplingAttempts = 0;
@@ -73,7 +73,7 @@ PreconditionedStochasticGradientDescent<TElastix>::PreconditionedStochasticGradi
  * ***************** BeforeRegistration ***********************
  */
 
-template <class TElastix>
+template <typename TElastix>
 void
 PreconditionedStochasticGradientDescent<TElastix>::BeforeRegistration()
 {
@@ -100,7 +100,7 @@ PreconditionedStochasticGradientDescent<TElastix>::BeforeRegistration()
  * ***************** BeforeEachResolution ***********************
  */
 
-template <class TElastix>
+template <typename TElastix>
 void
 PreconditionedStochasticGradientDescent<TElastix>::BeforeEachResolution()
 {
@@ -282,7 +282,7 @@ PreconditionedStochasticGradientDescent<TElastix>::BeforeEachResolution()
  * ***************** AfterEachIteration *************************
  */
 
-template <class TElastix>
+template <typename TElastix>
 void
 PreconditionedStochasticGradientDescent<TElastix>::AfterEachIteration()
 {
@@ -316,7 +316,7 @@ PreconditionedStochasticGradientDescent<TElastix>::AfterEachIteration()
  * ***************** AfterEachResolution *************************
  */
 
-template <class TElastix>
+template <typename TElastix>
 void
 PreconditionedStochasticGradientDescent<TElastix>::AfterEachResolution()
 {
@@ -376,7 +376,7 @@ PreconditionedStochasticGradientDescent<TElastix>::AfterEachResolution()
  * ******************* AfterRegistration ************************
  */
 
-template <class TElastix>
+template <typename TElastix>
 void
 PreconditionedStochasticGradientDescent<TElastix>::AfterRegistration()
 {
@@ -395,7 +395,7 @@ PreconditionedStochasticGradientDescent<TElastix>::AfterRegistration()
  * ****************** StartOptimization *************************
  */
 
-template <class TElastix>
+template <typename TElastix>
 void
 PreconditionedStochasticGradientDescent<TElastix>::StartOptimization()
 {
@@ -412,7 +412,7 @@ PreconditionedStochasticGradientDescent<TElastix>::StartOptimization()
  * ********************** AdvanceOneStep **********************
  */
 
-template <class TElastix>
+template <typename TElastix>
 void
 PreconditionedStochasticGradientDescent<TElastix>::AdvanceOneStep()
 {
@@ -449,7 +449,7 @@ PreconditionedStochasticGradientDescent<TElastix>::AdvanceOneStep()
  * ********************** ResumeOptimization **********************
  */
 
-template <class TElastix>
+template <typename TElastix>
 void
 PreconditionedStochasticGradientDescent<TElastix>::ResumeOptimization()
 {
@@ -471,7 +471,7 @@ PreconditionedStochasticGradientDescent<TElastix>::ResumeOptimization()
  * ****************** MetricErrorResponse *************************
  */
 
-template <class TElastix>
+template <typename TElastix>
 void
 PreconditionedStochasticGradientDescent<TElastix>::MetricErrorResponse(itk::ExceptionObject & err)
 {
@@ -503,7 +503,7 @@ PreconditionedStochasticGradientDescent<TElastix>::MetricErrorResponse(itk::Exce
  * ******************* AutomaticPreconditionerEstimation **********************
  */
 
-template <class TElastix>
+template <typename TElastix>
 void
 PreconditionedStochasticGradientDescent<TElastix>::AutomaticPreconditionerEstimation()
 {
@@ -697,7 +697,7 @@ PreconditionedStochasticGradientDescent<TElastix>::AutomaticPreconditionerEstima
  * ******************** SampleGradients **********************
  */
 
-template <class TElastix>
+template <typename TElastix>
 void
 PreconditionedStochasticGradientDescent<TElastix>::SampleGradients(const ParametersType & mu0,
                                                                    double                 perturbationSigma,
@@ -901,7 +901,7 @@ PreconditionedStochasticGradientDescent<TElastix>::SampleGradients(const Paramet
  * *************** GetScaledDerivativeWithExceptionHandling ***************
  */
 
-template <class TElastix>
+template <typename TElastix>
 void
 PreconditionedStochasticGradientDescent<TElastix>::GetScaledDerivativeWithExceptionHandling(
   const ParametersType & parameters,
@@ -926,7 +926,7 @@ PreconditionedStochasticGradientDescent<TElastix>::GetScaledDerivativeWithExcept
  * *************** AddRandomPerturbation ***************
  */
 
-template <class TElastix>
+template <typename TElastix>
 void
 PreconditionedStochasticGradientDescent<TElastix>::AddRandomPerturbation(ParametersType & parameters, double sigma)
 {

--- a/Components/Optimizers/QuasiNewtonLBFGS/elxQuasiNewtonLBFGS.h
+++ b/Components/Optimizers/QuasiNewtonLBFGS/elxQuasiNewtonLBFGS.h
@@ -84,7 +84,7 @@ namespace elastix
  * \ingroup Optimizers
  */
 
-template <class TElastix>
+template <typename TElastix>
 class ITK_TEMPLATE_EXPORT QuasiNewtonLBFGS
   : public itk::QuasiNewtonLBFGSOptimizer
   , public OptimizerBase<TElastix>

--- a/Components/Optimizers/QuasiNewtonLBFGS/elxQuasiNewtonLBFGS.hxx
+++ b/Components/Optimizers/QuasiNewtonLBFGS/elxQuasiNewtonLBFGS.hxx
@@ -31,7 +31,7 @@ namespace elastix
  * ********************* Constructor ****************************
  */
 
-template <class TElastix>
+template <typename TElastix>
 QuasiNewtonLBFGS<TElastix>::QuasiNewtonLBFGS()
 {
   this->m_LineOptimizer = LineOptimizerType::New();
@@ -54,7 +54,7 @@ QuasiNewtonLBFGS<TElastix>::QuasiNewtonLBFGS()
  * ***************** InvokeIterationEvent ************************
  */
 
-template <class TElastix>
+template <typename TElastix>
 void
 QuasiNewtonLBFGS<TElastix>::InvokeIterationEvent(const itk::EventObject & event)
 {
@@ -81,7 +81,7 @@ QuasiNewtonLBFGS<TElastix>::InvokeIterationEvent(const itk::EventObject & event)
  * ***************** StartOptimization ************************
  */
 
-template <class TElastix>
+template <typename TElastix>
 void
 QuasiNewtonLBFGS<TElastix>::StartOptimization()
 {
@@ -109,7 +109,7 @@ QuasiNewtonLBFGS<TElastix>::StartOptimization()
  * ***************** LineSearch ************************
  */
 
-template <class TElastix>
+template <typename TElastix>
 void
 QuasiNewtonLBFGS<TElastix>::LineSearch(const ParametersType searchDir,
                                        double &             step,
@@ -152,7 +152,7 @@ QuasiNewtonLBFGS<TElastix>::LineSearch(const ParametersType searchDir,
  * during iterating
  */
 
-template <class TElastix>
+template <typename TElastix>
 std::string
 QuasiNewtonLBFGS<TElastix>::DeterminePhase() const
 {
@@ -171,7 +171,7 @@ QuasiNewtonLBFGS<TElastix>::DeterminePhase() const
  * ***************** BeforeRegistration ***********************
  */
 
-template <class TElastix>
+template <typename TElastix>
 void
 QuasiNewtonLBFGS<TElastix>::BeforeRegistration()
 {
@@ -212,7 +212,7 @@ QuasiNewtonLBFGS<TElastix>::BeforeRegistration()
  * ***************** BeforeEachResolution ***********************
  */
 
-template <class TElastix>
+template <typename TElastix>
 void
 QuasiNewtonLBFGS<TElastix>::BeforeEachResolution()
 {
@@ -280,7 +280,7 @@ QuasiNewtonLBFGS<TElastix>::BeforeEachResolution()
  * ***************** AfterEachIteration *************************
  */
 
-template <class TElastix>
+template <typename TElastix>
 void
 QuasiNewtonLBFGS<TElastix>::AfterEachIteration()
 {
@@ -368,7 +368,7 @@ QuasiNewtonLBFGS<TElastix>::AfterEachIteration()
  * ***************** AfterEachResolution *************************
  */
 
-template <class TElastix>
+template <typename TElastix>
 void
 QuasiNewtonLBFGS<TElastix>::AfterEachResolution()
 {
@@ -434,7 +434,7 @@ QuasiNewtonLBFGS<TElastix>::AfterEachResolution()
  * ******************* AfterRegistration ************************
  */
 
-template <class TElastix>
+template <typename TElastix>
 void
 QuasiNewtonLBFGS<TElastix>::AfterRegistration()
 {
@@ -450,7 +450,7 @@ QuasiNewtonLBFGS<TElastix>::AfterRegistration()
  * *********************** TestConvergence *****************
  */
 
-template <class TElastix>
+template <typename TElastix>
 bool
 QuasiNewtonLBFGS<TElastix>::TestConvergence(bool firstLineSearchDone)
 {
@@ -478,7 +478,7 @@ QuasiNewtonLBFGS<TElastix>::TestConvergence(bool firstLineSearchDone)
  * ***************** GetLineSearchStopCondition *****************
  */
 
-template <class TElastix>
+template <typename TElastix>
 std::string
 QuasiNewtonLBFGS<TElastix>::GetLineSearchStopCondition() const
 {

--- a/Components/Optimizers/RSGDEachParameterApart/elxRSGDEachParameterApart.h
+++ b/Components/Optimizers/RSGDEachParameterApart/elxRSGDEachParameterApart.h
@@ -68,7 +68,7 @@ namespace elastix
  * \ingroup Optimizers
  */
 
-template <class TElastix>
+template <typename TElastix>
 class ITK_TEMPLATE_EXPORT RSGDEachParameterApart
   : public itk::RSGDEachParameterApartOptimizer
   , public OptimizerBase<TElastix>

--- a/Components/Optimizers/RSGDEachParameterApart/elxRSGDEachParameterApart.hxx
+++ b/Components/Optimizers/RSGDEachParameterApart/elxRSGDEachParameterApart.hxx
@@ -31,7 +31,7 @@ namespace elastix
  * ***************** BeforeRegistration ***********************
  */
 
-template <class TElastix>
+template <typename TElastix>
 void
 RSGDEachParameterApart<TElastix>::BeforeRegistration()
 {
@@ -52,7 +52,7 @@ RSGDEachParameterApart<TElastix>::BeforeRegistration()
  * ***************** BeforeEachResolution ***********************
  */
 
-template <class TElastix>
+template <typename TElastix>
 void
 RSGDEachParameterApart<TElastix>::BeforeEachResolution()
 {
@@ -100,7 +100,7 @@ RSGDEachParameterApart<TElastix>::BeforeEachResolution()
  * ***************** AfterEachIteration *************************
  */
 
-template <class TElastix>
+template <typename TElastix>
 void
 RSGDEachParameterApart<TElastix>::AfterEachIteration()
 {
@@ -116,7 +116,7 @@ RSGDEachParameterApart<TElastix>::AfterEachIteration()
  * ***************** AfterEachResolution *************************
  */
 
-template <class TElastix>
+template <typename TElastix>
 void
 RSGDEachParameterApart<TElastix>::AfterEachResolution()
 {
@@ -169,7 +169,7 @@ RSGDEachParameterApart<TElastix>::AfterEachResolution()
  * ******************* AfterRegistration ************************
  */
 
-template <class TElastix>
+template <typename TElastix>
 void
 RSGDEachParameterApart<TElastix>::AfterRegistration()
 {
@@ -184,7 +184,7 @@ RSGDEachParameterApart<TElastix>::AfterRegistration()
  * ******************* SetInitialPosition ***********************
  */
 
-template <class TElastix>
+template <typename TElastix>
 void
 RSGDEachParameterApart<TElastix>::SetInitialPosition(const ParametersType & param)
 {

--- a/Components/Optimizers/RegularStepGradientDescent/elxRegularStepGradientDescent.h
+++ b/Components/Optimizers/RegularStepGradientDescent/elxRegularStepGradientDescent.h
@@ -61,7 +61,7 @@ namespace elastix
  * \ingroup Optimizers
  */
 
-template <class TElastix>
+template <typename TElastix>
 class ITK_TEMPLATE_EXPORT RegularStepGradientDescent
   : public itk::RegularStepGradientDescentOptimizer
   , public OptimizerBase<TElastix>

--- a/Components/Optimizers/RegularStepGradientDescent/elxRegularStepGradientDescent.hxx
+++ b/Components/Optimizers/RegularStepGradientDescent/elxRegularStepGradientDescent.hxx
@@ -31,7 +31,7 @@ namespace elastix
  * ***************** BeforeRegistration ***********************
  */
 
-template <class TElastix>
+template <typename TElastix>
 void
 RegularStepGradientDescent<TElastix>::BeforeRegistration()
 {
@@ -52,7 +52,7 @@ RegularStepGradientDescent<TElastix>::BeforeRegistration()
  * ***************** BeforeEachResolution ***********************
  */
 
-template <class TElastix>
+template <typename TElastix>
 void
 RegularStepGradientDescent<TElastix>::BeforeEachResolution()
 {
@@ -96,7 +96,7 @@ RegularStepGradientDescent<TElastix>::BeforeEachResolution()
  * ***************** AfterEachIteration *************************
  */
 
-template <class TElastix>
+template <typename TElastix>
 void
 RegularStepGradientDescent<TElastix>::AfterEachIteration()
 {
@@ -111,7 +111,7 @@ RegularStepGradientDescent<TElastix>::AfterEachIteration()
  * ***************** AfterEachResolution *************************
  */
 
-template <class TElastix>
+template <typename TElastix>
 void
 RegularStepGradientDescent<TElastix>::AfterEachResolution()
 {
@@ -160,7 +160,7 @@ RegularStepGradientDescent<TElastix>::AfterEachResolution()
  * ******************* AfterRegistration ************************
  */
 
-template <class TElastix>
+template <typename TElastix>
 void
 RegularStepGradientDescent<TElastix>::AfterRegistration()
 {
@@ -175,7 +175,7 @@ RegularStepGradientDescent<TElastix>::AfterRegistration()
  * ******************* SetInitialPosition ***********************
  */
 
-template <class TElastix>
+template <typename TElastix>
 void
 RegularStepGradientDescent<TElastix>::SetInitialPosition(const ParametersType & param)
 {

--- a/Components/Optimizers/Simplex/elxSimplex.h
+++ b/Components/Optimizers/Simplex/elxSimplex.h
@@ -37,7 +37,7 @@ namespace elastix
  * \ingroup Optimizers
  */
 
-template <class TElastix>
+template <typename TElastix>
 class ITK_TEMPLATE_EXPORT Simplex
   : public itk::AmoebaOptimizer
   , public OptimizerBase<TElastix>

--- a/Components/Optimizers/Simplex/elxSimplex.hxx
+++ b/Components/Optimizers/Simplex/elxSimplex.hxx
@@ -31,7 +31,7 @@ namespace elastix
  * ***************** BeforeRegistration ***********************
  */
 
-template <class TElastix>
+template <typename TElastix>
 void
 Simplex<TElastix>::BeforeRegistration()
 {
@@ -52,7 +52,7 @@ Simplex<TElastix>::BeforeRegistration()
  * ***************** BeforeEachResolution ***********************
  */
 
-template <class TElastix>
+template <typename TElastix>
 void
 Simplex<TElastix>::BeforeEachResolution()
 {
@@ -98,7 +98,7 @@ Simplex<TElastix>::BeforeEachResolution()
  * ***************** AfterEachIteration *************************
  */
 
-template <class TElastix>
+template <typename TElastix>
 void
 Simplex<TElastix>::AfterEachIteration()
 {
@@ -113,7 +113,7 @@ Simplex<TElastix>::AfterEachIteration()
  * ***************** AfterEachResolution *************************
  */
 
-template <class TElastix>
+template <typename TElastix>
 void
 Simplex<TElastix>::AfterEachResolution()
 {
@@ -133,7 +133,7 @@ Simplex<TElastix>::AfterEachResolution()
  * ******************* AfterRegistration ************************
  */
 
-template <class TElastix>
+template <typename TElastix>
 void
 Simplex<TElastix>::AfterRegistration()
 {
@@ -149,7 +149,7 @@ Simplex<TElastix>::AfterRegistration()
  * ******************* SetInitialPosition ***********************
  */
 
-template <class TElastix>
+template <typename TElastix>
 void
 Simplex<TElastix>::SetInitialPosition(const ParametersType & param)
 {

--- a/Components/Optimizers/SimultaneousPerturbation/elxSimultaneousPerturbation.h
+++ b/Components/Optimizers/SimultaneousPerturbation/elxSimultaneousPerturbation.h
@@ -79,7 +79,7 @@ namespace elastix
  * \ingroup Optimizers
  */
 
-template <class TElastix>
+template <typename TElastix>
 class ITK_TEMPLATE_EXPORT SimultaneousPerturbation
   : public itk::SPSAOptimizer
   , public OptimizerBase<TElastix>

--- a/Components/Optimizers/SimultaneousPerturbation/elxSimultaneousPerturbation.hxx
+++ b/Components/Optimizers/SimultaneousPerturbation/elxSimultaneousPerturbation.hxx
@@ -32,7 +32,7 @@ namespace elastix
  * ********************* Constructor ****************************
  */
 
-template <class TElastix>
+template <typename TElastix>
 SimultaneousPerturbation<TElastix>::SimultaneousPerturbation()
 {
   this->m_ShowMetricValues = false;
@@ -43,7 +43,7 @@ SimultaneousPerturbation<TElastix>::SimultaneousPerturbation()
  * ***************** BeforeRegistration ***********************
  */
 
-template <class TElastix>
+template <typename TElastix>
 void
 SimultaneousPerturbation<TElastix>::BeforeRegistration()
 {
@@ -77,7 +77,7 @@ SimultaneousPerturbation<TElastix>::BeforeRegistration()
  * ***************** BeforeEachResolution ***********************
  */
 
-template <class TElastix>
+template <typename TElastix>
 void
 SimultaneousPerturbation<TElastix>::BeforeEachResolution()
 {
@@ -126,7 +126,7 @@ SimultaneousPerturbation<TElastix>::BeforeEachResolution()
  * ***************** AfterEachIteration *************************
  */
 
-template <class TElastix>
+template <typename TElastix>
 void
 SimultaneousPerturbation<TElastix>::AfterEachIteration()
 {
@@ -160,7 +160,7 @@ SimultaneousPerturbation<TElastix>::AfterEachIteration()
  * ***************** AfterEachResolution *************************
  */
 
-template <class TElastix>
+template <typename TElastix>
 void
 SimultaneousPerturbation<TElastix>::AfterEachResolution()
 {
@@ -197,7 +197,7 @@ SimultaneousPerturbation<TElastix>::AfterEachResolution()
  * ******************* AfterRegistration ************************
  */
 
-template <class TElastix>
+template <typename TElastix>
 void
 SimultaneousPerturbation<TElastix>::AfterRegistration()
 {
@@ -214,7 +214,7 @@ SimultaneousPerturbation<TElastix>::AfterRegistration()
  * ******************* SetInitialPosition ***********************
  */
 
-template <class TElastix>
+template <typename TElastix>
 void
 SimultaneousPerturbation<TElastix>::SetInitialPosition(const ParametersType & param)
 {

--- a/Components/Optimizers/StandardGradientDescent/elxStandardGradientDescent.h
+++ b/Components/Optimizers/StandardGradientDescent/elxStandardGradientDescent.h
@@ -64,7 +64,7 @@ namespace elastix
  * \ingroup Optimizers
  */
 
-template <class TElastix>
+template <typename TElastix>
 class ITK_TEMPLATE_EXPORT StandardGradientDescent
   : public itk::StandardGradientDescentOptimizer
   , public OptimizerBase<TElastix>

--- a/Components/Optimizers/StandardGradientDescent/elxStandardGradientDescent.hxx
+++ b/Components/Optimizers/StandardGradientDescent/elxStandardGradientDescent.hxx
@@ -30,7 +30,7 @@ namespace elastix
  * ***************** Constructor ***********************
  */
 
-template <class TElastix>
+template <typename TElastix>
 StandardGradientDescent<TElastix>::StandardGradientDescent()
 {
   this->m_MaximumNumberOfSamplingAttempts = 0;
@@ -44,7 +44,7 @@ StandardGradientDescent<TElastix>::StandardGradientDescent()
  * ***************** BeforeRegistration ***********************
  */
 
-template <class TElastix>
+template <typename TElastix>
 void
 StandardGradientDescent<TElastix>::BeforeRegistration()
 {
@@ -65,7 +65,7 @@ StandardGradientDescent<TElastix>::BeforeRegistration()
  * ***************** BeforeEachResolution ***********************
  */
 
-template <class TElastix>
+template <typename TElastix>
 void
 StandardGradientDescent<TElastix>::BeforeEachResolution()
 {
@@ -115,7 +115,7 @@ StandardGradientDescent<TElastix>::BeforeEachResolution()
  * ***************** AfterEachIteration *************************
  */
 
-template <class TElastix>
+template <typename TElastix>
 void
 StandardGradientDescent<TElastix>::AfterEachIteration()
 {
@@ -137,7 +137,7 @@ StandardGradientDescent<TElastix>::AfterEachIteration()
  * ***************** AfterEachResolution *************************
  */
 
-template <class TElastix>
+template <typename TElastix>
 void
 StandardGradientDescent<TElastix>::AfterEachResolution()
 {
@@ -171,7 +171,7 @@ StandardGradientDescent<TElastix>::AfterEachResolution()
  * ******************* AfterRegistration ************************
  */
 
-template <class TElastix>
+template <typename TElastix>
 void
 StandardGradientDescent<TElastix>::AfterRegistration()
 {
@@ -186,7 +186,7 @@ StandardGradientDescent<TElastix>::AfterRegistration()
  * ****************** StartOptimization *************************
  */
 
-template <class TElastix>
+template <typename TElastix>
 void
 StandardGradientDescent<TElastix>::StartOptimization()
 {
@@ -217,7 +217,7 @@ StandardGradientDescent<TElastix>::StartOptimization()
  * ****************** MetricErrorResponse *************************
  */
 
-template <class TElastix>
+template <typename TElastix>
 void
 StandardGradientDescent<TElastix>::MetricErrorResponse(itk::ExceptionObject & err)
 {

--- a/Components/Registrations/MultiMetricMultiResolutionRegistration/elxMultiMetricMultiResolutionRegistration.h
+++ b/Components/Registrations/MultiMetricMultiResolutionRegistration/elxMultiMetricMultiResolutionRegistration.h
@@ -91,7 +91,7 @@ namespace elastix
  * \ingroup Registrations
  */
 
-template <class TElastix>
+template <typename TElastix>
 class ITK_TEMPLATE_EXPORT MultiMetricMultiResolutionRegistration
   : public itk::MultiMetricMultiResolutionImageRegistrationMethod<typename RegistrationBase<TElastix>::FixedImageType,
                                                                   typename RegistrationBase<TElastix>::MovingImageType>

--- a/Components/Registrations/MultiMetricMultiResolutionRegistration/elxMultiMetricMultiResolutionRegistration.hxx
+++ b/Components/Registrations/MultiMetricMultiResolutionRegistration/elxMultiMetricMultiResolutionRegistration.hxx
@@ -29,7 +29,7 @@ namespace elastix
  * ******************* Constructor ***********************
  */
 
-template <class TElastix>
+template <typename TElastix>
 MultiMetricMultiResolutionRegistration<TElastix>::MultiMetricMultiResolutionRegistration()
 {
   this->m_ShowExactMetricValue = false;
@@ -40,7 +40,7 @@ MultiMetricMultiResolutionRegistration<TElastix>::MultiMetricMultiResolutionRegi
  * ******************* BeforeRegistration ***********************
  */
 
-template <class TElastix>
+template <typename TElastix>
 void
 MultiMetricMultiResolutionRegistration<TElastix>::BeforeRegistration()
 {
@@ -126,7 +126,7 @@ MultiMetricMultiResolutionRegistration<TElastix>::BeforeRegistration()
  * ******************* AfterEachIteration ***********************
  */
 
-template <class TElastix>
+template <typename TElastix>
 void
 MultiMetricMultiResolutionRegistration<TElastix>::AfterEachIteration()
 {
@@ -179,7 +179,7 @@ MultiMetricMultiResolutionRegistration<TElastix>::AfterEachIteration()
  * ******************* BeforeEachResolution ***********************
  */
 
-template <class TElastix>
+template <typename TElastix>
 void
 MultiMetricMultiResolutionRegistration<TElastix>::BeforeEachResolution()
 {
@@ -270,7 +270,7 @@ MultiMetricMultiResolutionRegistration<TElastix>::BeforeEachResolution()
  * *********************** SetComponents ************************
  */
 
-template <class TElastix>
+template <typename TElastix>
 void
 MultiMetricMultiResolutionRegistration<TElastix>::SetComponents()
 {
@@ -359,7 +359,7 @@ MultiMetricMultiResolutionRegistration<TElastix>::SetComponents()
  * ************************* UpdateFixedMasks ************************
  */
 
-template <class TElastix>
+template <typename TElastix>
 void
 MultiMetricMultiResolutionRegistration<TElastix>::UpdateFixedMasks(unsigned int level)
 {
@@ -447,7 +447,7 @@ MultiMetricMultiResolutionRegistration<TElastix>::UpdateFixedMasks(unsigned int 
  * ************************* UpdateMovingMasks ************************
  */
 
-template <class TElastix>
+template <typename TElastix>
 void
 MultiMetricMultiResolutionRegistration<TElastix>::UpdateMovingMasks(unsigned int level)
 {

--- a/Components/Registrations/MultiMetricMultiResolutionRegistration/itkCombinationImageToImageMetric.h
+++ b/Components/Registrations/MultiMetricMultiResolutionRegistration/itkCombinationImageToImageMetric.h
@@ -55,7 +55,7 @@ namespace itk
  *
  */
 
-template <class TFixedImage, class TMovingImage>
+template <typename TFixedImage, typename TMovingImage>
 class ITK_TEMPLATE_EXPORT CombinationImageToImageMetric : public AdvancedImageToImageMetric<TFixedImage, TMovingImage>
 {
 public:

--- a/Components/Registrations/MultiMetricMultiResolutionRegistration/itkCombinationImageToImageMetric.hxx
+++ b/Components/Registrations/MultiMetricMultiResolutionRegistration/itkCombinationImageToImageMetric.hxx
@@ -31,7 +31,7 @@
 
 /** For setting objects, implement two methods */
 #define itkImplementationSetObjectMacro2(_name, _type1, _type2)                                                        \
-  template <class TFixedImage, class TMovingImage>                                                                     \
+  template <typename TFixedImage, typename TMovingImage>                                                               \
   void CombinationImageToImageMetric<TFixedImage, TMovingImage>::Set##_name(_type1 _type2 * _arg, unsigned int pos)    \
   {                                                                                                                    \
     if (pos == 0)                                                                                                      \
@@ -49,7 +49,7 @@
       testPtr2->Set##_name(_arg);                                                                                      \
     }                                                                                                                  \
   }                                                                                                                    \
-  template <class TFixedImage, class TMovingImage>                                                                     \
+  template <typename TFixedImage, typename TMovingImage>                                                               \
   void CombinationImageToImageMetric<TFixedImage, TMovingImage>::Set##_name(_type1 _type2 * _arg)                      \
   {                                                                                                                    \
     for (unsigned int i = 0; i < this->GetNumberOfMetrics(); ++i)                                                      \
@@ -59,7 +59,7 @@
   } // comments for allowing ; after calling the macro
 
 #define itkImplementationSetObjectMacro1(_name, _type1, _type2)                                                        \
-  template <class TFixedImage, class TMovingImage>                                                                     \
+  template <typename TFixedImage, typename TMovingImage>                                                               \
   void CombinationImageToImageMetric<TFixedImage, TMovingImage>::Set##_name(_type1 _type2 * _arg, unsigned int pos)    \
   {                                                                                                                    \
     if (pos == 0)                                                                                                      \
@@ -72,7 +72,7 @@
       testPtr1->Set##_name(_arg);                                                                                      \
     }                                                                                                                  \
   }                                                                                                                    \
-  template <class TFixedImage, class TMovingImage>                                                                     \
+  template <typename TFixedImage, typename TMovingImage>                                                               \
   void CombinationImageToImageMetric<TFixedImage, TMovingImage>::Set##_name(_type1 _type2 * _arg)                      \
   {                                                                                                                    \
     for (unsigned int i = 0; i < this->GetNumberOfMetrics(); ++i)                                                      \
@@ -83,7 +83,7 @@
 
 /** for getting const object, implement one method */
 #define itkImplementationGetConstObjectMacro1(_name, _type)                                                            \
-  template <class TFixedImage, class TMovingImage>                                                                     \
+  template <typename TFixedImage, typename TMovingImage>                                                               \
   auto CombinationImageToImageMetric<TFixedImage, TMovingImage>::Get##_name(unsigned int pos) const->const _type *     \
   {                                                                                                                    \
     const ImageMetricType * testPtr1 = dynamic_cast<const ImageMetricType *>(this->GetMetric(pos));                    \
@@ -98,7 +98,7 @@
   } // comments for allowing ; after calling the macro
 
 #define itkImplementationGetConstObjectMacro2(_name, _type)                                                            \
-  template <class TFixedImage, class TMovingImage>                                                                     \
+  template <typename TFixedImage, typename TMovingImage>                                                               \
   auto CombinationImageToImageMetric<TFixedImage, TMovingImage>::Get##_name(unsigned int pos) const->const _type *     \
   {                                                                                                                    \
     const ImageMetricType *    testPtr1 = dynamic_cast<const ImageMetricType *>(this->GetMetric(pos));                 \
@@ -139,7 +139,7 @@ itkImplementationGetConstObjectMacro1(MovingImage, MovingImageType);
  * ********************* Constructor ****************************
  */
 
-template <class TFixedImage, class TMovingImage>
+template <typename TFixedImage, typename TMovingImage>
 CombinationImageToImageMetric<TFixedImage, TMovingImage>::CombinationImageToImageMetric()
 {
   this->ComputeGradientOff();
@@ -151,7 +151,7 @@ CombinationImageToImageMetric<TFixedImage, TMovingImage>::CombinationImageToImag
  * ********************* PrintSelf ****************************
  */
 
-template <class TFixedImage, class TMovingImage>
+template <typename TFixedImage, typename TMovingImage>
 void
 CombinationImageToImageMetric<TFixedImage, TMovingImage>::PrintSelf(std::ostream & os, Indent indent) const
 {
@@ -180,7 +180,7 @@ CombinationImageToImageMetric<TFixedImage, TMovingImage>::PrintSelf(std::ostream
  * ******************** SetFixedImageRegion ************************
  */
 
-template <class TFixedImage, class TMovingImage>
+template <typename TFixedImage, typename TMovingImage>
 void
 CombinationImageToImageMetric<TFixedImage, TMovingImage>::SetFixedImageRegion(const FixedImageRegionType _arg,
                                                                               unsigned int               pos)
@@ -202,7 +202,7 @@ CombinationImageToImageMetric<TFixedImage, TMovingImage>::SetFixedImageRegion(co
  * ******************** SetFixedImageRegion ************************
  */
 
-template <class TFixedImage, class TMovingImage>
+template <typename TFixedImage, typename TMovingImage>
 void
 CombinationImageToImageMetric<TFixedImage, TMovingImage>::SetFixedImageRegion(const FixedImageRegionType _arg)
 {
@@ -218,7 +218,7 @@ CombinationImageToImageMetric<TFixedImage, TMovingImage>::SetFixedImageRegion(co
  * ******************** GetFixedImageRegion ************************
  */
 
-template <class TFixedImage, class TMovingImage>
+template <typename TFixedImage, typename TMovingImage>
 auto
 CombinationImageToImageMetric<TFixedImage, TMovingImage>::GetFixedImageRegion(unsigned int pos) const
   -> const FixedImageRegionType &
@@ -240,7 +240,7 @@ CombinationImageToImageMetric<TFixedImage, TMovingImage>::GetFixedImageRegion(un
  * ********************* SetNumberOfMetrics ****************************
  */
 
-template <class TFixedImage, class TMovingImage>
+template <typename TFixedImage, typename TMovingImage>
 void
 CombinationImageToImageMetric<TFixedImage, TMovingImage>::SetNumberOfMetrics(unsigned int count)
 {
@@ -265,7 +265,7 @@ CombinationImageToImageMetric<TFixedImage, TMovingImage>::SetNumberOfMetrics(uns
  * ********************* SetMetric ****************************
  */
 
-template <class TFixedImage, class TMovingImage>
+template <typename TFixedImage, typename TMovingImage>
 void
 CombinationImageToImageMetric<TFixedImage, TMovingImage>::SetMetric(SingleValuedCostFunctionType * metric,
                                                                     unsigned int                   pos)
@@ -288,7 +288,7 @@ CombinationImageToImageMetric<TFixedImage, TMovingImage>::SetMetric(SingleValued
  * ********************* GetMetric ****************************
  */
 
-template <class TFixedImage, class TMovingImage>
+template <typename TFixedImage, typename TMovingImage>
 auto
 CombinationImageToImageMetric<TFixedImage, TMovingImage>::GetMetric(unsigned int pos) const
   -> SingleValuedCostFunctionType *
@@ -309,7 +309,7 @@ CombinationImageToImageMetric<TFixedImage, TMovingImage>::GetMetric(unsigned int
  * ********************* SetMetricWeight ****************************
  */
 
-template <class TFixedImage, class TMovingImage>
+template <typename TFixedImage, typename TMovingImage>
 void
 CombinationImageToImageMetric<TFixedImage, TMovingImage>::SetMetricWeight(double weight, unsigned int pos)
 {
@@ -331,7 +331,7 @@ CombinationImageToImageMetric<TFixedImage, TMovingImage>::SetMetricWeight(double
  * ********************* GetMetricWeight ****************************
  */
 
-template <class TFixedImage, class TMovingImage>
+template <typename TFixedImage, typename TMovingImage>
 double
 CombinationImageToImageMetric<TFixedImage, TMovingImage>::GetMetricWeight(unsigned int pos) const
 {
@@ -351,7 +351,7 @@ CombinationImageToImageMetric<TFixedImage, TMovingImage>::GetMetricWeight(unsign
  * ********************* SetMetricRelativeWeight ****************************
  */
 
-template <class TFixedImage, class TMovingImage>
+template <typename TFixedImage, typename TMovingImage>
 void
 CombinationImageToImageMetric<TFixedImage, TMovingImage>::SetMetricRelativeWeight(double weight, unsigned int pos)
 {
@@ -373,7 +373,7 @@ CombinationImageToImageMetric<TFixedImage, TMovingImage>::SetMetricRelativeWeigh
  * ********************* GetMetricRelativeWeight ****************************
  */
 
-template <class TFixedImage, class TMovingImage>
+template <typename TFixedImage, typename TMovingImage>
 double
 CombinationImageToImageMetric<TFixedImage, TMovingImage>::GetMetricRelativeWeight(unsigned int pos) const
 {
@@ -393,7 +393,7 @@ CombinationImageToImageMetric<TFixedImage, TMovingImage>::GetMetricRelativeWeigh
  * ********************* SetUseMetric ****************************
  */
 
-template <class TFixedImage, class TMovingImage>
+template <typename TFixedImage, typename TMovingImage>
 void
 CombinationImageToImageMetric<TFixedImage, TMovingImage>::SetUseMetric(const bool use, const unsigned int pos)
 {
@@ -415,7 +415,7 @@ CombinationImageToImageMetric<TFixedImage, TMovingImage>::SetUseMetric(const boo
  * ********************* SetUseAllMetrics ****************************
  */
 
-template <class TFixedImage, class TMovingImage>
+template <typename TFixedImage, typename TMovingImage>
 void
 CombinationImageToImageMetric<TFixedImage, TMovingImage>::SetUseAllMetrics()
 {
@@ -435,7 +435,7 @@ CombinationImageToImageMetric<TFixedImage, TMovingImage>::SetUseAllMetrics()
  * ********************* GetUseMetric ****************************
  */
 
-template <class TFixedImage, class TMovingImage>
+template <typename TFixedImage, typename TMovingImage>
 bool
 CombinationImageToImageMetric<TFixedImage, TMovingImage>::GetUseMetric(unsigned int pos) const
 {
@@ -455,7 +455,7 @@ CombinationImageToImageMetric<TFixedImage, TMovingImage>::GetUseMetric(unsigned 
  * ********************* GetMetricValue ****************************
  */
 
-template <class TFixedImage, class TMovingImage>
+template <typename TFixedImage, typename TMovingImage>
 auto
 CombinationImageToImageMetric<TFixedImage, TMovingImage>::GetMetricValue(unsigned int pos) const -> MeasureType
 {
@@ -475,7 +475,7 @@ CombinationImageToImageMetric<TFixedImage, TMovingImage>::GetMetricValue(unsigne
  * ********************* GetMetricDerivative ****************************
  */
 
-template <class TFixedImage, class TMovingImage>
+template <typename TFixedImage, typename TMovingImage>
 auto
 CombinationImageToImageMetric<TFixedImage, TMovingImage>::GetMetricDerivative(unsigned int pos) const
   -> const DerivativeType &
@@ -496,7 +496,7 @@ CombinationImageToImageMetric<TFixedImage, TMovingImage>::GetMetricDerivative(un
  * ********************* GetMetricDerivativeMagnitude ****************************
  */
 
-template <class TFixedImage, class TMovingImage>
+template <typename TFixedImage, typename TMovingImage>
 double
 CombinationImageToImageMetric<TFixedImage, TMovingImage>::GetMetricDerivativeMagnitude(unsigned int pos) const
 {
@@ -516,7 +516,7 @@ CombinationImageToImageMetric<TFixedImage, TMovingImage>::GetMetricDerivativeMag
  * ********************* GetMetricComputationTime ****************************
  */
 
-template <class TFixedImage, class TMovingImage>
+template <typename TFixedImage, typename TMovingImage>
 double
 CombinationImageToImageMetric<TFixedImage, TMovingImage>::GetMetricComputationTime(unsigned int pos) const
 {
@@ -536,7 +536,7 @@ CombinationImageToImageMetric<TFixedImage, TMovingImage>::GetMetricComputationTi
  * **************** GetNumberOfPixelsCounted ************************
  */
 
-template <class TFixedImage, class TMovingImage>
+template <typename TFixedImage, typename TMovingImage>
 const SizeValueType &
 CombinationImageToImageMetric<TFixedImage, TMovingImage>::GetNumberOfPixelsCounted() const
 {
@@ -560,7 +560,7 @@ CombinationImageToImageMetric<TFixedImage, TMovingImage>::GetNumberOfPixelsCount
  * ********************* Initialize ****************************
  */
 
-template <class TFixedImage, class TMovingImage>
+template <typename TFixedImage, typename TMovingImage>
 void
 CombinationImageToImageMetric<TFixedImage, TMovingImage>::Initialize()
 {
@@ -608,7 +608,7 @@ CombinationImageToImageMetric<TFixedImage, TMovingImage>::Initialize()
  * ******************* InitializeThreadingParameters *******************
  */
 
-template <class TFixedImage, class TMovingImage>
+template <typename TFixedImage, typename TMovingImage>
 void
 CombinationImageToImageMetric<TFixedImage, TMovingImage>::InitializeThreadingParameters() const
 {
@@ -624,7 +624,7 @@ CombinationImageToImageMetric<TFixedImage, TMovingImage>::InitializeThreadingPar
  * ******************* GetFinalMetricWeight *******************
  */
 
-template <class TFixedImage, class TMovingImage>
+template <typename TFixedImage, typename TMovingImage>
 double
 CombinationImageToImageMetric<TFixedImage, TMovingImage>::GetFinalMetricWeight(unsigned int pos) const
 {
@@ -656,7 +656,7 @@ CombinationImageToImageMetric<TFixedImage, TMovingImage>::GetFinalMetricWeight(u
  * ********************* GetValue ****************************
  */
 
-template <class TFixedImage, class TMovingImage>
+template <typename TFixedImage, typename TMovingImage>
 auto
 CombinationImageToImageMetric<TFixedImage, TMovingImage>::GetValue(const ParametersType & parameters) const
   -> MeasureType
@@ -714,7 +714,7 @@ CombinationImageToImageMetric<TFixedImage, TMovingImage>::GetValue(const Paramet
  * ********************* GetDerivative ****************************
  */
 
-template <class TFixedImage, class TMovingImage>
+template <typename TFixedImage, typename TMovingImage>
 void
 CombinationImageToImageMetric<TFixedImage, TMovingImage>::GetDerivative(const ParametersType & parameters,
                                                                         DerivativeType &       derivative) const
@@ -774,7 +774,7 @@ CombinationImageToImageMetric<TFixedImage, TMovingImage>::GetDerivative(const Pa
  * ********************* GetValueAndDerivative ****************************
  */
 
-template <class TFixedImage, class TMovingImage>
+template <typename TFixedImage, typename TMovingImage>
 void
 CombinationImageToImageMetric<TFixedImage, TMovingImage>::GetValueAndDerivative(const ParametersType & parameters,
                                                                                 MeasureType &          value,
@@ -865,7 +865,7 @@ CombinationImageToImageMetric<TFixedImage, TMovingImage>::GetValueAndDerivative(
  * ********************* GetMTime ****************************
  */
 
-template <class TFixedImage, class TMovingImage>
+template <typename TFixedImage, typename TMovingImage>
 ModifiedTimeType
 CombinationImageToImageMetric<TFixedImage, TMovingImage>::GetMTime() const
 {

--- a/Components/Registrations/MultiResolutionRegistration/elxMultiResolutionRegistration.h
+++ b/Components/Registrations/MultiResolutionRegistration/elxMultiResolutionRegistration.h
@@ -41,7 +41,7 @@ namespace elastix
  * \ingroup Registrations
  */
 
-template <class TElastix>
+template <typename TElastix>
 class ITK_TEMPLATE_EXPORT MultiResolutionRegistration
   : public RegistrationBase<TElastix>::ITKBaseType
   , public RegistrationBase<TElastix>

--- a/Components/Registrations/MultiResolutionRegistration/elxMultiResolutionRegistration.hxx
+++ b/Components/Registrations/MultiResolutionRegistration/elxMultiResolutionRegistration.hxx
@@ -29,7 +29,7 @@ namespace elastix
  * ******************* BeforeRegistration ***********************
  */
 
-template <class TElastix>
+template <typename TElastix>
 void
 MultiResolutionRegistration<TElastix>::BeforeRegistration()
 {
@@ -89,7 +89,7 @@ MultiResolutionRegistration<TElastix>::BeforeRegistration()
  * ******************* BeforeEachResolution ***********************
  */
 
-template <class TElastix>
+template <typename TElastix>
 void
 MultiResolutionRegistration<TElastix>::BeforeEachResolution()
 {
@@ -108,7 +108,7 @@ MultiResolutionRegistration<TElastix>::BeforeEachResolution()
  * *********************** SetComponents ************************
  */
 
-template <class TElastix>
+template <typename TElastix>
 void
 MultiResolutionRegistration<TElastix>::SetComponents()
 {
@@ -161,7 +161,7 @@ MultiResolutionRegistration<TElastix>::SetComponents()
  * ************************* UpdateMasks ************************
  **/
 
-template <class TElastix>
+template <typename TElastix>
 void
 MultiResolutionRegistration<TElastix>::UpdateMasks(unsigned int level)
 {

--- a/Components/Registrations/MultiResolutionRegistrationWithFeatures/elxMultiResolutionRegistrationWithFeatures.h
+++ b/Components/Registrations/MultiResolutionRegistrationWithFeatures/elxMultiResolutionRegistrationWithFeatures.h
@@ -49,7 +49,7 @@ namespace elastix
  * \ingroup Registrations
  */
 
-template <class TElastix>
+template <typename TElastix>
 class ITK_TEMPLATE_EXPORT MultiResolutionRegistrationWithFeatures
   : public itk::MultiResolutionImageRegistrationMethodWithFeatures<typename RegistrationBase<TElastix>::FixedImageType,
                                                                    typename RegistrationBase<TElastix>::MovingImageType>

--- a/Components/Registrations/MultiResolutionRegistrationWithFeatures/elxMultiResolutionRegistrationWithFeatures.hxx
+++ b/Components/Registrations/MultiResolutionRegistrationWithFeatures/elxMultiResolutionRegistrationWithFeatures.hxx
@@ -28,7 +28,7 @@ namespace elastix
  * ******************* BeforeRegistration ***********************
  */
 
-template <class TElastix>
+template <typename TElastix>
 void
 MultiResolutionRegistrationWithFeatures<TElastix>::BeforeRegistration()
 {
@@ -57,7 +57,7 @@ MultiResolutionRegistrationWithFeatures<TElastix>::BeforeRegistration()
  * ******************* BeforeEachResolution ***********************
  */
 
-template <class TElastix>
+template <typename TElastix>
 void
 MultiResolutionRegistrationWithFeatures<TElastix>::BeforeEachResolution()
 {
@@ -75,7 +75,7 @@ MultiResolutionRegistrationWithFeatures<TElastix>::BeforeEachResolution()
  * *********************** GetAndSetComponents ************************
  */
 
-template <class TElastix>
+template <typename TElastix>
 void
 MultiResolutionRegistrationWithFeatures<TElastix>::GetAndSetComponents()
 {
@@ -153,7 +153,7 @@ MultiResolutionRegistrationWithFeatures<TElastix>::GetAndSetComponents()
  * *********************** GetAndSetFixedImageRegions ************************
  */
 
-template <class TElastix>
+template <typename TElastix>
 void
 MultiResolutionRegistrationWithFeatures<TElastix>::GetAndSetFixedImageRegions()
 {
@@ -186,7 +186,7 @@ MultiResolutionRegistrationWithFeatures<TElastix>::GetAndSetFixedImageRegions()
  * *********************** GetAndSetFixedImageInterpolators ************************
  */
 
-template <class TElastix>
+template <typename TElastix>
 void
 MultiResolutionRegistrationWithFeatures<TElastix>::GetAndSetFixedImageInterpolators()
 {
@@ -217,7 +217,7 @@ MultiResolutionRegistrationWithFeatures<TElastix>::GetAndSetFixedImageInterpolat
  * ************************* UpdateFixedMasks ************************
  */
 
-template <class TElastix>
+template <typename TElastix>
 void
 MultiResolutionRegistrationWithFeatures<TElastix>::UpdateFixedMasks(unsigned int level)
 {
@@ -256,7 +256,7 @@ MultiResolutionRegistrationWithFeatures<TElastix>::UpdateFixedMasks(unsigned int
  * ************************* UpdateMovingMasks ************************
  */
 
-template <class TElastix>
+template <typename TElastix>
 void
 MultiResolutionRegistrationWithFeatures<TElastix>::UpdateMovingMasks(unsigned int level)
 {

--- a/Components/ResampleInterpolators/BSplineResampleInterpolator/elxBSplineResampleInterpolator.h
+++ b/Components/ResampleInterpolators/BSplineResampleInterpolator/elxBSplineResampleInterpolator.h
@@ -50,7 +50,7 @@ namespace elastix
  * \sa BSplineResampleInterpolatorFloat
  */
 
-template <class TElastix>
+template <typename TElastix>
 class ITK_TEMPLATE_EXPORT BSplineResampleInterpolator
   : public itk::BSplineInterpolateImageFunction<typename ResampleInterpolatorBase<TElastix>::InputImageType,
                                                 typename ResampleInterpolatorBase<TElastix>::CoordRepType,

--- a/Components/ResampleInterpolators/BSplineResampleInterpolator/elxBSplineResampleInterpolator.hxx
+++ b/Components/ResampleInterpolators/BSplineResampleInterpolator/elxBSplineResampleInterpolator.hxx
@@ -27,7 +27,7 @@ namespace elastix
  * ******************* BeforeRegistration ***********************
  */
 
-template <class TElastix>
+template <typename TElastix>
 void
 BSplineResampleInterpolator<TElastix>::BeforeRegistration()
 {
@@ -49,7 +49,7 @@ BSplineResampleInterpolator<TElastix>::BeforeRegistration()
  * ******************* ReadFromFile  ****************************
  */
 
-template <class TElastix>
+template <typename TElastix>
 void
 BSplineResampleInterpolator<TElastix>::ReadFromFile()
 {
@@ -74,7 +74,7 @@ BSplineResampleInterpolator<TElastix>::ReadFromFile()
  * ******************* CreateDerivedTransformParameterMap ******************************
  */
 
-template <class TElastix>
+template <typename TElastix>
 auto
 BSplineResampleInterpolator<TElastix>::CreateDerivedTransformParameterMap() const -> ParameterMapType
 {

--- a/Components/ResampleInterpolators/BSplineResampleInterpolatorFloat/elxBSplineResampleInterpolatorFloat.h
+++ b/Components/ResampleInterpolators/BSplineResampleInterpolatorFloat/elxBSplineResampleInterpolatorFloat.h
@@ -50,7 +50,7 @@ namespace elastix
  * \sa BSplineResampleInterpolator
  */
 
-template <class TElastix>
+template <typename TElastix>
 class ITK_TEMPLATE_EXPORT BSplineResampleInterpolatorFloat
   : public itk::BSplineInterpolateImageFunction<typename ResampleInterpolatorBase<TElastix>::InputImageType,
                                                 typename ResampleInterpolatorBase<TElastix>::CoordRepType,

--- a/Components/ResampleInterpolators/BSplineResampleInterpolatorFloat/elxBSplineResampleInterpolatorFloat.hxx
+++ b/Components/ResampleInterpolators/BSplineResampleInterpolatorFloat/elxBSplineResampleInterpolatorFloat.hxx
@@ -28,7 +28,7 @@ namespace elastix
  * ******************* BeforeRegistration ***********************
  */
 
-template <class TElastix>
+template <typename TElastix>
 void
 BSplineResampleInterpolatorFloat<TElastix>::BeforeRegistration()
 {
@@ -50,7 +50,7 @@ BSplineResampleInterpolatorFloat<TElastix>::BeforeRegistration()
  * ******************* ReadFromFile  ****************************
  */
 
-template <class TElastix>
+template <typename TElastix>
 void
 BSplineResampleInterpolatorFloat<TElastix>::ReadFromFile()
 {
@@ -75,7 +75,7 @@ BSplineResampleInterpolatorFloat<TElastix>::ReadFromFile()
  * ******************* CreateDerivedTransformParameterMap ******************************
  */
 
-template <class TElastix>
+template <typename TElastix>
 auto
 BSplineResampleInterpolatorFloat<TElastix>::CreateDerivedTransformParameterMap() const -> ParameterMapType
 {

--- a/Components/ResampleInterpolators/LinearResampleInterpolator/elxLinearResampleInterpolator.h
+++ b/Components/ResampleInterpolators/LinearResampleInterpolator/elxLinearResampleInterpolator.h
@@ -40,7 +40,7 @@ namespace elastix
  * \ingroup ResampleInterpolators
  */
 
-template <class TElastix>
+template <typename TElastix>
 class ITK_TEMPLATE_EXPORT LinearResampleInterpolator
   : public itk::LinearInterpolateImageFunction<typename ResampleInterpolatorBase<TElastix>::InputImageType,
                                                typename ResampleInterpolatorBase<TElastix>::CoordRepType>

--- a/Components/ResampleInterpolators/NearestNeighborResampleInterpolator/elxNearestNeighborResampleInterpolator.h
+++ b/Components/ResampleInterpolators/NearestNeighborResampleInterpolator/elxNearestNeighborResampleInterpolator.h
@@ -40,7 +40,7 @@ namespace elastix
  * \ingroup ResampleInterpolators
  */
 
-template <class TElastix>
+template <typename TElastix>
 class ITK_TEMPLATE_EXPORT NearestNeighborResampleInterpolator
   : public itk::NearestNeighborInterpolateImageFunction<typename ResampleInterpolatorBase<TElastix>::InputImageType,
                                                         typename ResampleInterpolatorBase<TElastix>::CoordRepType>

--- a/Components/ResampleInterpolators/RDBSplineResampleInterpolator/elxRDBSplineResampleInterpolator.h
+++ b/Components/ResampleInterpolators/RDBSplineResampleInterpolator/elxRDBSplineResampleInterpolator.h
@@ -50,7 +50,7 @@ namespace elastix
  * \sa ReducedDimensionBSplineResampleInterpolatorFloat
  */
 
-template <class TElastix>
+template <typename TElastix>
 class ITK_TEMPLATE_EXPORT ReducedDimensionBSplineResampleInterpolator
   : public itk::ReducedDimensionBSplineInterpolateImageFunction<
       typename ResampleInterpolatorBase<TElastix>::InputImageType,

--- a/Components/ResampleInterpolators/RDBSplineResampleInterpolator/elxRDBSplineResampleInterpolator.hxx
+++ b/Components/ResampleInterpolators/RDBSplineResampleInterpolator/elxRDBSplineResampleInterpolator.hxx
@@ -27,7 +27,7 @@ namespace elastix
  * ******************* BeforeRegistration ***********************
  */
 
-template <class TElastix>
+template <typename TElastix>
 void
 ReducedDimensionBSplineResampleInterpolator<TElastix>::BeforeRegistration()
 {
@@ -57,7 +57,7 @@ ReducedDimensionBSplineResampleInterpolator<TElastix>::BeforeRegistration()
  * ******************* ReadFromFile  ****************************
  */
 
-template <class TElastix>
+template <typename TElastix>
 void
 ReducedDimensionBSplineResampleInterpolator<TElastix>::ReadFromFile()
 {
@@ -90,7 +90,7 @@ ReducedDimensionBSplineResampleInterpolator<TElastix>::ReadFromFile()
  * ******************* CreateDerivedTransformParameterMap ******************************
  */
 
-template <class TElastix>
+template <typename TElastix>
 auto
 ReducedDimensionBSplineResampleInterpolator<TElastix>::CreateDerivedTransformParameterMap() const -> ParameterMapType
 {

--- a/Components/ResampleInterpolators/RayCastResampleInterpolator/elxRayCastResampleInterpolator.h
+++ b/Components/ResampleInterpolators/RayCastResampleInterpolator/elxRayCastResampleInterpolator.h
@@ -34,7 +34,7 @@ namespace elastix
  * \ingroup Interpolators
  */
 
-template <class TElastix>
+template <typename TElastix>
 class ITK_TEMPLATE_EXPORT RayCastResampleInterpolator
   : public itk::AdvancedRayCastInterpolateImageFunction<typename ResampleInterpolatorBase<TElastix>::InputImageType,
                                                         typename ResampleInterpolatorBase<TElastix>::CoordRepType>

--- a/Components/ResampleInterpolators/RayCastResampleInterpolator/elxRayCastResampleInterpolator.hxx
+++ b/Components/ResampleInterpolators/RayCastResampleInterpolator/elxRayCastResampleInterpolator.hxx
@@ -29,7 +29,7 @@ namespace elastix
  * ***************** BeforeAll *****************
  */
 
-template <class TElastix>
+template <typename TElastix>
 void
 RayCastResampleInterpolator<TElastix>::InitializeRayCastInterpolator()
 {
@@ -91,7 +91,7 @@ RayCastResampleInterpolator<TElastix>::InitializeRayCastInterpolator()
  * ***************** BeforeAll *****************
  */
 
-template <class TElastix>
+template <typename TElastix>
 int
 RayCastResampleInterpolator<TElastix>::BeforeAll()
 {
@@ -117,7 +117,7 @@ RayCastResampleInterpolator<TElastix>::BeforeAll()
  * ***************** BeforeRegistration *****************
  */
 
-template <class TElastix>
+template <typename TElastix>
 void
 RayCastResampleInterpolator<TElastix>::BeforeRegistration()
 {
@@ -131,7 +131,7 @@ RayCastResampleInterpolator<TElastix>::BeforeRegistration()
  * ***************** ReadFromFile *****************
  */
 
-template <class TElastix>
+template <typename TElastix>
 void
 RayCastResampleInterpolator<TElastix>::ReadFromFile()
 {
@@ -147,7 +147,7 @@ RayCastResampleInterpolator<TElastix>::ReadFromFile()
  * ******************* CreateDerivedTransformParameterMap ******************************
  */
 
-template <class TElastix>
+template <typename TElastix>
 auto
 RayCastResampleInterpolator<TElastix>::CreateDerivedTransformParameterMap() const -> ParameterMapType
 {

--- a/Components/Resamplers/DefaultResampler/elxDefaultResampler.h
+++ b/Components/Resamplers/DefaultResampler/elxDefaultResampler.h
@@ -35,7 +35,7 @@ namespace elastix
  * \ingroup Resamplers
  */
 
-template <class TElastix>
+template <typename TElastix>
 class ITK_TEMPLATE_EXPORT DefaultResampler
   : public ResamplerBase<TElastix>::ITKBaseType
   , public ResamplerBase<TElastix>

--- a/Components/Resamplers/OpenCLResampler/elxOpenCLResampler.h
+++ b/Components/Resamplers/OpenCLResampler/elxOpenCLResampler.h
@@ -46,7 +46,7 @@ namespace elastix
  * \ingroup Resamplers
  */
 
-template <class TElastix>
+template <typename TElastix>
 class OpenCLResampler
   : public itk::ResampleImageFilter<typename ResamplerBase<TElastix>::InputImageType,
                                     typename ResamplerBase<TElastix>::OutputImageType,

--- a/Components/Resamplers/OpenCLResampler/elxOpenCLResampler.hxx
+++ b/Components/Resamplers/OpenCLResampler/elxOpenCLResampler.hxx
@@ -28,7 +28,7 @@ namespace elastix
  * ******************* Constructor ***********************
  */
 
-template <class TElastix>
+template <typename TElastix>
 elastix::OpenCLResampler<TElastix>::OpenCLResampler()
 {
   // Check if the OpenCL context has been created.
@@ -78,7 +78,7 @@ elastix::OpenCLResampler<TElastix>::OpenCLResampler()
  * ******************* SetTransform ***********************
  */
 
-template <class TElastix>
+template <typename TElastix>
 void
 OpenCLResampler<TElastix>::SetTransform(const TransformType * _arg)
 {
@@ -99,7 +99,7 @@ OpenCLResampler<TElastix>::SetTransform(const TransformType * _arg)
  * ******************* SetInterpolator ***********************
  */
 
-template <class TElastix>
+template <typename TElastix>
 void
 OpenCLResampler<TElastix>::SetInterpolator(InterpolatorType * _arg)
 {
@@ -121,7 +121,7 @@ OpenCLResampler<TElastix>::SetInterpolator(InterpolatorType * _arg)
  * ******************* BeforeGenerateData ***********************
  */
 
-template <class TElastix>
+template <typename TElastix>
 void
 OpenCLResampler<TElastix>::BeforeGenerateData()
 {
@@ -223,7 +223,7 @@ OpenCLResampler<TElastix>::BeforeGenerateData()
  * ******************* GenerateData ***********************
  */
 
-template <class TElastix>
+template <typename TElastix>
 void
 OpenCLResampler<TElastix>::GenerateData()
 {
@@ -261,7 +261,7 @@ OpenCLResampler<TElastix>::GenerateData()
  * ******************* BeforeRegistration ***********************
  */
 
-template <class TElastix>
+template <typename TElastix>
 void
 OpenCLResampler<TElastix>::BeforeRegistration()
 {
@@ -276,7 +276,7 @@ OpenCLResampler<TElastix>::BeforeRegistration()
  * ******************* ReadFromFile  ****************************
  */
 
-template <class TElastix>
+template <typename TElastix>
 void
 OpenCLResampler<TElastix>::ReadFromFile()
 {
@@ -294,7 +294,7 @@ OpenCLResampler<TElastix>::ReadFromFile()
  * ************************* CreateDerivedTransformParameterMap ************************
  */
 
-template <class TElastix>
+template <typename TElastix>
 auto
 OpenCLResampler<TElastix>::CreateDerivedTransformParameterMap() const -> ParameterMapType
 {
@@ -307,7 +307,7 @@ OpenCLResampler<TElastix>::CreateDerivedTransformParameterMap() const -> Paramet
  * ************************* SwitchingToCPUAndReport ************************
  */
 
-template <class TElastix>
+template <typename TElastix>
 void
 OpenCLResampler<TElastix>::SwitchingToCPUAndReport(const bool configError)
 {
@@ -330,7 +330,7 @@ OpenCLResampler<TElastix>::SwitchingToCPUAndReport(const bool configError)
  * ************************* ReportToLog ************************************
  */
 
-template <class TElastix>
+template <typename TElastix>
 void
 OpenCLResampler<TElastix>::ReportToLog()
 {

--- a/Components/Transforms/AdvancedAffineTransform/elxAdvancedAffineTransform.h
+++ b/Components/Transforms/AdvancedAffineTransform/elxAdvancedAffineTransform.h
@@ -73,7 +73,7 @@ namespace elastix
  * \ingroup Transforms
  */
 
-template <class TElastix>
+template <typename TElastix>
 class ITK_TEMPLATE_EXPORT AdvancedAffineTransformElastix
   : public itk::AdvancedCombinationTransform<typename elx::TransformBase<TElastix>::CoordRepType,
                                              elx::TransformBase<TElastix>::FixedImageDimension>

--- a/Components/Transforms/AdvancedAffineTransform/elxAdvancedAffineTransform.hxx
+++ b/Components/Transforms/AdvancedAffineTransform/elxAdvancedAffineTransform.hxx
@@ -34,7 +34,7 @@ namespace elastix
  * ********************* Constructor ****************************
  */
 
-template <class TElastix>
+template <typename TElastix>
 AdvancedAffineTransformElastix<TElastix>::AdvancedAffineTransformElastix()
 {
   this->SetCurrentTransform(this->m_AffineTransform);
@@ -46,7 +46,7 @@ AdvancedAffineTransformElastix<TElastix>::AdvancedAffineTransformElastix()
  * ******************* BeforeRegistration ***********************
  */
 
-template <class TElastix>
+template <typename TElastix>
 void
 AdvancedAffineTransformElastix<TElastix>::BeforeRegistration()
 {
@@ -71,7 +71,7 @@ AdvancedAffineTransformElastix<TElastix>::BeforeRegistration()
  * ************************* ReadFromFile ************************
  */
 
-template <class TElastix>
+template <typename TElastix>
 void
 AdvancedAffineTransformElastix<TElastix>::ReadFromFile()
 {
@@ -124,7 +124,7 @@ AdvancedAffineTransformElastix<TElastix>::ReadFromFile()
  * ************************* CreateDerivedTransformParameterMap ************************
  */
 
-template <class TElastix>
+template <typename TElastix>
 auto
 AdvancedAffineTransformElastix<TElastix>::CreateDerivedTransformParameterMap() const -> ParameterMapType
 {
@@ -137,7 +137,7 @@ AdvancedAffineTransformElastix<TElastix>::CreateDerivedTransformParameterMap() c
  * ************************* InitializeTransform *********************
  */
 
-template <class TElastix>
+template <typename TElastix>
 void
 AdvancedAffineTransformElastix<TElastix>::InitializeTransform()
 {
@@ -323,7 +323,7 @@ AdvancedAffineTransformElastix<TElastix>::InitializeTransform()
  * ************************* SetScales *********************
  */
 
-template <class TElastix>
+template <typename TElastix>
 void
 AdvancedAffineTransformElastix<TElastix>::SetScales()
 {
@@ -435,7 +435,7 @@ AdvancedAffineTransformElastix<TElastix>::SetScales()
  * ******************** ReadCenterOfRotationPoint *********************
  */
 
-template <class TElastix>
+template <typename TElastix>
 bool
 AdvancedAffineTransformElastix<TElastix>::ReadCenterOfRotationPoint(InputPointType & rotationPoint) const
 {

--- a/Components/Transforms/AdvancedAffineTransform/itkCenteredTransformInitializer2.h
+++ b/Components/Transforms/AdvancedAffineTransform/itkCenteredTransformInitializer2.h
@@ -87,7 +87,7 @@ namespace itk
  *
  * \ingroup Transforms
  */
-template <class TTransform, class TFixedImage, class TMovingImage>
+template <typename TTransform, typename TFixedImage, typename TMovingImage>
 class ITK_TEMPLATE_EXPORT CenteredTransformInitializer2 : public Object
 {
 public:

--- a/Components/Transforms/AdvancedAffineTransform/itkCenteredTransformInitializer2.hxx
+++ b/Components/Transforms/AdvancedAffineTransform/itkCenteredTransformInitializer2.hxx
@@ -39,7 +39,7 @@
 namespace itk
 {
 
-template <class TTransform, class TFixedImage, class TMovingImage>
+template <typename TTransform, typename TFixedImage, typename TMovingImage>
 CenteredTransformInitializer2<TTransform, TFixedImage, TMovingImage>::CenteredTransformInitializer2()
 {
   m_FixedCalculator = FixedImageCalculatorType::New();
@@ -55,7 +55,7 @@ CenteredTransformInitializer2<TTransform, TFixedImage, TMovingImage>::CenteredTr
 
 
 /** Initialize the transform using data from the images */
-template <class TTransform, class TFixedImage, class TMovingImage>
+template <typename TTransform, typename TFixedImage, typename TMovingImage>
 void
 CenteredTransformInitializer2<TTransform, TFixedImage, TMovingImage>::InitializeTransform()
 {
@@ -339,7 +339,7 @@ CenteredTransformInitializer2<TTransform, TFixedImage, TMovingImage>::Initialize
 }
 
 
-template <class TTransform, class TFixedImage, class TMovingImage>
+template <typename TTransform, typename TFixedImage, typename TMovingImage>
 void
 CenteredTransformInitializer2<TTransform, TFixedImage, TMovingImage>::PrintSelf(std::ostream & os, Indent indent) const
 {

--- a/Components/Transforms/AdvancedBSplineTransform/elxAdvancedBSplineTransform.h
+++ b/Components/Transforms/AdvancedBSplineTransform/elxAdvancedBSplineTransform.h
@@ -106,7 +106,7 @@ namespace elastix
  * \ingroup Transforms
  */
 
-template <class TElastix>
+template <typename TElastix>
 class ITK_TEMPLATE_EXPORT AdvancedBSplineTransform
   : public itk::AdvancedCombinationTransform<typename elx::TransformBase<TElastix>::CoordRepType,
                                              elx::TransformBase<TElastix>::FixedImageDimension>

--- a/Components/Transforms/AdvancedBSplineTransform/elxAdvancedBSplineTransform.hxx
+++ b/Components/Transforms/AdvancedBSplineTransform/elxAdvancedBSplineTransform.hxx
@@ -31,7 +31,7 @@ namespace elastix
  * ************ InitializeBSplineTransform ***************
  */
 
-template <class TElastix>
+template <typename TElastix>
 unsigned int
 AdvancedBSplineTransform<TElastix>::InitializeBSplineTransform()
 {
@@ -63,7 +63,7 @@ AdvancedBSplineTransform<TElastix>::InitializeBSplineTransform()
  * ******************* BeforeAll ***********************
  */
 
-template <class TElastix>
+template <typename TElastix>
 int
 AdvancedBSplineTransform<TElastix>::BeforeAll()
 {
@@ -82,7 +82,7 @@ AdvancedBSplineTransform<TElastix>::BeforeAll()
  * ******************* BeforeRegistration ***********************
  */
 
-template <class TElastix>
+template <typename TElastix>
 void
 AdvancedBSplineTransform<TElastix>::BeforeRegistration()
 {
@@ -121,7 +121,7 @@ AdvancedBSplineTransform<TElastix>::BeforeRegistration()
  * ***************** BeforeEachResolution ***********************
  */
 
-template <class TElastix>
+template <typename TElastix>
 void
 AdvancedBSplineTransform<TElastix>::BeforeEachResolution()
 {
@@ -152,7 +152,7 @@ AdvancedBSplineTransform<TElastix>::BeforeEachResolution()
  * ******************** PreComputeGridInformation ***********************
  */
 
-template <class TElastix>
+template <typename TElastix>
 void
 AdvancedBSplineTransform<TElastix>::PreComputeGridInformation()
 {
@@ -305,7 +305,7 @@ AdvancedBSplineTransform<TElastix>::PreComputeGridInformation()
  * ******************** InitializeTransform ***********************
  */
 
-template <class TElastix>
+template <typename TElastix>
 void
 AdvancedBSplineTransform<TElastix>::InitializeTransform()
 {
@@ -333,7 +333,7 @@ AdvancedBSplineTransform<TElastix>::InitializeTransform()
  * *********************** IncreaseScale ************************
  */
 
-template <class TElastix>
+template <typename TElastix>
 void
 AdvancedBSplineTransform<TElastix>::IncreaseScale()
 {
@@ -392,7 +392,7 @@ AdvancedBSplineTransform<TElastix>::IncreaseScale()
  * ************************* ReadFromFile ************************
  */
 
-template <class TElastix>
+template <typename TElastix>
 void
 AdvancedBSplineTransform<TElastix>::ReadFromFile()
 {
@@ -448,7 +448,7 @@ AdvancedBSplineTransform<TElastix>::ReadFromFile()
  * ************************* CreateDerivedTransformParameterMap ************************
  */
 
-template <class TElastix>
+template <typename TElastix>
 auto
 AdvancedBSplineTransform<TElastix>::CreateDerivedTransformParameterMap() const -> ParameterMapType
 {
@@ -469,7 +469,7 @@ AdvancedBSplineTransform<TElastix>::CreateDerivedTransformParameterMap() const -
  * *********************** SetOptimizerScales ***********************
  */
 
-template <class TElastix>
+template <typename TElastix>
 void
 AdvancedBSplineTransform<TElastix>::SetOptimizerScales(const unsigned int edgeWidth)
 {

--- a/Components/Transforms/AffineDTITransform/elxAffineDTITransform.h
+++ b/Components/Transforms/AffineDTITransform/elxAffineDTITransform.h
@@ -74,7 +74,7 @@ namespace elastix
  * \sa AffineDTI3DTransform
  */
 
-template <class TElastix>
+template <typename TElastix>
 class ITK_TEMPLATE_EXPORT AffineDTITransformElastix
   : public itk::AdvancedCombinationTransform<typename elx::TransformBase<TElastix>::CoordRepType,
                                              elx::TransformBase<TElastix>::FixedImageDimension>

--- a/Components/Transforms/AffineDTITransform/elxAffineDTITransform.hxx
+++ b/Components/Transforms/AffineDTITransform/elxAffineDTITransform.hxx
@@ -28,7 +28,7 @@ namespace elastix
  * ********************* Constructor ****************************
  */
 
-template <class TElastix>
+template <typename TElastix>
 AffineDTITransformElastix<TElastix>::AffineDTITransformElastix()
 {
   this->SetCurrentTransform(this->m_AffineDTITransform);
@@ -40,7 +40,7 @@ AffineDTITransformElastix<TElastix>::AffineDTITransformElastix()
  * ******************* BeforeRegistration ***********************
  */
 
-template <class TElastix>
+template <typename TElastix>
 void
 AffineDTITransformElastix<TElastix>::BeforeRegistration()
 {
@@ -62,7 +62,7 @@ AffineDTITransformElastix<TElastix>::BeforeRegistration()
  * ************************* ReadFromFile ************************
  */
 
-template <class TElastix>
+template <typename TElastix>
 void
 AffineDTITransformElastix<TElastix>::ReadFromFile()
 {
@@ -97,7 +97,7 @@ AffineDTITransformElastix<TElastix>::ReadFromFile()
  * ************************* CreateDerivedTransformParameterMap ************************
  */
 
-template <class TElastix>
+template <typename TElastix>
 auto
 AffineDTITransformElastix<TElastix>::CreateDerivedTransformParameterMap() const -> ParameterMapType
 {
@@ -115,7 +115,7 @@ AffineDTITransformElastix<TElastix>::CreateDerivedTransformParameterMap() const 
  * ************************* InitializeTransform *********************
  */
 
-template <class TElastix>
+template <typename TElastix>
 void
 AffineDTITransformElastix<TElastix>::InitializeTransform()
 {
@@ -269,7 +269,7 @@ AffineDTITransformElastix<TElastix>::InitializeTransform()
  * ************************* SetScales *********************
  */
 
-template <class TElastix>
+template <typename TElastix>
 void
 AffineDTITransformElastix<TElastix>::SetScales()
 {
@@ -318,7 +318,7 @@ AffineDTITransformElastix<TElastix>::SetScales()
  * ******************** ReadCenterOfRotationPoint *********************
  */
 
-template <class TElastix>
+template <typename TElastix>
 bool
 AffineDTITransformElastix<TElastix>::ReadCenterOfRotationPoint(InputPointType & rotationPoint) const
 {

--- a/Components/Transforms/AffineDTITransform/itkAffineDTI2DTransform.h
+++ b/Components/Transforms/AffineDTITransform/itkAffineDTI2DTransform.h
@@ -60,7 +60,7 @@ namespace itk
  *
  * \ingroup Transforms
  */
-template <class TScalarType = double>
+template <typename TScalarType = double>
 // Data type for scalars (float or double)
 class AffineDTI2DTransform : public AdvancedMatrixOffsetTransformBase<TScalarType, 2, 2>
 {

--- a/Components/Transforms/AffineDTITransform/itkAffineDTI2DTransform.hxx
+++ b/Components/Transforms/AffineDTITransform/itkAffineDTI2DTransform.hxx
@@ -25,7 +25,7 @@ namespace itk
 {
 
 // Constructor with default arguments
-template <class TScalarType>
+template <typename TScalarType>
 AffineDTI2DTransform<TScalarType>::AffineDTI2DTransform()
   : Superclass(ParametersDimension)
 {
@@ -38,7 +38,7 @@ AffineDTI2DTransform<TScalarType>::AffineDTI2DTransform()
 
 
 // Constructor with default arguments
-template <class TScalarType>
+template <typename TScalarType>
 AffineDTI2DTransform<TScalarType>::AffineDTI2DTransform(const MatrixType & matrix, const OutputPointType & offset)
 {
   this->SetMatrix(matrix);
@@ -55,7 +55,7 @@ AffineDTI2DTransform<TScalarType>::AffineDTI2DTransform(const MatrixType & matri
 
 
 // Constructor with arguments
-template <class TScalarType>
+template <typename TScalarType>
 AffineDTI2DTransform<TScalarType>::AffineDTI2DTransform(unsigned int spaceDimension, unsigned int parametersDimension)
   : Superclass(spaceDimension, parametersDimension)
 {
@@ -67,7 +67,7 @@ AffineDTI2DTransform<TScalarType>::AffineDTI2DTransform(unsigned int spaceDimens
 
 
 // Set Angles etc
-template <class TScalarType>
+template <typename TScalarType>
 void
 AffineDTI2DTransform<TScalarType>::SetVarAngleScaleShear(ScalarArrayType angle,
                                                          ScalarArrayType shear,
@@ -80,7 +80,7 @@ AffineDTI2DTransform<TScalarType>::SetVarAngleScaleShear(ScalarArrayType angle,
 
 
 // Set Parameters
-template <class TScalarType>
+template <typename TScalarType>
 void
 AffineDTI2DTransform<TScalarType>::SetParameters(const ParametersType & parameters)
 {
@@ -109,7 +109,7 @@ AffineDTI2DTransform<TScalarType>::SetParameters(const ParametersType & paramete
 
 
 // Get Parameters
-template <class TScalarType>
+template <typename TScalarType>
 auto
 AffineDTI2DTransform<TScalarType>::GetParameters() const -> const ParametersType &
 {
@@ -125,7 +125,7 @@ AffineDTI2DTransform<TScalarType>::GetParameters() const -> const ParametersType
 }
 
 // SetIdentity()
-template <class TScalarType>
+template <typename TScalarType>
 void
 AffineDTI2DTransform<TScalarType>::SetIdentity()
 {
@@ -138,7 +138,7 @@ AffineDTI2DTransform<TScalarType>::SetIdentity()
 
 
 // Compute angles from the rotation matrix
-template <class TScalarType>
+template <typename TScalarType>
 void
 AffineDTI2DTransform<TScalarType>::ComputeMatrixParameters()
 {
@@ -149,7 +149,7 @@ AffineDTI2DTransform<TScalarType>::ComputeMatrixParameters()
 
 
 // Compute the matrix
-template <class TScalarType>
+template <typename TScalarType>
 void
 AffineDTI2DTransform<TScalarType>::ComputeMatrix()
 {
@@ -194,7 +194,7 @@ AffineDTI2DTransform<TScalarType>::ComputeMatrix()
 
 
 // Set parameters
-template <class TScalarType>
+template <typename TScalarType>
 void
 AffineDTI2DTransform<TScalarType>::GetJacobian(const InputPointType &       p,
                                                JacobianType &               j,
@@ -227,7 +227,7 @@ AffineDTI2DTransform<TScalarType>::GetJacobian(const InputPointType &       p,
 
 
 // Precompute Jacobian of Spatial Jacobian
-template <class TScalarType>
+template <typename TScalarType>
 void
 AffineDTI2DTransform<TScalarType>::PrecomputeJacobianOfSpatialJacobian()
 {
@@ -326,7 +326,7 @@ AffineDTI2DTransform<TScalarType>::PrecomputeJacobianOfSpatialJacobian()
 
 
 // Print self
-template <class TScalarType>
+template <typename TScalarType>
 void
 AffineDTI2DTransform<TScalarType>::PrintSelf(std::ostream & os, Indent indent) const
 {

--- a/Components/Transforms/AffineDTITransform/itkAffineDTI3DTransform.h
+++ b/Components/Transforms/AffineDTITransform/itkAffineDTI3DTransform.h
@@ -73,7 +73,7 @@ namespace itk
  *
  * \ingroup Transforms
  */
-template <class TScalarType = double>
+template <typename TScalarType = double>
 // Data type for scalars (float or double)
 class AffineDTI3DTransform : public AdvancedMatrixOffsetTransformBase<TScalarType, 3, 3>
 {

--- a/Components/Transforms/AffineDTITransform/itkAffineDTI3DTransform.hxx
+++ b/Components/Transforms/AffineDTITransform/itkAffineDTI3DTransform.hxx
@@ -40,7 +40,7 @@ namespace itk
 {
 
 // Constructor with default arguments
-template <class TScalarType>
+template <typename TScalarType>
 AffineDTI3DTransform<TScalarType>::AffineDTI3DTransform()
   : Superclass(ParametersDimension)
 {
@@ -53,7 +53,7 @@ AffineDTI3DTransform<TScalarType>::AffineDTI3DTransform()
 
 
 // Constructor with default arguments
-template <class TScalarType>
+template <typename TScalarType>
 AffineDTI3DTransform<TScalarType>::AffineDTI3DTransform(const MatrixType & matrix, const OutputPointType & offset)
 {
   this->SetMatrix(matrix);
@@ -70,7 +70,7 @@ AffineDTI3DTransform<TScalarType>::AffineDTI3DTransform(const MatrixType & matri
 
 
 // Constructor with arguments
-template <class TScalarType>
+template <typename TScalarType>
 AffineDTI3DTransform<TScalarType>::AffineDTI3DTransform(unsigned int spaceDimension, unsigned int parametersDimension)
   : Superclass(spaceDimension, parametersDimension)
 {
@@ -82,7 +82,7 @@ AffineDTI3DTransform<TScalarType>::AffineDTI3DTransform(unsigned int spaceDimens
 
 
 // Set Angles etc
-template <class TScalarType>
+template <typename TScalarType>
 void
 AffineDTI3DTransform<TScalarType>::SetVarAngleScaleShear(ScalarArrayType angle,
                                                          ScalarArrayType shear,
@@ -95,7 +95,7 @@ AffineDTI3DTransform<TScalarType>::SetVarAngleScaleShear(ScalarArrayType angle,
 
 
 // Set Parameters
-template <class TScalarType>
+template <typename TScalarType>
 void
 AffineDTI3DTransform<TScalarType>::SetParameters(const ParametersType & parameters)
 {
@@ -129,7 +129,7 @@ AffineDTI3DTransform<TScalarType>::SetParameters(const ParametersType & paramete
 
 
 // Get Parameters
-template <class TScalarType>
+template <typename TScalarType>
 auto
 AffineDTI3DTransform<TScalarType>::GetParameters() const -> const ParametersType &
 {
@@ -150,7 +150,7 @@ AffineDTI3DTransform<TScalarType>::GetParameters() const -> const ParametersType
 }
 
 // SetIdentity()
-template <class TScalarType>
+template <typename TScalarType>
 void
 AffineDTI3DTransform<TScalarType>::SetIdentity()
 {
@@ -163,7 +163,7 @@ AffineDTI3DTransform<TScalarType>::SetIdentity()
 
 
 // Compute angles from the rotation matrix
-template <class TScalarType>
+template <typename TScalarType>
 void
 AffineDTI3DTransform<TScalarType>::ComputeMatrixParameters()
 {
@@ -174,7 +174,7 @@ AffineDTI3DTransform<TScalarType>::ComputeMatrixParameters()
 
 
 // Compute the matrix
-template <class TScalarType>
+template <typename TScalarType>
 void
 AffineDTI3DTransform<TScalarType>::ComputeMatrix()
 {
@@ -277,7 +277,7 @@ AffineDTI3DTransform<TScalarType>::ComputeMatrix()
 
 
 // Set parameters
-template <class TScalarType>
+template <typename TScalarType>
 void
 AffineDTI3DTransform<TScalarType>::GetJacobian(const InputPointType &       p,
                                                JacobianType &               j,
@@ -310,7 +310,7 @@ AffineDTI3DTransform<TScalarType>::GetJacobian(const InputPointType &       p,
 
 
 // Precompute Jacobian of Spatial Jacobian
-template <class TScalarType>
+template <typename TScalarType>
 void
 AffineDTI3DTransform<TScalarType>::PrecomputeJacobianOfSpatialJacobian()
 {
@@ -561,7 +561,7 @@ AffineDTI3DTransform<TScalarType>::PrecomputeJacobianOfSpatialJacobian()
 
 
 // Print self
-template <class TScalarType>
+template <typename TScalarType>
 void
 AffineDTI3DTransform<TScalarType>::PrintSelf(std::ostream & os, Indent indent) const
 {

--- a/Components/Transforms/AffineDTITransform/itkAffineDTITransform.h
+++ b/Components/Transforms/AffineDTITransform/itkAffineDTITransform.h
@@ -35,7 +35,7 @@ template <unsigned int Dimension>
 class AffineDTIGroup
 {
 public:
-  template <class TScalarType>
+  template <typename TScalarType>
   using TransformAlias = AdvancedMatrixOffsetTransformBase<TScalarType, Dimension, Dimension>;
 };
 
@@ -49,7 +49,7 @@ template <>
 class AffineDTIGroup<2>
 {
 public:
-  template <class TScalarType>
+  template <typename TScalarType>
   using TransformAlias = AffineDTI2DTransform<TScalarType>;
 };
 
@@ -63,7 +63,7 @@ template <>
 class AffineDTIGroup<3>
 {
 public:
-  template <class TScalarType>
+  template <typename TScalarType>
   using TransformAlias = AffineDTI3DTransform<TScalarType>;
 };
 
@@ -71,7 +71,7 @@ public:
 /**
  * This alias templates the AffineDTIGroup over its dimension.
  */
-template <class TScalarType, unsigned int Dimension>
+template <typename TScalarType, unsigned int Dimension>
 using AffineDTIGroupTemplate = typename AffineDTIGroup<Dimension>::template TransformAlias<TScalarType>;
 
 
@@ -84,7 +84,7 @@ using AffineDTIGroupTemplate = typename AffineDTIGroup<Dimension>::template Tran
  * \ingroup Transforms
  */
 
-template <class TScalarType, unsigned int Dimension>
+template <typename TScalarType, unsigned int Dimension>
 class AffineDTITransform : public AffineDTIGroupTemplate<TScalarType, Dimension>
 {
 public:

--- a/Components/Transforms/AffineLogStackTransform/elxAffineLogStackTransform.h
+++ b/Components/Transforms/AffineLogStackTransform/elxAffineLogStackTransform.h
@@ -37,7 +37,7 @@ namespace elastix
  * \ingroup Transforms
  */
 
-template <class TElastix>
+template <typename TElastix>
 class ITK_TEMPLATE_EXPORT AffineLogStackTransform
   : public itk::AdvancedCombinationTransform<typename elx::TransformBase<TElastix>::CoordRepType,
                                              elx::TransformBase<TElastix>::FixedImageDimension>

--- a/Components/Transforms/AffineLogStackTransform/elxAffineLogStackTransform.hxx
+++ b/Components/Transforms/AffineLogStackTransform/elxAffineLogStackTransform.hxx
@@ -30,7 +30,7 @@ namespace elastix
 /**
  * ********************* InitializeAffineTransform ****************************
  */
-template <class TElastix>
+template <typename TElastix>
 unsigned int
 AffineLogStackTransform<TElastix>::InitializeAffineLogTransform()
 {
@@ -45,7 +45,7 @@ AffineLogStackTransform<TElastix>::InitializeAffineLogTransform()
  * ******************* BeforeAll ***********************
  */
 
-template <class TElastix>
+template <typename TElastix>
 int
 AffineLogStackTransform<TElastix>::BeforeAll()
 {
@@ -58,7 +58,7 @@ AffineLogStackTransform<TElastix>::BeforeAll()
  * ******************* BeforeRegistration ***********************
  */
 
-template <class TElastix>
+template <typename TElastix>
 void
 AffineLogStackTransform<TElastix>::BeforeRegistration()
 {
@@ -95,7 +95,7 @@ AffineLogStackTransform<TElastix>::BeforeRegistration()
  * ************************* ReadFromFile ************************
  */
 
-template <class TElastix>
+template <typename TElastix>
 void
 AffineLogStackTransform<TElastix>::ReadFromFile()
 {
@@ -145,7 +145,7 @@ AffineLogStackTransform<TElastix>::ReadFromFile()
  * ************************* CreateDerivedTransformParameterMap ************************
  */
 
-template <class TElastix>
+template <typename TElastix>
 auto
 AffineLogStackTransform<TElastix>::CreateDerivedTransformParameterMap() const -> ParameterMapType
 {
@@ -163,7 +163,7 @@ AffineLogStackTransform<TElastix>::CreateDerivedTransformParameterMap() const ->
  * ********************* InitializeTransform ****************************
  */
 
-template <class TElastix>
+template <typename TElastix>
 void
 AffineLogStackTransform<TElastix>::InitializeTransform()
 {
@@ -270,7 +270,7 @@ AffineLogStackTransform<TElastix>::InitializeTransform()
  * ************************* SetScales *********************
  */
 
-template <class TElastix>
+template <typename TElastix>
 void
 AffineLogStackTransform<TElastix>::SetScales()
 {
@@ -411,7 +411,7 @@ AffineLogStackTransform<TElastix>::SetScales()
  * ******************** ReadCenterOfRotationPoint *********************
  */
 
-template <class TElastix>
+template <typename TElastix>
 bool
 AffineLogStackTransform<TElastix>::ReadCenterOfRotationPoint(ReducedDimensionInputPointType & rotationPoint) const
 {

--- a/Components/Transforms/AffineLogTransform/elxAffineLogTransform.h
+++ b/Components/Transforms/AffineLogTransform/elxAffineLogTransform.h
@@ -39,7 +39,7 @@ namespace elastix
  * \sa AffineLogTransform
  */
 
-template <class TElastix>
+template <typename TElastix>
 class ITK_TEMPLATE_EXPORT AffineLogTransformElastix
   : public itk::AdvancedCombinationTransform<typename elx::TransformBase<TElastix>::CoordRepType,
                                              elx::TransformBase<TElastix>::FixedImageDimension>

--- a/Components/Transforms/AffineLogTransform/elxAffineLogTransform.hxx
+++ b/Components/Transforms/AffineLogTransform/elxAffineLogTransform.hxx
@@ -28,7 +28,7 @@ namespace elastix
  * ********************* Constructor ****************************
  */
 
-template <class TElastix>
+template <typename TElastix>
 AffineLogTransformElastix<TElastix>::AffineLogTransformElastix()
 {
   log::info("Constructor");
@@ -41,7 +41,7 @@ AffineLogTransformElastix<TElastix>::AffineLogTransformElastix()
  * ******************* BeforeRegistration ***********************
  */
 
-template <class TElastix>
+template <typename TElastix>
 void
 AffineLogTransformElastix<TElastix>::BeforeRegistration()
 {
@@ -59,7 +59,7 @@ AffineLogTransformElastix<TElastix>::BeforeRegistration()
  * ************************* ReadFromFile ************************
  */
 
-template <class TElastix>
+template <typename TElastix>
 void
 AffineLogTransformElastix<TElastix>::ReadFromFile()
 {
@@ -95,7 +95,7 @@ AffineLogTransformElastix<TElastix>::ReadFromFile()
  * ************************* CreateDerivedTransformParameterMap ************************
  */
 
-template <class TElastix>
+template <typename TElastix>
 auto
 AffineLogTransformElastix<TElastix>::CreateDerivedTransformParameterMap() const -> ParameterMapType
 {
@@ -113,7 +113,7 @@ AffineLogTransformElastix<TElastix>::CreateDerivedTransformParameterMap() const 
  * ************************* InitializeTransform *********************
  */
 
-template <class TElastix>
+template <typename TElastix>
 void
 AffineLogTransformElastix<TElastix>::InitializeTransform()
 {
@@ -268,7 +268,7 @@ AffineLogTransformElastix<TElastix>::InitializeTransform()
  * ************************* SetScales *********************
  */
 
-template <class TElastix>
+template <typename TElastix>
 void
 AffineLogTransformElastix<TElastix>::SetScales()
 {
@@ -318,7 +318,7 @@ AffineLogTransformElastix<TElastix>::SetScales()
  * ******************** ReadCenterOfRotationPoint *********************
  */
 
-template <class TElastix>
+template <typename TElastix>
 bool
 AffineLogTransformElastix<TElastix>::ReadCenterOfRotationPoint(InputPointType & rotationPoint) const
 {

--- a/Components/Transforms/AffineLogTransform/itkAffineLogTransform.h
+++ b/Components/Transforms/AffineLogTransform/itkAffineLogTransform.h
@@ -29,7 +29,7 @@ namespace itk
  *
  * \ingroup Transforms
  */
-template <class TScalarType = double, unsigned int Dimension = 2> // Data type for scalars (float or double)
+template <typename TScalarType = double, unsigned int Dimension = 2> // Data type for scalars (float or double)
 class AffineLogTransform : public AdvancedMatrixOffsetTransformBase<TScalarType, Dimension, Dimension>
 {
 public:

--- a/Components/Transforms/AffineLogTransform/itkAffineLogTransform.hxx
+++ b/Components/Transforms/AffineLogTransform/itkAffineLogTransform.hxx
@@ -26,7 +26,7 @@ namespace itk
 {
 
 // Constructor with default arguments
-template <class TScalarType, unsigned int Dimension>
+template <typename TScalarType, unsigned int Dimension>
 AffineLogTransform<TScalarType, Dimension>::AffineLogTransform()
   : Superclass(ParametersDimension)
 {
@@ -36,7 +36,7 @@ AffineLogTransform<TScalarType, Dimension>::AffineLogTransform()
 
 
 // Constructor with default arguments
-template <class TScalarType, unsigned int Dimension>
+template <typename TScalarType, unsigned int Dimension>
 AffineLogTransform<TScalarType, Dimension>::AffineLogTransform(const MatrixType &      matrix,
                                                                const OutputPointType & offset)
 {
@@ -54,7 +54,7 @@ AffineLogTransform<TScalarType, Dimension>::AffineLogTransform(const MatrixType 
 
 
 // Constructor with arguments
-template <class TScalarType, unsigned int Dimension>
+template <typename TScalarType, unsigned int Dimension>
 AffineLogTransform<TScalarType, Dimension>::AffineLogTransform(unsigned int spaceDimension,
                                                                unsigned int parametersDimension)
   : Superclass(spaceDimension, parametersDimension)
@@ -65,7 +65,7 @@ AffineLogTransform<TScalarType, Dimension>::AffineLogTransform(unsigned int spac
 
 
 // Set Parameters
-template <class TScalarType, unsigned int Dimension>
+template <typename TScalarType, unsigned int Dimension>
 void
 AffineLogTransform<TScalarType, Dimension>::SetParameters(const ParametersType & parameters)
 {
@@ -109,7 +109,7 @@ AffineLogTransform<TScalarType, Dimension>::SetParameters(const ParametersType &
 
 
 // Get Parameters
-template <class TScalarType, unsigned int Dimension>
+template <typename TScalarType, unsigned int Dimension>
 auto
 AffineLogTransform<TScalarType, Dimension>::GetParameters() const -> const ParametersType &
 {
@@ -134,7 +134,7 @@ AffineLogTransform<TScalarType, Dimension>::GetParameters() const -> const Param
 }
 
 // SetIdentity
-template <class TScalarType, unsigned int Dimension>
+template <typename TScalarType, unsigned int Dimension>
 void
 AffineLogTransform<TScalarType, Dimension>::SetIdentity()
 {
@@ -145,7 +145,7 @@ AffineLogTransform<TScalarType, Dimension>::SetIdentity()
 
 
 // Get Jacobian
-template <class TScalarType, unsigned int Dimension>
+template <typename TScalarType, unsigned int Dimension>
 void
 AffineLogTransform<TScalarType, Dimension>::GetJacobian(const InputPointType &       p,
                                                         JacobianType &               j,
@@ -179,7 +179,7 @@ AffineLogTransform<TScalarType, Dimension>::GetJacobian(const InputPointType &  
 
 
 // Precompute Jacobian of Spatial Jacobian
-template <class TScalarType, unsigned int Dimension>
+template <typename TScalarType, unsigned int Dimension>
 void
 AffineLogTransform<TScalarType, Dimension>::PrecomputeJacobianOfSpatialJacobian()
 {
@@ -256,7 +256,7 @@ AffineLogTransform<TScalarType, Dimension>::PrecomputeJacobianOfSpatialJacobian(
 
 
 // Print self
-template <class TScalarType, unsigned int Dimension>
+template <typename TScalarType, unsigned int Dimension>
 void
 AffineLogTransform<TScalarType, Dimension>::PrintSelf(std::ostream & os, Indent indent) const
 {

--- a/Components/Transforms/BSplineDeformableTransformWithDiffusion/elxBSplineTransformWithDiffusion.h
+++ b/Components/Transforms/BSplineDeformableTransformWithDiffusion/elxBSplineTransformWithDiffusion.h
@@ -155,7 +155,7 @@ namespace elastix
  * \ingroup Transforms
  */
 
-template <class TElastix>
+template <typename TElastix>
 class ITK_TEMPLATE_EXPORT BSplineTransformWithDiffusion
   : public itk::DeformationFieldRegulizer<itk::AdvancedCombinationTransform<
       // BSplineCombinationTransform<

--- a/Components/Transforms/BSplineDeformableTransformWithDiffusion/elxBSplineTransformWithDiffusion.hxx
+++ b/Components/Transforms/BSplineDeformableTransformWithDiffusion/elxBSplineTransformWithDiffusion.hxx
@@ -33,7 +33,7 @@ namespace elastix
  * ********************* Constructor ****************************
  */
 
-template <class TElastix>
+template <typename TElastix>
 BSplineTransformWithDiffusion<TElastix>::BSplineTransformWithDiffusion()
 {
   /** Set up CombinationTransform */
@@ -77,7 +77,7 @@ BSplineTransformWithDiffusion<TElastix>::BSplineTransformWithDiffusion()
  * ******************* BeforeRegistration ***********************
  */
 
-template <class TElastix>
+template <typename TElastix>
 void
 BSplineTransformWithDiffusion<TElastix>::BeforeRegistration()
 {
@@ -396,7 +396,7 @@ BSplineTransformWithDiffusion<TElastix>::BeforeRegistration()
  * ***************** BeforeEachResolution ***********************
  */
 
-template <class TElastix>
+template <typename TElastix>
 void
 BSplineTransformWithDiffusion<TElastix>::BeforeEachResolution()
 {
@@ -444,7 +444,7 @@ BSplineTransformWithDiffusion<TElastix>::BeforeEachResolution()
  * ********************* AfterEachIteration *********************
  */
 
-template <class TElastix>
+template <typename TElastix>
 void
 BSplineTransformWithDiffusion<TElastix>::AfterEachIteration()
 {
@@ -551,7 +551,7 @@ BSplineTransformWithDiffusion<TElastix>::AfterEachIteration()
  * ******************* AfterRegistration ***********************
  */
 
-template <class TElastix>
+template <typename TElastix>
 void
 BSplineTransformWithDiffusion<TElastix>::AfterRegistration()
 {
@@ -598,7 +598,7 @@ BSplineTransformWithDiffusion<TElastix>::AfterRegistration()
  * to take into account the support region of the B-splines.
  */
 
-template <class TElastix>
+template <typename TElastix>
 void
 BSplineTransformWithDiffusion<TElastix>::SetInitialGrid(bool upsampleGridOption)
 {
@@ -675,7 +675,7 @@ BSplineTransformWithDiffusion<TElastix>::SetInitialGrid(bool upsampleGridOption)
  * Upsample the grid of control points.
  */
 
-template <class TElastix>
+template <typename TElastix>
 void
 BSplineTransformWithDiffusion<TElastix>::IncreaseScale()
 {
@@ -828,7 +828,7 @@ BSplineTransformWithDiffusion<TElastix>::IncreaseScale()
  * ************************* ReadFromFile ************************
  */
 
-template <class TElastix>
+template <typename TElastix>
 void
 BSplineTransformWithDiffusion<TElastix>::ReadFromFile()
 {
@@ -987,7 +987,7 @@ BSplineTransformWithDiffusion<TElastix>::ReadFromFile()
  * also as a deformation field.
  */
 
-template <class TElastix>
+template <typename TElastix>
 void
 BSplineTransformWithDiffusion<TElastix>::WriteDerivedTransformDataToFile() const
 {
@@ -1014,7 +1014,7 @@ BSplineTransformWithDiffusion<TElastix>::WriteDerivedTransformDataToFile() const
  * ************************* CustomizeTransformParameterMap ************************
  */
 
-template <class TElastix>
+template <typename TElastix>
 auto
 BSplineTransformWithDiffusion<TElastix>::CreateDerivedTransformParameterMap() const -> ParameterMapType
 {
@@ -1037,7 +1037,7 @@ BSplineTransformWithDiffusion<TElastix>::CreateDerivedTransformParameterMap() co
  * ******************* DiffuseDeformationField ******************
  */
 
-template <class TElastix>
+template <typename TElastix>
 void
 BSplineTransformWithDiffusion<TElastix>::DiffuseDeformationField()
 {
@@ -1352,7 +1352,7 @@ BSplineTransformWithDiffusion<TElastix>::DiffuseDeformationField()
  * ******************* TransformPoint ******************
  */
 
-template <class TElastix>
+template <typename TElastix>
 auto
 BSplineTransformWithDiffusion<TElastix>::TransformPoint(const InputPointType & point) const -> OutputPointType
 {

--- a/Components/Transforms/BSplineDeformableTransformWithDiffusion/itkDeformationFieldRegulizer.h
+++ b/Components/Transforms/BSplineDeformableTransformWithDiffusion/itkDeformationFieldRegulizer.h
@@ -37,7 +37,7 @@ namespace itk
  * \ingroup Common
  */
 
-template <class TAnyITKTransform>
+template <typename TAnyITKTransform>
 class ITK_TEMPLATE_EXPORT DeformationFieldRegulizer : public TAnyITKTransform
 {
 public:

--- a/Components/Transforms/BSplineDeformableTransformWithDiffusion/itkDeformationFieldRegulizer.hxx
+++ b/Components/Transforms/BSplineDeformableTransformWithDiffusion/itkDeformationFieldRegulizer.hxx
@@ -28,7 +28,7 @@ namespace itk
  * ************************ Constructor *************************
  */
 
-template <class TAnyITKTransform>
+template <typename TAnyITKTransform>
 DeformationFieldRegulizer<TAnyITKTransform>::DeformationFieldRegulizer()
 {
   /** Initialize. */
@@ -42,7 +42,7 @@ DeformationFieldRegulizer<TAnyITKTransform>::DeformationFieldRegulizer()
  * ********* InitializeIntermediaryDeformationField **************
  */
 
-template <class TAnyITKTransform>
+template <typename TAnyITKTransform>
 void
 DeformationFieldRegulizer<TAnyITKTransform>::InitializeDeformationFields()
 {
@@ -91,7 +91,7 @@ DeformationFieldRegulizer<TAnyITKTransform>::InitializeDeformationFields()
  * *********************** TransformPoint ***********************
  */
 
-template <class TAnyITKTransform>
+template <typename TAnyITKTransform>
 auto
 DeformationFieldRegulizer<TAnyITKTransform>::TransformPoint(const InputPointType & inputPoint) const -> OutputPointType
 {
@@ -116,7 +116,7 @@ DeformationFieldRegulizer<TAnyITKTransform>::TransformPoint(const InputPointType
  * ******** UpdateIntermediaryDeformationFieldTransform *********
  */
 
-template <class TAnyITKTransform>
+template <typename TAnyITKTransform>
 void
 DeformationFieldRegulizer<TAnyITKTransform>::UpdateIntermediaryDeformationFieldTransform(
   typename VectorImageType::Pointer vecImage)

--- a/Components/Transforms/BSplineDeformableTransformWithDiffusion/itkDeformationVectorFieldTransform.h
+++ b/Components/Transforms/BSplineDeformableTransformWithDiffusion/itkDeformationVectorFieldTransform.h
@@ -42,7 +42,7 @@ namespace itk
  * the spline order.
  */
 
-template <class TScalarType = double, unsigned int NDimensions = 3>
+template <typename TScalarType = double, unsigned int NDimensions = 3>
 class ITK_TEMPLATE_EXPORT DeformationVectorFieldTransform
   : public AdvancedBSplineDeformableTransform<TScalarType, NDimensions, 0>
 {

--- a/Components/Transforms/BSplineDeformableTransformWithDiffusion/itkDeformationVectorFieldTransform.hxx
+++ b/Components/Transforms/BSplineDeformableTransformWithDiffusion/itkDeformationVectorFieldTransform.hxx
@@ -30,7 +30,7 @@ namespace itk
  * *********************** Constructor **************************
  */
 
-template <class TScalarType, unsigned int NDimensions>
+template <typename TScalarType, unsigned int NDimensions>
 DeformationVectorFieldTransform<TScalarType, NDimensions>::DeformationVectorFieldTransform()
 {
   /** Initialize m_Images. */
@@ -46,7 +46,7 @@ DeformationVectorFieldTransform<TScalarType, NDimensions>::DeformationVectorFiel
  * *********************** Destructor ***************************
  */
 
-template <class TScalarType, unsigned int NDimensions>
+template <typename TScalarType, unsigned int NDimensions>
 DeformationVectorFieldTransform<TScalarType, NDimensions>::~DeformationVectorFieldTransform()
 {
   /** Initialize m_Images. */
@@ -65,7 +65,7 @@ DeformationVectorFieldTransform<TScalarType, NDimensions>::~DeformationVectorFie
  * image as input.
  */
 
-template <class TScalarType, unsigned int NDimensions>
+template <typename TScalarType, unsigned int NDimensions>
 void
 DeformationVectorFieldTransform<TScalarType, NDimensions>::SetCoefficientVectorImage(
   const CoefficientVectorImageType * vecImage)
@@ -122,7 +122,7 @@ DeformationVectorFieldTransform<TScalarType, NDimensions>::SetCoefficientVectorI
  *
  */
 
-template <class TScalarType, unsigned int NDimensions>
+template <typename TScalarType, unsigned int NDimensions>
 void
 DeformationVectorFieldTransform<TScalarType, NDimensions>::GetCoefficientVectorImage(
   CoefficientVectorImagePointer & vecImage) const

--- a/Components/Transforms/BSplineDeformableTransformWithDiffusion/itkVectorMeanDiffusionImageFilter.h
+++ b/Components/Transforms/BSplineDeformableTransformWithDiffusion/itkVectorMeanDiffusionImageFilter.h
@@ -45,7 +45,7 @@ namespace itk
  * \ingroup IntensityImageFilters
  */
 
-template <class TInputImage, class TGrayValueImage>
+template <typename TInputImage, typename TGrayValueImage>
 class ITK_TEMPLATE_EXPORT VectorMeanDiffusionImageFilter : public ImageToImageFilter<TInputImage, TInputImage>
 {
 public:

--- a/Components/Transforms/BSplineDeformableTransformWithDiffusion/itkVectorMeanDiffusionImageFilter.hxx
+++ b/Components/Transforms/BSplineDeformableTransformWithDiffusion/itkVectorMeanDiffusionImageFilter.hxx
@@ -34,7 +34,7 @@ namespace itk
  * *********************** Constructor **************************
  */
 
-template <class TInputImage, class TGrayValueImage>
+template <typename TInputImage, typename TGrayValueImage>
 VectorMeanDiffusionImageFilter<TInputImage, TGrayValueImage>::VectorMeanDiffusionImageFilter()
 {
   /** Initialize things for the filter. */
@@ -51,7 +51,7 @@ VectorMeanDiffusionImageFilter<TInputImage, TGrayValueImage>::VectorMeanDiffusio
  * *************** GenerateInputRequestedRegion *****************
  */
 
-template <class TInputImage, class TGrayValueImage>
+template <typename TInputImage, typename TGrayValueImage>
 void
 VectorMeanDiffusionImageFilter<TInputImage, TGrayValueImage>::GenerateInputRequestedRegion()
 {
@@ -106,7 +106,7 @@ VectorMeanDiffusionImageFilter<TInputImage, TGrayValueImage>::GenerateInputReque
  * ********************** GenerateData **************************
  */
 
-template <class TInputImage, class TGrayValueImage>
+template <typename TInputImage, typename TGrayValueImage>
 void
 VectorMeanDiffusionImageFilter<TInputImage, TGrayValueImage>::GenerateData()
 {
@@ -302,7 +302,7 @@ VectorMeanDiffusionImageFilter<TInputImage, TGrayValueImage>::GenerateData()
  * ********************* PrintSelf ******************************
  */
 
-template <class TInputImage, class TGrayValueImage>
+template <typename TInputImage, typename TGrayValueImage>
 void
 VectorMeanDiffusionImageFilter<TInputImage, TGrayValueImage>::PrintSelf(std::ostream & os, Indent indent) const
 {
@@ -317,7 +317,7 @@ VectorMeanDiffusionImageFilter<TInputImage, TGrayValueImage>::PrintSelf(std::ost
  * ******************** SetGrayValueImage ***********************
  */
 
-template <class TInputImage, class TGrayValueImage>
+template <typename TInputImage, typename TGrayValueImage>
 void
 VectorMeanDiffusionImageFilter<TInputImage, TGrayValueImage>::SetGrayValueImage(GrayValueImageType * _arg)
 {
@@ -337,7 +337,7 @@ VectorMeanDiffusionImageFilter<TInputImage, TGrayValueImage>::SetGrayValueImage(
  * the coefficient image or not.
  */
 
-template <class TInputImage, class TGrayValueImage>
+template <typename TInputImage, typename TGrayValueImage>
 void
 VectorMeanDiffusionImageFilter<TInputImage, TGrayValueImage>::FilterGrayValueImage()
 {

--- a/Components/Transforms/BSplineStackTransform/elxBSplineStackTransform.h
+++ b/Components/Transforms/BSplineStackTransform/elxBSplineStackTransform.h
@@ -109,7 +109,7 @@ namespace elastix
  * \ingroup Transforms
  */
 
-template <class TElastix>
+template <typename TElastix>
 class ITK_TEMPLATE_EXPORT BSplineStackTransform
   : public itk::AdvancedCombinationTransform<typename elx::TransformBase<TElastix>::CoordRepType,
                                              elx::TransformBase<TElastix>::FixedImageDimension>

--- a/Components/Transforms/BSplineStackTransform/elxBSplineStackTransform.hxx
+++ b/Components/Transforms/BSplineStackTransform/elxBSplineStackTransform.hxx
@@ -30,7 +30,7 @@ namespace elastix
 /**
  * ************ InitializeBSplineTransform ***************
  */
-template <class TElastix>
+template <typename TElastix>
 unsigned int
 BSplineStackTransform<TElastix>::InitializeBSplineTransform()
 {
@@ -59,7 +59,7 @@ BSplineStackTransform<TElastix>::InitializeBSplineTransform()
  * ******************* BeforeAll ***********************
  */
 
-template <class TElastix>
+template <typename TElastix>
 int
 BSplineStackTransform<TElastix>::BeforeAll()
 {
@@ -77,7 +77,7 @@ BSplineStackTransform<TElastix>::BeforeAll()
  * ******************* BeforeRegistration ***********************
  */
 
-template <class TElastix>
+template <typename TElastix>
 void
 BSplineStackTransform<TElastix>::BeforeRegistration()
 {
@@ -132,7 +132,7 @@ BSplineStackTransform<TElastix>::BeforeRegistration()
  * ***************** BeforeEachResolution ***********************
  */
 
-template <class TElastix>
+template <typename TElastix>
 void
 BSplineStackTransform<TElastix>::BeforeEachResolution()
 {
@@ -163,7 +163,7 @@ BSplineStackTransform<TElastix>::BeforeEachResolution()
  * ******************** PreComputeGridInformation ***********************
  */
 
-template <class TElastix>
+template <typename TElastix>
 void
 BSplineStackTransform<TElastix>::PreComputeGridInformation()
 {
@@ -339,7 +339,7 @@ BSplineStackTransform<TElastix>::PreComputeGridInformation()
  * ******************** InitializeTransform ***********************
  */
 
-template <class TElastix>
+template <typename TElastix>
 void
 BSplineStackTransform<TElastix>::InitializeTransform()
 {
@@ -370,7 +370,7 @@ BSplineStackTransform<TElastix>::InitializeTransform()
  * *********************** IncreaseScale ************************
  */
 
-template <class TElastix>
+template <typename TElastix>
 void
 BSplineStackTransform<TElastix>::IncreaseScale()
 {
@@ -440,7 +440,7 @@ BSplineStackTransform<TElastix>::IncreaseScale()
  * ************************* ReadFromFile ************************
  */
 
-template <class TElastix>
+template <typename TElastix>
 void
 BSplineStackTransform<TElastix>::ReadFromFile()
 {
@@ -521,7 +521,7 @@ BSplineStackTransform<TElastix>::ReadFromFile()
  * *********************** SetOptimizerScales ***********************
  */
 
-template <class TElastix>
+template <typename TElastix>
 void
 BSplineStackTransform<TElastix>::SetOptimizerScales(const unsigned int edgeWidth)
 {
@@ -600,7 +600,7 @@ BSplineStackTransform<TElastix>::SetOptimizerScales(const unsigned int edgeWidth
  * ************************* CreateDerivedTransformParameterMap ************************
  */
 
-template <class TElastix>
+template <typename TElastix>
 auto
 BSplineStackTransform<TElastix>::CreateDerivedTransformParameterMap() const -> ParameterMapType
 {

--- a/Components/Transforms/DeformationFieldTransform/elxDeformationFieldTransform.h
+++ b/Components/Transforms/DeformationFieldTransform/elxDeformationFieldTransform.h
@@ -50,7 +50,7 @@ namespace elastix
  * \ingroup Transforms
  */
 
-template <class TElastix>
+template <typename TElastix>
 class ITK_TEMPLATE_EXPORT DeformationFieldTransform
   : public itk::AdvancedCombinationTransform<typename elx::TransformBase<TElastix>::CoordRepType,
                                              elx::TransformBase<TElastix>::FixedImageDimension>

--- a/Components/Transforms/DeformationFieldTransform/elxDeformationFieldTransform.hxx
+++ b/Components/Transforms/DeformationFieldTransform/elxDeformationFieldTransform.hxx
@@ -35,7 +35,7 @@ namespace elastix
  * ********************* Constructor ****************************
  */
 
-template <class TElastix>
+template <typename TElastix>
 DeformationFieldTransform<TElastix>::DeformationFieldTransform()
 {
   /** Initialize. */
@@ -55,7 +55,7 @@ DeformationFieldTransform<TElastix>::DeformationFieldTransform()
  * ************************* ReadFromFile ************************
  */
 
-template <class TElastix>
+template <typename TElastix>
 void
 DeformationFieldTransform<TElastix>::ReadFromFile()
 {
@@ -137,7 +137,7 @@ DeformationFieldTransform<TElastix>::ReadFromFile()
  * also as a deformation field.
  */
 
-template <class TElastix>
+template <typename TElastix>
 void
 DeformationFieldTransform<TElastix>::WriteDerivedTransformDataToFile() const
 {
@@ -176,7 +176,7 @@ DeformationFieldTransform<TElastix>::WriteDerivedTransformDataToFile() const
  * ************************* CustomizeTransformParameterMap ************************
  */
 
-template <class TElastix>
+template <typename TElastix>
 auto
 DeformationFieldTransform<TElastix>::CreateDerivedTransformParameterMap() const -> ParameterMapType
 {

--- a/Components/Transforms/DeformationFieldTransform/itkDeformationFieldInterpolatingTransform.h
+++ b/Components/Transforms/DeformationFieldTransform/itkDeformationFieldInterpolatingTransform.h
@@ -39,9 +39,9 @@ namespace itk
  * \ingroup Transforms
  */
 
-template <class TScalarType = double,   // Data type for scalars (float or double)
-          unsigned int NDimensions = 3, // Number of input dimensions
-          class TComponentType = double>
+template <typename TScalarType = double, // Data type for scalars (float or double)
+          unsigned int NDimensions = 3,  // Number of input dimensions
+          typename TComponentType = double>
 // ComponentType of the deformation field
 class ITK_TEMPLATE_EXPORT DeformationFieldInterpolatingTransform
   : public AdvancedTransform<TScalarType, NDimensions, NDimensions>

--- a/Components/Transforms/DeformationFieldTransform/itkDeformationFieldInterpolatingTransform.hxx
+++ b/Components/Transforms/DeformationFieldTransform/itkDeformationFieldInterpolatingTransform.hxx
@@ -24,7 +24,7 @@ namespace itk
 {
 
 // Constructor with default arguments
-template <class TScalarType, unsigned int NDimensions, class TComponentType>
+template <typename TScalarType, unsigned int NDimensions, typename TComponentType>
 DeformationFieldInterpolatingTransform<TScalarType, NDimensions, TComponentType>::
   DeformationFieldInterpolatingTransform()
   : Superclass(OutputSpaceDimension)
@@ -40,7 +40,7 @@ DeformationFieldInterpolatingTransform<TScalarType, NDimensions, TComponentType>
 
 
 // Transform a point
-template <class TScalarType, unsigned int NDimensions, class TComponentType>
+template <typename TScalarType, unsigned int NDimensions, typename TComponentType>
 auto
 DeformationFieldInterpolatingTransform<TScalarType, NDimensions, TComponentType>::TransformPoint(
   const InputPointType & point) const -> OutputPointType
@@ -66,7 +66,7 @@ DeformationFieldInterpolatingTransform<TScalarType, NDimensions, TComponentType>
 
 
 // Set the deformation field
-template <class TScalarType, unsigned int NDimensions, class TComponentType>
+template <typename TScalarType, unsigned int NDimensions, typename TComponentType>
 void
 DeformationFieldInterpolatingTransform<TScalarType, NDimensions, TComponentType>::SetDeformationField(
   DeformationFieldType * _arg)
@@ -85,7 +85,7 @@ DeformationFieldInterpolatingTransform<TScalarType, NDimensions, TComponentType>
 
 
 // Set the deformation field interpolator
-template <class TScalarType, unsigned int NDimensions, class TComponentType>
+template <typename TScalarType, unsigned int NDimensions, typename TComponentType>
 void
 DeformationFieldInterpolatingTransform<TScalarType, NDimensions, TComponentType>::SetDeformationFieldInterpolator(
   DeformationFieldInterpolatorType * _arg)
@@ -104,7 +104,7 @@ DeformationFieldInterpolatingTransform<TScalarType, NDimensions, TComponentType>
 
 
 // Print self
-template <class TScalarType, unsigned int NDimensions, class TComponentType>
+template <typename TScalarType, unsigned int NDimensions, typename TComponentType>
 void
 DeformationFieldInterpolatingTransform<TScalarType, NDimensions, TComponentType>::PrintSelf(std::ostream & os,
                                                                                             Indent         indent) const
@@ -118,7 +118,7 @@ DeformationFieldInterpolatingTransform<TScalarType, NDimensions, TComponentType>
 
 
 // Set the parameters for an Identity transform of this class
-template <class TScalarType, unsigned int NDimensions, class TComponentType>
+template <typename TScalarType, unsigned int NDimensions, typename TComponentType>
 void
 DeformationFieldInterpolatingTransform<TScalarType, NDimensions, TComponentType>::SetIdentity()
 {

--- a/Components/Transforms/EulerStackTransform/elxEulerStackTransform.h
+++ b/Components/Transforms/EulerStackTransform/elxEulerStackTransform.h
@@ -80,7 +80,7 @@ namespace elastix
  * \ingroup Transforms
  */
 
-template <class TElastix>
+template <typename TElastix>
 class ITK_TEMPLATE_EXPORT EulerStackTransform
   : public itk::AdvancedCombinationTransform<typename elx::TransformBase<TElastix>::CoordRepType,
                                              elx::TransformBase<TElastix>::FixedImageDimension>

--- a/Components/Transforms/EulerStackTransform/elxEulerStackTransform.hxx
+++ b/Components/Transforms/EulerStackTransform/elxEulerStackTransform.hxx
@@ -27,7 +27,7 @@ namespace elastix
 /**
  * ********************* InitializeAffineTransform ****************************
  */
-template <class TElastix>
+template <typename TElastix>
 unsigned int
 EulerStackTransform<TElastix>::InitializeEulerTransform()
 {
@@ -41,7 +41,7 @@ EulerStackTransform<TElastix>::InitializeEulerTransform()
  * ******************* BeforeAll ***********************
  */
 
-template <class TElastix>
+template <typename TElastix>
 int
 EulerStackTransform<TElastix>::BeforeAll()
 {
@@ -54,7 +54,7 @@ EulerStackTransform<TElastix>::BeforeAll()
  * ******************* BeforeRegistration ***********************
  */
 
-template <class TElastix>
+template <typename TElastix>
 void
 EulerStackTransform<TElastix>::BeforeRegistration()
 {
@@ -91,7 +91,7 @@ EulerStackTransform<TElastix>::BeforeRegistration()
  * ************************* ReadFromFile ************************
  */
 
-template <class TElastix>
+template <typename TElastix>
 void
 EulerStackTransform<TElastix>::ReadFromFile()
 {
@@ -150,7 +150,7 @@ EulerStackTransform<TElastix>::ReadFromFile()
  * ************************* CreateDerivedTransformParameterMap ************************
  */
 
-template <class TElastix>
+template <typename TElastix>
 auto
 EulerStackTransform<TElastix>::CreateDerivedTransformParameterMap() const -> ParameterMapType
 {
@@ -177,7 +177,7 @@ EulerStackTransform<TElastix>::CreateDerivedTransformParameterMap() const -> Par
  * ********************* InitializeTransform ****************************
  */
 
-template <class TElastix>
+template <typename TElastix>
 void
 EulerStackTransform<TElastix>::InitializeTransform()
 {
@@ -285,7 +285,7 @@ EulerStackTransform<TElastix>::InitializeTransform()
 } // end InitializeTransform()
 
 
-template <class TElastix>
+template <typename TElastix>
 void
 EulerStackTransform<TElastix>::InitialTransformCenter(ReducedDimensionInputPointType & point)
 {
@@ -346,7 +346,7 @@ EulerStackTransform<TElastix>::InitialTransformCenter(ReducedDimensionInputPoint
  * ************************* SetScales *********************
  */
 
-template <class TElastix>
+template <typename TElastix>
 void
 EulerStackTransform<TElastix>::SetScales()
 {
@@ -492,7 +492,7 @@ EulerStackTransform<TElastix>::SetScales()
  * ******************** ReadCenterOfRotationPoint *********************
  */
 
-template <class TElastix>
+template <typename TElastix>
 bool
 EulerStackTransform<TElastix>::ReadCenterOfRotationPoint(ReducedDimensionInputPointType & rotationPoint) const
 {

--- a/Components/Transforms/EulerTransform/elxEulerTransform.h
+++ b/Components/Transforms/EulerTransform/elxEulerTransform.h
@@ -72,7 +72,7 @@ namespace elastix
  * \ingroup Transforms
  */
 
-template <class TElastix>
+template <typename TElastix>
 class ITK_TEMPLATE_EXPORT EulerTransformElastix
   : public itk::AdvancedCombinationTransform<typename elx::TransformBase<TElastix>::CoordRepType,
                                              elx::TransformBase<TElastix>::FixedImageDimension>

--- a/Components/Transforms/EulerTransform/elxEulerTransform.hxx
+++ b/Components/Transforms/EulerTransform/elxEulerTransform.hxx
@@ -30,7 +30,7 @@ namespace elastix
  * ********************* Constructor ****************************
  */
 
-template <class TElastix>
+template <typename TElastix>
 EulerTransformElastix<TElastix>::EulerTransformElastix()
 {
   this->SetCurrentTransform(this->m_EulerTransform);
@@ -42,7 +42,7 @@ EulerTransformElastix<TElastix>::EulerTransformElastix()
  * ******************* BeforeRegistration ***********************
  */
 
-template <class TElastix>
+template <typename TElastix>
 void
 EulerTransformElastix<TElastix>::BeforeRegistration()
 {
@@ -59,7 +59,7 @@ EulerTransformElastix<TElastix>::BeforeRegistration()
  * ************************* ReadFromFile ************************
  */
 
-template <class TElastix>
+template <typename TElastix>
 void
 EulerTransformElastix<TElastix>::ReadFromFile()
 {
@@ -108,7 +108,7 @@ EulerTransformElastix<TElastix>::ReadFromFile()
  * ************************* CreateDerivedTransformParameterMap ************************
  */
 
-template <class TElastix>
+template <typename TElastix>
 auto
 EulerTransformElastix<TElastix>::CreateDerivedTransformParameterMap() const -> ParameterMapType
 {
@@ -130,7 +130,7 @@ EulerTransformElastix<TElastix>::CreateDerivedTransformParameterMap() const -> P
  * ************************* InitializeTransform *********************
  */
 
-template <class TElastix>
+template <typename TElastix>
 void
 EulerTransformElastix<TElastix>::InitializeTransform()
 {
@@ -284,7 +284,7 @@ EulerTransformElastix<TElastix>::InitializeTransform()
  * ************************* SetScales *********************
  */
 
-template <class TElastix>
+template <typename TElastix>
 void
 EulerTransformElastix<TElastix>::SetScales()
 {
@@ -402,7 +402,7 @@ EulerTransformElastix<TElastix>::SetScales()
  * ******************** ReadCenterOfRotationPoint *********************
  */
 
-template <class TElastix>
+template <typename TElastix>
 bool
 EulerTransformElastix<TElastix>::ReadCenterOfRotationPoint(InputPointType & rotationPoint) const
 {

--- a/Components/Transforms/ExternalTransform/elxAdvancedTransformAdapter.h
+++ b/Components/Transforms/ExternalTransform/elxAdvancedTransformAdapter.h
@@ -34,7 +34,7 @@ namespace elastix
  * \ingroup Transforms
  */
 
-template <class TScalarType, unsigned int NDimensions>
+template <typename TScalarType, unsigned int NDimensions>
 class ITK_TEMPLATE_EXPORT AdvancedTransformAdapter
   : public itk::AdvancedTransform<TScalarType, NDimensions, NDimensions>
 {

--- a/Components/Transforms/ExternalTransform/elxExternalTransform.h
+++ b/Components/Transforms/ExternalTransform/elxExternalTransform.h
@@ -44,7 +44,7 @@ namespace elastix
  * \ingroup Transforms
  */
 
-template <class TElastix>
+template <typename TElastix>
 class ITK_TEMPLATE_EXPORT ExternalTransform
   : public itk::AdvancedCombinationTransform<typename elx::TransformBase<TElastix>::CoordRepType,
                                              elx::TransformBase<TElastix>::FixedImageDimension>

--- a/Components/Transforms/ExternalTransform/elxExternalTransform.hxx
+++ b/Components/Transforms/ExternalTransform/elxExternalTransform.hxx
@@ -28,7 +28,7 @@ namespace elastix
  * ********************* Constructor ****************************
  */
 
-template <class TElastix>
+template <typename TElastix>
 ExternalTransform<TElastix>::ExternalTransform()
 {
   Superclass1::SetCurrentTransform(m_AdvancedTransformAdapter);
@@ -38,7 +38,7 @@ ExternalTransform<TElastix>::ExternalTransform()
  * ************************* ReadFromFile ************************
  */
 
-template <class TElastix>
+template <typename TElastix>
 void
 ExternalTransform<TElastix>::ReadFromFile()
 {
@@ -69,7 +69,7 @@ ExternalTransform<TElastix>::ReadFromFile()
  * ************************* CreateDerivedTransformParameterMap ************************
  */
 
-template <class TElastix>
+template <typename TElastix>
 auto
 ExternalTransform<TElastix>::CreateDerivedTransformParameterMap() const -> ParameterMapType
 {

--- a/Components/Transforms/MultiBSplineTransformWithNormal/elxMultiBSplineTransformWithNormal.h
+++ b/Components/Transforms/MultiBSplineTransformWithNormal/elxMultiBSplineTransformWithNormal.h
@@ -87,7 +87,7 @@ namespace elastix
  * \ingroup Transforms
  */
 
-template <class TElastix>
+template <typename TElastix>
 class ITK_TEMPLATE_EXPORT MultiBSplineTransformWithNormal
   : public itk::AdvancedCombinationTransform<typename elx::TransformBase<TElastix>::CoordRepType,
                                              elx::TransformBase<TElastix>::FixedImageDimension>

--- a/Components/Transforms/MultiBSplineTransformWithNormal/elxMultiBSplineTransformWithNormal.hxx
+++ b/Components/Transforms/MultiBSplineTransformWithNormal/elxMultiBSplineTransformWithNormal.hxx
@@ -34,7 +34,7 @@ namespace elastix
  * ************ InitializeBSplineTransform ***************
  */
 
-template <class TElastix>
+template <typename TElastix>
 unsigned int
 MultiBSplineTransformWithNormal<TElastix>::InitializeBSplineTransform()
 {
@@ -74,7 +74,7 @@ MultiBSplineTransformWithNormal<TElastix>::InitializeBSplineTransform()
  * ******************* BeforeAll ***********************
  */
 
-template <class TElastix>
+template <typename TElastix>
 int
 MultiBSplineTransformWithNormal<TElastix>::BeforeAll()
 {
@@ -104,7 +104,7 @@ MultiBSplineTransformWithNormal<TElastix>::BeforeAll()
  * ******************* BeforeRegistration ***********************
  */
 
-template <class TElastix>
+template <typename TElastix>
 void
 MultiBSplineTransformWithNormal<TElastix>::BeforeRegistration()
 {
@@ -143,7 +143,7 @@ MultiBSplineTransformWithNormal<TElastix>::BeforeRegistration()
  * ***************** BeforeEachResolution ***********************
  */
 
-template <class TElastix>
+template <typename TElastix>
 void
 MultiBSplineTransformWithNormal<TElastix>::BeforeEachResolution()
 {
@@ -168,7 +168,7 @@ MultiBSplineTransformWithNormal<TElastix>::BeforeEachResolution()
  * ******************** PreComputeGridInformation ***********************
  */
 
-template <class TElastix>
+template <typename TElastix>
 void
 MultiBSplineTransformWithNormal<TElastix>::PreComputeGridInformation()
 {
@@ -325,7 +325,7 @@ MultiBSplineTransformWithNormal<TElastix>::PreComputeGridInformation()
  * the parameters to 0.
  */
 
-template <class TElastix>
+template <typename TElastix>
 void
 MultiBSplineTransformWithNormal<TElastix>::InitializeTransform()
 {
@@ -357,7 +357,7 @@ MultiBSplineTransformWithNormal<TElastix>::InitializeTransform()
  * Upsample the grid of control points.
  */
 
-template <class TElastix>
+template <typename TElastix>
 void
 MultiBSplineTransformWithNormal<TElastix>::IncreaseScale()
 {
@@ -519,7 +519,7 @@ MultiBSplineTransformWithNormal<TElastix>::IncreaseScale()
  * ************************* ReadFromFile ************************
  */
 
-template <class TElastix>
+template <typename TElastix>
 void
 MultiBSplineTransformWithNormal<TElastix>::ReadFromFile()
 {
@@ -583,7 +583,7 @@ MultiBSplineTransformWithNormal<TElastix>::ReadFromFile()
  * ************************* CustomizeTransformParameterMap ************************
  */
 
-template <class TElastix>
+template <typename TElastix>
 auto
 MultiBSplineTransformWithNormal<TElastix>::CreateDerivedTransformParameterMap() const -> ParameterMapType
 {
@@ -607,7 +607,7 @@ MultiBSplineTransformWithNormal<TElastix>::CreateDerivedTransformParameterMap() 
  * Set the optimizer scales of the edge coefficients to infinity.
  */
 
-template <class TElastix>
+template <typename TElastix>
 void
 MultiBSplineTransformWithNormal<TElastix>::SetOptimizerScales(const unsigned int edgeWidth)
 {

--- a/Components/Transforms/MultiBSplineTransformWithNormal/itkMultiBSplineDeformableTransformWithNormal.h
+++ b/Components/Transforms/MultiBSplineTransformWithNormal/itkMultiBSplineDeformableTransformWithNormal.h
@@ -35,8 +35,8 @@ namespace itk
  * \ingroup Transforms
  */
 
-template <class TScalarType = double,   // Data type for scalars
-          unsigned int NDimensions = 3, // Number of dimensions
+template <typename TScalarType = double, // Data type for scalars
+          unsigned int NDimensions = 3,  // Number of dimensions
           unsigned int VSplineOrder = 3>
 // Spline order
 class ITK_TEMPLATE_EXPORT MultiBSplineDeformableTransformWithNormal

--- a/Components/Transforms/MultiBSplineTransformWithNormal/itkMultiBSplineDeformableTransformWithNormal.hxx
+++ b/Components/Transforms/MultiBSplineTransformWithNormal/itkMultiBSplineDeformableTransformWithNormal.hxx
@@ -36,7 +36,7 @@ namespace itk
 {
 
 // Constructor with default arguments
-template <class TScalarType, unsigned int NDimensions, unsigned int VSplineOrder>
+template <typename TScalarType, unsigned int NDimensions, unsigned int VSplineOrder>
 MultiBSplineDeformableTransformWithNormal<TScalarType, NDimensions, VSplineOrder>::
   MultiBSplineDeformableTransformWithNormal()
   : Superclass(SpaceDimension)
@@ -58,7 +58,7 @@ MultiBSplineDeformableTransformWithNormal<TScalarType, NDimensions, VSplineOrder
 
 
 // Get the number of parameters
-template <class TScalarType, unsigned int NDimensions, unsigned int VSplineOrder>
+template <typename TScalarType, unsigned int NDimensions, unsigned int VSplineOrder>
 auto
 MultiBSplineDeformableTransformWithNormal<TScalarType, NDimensions, VSplineOrder>::GetNumberOfParameters() const
   -> NumberOfParametersType
@@ -76,7 +76,7 @@ MultiBSplineDeformableTransformWithNormal<TScalarType, NDimensions, VSplineOrder
 
 // Get the number of parameters per dimension
 // FIXME :  Do we need to declare this function ?
-template <class TScalarType, unsigned int NDimensions, unsigned int VSplineOrder>
+template <typename TScalarType, unsigned int NDimensions, unsigned int VSplineOrder>
 auto
 MultiBSplineDeformableTransformWithNormal<TScalarType, NDimensions, VSplineOrder>::GetNumberOfParametersPerDimension()
   const -> NumberOfParametersType
@@ -100,7 +100,7 @@ MultiBSplineDeformableTransformWithNormal<TScalarType, NDimensions, VSplineOrder
   }
 
 #define SET_ALL_LABELS(FUNC, TYPE)                                                                                     \
-  template <class TScalarType, unsigned int NDimensions, unsigned int VSplineOrder>                                    \
+  template <typename TScalarType, unsigned int NDimensions, unsigned int VSplineOrder>                                 \
   void MultiBSplineDeformableTransformWithNormal<TScalarType, NDimensions, VSplineOrder>::Set##FUNC(const TYPE _arg)   \
   {                                                                                                                    \
     if (_arg != this->Get##FUNC())                                                                                     \
@@ -111,7 +111,7 @@ MultiBSplineDeformableTransformWithNormal<TScalarType, NDimensions, VSplineOrder
   }
 
 #define GET_FIRST_LABEL(FUNC, TYPE)                                                                                    \
-  template <class TScalarType, unsigned int NDimensions, unsigned int VSplineOrder>                                    \
+  template <typename TScalarType, unsigned int NDimensions, unsigned int VSplineOrder>                                 \
   auto MultiBSplineDeformableTransformWithNormal<TScalarType, NDimensions, VSplineOrder>::Get##FUNC() const->TYPE      \
   {                                                                                                                    \
     return m_Trans[0]->Get##FUNC();                                                                                    \
@@ -144,7 +144,7 @@ GET_FIRST_LABEL(GridOrigin, OriginType);
 #undef SET_ALL_LABELS
 #undef GET_FIRST_LABEL
 
-template <class TScalarType, unsigned int NDimensions, unsigned int VSplineOrder>
+template <typename TScalarType, unsigned int NDimensions, unsigned int VSplineOrder>
 void
 MultiBSplineDeformableTransformWithNormal<TScalarType, NDimensions, VSplineOrder>::SetLabels(ImageLabelType * labels)
 {
@@ -172,7 +172,7 @@ MultiBSplineDeformableTransformWithNormal<TScalarType, NDimensions, VSplineOrder
 }
 
 
-template <class TScalarType, unsigned int NDimensions>
+template <typename TScalarType, unsigned int NDimensions>
 struct UpdateLocalBases_impl
 {
   using VectorType = itk::Vector<TScalarType, NDimensions>;
@@ -189,7 +189,7 @@ struct UpdateLocalBases_impl
   }
 };
 
-template <class TScalarType>
+template <typename TScalarType>
 struct UpdateLocalBases_impl<TScalarType, 2>
 {
   static const unsigned NDimensions = 2;
@@ -247,7 +247,7 @@ struct UpdateLocalBases_impl<TScalarType, 2>
   }
 };
 
-template <class TScalarType>
+template <typename TScalarType>
 struct UpdateLocalBases_impl<TScalarType, 3>
 {
   static const unsigned NDimensions = 3;
@@ -339,7 +339,7 @@ struct UpdateLocalBases_impl<TScalarType, 3>
   }
 };
 
-template <class TScalarType, unsigned int NDimensions, unsigned int VSplineOrder>
+template <typename TScalarType, unsigned int NDimensions, unsigned int VSplineOrder>
 void
 MultiBSplineDeformableTransformWithNormal<TScalarType, NDimensions, VSplineOrder>::UpdateLocalBases()
 {
@@ -443,7 +443,7 @@ MultiBSplineDeformableTransformWithNormal<TScalarType, NDimensions, VSplineOrder
 
 
 // Set the parameters
-template <class TScalarType, unsigned int NDimensions, unsigned int VSplineOrder>
+template <typename TScalarType, unsigned int NDimensions, unsigned int VSplineOrder>
 void
 MultiBSplineDeformableTransformWithNormal<TScalarType, NDimensions, VSplineOrder>::SetIdentity()
 {
@@ -462,7 +462,7 @@ MultiBSplineDeformableTransformWithNormal<TScalarType, NDimensions, VSplineOrder
 }
 
 
-template <class TScalarType, unsigned int NDimensions, unsigned int VSplineOrder>
+template <typename TScalarType, unsigned int NDimensions, unsigned int VSplineOrder>
 void
 MultiBSplineDeformableTransformWithNormal<TScalarType, NDimensions, VSplineOrder>::DispatchParameters(
   const ParametersType & parameters)
@@ -510,7 +510,7 @@ MultiBSplineDeformableTransformWithNormal<TScalarType, NDimensions, VSplineOrder
 
 
 // Set the parameters
-template <class TScalarType, unsigned int NDimensions, unsigned int VSplineOrder>
+template <typename TScalarType, unsigned int NDimensions, unsigned int VSplineOrder>
 void
 MultiBSplineDeformableTransformWithNormal<TScalarType, NDimensions, VSplineOrder>::SetParameters(
   const ParametersType & parameters)
@@ -538,7 +538,7 @@ MultiBSplineDeformableTransformWithNormal<TScalarType, NDimensions, VSplineOrder
 
 
 // Set the Fixed Parameters
-template <class TScalarType, unsigned int NDimensions, unsigned int VSplineOrder>
+template <typename TScalarType, unsigned int NDimensions, unsigned int VSplineOrder>
 void
 MultiBSplineDeformableTransformWithNormal<TScalarType, NDimensions, VSplineOrder>::SetFixedParameters(
   const ParametersType & passedParameters)
@@ -549,7 +549,7 @@ MultiBSplineDeformableTransformWithNormal<TScalarType, NDimensions, VSplineOrder
 
 
 // Set the parameters by value
-template <class TScalarType, unsigned int NDimensions, unsigned int VSplineOrder>
+template <typename TScalarType, unsigned int NDimensions, unsigned int VSplineOrder>
 void
 MultiBSplineDeformableTransformWithNormal<TScalarType, NDimensions, VSplineOrder>::SetParametersByValue(
   const ParametersType & parameters)
@@ -575,7 +575,7 @@ MultiBSplineDeformableTransformWithNormal<TScalarType, NDimensions, VSplineOrder
 
 
 // Get the parameters
-template <class TScalarType, unsigned int NDimensions, unsigned int VSplineOrder>
+template <typename TScalarType, unsigned int NDimensions, unsigned int VSplineOrder>
 auto
 MultiBSplineDeformableTransformWithNormal<TScalarType, NDimensions, VSplineOrder>::GetParameters() const
   -> const ParametersType &
@@ -593,7 +593,7 @@ MultiBSplineDeformableTransformWithNormal<TScalarType, NDimensions, VSplineOrder
 }
 
 // Get the parameters
-template <class TScalarType, unsigned int NDimensions, unsigned int VSplineOrder>
+template <typename TScalarType, unsigned int NDimensions, unsigned int VSplineOrder>
 auto
 MultiBSplineDeformableTransformWithNormal<TScalarType, NDimensions, VSplineOrder>::GetFixedParameters() const
   -> const ParametersType &
@@ -602,7 +602,7 @@ MultiBSplineDeformableTransformWithNormal<TScalarType, NDimensions, VSplineOrder
 }
 
 // Print self
-template <class TScalarType, unsigned int NDimensions, unsigned int VSplineOrder>
+template <typename TScalarType, unsigned int NDimensions, unsigned int VSplineOrder>
 void
 MultiBSplineDeformableTransformWithNormal<TScalarType, NDimensions, VSplineOrder>::PrintSelf(std::ostream & os,
                                                                                              Indent indent) const
@@ -624,7 +624,7 @@ MultiBSplineDeformableTransformWithNormal<TScalarType, NDimensions, VSplineOrder
 
 #undef LOOP_ON_LABELS
 
-template <class TScalarType, unsigned int NDimensions, unsigned int VSplineOrder>
+template <typename TScalarType, unsigned int NDimensions, unsigned int VSplineOrder>
 void
 MultiBSplineDeformableTransformWithNormal<TScalarType, NDimensions, VSplineOrder>::PointToLabel(
   const InputPointType & p,
@@ -641,7 +641,7 @@ MultiBSplineDeformableTransformWithNormal<TScalarType, NDimensions, VSplineOrder
 }
 
 
-template <class TScalarType, unsigned int NDimensions, unsigned int VSplineOrder>
+template <typename TScalarType, unsigned int NDimensions, unsigned int VSplineOrder>
 auto
 MultiBSplineDeformableTransformWithNormal<TScalarType, NDimensions, VSplineOrder>::TransformPoint(
   const InputPointType & point) const -> OutputPointType
@@ -678,7 +678,7 @@ MultiBSplineDeformableTransformWithNormal<TScalarType, NDimensions, VSplineOrder
  * ********************* GetJacobian ****************************
  */
 
-template <class TScalarType, unsigned int NDimensions, unsigned int VSplineOrder>
+template <typename TScalarType, unsigned int NDimensions, unsigned int VSplineOrder>
 void
 MultiBSplineDeformableTransformWithNormal<TScalarType, NDimensions, VSplineOrder>::GetJacobian(
   const InputPointType &       inputPoint,
@@ -778,7 +778,7 @@ MultiBSplineDeformableTransformWithNormal<TScalarType, NDimensions, VSplineOrder
 } // end GetJacobian()
 
 
-template <class TScalarType, unsigned int NDimensions, unsigned int VSplineOrder>
+template <typename TScalarType, unsigned int NDimensions, unsigned int VSplineOrder>
 void
 MultiBSplineDeformableTransformWithNormal<TScalarType, NDimensions, VSplineOrder>::GetSpatialJacobian(
   const InputPointType & inputPoint,
@@ -811,7 +811,7 @@ MultiBSplineDeformableTransformWithNormal<TScalarType, NDimensions, VSplineOrder
 }
 
 
-template <class TScalarType, unsigned int NDimensions, unsigned int VSplineOrder>
+template <typename TScalarType, unsigned int NDimensions, unsigned int VSplineOrder>
 void
 MultiBSplineDeformableTransformWithNormal<TScalarType, NDimensions, VSplineOrder>::GetSpatialHessian(
   const InputPointType & inputPoint,
@@ -860,7 +860,7 @@ MultiBSplineDeformableTransformWithNormal<TScalarType, NDimensions, VSplineOrder
 }
 
 
-template <class TScalarType, unsigned int NDimensions, unsigned int VSplineOrder>
+template <typename TScalarType, unsigned int NDimensions, unsigned int VSplineOrder>
 void
 MultiBSplineDeformableTransformWithNormal<TScalarType, NDimensions, VSplineOrder>::GetJacobianOfSpatialJacobian(
   const InputPointType &,
@@ -872,7 +872,7 @@ MultiBSplineDeformableTransformWithNormal<TScalarType, NDimensions, VSplineOrder
 } // end GetJacobianOfSpatialJacobian()
 
 
-template <class TScalarType, unsigned int NDimensions, unsigned int VSplineOrder>
+template <typename TScalarType, unsigned int NDimensions, unsigned int VSplineOrder>
 void
 MultiBSplineDeformableTransformWithNormal<TScalarType, NDimensions, VSplineOrder>::GetJacobianOfSpatialJacobian(
   const InputPointType &          inputPoint,
@@ -969,7 +969,7 @@ MultiBSplineDeformableTransformWithNormal<TScalarType, NDimensions, VSplineOrder
 }
 
 
-template <class TScalarType, unsigned int NDimensions, unsigned int VSplineOrder>
+template <typename TScalarType, unsigned int NDimensions, unsigned int VSplineOrder>
 void
 MultiBSplineDeformableTransformWithNormal<TScalarType, NDimensions, VSplineOrder>::GetJacobianOfSpatialHessian(
   const InputPointType &         inputPoint,

--- a/Components/Transforms/RecursiveBSplineTransform/elxRecursiveBSplineTransform.h
+++ b/Components/Transforms/RecursiveBSplineTransform/elxRecursiveBSplineTransform.h
@@ -106,7 +106,7 @@ namespace elastix
  * \ingroup Transforms
  */
 
-template <class TElastix>
+template <typename TElastix>
 class ITK_TEMPLATE_EXPORT RecursiveBSplineTransform
   : public itk::AdvancedCombinationTransform<typename elx::TransformBase<TElastix>::CoordRepType,
                                              elx::TransformBase<TElastix>::FixedImageDimension>

--- a/Components/Transforms/RecursiveBSplineTransform/elxRecursiveBSplineTransform.hxx
+++ b/Components/Transforms/RecursiveBSplineTransform/elxRecursiveBSplineTransform.hxx
@@ -33,7 +33,7 @@ namespace elastix
  * ************ InitializeBSplineTransform ***************
  */
 
-template <class TElastix>
+template <typename TElastix>
 unsigned int
 RecursiveBSplineTransform<TElastix>::InitializeBSplineTransform()
 {
@@ -64,7 +64,7 @@ RecursiveBSplineTransform<TElastix>::InitializeBSplineTransform()
  * ******************* BeforeAll ***********************
  */
 
-template <class TElastix>
+template <typename TElastix>
 int
 RecursiveBSplineTransform<TElastix>::BeforeAll()
 {
@@ -83,7 +83,7 @@ RecursiveBSplineTransform<TElastix>::BeforeAll()
  * ******************* BeforeRegistration ***********************
  */
 
-template <class TElastix>
+template <typename TElastix>
 void
 RecursiveBSplineTransform<TElastix>::BeforeRegistration()
 {
@@ -122,7 +122,7 @@ RecursiveBSplineTransform<TElastix>::BeforeRegistration()
  * ***************** BeforeEachResolution ***********************
  */
 
-template <class TElastix>
+template <typename TElastix>
 void
 RecursiveBSplineTransform<TElastix>::BeforeEachResolution()
 {
@@ -153,7 +153,7 @@ RecursiveBSplineTransform<TElastix>::BeforeEachResolution()
  * ******************** PreComputeGridInformation ***********************
  */
 
-template <class TElastix>
+template <typename TElastix>
 void
 RecursiveBSplineTransform<TElastix>::PreComputeGridInformation()
 {
@@ -306,7 +306,7 @@ RecursiveBSplineTransform<TElastix>::PreComputeGridInformation()
  * ******************** InitializeTransform ***********************
  */
 
-template <class TElastix>
+template <typename TElastix>
 void
 RecursiveBSplineTransform<TElastix>::InitializeTransform()
 {
@@ -334,7 +334,7 @@ RecursiveBSplineTransform<TElastix>::InitializeTransform()
  * *********************** IncreaseScale ************************
  */
 
-template <class TElastix>
+template <typename TElastix>
 void
 RecursiveBSplineTransform<TElastix>::IncreaseScale()
 {
@@ -393,7 +393,7 @@ RecursiveBSplineTransform<TElastix>::IncreaseScale()
  * ************************* ReadFromFile ************************
  */
 
-template <class TElastix>
+template <typename TElastix>
 void
 RecursiveBSplineTransform<TElastix>::ReadFromFile()
 {
@@ -476,7 +476,7 @@ RecursiveBSplineTransform<TElastix>::ReadFromFile()
  * ************************* CreateDerivedTransformParameterMap ************************
  */
 
-template <class TElastix>
+template <typename TElastix>
 auto
 RecursiveBSplineTransform<TElastix>::CreateDerivedTransformParameterMap() const -> ParameterMapType
 {
@@ -497,7 +497,7 @@ RecursiveBSplineTransform<TElastix>::CreateDerivedTransformParameterMap() const 
  * *********************** SetOptimizerScales ***********************
  */
 
-template <class TElastix>
+template <typename TElastix>
 void
 RecursiveBSplineTransform<TElastix>::SetOptimizerScales(const unsigned int edgeWidth)
 {

--- a/Components/Transforms/SimilarityTransform/elxSimilarityTransform.h
+++ b/Components/Transforms/SimilarityTransform/elxSimilarityTransform.h
@@ -75,7 +75,7 @@ namespace elastix
  * \ingroup Transforms
  */
 
-template <class TElastix>
+template <typename TElastix>
 class ITK_TEMPLATE_EXPORT SimilarityTransformElastix
   : public itk::AdvancedCombinationTransform<typename elx::TransformBase<TElastix>::CoordRepType,
                                              elx::TransformBase<TElastix>::FixedImageDimension>

--- a/Components/Transforms/SimilarityTransform/elxSimilarityTransform.hxx
+++ b/Components/Transforms/SimilarityTransform/elxSimilarityTransform.hxx
@@ -29,7 +29,7 @@ namespace elastix
  * ********************* Constructor ****************************
  */
 
-template <class TElastix>
+template <typename TElastix>
 SimilarityTransformElastix<TElastix>::SimilarityTransformElastix()
 {
   this->SetCurrentTransform(this->m_SimilarityTransform);
@@ -41,7 +41,7 @@ SimilarityTransformElastix<TElastix>::SimilarityTransformElastix()
  * ******************* BeforeRegistration ***********************
  */
 
-template <class TElastix>
+template <typename TElastix>
 void
 SimilarityTransformElastix<TElastix>::BeforeRegistration()
 {
@@ -58,7 +58,7 @@ SimilarityTransformElastix<TElastix>::BeforeRegistration()
  * ************************* ReadFromFile ************************
  */
 
-template <class TElastix>
+template <typename TElastix>
 void
 SimilarityTransformElastix<TElastix>::ReadFromFile()
 {
@@ -106,7 +106,7 @@ SimilarityTransformElastix<TElastix>::ReadFromFile()
  * ************************* CreateDerivedTransformParameterMap ************************
  */
 
-template <class TElastix>
+template <typename TElastix>
 auto
 SimilarityTransformElastix<TElastix>::CreateDerivedTransformParameterMap() const -> ParameterMapType
 {
@@ -119,7 +119,7 @@ SimilarityTransformElastix<TElastix>::CreateDerivedTransformParameterMap() const
  * ************************* InitializeTransform *********************
  */
 
-template <class TElastix>
+template <typename TElastix>
 void
 SimilarityTransformElastix<TElastix>::InitializeTransform()
 {
@@ -269,7 +269,7 @@ SimilarityTransformElastix<TElastix>::InitializeTransform()
  * ************************* SetScales *********************
  */
 
-template <class TElastix>
+template <typename TElastix>
 void
 SimilarityTransformElastix<TElastix>::SetScales()
 {
@@ -330,7 +330,7 @@ SimilarityTransformElastix<TElastix>::SetScales()
  * ******************** ReadCenterOfRotationIndex *********************
  */
 
-template <class TElastix>
+template <typename TElastix>
 bool
 SimilarityTransformElastix<TElastix>::ReadCenterOfRotationIndex(InputPointType & rotationPoint) const
 {
@@ -432,7 +432,7 @@ SimilarityTransformElastix<TElastix>::ReadCenterOfRotationIndex(InputPointType &
  * ******************** ReadCenterOfRotationPoint *********************
  */
 
-template <class TElastix>
+template <typename TElastix>
 bool
 SimilarityTransformElastix<TElastix>::ReadCenterOfRotationPoint(InputPointType & rotationPoint) const
 {

--- a/Components/Transforms/SimilarityTransform/itkSimilarityTransform.h
+++ b/Components/Transforms/SimilarityTransform/itkSimilarityTransform.h
@@ -36,7 +36,7 @@ template <unsigned int Dimension>
 class ITK_TEMPLATE_EXPORT SimilarityGroup
 {
 public:
-  template <class TScalarType>
+  template <typename TScalarType>
   using TransformAlias = AdvancedMatrixOffsetTransformBase<TScalarType, Dimension, Dimension>;
 };
 
@@ -50,7 +50,7 @@ template <>
 class ITK_TEMPLATE_EXPORT SimilarityGroup<2>
 {
 public:
-  template <class TScalarType>
+  template <typename TScalarType>
   using TransformAlias = AdvancedSimilarity2DTransform<TScalarType>;
 };
 
@@ -64,7 +64,7 @@ template <>
 class ITK_TEMPLATE_EXPORT SimilarityGroup<3>
 {
 public:
-  template <class TScalarType>
+  template <typename TScalarType>
   using TransformAlias = AdvancedSimilarity3DTransform<TScalarType>;
 };
 
@@ -72,7 +72,7 @@ public:
 /**
  * This alias templates the SimilarityGroup over its dimension.
  */
-template <class TScalarType, unsigned int Dimension>
+template <typename TScalarType, unsigned int Dimension>
 using SimilarityGroupTemplate = typename SimilarityGroup<Dimension>::template TransformAlias<TScalarType>;
 
 
@@ -85,7 +85,7 @@ using SimilarityGroupTemplate = typename SimilarityGroup<Dimension>::template Tr
  * \ingroup Transforms
  */
 
-template <class TScalarType, unsigned int Dimension>
+template <typename TScalarType, unsigned int Dimension>
 class ITK_TEMPLATE_EXPORT SimilarityTransform : public SimilarityGroupTemplate<TScalarType, Dimension>
 {
 public:

--- a/Components/Transforms/SplineKernelTransform/elxSplineKernelTransform.h
+++ b/Components/Transforms/SplineKernelTransform/elxSplineKernelTransform.h
@@ -111,7 +111,7 @@ namespace elastix
  * \ingroup Transforms
  */
 
-template <class TElastix>
+template <typename TElastix>
 class ITK_TEMPLATE_EXPORT SplineKernelTransform
   : public itk::AdvancedCombinationTransform<typename elx::TransformBase<TElastix>::CoordRepType,
                                              elx::TransformBase<TElastix>::FixedImageDimension>

--- a/Components/Transforms/SplineKernelTransform/elxSplineKernelTransform.hxx
+++ b/Components/Transforms/SplineKernelTransform/elxSplineKernelTransform.hxx
@@ -31,7 +31,7 @@ namespace elastix
  * ********************* Constructor ****************************
  */
 
-template <class TElastix>
+template <typename TElastix>
 SplineKernelTransform<TElastix>::SplineKernelTransform()
 {
   this->SetKernelType("unknown");
@@ -42,7 +42,7 @@ SplineKernelTransform<TElastix>::SplineKernelTransform()
  * ******************* SetKernelType ***********************
  */
 
-template <class TElastix>
+template <typename TElastix>
 bool
 SplineKernelTransform<TElastix>::SetKernelType(const std::string & kernelType)
 {
@@ -100,7 +100,7 @@ SplineKernelTransform<TElastix>::SetKernelType(const std::string & kernelType)
  * ******************* BeforeAll ***********************
  */
 
-template <class TElastix>
+template <typename TElastix>
 int
 SplineKernelTransform<TElastix>::BeforeAll()
 {
@@ -155,7 +155,7 @@ SplineKernelTransform<TElastix>::BeforeAll()
  * ******************* BeforeRegistration ***********************
  */
 
-template <class TElastix>
+template <typename TElastix>
 void
 SplineKernelTransform<TElastix>::BeforeRegistration()
 {
@@ -212,7 +212,7 @@ SplineKernelTransform<TElastix>::BeforeRegistration()
  * ************************* DetermineSourceLandmarks *********************
  */
 
-template <class TElastix>
+template <typename TElastix>
 void
 SplineKernelTransform<TElastix>::DetermineSourceLandmarks()
 {
@@ -246,7 +246,7 @@ SplineKernelTransform<TElastix>::DetermineSourceLandmarks()
  * ************************* DetermineTargetLandmarks *********************
  */
 
-template <class TElastix>
+template <typename TElastix>
 bool
 SplineKernelTransform<TElastix>::DetermineTargetLandmarks()
 {
@@ -282,7 +282,7 @@ SplineKernelTransform<TElastix>::DetermineTargetLandmarks()
  * ************************* ReadLandmarkFile *********************
  */
 
-template <class TElastix>
+template <typename TElastix>
 void
 SplineKernelTransform<TElastix>::ReadLandmarkFile(const std::string & filename,
                                                   PointSetPointer &   landmarkPointSet,
@@ -376,7 +376,7 @@ SplineKernelTransform<TElastix>::ReadLandmarkFile(const std::string & filename,
  * ************************* ReadFromFile ************************
  */
 
-template <class TElastix>
+template <typename TElastix>
 void
 SplineKernelTransform<TElastix>::ReadFromFile()
 {
@@ -440,7 +440,7 @@ SplineKernelTransform<TElastix>::ReadFromFile()
  * ************************* CustomizeTransformParameterMap ************************
  */
 
-template <class TElastix>
+template <typename TElastix>
 auto
 SplineKernelTransform<TElastix>::CreateDerivedTransformParameterMap() const -> ParameterMapType
 {

--- a/Components/Transforms/SplineKernelTransform/itkElasticBodyReciprocalSplineKernelTransform2.h
+++ b/Components/Transforms/SplineKernelTransform/itkElasticBodyReciprocalSplineKernelTransform2.h
@@ -50,7 +50,7 @@ namespace itk
  *
  * \ingroup Transforms
  */
-template <class TScalarType = double, // Data type for scalars (float or double)
+template <typename TScalarType = double, // Data type for scalars (float or double)
           unsigned int NDimensions = 3>
 // Number of dimensions
 class ITK_TEMPLATE_EXPORT ElasticBodyReciprocalSplineKernelTransform2

--- a/Components/Transforms/SplineKernelTransform/itkElasticBodyReciprocalSplineKernelTransform2.hxx
+++ b/Components/Transforms/SplineKernelTransform/itkElasticBodyReciprocalSplineKernelTransform2.hxx
@@ -38,14 +38,14 @@
 namespace itk
 {
 
-template <class TScalarType, unsigned int NDimensions>
+template <typename TScalarType, unsigned int NDimensions>
 ElasticBodyReciprocalSplineKernelTransform2<TScalarType, NDimensions>::ElasticBodyReciprocalSplineKernelTransform2()
 {
   this->m_Alpha = 8.0 * (1.0 - .25) - 1.0;
 }
 
 
-template <class TScalarType, unsigned int NDimensions>
+template <typename TScalarType, unsigned int NDimensions>
 void
 ElasticBodyReciprocalSplineKernelTransform2<TScalarType, NDimensions>::ComputeG(const InputVectorType & x,
                                                                                 GMatrixType &           GMatrix) const
@@ -69,7 +69,7 @@ ElasticBodyReciprocalSplineKernelTransform2<TScalarType, NDimensions>::ComputeG(
 } // end ComputeG()
 
 
-template <class TScalarType, unsigned int NDimensions>
+template <typename TScalarType, unsigned int NDimensions>
 void
 ElasticBodyReciprocalSplineKernelTransform2<TScalarType, NDimensions>::PrintSelf(std::ostream & os, Indent indent) const
 {

--- a/Components/Transforms/SplineKernelTransform/itkElasticBodySplineKernelTransform2.h
+++ b/Components/Transforms/SplineKernelTransform/itkElasticBodySplineKernelTransform2.h
@@ -50,7 +50,7 @@ namespace itk
  *
  * \ingroup Transforms
  */
-template <class TScalarType = double, // Data type for scalars (float or double)
+template <typename TScalarType = double, // Data type for scalars (float or double)
           unsigned int NDimensions = 3>
 // Number of dimensions
 class ITK_TEMPLATE_EXPORT ElasticBodySplineKernelTransform2 : public KernelTransform2<TScalarType, NDimensions>

--- a/Components/Transforms/SplineKernelTransform/itkElasticBodySplineKernelTransform2.hxx
+++ b/Components/Transforms/SplineKernelTransform/itkElasticBodySplineKernelTransform2.hxx
@@ -38,14 +38,14 @@
 namespace itk
 {
 
-template <class TScalarType, unsigned int NDimensions>
+template <typename TScalarType, unsigned int NDimensions>
 ElasticBodySplineKernelTransform2<TScalarType, NDimensions>::ElasticBodySplineKernelTransform2()
 {
   this->m_Alpha = 12.0 * (1.0 - .25) - 1.0;
 }
 
 
-template <class TScalarType, unsigned int NDimensions>
+template <typename TScalarType, unsigned int NDimensions>
 void
 ElasticBodySplineKernelTransform2<TScalarType, NDimensions>::ComputeG(const InputVectorType & x,
                                                                       GMatrixType &           GMatrix) const
@@ -69,7 +69,7 @@ ElasticBodySplineKernelTransform2<TScalarType, NDimensions>::ComputeG(const Inpu
 } // end ComputeG()
 
 
-template <class TScalarType, unsigned int NDimensions>
+template <typename TScalarType, unsigned int NDimensions>
 void
 ElasticBodySplineKernelTransform2<TScalarType, NDimensions>::PrintSelf(std::ostream & os, Indent indent) const
 {

--- a/Components/Transforms/SplineKernelTransform/itkKernelTransform2.h
+++ b/Components/Transforms/SplineKernelTransform/itkKernelTransform2.h
@@ -91,7 +91,7 @@ namespace itk
  *
  */
 
-template <class TScalarType, // probably only float and double make sense here
+template <typename TScalarType, // probably only float and double make sense here
           unsigned int NDimensions>
 // Number of dimensions
 class ITK_TEMPLATE_EXPORT KernelTransform2 : public AdvancedTransform<TScalarType, NDimensions, NDimensions>

--- a/Components/Transforms/SplineKernelTransform/itkKernelTransform2.hxx
+++ b/Components/Transforms/SplineKernelTransform/itkKernelTransform2.hxx
@@ -45,7 +45,7 @@ namespace itk
  * ******************* Constructor *******************
  */
 
-template <class TScalarType, unsigned int NDimensions>
+template <typename TScalarType, unsigned int NDimensions>
 KernelTransform2<TScalarType, NDimensions>::KernelTransform2()
   : Superclass(NDimensions)
 // the 0 is provided as
@@ -83,7 +83,7 @@ KernelTransform2<TScalarType, NDimensions>::KernelTransform2()
  * ******************* Destructor *******************
  */
 
-template <class TScalarType, unsigned int NDimensions>
+template <typename TScalarType, unsigned int NDimensions>
 KernelTransform2<TScalarType, NDimensions>::~KernelTransform2()
 {
   delete m_LMatrixDecompositionSVD;
@@ -96,7 +96,7 @@ KernelTransform2<TScalarType, NDimensions>::~KernelTransform2()
  * ******************* SetSourceLandmarks *******************
  */
 
-template <class TScalarType, unsigned int NDimensions>
+template <typename TScalarType, unsigned int NDimensions>
 void
 KernelTransform2<TScalarType, NDimensions>::SetSourceLandmarks(PointSetType * landmarks)
 {
@@ -129,7 +129,7 @@ KernelTransform2<TScalarType, NDimensions>::SetSourceLandmarks(PointSetType * la
  * ******************* SetTargetLandmarks *******************
  */
 
-template <class TScalarType, unsigned int NDimensions>
+template <typename TScalarType, unsigned int NDimensions>
 void
 KernelTransform2<TScalarType, NDimensions>::SetTargetLandmarks(PointSetType * landmarks)
 {
@@ -152,7 +152,7 @@ KernelTransform2<TScalarType, NDimensions>::SetTargetLandmarks(PointSetType * la
  * **************** ComputeG ***********************************
  */
 
-template <class TScalarType, unsigned int NDimensions>
+template <typename TScalarType, unsigned int NDimensions>
 void
 KernelTransform2<TScalarType, NDimensions>::ComputeG(const InputVectorType &, GMatrixType &) const
 {
@@ -164,7 +164,7 @@ KernelTransform2<TScalarType, NDimensions>::ComputeG(const InputVectorType &, GM
  * ******************* ComputeReflexiveG *******************
  */
 
-template <class TScalarType, unsigned int NDimensions>
+template <typename TScalarType, unsigned int NDimensions>
 void
 KernelTransform2<TScalarType, NDimensions>::ComputeReflexiveG(PointsIterator, GMatrixType & GMatrix) const
 {
@@ -181,7 +181,7 @@ KernelTransform2<TScalarType, NDimensions>::ComputeReflexiveG(PointsIterator, GM
  * in transforms whose kernel produce diagonal G matrices.
  */
 
-template <class TScalarType, unsigned int NDimensions>
+template <typename TScalarType, unsigned int NDimensions>
 void
 KernelTransform2<TScalarType, NDimensions>::ComputeDeformationContribution(const InputPointType & thisPoint,
                                                                            OutputPointType &      opp) const
@@ -211,7 +211,7 @@ KernelTransform2<TScalarType, NDimensions>::ComputeDeformationContribution(const
  * ******************* ComputeD *******************
  */
 
-template <class TScalarType, unsigned int NDimensions>
+template <typename TScalarType, unsigned int NDimensions>
 void
 KernelTransform2<TScalarType, NDimensions>::ComputeD()
 {
@@ -238,7 +238,7 @@ KernelTransform2<TScalarType, NDimensions>::ComputeD()
  * ******************* ComputeWMatrix *******************
  */
 
-template <class TScalarType, unsigned int NDimensions>
+template <typename TScalarType, unsigned int NDimensions>
 void
 KernelTransform2<TScalarType, NDimensions>::ComputeWMatrix()
 {
@@ -296,7 +296,7 @@ KernelTransform2<TScalarType, NDimensions>::ComputeWMatrix()
  * ******************* ComputeLInverse *******************
  */
 
-template <class TScalarType, unsigned int NDimensions>
+template <typename TScalarType, unsigned int NDimensions>
 void
 KernelTransform2<TScalarType, NDimensions>::ComputeLInverse()
 {
@@ -328,7 +328,7 @@ KernelTransform2<TScalarType, NDimensions>::ComputeLInverse()
  * ******************* ComputeL *******************
  */
 
-template <class TScalarType, unsigned int NDimensions>
+template <typename TScalarType, unsigned int NDimensions>
 void
 KernelTransform2<TScalarType, NDimensions>::ComputeL()
 {
@@ -355,7 +355,7 @@ KernelTransform2<TScalarType, NDimensions>::ComputeL()
  * ******************* ComputeK *******************
  */
 
-template <class TScalarType, unsigned int NDimensions>
+template <typename TScalarType, unsigned int NDimensions>
 void
 KernelTransform2<TScalarType, NDimensions>::ComputeK()
 {
@@ -406,7 +406,7 @@ KernelTransform2<TScalarType, NDimensions>::ComputeK()
  * ******************* ComputeP *******************
  */
 
-template <class TScalarType, unsigned int NDimensions>
+template <typename TScalarType, unsigned int NDimensions>
 void
 KernelTransform2<TScalarType, NDimensions>::ComputeP()
 {
@@ -440,7 +440,7 @@ KernelTransform2<TScalarType, NDimensions>::ComputeP()
  * ******************* ComputeY *******************
  */
 
-template <class TScalarType, unsigned int NDimensions>
+template <typename TScalarType, unsigned int NDimensions>
 void
 KernelTransform2<TScalarType, NDimensions>::ComputeY()
 {
@@ -474,7 +474,7 @@ KernelTransform2<TScalarType, NDimensions>::ComputeY()
  * ******************* ReorganizeW *******************
  */
 
-template <class TScalarType, unsigned int NDimensions>
+template <typename TScalarType, unsigned int NDimensions>
 void
 KernelTransform2<TScalarType, NDimensions>::ReorganizeW()
 {
@@ -518,7 +518,7 @@ KernelTransform2<TScalarType, NDimensions>::ReorganizeW()
  * ******************* TransformPoint *******************
  */
 
-template <class TScalarType, unsigned int NDimensions>
+template <typename TScalarType, unsigned int NDimensions>
 auto
 KernelTransform2<TScalarType, NDimensions>::TransformPoint(const InputPointType & thisPoint) const -> OutputPointType
 {
@@ -553,7 +553,7 @@ KernelTransform2<TScalarType, NDimensions>::TransformPoint(const InputPointType 
  * and target landmarks the same.
  */
 
-template <class TScalarType, unsigned int NDimensions>
+template <typename TScalarType, unsigned int NDimensions>
 void
 KernelTransform2<TScalarType, NDimensions>::SetIdentity()
 {
@@ -571,7 +571,7 @@ KernelTransform2<TScalarType, NDimensions>::SetIdentity()
  * registration.
  */
 
-template <class TScalarType, unsigned int NDimensions>
+template <typename TScalarType, unsigned int NDimensions>
 void
 KernelTransform2<TScalarType, NDimensions>::SetParameters(const ParametersType & parameters)
 {
@@ -617,7 +617,7 @@ KernelTransform2<TScalarType, NDimensions>::SetParameters(const ParametersType &
  * I/O mechanism to be supported.
  */
 
-template <class TScalarType, unsigned int NDimensions>
+template <typename TScalarType, unsigned int NDimensions>
 void
 KernelTransform2<TScalarType, NDimensions>::SetFixedParameters(const ParametersType & parameters)
 {
@@ -659,7 +659,7 @@ KernelTransform2<TScalarType, NDimensions>::SetFixedParameters(const ParametersT
  * ******************* UpdateParameters *******************
  */
 
-template <class TScalarType, unsigned int NDimensions>
+template <typename TScalarType, unsigned int NDimensions>
 void
 KernelTransform2<TScalarType, NDimensions>::UpdateParameters()
 {
@@ -687,7 +687,7 @@ KernelTransform2<TScalarType, NDimensions>::UpdateParameters()
  * ******************* GetParameters *******************
  */
 
-template <class TScalarType, unsigned int NDimensions>
+template <typename TScalarType, unsigned int NDimensions>
 auto
 KernelTransform2<TScalarType, NDimensions>::GetParameters() const -> const ParametersType &
 {
@@ -698,7 +698,7 @@ KernelTransform2<TScalarType, NDimensions>::GetParameters() const -> const Param
  * ******************* GetFixedParameters *******************
  */
 
-template <class TScalarType, unsigned int NDimensions>
+template <typename TScalarType, unsigned int NDimensions>
 auto
 KernelTransform2<TScalarType, NDimensions>::GetFixedParameters() const -> const ParametersType &
 {
@@ -726,7 +726,7 @@ KernelTransform2<TScalarType, NDimensions>::GetFixedParameters() const -> const 
  * ********************* GetJacobian ****************************
  */
 
-template <class TScalarType, unsigned int NDimensions>
+template <typename TScalarType, unsigned int NDimensions>
 void
 KernelTransform2<TScalarType, NDimensions>::GetJacobian(const InputPointType &       p,
                                                         JacobianType &               jac,
@@ -870,7 +870,7 @@ KernelTransform2<TScalarType, NDimensions>::GetJacobian(const InputPointType &  
  * ******************* PrintSelf *******************
  */
 
-template <class TScalarType, unsigned int NDimensions>
+template <typename TScalarType, unsigned int NDimensions>
 void
 KernelTransform2<TScalarType, NDimensions>::PrintSelf(std::ostream & os, Indent indent) const
 {

--- a/Components/Transforms/SplineKernelTransform/itkThinPlateR2LogRSplineKernelTransform2.h
+++ b/Components/Transforms/SplineKernelTransform/itkThinPlateR2LogRSplineKernelTransform2.h
@@ -47,7 +47,7 @@ namespace itk
  *
  * \ingroup Transforms
  */
-template <class TScalarType, // Data type for scalars (float or double)
+template <typename TScalarType, // Data type for scalars (float or double)
           unsigned int NDimensions = 3>
 // Number of dimensions
 class ITK_TEMPLATE_EXPORT ThinPlateR2LogRSplineKernelTransform2 : public KernelTransform2<TScalarType, NDimensions>

--- a/Components/Transforms/SplineKernelTransform/itkThinPlateR2LogRSplineKernelTransform2.hxx
+++ b/Components/Transforms/SplineKernelTransform/itkThinPlateR2LogRSplineKernelTransform2.hxx
@@ -38,7 +38,7 @@
 namespace itk
 {
 
-template <class TScalarType, unsigned int NDimensions>
+template <typename TScalarType, unsigned int NDimensions>
 void
 ThinPlateR2LogRSplineKernelTransform2<TScalarType, NDimensions>::ComputeG(const InputVectorType & x,
                                                                           GMatrixType &           GMatrix) const
@@ -51,7 +51,7 @@ ThinPlateR2LogRSplineKernelTransform2<TScalarType, NDimensions>::ComputeG(const 
 }
 
 
-template <class TScalarType, unsigned int NDimensions>
+template <typename TScalarType, unsigned int NDimensions>
 void
 ThinPlateR2LogRSplineKernelTransform2<TScalarType, NDimensions>::ComputeDeformationContribution(
   const InputPointType & thisPoint,

--- a/Components/Transforms/SplineKernelTransform/itkThinPlateSplineKernelTransform2.h
+++ b/Components/Transforms/SplineKernelTransform/itkThinPlateSplineKernelTransform2.h
@@ -45,7 +45,7 @@ namespace itk
  *
  * \ingroup Transforms
  */
-template <class TScalarType, // Data type for scalars (float or double)
+template <typename TScalarType, // Data type for scalars (float or double)
           unsigned int NDimensions = 3>
 // Number of dimensions
 class ITK_TEMPLATE_EXPORT ThinPlateSplineKernelTransform2 : public KernelTransform2<TScalarType, NDimensions>

--- a/Components/Transforms/SplineKernelTransform/itkThinPlateSplineKernelTransform2.hxx
+++ b/Components/Transforms/SplineKernelTransform/itkThinPlateSplineKernelTransform2.hxx
@@ -42,7 +42,7 @@ namespace itk
  * ******************* Constructor *******************
  */
 
-template <class TScalarType, unsigned int NDimensions>
+template <typename TScalarType, unsigned int NDimensions>
 void
 ThinPlateSplineKernelTransform2<TScalarType, NDimensions>::ComputeG(const InputVectorType & x,
                                                                     GMatrixType &           GMatrix) const
@@ -58,7 +58,7 @@ ThinPlateSplineKernelTransform2<TScalarType, NDimensions>::ComputeG(const InputV
  * ******************* ComputeDeformationContribution *******************
  */
 
-template <class TScalarType, unsigned int NDimensions>
+template <typename TScalarType, unsigned int NDimensions>
 void
 ThinPlateSplineKernelTransform2<TScalarType, NDimensions>::ComputeDeformationContribution(
   const InputPointType & thisPoint,

--- a/Components/Transforms/SplineKernelTransform/itkVolumeSplineKernelTransform2.h
+++ b/Components/Transforms/SplineKernelTransform/itkVolumeSplineKernelTransform2.h
@@ -45,7 +45,7 @@ namespace itk
  *
  * \ingroup Transforms
  */
-template <class TScalarType, // Data type for scalars (float or double)
+template <typename TScalarType, // Data type for scalars (float or double)
           unsigned int NDimensions = 3>
 // Number of dimensions
 class ITK_TEMPLATE_EXPORT VolumeSplineKernelTransform2 : public KernelTransform2<TScalarType, NDimensions>

--- a/Components/Transforms/SplineKernelTransform/itkVolumeSplineKernelTransform2.hxx
+++ b/Components/Transforms/SplineKernelTransform/itkVolumeSplineKernelTransform2.hxx
@@ -38,7 +38,7 @@
 namespace itk
 {
 
-template <class TScalarType, unsigned int NDimensions>
+template <typename TScalarType, unsigned int NDimensions>
 void
 VolumeSplineKernelTransform2<TScalarType, NDimensions>::ComputeG(const InputVectorType & x, GMatrixType & GMatrix) const
 {
@@ -54,7 +54,7 @@ VolumeSplineKernelTransform2<TScalarType, NDimensions>::ComputeG(const InputVect
 } // end ComputeG()
 
 
-template <class TScalarType, unsigned int NDimensions>
+template <typename TScalarType, unsigned int NDimensions>
 void
 VolumeSplineKernelTransform2<TScalarType, NDimensions>::ComputeDeformationContribution(const InputPointType & thisPoint,
                                                                                        OutputPointType &      opp) const

--- a/Components/Transforms/TranslationStackTransform/elxTranslationStackTransform.h
+++ b/Components/Transforms/TranslationStackTransform/elxTranslationStackTransform.h
@@ -53,7 +53,7 @@
 
 namespace elastix
 {
-template <class TElastix>
+template <typename TElastix>
 class ITK_TEMPLATE_EXPORT TranslationStackTransform
   : public itk::AdvancedCombinationTransform<typename elx::TransformBase<TElastix>::CoordRepType,
                                              elx::TransformBase<TElastix>::FixedImageDimension>

--- a/Components/Transforms/TranslationStackTransform/elxTranslationStackTransform.hxx
+++ b/Components/Transforms/TranslationStackTransform/elxTranslationStackTransform.hxx
@@ -31,7 +31,7 @@ namespace elastix
  * ******************* InitializeTranslationTransform ***********************
  */
 
-template <class TElastix>
+template <typename TElastix>
 unsigned int
 TranslationStackTransform<TElastix>::InitializeTranslationTransform()
 {
@@ -46,7 +46,7 @@ TranslationStackTransform<TElastix>::InitializeTranslationTransform()
  * ******************* BeforeAll ***********************
  */
 
-template <class TElastix>
+template <typename TElastix>
 int
 TranslationStackTransform<TElastix>::BeforeAll()
 {
@@ -61,7 +61,7 @@ TranslationStackTransform<TElastix>::BeforeAll()
  * ******************* BeforeRegistration ***********************
  */
 
-template <class TElastix>
+template <typename TElastix>
 void
 TranslationStackTransform<TElastix>::BeforeRegistration()
 {
@@ -94,7 +94,7 @@ TranslationStackTransform<TElastix>::BeforeRegistration()
  * ********************* InitializeTransform ****************************
  */
 
-template <class TElastix>
+template <typename TElastix>
 void
 TranslationStackTransform<TElastix>::InitializeTransform()
 {
@@ -117,7 +117,7 @@ TranslationStackTransform<TElastix>::InitializeTransform()
  * ************************* ReadFromFile ************************
  */
 
-template <class TElastix>
+template <typename TElastix>
 void
 TranslationStackTransform<TElastix>::ReadFromFile()
 {
@@ -154,7 +154,7 @@ TranslationStackTransform<TElastix>::ReadFromFile()
  * ************************* CustomizeTransformParameterMap ************************
  */
 
-template <class TElastix>
+template <typename TElastix>
 auto
 TranslationStackTransform<TElastix>::CreateDerivedTransformParameterMap() const -> ParameterMapType
 {

--- a/Components/Transforms/TranslationTransform/elxTranslationTransform.h
+++ b/Components/Transforms/TranslationTransform/elxTranslationTransform.h
@@ -46,7 +46,7 @@ namespace elastix
  * \ingroup Transforms
  */
 
-template <class TElastix>
+template <typename TElastix>
 class ITK_TEMPLATE_EXPORT TranslationTransformElastix
   : public itk::AdvancedCombinationTransform<typename elx::TransformBase<TElastix>::CoordRepType,
                                              elx::TransformBase<TElastix>::FixedImageDimension>

--- a/Components/Transforms/TranslationTransform/elxTranslationTransform.hxx
+++ b/Components/Transforms/TranslationTransform/elxTranslationTransform.hxx
@@ -27,7 +27,7 @@ namespace elastix
  * ********************* Constructor ****************************
  */
 
-template <class TElastix>
+template <typename TElastix>
 TranslationTransformElastix<TElastix>::TranslationTransformElastix()
 {
   this->SetCurrentTransform(this->m_TranslationTransform);
@@ -38,7 +38,7 @@ TranslationTransformElastix<TElastix>::TranslationTransformElastix()
  * ******************* BeforeRegistration ***********************
  */
 
-template <class TElastix>
+template <typename TElastix>
 void
 TranslationTransformElastix<TElastix>::BeforeRegistration()
 {
@@ -51,7 +51,7 @@ TranslationTransformElastix<TElastix>::BeforeRegistration()
  * ************************* InitializeTransform *********************
  */
 
-template <class TElastix>
+template <typename TElastix>
 void
 TranslationTransformElastix<TElastix>::InitializeTransform()
 {
@@ -107,7 +107,7 @@ TranslationTransformElastix<TElastix>::InitializeTransform()
  * ************************* CustomizeTransformParameterMap ************************
  */
 
-template <class TElastix>
+template <typename TElastix>
 auto
 TranslationTransformElastix<TElastix>::CreateDerivedTransformParameterMap() const -> ParameterMapType
 {

--- a/Components/Transforms/TranslationTransform/itkTranslationTransformInitializer.h
+++ b/Components/Transforms/TranslationTransform/itkTranslationTransformInitializer.h
@@ -57,7 +57,7 @@ namespace itk
  *
  * \ingroup Transforms
  */
-template <class TTransform, class TFixedImage, class TMovingImage>
+template <typename TTransform, typename TFixedImage, typename TMovingImage>
 class ITK_TEMPLATE_EXPORT TranslationTransformInitializer : public Object
 {
 public:

--- a/Components/Transforms/TranslationTransform/itkTranslationTransformInitializer.hxx
+++ b/Components/Transforms/TranslationTransform/itkTranslationTransformInitializer.hxx
@@ -29,7 +29,7 @@ namespace itk
  * ************************* Constructor *********************
  */
 
-template <class TTransform, class TFixedImage, class TMovingImage>
+template <typename TTransform, typename TFixedImage, typename TMovingImage>
 TranslationTransformInitializer<TTransform, TFixedImage, TMovingImage>::TranslationTransformInitializer()
 {
   this->m_FixedCalculator = FixedImageCalculatorType::New();
@@ -41,7 +41,7 @@ TranslationTransformInitializer<TTransform, TFixedImage, TMovingImage>::Translat
  * ************************* InitializeTransform *********************
  */
 
-template <class TTransform, class TFixedImage, class TMovingImage>
+template <typename TTransform, typename TFixedImage, typename TMovingImage>
 void
 TranslationTransformInitializer<TTransform, TFixedImage, TMovingImage>::InitializeTransform() const
 {
@@ -168,7 +168,7 @@ TranslationTransformInitializer<TTransform, TFixedImage, TMovingImage>::Initiali
  * ************************* PrintSelf *********************
  */
 
-template <class TTransform, class TFixedImage, class TMovingImage>
+template <typename TTransform, typename TFixedImage, typename TMovingImage>
 void
 TranslationTransformInitializer<TTransform, TFixedImage, TMovingImage>::PrintSelf(std::ostream & os,
                                                                                   Indent         indent) const

--- a/Components/Transforms/WeightedCombinationTransform/elxWeightedCombinationTransform.h
+++ b/Components/Transforms/WeightedCombinationTransform/elxWeightedCombinationTransform.h
@@ -78,7 +78,7 @@ namespace elastix
  * \sa WeightedCombinationTransform
  */
 
-template <class TElastix>
+template <typename TElastix>
 class ITK_TEMPLATE_EXPORT WeightedCombinationTransformElastix
   : public itk::AdvancedCombinationTransform<typename elx::TransformBase<TElastix>::CoordRepType,
                                              elx::TransformBase<TElastix>::FixedImageDimension>

--- a/Components/Transforms/WeightedCombinationTransform/elxWeightedCombinationTransform.hxx
+++ b/Components/Transforms/WeightedCombinationTransform/elxWeightedCombinationTransform.hxx
@@ -28,7 +28,7 @@ namespace elastix
  * ********************* Constructor ****************************
  */
 
-template <class TElastix>
+template <typename TElastix>
 WeightedCombinationTransformElastix<TElastix>::WeightedCombinationTransformElastix()
 {
   this->SetCurrentTransform(this->m_WeightedCombinationTransform);
@@ -39,7 +39,7 @@ WeightedCombinationTransformElastix<TElastix>::WeightedCombinationTransformElast
  * ******************* BeforeRegistration ***********************
  */
 
-template <class TElastix>
+template <typename TElastix>
 void
 WeightedCombinationTransformElastix<TElastix>::BeforeRegistration()
 {
@@ -63,7 +63,7 @@ WeightedCombinationTransformElastix<TElastix>::BeforeRegistration()
  * Initialize transform to prepare it for registration.
  */
 
-template <class TElastix>
+template <typename TElastix>
 void
 WeightedCombinationTransformElastix<TElastix>::InitializeTransform()
 {
@@ -96,7 +96,7 @@ WeightedCombinationTransformElastix<TElastix>::InitializeTransform()
  * ************************* ReadFromFile ************************
  */
 
-template <class TElastix>
+template <typename TElastix>
 void
 WeightedCombinationTransformElastix<TElastix>::ReadFromFile()
 {
@@ -118,7 +118,7 @@ WeightedCombinationTransformElastix<TElastix>::ReadFromFile()
  * ************************* CustomizeTransformParameterMap ************************
  */
 
-template <class TElastix>
+template <typename TElastix>
 auto
 WeightedCombinationTransformElastix<TElastix>::CreateDerivedTransformParameterMap() const -> ParameterMapType
 {
@@ -134,7 +134,7 @@ WeightedCombinationTransformElastix<TElastix>::CreateDerivedTransformParameterMa
  * ************************* SetScales *********************
  */
 
-template <class TElastix>
+template <typename TElastix>
 void
 WeightedCombinationTransformElastix<TElastix>::SetScales()
 {
@@ -188,7 +188,7 @@ WeightedCombinationTransformElastix<TElastix>::SetScales()
  * ************************* LoadSubTransforms *********************
  */
 
-template <class TElastix>
+template <typename TElastix>
 void
 WeightedCombinationTransformElastix<TElastix>::LoadSubTransforms()
 {

--- a/Components/Transforms/WeightedCombinationTransform/itkWeightedCombinationTransform.h
+++ b/Components/Transforms/WeightedCombinationTransform/itkWeightedCombinationTransform.h
@@ -38,7 +38,7 @@ namespace itk
  * \ingroup Transforms
  *
  */
-template <class TScalarType, unsigned int NInputDimensions = 3, unsigned int NOutputDimensions = 3>
+template <typename TScalarType, unsigned int NInputDimensions = 3, unsigned int NOutputDimensions = 3>
 class ITK_TEMPLATE_EXPORT WeightedCombinationTransform
   : public AdvancedTransform<TScalarType, NInputDimensions, NOutputDimensions>
 {

--- a/Components/Transforms/WeightedCombinationTransform/itkWeightedCombinationTransform.hxx
+++ b/Components/Transforms/WeightedCombinationTransform/itkWeightedCombinationTransform.hxx
@@ -29,7 +29,7 @@ namespace itk
  * ********************* Constructor ****************************
  */
 
-template <class TScalarType, unsigned int NInputDimensions, unsigned int NOutputDimensions>
+template <typename TScalarType, unsigned int NInputDimensions, unsigned int NOutputDimensions>
 WeightedCombinationTransform<TScalarType, NInputDimensions, NOutputDimensions>::WeightedCombinationTransform()
   : Superclass(OutputSpaceDimension)
 {
@@ -44,7 +44,7 @@ WeightedCombinationTransform<TScalarType, NInputDimensions, NOutputDimensions>::
  * ************************ SetParameters ***********************
  */
 
-template <class TScalarType, unsigned int NInputDimensions, unsigned int NOutputDimensions>
+template <typename TScalarType, unsigned int NInputDimensions, unsigned int NOutputDimensions>
 void
 WeightedCombinationTransform<TScalarType, NInputDimensions, NOutputDimensions>::SetParameters(
   const ParametersType & param)
@@ -79,7 +79,7 @@ WeightedCombinationTransform<TScalarType, NInputDimensions, NOutputDimensions>::
  * ********************* TransformPoint ****************************
  */
 
-template <class TScalarType, unsigned int NInputDimensions, unsigned int NOutputDimensions>
+template <typename TScalarType, unsigned int NInputDimensions, unsigned int NOutputDimensions>
 auto
 WeightedCombinationTransform<TScalarType, NInputDimensions, NOutputDimensions>::TransformPoint(
   const InputPointType & inputPoint) const -> OutputPointType
@@ -127,7 +127,7 @@ WeightedCombinationTransform<TScalarType, NInputDimensions, NOutputDimensions>::
  * ********************* GetJacobian ****************************
  */
 
-template <class TScalarType, unsigned int NInputDimensions, unsigned int NOutputDimensions>
+template <typename TScalarType, unsigned int NInputDimensions, unsigned int NOutputDimensions>
 void
 WeightedCombinationTransform<TScalarType, NInputDimensions, NOutputDimensions>::GetJacobian(
   const InputPointType &       inputPoint,

--- a/Components/elxGenericPyramidHelper.h
+++ b/Components/elxGenericPyramidHelper.h
@@ -26,10 +26,10 @@
 
 namespace elastix
 {
-template <class TElastix>
+template <typename TElastix>
 class FixedGenericPyramid;
 
-template <class TElastix>
+template <typename TElastix>
 class MovingGenericPyramid;
 
 /** Internal helper class for FixedGenericPyramid and MovingGenericPyramid. */

--- a/Core/ComponentBaseClasses/elxFixedImagePyramidBase.h
+++ b/Core/ComponentBaseClasses/elxFixedImagePyramidBase.h
@@ -54,7 +54,7 @@ namespace elastix
  * \ingroup ComponentBaseClasses
  */
 
-template <class TElastix>
+template <typename TElastix>
 class ITK_TEMPLATE_EXPORT FixedImagePyramidBase : public BaseComponentSE<TElastix>
 {
 public:

--- a/Core/ComponentBaseClasses/elxFixedImagePyramidBase.hxx
+++ b/Core/ComponentBaseClasses/elxFixedImagePyramidBase.hxx
@@ -29,7 +29,7 @@ namespace elastix
  * ******************* BeforeRegistrationBase *******************
  */
 
-template <class TElastix>
+template <typename TElastix>
 void
 FixedImagePyramidBase<TElastix>::BeforeRegistrationBase()
 {
@@ -43,7 +43,7 @@ FixedImagePyramidBase<TElastix>::BeforeRegistrationBase()
  * ******************* BeforeEachResolutionBase *******************
  */
 
-template <class TElastix>
+template <typename TElastix>
 void
 FixedImagePyramidBase<TElastix>::BeforeEachResolutionBase()
 {
@@ -91,7 +91,7 @@ FixedImagePyramidBase<TElastix>::BeforeEachResolutionBase()
  * ********************** SetFixedSchedule **********************
  */
 
-template <class TElastix>
+template <typename TElastix>
 void
 FixedImagePyramidBase<TElastix>::SetFixedSchedule()
 {
@@ -153,7 +153,7 @@ FixedImagePyramidBase<TElastix>::SetFixedSchedule()
  * ******************* WritePyramidImage ********************
  */
 
-template <class TElastix>
+template <typename TElastix>
 void
 FixedImagePyramidBase<TElastix>::WritePyramidImage(const std::string & filename,
                                                    const unsigned int  level) // const

--- a/Core/ComponentBaseClasses/elxImageSamplerBase.h
+++ b/Core/ComponentBaseClasses/elxImageSamplerBase.h
@@ -47,7 +47,7 @@ namespace elastix
  * \ingroup ComponentBaseClasses
  */
 
-template <class TElastix>
+template <typename TElastix>
 class ITK_TEMPLATE_EXPORT ImageSamplerBase : public BaseComponentSE<TElastix>
 {
 public:

--- a/Core/ComponentBaseClasses/elxImageSamplerBase.hxx
+++ b/Core/ComponentBaseClasses/elxImageSamplerBase.hxx
@@ -29,7 +29,7 @@ namespace elastix
  * ******************* BeforeRegistrationBase ******************
  */
 
-template <class TElastix>
+template <typename TElastix>
 void
 ImageSamplerBase<TElastix>::BeforeRegistrationBase()
 {
@@ -42,7 +42,7 @@ ImageSamplerBase<TElastix>::BeforeRegistrationBase()
  * ******************* BeforeEachResolutionBase ******************
  */
 
-template <class TElastix>
+template <typename TElastix>
 void
 ImageSamplerBase<TElastix>::BeforeEachResolutionBase()
 {

--- a/Core/ComponentBaseClasses/elxInterpolatorBase.h
+++ b/Core/ComponentBaseClasses/elxInterpolatorBase.h
@@ -40,7 +40,7 @@ namespace elastix
  * \ingroup ComponentBaseClasses
  */
 
-template <class TElastix>
+template <typename TElastix>
 class ITK_TEMPLATE_EXPORT InterpolatorBase : public BaseComponentSE<TElastix>
 {
 public:

--- a/Core/ComponentBaseClasses/elxMetricBase.h
+++ b/Core/ComponentBaseClasses/elxMetricBase.h
@@ -68,7 +68,7 @@ namespace elastix
  * \ingroup ComponentBaseClasses
  */
 
-template <class TElastix>
+template <typename TElastix>
 class ITK_TEMPLATE_EXPORT MetricBase : public BaseComponentSE<TElastix>
 {
 public:

--- a/Core/ComponentBaseClasses/elxMetricBase.hxx
+++ b/Core/ComponentBaseClasses/elxMetricBase.hxx
@@ -27,7 +27,7 @@ namespace elastix
  * ******************* BeforeEachResolutionBase ******************
  */
 
-template <class TElastix>
+template <typename TElastix>
 void
 MetricBase<TElastix>::BeforeEachResolutionBase()
 {
@@ -158,7 +158,7 @@ MetricBase<TElastix>::BeforeEachResolutionBase()
  * ******************* AfterEachIterationBase ******************
  */
 
-template <class TElastix>
+template <typename TElastix>
 void
 MetricBase<TElastix>::AfterEachIterationBase()
 {
@@ -185,7 +185,7 @@ MetricBase<TElastix>::AfterEachIterationBase()
  * ********************* SelectNewSamples ************************
  */
 
-template <class TElastix>
+template <typename TElastix>
 void
 MetricBase<TElastix>::SelectNewSamples()
 {
@@ -211,7 +211,7 @@ MetricBase<TElastix>::SelectNewSamples()
  * ********************* GetExactValue ************************
  */
 
-template <class TElastix>
+template <typename TElastix>
 auto
 MetricBase<TElastix>::GetExactValue(const ParametersType & parameters) -> MeasureType
 {
@@ -266,7 +266,7 @@ MetricBase<TElastix>::GetExactValue(const ParametersType & parameters) -> Measur
  * ******************* GetAdvancedMetricUseImageSampler ********************
  */
 
-template <class TElastix>
+template <typename TElastix>
 bool
 MetricBase<TElastix>::GetAdvancedMetricUseImageSampler() const
 {
@@ -288,7 +288,7 @@ MetricBase<TElastix>::GetAdvancedMetricUseImageSampler() const
  * ******************* SetAdvancedMetricImageSampler ********************
  */
 
-template <class TElastix>
+template <typename TElastix>
 void
 MetricBase<TElastix>::SetAdvancedMetricImageSampler(ImageSamplerBaseType * sampler)
 {
@@ -317,7 +317,7 @@ MetricBase<TElastix>::SetAdvancedMetricImageSampler(ImageSamplerBaseType * sampl
  * ******************* GetAdvancedMetricImageSampler ********************
  */
 
-template <class TElastix>
+template <typename TElastix>
 auto
 MetricBase<TElastix>::GetAdvancedMetricImageSampler() const -> ImageSamplerBaseType *
 {

--- a/Core/ComponentBaseClasses/elxMovingImagePyramidBase.h
+++ b/Core/ComponentBaseClasses/elxMovingImagePyramidBase.h
@@ -56,7 +56,7 @@ namespace elastix
  * \ingroup ComponentBaseClasses
  */
 
-template <class TElastix>
+template <typename TElastix>
 class ITK_TEMPLATE_EXPORT MovingImagePyramidBase : public BaseComponentSE<TElastix>
 {
 public:

--- a/Core/ComponentBaseClasses/elxMovingImagePyramidBase.hxx
+++ b/Core/ComponentBaseClasses/elxMovingImagePyramidBase.hxx
@@ -30,7 +30,7 @@ namespace elastix
  * ******************* BeforeRegistrationBase *******************
  */
 
-template <class TElastix>
+template <typename TElastix>
 void
 MovingImagePyramidBase<TElastix>::BeforeRegistrationBase()
 {
@@ -44,7 +44,7 @@ MovingImagePyramidBase<TElastix>::BeforeRegistrationBase()
  * ******************* BeforeEachResolutionBase *******************
  */
 
-template <class TElastix>
+template <typename TElastix>
 void
 MovingImagePyramidBase<TElastix>::BeforeEachResolutionBase()
 {
@@ -92,7 +92,7 @@ MovingImagePyramidBase<TElastix>::BeforeEachResolutionBase()
  * ********************** SetMovingSchedule **********************
  */
 
-template <class TElastix>
+template <typename TElastix>
 void
 MovingImagePyramidBase<TElastix>::SetMovingSchedule()
 {
@@ -154,7 +154,7 @@ MovingImagePyramidBase<TElastix>::SetMovingSchedule()
  * ******************* WritePyramidImage ********************
  */
 
-template <class TElastix>
+template <typename TElastix>
 void
 MovingImagePyramidBase<TElastix>::WritePyramidImage(const std::string & filename,
                                                     const unsigned int  level) // const

--- a/Core/ComponentBaseClasses/elxOptimizerBase.h
+++ b/Core/ComponentBaseClasses/elxOptimizerBase.h
@@ -49,7 +49,7 @@ namespace elastix
  * \ingroup ComponentBaseClasses
  */
 
-template <class TElastix>
+template <typename TElastix>
 class ITK_TEMPLATE_EXPORT OptimizerBase : public BaseComponentSE<TElastix>
 {
 public:

--- a/Core/ComponentBaseClasses/elxOptimizerBase.hxx
+++ b/Core/ComponentBaseClasses/elxOptimizerBase.hxx
@@ -32,7 +32,7 @@ namespace elastix
  * ****************** SetCurrentPositionPublic ************************
  */
 
-template <class TElastix>
+template <typename TElastix>
 void
 OptimizerBase<TElastix>::SetCurrentPositionPublic(const ParametersType & /** param */)
 {
@@ -51,7 +51,7 @@ OptimizerBase<TElastix>::SetCurrentPositionPublic(const ParametersType & /** par
  * ****************** BeforeEachResolutionBase **********************
  */
 
-template <class TElastix>
+template <typename TElastix>
 void
 OptimizerBase<TElastix>::BeforeEachResolutionBase()
 {
@@ -72,7 +72,7 @@ OptimizerBase<TElastix>::BeforeEachResolutionBase()
  * ****************** AfterRegistrationBase **********************
  */
 
-template <class TElastix>
+template <typename TElastix>
 void
 OptimizerBase<TElastix>::AfterRegistrationBase()
 {
@@ -101,7 +101,7 @@ OptimizerBase<TElastix>::AfterRegistrationBase()
  * ****************** SelectNewSamples ****************************
  */
 
-template <class TElastix>
+template <typename TElastix>
 void
 OptimizerBase<TElastix>::SelectNewSamples()
 {
@@ -120,7 +120,7 @@ OptimizerBase<TElastix>::SelectNewSamples()
  * ****************** GetNewSamplesEveryIteration ********************
  */
 
-template <class TElastix>
+template <typename TElastix>
 bool
 OptimizerBase<TElastix>::GetNewSamplesEveryIteration() const
 {
@@ -134,7 +134,7 @@ OptimizerBase<TElastix>::GetNewSamplesEveryIteration() const
  * **************** PrintSettingsVector **********************
  */
 
-template <class TElastix>
+template <typename TElastix>
 void
 OptimizerBase<TElastix>::PrintSettingsVector(const SettingsVectorType & settings)
 {
@@ -195,7 +195,7 @@ OptimizerBase<TElastix>::PrintSettingsVector(const SettingsVectorType & settings
  * ****************** SetSinusScales ********************
  */
 
-template <class TElastix>
+template <typename TElastix>
 void
 OptimizerBase<TElastix>::SetSinusScales(double amplitude, double frequency, unsigned long numberOfParameters)
 {

--- a/Core/ComponentBaseClasses/elxRegistrationBase.h
+++ b/Core/ComponentBaseClasses/elxRegistrationBase.h
@@ -71,7 +71,7 @@ namespace elastix
  * \ingroup ComponentBaseClasses
  */
 
-template <class TElastix>
+template <typename TElastix>
 class ITK_TEMPLATE_EXPORT RegistrationBase : public BaseComponentSE<TElastix>
 {
 public:

--- a/Core/ComponentBaseClasses/elxRegistrationBase.hxx
+++ b/Core/ComponentBaseClasses/elxRegistrationBase.hxx
@@ -28,7 +28,7 @@ namespace elastix
  * ********************* ReadMaskParameters ************************
  */
 
-template <class TElastix>
+template <typename TElastix>
 bool
 RegistrationBase<TElastix>::ReadMaskParameters(UseMaskErosionArrayType & useMaskErosionArray,
                                                const unsigned int        nrOfMasks,
@@ -97,7 +97,7 @@ RegistrationBase<TElastix>::ReadMaskParameters(UseMaskErosionArrayType & useMask
  * ******************* GenerateFixedMaskSpatialObject **********************
  */
 
-template <class TElastix>
+template <typename TElastix>
 auto
 RegistrationBase<TElastix>::GenerateFixedMaskSpatialObject(const FixedMaskImageType *    maskImage,
                                                            bool                          useMaskErosion,
@@ -159,7 +159,7 @@ RegistrationBase<TElastix>::GenerateFixedMaskSpatialObject(const FixedMaskImageT
  * ******************* GenerateMovingMaskSpatialObject **********************
  */
 
-template <class TElastix>
+template <typename TElastix>
 auto
 RegistrationBase<TElastix>::GenerateMovingMaskSpatialObject(const MovingMaskImageType *    maskImage,
                                                             bool                           useMaskErosion,

--- a/Core/ComponentBaseClasses/elxResampleInterpolatorBase.h
+++ b/Core/ComponentBaseClasses/elxResampleInterpolatorBase.h
@@ -39,7 +39,7 @@ namespace elastix
  * \ingroup ComponentBaseClasses
  */
 
-template <class TElastix>
+template <typename TElastix>
 class ITK_TEMPLATE_EXPORT ResampleInterpolatorBase : public BaseComponentSE<TElastix>
 {
 public:

--- a/Core/ComponentBaseClasses/elxResampleInterpolatorBase.hxx
+++ b/Core/ComponentBaseClasses/elxResampleInterpolatorBase.hxx
@@ -31,7 +31,7 @@ namespace elastix
  * ******************* ReadFromFile *****************************
  */
 
-template <class TElastix>
+template <typename TElastix>
 void
 ResampleInterpolatorBase<TElastix>::ReadFromFile()
 {
@@ -44,7 +44,7 @@ ResampleInterpolatorBase<TElastix>::ReadFromFile()
  * ******************* WriteToFile ******************************
  */
 
-template <class TElastix>
+template <typename TElastix>
 void
 ResampleInterpolatorBase<TElastix>::WriteToFile(std::ostream & transformationParameterInfo) const
 {
@@ -62,7 +62,7 @@ ResampleInterpolatorBase<TElastix>::WriteToFile(std::ostream & transformationPar
  * ******************* CreateTransformParameterMap ****************
  */
 
-template <class TElastix>
+template <typename TElastix>
 void
 ResampleInterpolatorBase<TElastix>::CreateTransformParameterMap(ParameterMapType & parameterMap) const
 {

--- a/Core/ComponentBaseClasses/elxResamplerBase.h
+++ b/Core/ComponentBaseClasses/elxResamplerBase.h
@@ -73,7 +73,7 @@ namespace elastix
  * \ingroup ComponentBaseClasses
  */
 
-template <class TElastix>
+template <typename TElastix>
 class ITK_TEMPLATE_EXPORT ResamplerBase : public BaseComponentSE<TElastix>
 {
 public:

--- a/Core/ComponentBaseClasses/elxResamplerBase.hxx
+++ b/Core/ComponentBaseClasses/elxResamplerBase.hxx
@@ -36,7 +36,7 @@ namespace elastix
  * ******************* BeforeRegistrationBase *******************
  */
 
-template <class TElastix>
+template <typename TElastix>
 void
 ResamplerBase<TElastix>::BeforeRegistrationBase()
 {
@@ -77,7 +77,7 @@ ResamplerBase<TElastix>::BeforeRegistrationBase()
  * ******************* AfterEachResolutionBase ********************
  */
 
-template <class TElastix>
+template <typename TElastix>
 void
 ResamplerBase<TElastix>::AfterEachResolutionBase()
 {
@@ -135,7 +135,7 @@ ResamplerBase<TElastix>::AfterEachResolutionBase()
  * ******************* AfterEachIterationBase ********************
  */
 
-template <class TElastix>
+template <typename TElastix>
 void
 ResamplerBase<TElastix>::AfterEachIterationBase()
 {
@@ -186,7 +186,7 @@ ResamplerBase<TElastix>::AfterEachIterationBase()
  * ******************* AfterRegistrationBase ********************
  */
 
-template <class TElastix>
+template <typename TElastix>
 void
 ResamplerBase<TElastix>::AfterRegistrationBase()
 {
@@ -275,7 +275,7 @@ ResamplerBase<TElastix>::AfterRegistrationBase()
  * *********************** SetComponents ************************
  */
 
-template <class TElastix>
+template <typename TElastix>
 void
 ResamplerBase<TElastix>::SetComponents()
 {
@@ -297,7 +297,7 @@ ResamplerBase<TElastix>::SetComponents()
  * ******************* ResampleAndWriteResultImage ********************
  */
 
-template <class TElastix>
+template <typename TElastix>
 void
 ResamplerBase<TElastix>::ResampleAndWriteResultImage(const std::string & filename, const bool showProgress)
 {
@@ -346,7 +346,7 @@ ResamplerBase<TElastix>::ResampleAndWriteResultImage(const std::string & filenam
  * ******************* WriteResultImage ********************
  */
 
-template <class TElastix>
+template <typename TElastix>
 void
 ResamplerBase<TElastix>::WriteResultImage(OutputImageType *   image,
                                           const std::string & filename,
@@ -421,7 +421,7 @@ ResamplerBase<TElastix>::WriteResultImage(OutputImageType *   image,
  * \todo: avoid code duplication with WriteResultImage function
  */
 
-template <class TElastix>
+template <typename TElastix>
 void
 ResamplerBase<TElastix>::CreateItkResultImage()
 {
@@ -547,7 +547,7 @@ ResamplerBase<TElastix>::CreateItkResultImage()
  * ************************* ReadFromFile ***********************
  */
 
-template <class TElastix>
+template <typename TElastix>
 void
 ResamplerBase<TElastix>::ReadFromFile()
 {
@@ -637,7 +637,7 @@ ResamplerBase<TElastix>::ReadFromFile()
  * ******************* WriteToFile ******************************
  */
 
-template <class TElastix>
+template <typename TElastix>
 void
 ResamplerBase<TElastix>::WriteToFile(std::ostream & transformationParameterInfo) const
 {
@@ -654,7 +654,7 @@ ResamplerBase<TElastix>::WriteToFile(std::ostream & transformationParameterInfo)
  * ******************* CreateTransformParameterMap ******************************
  */
 
-template <class TElastix>
+template <typename TElastix>
 void
 ResamplerBase<TElastix>::CreateTransformParameterMap(ParameterMapType & parameterMap) const
 {
@@ -696,7 +696,7 @@ ResamplerBase<TElastix>::CreateTransformParameterMap(ParameterMapType & paramete
  * ******************* ReleaseMemory ********************
  */
 
-template <class TElastix>
+template <typename TElastix>
 void
 ResamplerBase<TElastix>::ReleaseMemory()
 {

--- a/Core/ComponentBaseClasses/elxTransformBase.h
+++ b/Core/ComponentBaseClasses/elxTransformBase.h
@@ -137,7 +137,7 @@ namespace elastix
  * \ingroup ComponentBaseClasses
  */
 
-template <class TElastix>
+template <typename TElastix>
 class ITK_TEMPLATE_EXPORT TransformBase : public BaseComponentSE<TElastix>
 {
 public:

--- a/Core/ComponentBaseClasses/elxTransformBase.hxx
+++ b/Core/ComponentBaseClasses/elxTransformBase.hxx
@@ -55,7 +55,7 @@ namespace elastix
  * ******************** BeforeAllBase ***************************
  */
 
-template <class TElastix>
+template <typename TElastix>
 int
 TransformBase<TElastix>::BeforeAllBase()
 {
@@ -87,7 +87,7 @@ TransformBase<TElastix>::BeforeAllBase()
  * ******************** BeforeAllTransformix ********************
  */
 
-template <class TElastix>
+template <typename TElastix>
 int
 TransformBase<TElastix>::BeforeAllTransformix()
 {
@@ -151,7 +151,7 @@ TransformBase<TElastix>::BeforeAllTransformix()
  * ******************* BeforeRegistrationBase *******************
  */
 
-template <class TElastix>
+template <typename TElastix>
 void
 TransformBase<TElastix>::BeforeRegistrationBase()
 {
@@ -217,7 +217,7 @@ TransformBase<TElastix>::BeforeRegistrationBase()
  * ******************* GetInitialTransform **********************
  */
 
-template <class TElastix>
+template <typename TElastix>
 auto
 TransformBase<TElastix>::GetInitialTransform() const -> const InitialTransformType *
 {
@@ -230,7 +230,7 @@ TransformBase<TElastix>::GetInitialTransform() const -> const InitialTransformTy
  * ******************* SetInitialTransform **********************
  */
 
-template <class TElastix>
+template <typename TElastix>
 void
 TransformBase<TElastix>::SetInitialTransform(InitialTransformType * _arg)
 {
@@ -246,7 +246,7 @@ TransformBase<TElastix>::SetInitialTransform(InitialTransformType * _arg)
  * ******************* SetFinalParameters ********************
  */
 
-template <class TElastix>
+template <typename TElastix>
 void
 TransformBase<TElastix>::SetFinalParameters()
 {
@@ -265,7 +265,7 @@ TransformBase<TElastix>::SetFinalParameters()
  * ******************* AfterRegistrationBase ********************
  */
 
-template <class TElastix>
+template <typename TElastix>
 void
 TransformBase<TElastix>::AfterRegistrationBase()
 {
@@ -279,7 +279,7 @@ TransformBase<TElastix>::AfterRegistrationBase()
  * ******************* ReadFromFile *****************************
  */
 
-template <class TElastix>
+template <typename TElastix>
 void
 TransformBase<TElastix>::ReadFromFile()
 {
@@ -450,7 +450,7 @@ TransformBase<TElastix>::ReadFromFile()
  * ******************* ReadInitialTransformFromFile *************
  */
 
-template <class TElastix>
+template <typename TElastix>
 void
 TransformBase<TElastix>::ReadInitialTransformFromFile(const std::string & transformParameterFileName)
 {
@@ -472,7 +472,7 @@ TransformBase<TElastix>::ReadInitialTransformFromFile(const std::string & transf
  * ******************* ReadInitialTransformFromConfiguration *****************************
  */
 
-template <class TElastix>
+template <typename TElastix>
 void
 TransformBase<TElastix>::ReadInitialTransformFromConfiguration(
   const Configuration::ConstPointer configurationInitialTransform)
@@ -510,7 +510,7 @@ TransformBase<TElastix>::ReadInitialTransformFromConfiguration(
  * ******************* WriteToFile ******************************
  */
 
-template <class TElastix>
+template <typename TElastix>
 void
 TransformBase<TElastix>::WriteToFile(std::ostream & transformationParameterInfo, const ParametersType & param) const
 {
@@ -580,7 +580,7 @@ TransformBase<TElastix>::WriteToFile(std::ostream & transformationParameterInfo,
  * ******************* CreateTransformParameterMap ******************************
  */
 
-template <class TElastix>
+template <typename TElastix>
 void
 TransformBase<TElastix>::CreateTransformParameterMap(const ParametersType & param,
                                                      ParameterMapType &     parameterMap,
@@ -655,7 +655,7 @@ TransformBase<TElastix>::CreateTransformParameterMap(const ParametersType & para
  * coordinates.
  */
 
-template <class TElastix>
+template <typename TElastix>
 void
 TransformBase<TElastix>::TransformPoints() const
 {
@@ -719,7 +719,7 @@ TransformBase<TElastix>::TransformPoints() const
  * the input point. Save the results.
  */
 
-template <class TElastix>
+template <typename TElastix>
 void
 TransformBase<TElastix>::TransformPointsSomePoints(const std::string & filename) const
 {
@@ -920,7 +920,7 @@ TransformBase<TElastix>::TransformPointsSomePoints(const std::string & filename)
  * Computes the transformed points, save as outputpoints.vtk.
  */
 
-template <class TElastix>
+template <typename TElastix>
 void
 TransformBase<TElastix>::TransformPointsSomePointsVTK(const std::string & filename) const
 {
@@ -994,7 +994,7 @@ TransformBase<TElastix>::TransformPointsSomePointsVTK(const std::string & filena
  * stored in an image of vectors (of floats).
  */
 
-template <class TElastix>
+template <typename TElastix>
 void
 TransformBase<TElastix>::TransformPointsAllPoints() const
 {
@@ -1020,7 +1020,7 @@ TransformBase<TElastix>::TransformPointsAllPoints() const
  * stored in an image of vectors (of floats).
  */
 
-template <class TElastix>
+template <typename TElastix>
 auto
 TransformBase<TElastix>::GenerateDeformationFieldImage() const -> typename DeformationFieldImageType::Pointer
 {
@@ -1075,7 +1075,7 @@ TransformBase<TElastix>::GenerateDeformationFieldImage() const -> typename Defor
  * ************** WriteDeformationFieldImage **********************
  */
 
-template <class TElastix>
+template <typename TElastix>
 void
 TransformBase<TElastix>::WriteDeformationFieldImage(
   typename TransformBase<TElastix>::DeformationFieldImageType::Pointer deformationfield) const
@@ -1112,7 +1112,7 @@ TransformBase<TElastix>::WriteDeformationFieldImage(
  * ************** ComputeSpatialJacobianDeterminantImage **********************
  */
 
-template <class TElastix>
+template <typename TElastix>
 auto
 TransformBase<TElastix>::ComputeSpatialJacobianDeterminantImage() const ->
   typename SpatialJacobianDeterminantImageType::Pointer
@@ -1129,7 +1129,7 @@ TransformBase<TElastix>::ComputeSpatialJacobianDeterminantImage() const ->
  * ************** ComputeSpatialJacobianMatrixImage **********************
  */
 
-template <class TElastix>
+template <typename TElastix>
 auto
 TransformBase<TElastix>::ComputeSpatialJacobianMatrixImage() const -> typename SpatialJacobianMatrixImageType::Pointer
 {
@@ -1144,7 +1144,7 @@ TransformBase<TElastix>::ComputeSpatialJacobianMatrixImage() const -> typename S
  * ************** ComputeAndWriteSpatialJacobianDeterminantImage **********************
  */
 
-template <class TElastix>
+template <typename TElastix>
 void
 TransformBase<TElastix>::ComputeAndWriteSpatialJacobianDeterminantImage() const
 {
@@ -1210,7 +1210,7 @@ TransformBase<TElastix>::ComputeAndWriteSpatialJacobianDeterminantImage() const
  * ************** ComputeAndWriteSpatialJacobianMatrixImage **********************
  */
 
-template <class TElastix>
+template <typename TElastix>
 void
 TransformBase<TElastix>::ComputeAndWriteSpatialJacobianMatrixImage() const
 {
@@ -1320,7 +1320,7 @@ TransformBase<TElastix>::ComputeAndWriteSpatialJacobianMatrixImage() const
  * ************** SetTransformParameterFileName ****************
  */
 
-template <class TElastix>
+template <typename TElastix>
 void
 TransformBase<TElastix>::SetTransformParameterFileName(const std::string & filename)
 {
@@ -1339,7 +1339,7 @@ TransformBase<TElastix>::SetTransformParameterFileName(const std::string & filen
  * ************** SetReadWriteTransformParameters ***************
  */
 
-template <class TElastix>
+template <typename TElastix>
 void
 TransformBase<TElastix>::SetReadWriteTransformParameters(const bool _arg)
 {
@@ -1357,7 +1357,7 @@ TransformBase<TElastix>::SetReadWriteTransformParameters(const bool _arg)
  * ************** AutomaticScalesEstimation ***************
  */
 
-template <class TElastix>
+template <typename TElastix>
 void
 TransformBase<TElastix>::AutomaticScalesEstimation(ScalesType & scales) const
 {
@@ -1419,7 +1419,7 @@ TransformBase<TElastix>::AutomaticScalesEstimation(ScalesType & scales) const
  * ************** AutomaticScalesEstimationStackTransform ***************
  */
 
-template <class TElastix>
+template <typename TElastix>
 void
 TransformBase<TElastix>::AutomaticScalesEstimationStackTransform(const unsigned int numberOfSubTransforms,
                                                                  ScalesType &       scales) const

--- a/Core/Configuration/elxConfiguration.h
+++ b/Core/Configuration/elxConfiguration.h
@@ -145,7 +145,7 @@ public:
 
 
   /** Read a parameter from the parameter file. */
-  template <class T>
+  template <typename T>
   bool
   ReadParameter(T &                 parameterValue,
                 const std::string & parameterName,
@@ -165,7 +165,7 @@ public:
 
 
   /** Read a parameter from the parameter file. */
-  template <class T>
+  template <typename T>
   bool
   ReadParameter(T & parameterValue, const std::string & parameterName, const unsigned int entry_nr) const
   {
@@ -181,7 +181,7 @@ public:
 
 
   /** Read a parameter from the parameter file. */
-  template <class T>
+  template <typename T>
   bool
   ReadParameter(T &                 parameterValue,
                 const std::string & parameterName,
@@ -203,7 +203,7 @@ public:
 
 
   /** Read a parameter from the parameter file. */
-  template <class T>
+  template <typename T>
   bool
   ReadParameter(T &                 parameterValue,
                 const std::string & parameterName,
@@ -279,7 +279,7 @@ public:
 
 
   /** Read a range of parameters from the parameter file. */
-  template <class T>
+  template <typename T>
   bool
   ReadParameter(std::vector<T> &    parameterValues,
                 const std::string & parameterName,

--- a/Core/Install/elxBaseComponentSE.h
+++ b/Core/Install/elxBaseComponentSE.h
@@ -43,7 +43,7 @@ namespace elastix
  * \ingroup Install
  */
 
-template <class TElastix>
+template <typename TElastix>
 class ITK_TEMPLATE_EXPORT BaseComponentSE : public BaseComponent
 {
 public:

--- a/Core/Install/elxBaseComponentSE.hxx
+++ b/Core/Install/elxBaseComponentSE.hxx
@@ -29,7 +29,7 @@ namespace elastix
  * *********************** SetElastix ***************************
  */
 
-template <class TElastix>
+template <typename TElastix>
 void
 BaseComponentSE<TElastix>::SetElastix(TElastix * const _arg)
 {
@@ -55,7 +55,7 @@ BaseComponentSE<TElastix>::SetElastix(TElastix * const _arg)
  * Added for transformix.
  */
 
-template <class TElastix>
+template <typename TElastix>
 void
 BaseComponentSE<TElastix>::SetConfiguration(const Configuration * const _arg)
 {

--- a/Core/Install/elxComponentInstaller.h
+++ b/Core/Install/elxComponentInstaller.h
@@ -28,7 +28,7 @@ namespace elastix
 /** Installs the component specified by its first argument. Note that `TComponent` is a "template template parameter".
  * It has a `TElastix` as template parameter, for example `elastix::TranslationTransformElastix` or
  * `elastix::FixedSmoothingPyramid`. */
-template <template <class TElastix> class TComponent, unsigned VIndex = 1>
+template <template <typename TElastix> class TComponent, unsigned VIndex = 1>
 class ComponentInstaller
 {
 public:
@@ -47,7 +47,7 @@ public:
 };
 
 
-template <template <class TElastix> class TComponent>
+template <template <typename TElastix> class TComponent>
 class ComponentInstaller<TComponent, NrOfSupportedImageTypes + 1>
 {
 public:

--- a/Core/Install/elxConversion.h
+++ b/Core/Install/elxConversion.h
@@ -169,7 +169,7 @@ public:
    * Returns true when casting was successful and false otherwise.
    * We make use of the casting functionality of string streams.
    */
-  template <class T>
+  template <typename T>
   static bool
   StringToValue(const std::string & str, T & value)
   {

--- a/Core/Install/elxIncludes.h
+++ b/Core/Install/elxIncludes.h
@@ -30,7 +30,7 @@
  * namespace elx
  * {
  *
- * template <class TElastix>
+ * template <typename TElastix>
  * class ITK_TEMPLATE_EXPORT MattesMetric :
  * etc...
  */

--- a/Core/Install/elxInstallFunctions.h
+++ b/Core/Install/elxInstallFunctions.h
@@ -42,7 +42,7 @@ namespace elastix
  * \ingroup Install
  */
 
-template <class TAnyItkObject>
+template <typename TAnyItkObject>
 class ITK_TEMPLATE_EXPORT InstallFunctions
 {
 public:

--- a/Core/Install/elxMacro.h
+++ b/Core/Install/elxMacro.h
@@ -48,7 +48,7 @@
  *
  * namespace elastix {
  *
- *   template <class TElastix>
+ *   template <typename TElastix>
  *     class ITK_TEMPLATE_EXPORT MyMetric : public MetricBase<TElastix>,
  *      public itk::MattesMutualInformationImageToImageMetric
  *           < MetricBase<TElastix>::FixedImageType

--- a/Core/Kernel/elxElastixBase.h
+++ b/Core/Kernel/elxElastixBase.h
@@ -419,7 +419,7 @@ protected:
    * cosines. Set it to false to force the direction cosines to identity.
    * The original direction cosines are returned separately.
    */
-  template <class TImage>
+  template <typename TImage>
   class ITK_TEMPLATE_EXPORT MultipleImageLoader
   {
   public:

--- a/Core/Kernel/elxElastixTemplate.h
+++ b/Core/Kernel/elxElastixTemplate.h
@@ -99,7 +99,7 @@ namespace elastix
  * \ingroup Kernel
  */
 
-template <class TFixedImage, class TMovingImage>
+template <typename TFixedImage, typename TMovingImage>
 class ITK_TEMPLATE_EXPORT ElastixTemplate final : public ElastixBase
 {
 public:

--- a/Core/Kernel/elxElastixTemplate.hxx
+++ b/Core/Kernel/elxElastixTemplate.hxx
@@ -43,7 +43,7 @@ namespace elastix
  * ********************** GetFixedImage *************************
  */
 
-template <class TFixedImage, class TMovingImage>
+template <typename TFixedImage, typename TMovingImage>
 auto
 ElastixTemplate<TFixedImage, TMovingImage>::GetFixedImage(unsigned int idx) const -> FixedImageType *
 {
@@ -60,7 +60,7 @@ ElastixTemplate<TFixedImage, TMovingImage>::GetFixedImage(unsigned int idx) cons
  * ********************** GetMovingImage *************************
  */
 
-template <class TFixedImage, class TMovingImage>
+template <typename TFixedImage, typename TMovingImage>
 auto
 ElastixTemplate<TFixedImage, TMovingImage>::GetMovingImage(unsigned int idx) const -> MovingImageType *
 {
@@ -77,7 +77,7 @@ ElastixTemplate<TFixedImage, TMovingImage>::GetMovingImage(unsigned int idx) con
  * ********************** GetFixedMask *************************
  */
 
-template <class TFixedImage, class TMovingImage>
+template <typename TFixedImage, typename TMovingImage>
 auto
 ElastixTemplate<TFixedImage, TMovingImage>::GetFixedMask(unsigned int idx) const -> FixedMaskType *
 {
@@ -94,7 +94,7 @@ ElastixTemplate<TFixedImage, TMovingImage>::GetFixedMask(unsigned int idx) const
  * ********************** GetMovingMask *************************
  */
 
-template <class TFixedImage, class TMovingImage>
+template <typename TFixedImage, typename TMovingImage>
 auto
 ElastixTemplate<TFixedImage, TMovingImage>::GetMovingMask(unsigned int idx) const -> MovingMaskType *
 {
@@ -112,7 +112,7 @@ ElastixTemplate<TFixedImage, TMovingImage>::GetMovingMask(unsigned int idx) cons
  * **************************** Run *****************************
  */
 
-template <class TFixedImage, class TMovingImage>
+template <typename TFixedImage, typename TMovingImage>
 int
 ElastixTemplate<TFixedImage, TMovingImage>::Run()
 {
@@ -252,7 +252,7 @@ ElastixTemplate<TFixedImage, TMovingImage>::Run()
  * ************************ ApplyTransform **********************
  */
 
-template <class TFixedImage, class TMovingImage>
+template <typename TFixedImage, typename TMovingImage>
 int
 ElastixTemplate<TFixedImage, TMovingImage>::ApplyTransform(const bool doReadTransform)
 {
@@ -418,7 +418,7 @@ ElastixTemplate<TFixedImage, TMovingImage>::ApplyTransform(const bool doReadTran
  * ************************ BeforeAll ***************************
  */
 
-template <class TFixedImage, class TMovingImage>
+template <typename TFixedImage, typename TMovingImage>
 int
 ElastixTemplate<TFixedImage, TMovingImage>::BeforeAll()
 {
@@ -440,7 +440,7 @@ ElastixTemplate<TFixedImage, TMovingImage>::BeforeAll()
  * ******************** BeforeAllTransformix ********************
  */
 
-template <class TFixedImage, class TMovingImage>
+template <typename TFixedImage, typename TMovingImage>
 int
 ElastixTemplate<TFixedImage, TMovingImage>::BeforeAllTransformix()
 {
@@ -480,7 +480,7 @@ ElastixTemplate<TFixedImage, TMovingImage>::BeforeAllTransformix()
  * **************** BeforeRegistration *****************
  */
 
-template <class TFixedImage, class TMovingImage>
+template <typename TFixedImage, typename TMovingImage>
 void
 ElastixTemplate<TFixedImage, TMovingImage>::BeforeRegistration()
 {
@@ -518,7 +518,7 @@ ElastixTemplate<TFixedImage, TMovingImage>::BeforeRegistration()
  * ************** BeforeEachResolution *****************
  */
 
-template <class TFixedImage, class TMovingImage>
+template <typename TFixedImage, typename TMovingImage>
 void
 ElastixTemplate<TFixedImage, TMovingImage>::BeforeEachResolution()
 {
@@ -577,7 +577,7 @@ ElastixTemplate<TFixedImage, TMovingImage>::BeforeEachResolution()
  * ************** AfterEachResolution *****************
  */
 
-template <class TFixedImage, class TMovingImage>
+template <typename TFixedImage, typename TMovingImage>
 void
 ElastixTemplate<TFixedImage, TMovingImage>::AfterEachResolution()
 {
@@ -630,7 +630,7 @@ ElastixTemplate<TFixedImage, TMovingImage>::AfterEachResolution()
  * ************** AfterEachIteration *******************
  */
 
-template <class TFixedImage, class TMovingImage>
+template <typename TFixedImage, typename TMovingImage>
 void
 ElastixTemplate<TFixedImage, TMovingImage>::AfterEachIteration()
 {
@@ -712,7 +712,7 @@ ElastixTemplate<TFixedImage, TMovingImage>::AfterEachIteration()
  * ************** AfterRegistration *******************
  */
 
-template <class TFixedImage, class TMovingImage>
+template <typename TFixedImage, typename TMovingImage>
 void
 ElastixTemplate<TFixedImage, TMovingImage>::AfterRegistration()
 {
@@ -770,7 +770,7 @@ ElastixTemplate<TFixedImage, TMovingImage>::AfterRegistration()
  * contain the final transform parameters.
  */
 
-template <class TFixedImage, class TMovingImage>
+template <typename TFixedImage, typename TMovingImage>
 void
 ElastixTemplate<TFixedImage, TMovingImage>::CreateTransformParameterFile(const std::string & fileName, const bool toLog)
 {
@@ -823,7 +823,7 @@ ElastixTemplate<TFixedImage, TMovingImage>::CreateTransformParameterFile(const s
  * ************** CreateTransformParameterMap ******************
  */
 
-template <class TFixedImage, class TMovingImage>
+template <typename TFixedImage, typename TMovingImage>
 void
 ElastixTemplate<TFixedImage, TMovingImage>::CreateTransformParameterMap()
 {
@@ -839,7 +839,7 @@ ElastixTemplate<TFixedImage, TMovingImage>::CreateTransformParameterMap()
  * ****************** CallInEachComponent ***********************
  */
 
-template <class TFixedImage, class TMovingImage>
+template <typename TFixedImage, typename TMovingImage>
 void
 ElastixTemplate<TFixedImage, TMovingImage>::CallInEachComponent(PtrToMemberFunction func)
 {
@@ -894,7 +894,7 @@ ElastixTemplate<TFixedImage, TMovingImage>::CallInEachComponent(PtrToMemberFunct
  * ****************** CallInEachComponentInt ********************
  */
 
-template <class TFixedImage, class TMovingImage>
+template <typename TFixedImage, typename TMovingImage>
 int
 ElastixTemplate<TFixedImage, TMovingImage>::CallInEachComponentInt(PtrToMemberFunction2 func)
 {
@@ -955,7 +955,7 @@ ElastixTemplate<TFixedImage, TMovingImage>::CallInEachComponentInt(PtrToMemberFu
  * ****************** ConfigureComponents *******************
  */
 
-template <class TFixedImage, class TMovingImage>
+template <typename TFixedImage, typename TMovingImage>
 void
 ElastixTemplate<TFixedImage, TMovingImage>::ConfigureComponents(Self * This)
 {
@@ -1021,7 +1021,7 @@ ElastixTemplate<TFixedImage, TMovingImage>::ConfigureComponents(Self * This)
  * which will contain the iteration info table.
  */
 
-template <class TFixedImage, class TMovingImage>
+template <typename TFixedImage, typename TMovingImage>
 void
 ElastixTemplate<TFixedImage, TMovingImage>::OpenIterationInfoFile()
 {
@@ -1067,7 +1067,7 @@ ElastixTemplate<TFixedImage, TMovingImage>::OpenIterationInfoFile()
  * This function retrieves the true direction cosines.
  */
 
-template <class TFixedImage, class TMovingImage>
+template <typename TFixedImage, typename TMovingImage>
 bool
 ElastixTemplate<TFixedImage, TMovingImage>::GetOriginalFixedImageDirection(FixedImageDirectionType & direction) const
 {
@@ -1115,7 +1115,7 @@ ElastixTemplate<TFixedImage, TMovingImage>::GetOriginalFixedImageDirection(Fixed
  * ************** SetOriginalFixedImageDirection *********************
  */
 
-template <class TFixedImage, class TMovingImage>
+template <typename TFixedImage, typename TMovingImage>
 void
 ElastixTemplate<TFixedImage, TMovingImage>::SetOriginalFixedImageDirection(const FixedImageDirectionType & arg)
 {

--- a/Testing/itkBSplineTransformPointPerformanceTest.cxx
+++ b/Testing/itkBSplineTransformPointPerformanceTest.cxx
@@ -30,7 +30,7 @@
 // and adds the previous un-optimized TransformPoint function.
 namespace itk
 {
-template <class TScalarType = double, unsigned int NDimensions = 3, unsigned int VSplineOrder = 3>
+template <typename TScalarType = double, unsigned int NDimensions = 3, unsigned int VSplineOrder = 3>
 class BSplineTransform_TEST : public AdvancedBSplineDeformableTransform<TScalarType, NDimensions, VSplineOrder>
 {
 public:

--- a/Testing/itkCommandLineArgumentParser.h
+++ b/Testing/itkCommandLineArgumentParser.h
@@ -139,7 +139,7 @@ public:
   itkGetConstMacro(ProgramHelpText, std::string);
 
   /** Get command line argument if arg is a vector type. */
-  template <class T>
+  template <typename T>
   bool
   GetCommandLineArgument(const std::string & key, std::vector<T> & arg)
   {
@@ -212,7 +212,7 @@ public:
    * We do this by creating a 1D vector, using the GetCommandLineArgument
    * for vector types, and then returning the first element.
    */
-  template <class T>
+  template <typename T>
   bool
   GetCommandLineArgument(const std::string & key, T & arg)
   {
@@ -244,7 +244,7 @@ protected:
    * Returns true when casting was successful and false otherwise.
    * We make use of the casting functionality of string streams.
    */
-  template <class T>
+  template <typename T>
   bool
   StringCast(const std::string & parameterValue, T & casted) const
   {

--- a/Testing/itkOpenCLBufferTest.cxx
+++ b/Testing/itkOpenCLBufferTest.cxx
@@ -21,7 +21,7 @@
 #include <algorithm>
 
 //------------------------------------------------------------------------------
-template <class type>
+template <typename type>
 bool
 std_all_of(const std::vector<type> & v, const type value)
 {

--- a/Testing/itkOpenCLVectorTest.cxx
+++ b/Testing/itkOpenCLVectorTest.cxx
@@ -21,7 +21,7 @@
 #include <algorithm>
 
 //------------------------------------------------------------------------------
-template <class type>
+template <typename type>
 bool
 std_all_of(const typename std::vector<type> & v, const type value)
 {
@@ -37,7 +37,7 @@ std_all_of(const typename std::vector<type> & v, const type value)
 
 
 //------------------------------------------------------------------------------
-template <class type>
+template <typename type>
 bool
 std_first_of(const typename std::vector<type> & v, const std::size_t n, const type value)
 {

--- a/Testing/itkTestHelper.h
+++ b/Testing/itkTestHelper.h
@@ -211,7 +211,7 @@ GetLogFileName()
 
 //------------------------------------------------------------------------------
 // Helper function to compute RMSE
-template <class TScalarType, class CPUImageType, class GPUImageType>
+template <typename TScalarType, typename CPUImageType, typename GPUImageType>
 TScalarType
 ComputeRMSE(const CPUImageType * cpuImage, const GPUImageType * gpuImage, TScalarType & rmsRelative)
 {
@@ -238,7 +238,7 @@ ComputeRMSE(const CPUImageType * cpuImage, const GPUImageType * gpuImage, TScala
 
 //------------------------------------------------------------------------------
 // Helper function to compute RMSE
-template <class TScalarType, class CPUImageType, class GPUImageType>
+template <typename TScalarType, typename CPUImageType, typename GPUImageType>
 TScalarType
 ComputeRMSE2(const CPUImageType * cpuImage, const GPUImageType * gpuImage, const float & threshold)
 {
@@ -262,7 +262,7 @@ ComputeRMSE2(const CPUImageType * cpuImage, const GPUImageType * gpuImage, const
 
 //------------------------------------------------------------------------------
 // Helper function to get test result from output images
-template <class TScalarType, class CPUImageType, class GPUImageType>
+template <typename TScalarType, typename CPUImageType, typename GPUImageType>
 void
 GetTestOutputResult(const CPUImageType *           cpuImage,
                     const GPUImageType *           gpuImage,
@@ -304,7 +304,7 @@ GetTestOutputResult(const CPUImageType *           cpuImage,
 
 //------------------------------------------------------------------------------
 // Helper function to get test result from filters
-template <class TScalarType, class ImageToImageFilterType, class OutputImage>
+template <typename TScalarType, typename ImageToImageFilterType, typename OutputImage>
 void
 GetTestFilterResult(typename ImageToImageFilterType::Pointer & cpuFilter,
                     typename ImageToImageFilterType::Pointer & gpuFilter,
@@ -355,7 +355,7 @@ GetTestFilterResult(typename ImageToImageFilterType::Pointer & cpuFilter,
 
 //------------------------------------------------------------------------------
 // Helper function to compute RMSE with masks
-template <class TScalarType, class CPUImageType, class GPUImageType, class MaskImageType>
+template <typename TScalarType, typename CPUImageType, typename GPUImageType, typename MaskImageType>
 TScalarType
 ComputeRMSE(const CPUImageType *  cpuImage,
             const GPUImageType *  gpuImage,
@@ -400,7 +400,7 @@ ComputeRMSE(const CPUImageType *  cpuImage,
 
 //------------------------------------------------------------------------------
 // Helper function to compute RMSE with masks and threshold
-template <class TScalarType, class CPUImageType, class GPUImageType, class MaskImageType>
+template <typename TScalarType, typename CPUImageType, typename GPUImageType, typename MaskImageType>
 TScalarType
 ComputeRMSE2(const CPUImageType *  cpuImage,
              const GPUImageType *  gpuImage,
@@ -449,7 +449,7 @@ ComputeRMSE2(const CPUImageType *  cpuImage,
 
 //----------------------------------------------------------------------------
 // Write log file in Microsoft Excel semicolon separated format.
-template <class ImageType>
+template <typename ImageType>
 void
 WriteLog(const std::string &                  filename,
          const unsigned int                   dim,

--- a/Testing/itkThinPlateSplineTransformPerformanceTest.cxx
+++ b/Testing/itkThinPlateSplineTransformPerformanceTest.cxx
@@ -38,7 +38,7 @@
 namespace itk
 {
 
-template <class TScalarType, unsigned int NDimensions>
+template <typename TScalarType, unsigned int NDimensions>
 class KernelTransformPublic : public ThinPlateSplineKernelTransform2<TScalarType, NDimensions>
 {
 public:


### PR DESCRIPTION
Replaced "class" with "typename" in `template <class `, `, class `, and `          class `.

Following ITK commit https://github.com/InsightSoftwareConsortium/ITK/commit/86bbb9d092d21bb309b0260c0b4082d9af966b67, Hans Johnson, September 15, 2013.