### PR TITLE
PERF: EuclideanDistanceMetric get vector norm without GetVnlVector()

### DIFF
--- a/Components/Metrics/CorrespondingPointsEuclideanDistanceMetric/itkCorrespondingPointsEuclideanDistancePointMetric.hxx
+++ b/Components/Metrics/CorrespondingPointsEuclideanDistanceMetric/itkCorrespondingPointsEuclideanDistancePointMetric.hxx
@@ -59,9 +59,8 @@ CorrespondingPointsEuclideanDistancePointMetric<TFixedPointSet, TMovingPointSet>
     if ((Superclass::m_MovingImageMask == nullptr) || Superclass::m_MovingImageMask->IsInsideInWorldSpace(mappedPoint))
     {
       Superclass::m_NumberOfPointsCounted++;
-
-      VnlVectorType diffPoint = (movingPoint - mappedPoint).GetVnlVector();
-      measure += diffPoint.magnitude();
+      const auto diffVector = movingPoint - mappedPoint;
+      measure += diffVector.GetNorm();
 
     } // end if sampleOk
 
@@ -154,14 +153,14 @@ CorrespondingPointsEuclideanDistancePointMetric<TFixedPointSet, TMovingPointSet>
       // this->EvaluateTransformJacobian( fixedPoint, jacobian, nzji );
       Superclass::m_Transform->GetJacobian(fixedPoint, jacobian, nzji);
 
-      VnlVectorType diffPoint = (movingPoint - mappedPoint).GetVnlVector();
-      MeasureType   distance = diffPoint.magnitude();
+      const auto  diffVector = movingPoint - mappedPoint;
+      MeasureType distance = diffVector.GetNorm();
       measure += distance;
 
       /** Calculate the contributions to the derivatives with respect to each parameter. */
       if (distance > std::numeric_limits<MeasureType>::epsilon())
       {
-        VnlVectorType diff_2 = diffPoint / distance;
+        VnlVectorType diff_2 = (diffVector / distance).GetVnlVector();
         if (nzji.size() == this->GetNumberOfParameters())
         {
           /** Loop over all Jacobians. */


### PR DESCRIPTION
Removed unnecessary conversion from `itk::Vector` to vnl_vector, when retrieving the norm (the magnitude) of a vector (movingPoint - mappedPoint), in `CorrespondingPointsEuclideanDistancePointMetric`.

Appears to make `GetValue` more that 7 times faster (from more than 0.07 sec. down to less than 0.009 sec. on 1 million 3D points), as observed on Visual C++ 2022.