### PR TITLE
Use `vnl_sparse_matrix::get` in `ComputeJacobianTerms::Compute()` 

### DIFF
--- a/Common/itkComputeJacobianTerms.hxx
+++ b/Common/itkComputeJacobianTerms.hxx
@@ -69,9 +69,6 @@ ComputeJacobianTerms<TFixedImage, TTransform>::Compute() const -> Terms
 
   static constexpr unsigned int outdim{ TTransform::OutputSpaceDimension };
 
-  /** Get scales vector */
-  const ScalesType & scales = m_Scales;
-
   /** Variables for nonzerojacobian indices and the Jacobian. */
   const NumberOfParametersType sizejacind = m_Transform->GetNumberOfNonZeroJacobianIndices();
   JacobianType                 jacj(outdim, sizejacind, 0.0);
@@ -307,7 +304,7 @@ ComputeJacobianTerms<TFixedImage, TTransform>::Compute() const -> Terms
     while (cov.next())
     {
       const int col = cov.getcolumn();
-      cov(cov.getrow(), col) /= scales[col];
+      cov(cov.getrow(), col) /= m_Scales[col];
     }
   }
 
@@ -371,7 +368,7 @@ ComputeJacobianTerms<TFixedImage, TTransform>::Compute() const -> Terms
       for (unsigned int pi = 0; pi < sizejacind; ++pi)
       {
         const unsigned int p = jacind[pi];
-        jacj.scale_column(pi, 1.0 / scales[p]);
+        jacj.scale_column(pi, 1.0 / m_Scales[p]);
       }
     }
 

--- a/Common/itkComputeJacobianTerms.hxx
+++ b/Common/itkComputeJacobianTerms.hxx
@@ -312,13 +312,10 @@ ComputeJacobianTerms<TFixedImage, TTransform>::Compute() const -> Terms
   double TrC = 0.0;
   for (unsigned int p = 0; p < numberOfParameters; ++p)
   {
-    if (!cov.empty_row(p))
-    {
-      // avoid creation of element if the row is empty
-      CovarianceValueType & covpp = cov(p, p);
-      TrC += covpp;
-      diagcov[p] = covpp;
-    }
+    // Do cov.get(p, p) instead of cov(p, p) to avoid creation of an entry that just has zero.
+    const CovarianceValueType covpp = cov.get(p, p);
+    TrC += covpp;
+    diagcov[p] = covpp;
   }
 
   /**


### PR DESCRIPTION
`vnl_sparse_matrix::get(r, c)` just returns zero when the entry isn't there, and it returns immediately when the row is empty.

The performance of `vnl_sparse_matrix::get` was improved by:
- https://github.com/vxl/vxl/pull/932 commit https://github.com/vxl/vxl/commit/b37c7a22cd0ae5d50fe940f58e2c8e0ebc6ccd24


A performance improvement may not be noticeable, but it won't harm.