### PR TITLE
STYLE: Remove `sigma4factor` from StochasticGradientDescent Optimizers

### DIFF
--- a/Components/Optimizers/AdaptiveStochasticGradientDescent/elxAdaptiveStochasticGradientDescent.hxx
+++ b/Components/Optimizers/AdaptiveStochasticGradientDescent/elxAdaptiveStochasticGradientDescent.hxx
@@ -588,13 +588,12 @@ AdaptiveStochasticGradientDescent<TElastix>::AutomaticParameterEstimationOrigina
   }
 
   /** Measure square magnitude of exact gradient and approximation error. */
-  const double sigma4factor = 1.0;
-  double       sigma4 = 0.0;
-  double       gg = 0.0;
-  double       ee = 0.0;
+  double sigma4 = 0.0;
+  double gg = 0.0;
+  double ee = 0.0;
   if (maxJJ > 1e-14)
   {
-    sigma4 = sigma4factor * delta / std::sqrt(maxJJ);
+    sigma4 = delta / std::sqrt(maxJJ);
   }
   this->SampleGradients(this->GetScaledCurrentPosition(), sigma4, gg, ee);
   timer3.Stop();
@@ -723,7 +722,6 @@ AdaptiveStochasticGradientDescent<TElastix>::AutomaticParameterEstimationUsingDi
     double sigma4 = 0.0;
     double gg = 0.0;
     double ee = 0.0;
-    double sigma4factor = 1.0;
 
     /** Sample the grid and random sampler container to estimate the noise factor. */
     if (this->m_NumberOfGradientMeasurements == 0)
@@ -736,7 +734,7 @@ AdaptiveStochasticGradientDescent<TElastix>::AutomaticParameterEstimationUsingDi
     timer5.Start();
     if (maxJJ > 1e-14)
     {
-      sigma4 = sigma4factor * delta / std::sqrt(maxJJ);
+      sigma4 = delta / std::sqrt(maxJJ);
     }
     this->SampleGradients(this->GetScaledCurrentPosition(), sigma4, gg, ee);
 

--- a/Components/Optimizers/PreconditionedStochasticGradientDescent/elxPreconditionedStochasticGradientDescent.hxx
+++ b/Components/Optimizers/PreconditionedStochasticGradientDescent/elxPreconditionedStochasticGradientDescent.hxx
@@ -645,12 +645,11 @@ PreconditionedStochasticGradientDescent<TElastix>::AutomaticPreconditionerEstima
   /** Sample the fixed image to estimate the noise factor. */
   itk::TimeProbe timer_noise;
   timer_noise.Start();
-  double sigma4factor = 1.0;
   double sigma4 = 0.0;
   log::info(std::ostringstream{} << "  The estimated MaxJJ is: " << maxJJ);
   if (maxJJ > 1e-14)
   {
-    sigma4 = sigma4factor * this->m_MaximumStepLength / std::sqrt(maxJJ);
+    sigma4 = this->m_MaximumStepLength / std::sqrt(maxJJ);
   }
   double gg = 0.0;
   double ee = 0.0;


### PR DESCRIPTION
The local variable `sigma4factor` has been equal to `1.0` for more than 16 years. (Starting with commit a90c96af2cfd9d79cf2b154b74b8ca7be5818550, 16 Jan 2008).

----

@stefanklein Looks like you introduced this constant with 27f26bf48252bf888bbe1107b237b66de3f0fcb5 and then set it to `1.0` with the next commit (a90c96af2cfd9d79cf2b154b74b8ca7be5818550), on the very same day, 16 Jan 2008. Do you agree that it may be removed now?