### PR TITLE
Remove `std::ostringstream{} << ` when logging a literal string or a command-line argument

### DIFF
--- a/Components/Metrics/CorrespondingPointsEuclideanDistanceMetric/elxCorrespondingPointsEuclideanDistanceMetric.hxx
+++ b/Components/Metrics/CorrespondingPointsEuclideanDistanceMetric/elxCorrespondingPointsEuclideanDistanceMetric.hxx
@@ -83,7 +83,7 @@ CorrespondingPointsEuclideanDistanceMetric<TElastix>::BeforeAllBase()
   }
   else
   {
-    log::info(std::ostringstream{} << "-fp       " << commandLineArgument);
+    log::info("-fp       " + commandLineArgument);
   }
 
   /** Check for appearance of "-mp". */
@@ -93,7 +93,7 @@ CorrespondingPointsEuclideanDistanceMetric<TElastix>::BeforeAllBase()
   }
   else
   {
-    log::info(std::ostringstream{} << "-mp       " << commandLineArgument);
+    log::info("-mp       " + commandLineArgument);
   }
 
   /** Return a value. */

--- a/Components/Metrics/MissingStructurePenalty/elxMissingStructurePenalty.hxx
+++ b/Components/Metrics/MissingStructurePenalty/elxMissingStructurePenalty.hxx
@@ -111,7 +111,7 @@ MissingStructurePenalty<TElastix>::BeforeAllBase()
     }
     else
     {
-      log::info(std::ostringstream{} << fmeshArgument.str() << "\t" << commandLineArgument);
+      log::info(fmeshArgument.str() + "\t" + commandLineArgument);
       this->m_NumberOfMeshes++;
     }
   }

--- a/Components/Metrics/PolydataDummyPenalty/elxPolydataDummyPenalty.hxx
+++ b/Components/Metrics/PolydataDummyPenalty/elxPolydataDummyPenalty.hxx
@@ -99,7 +99,7 @@ PolydataDummyPenalty<TElastix>::BeforeAllBase()
     }
     else
     {
-      log::info(std::ostringstream{} << fmeshArgument.str() << "\t" << commandLineArgument);
+      log::info(fmeshArgument.str() + "\t" + commandLineArgument);
       this->m_NumberOfMeshes++;
     }
   }

--- a/Core/ComponentBaseClasses/elxTransformBase.hxx
+++ b/Core/ComponentBaseClasses/elxTransformBase.hxx
@@ -99,7 +99,7 @@ TransformBase<TElastix>::BeforeAllTransformix()
   {
     log::info(std::ostringstream{} << "-ipp      " << commandLineArgument);
     // Deprecated since elastix 4.3
-    log::warn(std::ostringstream{} << "WARNING: \"-ipp\" is deprecated, use \"-def\" instead!");
+    log::warn("WARNING: \"-ipp\" is deprecated, use \"-def\" instead!");
   }
 
   /** Check for appearance of "-def". */
@@ -692,7 +692,7 @@ TransformBase<TElastix>::TransformPoints() const
   else
   {
     // just a message
-    log::info(std::ostringstream{} << "  The command-line option \"-def\" is not used, so no points are transformed");
+    log::info("  The command-line option \"-def\" is not used, so no points are transformed");
   }
 
 } // end TransformPoints()
@@ -1148,7 +1148,7 @@ TransformBase<TElastix>::ComputeAndWriteSpatialJacobianDeterminantImage() const
   std::string jac = configuration.GetCommandLineArgument("-jac");
   if (jac.empty())
   {
-    log::info(std::ostringstream{} << "  The command-line option \"-jac\" is not used, so no det(dT/dx) computed.");
+    log::info("  The command-line option \"-jac\" is not used, so no det(dT/dx) computed.");
     return;
   }
   else if (jac != "all")
@@ -1214,7 +1214,7 @@ TransformBase<TElastix>::ComputeAndWriteSpatialJacobianMatrixImage() const
   std::string jac = configuration.GetCommandLineArgument("-jacmat");
   if (jac != "all")
   {
-    log::info(std::ostringstream{} << "  The command-line option \"-jacmat\" is not used, so no dT/dx computed.");
+    log::info("  The command-line option \"-jacmat\" is not used, so no dT/dx computed.");
     return;
   }
 

--- a/Core/ComponentBaseClasses/elxTransformBase.hxx
+++ b/Core/ComponentBaseClasses/elxTransformBase.hxx
@@ -71,7 +71,7 @@ TransformBase<TElastix>::BeforeAllBase()
   }
   else
   {
-    log::info(std::ostringstream{} << "-t0       " << commandLineArgument);
+    log::info("-t0       " + commandLineArgument);
   }
 
   /** Return a value. */
@@ -97,7 +97,7 @@ TransformBase<TElastix>::BeforeAllTransformix()
   if (const std::string commandLineArgument = configuration.GetCommandLineArgument("-ipp");
       !commandLineArgument.empty())
   {
-    log::info(std::ostringstream{} << "-ipp      " << commandLineArgument);
+    log::info("-ipp      " + commandLineArgument);
     // Deprecated since elastix 4.3
     log::warn("WARNING: \"-ipp\" is deprecated, use \"-def\" instead!");
   }
@@ -109,7 +109,7 @@ TransformBase<TElastix>::BeforeAllTransformix()
   }
   else
   {
-    log::info(std::ostringstream{} << "-def      " << commandLineArgument);
+    log::info("-def      " + commandLineArgument);
   }
 
   /** Check for appearance of "-jac". */
@@ -119,7 +119,7 @@ TransformBase<TElastix>::BeforeAllTransformix()
   }
   else
   {
-    log::info(std::ostringstream{} << "-jac      " << commandLineArgument);
+    log::info("-jac      " + commandLineArgument);
   }
 
   /** Check for appearance of "-jacmat". */
@@ -130,7 +130,7 @@ TransformBase<TElastix>::BeforeAllTransformix()
   }
   else
   {
-    log::info(std::ostringstream{} << "-jacmat   " << commandLineArgument);
+    log::info("-jacmat   " + commandLineArgument);
   }
 
   /** Return a value. */

--- a/Core/Configuration/elxConfiguration.cxx
+++ b/Core/Configuration/elxConfiguration.cxx
@@ -177,7 +177,7 @@ Configuration::Initialize(const CommandLineArgumentMapType & _arg)
   else
   {
     /** Both "p" and "tp" are used, which is prohibited. */
-    log::error(std::ostringstream{} << "ERROR: Both \"-p\" and \"-tp\" are used, which is prohibited.");
+    log::error("ERROR: Both \"-p\" and \"-tp\" are used, which is prohibited.");
     return 1;
   }
 

--- a/Core/Kernel/elxElastixBase.cxx
+++ b/Core/Kernel/elxElastixBase.cxx
@@ -84,7 +84,7 @@ GenerateFileNameContainer(const Configuration & configuration,
       unsigned int nrSpaces = nrSpaces0 > 1 ? nrSpaces0 : 1;
       std::string  spaces = "";
       spaces.resize(nrSpaces, ' ');
-      log::info(std::ostringstream{} << argused << spaces << commandLineArgument);
+      log::info(argused + spaces + commandLineArgument);
     }
     fileNameContainer->CreateElementAt(0) = commandLineArgument;
 
@@ -110,7 +110,7 @@ GenerateFileNameContainer(const Configuration & configuration,
           unsigned int nrSpaces = nrSpaces0 > 1 ? nrSpaces0 : 1;
           std::string  spaces = "";
           spaces.resize(nrSpaces, ' ');
-          log::info(std::ostringstream{} << argused << spaces << commandLineArgument);
+          log::info(argused + spaces + commandLineArgument);
         }
         fileNameContainer->CreateElementAt(i) = commandLineArgument;
         ++i;
@@ -223,7 +223,7 @@ ElastixBase::BeforeAllBase()
 
       m_Configuration->SetCommandLineArgument("-out", folder);
     }
-    log::info(std::ostringstream{} << "-out      " << commandLineArgument);
+    log::info("-out      " + commandLineArgument);
   }
 
   /** Print all "-p". */
@@ -254,7 +254,7 @@ ElastixBase::BeforeAllBase()
   }
   else
   {
-    log::info(std::ostringstream{} << "-priority " << commandLineArgument);
+    log::info("-priority " + commandLineArgument);
   }
 #endif
 
@@ -266,7 +266,7 @@ ElastixBase::BeforeAllBase()
   }
   else
   {
-    log::info(std::ostringstream{} << "-threads  " << commandLineArgument);
+    log::info("-threads  " + commandLineArgument);
   }
 
   /** Check the very important UseDirectionCosines parameter. */
@@ -334,7 +334,7 @@ ElastixBase::BeforeAllTransformixBase()
     {
       m_Configuration->SetCommandLineArgument("-out", commandLineArgument + '/');
     }
-    log::info(std::ostringstream{} << "-out      " << commandLineArgument);
+    log::info("-out      " + commandLineArgument);
   }
 
   /** Check for appearance of -threads, which specifies the maximum number of threads. */
@@ -345,13 +345,13 @@ ElastixBase::BeforeAllTransformixBase()
   }
   else
   {
-    log::info(std::ostringstream{} << "-threads  " << commandLineArgument);
+    log::info("-threads  " + commandLineArgument);
   }
   if (!BaseComponent::IsElastixLibrary())
   {
     /** Print "-tp". */
     const std::string commandLineArgument = m_Configuration->GetCommandLineArgument("-tp");
-    log::info(std::ostringstream{} << "-tp       " << commandLineArgument);
+    log::info("-tp       " + commandLineArgument);
   }
   /** Retrieve the very important UseDirectionCosines parameter. */
   m_Configuration->ReadParameter(m_UseDirectionCosines, "UseDirectionCosines", 0);


### PR DESCRIPTION
- Following pull request #799 commit 79e227907b4887453ce5af1460ae32131bdc2014 "ENH: Replace xout with log warn, error, info, to_stdout, to_log_file"
