### PR TITLE
COMP: Add missing semicolon to macro call itkOpenCLVector.hxx line 113

### DIFF
--- a/Common/OpenCL/ITKimprovements/itkOpenCLVector.hxx
+++ b/Common/OpenCL/ITKimprovements/itkOpenCLVector.hxx
@@ -110,9 +110,9 @@ OpenCLVector<T>::Write(const T * data, const std::size_t count, const std::size_
 {
   itkAssertOrThrowMacro(((offset + count) <= this->m_Size),
                         "OpenCLVector<T>::Write(data, " << count << ", " << offset
-                                                        << ") (offset + count) is out of range")
+                                                        << ") (offset + count) is out of range");
 
-    OpenCLVectorBase::Write(data, count * sizeof(T), offset * sizeof(T));
+  OpenCLVectorBase::Write(data, count * sizeof(T), offset * sizeof(T));
 }
 
 


### PR DESCRIPTION
- Fixed issue #1248 "itkOpenCLVector.hxx line 113, missing ;", submitted by Nick Lekkas (@NickLekkas-AIMedical)
- Follow-up to pull request https://github.com/SuperElastix/elastix/pull/1228 commit c41fdd6a4ceb460348e25b8bb0861a536c97dd5e "COMP: Add missing semicolons to ElastixRegistrationMethod and OpenCL"

Co-authored-by: NickLekkas-AIMedical