### PR TITLE
COMP: Make itkUseMevisDicomTiff.cxx compile with ITK >= 5.1

### DIFF
--- a/Common/MevisDicomTiff/itkUseMevisDicomTiff.cxx
+++ b/Common/MevisDicomTiff/itkUseMevisDicomTiff.cxx
@@ -32,6 +32,6 @@ RegisterMevisDicomTiff()
 {
 #ifdef _ELASTIX_USE_MEVISDICOMTIFF
   itk::ObjectFactoryBase::RegisterFactory(itk::MevisDicomTiffImageIOFactory::New(),
-                                          itk::ObjectFactoryBase::INSERT_AT_FRONT);
+                                          itk::ObjectFactoryBase::InsertionPositionEnum::INSERT_AT_FRONT);
 #endif
 }


### PR DESCRIPTION
The definition of the enumerator `INSERT_AT_FRONT` has moved into an `enum class`, with pull request https://github.com/InsightSoftwareConsortium/ITK/pull/1061 commit https://github.com/InsightSoftwareConsortium/ITK/commit/4fe3b5de74c6114e907747758746b3c4ea4406ff "STYLE: Convert 'enum' to 'enum class' objects with print enum function", Hans Johnson and Mathew J. Seng, merged on August 23, 2019. As this ITK commit was included with ITK 5.1, the `ELASTIX_USE_MEVISDICOMTIFF` option would depend on ITK's legacy support, in order to make it compile with elastix 5.0.1, 5.1.0, or 5.2.0.