### PR TITLE
Use GetFixedPoints, GetMovingPoints in CorrespondingPointsEuclideanDistanceMetric and other style improvements

### DIFF
--- a/Common/CostFunctions/itkSingleValuedPointSetToPointSetMetric.h
+++ b/Common/CostFunctions/itkSingleValuedPointSetToPointSetMetric.h
@@ -39,6 +39,7 @@
 #include "itkMacro.h"
 #include "itkImageMaskSpatialObject.h"
 #include "itkPointSet.h"
+#include "itkDeref.h"
 
 namespace itk
 {
@@ -178,6 +179,30 @@ protected:
   /** PrintSelf. */
   void
   PrintSelf(std::ostream & os, Indent indent) const override;
+
+  /** Returns a reference to the STL container of fixed points. */
+  const auto &
+  GetFixedPoints() const
+  {
+    // Sanity check.
+    if (!m_FixedPointSet)
+    {
+      itkExceptionMacro("Fixed point set has not been assigned");
+    }
+    return Deref(m_FixedPointSet->GetPoints()).CastToSTLConstContainer();
+  }
+
+  /** Returns a reference to the STL container of moving points. */
+  const auto &
+  GetMovingPoints() const
+  {
+    // Sanity check.
+    if (!m_MovingPointSet)
+    {
+      itkExceptionMacro("Moving point set has not been assigned");
+    }
+    return Deref(m_MovingPointSet->GetPoints()).CastToSTLConstContainer();
+  }
 
   /** Member variables. */
   FixedPointSetConstPointer   m_FixedPointSet{ nullptr };

--- a/Components/Metrics/CorrespondingPointsEuclideanDistanceMetric/itkCorrespondingPointsEuclideanDistancePointMetric.hxx
+++ b/Components/Metrics/CorrespondingPointsEuclideanDistanceMetric/itkCorrespondingPointsEuclideanDistancePointMetric.hxx
@@ -37,8 +37,7 @@ CorrespondingPointsEuclideanDistancePointMetric<TFixedPointSet, TMovingPointSet>
 
   /** Initialize some variables. */
   Superclass::m_NumberOfPointsCounted = 0;
-  MeasureType     measure{};
-  OutputPointType mappedPoint;
+  MeasureType measure{};
 
   /** Make sure the transform parameters are up to date. */
   this->SetTransformParameters(parameters);
@@ -54,7 +53,7 @@ CorrespondingPointsEuclideanDistancePointMetric<TFixedPointSet, TMovingPointSet>
 
     /** Transform point and check if it is inside the B-spline support region. */
     // bool sampleOk = this->TransformPoint( fixedPoint, mappedPoint );
-    mappedPoint = Superclass::m_Transform->TransformPoint(fixedPoint);
+    const OutputPointType mappedPoint = Superclass::m_Transform->TransformPoint(fixedPoint);
 
     /** Check if the point is inside the moving mask. */
     if ((Superclass::m_MovingImageMask == nullptr) || Superclass::m_MovingImageMask->IsInsideInWorldSpace(mappedPoint))
@@ -118,7 +117,6 @@ CorrespondingPointsEuclideanDistancePointMetric<TFixedPointSet, TMovingPointSet>
   NonZeroJacobianIndicesType nzji(Superclass::m_Transform->GetNumberOfNonZeroJacobianIndices());
   TransformJacobianType      jacobian;
 
-  OutputPointType mappedPoint;
   /** Call non-thread-safe stuff, such as:
    *   this->SetTransformParameters( parameters );
    *   this->GetImageSampler()->Update();
@@ -145,7 +143,7 @@ CorrespondingPointsEuclideanDistancePointMetric<TFixedPointSet, TMovingPointSet>
 
     /** Transform point and check if it is inside the B-spline support region. */
     // bool sampleOk = this->TransformPoint( fixedPoint, mappedPoint );
-    mappedPoint = Superclass::m_Transform->TransformPoint(fixedPoint);
+    const OutputPointType mappedPoint = Superclass::m_Transform->TransformPoint(fixedPoint);
 
     /** Check if the point is inside the moving mask. */
     if ((Superclass::m_MovingImageMask == nullptr) || Superclass::m_MovingImageMask->IsInsideInWorldSpace(mappedPoint))

--- a/Components/Metrics/CorrespondingPointsEuclideanDistanceMetric/itkCorrespondingPointsEuclideanDistancePointMetric.hxx
+++ b/Components/Metrics/CorrespondingPointsEuclideanDistanceMetric/itkCorrespondingPointsEuclideanDistancePointMetric.hxx
@@ -57,17 +57,7 @@ CorrespondingPointsEuclideanDistancePointMetric<TFixedPointSet, TMovingPointSet>
     mappedPoint = Superclass::m_Transform->TransformPoint(fixedPoint);
 
     /** Check if the point is inside the moving mask. */
-    bool sampleOk = true;
-    if (sampleOk)
-    {
-      // sampleOk = this->IsInsideMovingMask( mappedPoint );
-      if (Superclass::m_MovingImageMask.IsNotNull())
-      {
-        sampleOk = Superclass::m_MovingImageMask->IsInsideInWorldSpace(mappedPoint);
-      }
-    }
-
-    if (sampleOk)
+    if ((Superclass::m_MovingImageMask == nullptr) || Superclass::m_MovingImageMask->IsInsideInWorldSpace(mappedPoint))
     {
       Superclass::m_NumberOfPointsCounted++;
 
@@ -158,17 +148,7 @@ CorrespondingPointsEuclideanDistancePointMetric<TFixedPointSet, TMovingPointSet>
     mappedPoint = Superclass::m_Transform->TransformPoint(fixedPoint);
 
     /** Check if the point is inside the moving mask. */
-    bool sampleOk = true;
-    if (sampleOk)
-    {
-      // sampleOk = this->IsInsideMovingMask( mappedPoint );
-      if (Superclass::m_MovingImageMask.IsNotNull())
-      {
-        sampleOk = Superclass::m_MovingImageMask->IsInsideInWorldSpace(mappedPoint);
-      }
-    }
-
-    if (sampleOk)
+    if ((Superclass::m_MovingImageMask == nullptr) || Superclass::m_MovingImageMask->IsInsideInWorldSpace(mappedPoint))
     {
       Superclass::m_NumberOfPointsCounted++;
 

--- a/Components/Metrics/CorrespondingPointsEuclideanDistanceMetric/itkCorrespondingPointsEuclideanDistancePointMetric.hxx
+++ b/Components/Metrics/CorrespondingPointsEuclideanDistanceMetric/itkCorrespondingPointsEuclideanDistancePointMetric.hxx
@@ -36,7 +36,7 @@ CorrespondingPointsEuclideanDistancePointMetric<TFixedPointSet, TMovingPointSet>
   const auto & movingPoints = this->Superclass::GetMovingPoints();
 
   /** Initialize some variables. */
-  this->m_NumberOfPointsCounted = 0;
+  Superclass::m_NumberOfPointsCounted = 0;
   MeasureType     measure{};
   OutputPointType mappedPoint;
 
@@ -54,22 +54,22 @@ CorrespondingPointsEuclideanDistancePointMetric<TFixedPointSet, TMovingPointSet>
 
     /** Transform point and check if it is inside the B-spline support region. */
     // bool sampleOk = this->TransformPoint( fixedPoint, mappedPoint );
-    mappedPoint = this->m_Transform->TransformPoint(fixedPoint);
+    mappedPoint = Superclass::m_Transform->TransformPoint(fixedPoint);
 
     /** Check if the point is inside the moving mask. */
     bool sampleOk = true;
     if (sampleOk)
     {
       // sampleOk = this->IsInsideMovingMask( mappedPoint );
-      if (this->m_MovingImageMask.IsNotNull())
+      if (Superclass::m_MovingImageMask.IsNotNull())
       {
-        sampleOk = this->m_MovingImageMask->IsInsideInWorldSpace(mappedPoint);
+        sampleOk = Superclass::m_MovingImageMask->IsInsideInWorldSpace(mappedPoint);
       }
     }
 
     if (sampleOk)
     {
-      this->m_NumberOfPointsCounted++;
+      Superclass::m_NumberOfPointsCounted++;
 
       VnlVectorType diffPoint = (movingPoint - mappedPoint).GetVnlVector();
       measure += diffPoint.magnitude();
@@ -80,7 +80,7 @@ CorrespondingPointsEuclideanDistancePointMetric<TFixedPointSet, TMovingPointSet>
 
   } // end loop over all corresponding points
 
-  return measure / this->m_NumberOfPointsCounted;
+  return measure / Superclass::m_NumberOfPointsCounted;
 
 } // end GetValue()
 
@@ -121,11 +121,11 @@ CorrespondingPointsEuclideanDistancePointMetric<TFixedPointSet, TMovingPointSet>
   const auto & movingPoints = this->Superclass::GetMovingPoints();
 
   /** Initialize some variables */
-  this->m_NumberOfPointsCounted = 0;
+  Superclass::m_NumberOfPointsCounted = 0;
   MeasureType measure{};
   derivative.set_size(this->GetNumberOfParameters());
   derivative.Fill(DerivativeValueType{});
-  NonZeroJacobianIndicesType nzji(this->m_Transform->GetNumberOfNonZeroJacobianIndices());
+  NonZeroJacobianIndicesType nzji(Superclass::m_Transform->GetNumberOfNonZeroJacobianIndices());
   TransformJacobianType      jacobian;
 
   OutputPointType mappedPoint;
@@ -155,26 +155,26 @@ CorrespondingPointsEuclideanDistancePointMetric<TFixedPointSet, TMovingPointSet>
 
     /** Transform point and check if it is inside the B-spline support region. */
     // bool sampleOk = this->TransformPoint( fixedPoint, mappedPoint );
-    mappedPoint = this->m_Transform->TransformPoint(fixedPoint);
+    mappedPoint = Superclass::m_Transform->TransformPoint(fixedPoint);
 
     /** Check if the point is inside the moving mask. */
     bool sampleOk = true;
     if (sampleOk)
     {
       // sampleOk = this->IsInsideMovingMask( mappedPoint );
-      if (this->m_MovingImageMask.IsNotNull())
+      if (Superclass::m_MovingImageMask.IsNotNull())
       {
-        sampleOk = this->m_MovingImageMask->IsInsideInWorldSpace(mappedPoint);
+        sampleOk = Superclass::m_MovingImageMask->IsInsideInWorldSpace(mappedPoint);
       }
     }
 
     if (sampleOk)
     {
-      this->m_NumberOfPointsCounted++;
+      Superclass::m_NumberOfPointsCounted++;
 
       /** Get the TransformJacobian dT/dmu. */
       // this->EvaluateTransformJacobian( fixedPoint, jacobian, nzji );
-      this->m_Transform->GetJacobian(fixedPoint, jacobian, nzji);
+      Superclass::m_Transform->GetJacobian(fixedPoint, jacobian, nzji);
 
       VnlVectorType diffPoint = (movingPoint - mappedPoint).GetVnlVector();
       MeasureType   distance = diffPoint.magnitude();
@@ -209,14 +209,14 @@ CorrespondingPointsEuclideanDistancePointMetric<TFixedPointSet, TMovingPointSet>
 
   /** Check if enough samples were valid. */
   //   this->CheckNumberOfSamples(
-  //     fixedPointSet->GetNumberOfPoints(), this->m_NumberOfPointsCounted );
+  //     fixedPointSet->GetNumberOfPoints(), Superclass::m_NumberOfPointsCounted );
 
   /** Copy the measure to value. */
   value = measure;
-  if (this->m_NumberOfPointsCounted > 0)
+  if (Superclass::m_NumberOfPointsCounted > 0)
   {
-    derivative /= this->m_NumberOfPointsCounted;
-    value = measure / this->m_NumberOfPointsCounted;
+    derivative /= Superclass::m_NumberOfPointsCounted;
+    value = measure / Superclass::m_NumberOfPointsCounted;
   }
 
 } // end GetValueAndDerivative()

--- a/Components/Metrics/CorrespondingPointsEuclideanDistanceMetric/itkCorrespondingPointsEuclideanDistancePointMetric.hxx
+++ b/Components/Metrics/CorrespondingPointsEuclideanDistanceMetric/itkCorrespondingPointsEuclideanDistancePointMetric.hxx
@@ -32,39 +32,25 @@ auto
 CorrespondingPointsEuclideanDistancePointMetric<TFixedPointSet, TMovingPointSet>::GetValue(
   const TransformParametersType & parameters) const -> MeasureType
 {
-  /** Sanity checks. */
-  FixedPointSetConstPointer fixedPointSet = this->GetFixedPointSet();
-  if (!fixedPointSet)
-  {
-    itkExceptionMacro("Fixed point set has not been assigned");
-  }
-
-  MovingPointSetConstPointer movingPointSet = this->GetMovingPointSet();
-  if (!movingPointSet)
-  {
-    itkExceptionMacro("Moving point set has not been assigned");
-  }
+  const auto & fixedPoints = this->Superclass::GetFixedPoints();
+  const auto & movingPoints = this->Superclass::GetMovingPoints();
 
   /** Initialize some variables. */
   this->m_NumberOfPointsCounted = 0;
   MeasureType     measure{};
-  InputPointType  movingPoint;
-  OutputPointType fixedPoint, mappedPoint;
+  OutputPointType mappedPoint;
 
   /** Make sure the transform parameters are up to date. */
   this->SetTransformParameters(parameters);
 
-  /** Create iterators. */
-  PointIterator pointItFixed = fixedPointSet->GetPoints()->Begin();
-  PointIterator pointItMoving = movingPointSet->GetPoints()->Begin();
-  PointIterator pointEnd = fixedPointSet->GetPoints()->End();
+  /** Create iterator. */
+  auto pointItMoving = movingPoints.cbegin();
 
   /** Loop over the corresponding points. */
-  while (pointItFixed != pointEnd)
+  for (const OutputPointType & fixedPoint : fixedPoints)
   {
-    /** Get the current corresponding points. */
-    fixedPoint = pointItFixed.Value();
-    movingPoint = pointItMoving.Value();
+    /** Get the current corresponding moving point. */
+    const InputPointType & movingPoint = *pointItMoving;
 
     /** Transform point and check if it is inside the B-spline support region. */
     // bool sampleOk = this->TransformPoint( fixedPoint, mappedPoint );
@@ -90,7 +76,6 @@ CorrespondingPointsEuclideanDistancePointMetric<TFixedPointSet, TMovingPointSet>
 
     } // end if sampleOk
 
-    ++pointItFixed;
     ++pointItMoving;
 
   } // end loop over all corresponding points
@@ -132,18 +117,8 @@ CorrespondingPointsEuclideanDistancePointMetric<TFixedPointSet, TMovingPointSet>
   MeasureType &                   value,
   DerivativeType &                derivative) const
 {
-  /** Sanity checks. */
-  FixedPointSetConstPointer fixedPointSet = this->GetFixedPointSet();
-  if (!fixedPointSet)
-  {
-    itkExceptionMacro("Fixed point set has not been assigned");
-  }
-
-  MovingPointSetConstPointer movingPointSet = this->GetMovingPointSet();
-  if (!movingPointSet)
-  {
-    itkExceptionMacro("Moving point set has not been assigned");
-  }
+  const auto & fixedPoints = this->Superclass::GetFixedPoints();
+  const auto & movingPoints = this->Superclass::GetMovingPoints();
 
   /** Initialize some variables */
   this->m_NumberOfPointsCounted = 0;
@@ -153,9 +128,7 @@ CorrespondingPointsEuclideanDistancePointMetric<TFixedPointSet, TMovingPointSet>
   NonZeroJacobianIndicesType nzji(this->m_Transform->GetNumberOfNonZeroJacobianIndices());
   TransformJacobianType      jacobian;
 
-  InputPointType  movingPoint;
-  OutputPointType fixedPoint, mappedPoint;
-
+  OutputPointType mappedPoint;
   /** Call non-thread-safe stuff, such as:
    *   this->SetTransformParameters( parameters );
    *   this->GetImageSampler()->Update();
@@ -171,17 +144,14 @@ CorrespondingPointsEuclideanDistancePointMetric<TFixedPointSet, TMovingPointSet>
    */
   this->BeforeThreadedGetValueAndDerivative(parameters);
 
-  /** Create iterators. */
-  PointIterator pointItFixed = fixedPointSet->GetPoints()->Begin();
-  PointIterator pointItMoving = movingPointSet->GetPoints()->Begin();
-  PointIterator pointEnd = fixedPointSet->GetPoints()->End();
+  /** Create iterator. */
+  auto pointItMoving = movingPoints.cbegin();
 
   /** Loop over the corresponding points. */
-  while (pointItFixed != pointEnd)
+  for (const OutputPointType & fixedPoint : fixedPoints)
   {
-    /** Get the current corresponding points. */
-    fixedPoint = pointItFixed.Value();
-    movingPoint = pointItMoving.Value();
+    /** Get the current corresponding moving point. */
+    const InputPointType & movingPoint = *pointItMoving;
 
     /** Transform point and check if it is inside the B-spline support region. */
     // bool sampleOk = this->TransformPoint( fixedPoint, mappedPoint );
@@ -233,7 +203,6 @@ CorrespondingPointsEuclideanDistancePointMetric<TFixedPointSet, TMovingPointSet>
 
     } // end if sampleOk
 
-    ++pointItFixed;
     ++pointItMoving;
 
   } // end loop over all corresponding points


### PR DESCRIPTION
The use of `GetFixedPoints()` and `GetMovingPoints()`, which return a reference to the internal `std::vector` of the point set, may slightly improve the run-time performance.