### PR TITLE
Print the parameter map to log, when there is no parameter file

### DIFF
--- a/Common/ParameterFileParser/itkParameterMapInterface.h
+++ b/Common/ParameterFileParser/itkParameterMapInterface.h
@@ -100,6 +100,13 @@ public:
   void
   SetParameterMap(const ParameterMapType & parMap);
 
+  /** Returns the parameter map. */
+  const ParameterMapType &
+  GetParameterMap() const
+  {
+    return m_ParameterMap;
+  }
+
   /** Option to print error and warning messages to a stream.
    * The default is true. If set to false no messages are printed.
    */

--- a/Core/Configuration/elxConfiguration.cxx
+++ b/Core/Configuration/elxConfiguration.cxx
@@ -100,13 +100,31 @@ Configuration::PrintParameterFile() const
 
 
 /**
+ * ******************** PrintParameterMap ***************************
+ */
+
+void
+Configuration::PrintParameterMap() const
+{
+  // Separate clearly in log-file, before and after writing the parameter map.
+  log::info_to_log_file(std::ostringstream{}
+                        << "\n=============== start of ParameterMap ===============\n"
+                        << Conversion::ParameterMapToString(m_ParameterMapInterface->GetParameterMap())
+                        << "\n=============== end of ParameterMap ===============\n");
+
+} // end PrintParameterMap()
+/**
  * ************************ BeforeAll ***************************
  */
 
 int
 Configuration::BeforeAll()
 {
-  if (!BaseComponent::IsElastixLibrary())
+  if (m_ParameterFileName.empty())
+  {
+    this->PrintParameterMap();
+  }
+  else
   {
     this->PrintParameterFile();
   }

--- a/Core/Configuration/elxConfiguration.h
+++ b/Core/Configuration/elxConfiguration.h
@@ -310,6 +310,10 @@ protected:
   void
   PrintParameterFile() const;
 
+  /** Print the parameter map to the log file. */
+  void
+  PrintParameterMap() const;
+
 private:
   CommandLineArgumentMapType                m_CommandLineArgumentMap{};
   std::string                               m_ParameterFileName{};


### PR DESCRIPTION
- Addresses issue #1284 

Example "elastix.log" file, with this pull request:
```
WARNING: The parameter "FixedInternalImagePixelType", requested at entry number 0, does not exist at all.
  The default value "float" is used instead.
  [...]
WARNING: The parameter "Resampler", requested at entry number 0, does not exist at all.
  The default value "DefaultResampler" is used instead.
ELASTIX version: 5.2.0
Command line options from ElastixBase:
-out      B:/data/output/
-priority unspecified, so NORMAL process priority
-threads  unspecified, so all available threads are used
WARNING: The parameter "UseDirectionCosines", requested at entry number 0, does not exist at all.
  The default value "true" is used instead.

WARNING: The option "UseDirectionCosines" was not found in your parameter file.
  From elastix 4.8 it defaults to true!
This may change the behavior of your registrations considerably.

Command line options from TransformBase:
-t0       unspecified, so no initial transform used

=============== start of ParameterMap ===============
(FixedImageDimension 2)
(ImageSampler "Full")
(MaximumNumberOfIterations 2)
(Metric "AdvancedNormalizedCorrelation")
(MovingImageDimension 2)
(NumberOfResolutions 2)
(Optimizer "AdaptiveStochasticGradientDescent")
(ResultImagePixelType "float")
(Transform "TranslationTransform")
(WriteResultImageAfterEachResolution "true")

=============== end of ParameterMap ===============


Reading images...
```
[elastix.log](https://github.com/user-attachments/files/18629047/elastix.log)
