### PR TITLE
Remove unused `PointDataIterator` and `PointSetPixelType` typedefs

### DIFF
--- a/Common/CostFunctions/itkSingleValuedPointSetToPointSetMetric.h
+++ b/Common/CostFunctions/itkSingleValuedPointSetToPointSetMetric.h
@@ -78,10 +78,8 @@ public:
 
   /** Typedefs. */
   using FixedPointSetType = TFixedPointSet;
-  using FixedPointSetPixelType = typename FixedPointSetType::PixelType;
   using FixedPointSetConstPointer = typename FixedPointSetType::ConstPointer;
   using MovingPointSetType = TMovingPointSet;
-  using MovingPointSetPixelType = typename MovingPointSetType::PixelType;
   using MovingPointSetConstPointer = typename MovingPointSetType::ConstPointer;
   using PointIterator = typename FixedPointSetType::PointsContainer::ConstIterator;
 

--- a/Common/CostFunctions/itkSingleValuedPointSetToPointSetMetric.h
+++ b/Common/CostFunctions/itkSingleValuedPointSetToPointSetMetric.h
@@ -84,7 +84,6 @@ public:
   using MovingPointSetPixelType = typename MovingPointSetType::PixelType;
   using MovingPointSetConstPointer = typename MovingPointSetType::ConstPointer;
   using PointIterator = typename FixedPointSetType::PointsContainer::ConstIterator;
-  using PointDataIterator = typename FixedPointSetType::PointDataContainer::ConstIterator;
 
   /** Constants for the pointset dimensions. */
   itkStaticConstMacro(FixedPointSetDimension, unsigned int, TFixedPointSet::PointDimension);

--- a/Components/Metrics/CorrespondingPointsEuclideanDistanceMetric/itkCorrespondingPointsEuclideanDistancePointMetric.h
+++ b/Components/Metrics/CorrespondingPointsEuclideanDistanceMetric/itkCorrespondingPointsEuclideanDistancePointMetric.h
@@ -69,7 +69,6 @@ public:
   using typename Superclass::MovingPointSetConstPointer;
 
   using typename Superclass::PointIterator;
-  using typename Superclass::PointDataIterator;
 
   using typename Superclass::InputPointType;
   using typename Superclass::OutputPointType;

--- a/Components/Metrics/MissingStructurePenalty/itkMissingStructurePenalty.h
+++ b/Components/Metrics/MissingStructurePenalty/itkMissingStructurePenalty.h
@@ -109,7 +109,6 @@ public:
   using MeshPointDataContainerPointer = typename FixedMeshType::PointDataContainerPointer;
   // typedef typename FixedMeshType::PointDataContainerConstIterator     MeshPointDataContainerConstIteratorType;
   using MeshPointDataContainerConstIteratorType = typename FixedMeshType::PointDataContainerIterator;
-  using MeshPointDataContainerIteratorType = typename MeshPointDataContainerType::Iterator;
 
   using MeshIdType = unsigned int;
   using FixedMeshContainerType = VectorContainer<MeshIdType, FixedMeshConstPointer>;

--- a/Components/Metrics/PolydataDummyPenalty/itkPolydataDummyPenalty.h
+++ b/Components/Metrics/PolydataDummyPenalty/itkPolydataDummyPenalty.h
@@ -102,9 +102,7 @@ public:
   using MeshPointDataContainerType = typename FixedMeshType::PointDataContainer;
   using MeshPointDataContainerConstPointer = typename FixedMeshType::PointDataContainerConstPointer;
   using MeshPointDataContainerPointer = typename FixedMeshType::PointDataContainerPointer;
-  // typedef typename FixedMeshType::PointDataContainerConstIterator     MeshPointDataContainerConstIteratorType;
   using MeshPointDataContainerConstIteratorType = typename FixedMeshType::PointDataContainerIterator;
-  using MeshPointDataContainerIteratorType = typename MeshPointDataContainerType::Iterator;
 
   using MeshIdType = unsigned int;
   using FixedMeshContainerType = VectorContainer<MeshIdType, FixedMeshConstPointer>;

--- a/Components/Metrics/PolydataDummyPenalty/itkPolydataDummyPenalty.hxx
+++ b/Components/Metrics/PolydataDummyPenalty/itkPolydataDummyPenalty.hxx
@@ -204,8 +204,8 @@ MeshPenalty<TFixedPointSet, TMovingPointSet>::GetValueAndDerivative(const Transf
     MeshPointsContainerIteratorType      mappedPointIt = mappedPoints->Begin();
     MeshPointsContainerConstIteratorType fixedPointEnd = fixedPoints->End();
 
-    // MeshPointDataContainerConstIteratorType fixedPointDataIt =fixedNormals->Begin();
-    // MeshPointDataContainerIteratorType mappedPointDataIt = mappedNormals->Begin();
+    // auto fixedPointDataIt =fixedNormals->Begin();
+    // auto mappedPointDataIt = mappedNormals->Begin();
 
     /* Transform all points and their normals by current transformation*/
     for (; fixedPointIt != fixedPointEnd; ++fixedPointIt, ++mappedPointIt) //,++fixedPointDataIt,++mappedPointDataIt)

--- a/Components/Metrics/StatisticalShapePenalty/itkStatisticalShapePointPenalty.h
+++ b/Components/Metrics/StatisticalShapePenalty/itkStatisticalShapePointPenalty.h
@@ -87,7 +87,6 @@ public:
   using typename Superclass::MovingPointSetConstPointer;
 
   using typename Superclass::PointIterator;
-  using typename Superclass::PointDataIterator;
 
   using typename Superclass::InputPointType;
   using typename Superclass::OutputPointType;


### PR DESCRIPTION
Paving the way to extend PointSet support. 