### PR TITLE
Make `ReturnParameterFileAsString` static, remove `m_ParameterFileParser` from `Configuration`

### DIFF
--- a/Common/ParameterFileParser/itkParameterFileParser.cxx
+++ b/Common/ParameterFileParser/itkParameterFileParser.cxx
@@ -356,18 +356,18 @@ ParameterFileParser::ReadParameterFile()
  */
 
 std::string
-ParameterFileParser::ReturnParameterFileAsString()
+ParameterFileParser::ReturnParameterFileAsString(const std::string & fileName)
 {
   /** Perform some basic checks. */
-  BasicFileChecking(m_ParameterFileName);
+  BasicFileChecking(fileName);
 
   /** Open the parameter file for reading. */
-  std::ifstream parameterFile(m_ParameterFileName);
+  std::ifstream parameterFile(fileName);
 
   /** Check if it opened. */
   if (!parameterFile.is_open())
   {
-    itkExceptionMacro("ERROR: could not open " << m_ParameterFileName << " for reading.");
+    itkGenericExceptionMacro("ERROR: could not open " << fileName << " for reading.");
   }
 
   /** Loop over the parameter file, line by line. */

--- a/Common/ParameterFileParser/itkParameterFileParser.h
+++ b/Common/ParameterFileParser/itkParameterFileParser.h
@@ -111,8 +111,8 @@ public:
   /** Read the parameter file and return the content as a string.
    * Useful for printing the content.
    */
-  std::string
-  ReturnParameterFileAsString();
+  static std::string
+  ReturnParameterFileAsString(const std::string & fileName);
 
   /** Read the specified file into a parameter map and return the map. */
   static ParameterMapType

--- a/Core/Configuration/elxConfiguration.cxx
+++ b/Core/Configuration/elxConfiguration.cxx
@@ -87,7 +87,7 @@ void
 Configuration::PrintParameterFile() const
 {
   /** Read what's in the parameter file. */
-  std::string params = m_ParameterFileParser->ReturnParameterFileAsString();
+  std::string params = itk::ParameterFileParser::ReturnParameterFileAsString(m_ParameterFileName);
 
   /** Separate clearly in log-file, before and after writing the parameter file. */
   log::info_to_log_file(std::ostringstream{}

--- a/Core/Configuration/elxConfiguration.cxx
+++ b/Core/Configuration/elxConfiguration.cxx
@@ -90,12 +90,11 @@ Configuration::PrintParameterFile() const
   std::string params = m_ParameterFileParser->ReturnParameterFileAsString();
 
   /** Separate clearly in log-file, before and after writing the parameter file. */
-  log::info_to_log_file(std::ostringstream{} << '\n'
-                                             << "=============== start of ParameterFile: "
-                                             << this->GetParameterFileName() << " ===============\n"
-                                             << params << '\n'
-                                             << "=============== end of ParameterFile: " << this->GetParameterFileName()
-                                             << " ===============\n");
+  log::info_to_log_file(std::ostringstream{}
+                        << '\n'
+                        << "=============== start of ParameterFile: " << m_ParameterFileName << " ===============\n"
+                        << params << '\n'
+                        << "=============== end of ParameterFile: " << m_ParameterFileName << " ===============\n");
 
 } // end PrintParameterFile()
 
@@ -160,12 +159,12 @@ Configuration::Initialize(const CommandLineArgumentMapType & _arg)
   if (!p.empty() && tp.empty())
   {
     /** elastix called Initialize(). */
-    this->SetParameterFileName(p);
+    m_ParameterFileName = p;
   }
   else if (p.empty() && !tp.empty())
   {
     /** transformix called Initialize(). */
-    this->SetParameterFileName(tp);
+    m_ParameterFileName = tp;
   }
   else if (p.empty() && tp.empty())
   {

--- a/Core/Configuration/elxConfiguration.cxx
+++ b/Core/Configuration/elxConfiguration.cxx
@@ -180,12 +180,14 @@ Configuration::Initialize(const CommandLineArgumentMapType & _arg)
     return 1;
   }
 
+  const auto parameterFileParser = itk::ParameterFileParser::New();
+
   /** Read the ParameterFile. */
-  m_ParameterFileParser->SetParameterFileName(m_ParameterFileName);
+  parameterFileParser->SetParameterFileName(m_ParameterFileName);
   try
   {
     log::info("Reading the elastix parameters from file ...\n");
-    m_ParameterFileParser->ReadParameterFile();
+    parameterFileParser->ReadParameterFile();
   }
   catch (const itk::ExceptionObject & excp)
   {
@@ -195,7 +197,7 @@ Configuration::Initialize(const CommandLineArgumentMapType & _arg)
 
   /** Connect the parameter file reader to the interface. */
   m_ParameterMapInterface->SetParameterMap(
-    AddDataFromExternalTransformFile(m_ParameterFileName, m_ParameterFileParser->GetParameterMap()));
+    AddDataFromExternalTransformFile(m_ParameterFileName, parameterFileParser->GetParameterMap()));
 
   /** Silently check in the parameter file if error messages should be printed. */
   m_ParameterMapInterface->SetPrintErrorMessages(false);

--- a/Core/Configuration/elxConfiguration.h
+++ b/Core/Configuration/elxConfiguration.h
@@ -313,7 +313,6 @@ protected:
 private:
   CommandLineArgumentMapType                m_CommandLineArgumentMap{};
   std::string                               m_ParameterFileName{};
-  const itk::ParameterFileParser::Pointer   m_ParameterFileParser{ itk::ParameterFileParser::New() };
   const itk::ParameterMapInterface::Pointer m_ParameterMapInterface{ itk::ParameterMapInterface::New() };
 
   bool         m_IsInitialized{ false };


### PR DESCRIPTION
Three style commits to clarify how `Configuration` uses `ParameterFileParser`.