### PR TITLE
COMP: Upgrade GitHub actions/upload-artifact from v3 to v4.4.3

### DIFF
--- a/.github/workflows/ElastixGitHubActions.yml
+++ b/.github/workflows/ElastixGitHubActions.yml
@@ -212,7 +212,7 @@ jobs:
         mv Elastix-build/bin/${{ matrix.ANNLib }} uploads
   
     - name: Publish Artifacts
-      uses: actions/upload-artifact@v3
+      uses: actions/upload-artifact@v4.4.3
       with: 
         name: "${{ matrix.os }}"
         path: uploads


### PR DESCRIPTION
Upgraded to the latest release (released on October 9, 2024): https://github.com/actions/upload-artifact/releases/tag/v4.4.3

Aims to address the notification "Artifacts v3 Upcoming Deprecation Notice" that we received by mail, as well as notifications at the Summary page, saying:

> The following artifacts were uploaded using a version of actions/upload-artifact that is scheduled for deprecation: "macos-12", "ubuntu-22.04", "windows-2022".
> Please update your workflow to use v4 of the artifact actions.
> Learn more: https://github.blog/changelog/2024-04-16-deprecation-notice-v3-of-the-artifact-actions/

----

@mstaring FYI This pull request appears to address that notification mail from GitHub.