### PR TITLE
STYLE: Replace `Fill(0U)` and `Fill(0.0f)` on local variables with `{}`

### DIFF
--- a/Components/Metrics/RigidityPenalty/itkTransformRigidityPenaltyTerm.hxx
+++ b/Components/Metrics/RigidityPenalty/itkTransformRigidityPenaltyTerm.hxx
@@ -1917,8 +1917,7 @@ TransformRigidityPenaltyTerm<TFixedImage, TScalarType>::Create1DOperator(
   const CoefficientImageSpacingType & spacing) const
 {
   /** Create an operator size and set it in the operator. */
-  NeighborhoodSizeType r;
-  r.Fill(0U);
+  NeighborhoodSizeType r{};
   r[WhichDimension - 1] = 1;
   F.SetRadius(r);
 

--- a/Components/Transforms/SplineKernelTransform/elxSplineKernelTransform.hxx
+++ b/Components/Transforms/SplineKernelTransform/elxSplineKernelTransform.hxx
@@ -338,9 +338,8 @@ SplineKernelTransform<TElastix>::ReadLandmarkFile(const std::string & filename,
     typename FixedImageType::Pointer  fixedImage = this->GetElastix()->GetFixedImage();
     typename MovingImageType::Pointer movingImage = this->GetElastix()->GetMovingImage();
 
-    InputPointType landmarkPoint;
-    landmarkPoint.Fill(0.0f);
-    IndexType landmarkIndex;
+    InputPointType landmarkPoint{};
+    IndexType      landmarkIndex;
     for (unsigned int j = 0; j < nrofpoints; ++j)
     {
       /** The read point from the inputPointSet is actually an index
@@ -369,8 +368,7 @@ SplineKernelTransform<TElastix>::ReadLandmarkFile(const std::string & filename,
   if (const auto * const initialTransform = this->Superclass1::GetInitialTransform();
       initialTransform != nullptr && landmarksInFixedImage && this->GetUseComposition())
   {
-    InputPointType inputPoint;
-    inputPoint.Fill(0.0f);
+    InputPointType inputPoint{};
     for (unsigned int j = 0; j < nrofpoints; ++j)
     {
       landmarkPointSet->GetPoint(j, &inputPoint);

--- a/Components/Transforms/SplineKernelTransform/itkKernelTransform2.hxx
+++ b/Components/Transforms/SplineKernelTransform/itkKernelTransform2.hxx
@@ -416,8 +416,7 @@ KernelTransform2<TScalarType, NDimensions>::ComputeP()
   IMatrixType    temp;
   const auto     temp_ref = temp.as_ref();
   const auto     I_ref = I.as_ref();
-  InputPointType p;
-  p.Fill(0.0f);
+  InputPointType p{};
 
   this->m_PMatrix.set_size(NDimensions * numberOfLandmarks, NDimensions * (NDimensions + 1));
   this->m_PMatrix.fill(0.0f);


### PR DESCRIPTION
Using Notepad++, Replace in Files, doing:

    Find what: ^( [ ]+)([^ ].* )(\w+);[\r\n]+\1\3\.Fill\(0[uU]\);
    Find what: ^( [ ]+)([^ ].* )(\w+);[\r\n]+\1\3\.Fill\(0.0[fF]\);
    Replace with: $1$2$3{};
    [v] Match case
    (*) Regular expression

- Follow-up to pull request https://github.com/SuperElastix/elastix/pull/1257 commit 0bece236791d1f0cc165b94de090add7ed45fece "STYLE: Replace `Fill(0)` on local variables with `{}` initialization"