### PR TITLE
Replace `T var; var.Fill` with `auto var = T::Filled`, for both `Index` and `Size`

### DIFF
--- a/Common/Transforms/itkTransformToDeterminantOfSpatialJacobianSource.hxx
+++ b/Common/Transforms/itkTransformToDeterminantOfSpatialJacobianSource.hxx
@@ -269,8 +269,7 @@ TransformToDeterminantOfSpatialJacobianSource<TOutputImage, TTransformPrecisionT
 
   // For linear transformation the spatial derivative is a constant,
   // i.e. it is independent of the spatial position.
-  IndexType index;
-  index.Fill(1);
+  auto      index = IndexType::Filled(1);
   PointType point;
   outputPtr->TransformIndexToPhysicalPoint(index, point);
   SpatialJacobianType sj;

--- a/Common/Transforms/itkTransformToSpatialJacobianSource.hxx
+++ b/Common/Transforms/itkTransformToSpatialJacobianSource.hxx
@@ -263,8 +263,7 @@ TransformToSpatialJacobianSource<TOutputImage, TTransformPrecisionType>::LinearG
 
   // For linear transformation the spatial derivative is a constant,
   // i.e. it is independent of the spatial position.
-  IndexType index;
-  index.Fill(1);
+  auto      index = IndexType::Filled(1);
   PointType point;
   outputPtr->TransformIndexToPhysicalPoint(index, point);
 

--- a/Common/itkComputePreconditionerUsingDisplacementDistribution.hxx
+++ b/Common/itkComputePreconditionerUsingDisplacementDistribution.hxx
@@ -596,8 +596,7 @@ ComputePreconditionerUsingDisplacementDistribution<TFixedImage, TTransform>::Pre
     // average over the neighborhood using only the non -1 entries
     // we should repeat this a couple of times, until no -1's are left
     double tmp = 0.0;
-    GridSizeType radius;
-    radius.Fill(1);
+    auto radius = GridSizeType::Filled(1);
     NeighborhoodIterator<CoefficientImageType> nit(radius, coefImage, region2);
     while (!nit.IsAtEnd())
     {

--- a/Components/Metrics/RigidityPenalty/itkTransformRigidityPenaltyTerm.hxx
+++ b/Components/Metrics/RigidityPenalty/itkTransformRigidityPenaltyTerm.hxx
@@ -2161,8 +2161,7 @@ TransformRigidityPenaltyTerm<TFixedImage, TScalarType>::CreateNDOperator(
   const CoefficientImageSpacingType & spacing) const
 {
   /** Create an operator size and set it in the operator. */
-  NeighborhoodSizeType r;
-  r.Fill(1);
+  auto r = NeighborhoodSizeType::Filled(1);
   F.SetRadius(r);
 
   /** Get the image spacing factors that we are going to use. */

--- a/Testing/elxTransformParametersCompare.cxx
+++ b/Testing/elxTransformParametersCompare.cxx
@@ -206,8 +206,7 @@ main(int argc, char ** argv)
     config->ReadParameter(dimension, "FixedImageDimension", 0, true, dummyErrorMessage);
 
     /** Get coefficient image information. */
-    SizeType gridSize;
-    gridSize.Fill(1);
+    auto        gridSize = SizeType::Filled(1);
     IndexType   gridIndex{};
     SpacingType gridSpacing;
     gridSpacing.Fill(1.0);

--- a/Testing/itkBSplineInterpolationDerivativeWeightFunctionTest.cxx
+++ b/Testing/itkBSplineInterpolationDerivativeWeightFunctionTest.cxx
@@ -159,8 +159,7 @@ main()
     return 1;
   }
 
-  DerivativeWeightFunctionType::SizeType trueSize;
-  trueSize.Fill(SplineOrder + 1);
+  auto trueSize = DerivativeWeightFunctionType::SizeType::Filled(SplineOrder + 1);
   if (DerivativeWeightFunctionType::SupportSize != trueSize)
   {
     std::cerr << "ERROR: wrong support size was computed." << std::endl;

--- a/Testing/itkBSplineInterpolationSODerivativeWeightFunctionTest.cxx
+++ b/Testing/itkBSplineInterpolationSODerivativeWeightFunctionTest.cxx
@@ -248,8 +248,7 @@ main()
     return 1;
   }
 
-  SODerivativeWeightFunctionType::SizeType trueSize;
-  trueSize.Fill(SplineOrder + 1);
+  auto trueSize = SODerivativeWeightFunctionType::SizeType::Filled(SplineOrder + 1);
   if (SODerivativeWeightFunctionType::SupportSize != trueSize)
   {
     std::cerr << "ERROR: wrong support size was computed." << std::endl;

--- a/Testing/itkBSplineInterpolationWeightFunctionTest.cxx
+++ b/Testing/itkBSplineInterpolationWeightFunctionTest.cxx
@@ -245,8 +245,7 @@ main()
     return EXIT_FAILURE;
   }
 
-  WeightFunction2Type2D::SizeType trueSize;
-  trueSize.Fill(SplineOrder + 1);
+  auto trueSize = WeightFunction2Type2D::SizeType::Filled(SplineOrder + 1);
   if (WeightFunction2Type2D::SupportSize != trueSize)
   {
     std::cerr << "ERROR: wrong support size was computed." << std::endl;

--- a/Testing/itkBSplineInterpolationWeightFunctionTest.cxx
+++ b/Testing/itkBSplineInterpolationWeightFunctionTest.cxx
@@ -236,8 +236,7 @@ main()
 
   /** Just call all available public functions. */
   WeightFunction2Type2D::IndexType startIndex;
-  WeightFunction2Type2D::IndexType trueStartIndex;
-  trueStartIndex.Fill(-1);
+  auto                             trueStartIndex = WeightFunction2Type2D::IndexType::Filled(-1);
   weight2Function2D->ComputeStartIndex(cindex, startIndex);
   if (startIndex != trueStartIndex)
   {

--- a/Testing/itkGPUResampleImageFilterTest.cxx
+++ b/Testing/itkGPUResampleImageFilterTest.cxx
@@ -441,8 +441,7 @@ SetTransform(const std::size_t                                            transf
     const typename InputImageType::SizeType      inputSize = inputRegion.GetSize();
 
     using MeshSizeType = typename BSplineTransformType::MeshSizeType;
-    MeshSizeType gridSize;
-    gridSize.Fill(4);
+    auto gridSize = MeshSizeType::Filled(4);
 
     using PhysicalDimensionsType = typename BSplineTransformType::PhysicalDimensionsType;
     PhysicalDimensionsType gridSpacing;


### PR DESCRIPTION
- Following ITK pull request https://github.com/InsightSoftwareConsortium/ITK/pull/4906