### PR TITLE
PERF: Make `GPUImageDataManager->m_Image` a weak pointer

### DIFF
--- a/Common/OpenCL/ITKimprovements/itkGPUImageDataManager.h
+++ b/Common/OpenCL/ITKimprovements/itkGPUImageDataManager.h
@@ -81,7 +81,7 @@ public:
   itkTypeMacro(GPUImageDataManager, GPUDataManager);
 
   void
-  SetImagePointer(typename ImageType::Pointer img);
+  SetImagePointer(ImageType * img);
 
   /** actual GPU->CPU memory copy takes place here */
   void
@@ -100,7 +100,8 @@ protected:
   ~GPUImageDataManager() override = default;
 
 private:
-  typename ImageType::Pointer m_Image{};
+  WeakPointer<ImageType> m_Image; // WeakPointer has to be used here
+                                  // to avoid SmartPointer loop
 };
 
 } // namespace itk

--- a/Common/OpenCL/ITKimprovements/itkGPUImageDataManager.hxx
+++ b/Common/OpenCL/ITKimprovements/itkGPUImageDataManager.hxx
@@ -43,7 +43,7 @@ namespace itk
 {
 template <typename ImageType>
 void
-GPUImageDataManager<ImageType>::SetImagePointer(typename ImageType::Pointer img)
+GPUImageDataManager<ImageType>::SetImagePointer(ImageType * img)
 {
   m_Image = img;
 }


### PR DESCRIPTION
This fixes a memory leak issue, #37.

The problem is a circular reference between `GPUImage` and `GPUImageDataManager` in the function [`GPUImage::AllocateGPU()`](https://github.com/SuperElastix/elastix/blob/368d71649c9052b47396b9eb7c0069fa7ea24b7f/Common/OpenCL/ITKimprovements/itkGPUImage.hxx#L80), which calls `m_DataManager->SetImagePointer(this);` using a smart pointer as argument.

The solution is given in the ITK library, [`itkGPUImageDataManager.h`](https://github.com/InsightSoftwareConsortium/ITK/blob/master/Modules/Core/GPUCommon/include/itkGPUImageDataManager.h), which makes `m_Image` a weak pointer.