### PR TITLE
COMP: Add missing semicolons to ITK macro calls

### DIFF
--- a/Components/Optimizers/ConjugateGradient/itkGenericConjugateGradientOptimizer.h
+++ b/Components/Optimizers/ConjugateGradient/itkGenericConjugateGradientOptimizer.h
@@ -111,16 +111,16 @@ public:
    *   GradientMagnitudeTolerance * \max(1, \|CurrentPosition\| ) \f$
    */
   itkGetConstMacro(GradientMagnitudeTolerance, double);
-  itkSetMacro(GradientMagnitudeTolerance, double)
+  itkSetMacro(GradientMagnitudeTolerance, double);
 
-    /** Setting: a stopping criterion, the value tolerance. By default 1e-5.
-     *
-     * The optimizer stops when
-     * \f[ 2.0 * | f_k - f_{k-1} | \le
-     *   ValueTolerance * ( |f_k| + |f_{k-1}| + 1e-20 ) \f]
-     * is satisfied MaxNrOfItWithoutImprovement times in a row.
-     */
-    itkGetConstMacro(ValueTolerance, double);
+  /** Setting: a stopping criterion, the value tolerance. By default 1e-5.
+   *
+   * The optimizer stops when
+   * \f[ 2.0 * | f_k - f_{k-1} | \le
+   *   ValueTolerance * ( |f_k| + |f_{k-1}| + 1e-20 ) \f]
+   * is satisfied MaxNrOfItWithoutImprovement times in a row.
+   */
+  itkGetConstMacro(ValueTolerance, double);
   itkSetMacro(ValueTolerance, double);
 
   /** Setting: the maximum number of iterations in a row that

--- a/Components/Transforms/AdvancedAffineTransform/elxAdvancedAffineTransform.hxx
+++ b/Components/Transforms/AdvancedAffineTransform/elxAdvancedAffineTransform.hxx
@@ -107,7 +107,7 @@ AdvancedAffineTransformElastix<TElastix>::ReadFromFile()
     if (itkFixedParameterValues == nullptr)
     {
       log::error("ERROR: No center of rotation is specified in the transform parameter file");
-      itkExceptionMacro("Transform parameter file is corrupt.")
+      itkExceptionMacro("Transform parameter file is corrupt.");
     }
   }
 

--- a/Components/Transforms/AffineDTITransform/elxAffineDTITransform.hxx
+++ b/Components/Transforms/AffineDTITransform/elxAffineDTITransform.hxx
@@ -78,7 +78,7 @@ AffineDTITransformElastix<TElastix>::ReadFromFile()
   if (!pointRead)
   {
     log::error("ERROR: No center of rotation is specified in the transform parameter file");
-    itkExceptionMacro("Transform parameter file is corrupt.")
+    itkExceptionMacro("Transform parameter file is corrupt.");
   }
 
   /** Set the center in this Transform. */

--- a/Components/Transforms/AffineLogStackTransform/elxAffineLogStackTransform.hxx
+++ b/Components/Transforms/AffineLogStackTransform/elxAffineLogStackTransform.hxx
@@ -119,7 +119,7 @@ AffineLogStackTransform<TElastix>::ReadFromFile()
     if (!pointRead)
     {
       log::error("ERROR: No center of rotation is specified in the transform parameter file");
-      itkExceptionMacro("Transform parameter file is corrupt.")
+      itkExceptionMacro("Transform parameter file is corrupt.");
     }
 
     this->InitializeAffineLogTransform();

--- a/Components/Transforms/BSplineStackTransform/elxBSplineStackTransform.hxx
+++ b/Components/Transforms/BSplineStackTransform/elxBSplineStackTransform.hxx
@@ -494,7 +494,7 @@ BSplineStackTransform<TElastix>::ReadFromFile()
     {
       itkExceptionMacro("NumberOfSubTransforms, StackOrigin, StackSpacing, GridSize, GridIndex, GridSpacing and "
                         "GridOrigin is required by "
-                        << this->GetNameOfClass() << ".")
+                        << this->GetNameOfClass() << ".");
     }
 
     /** Set it all. */

--- a/Components/Transforms/EulerStackTransform/elxEulerStackTransform.hxx
+++ b/Components/Transforms/EulerStackTransform/elxEulerStackTransform.hxx
@@ -117,7 +117,7 @@ EulerStackTransform<TElastix>::ReadFromFile()
     if (!pointRead && !indexRead)
     {
       log::error("ERROR: No center of rotation is specified in the transform parameter file");
-      itkExceptionMacro("Transform parameter file is corrupt.")
+      itkExceptionMacro("Transform parameter file is corrupt.");
     }
 
     this->InitializeEulerTransform();

--- a/Components/Transforms/EulerTransform/elxEulerTransform.hxx
+++ b/Components/Transforms/EulerTransform/elxEulerTransform.hxx
@@ -77,7 +77,7 @@ EulerTransformElastix<TElastix>::ReadFromFile()
     if (!pointRead)
     {
       log::error("ERROR: No center of rotation is specified in the transform parameter file");
-      itkExceptionMacro("Transform parameter file is corrupt.")
+      itkExceptionMacro("Transform parameter file is corrupt.");
     }
 
     /** Set the center in this Transform. */

--- a/Components/Transforms/SimilarityTransform/elxSimilarityTransform.hxx
+++ b/Components/Transforms/SimilarityTransform/elxSimilarityTransform.hxx
@@ -86,7 +86,7 @@ SimilarityTransformElastix<TElastix>::ReadFromFile()
     if (!pointRead && !indexRead)
     {
       log::error("ERROR: No center of rotation is specified in the transform parameter file.");
-      itkExceptionMacro("Transform parameter file is corrupt.")
+      itkExceptionMacro("Transform parameter file is corrupt.");
     }
 
     /** Set the center in this Transform. */

--- a/Core/Main/elxParameterObject.cxx
+++ b/Core/Main/elxParameterObject.cxx
@@ -229,7 +229,7 @@ ParameterObject::ReadParameterFiles(const ParameterFileNameVectorType & paramete
   {
     if (!itksys::SystemTools::FileExists(parameterFileName))
     {
-      itkExceptionMacro("Parameter file \"" << parameterFileName << "\" does not exist.")
+      itkExceptionMacro("Parameter file \"" << parameterFileName << "\" does not exist.");
     }
 
     this->AddParameterFile(parameterFileName);

--- a/Core/Main/itkTransformixFilter.hxx
+++ b/Core/Main/itkTransformixFilter.hxx
@@ -82,7 +82,7 @@ TransformixFilter<TImage>::GenerateData()
   if (m_ComputeDeformationField && !m_FixedPointSetFileName.empty())
   {
     itkExceptionMacro("For backwards compatibility, only one of ComputeDeformationFieldOn() or "
-                      "SetFixedPointSetFileName() can be active at any one time.")
+                      "SetFixedPointSetFileName() can be active at any one time.");
   }
 
   // Setup argument map which transformix uses internally ito figure out what needs to be done
@@ -124,7 +124,7 @@ TransformixFilter<TImage>::GenerateData()
 
   if (!m_OutputDirectory.empty() && !itksys::SystemTools::FileExists(m_OutputDirectory))
   {
-    itkExceptionMacro("Output directory \"" << m_OutputDirectory << "\" does not exist.")
+    itkExceptionMacro("Output directory \"" << m_OutputDirectory << "\" does not exist.");
   }
 
   if (!m_OutputDirectory.empty())


### PR DESCRIPTION
Aims to resolve issue https://github.com/SuperElastix/elastix/issues/1224 "Missing semicolons causing compile issues with some compilers".

ITK has become stricter with respect to those semicolons from ITK pull request https://github.com/InsightSoftwareConsortium/ITK/pull/4706 commit https://github.com/InsightSoftwareConsortium/ITK/commit/55e23393e1d2c2e71d919d33459201fcee364655 "ENH: Default to allow ITK_MACROEND_NOOP_STATEMENT", Hans Johnson, June 4, 2024.