### PR TITLE
COMP: Replace `macos-12`/`macOS-12` with `macos-13`/`macOS-13`, in *.yml

### DIFF
--- a/.github/workflows/ElastixGitHubActions.yml
+++ b/.github/workflows/ElastixGitHubActions.yml
@@ -13,7 +13,7 @@ jobs:
     strategy:
       max-parallel: 3
       matrix:
-        os: [ubuntu-22.04, windows-2022, macos-12]
+        os: [ubuntu-22.04, windows-2022, macos-13]
         include:
           - os: ubuntu-22.04
             c-compiler: "gcc"
@@ -29,7 +29,7 @@ jobs:
             cmake-build-type: "Release"
             ANNLib: "ANNlib-5.2.dll"
             vcvars64: "C:/Program Files/Microsoft Visual Studio/2022/Enterprise/VC/Auxiliary/Build/vcvars64.bat"
-          - os: macos-12
+          - os: macos-13
             c-compiler: "clang"  
             cxx-compiler: "clang++"
             itk-git-tag: "v5.4.0"

--- a/Testing/CI/Azure/ci.yml
+++ b/Testing/CI/Azure/ci.yml
@@ -135,7 +135,7 @@ jobs:
 - job: macOS
   timeoutInMinutes: 0
   pool:
-    vmImage: 'macOS-12'
+    vmImage: 'macOS-13'
   strategy:
     matrix:
       ITKv5:


### PR DESCRIPTION
Addressed https://github.com/SuperElastix/elastix/actions/runs/12160720437/job/33913645243 saying:

> The macOS-12 environment is deprecated, consider switching to macOS-13, macOS-14 (macos-latest) or macOS-15. For more details, see https://github.com/actions/runner-images/issues/10721