### PR TITLE
PERF: itkGPUShrinkImageFilter use faster TransformPhysicalPointToIndex

### DIFF
--- a/Common/OpenCL/Filters/itkGPUShrinkImageFilter.hxx
+++ b/Common/OpenCL/Filters/itkGPUShrinkImageFilter.hxx
@@ -95,7 +95,6 @@ GPUShrinkImageFilter<TInputImage, TOutputImage>::GPUGenerateData()
   // Define a few indices that will be used to transform from an input pixel
   // to an output pixel
   OutputIndexType  outputIndex;
-  InputIndexType   inputIndex;
   OutputOffsetType offsetIndex;
 
   typename TOutputImage::PointType tempPoint;
@@ -106,7 +105,7 @@ GPUShrinkImageFilter<TInputImage, TOutputImage>::GPUGenerateData()
   // We wish to perform the following mapping of outputIndex to
   // inputIndex on all points in our region
   otPtr->TransformIndexToPhysicalPoint(outputIndex, tempPoint);
-  inPtr->TransformPhysicalPointToIndex(tempPoint, inputIndex);
+  const InputIndexType inputIndex = inPtr->TransformPhysicalPointToIndex(tempPoint);
 
   // Given that the size is scaled by a constant factor eq:
   // inputIndex = outputIndex * factorSize


### PR DESCRIPTION
Adjusted its `GPUGenerateData()` member function to call the faster `TransformPhysicalPointToIndex` overload.

Addresses MSVC compiler warnings saying:

    itkGPUShrinkImageFilter.hxx(109,39): warning C4834: discarding return value of function with [[nodiscard]] attribute

Similar to pull request https://github.com/InsightSoftwareConsortium/ITK/pull/2873 commit https://github.com/InsightSoftwareConsortium/ITK/commit/eb6ac88c8209ff6cfb3f280bb25e8388f236e211 "Use the faster `TransformPhysicalPointToIndex` overload in filter", November 16, 2021.