### PR TITLE
Use modern C++ range-based for loops in OpenCL/GPU based code

### DIFF
--- a/Common/OpenCL/ITKimprovements/itkOpenCLContext.cxx
+++ b/Common/OpenCL/ITKimprovements/itkOpenCLContext.cxx
@@ -212,9 +212,9 @@ OpenCLContext::Create(const std::list<OpenCLDevice> & devices)
     return false;
   }
   std::vector<cl_device_id> devs;
-  for (auto dev = devices.begin(); dev != devices.end(); ++dev)
+  for (const OpenCLDevice & device : devices)
   {
-    devs.push_back(dev->GetDeviceId());
+    devs.push_back(device.GetDeviceId());
   }
 
   cl_platform_id        platform = devices.front().GetPlatform().GetPlatformId();
@@ -495,10 +495,10 @@ OpenCLContext::CreateContext(const std::list<OpenCLDevice> & devices, OpenCLCont
   if (!devices.empty())
   {
     std::vector<cl_device_id> devs;
-    for (auto dev = devices.begin(); dev != devices.end(); ++dev)
+    for (const OpenCLDevice & device : devices)
 
     {
-      devs.push_back(dev->GetDeviceId());
+      devs.push_back(device.GetDeviceId());
     }
 
     cl_context_properties props[] = { CL_CONTEXT_PLATFORM,
@@ -1425,12 +1425,11 @@ OpenCLContext::GetSupportedImageFormats(const OpenCLImageFormat::ImageType image
 
   // Compose the final list
   std::list<OpenCLImageFormat> list;
-  for (std::list<OpenCLImageFormat>::const_iterator it = list_image_formats.begin(); it != list_image_formats.end();
-       ++it)
+  for (const OpenCLImageFormat & format : list_image_formats)
   {
     list.push_back(OpenCLImageFormat(OpenCLImageFormat::ImageType(image_type),
-                                     OpenCLImageFormat::ChannelOrder(it->GetChannelOrder()),
-                                     OpenCLImageFormat::ChannelType(it->GetChannelType())));
+                                     OpenCLImageFormat::ChannelOrder(format.GetChannelOrder()),
+                                     OpenCLImageFormat::ChannelType(format.GetChannelType())));
   }
 
   return list;

--- a/Common/OpenCL/ITKimprovements/itkOpenCLDevice.cxx
+++ b/Common/OpenCL/ITKimprovements/itkOpenCLDevice.cxx
@@ -727,21 +727,20 @@ OpenCLDevice::HasExtension(const std::string & name) const
 std::list<OpenCLDevice>
 OpenCLDevice::GetAllDevices()
 {
-  const std::list<itk::OpenCLPlatform> platforms = OpenCLPlatform::GetAllPlatforms();
-  std::list<OpenCLDevice>              devices;
+  std::list<OpenCLDevice> devices;
 
-  for (auto platform = platforms.begin(); platform != platforms.end(); ++platform)
+  for (const OpenCLPlatform & platform : OpenCLPlatform::GetAllPlatforms())
   {
     cl_uint size;
-    if (clGetDeviceIDs(platform->GetPlatformId(), CL_DEVICE_TYPE_ALL, 0, 0, &size) != CL_SUCCESS)
+    if (clGetDeviceIDs(platform.GetPlatformId(), CL_DEVICE_TYPE_ALL, 0, 0, &size) != CL_SUCCESS)
     {
       continue;
     }
     std::vector<cl_device_id> buffer(size);
-    clGetDeviceIDs(platform->GetPlatformId(), CL_DEVICE_TYPE_ALL, size, &buffer[0], &size);
-    for (auto device = buffer.begin(); device != buffer.end(); ++device)
+    clGetDeviceIDs(platform.GetPlatformId(), CL_DEVICE_TYPE_ALL, size, &buffer[0], &size);
+    for (const cl_device_id deviceId : buffer)
     {
-      devices.push_back(OpenCLDevice(*device));
+      devices.push_back(OpenCLDevice(deviceId));
     }
   }
   return devices;
@@ -763,10 +762,10 @@ OpenCLDevice::GetDevices(const OpenCLDevice::DeviceType types, const OpenCLPlatf
   {
     platforms.push_back(platform);
   }
-  for (auto platform = platforms.begin(); platform != platforms.end(); ++platform)
+  for (const OpenCLPlatform & platform : platforms)
   {
     cl_uint size;
-    if (clGetDeviceIDs(platform->GetPlatformId(), cl_device_type(types), 0, 0, &size) != CL_SUCCESS)
+    if (clGetDeviceIDs(platform.GetPlatformId(), cl_device_type(types), 0, 0, &size) != CL_SUCCESS)
     {
       continue;
     }
@@ -775,10 +774,10 @@ OpenCLDevice::GetDevices(const OpenCLDevice::DeviceType types, const OpenCLPlatf
       continue;
     }
     std::vector<cl_device_id> buffer(size);
-    clGetDeviceIDs(platform->GetPlatformId(), cl_device_type(types), size, &buffer[0], &size);
-    for (auto device = buffer.begin(); device != buffer.end(); ++device)
+    clGetDeviceIDs(platform.GetPlatformId(), cl_device_type(types), size, &buffer[0], &size);
+    for (const cl_device_id deviceId : buffer)
     {
-      devices.push_back(OpenCLDevice(*device));
+      devices.push_back(OpenCLDevice(deviceId));
     }
     break;
   }
@@ -798,13 +797,12 @@ OpenCLDevice::GetDevices(const OpenCLDevice::DeviceType type, const OpenCLPlatfo
   }
   else
   {
-    const std::list<itk::OpenCLDevice> allDevices = itk::OpenCLDevice::GetDevices(type, platform);
-    std::list<OpenCLDevice>            devices;
-    for (auto dev = allDevices.begin(); dev != allDevices.end(); ++dev)
+    std::list<OpenCLDevice> devices;
+    for (const OpenCLDevice & device : OpenCLDevice::GetDevices(type, platform))
     {
-      if ((dev->GetDeviceType() & type) != 0)
+      if ((device.GetDeviceType() & type) != 0)
       {
-        devices.push_back(*dev);
+        devices.push_back(device);
       }
     }
     return devices;
@@ -824,13 +822,13 @@ OpenCLDevice::GetMaximumFlopsDevice(const std::list<OpenCLDevice> & devices, con
   // Find the device that has maximum Flops
   int          maxFlops = 0;
   cl_device_id id = 0;
-  for (auto device = devices.begin(); device != devices.end(); ++device)
+  for (const OpenCLDevice & device : devices)
   {
-    int deviceFlops = device->GetComputeUnits() * device->GetClockFrequency();
-    if (deviceFlops > maxFlops && (device->GetDeviceType() == type))
+    int deviceFlops = device.GetComputeUnits() * device.GetClockFrequency();
+    if (deviceFlops > maxFlops && (device.GetDeviceType() == type))
     {
       maxFlops = deviceFlops;
-      id = device->GetDeviceId();
+      id = device.GetDeviceId();
     }
   }
 
@@ -884,10 +882,10 @@ OpenCLDevice::GetMaximumFlopsDevices(const OpenCLDevice::DeviceType type, const 
   using DeviceType = std::pair<std::size_t, cl_device_id>;
   using MaximumFlopsDevicesType = std::set<DeviceType>;
   MaximumFlopsDevicesType maximumFlopsDevices;
-  for (auto device = allDevices.begin(); device != allDevices.end(); ++device)
+  for (const OpenCLDevice & device : allDevices)
   {
-    int        deviceFlops = device->GetComputeUnits() * device->GetClockFrequency();
-    DeviceType deviceWithFlops(deviceFlops, device->GetDeviceId());
+    int        deviceFlops = device.GetComputeUnits() * device.GetClockFrequency();
+    DeviceType deviceWithFlops(deviceFlops, device.GetDeviceId());
     maximumFlopsDevices.insert(deviceWithFlops);
   }
 

--- a/Common/OpenCL/ITKimprovements/itkOpenCLDevice.h
+++ b/Common/OpenCL/ITKimprovements/itkOpenCLDevice.h
@@ -863,9 +863,9 @@ operator<<(std::basic_ostream<charT, traits> & strm, const OpenCLDevice & device
   else
   {
     strm << std::endl;
-    for (auto it = extensions.begin(); it != extensions.end(); ++it)
+    for (const std::string & extension : extensions)
     {
-      strm << indent << indent << "- " << *it << std::endl;
+      strm << indent << indent << "- " << extension << std::endl;
     }
   }
 

--- a/Common/OpenCL/ITKimprovements/itkOpenCLEventList.cxx
+++ b/Common/OpenCL/ITKimprovements/itkOpenCLEventList.cxx
@@ -37,9 +37,9 @@ OpenCLEventList::OpenCLEventList(const OpenCLEvent & event)
 OpenCLEventList::OpenCLEventList(const OpenCLEventList & other)
   : m_Events(other.m_Events)
 {
-  for (std::size_t index = 0; index < this->m_Events.size(); ++index)
+  for (const cl_event eventId : this->m_Events)
   {
-    clRetainEvent(this->m_Events[index]);
+    clRetainEvent(eventId);
   }
 }
 
@@ -47,9 +47,9 @@ OpenCLEventList::OpenCLEventList(const OpenCLEventList & other)
 //------------------------------------------------------------------------------
 OpenCLEventList::~OpenCLEventList()
 {
-  for (std::size_t index = 0; index < this->m_Events.size(); ++index)
+  for (const cl_event eventId : this->m_Events)
   {
-    clReleaseEvent(this->m_Events[index]);
+    clReleaseEvent(eventId);
   }
 }
 
@@ -60,14 +60,14 @@ OpenCLEventList::operator=(const OpenCLEventList & other)
 {
   if (this != &other)
   {
-    for (std::size_t index = 0; index < this->m_Events.size(); ++index)
+    for (const cl_event eventId : this->m_Events)
     {
-      clReleaseEvent(this->m_Events[index]);
+      clReleaseEvent(eventId);
     }
     this->m_Events = other.m_Events;
-    for (std::size_t index = 0; index < this->m_Events.size(); ++index)
+    for (const cl_event eventId : this->m_Events)
     {
-      clRetainEvent(this->m_Events[index]);
+      clRetainEvent(eventId);
     }
   }
   return *this;
@@ -92,11 +92,10 @@ OpenCLEventList::Append(const OpenCLEvent & event)
 void
 OpenCLEventList::Append(const OpenCLEventList & other)
 {
-  for (std::size_t index = 0; index < other.m_Events.size(); ++index)
+  for (const cl_event eventId : other.m_Events)
   {
-    cl_event id = other.m_Events[index];
-    clRetainEvent(id);
-    this->m_Events.push_back(id);
+    clRetainEvent(eventId);
+    this->m_Events.push_back(eventId);
   }
 }
 

--- a/Common/OpenCL/ITKimprovements/itkOpenCLKernelManager.cxx
+++ b/Common/OpenCL/ITKimprovements/itkOpenCLKernelManager.cxx
@@ -390,9 +390,9 @@ OpenCLKernelManager::SetGlobalWorkSizeForAllKernels(const OpenCLSize & size)
     return;
   }
 
-  for (auto kernel = this->m_Kernels.begin(); kernel != this->m_Kernels.end(); ++kernel)
+  for (OpenCLKernel & kernel : this->m_Kernels)
   {
-    kernel->SetGlobalWorkSize(size);
+    kernel.SetGlobalWorkSize(size);
   }
 }
 
@@ -406,9 +406,9 @@ OpenCLKernelManager::SetLocalWorkSizeForAllKernels(const OpenCLSize & size)
     return;
   }
 
-  for (auto kernel = this->m_Kernels.begin(); kernel != this->m_Kernels.end(); ++kernel)
+  for (OpenCLKernel & kernel : this->m_Kernels)
   {
-    kernel->SetLocalWorkSize(size);
+    kernel.SetLocalWorkSize(size);
   }
 }
 
@@ -422,9 +422,9 @@ OpenCLKernelManager::SetGlobalWorkOffsetForAllKernels(const OpenCLSize & offset)
     return;
   }
 
-  for (auto kernel = this->m_Kernels.begin(); kernel != this->m_Kernels.end(); ++kernel)
+  for (OpenCLKernel & kernel : this->m_Kernels)
   {
-    kernel->SetGlobalWorkOffset(offset);
+    kernel.SetGlobalWorkOffset(offset);
   }
 }
 

--- a/Common/OpenCL/ITKimprovements/itkOpenCLPlatform.cxx
+++ b/Common/OpenCL/ITKimprovements/itkOpenCLPlatform.cxx
@@ -169,9 +169,9 @@ OpenCLPlatform::GetAllPlatforms()
   std::vector<cl_platform_id> buffer(size);
   clGetPlatformIDs(size, &buffer[0], &size);
   std::list<OpenCLPlatform> platforms;
-  for (std::size_t index = 0; index < buffer.size(); ++index)
+  for (const cl_platform_id platformId : buffer)
   {
-    platforms.push_back(OpenCLPlatform(buffer[index]));
+    platforms.push_back(OpenCLPlatform(platformId));
   }
   return platforms;
 }
@@ -190,28 +190,28 @@ OpenCLPlatform::GetPlatform(const OpenCLPlatform::VendorType vendor)
 
   cl_platform_id platformID = 0;
 
-  for (auto platform = platforms.begin(); platform != platforms.end(); ++platform)
+  for (const OpenCLPlatform & platform : platforms)
   {
-    const std::string vendorName = opencl_simplified(platform->GetVendor());
+    const std::string vendorName = opencl_simplified(platform.GetVendor());
 
     if ((vendorName.compare(0, 20, "Intel(R) Corporation") == 0) && (vendor == OpenCLPlatform::Intel))
     {
-      platformID = platform->GetPlatformId();
+      platformID = platform.GetPlatformId();
       break;
     }
     else if ((vendorName.compare(0, 18, "NVIDIA Corporation") == 0) && (vendor == OpenCLPlatform::NVidia))
     {
-      platformID = platform->GetPlatformId();
+      platformID = platform.GetPlatformId();
       break;
     }
     else if ((vendorName.compare(0, 28, "Advanced Micro Devices, Inc.") == 0) && (vendor == OpenCLPlatform::AMD))
     {
-      platformID = platform->GetPlatformId();
+      platformID = platform.GetPlatformId();
       break;
     }
     else if ((vendorName.compare(0, 3, "IBM") == 0) && (vendor == OpenCLPlatform::IBM))
     {
-      platformID = platform->GetPlatformId();
+      platformID = platform.GetPlatformId();
       break;
     }
   }

--- a/Common/OpenCL/ITKimprovements/itkOpenCLPlatform.h
+++ b/Common/OpenCL/ITKimprovements/itkOpenCLPlatform.h
@@ -231,9 +231,9 @@ operator<<(std::basic_ostream<charT, traits> & strm, const OpenCLPlatform & plat
   else
   {
     strm << std::endl;
-    for (auto it = extensions.begin(); it != extensions.end(); ++it)
+    for (const std::string & extension : extensions)
     {
-      strm << indent << indent << "- " << *it << std::endl;
+      strm << indent << indent << "- " << extension << std::endl;
     }
   }
 

--- a/Common/OpenCL/ITKimprovements/itkOpenCLProgram.cxx
+++ b/Common/OpenCL/ITKimprovements/itkOpenCLProgram.cxx
@@ -246,11 +246,11 @@ OpenCLProgram::Build(const std::list<OpenCLDevice> & devices, const std::string 
 {
   std::vector<cl_device_id> devs;
 
-  for (auto dev = devices.begin(); dev != devices.end(); ++dev)
+  for (const OpenCLDevice & device : devices)
   {
-    if (dev->GetDeviceId())
+    if (device.GetDeviceId())
     {
-      devs.push_back(dev->GetDeviceId());
+      devs.push_back(device.GetDeviceId());
     }
   }
 
@@ -339,19 +339,18 @@ OpenCLProgram::GetLog() const
     return std::string();
   }
 
-  const std::list<OpenCLDevice> devs = ctx->GetDevices();
-
   // Retrieve the device GetLogs and concatenate them.
   std::string log;
-  for (auto dev = devs.begin(); dev != devs.end(); ++dev)
+  for (const OpenCLDevice & device : ctx->GetDevices())
   {
     std::size_t size = 0;
-    if (clGetProgramBuildInfo(this->m_Id, dev->GetDeviceId(), CL_PROGRAM_BUILD_LOG, 0, 0, &size) != CL_SUCCESS || !size)
+    if (clGetProgramBuildInfo(this->m_Id, device.GetDeviceId(), CL_PROGRAM_BUILD_LOG, 0, 0, &size) != CL_SUCCESS ||
+        !size)
     {
       continue;
     }
     std::string buffer(size, '\0');
-    if (clGetProgramBuildInfo(this->m_Id, dev->GetDeviceId(), CL_PROGRAM_BUILD_LOG, size, &buffer[0], 0) !=
+    if (clGetProgramBuildInfo(this->m_Id, device.GetDeviceId(), CL_PROGRAM_BUILD_LOG, size, &buffer[0], 0) !=
           CL_SUCCESS ||
         !size)
     {
@@ -380,9 +379,9 @@ OpenCLProgram::GetDevices() const
     return list;
   }
 
-  for (std::vector<cl_device_id>::const_iterator dev = buffer.begin(); dev != buffer.end(); ++dev)
+  for (const cl_device_id deviceId : buffer)
   {
-    list.push_back(OpenCLDevice(*dev));
+    list.push_back(OpenCLDevice(deviceId));
   }
   return list;
 }
@@ -422,9 +421,9 @@ OpenCLProgram::CreateKernels() const
   {
     return list;
   }
-  for (std::vector<cl_kernel>::const_iterator kernel = kernels.begin(); kernel != kernels.end(); ++kernel)
+  for (const cl_kernel kernelId : kernels)
   {
-    list.push_back(OpenCLKernel(this->m_Context, *kernel));
+    list.push_back(OpenCLKernel(this->m_Context, kernelId));
   }
   return list;
 }

--- a/Common/OpenCL/itkOpenCLSetup.cxx
+++ b/Common/OpenCL/itkOpenCLSetup.cxx
@@ -73,13 +73,12 @@ CreateOpenCLContext(std::string & errorMessage, const std::string openCLDeviceTy
   }
 
   /** Get a list of all OpenCL devices. */
-  std::list<itk::OpenCLDevice>       devicesByType;
-  const std::list<itk::OpenCLDevice> allDevices = itk::OpenCLDevice::GetAllDevices();
-  for (auto device = allDevices.begin(); device != allDevices.end(); ++device)
+  std::list<itk::OpenCLDevice> devicesByType;
+  for (const OpenCLDevice & device : OpenCLDevice::GetAllDevices())
   {
-    if ((device->GetDeviceType() & deviceType) != 0)
+    if ((device.GetDeviceType() & deviceType) != 0)
     {
-      devicesByType.push_back(*device);
+      devicesByType.push_back(device);
     }
   }
 
@@ -94,16 +93,15 @@ CreateOpenCLContext(std::string & errorMessage, const std::string openCLDeviceTy
                        << " OpenCL-enabled device" << s << " present on this system:" << std::endl;
 
     unsigned int deviceID = 0;
-    for (std::list<itk::OpenCLDevice>::const_iterator device = devicesByType.begin(); device != devicesByType.end();
-         ++device)
+    for (const OpenCLDevice & device : devicesByType)
     {
       errorMessageStream << indent << "OpenCL device ID: " << deviceID << std::endl;
-      errorMessageStream << indent << indent << "Name: " << device->GetName() << std::endl;
-      errorMessageStream << indent << indent << "Vendor: " << device->GetVendor() << std::endl;
-      errorMessageStream << indent << indent << "Has double support: " << (device->HasDouble() ? "Yes" : "No")
+      errorMessageStream << indent << indent << "Name: " << device.GetName() << std::endl;
+      errorMessageStream << indent << indent << "Vendor: " << device.GetVendor() << std::endl;
+      errorMessageStream << indent << indent << "Has double support: " << (device.HasDouble() ? "Yes" : "No")
                          << std::endl;
       errorMessageStream << indent << indent << "Device type: ";
-      switch (device->GetDeviceType())
+      switch (device.GetDeviceType())
       {
         case OpenCLDevice::Default:
           errorMessageStream << "Default";
@@ -140,12 +138,12 @@ CreateOpenCLContext(std::string & errorMessage, const std::string openCLDeviceTy
    * We have to loop over devicesByType and select it. */
   std::list<itk::OpenCLDevice> selected;
   int                          deviceID = 0;
-  for (std::list<OpenCLDevice>::const_iterator device = devicesByType.begin(); device != devicesByType.end(); ++device)
+  for (const OpenCLDevice & device : devicesByType)
   {
     {
       if (deviceID == openCLDeviceID)
       {
-        selected.push_back(*device);
+        selected.push_back(device);
         break;
       }
       ++deviceID;

--- a/Testing/itkGPUFactoriesTest.cxx
+++ b/Testing/itkGPUFactoriesTest.cxx
@@ -61,18 +61,16 @@ void
 PrintAllRegisteredFactories()
 {
   // List all registered factories
-  std::list<itk::ObjectFactoryBase *> factories = itk::ObjectFactoryBase::GetRegisteredFactories();
-
   std::cout << "----- Registered factories -----" << std::endl;
-  for (auto f = factories.begin(); f != factories.end(); ++f)
+  for (itk::ObjectFactoryBase * const factory : itk::ObjectFactoryBase::GetRegisteredFactories())
   {
-    std::cout << "  Factory version: " << (*f)->GetITKSourceVersion() << '\n'
-              << "  Factory description: " << (*f)->GetDescription() << std::endl;
+    std::cout << "  Factory version: " << factory->GetITKSourceVersion() << '\n'
+              << "  Factory description: " << factory->GetDescription() << std::endl;
 
-    std::list<std::string> overrides = (*f)->GetClassOverrideNames();
-    std::list<std::string> names = (*f)->GetClassOverrideWithNames();
-    std::list<std::string> descriptions = (*f)->GetClassOverrideDescriptions();
-    std::list<bool>        enableflags = (*f)->GetEnableFlags();
+    std::list<std::string> overrides = factory->GetClassOverrideNames();
+    std::list<std::string> names = factory->GetClassOverrideWithNames();
+    std::list<std::string> descriptions = factory->GetClassOverrideDescriptions();
+    std::list<bool>        enableflags = factory->GetEnableFlags();
 
     std::list<std::string>::const_iterator n = names.begin();
     std::list<std::string>::const_iterator d = descriptions.begin();

--- a/Testing/itkGPUResampleImageFilterTest.cxx
+++ b/Testing/itkGPUResampleImageFilterTest.cxx
@@ -191,9 +191,9 @@ DefineAffineParameters(typename AffineTransformType::ParametersType & parameters
       0.0, 0.0, // translation
     };
 
-    for (std::size_t i = 0; i < 6; ++i)
+    for (const double matrixElement : matrix)
     {
-      parameters[par++] = matrix[i];
+      parameters[par++] = matrixElement;
     }
   }
   else if constexpr (Dimension == 3)
@@ -205,9 +205,9 @@ DefineAffineParameters(typename AffineTransformType::ParametersType & parameters
       -3.02,  1.3,    -0.045 // translation
     };
 
-    for (std::size_t i = 0; i < 12; ++i)
+    for (const double matrixElement : matrix)
     {
-      parameters[par++] = matrix[i];
+      parameters[par++] = matrixElement;
     }
   }
 }
@@ -678,9 +678,8 @@ main(int argc, char * argv[])
   }
 
   // check for supported transforms
-  for (std::size_t i = 0; i < transforms.size(); ++i)
+  for (const std::string & transformName : transforms)
   {
-    const std::string transformName = transforms[i];
     if (transformName != "Affine" && transformName != "Translation" && transformName != "BSpline" &&
         transformName != "Euler" && transformName != "Similarity")
     {
@@ -693,9 +692,9 @@ main(int argc, char * argv[])
 
   unsigned int runTimes = 1;
   std::string  parametersFileName = "";
-  for (std::size_t i = 0; i < transforms.size(); ++i)
+  for (const std::string & transformName : transforms)
   {
-    if (transforms[i] == "BSpline")
+    if (transformName == "BSpline")
     {
       const bool retp = parser->GetCommandLineArgument("-p", parametersFileName);
       if (!retp)

--- a/Testing/itkOpenCLContextTest.cxx
+++ b/Testing/itkOpenCLContextTest.cxx
@@ -47,10 +47,9 @@ main()
     return EXIT_FAILURE;
   }
 
-  std::list<itk::OpenCLDevice> devices = context->GetDevices();
-  for (std::list<itk::OpenCLDevice>::const_iterator dev = devices.begin(); dev != devices.end(); ++dev)
+  for (const itk::OpenCLDevice & device : context->GetDevices())
   {
-    std::cout << (*dev) << std::endl;
+    std::cout << device << std::endl;
   }
 
   // Release and exit

--- a/Testing/itkOpenCLDeviceTest.cxx
+++ b/Testing/itkOpenCLDeviceTest.cxx
@@ -30,14 +30,13 @@ main()
   }
 
   // Get all devices
-  std::list<itk::OpenCLDevice>       gpus;
-  const std::list<itk::OpenCLDevice> devices = itk::OpenCLDevice::GetAllDevices();
-  for (auto dev = devices.begin(); dev != devices.end(); ++dev)
+  std::list<itk::OpenCLDevice> gpus;
+  for (const itk::OpenCLDevice & device : itk::OpenCLDevice::GetAllDevices())
   {
-    if ((dev->GetDeviceType() & itk::OpenCLDevice::GPU) != 0)
+    if ((device.GetDeviceType() & itk::OpenCLDevice::GPU) != 0)
     {
-      gpus.push_back(*dev);
-      std::cout << (*dev);
+      gpus.push_back(device);
+      std::cout << device;
     }
   }
 

--- a/Testing/itkOpenCLPlatformTest.cxx
+++ b/Testing/itkOpenCLPlatformTest.cxx
@@ -36,9 +36,9 @@ main()
 
   // Get all platforms and print it
   const std::list<itk::OpenCLPlatform> platforms = itk::OpenCLPlatform::GetAllPlatforms();
-  for (auto it = platforms.begin(); it != platforms.end(); ++it)
+  for (const auto & platform : platforms)
   {
-    std::cout << *it;
+    std::cout << platform;
   }
 
   return EXIT_SUCCESS;


### PR DESCRIPTION
Addressed clang-tidy (LLVM 18.1.8) messages, saying

> use range-based for loop instead [modernize-loop-convert]

@dpshamonin Can you please have a look?