### PR TITLE
STYLE: Remove top level const from GetDefaultParameterMap return type

### DIFF
--- a/Core/Main/elxParameterObject.cxx
+++ b/Core/Main/elxParameterObject.cxx
@@ -395,7 +395,7 @@ ParameterObject::WriteParameterFiles(const ParameterFileNameVectorType & paramet
  * ********************* GetDefaultParameterMap *********************
  */
 
-const ParameterObject::ParameterMapType
+ParameterObject::ParameterMapType
 ParameterObject::GetDefaultParameterMap(const std::string & transformName,
                                         const unsigned int  numberOfResolutions,
                                         const double        finalGridSpacingInPhysicalUnits)

--- a/Core/Main/elxParameterObject.h
+++ b/Core/Main/elxParameterObject.h
@@ -141,7 +141,7 @@ public:
                       const ParameterFileNameVectorType & parameterFileNameVector);
 
   /* Get preconfigured parameter maps. */
-  static const ParameterMapType
+  static ParameterMapType
   GetDefaultParameterMap(const std::string & transformName,
                          const unsigned int  numberOfResolutions = 4u,
                          const double        finalGridSpacingInPhysicalUnits = 10.0);


### PR DESCRIPTION
Addressed LLVM 19.1.0 clang-tidy warnings, saying:

> warning: return type 'const ParameterObject::ParameterMapType' is 'const'-qualified at the top level, which may reduce code readability without improving const correctness [readability-const-return-type]