### PR TITLE
STYLE: Use modern C++ range-based `for` loops in Core/Main and Common

### DIFF
--- a/Common/Transforms/itkCyclicBSplineDeformableTransform.hxx
+++ b/Common/Transforms/itkCyclicBSplineDeformableTransform.hxx
@@ -177,7 +177,7 @@ CyclicBSplineDeformableTransform<TScalarType, NDimensions, VSplineOrder>::Transf
   OutputPointType outputPoint{};
 
   unsigned long counter = 0;
-  for (unsigned int r = 0; r < 2; ++r)
+  for (const auto & region : supportRegions)
   {
     /** Create iterators over the coefficient images
      * (for both supportRegion1 and supportRegion2.
@@ -187,7 +187,7 @@ CyclicBSplineDeformableTransform<TScalarType, NDimensions, VSplineOrder>::Transf
 
     for (unsigned int j = 0; j < SpaceDimension - 1; ++j)
     {
-      iterators[j] = IteratorType(this->m_CoefficientImages[j], supportRegions[r]);
+      iterators[j] = IteratorType(this->m_CoefficientImages[j], region);
     }
 
     /** Loop over this support region. */
@@ -252,9 +252,9 @@ CyclicBSplineDeformableTransform<TScalarType, NDimensions, VSplineOrder>::GetJac
 
   /** For each dimension, copy the weight to the support region. */
   unsigned long counter = 0;
-  for (unsigned int r = 0; r < 2; ++r)
+  for (const auto & region : supportRegions)
   {
-    ImageRegionIterator<JacobianImageType> iterator(this->m_CoefficientImages[0], supportRegions[r]);
+    ImageRegionIterator<JacobianImageType> iterator(this->m_CoefficientImages[0], region);
 
     while (!iterator.IsAtEnd())
     {
@@ -331,12 +331,12 @@ CyclicBSplineDeformableTransform<TScalarType, NDimensions, VSplineOrder>::GetSpa
 
       typename WeightsType::const_iterator itWeights = weights.begin();
 
-      for (unsigned int r = 0; r < 2; ++r)
+      for (const auto & region : supportRegions)
       {
         /** Create an iterator over the correct part of the coefficient
          * image. Create an iterator over the weights vector.
          */
-        ImageRegionConstIterator<ImageType> itCoef(this->m_CoefficientImages[dim], supportRegions[r]);
+        ImageRegionConstIterator<ImageType> itCoef(this->m_CoefficientImages[dim], region);
 
         while (!itCoef.IsAtEnd())
         {
@@ -385,10 +385,10 @@ CyclicBSplineDeformableTransform<TScalarType, NDimensions, VSplineOrder>::Comput
   const SizeValueType parametersPerDim = this->GetNumberOfParametersPerDimension();
   unsigned long       mu = 0;
 
-  for (unsigned int r = 0; r < 2; ++r)
+  for (const auto & region : supportRegions)
   {
     /** Create iterator over the coefficient image (for current supportRegion). */
-    ImageRegionConstIteratorWithIndex<ImageType> iterator(this->m_CoefficientImages[0], supportRegions[r]);
+    ImageRegionConstIteratorWithIndex<ImageType> iterator(this->m_CoefficientImages[0], region);
 
     /** For all control points in the support region, set which of the
      * indices in the parameter array are non-zero.

--- a/Core/Main/elxParameterObject.cxx
+++ b/Core/Main/elxParameterObject.cxx
@@ -524,14 +524,14 @@ ParameterObject::PrintSelf(std::ostream & os, itk::Indent indent) const
       os << "  (" << parameterMapIterator->first;
       ParameterValueVectorType parameterMapValueVector = parameterMapIterator->second;
 
-      for (unsigned int j = 0; j < parameterMapValueVector.size(); ++j)
+      for (const std::string & value : parameterMapValueVector)
       {
-        std::istringstream stream(parameterMapValueVector[j]);
+        std::istringstream stream(value);
         float              number;
         stream >> number;
         if (stream.fail())
         {
-          os << " \"" << parameterMapValueVector[j] << "\"";
+          os << " \"" << value << "\"";
         }
         else
         {

--- a/Core/Main/itkTransformixFilter.hxx
+++ b/Core/Main/itkTransformixFilter.hxx
@@ -254,10 +254,8 @@ TransformixFilter<TImage>::GenerateData()
   const auto movingImagePixelTypeString = elx::PixelTypeToString<typename TImage::PixelType>();
 
   // Set pixel types from input image, override user settings
-  for (unsigned int i = 0; i < transformParameterMapVector.size(); ++i)
+  for (auto & transformParameterMap : transformParameterMapVector)
   {
-    auto & transformParameterMap = transformParameterMapVector[i];
-
     SetParameterValueAndWarnOnOverride(transformParameterMap, "FixedImageDimension", movingImageDimensionString);
     SetParameterValueAndWarnOnOverride(transformParameterMap, "MovingImageDimension", movingImageDimensionString);
     SetParameterValueAndWarnOnOverride(transformParameterMap, "ResultImagePixelType", movingImagePixelTypeString);


### PR DESCRIPTION
Addressed clang-tidy (LLVM 18.1.8) messages, saying

> use range-based for loop instead [modernize-loop-convert]