### PR TITLE
ENH: Support `OutputTransformParameterFileFormat` parameter for TOML

### DIFF
--- a/Common/GTesting/elxConversionGTest.cxx
+++ b/Common/GTesting/elxConversionGTest.cxx
@@ -325,11 +325,14 @@ GTEST_TEST(Conversion, ToOptimizerParameters)
 
 GTEST_TEST(Conversion, ParameterMapToString)
 {
-  EXPECT_EQ(Conversion::ParameterMapToString({}), std::string{});
-  EXPECT_EQ(Conversion::ParameterMapToString({ { "A", {} } }), "(A)\n");
-  EXPECT_EQ(Conversion::ParameterMapToString({ { "Numbers", { "0", "1" } } }), "(Numbers 0 1)\n");
-  EXPECT_EQ(Conversion::ParameterMapToString({ { "Letters", { "a", "z" } } }), "(Letters \"a\" \"z\")\n");
-  EXPECT_EQ(Conversion::ParameterMapToString(TestExample::parameterMap), TestExample::parameterMapTextString);
+  EXPECT_EQ(Conversion::ParameterMapToString({}, elx::ParameterMapStringFormat::LegacyTxt), std::string{});
+  EXPECT_EQ(Conversion::ParameterMapToString({ { "A", {} } }, elx::ParameterMapStringFormat::LegacyTxt), "(A)\n");
+  EXPECT_EQ(Conversion::ParameterMapToString({ { "Numbers", { "0", "1" } } }, elx::ParameterMapStringFormat::LegacyTxt),
+            "(Numbers 0 1)\n");
+  EXPECT_EQ(Conversion::ParameterMapToString({ { "Letters", { "a", "z" } } }, elx::ParameterMapStringFormat::LegacyTxt),
+            "(Letters \"a\" \"z\")\n");
+  EXPECT_EQ(Conversion::ParameterMapToString(TestExample::parameterMap, elx::ParameterMapStringFormat::LegacyTxt),
+            TestExample::parameterMapTextString);
 }
 
 

--- a/Core/ComponentBaseClasses/elxResampleInterpolatorBase.hxx
+++ b/Core/ComponentBaseClasses/elxResampleInterpolatorBase.hxx
@@ -20,7 +20,10 @@
 #define elxResampleInterpolatorBase_hxx
 
 #include "elxResampleInterpolatorBase.h"
+#include "elxConfiguration.h"
 #include "elxConversion.h"
+
+#include "itkDeref.h"
 
 #include <cassert>
 
@@ -48,12 +51,21 @@ template <typename TElastix>
 void
 ResampleInterpolatorBase<TElastix>::WriteToFile(std::ostream & transformationParameterInfo) const
 {
+  const Configuration & configuration = itk::Deref(Superclass::GetConfiguration());
+
   ParameterMapType parameterMap;
   this->CreateTransformParameterMap(parameterMap);
 
+  const std::string parameterMapFileFormat =
+    configuration.RetrieveParameterStringValue("", "OutputTransformParameterFileFormat", 0, false);
+
+  const auto format = Conversion::StringToParameterMapStringFormat(parameterMapFileFormat);
+
   /** Write ResampleInterpolator specific things. */
-  transformationParameterInfo << ("\n// ResampleInterpolator specific\n" +
-                                  Conversion::ParameterMapToString(parameterMap));
+  transformationParameterInfo << '\n'
+                              << Conversion::ParameterMapStartOfCommentString(format)
+                              << " ResampleInterpolator specific\n " +
+                                   Conversion::ParameterMapToString(parameterMap, format);
 
 } // end WriteToFile()
 

--- a/Core/ComponentBaseClasses/elxResamplerBase.hxx
+++ b/Core/ComponentBaseClasses/elxResamplerBase.hxx
@@ -641,11 +641,20 @@ template <typename TElastix>
 void
 ResamplerBase<TElastix>::WriteToFile(std::ostream & transformationParameterInfo) const
 {
+  const Configuration & configuration = itk::Deref(Superclass::GetConfiguration());
+
   ParameterMapType parameterMap;
   Self::CreateTransformParameterMap(parameterMap);
 
+  const std::string parameterMapFileFormat =
+    configuration.RetrieveParameterStringValue("", "OutputTransformParameterFileFormat", 0, false);
+
+  const auto format = Conversion::StringToParameterMapStringFormat(parameterMapFileFormat);
+
   /** Write resampler specific things. */
-  transformationParameterInfo << ("\n// Resampler specific\n" + Conversion::ParameterMapToString(parameterMap));
+  transformationParameterInfo << '\n'
+                              << Conversion::ParameterMapStartOfCommentString(format)
+                              << " Resampler specific\n " + Conversion::ParameterMapToString(parameterMap, format);
 
 } // end WriteToFile()
 

--- a/Core/ComponentBaseClasses/elxTransformBase.hxx
+++ b/Core/ComponentBaseClasses/elxTransformBase.hxx
@@ -561,7 +561,12 @@ TransformBase<TElastix>::WriteToFile(std::ostream & transformationParameterInfo,
     }
   }
 
-  transformationParameterInfo << Conversion::ParameterMapToString(parameterMap);
+  const std::string parameterMapFileFormat =
+    configuration.RetrieveParameterStringValue("", "OutputTransformParameterFileFormat", 0, false);
+
+  const auto format = Conversion::StringToParameterMapStringFormat(parameterMapFileFormat);
+
+  transformationParameterInfo << Conversion::ParameterMapToString(parameterMap, format);
 
   WriteDerivedTransformDataToFile();
 

--- a/Core/Configuration/elxConfiguration.cxx
+++ b/Core/Configuration/elxConfiguration.cxx
@@ -109,7 +109,8 @@ Configuration::PrintParameterMap() const
   // Separate clearly in log-file, before and after writing the parameter map.
   log::info_to_log_file(std::ostringstream{}
                         << "\n=============== start of ParameterMap ===============\n"
-                        << Conversion::ParameterMapToString(m_ParameterMapInterface->GetParameterMap())
+                        << Conversion::ParameterMapToString(m_ParameterMapInterface->GetParameterMap(),
+                                                            ParameterMapStringFormat::LegacyTxt)
                         << "\n=============== end of ParameterMap ===============\n");
 
 } // end PrintParameterMap()

--- a/Core/Install/elxConversion.h
+++ b/Core/Install/elxConversion.h
@@ -35,6 +35,12 @@ class ITK_TEMPLATE_EXPORT OptimizerParameters;
 
 namespace elastix
 {
+enum class ParameterMapStringFormat
+{
+  LegacyTxt,
+  Toml
+};
+
 /**
  * \class Conversion
  *
@@ -68,9 +74,16 @@ public:
   static itk::OptimizerParameters<double>
   ToOptimizerParameters(const std::vector<double> &);
 
-  /** Converts the specified parameter map to a text string, according to the elastix parameter text file format. */
+  /** Converts the specified parameter map to a string, according to the specified format. */
   static std::string
-  ParameterMapToString(const ParameterMapType &);
+  ParameterMapToString(const ParameterMapType &, const ParameterMapStringFormat);
+
+  /** Resturns the character sequence to indicate the start of a comment, for the specified format. */
+  static std::string_view
+  ParameterMapStartOfCommentString(const ParameterMapStringFormat format)
+  {
+    return format == ParameterMapStringFormat::Toml ? "#" : "//";
+  }
 
   /** Convenience function overload to convert a Boolean to a text string. */
   static std::string
@@ -235,6 +248,15 @@ public:
    */
   static bool
   StringToValue(const std::string & str, itk::Object *& value);
+
+  /** Converts the specified string to the corresponding enum value. Returns ParameterMapStringFormat::LegacyTxt when
+   * the string is empty. */
+  static ParameterMapStringFormat
+  StringToParameterMapStringFormat(const std::string & str);
+
+  /** Creates a parameter map file name extension for the corresponding format. */
+  static std::string
+  CreateParameterMapFileNameExtension(const ParameterMapStringFormat format);
 };
 
 } // end namespace elastix

--- a/Core/Kernel/elxElastixTemplate.hxx
+++ b/Core/Kernel/elxElastixTemplate.hxx
@@ -732,8 +732,13 @@ ElastixTemplate<TFixedImage, TMovingImage>::AfterRegistration()
 
   if (writeFinalTansformParameters && !outputDirectoryPath.empty())
   {
+    const std::string parameterMapFileFormat =
+      configuration.RetrieveParameterStringValue("", "OutputTransformParameterFileFormat", 0, false);
+    const auto format = Conversion::StringToParameterMapStringFormat(parameterMapFileFormat);
+
     std::ostringstream makeFileName;
-    makeFileName << outputDirectoryPath << "TransformParameters." << configuration.GetElastixLevel() << ".txt";
+    makeFileName << outputDirectoryPath << "TransformParameters." << configuration.GetElastixLevel()
+                 << Conversion::CreateParameterMapFileNameExtension(format);
     std::string FileName = makeFileName.str();
 
     /** Create a final TransformParameterFile. */

--- a/Core/Main/elxParameterObject.cxx
+++ b/Core/Main/elxParameterObject.cxx
@@ -280,7 +280,12 @@ ParameterObject::WriteParameterFile(const ParameterMapType &      parameterMap,
 
   try
   {
-    parameterFile << Conversion::ParameterMapToString(parameterMap);
+    const auto format = itksys::SystemTools::GetFilenameLastExtension(parameterFileName) ==
+                            Conversion::CreateParameterMapFileNameExtension(ParameterMapStringFormat::Toml)
+                          ? ParameterMapStringFormat::Toml
+                          : ParameterMapStringFormat::LegacyTxt;
+
+    parameterFile << Conversion::ParameterMapToString(parameterMap, format);
   }
   catch (const std::ios_base::failure & e)
   {


### PR DESCRIPTION
Supports the parameter `OutputTransformParameterMapFileFormat"` in elastix registration parameter files. Allows specifying the file format of the output transform parameter files.

Possible values:

 - `"txt"`: Use the legacy file format, "TransformParameters.*.txt" (the default)
 - `"TOML"`: Use the TOML file format, "TransformParameters.*.toml"
 - `""` (empty string): Use the default

----

- Complementary to pull request #1288