### PR TITLE
ENH: Add `ElastixRegistrationMethod::ImageDimension`

### DIFF
--- a/Core/Main/itkElastixRegistrationMethod.h
+++ b/Core/Main/itkElastixRegistrationMethod.h
@@ -99,6 +99,10 @@ public:
   static constexpr unsigned int FixedImageDimension = TFixedImage::ImageDimension;
   static constexpr unsigned int MovingImageDimension = TMovingImage::ImageDimension;
 
+  static_assert(FixedImageDimension == MovingImageDimension,
+                "ElastixRegistrationMethod assumes that fixed and moving image have the same number of dimensions.");
+  static constexpr unsigned int ImageDimension = TFixedImage::ImageDimension;
+
   using FixedMaskType = Image<unsigned char, FixedImageDimension>;
   using MovingMaskType = Image<unsigned char, MovingImageDimension>;
   using TransformType = Transform<double, FixedImageDimension, MovingImageDimension>;


### PR DESCRIPTION
Added a constant for the common dimensionality of fixed and moving image. Assumed that `FixedImageDimension` and `MovingImageDimension` are always equal. Discussed with Marius (@mstaring), yesterday at the weekly internal elastix sprint.

@stefanklein I hope you agree! Otherwise please say so!