### PR TITLE
COMP: Add missing semicolons to ElastixRegistrationMethod and OpenCL

### DIFF
--- a/Common/OpenCL/ITKimprovements/itkOpenCLVector.hxx
+++ b/Common/OpenCL/ITKimprovements/itkOpenCLVector.hxx
@@ -123,9 +123,9 @@ OpenCLVector<T>::Read(T * data, const std::size_t count, const std::size_t offse
 {
   itkAssertOrThrowMacro(((offset + count) <= this->m_Size),
                         "OpenCLVector<T>::Read(data, " << count << ", " << offset
-                                                       << ") (offset + count) is out of range")
+                                                       << ") (offset + count) is out of range");
 
-    OpenCLVectorBase::Read(data, count * sizeof(T), offset * sizeof(T));
+  OpenCLVectorBase::Read(data, count * sizeof(T), offset * sizeof(T));
 }
 
 

--- a/Core/Main/itkElastixRegistrationMethod.hxx
+++ b/Core/Main/itkElastixRegistrationMethod.hxx
@@ -150,7 +150,7 @@ ElastixRegistrationMethod<TFixedImage, TMovingImage>::GenerateData()
   {
     if (m_LogToFile)
     {
-      itkExceptionMacro("LogToFileOn() requires an output directory to be specified.")
+      itkExceptionMacro("LogToFileOn() requires an output directory to be specified.");
     }
   }
   else


### PR DESCRIPTION
- Follow-up to pull request https://github.com/SuperElastix/elastix/pull/1227 commit 7b99c207a222fec33bf4aceaf47a949c0f341afb "COMP: Add missing semicolons to ITK macro calls"