### PR TITLE
Add SetFixedPoints and SetMovingPoints to ElastixRegistrationMethod, for point-to-point EuclideanDistanceMetric 

### DIFF
--- a/Core/Kernel/elxElastixBase.h
+++ b/Core/Kernel/elxElastixBase.h
@@ -231,6 +231,12 @@ public:
   elxSetObjectMacro(FixedMaskContainer, DataObjectContainerType);
   elxSetObjectMacro(MovingMaskContainer, DataObjectContainerType);
 
+  /** Set/Get the fixed/moving points (landmarks, used by the CorrespondingPointsEuclideanDistance metric). */
+  elxGetObjectMacro(FixedPoints, const itk::Object);
+  elxGetObjectMacro(MovingPoints, const itk::Object);
+  elxSetObjectMacro(FixedPoints, const itk::Object);
+  elxSetObjectMacro(MovingPoints, const itk::Object);
+
   /** Set/Get the result image container. */
   elxGetObjectMacro(ResultImageContainer, DataObjectContainerType);
   elxSetObjectMacro(ResultImageContainer, DataObjectContainerType);
@@ -509,6 +515,10 @@ private:
   DataObjectContainerPointer m_MovingImageContainer{ DataObjectContainerType::New() };
   DataObjectContainerPointer m_FixedMaskContainer{ DataObjectContainerType::New() };
   DataObjectContainerPointer m_MovingMaskContainer{ DataObjectContainerType::New() };
+
+  /** The fixed and moving points (landmarks, used by the CorrespondingPointsEuclideanDistance metric). */
+  itk::SmartPointer<const itk::Object> m_FixedPoints{ nullptr };
+  itk::SmartPointer<const itk::Object> m_MovingPoints{ nullptr };
 
   /** The result image container. These are stored as pointers to itk::DataObject. */
   DataObjectContainerPointer m_ResultImageContainer{ DataObjectContainerType::New() };

--- a/Core/Kernel/elxElastixMain.cxx
+++ b/Core/Kernel/elxElastixMain.cxx
@@ -154,6 +154,9 @@ ElastixMain::Run()
   elastixBase.SetMovingMaskContainer(this->GetModifiableMovingMaskContainer());
   elastixBase.SetResultImageContainer(this->GetModifiableResultImageContainer());
 
+  elastixBase.SetFixedPoints(m_FixedPoints);
+  elastixBase.SetMovingPoints(m_MovingPoints);
+
   /** Set the initial transform, if it happens to be there. */
   elastixBase.SetInitialTransform(this->GetModifiableInitialTransform());
 

--- a/Core/Kernel/elxElastixMain.h
+++ b/Core/Kernel/elxElastixMain.h
@@ -98,6 +98,9 @@ public:
   itkGetModifiableObjectMacro(FixedMaskContainer, DataObjectContainerType);
   itkGetModifiableObjectMacro(MovingMaskContainer, DataObjectContainerType);
 
+  itkSetConstObjectMacro(FixedPoints, itk::Object);
+  itkSetConstObjectMacro(MovingPoints, itk::Object);
+
   /** Get the final transform (the result of running elastix).
    * You may pass this as an InitialTransform in an other instantiation
    * of ElastixMain.
@@ -174,6 +177,10 @@ private:
   DataObjectContainerPointer m_FixedMaskContainer{ nullptr };
   DataObjectContainerPointer m_MovingMaskContainer{ nullptr };
   DataObjectContainerPointer m_ResultImageContainer{ nullptr };
+
+  itk::SmartPointer<const itk::Object> m_FixedPoints{ nullptr };
+  itk::SmartPointer<const itk::Object> m_MovingPoints{ nullptr };
+
 
   /** A transform that is the result of registration. */
   ObjectPointer m_FinalTransform{ nullptr };

--- a/Core/Main/GTesting/itkElastixRegistrationMethodGTest.cxx
+++ b/Core/Main/GTesting/itkElastixRegistrationMethodGTest.cxx
@@ -2595,7 +2595,7 @@ GTEST_TEST(itkElastixRegistrationMethod, EuclideanDistancePointMetric)
 
   elx::DefaultConstruct<ElastixRegistrationMethodType<ImageType>> registration{};
 
-  using PointType = itk::Point<double, ImageDimension>;
+  using PointType = itk::Point<float, ImageDimension>;
 
   const PointType fixedPoint{};
   PointType       movingPoint = fixedPoint;
@@ -2607,8 +2607,8 @@ GTEST_TEST(itkElastixRegistrationMethod, EuclideanDistancePointMetric)
 
   registration.SetFixedImage(fixedImage);
   registration.SetMovingImage(movingImage);
-  registration.SetFixedPoints(MakeVectorContainer(std::vector<PointType>{ fixedPoint }));
-  registration.SetMovingPoints(MakeVectorContainer(std::vector<PointType>{ movingPoint }));
+  registration.SetFixedPoints(::MakeVectorContainer(std::vector<PointType>{ fixedPoint }));
+  registration.SetMovingPoints(::MakeVectorContainer(std::vector<PointType>{ movingPoint }));
   registration.SetParameterObject(CreateParameterObject(
     ParameterMapType{ // Parameters in alphabetic order:
                       { "ImageSampler", { "Full" } },

--- a/Core/Main/GTesting/itkElastixRegistrationMethodGTest.cxx
+++ b/Core/Main/GTesting/itkElastixRegistrationMethodGTest.cxx
@@ -513,6 +513,16 @@ GetNumberOfTransforms(const itk::Transform<TParametersValueType, VInputDimension
   return 1;
 };
 
+
+template <typename T>
+auto
+MakeVectorContainer(std::vector<T> stdVector)
+{
+  const auto vectorContainer = itk::VectorContainer<itk::SizeValueType, T>::New();
+  vectorContainer->CastToSTLContainer() = std::move(stdVector);
+  return vectorContainer;
+}
+
 } // namespace
 
 
@@ -2566,4 +2576,49 @@ GTEST_TEST(itkElastixRegistrationMethod, EulerStackTransformComputeZYX)
 
   // Expect that the result is different that, when running with computeZYX = false.
   EXPECT_NE(transformParameters, doRegistration(false));
+}
+
+
+GTEST_TEST(itkElastixRegistrationMethod, EuclideanDistancePointMetric)
+{
+  static constexpr auto ImageDimension = 2U;
+  using PixelType = float;
+  using ImageType = itk::Image<PixelType, ImageDimension>;
+  using SizeType = itk::Size<ImageDimension>;
+  using OffsetType = itk::Offset<ImageDimension>;
+
+  const OffsetType translationOffset{ { 1, -2 } };
+  const SizeType   imageSize{ { 5, 6 } };
+
+  const auto fixedImage = CreateImage<PixelType>(imageSize);
+  const auto movingImage = CreateImage<PixelType>(imageSize);
+
+  elx::DefaultConstruct<ElastixRegistrationMethodType<ImageType>> registration{};
+
+  using PointType = itk::Point<double, ImageDimension>;
+
+  const PointType fixedPoint{};
+  PointType       movingPoint = fixedPoint;
+
+  for (unsigned int i{}; i < ImageDimension; ++i)
+  {
+    movingPoint[i] += translationOffset[i];
+  }
+
+  registration.SetFixedImage(fixedImage);
+  registration.SetMovingImage(movingImage);
+  registration.SetFixedPoints(MakeVectorContainer(std::vector<PointType>{ fixedPoint }));
+  registration.SetMovingPoints(MakeVectorContainer(std::vector<PointType>{ movingPoint }));
+  registration.SetParameterObject(CreateParameterObject(
+    ParameterMapType{ // Parameters in alphabetic order:
+                      { "ImageSampler", { "Full" } },
+                      { "MaximumNumberOfIterations", { "2" } },
+                      { "Metric", { "AdvancedNormalizedCorrelation", "CorrespondingPointsEuclideanDistanceMetric" } },
+                      { "Optimizer", { "AdaptiveStochasticGradientDescent" } },
+                      { "Registration", { "MultiMetricMultiResolutionRegistration" } },
+                      { "Transform", { "TranslationTransform" } } }));
+  registration.Update();
+
+  const auto transformParameters = GetTransformParametersFromFilter(registration);
+  EXPECT_EQ(ConvertToOffset<ImageDimension>(transformParameters), translationOffset);
 }

--- a/Core/Main/itkElastixRegistrationMethod.h
+++ b/Core/Main/itkElastixRegistrationMethod.h
@@ -103,8 +103,8 @@ public:
                 "ElastixRegistrationMethod assumes that fixed and moving image have the same number of dimensions.");
   static constexpr unsigned int ImageDimension = TFixedImage::ImageDimension;
 
-  using PointType = Point<double, ImageDimension>;
-  using PointVectorContainerType = VectorContainer<IdentifierType, PointType>;
+  template <typename TCoordinate>
+  using PointContainerType = VectorContainer<IdentifierType, Point<TCoordinate, ImageDimension>>;
 
   using FixedMaskType = Image<unsigned char, FixedImageDimension>;
   using MovingMaskType = Image<unsigned char, MovingImageDimension>;
@@ -166,8 +166,20 @@ public:
   unsigned int
   GetNumberOfMovingMasks() const;
 
-  itkSetConstObjectMacro(FixedPoints, PointVectorContainerType);
-  itkSetConstObjectMacro(MovingPoints, PointVectorContainerType);
+  itkSetConstObjectMacro(FixedPoints, PointContainerType<double>);
+  itkSetConstObjectMacro(MovingPoints, PointContainerType<double>);
+
+  void
+  SetFixedPoints(const PointContainerType<float> * const points)
+  {
+    SetFixedPoints(ConvertToPointContainerOfDoubleCoordinates(points));
+  }
+
+  void
+  SetMovingPoints(const PointContainerType<float> * const points)
+  {
+    SetMovingPoints(ConvertToPointContainerOfDoubleCoordinates(points));
+  }
 
   /** Set/Get parameter object.*/
   virtual void
@@ -329,6 +341,21 @@ protected:
   MakeOutput(DataObjectPointerArraySizeType idx) override;
 
 private:
+  static SmartPointer<PointContainerType<double>>
+  ConvertToPointContainerOfDoubleCoordinates(const PointContainerType<float> * const floatPointContainer)
+  {
+    if (floatPointContainer)
+    {
+      const auto result = PointContainerType<double>::New();
+      result->assign(floatPointContainer->cbegin(), floatPointContainer->cend());
+      return result;
+    }
+    else
+    {
+      return nullptr;
+    }
+  }
+
   /** MakeUniqueName. */
   std::string
   MakeUniqueName(const DataObjectIdentifierType & key);
@@ -401,8 +428,8 @@ private:
   std::string m_FixedPointSetFileName{};
   std::string m_MovingPointSetFileName{};
 
-  SmartPointer<const PointVectorContainerType> m_FixedPoints{};
-  SmartPointer<const PointVectorContainerType> m_MovingPoints{};
+  SmartPointer<const PointContainerType<double>> m_FixedPoints{};
+  SmartPointer<const PointContainerType<double>> m_MovingPoints{};
 
   std::string m_OutputDirectory{};
   std::string m_LogFileName{};

--- a/Core/Main/itkElastixRegistrationMethod.h
+++ b/Core/Main/itkElastixRegistrationMethod.h
@@ -103,6 +103,9 @@ public:
                 "ElastixRegistrationMethod assumes that fixed and moving image have the same number of dimensions.");
   static constexpr unsigned int ImageDimension = TFixedImage::ImageDimension;
 
+  using PointType = Point<double, ImageDimension>;
+  using PointVectorContainerType = VectorContainer<IdentifierType, PointType>;
+
   using FixedMaskType = Image<unsigned char, FixedImageDimension>;
   using MovingMaskType = Image<unsigned char, MovingImageDimension>;
   using TransformType = Transform<double, FixedImageDimension, MovingImageDimension>;
@@ -162,6 +165,9 @@ public:
   RemoveMovingMask();
   unsigned int
   GetNumberOfMovingMasks() const;
+
+  itkSetConstObjectMacro(FixedPoints, PointVectorContainerType);
+  itkSetConstObjectMacro(MovingPoints, PointVectorContainerType);
 
   /** Set/Get parameter object.*/
   virtual void
@@ -394,6 +400,9 @@ private:
 
   std::string m_FixedPointSetFileName{};
   std::string m_MovingPointSetFileName{};
+
+  SmartPointer<const PointVectorContainerType> m_FixedPoints{};
+  SmartPointer<const PointVectorContainerType> m_MovingPoints{};
 
   std::string m_OutputDirectory{};
   std::string m_LogFileName{};

--- a/Core/Main/itkElastixRegistrationMethod.hxx
+++ b/Core/Main/itkElastixRegistrationMethod.hxx
@@ -363,6 +363,8 @@ ElastixRegistrationMethod<TFixedImage, TMovingImage>::GenerateData()
                            movingInternalImageContainers));
     elastixMain->SetFixedMaskContainer(registrationData.fixedMaskContainer);
     elastixMain->SetMovingMaskContainer(registrationData.movingMaskContainer);
+    elastixMain->SetFixedPoints(m_FixedPoints);
+    elastixMain->SetMovingPoints(m_MovingPoints);
     elastixMain->SetResultImageContainer(registrationData.resultImageContainer);
     elastixMain->SetOriginalFixedImageDirectionFlat(registrationData.fixedImageOriginalDirectionFlat);
 


### PR DESCRIPTION
Currently trying it out in Python:

```python
Dimension = 2
ImageType = itk.Image[itk.UC, Dimension]
PointType = itk.Point[itk.D, Dimension]
PointContainerType = itk.VectorContainer[itk.ULL, PointType]

fixed_image = ImageType.New()
fixed_image.SetRegions(itk.Size[Dimension].Filled(8))
fixed_image.AllocateInitialized()

moving_image = ImageType.New()
moving_image.SetRegions(itk.Size[Dimension].Filled(8))
moving_image.AllocateInitialized()

fixed_point = PointType([0.0, 0.0])
fixed_points = PointContainerType.New()
fixed_points.InsertElement(0, fixed_point)

moving_point = PointType([1.0, -2.0])
moving_points = PointContainerType.New()
moving_points.InsertElement(0, moving_point)

parameter_object = itk.ParameterObject.New()
parameter_object.AddParameterMap(
    {"ImageSampler": ("Full",),
    "MaximumNumberOfIterations": ("2",),
    "Metric": ("AdvancedNormalizedCorrelation", "CorrespondingPointsEuclideanDistanceMetric"),
    "Optimizer": ("AdaptiveStochasticGradientDescent",),
    "Registration": ( "MultiMetricMultiResolutionRegistration",),
    "Transform": ("TranslationTransform",)})

result_image, result_transform_parameters = itk.elastix_registration_method(
    fixed_image, moving_image, fixed_points=fixed_points, moving_points=moving_points,
    parameter_object=parameter_object)

print(result_transform_parameters)
```

Output:
```

ParameterObject (000001D212B702D0)
  RTTI typeinfo:   class elastix::ParameterObject
  Reference Count: 1
  Modified Time: 10574
  Debug: Off
  Object Name: 
  Observers: 
    none
ParameterMap 0: 
  (CompressResultImage "false")
  (DefaultPixelValue)
  (Direction 1 0 0 1)
  (FinalBSplineInterpolationOrder 3)
  (FixedImageDimension 2)
  (FixedInternalImagePixelType "float")
  (HowToCombineTransforms "Compose")
  (Index 0 0)
  (InitialTransformParameterFileName "NoInitialTransform")
  (MovingImageDimension 2)
  (MovingInternalImagePixelType "float")
  (NumberOfParameters 2)
  (Origin 0 0)
  (ResampleInterpolator "FinalBSplineInterpolator")
  (Resampler "DefaultResampler")
  (ResultImageFormat "mhd")
  (ResultImagePixelType "unsigned char")
  (Size 8 8)
  (Spacing 1 1)
  (Transform "TranslationTransform")
  (TransformParameters 0.983615 -1.96723)
  (UseDirectionCosines "true")
```