### PR TITLE
STYLE: Replace `Fill(0)` on local variables with `{}` initialization

### DIFF
--- a/Common/OpenCL/itkGPUKernelManagerHelperFunctions.h
+++ b/Common/OpenCL/itkGPUKernelManagerHelperFunctions.h
@@ -286,8 +286,7 @@ SetKernelWithITKImage(OpenCLKernelManager::Pointer &      kernelManager,
     }
     else
     {
-      typename ImageType::DirectionType dir_null;
-      dir_null.Fill(0);
+      typename ImageType::DirectionType dir_null{};
       SetKernelWithDirection<ImageType>(dir_null, imageBase1D.Direction, imageBase2D.Direction, imageBase3D.Direction);
 
       SetKernelWithDirection<ImageType>(

--- a/Components/Interpolators/RayCastInterpolator/elxRayCastInterpolator.hxx
+++ b/Components/Interpolators/RayCastInterpolator/elxRayCastInterpolator.hxx
@@ -79,8 +79,7 @@ RayCastInterpolator<TElastix>::BeforeRegistration()
 
   this->SetTransform(this->m_CombinationTransform);
 
-  PointType focalPoint;
-  focalPoint.Fill(0.);
+  PointType focalPoint{};
 
   for (unsigned int i = 0; i < TElastix::FixedDimension; ++i)
   {

--- a/Components/ResampleInterpolators/RayCastResampleInterpolator/elxRayCastResampleInterpolator.hxx
+++ b/Components/ResampleInterpolators/RayCastResampleInterpolator/elxRayCastResampleInterpolator.hxx
@@ -51,8 +51,7 @@ RayCastResampleInterpolator<TElastix>::InitializeRayCastInterpolator()
     }
   }
 
-  typename EulerTransformType::InputPointType centerofrotation;
-  centerofrotation.Fill(0.0);
+  typename EulerTransformType::InputPointType centerofrotation{};
 
   for (unsigned int i = 0; i < TElastix::MovingDimension; ++i)
   {

--- a/Components/Transforms/BSplineDeformableTransformWithDiffusion/itkDeformationFieldRegulizer.hxx
+++ b/Components/Transforms/BSplineDeformableTransformWithDiffusion/itkDeformationFieldRegulizer.hxx
@@ -70,8 +70,7 @@ DeformationFieldRegulizer<TAnyITKTransform>::InitializeDeformationFields()
 
   /** Set everything to zero. */
   IteratorType    it(intermediaryDeformationField, intermediaryDeformationField->GetLargestPossibleRegion());
-  VectorPixelType vec;
-  vec.Fill(ScalarType{});
+  VectorPixelType vec{};
   while (!it.IsAtEnd())
   {
     it.Set(vec);

--- a/Components/Transforms/DeformationFieldTransform/itkDeformationFieldInterpolatingTransform.hxx
+++ b/Components/Transforms/DeformationFieldTransform/itkDeformationFieldInterpolatingTransform.hxx
@@ -31,8 +31,7 @@ DeformationFieldInterpolatingTransform<TScalarType, NDimensions, TComponentType>
 {
   this->m_DeformationField = nullptr;
   this->m_ZeroDeformationField = DeformationFieldType::New();
-  typename DeformationFieldType::SizeType dummySize;
-  dummySize.Fill(0);
+  typename DeformationFieldType::SizeType dummySize{};
   this->m_ZeroDeformationField->SetRegions(dummySize);
   this->SetIdentity();
 

--- a/Components/Transforms/SplineKernelTransform/itkKernelTransform2.hxx
+++ b/Components/Transforms/SplineKernelTransform/itkKernelTransform2.hxx
@@ -522,8 +522,7 @@ template <typename TScalarType, unsigned int NDimensions>
 auto
 KernelTransform2<TScalarType, NDimensions>::TransformPoint(const InputPointType & thisPoint) const -> OutputPointType
 {
-  OutputPointType opp;
-  opp.Fill(typename OutputPointType::ValueType{});
+  OutputPointType opp{};
   this->ComputeDeformationContribution(thisPoint, opp);
 
   // Add the rotational part of the Affine component


### PR DESCRIPTION
Replaced code of the form

    Type var;
    var.Fill(0);

and

    Type var;
    var.Fill(ElementType{});

with `Type var{};`

Using Notepad++, Replace in Files, doing:

    Find what: ^( [ ]+)([^ ].* )(\w+);[\r\n]+\1\3\.Fill\(0\.?0?\);
    Find what: ^( [ ]+)([^ ].* )(\w+);[\r\n]+\1\3\.Fill\(.*{}\);
    Replace with: $1$2$3{};
    [v] Match case
    (*) Regular expression

- Following ITK pull request https://github.com/InsightSoftwareConsortium/ITK/pull/4897 commit https://github.com/InsightSoftwareConsortium/ITK/commit/47335501a5a16c6eb42538a829d4b49229284dd6