### PR TITLE
Transform VTK files in accordance with their format and floating point precision

### DIFF
--- a/Core/ComponentBaseClasses/elxTransformBase.hxx
+++ b/Core/ComponentBaseClasses/elxTransformBase.hxx
@@ -967,7 +967,16 @@ TransformBase<TElastix>::TransformPointsSomePointsVTK(const std::string & filena
 
     try
     {
-      itk::WriteMesh(outputMesh, outputPointsFileName);
+      const auto writer = itk::MeshFileWriter<MeshType>::New();
+      writer->SetInput(outputMesh);
+      writer->SetFileName(outputPointsFileName);
+
+      if (itk::Deref(meshReader->GetModifiableMeshIO()).GetFileType() == itk::IOFileEnum::Binary)
+      {
+        writer->SetFileTypeAsBINARY();
+      }
+
+      writer->Update();
     }
     catch (const itk::ExceptionObject & err)
     {


### PR DESCRIPTION
When using transformix command-line option "-def" to transform the points of a VTK file, the output was always an ASCII file, having double-precision (64-bit) floating point numbers.

With this pull request, the format (ASCII or binary) and the floating point precision of the output file will correspond with the input file, instead.

- Inspired by pull request #943, @ChristophKirst, Aug 2, 2023.

---

When reviewing this pull request, it may be convenient to ignore whitespace changes: https://github.com/SuperElastix/elastix/pull/1253/files?w=1