### PR TITLE
COMP: Upgrade clang-format-lint-action to v0.18.2

### DIFF
--- a/.github/workflows/clang_format_check.yml
+++ b/.github/workflows/clang_format_check.yml
@@ -7,8 +7,8 @@ jobs:
     runs-on: ubuntu-latest
 
     steps:
-    - uses: actions/checkout@v2
-    - uses: DoozyX/clang-format-lint-action@v0.11
+    - uses: actions/checkout@v4.1.7
+    - uses: DoozyX/clang-format-lint-action@v0.18.2
       with:
         source: '.'
         exclude: './CMake'


### PR DESCRIPTION
Aims to fix errors at the CI, saying:

      File "/run-clang-format.py", line 25, in <module>
        from distutils.util import strtobool
    ModuleNotFoundError: No module named 'distutils'

----

Upgraded clang-format-lint-action to its latest tag, https://github.com/DoozyX/clang-format-lint-action/releases/tag/v0.18.2 released on September 4, 2024.

Also upgraded actions/checkout to its latest tag, https://github.com/actions/checkout/releases/tag/v4.1.7 from June 12, 2024