### PR TITLE
STYLE: Simplify creating string representation of stop conditions

### DIFF
--- a/Components/Optimizers/AdaGrad/elxAdaGrad.hxx
+++ b/Components/Optimizers/AdaGrad/elxAdaGrad.hxx
@@ -324,26 +324,19 @@ AdaGrad<TElastix>::AfterEachResolution()
    *   MetricError,
    *   MinimumStepSize } ;
    */
-  std::string stopcondition;
-
-  switch (this->GetStopCondition())
-  {
-    case MaximumNumberOfIterations:
-      stopcondition = "Maximum number of iterations has been reached";
-      break;
-
-    case MetricError:
-      stopcondition = "Error in metric";
-      break;
-
-    case MinimumStepSize:
-      stopcondition = "The minimum step length has been reached";
-      break;
-
-    default:
-      stopcondition = "Unknown";
-      break;
-  }
+  const std::string stopcondition = [this] {
+    switch (this->GetStopCondition())
+    {
+      case MaximumNumberOfIterations:
+        return "Maximum number of iterations has been reached";
+      case MetricError:
+        return "Error in metric";
+      case MinimumStepSize:
+        return "The minimum step length has been reached";
+      default:
+        return "Unknown";
+    }
+  }();
 
   /** Print the stopping condition. */
   log::info(std::ostringstream{} << "Stopping condition: " << stopcondition << ".");

--- a/Components/Optimizers/AdaptiveStochasticGradientDescent/elxAdaptiveStochasticGradientDescent.hxx
+++ b/Components/Optimizers/AdaptiveStochasticGradientDescent/elxAdaptiveStochasticGradientDescent.hxx
@@ -304,26 +304,19 @@ AdaptiveStochasticGradientDescent<TElastix>::AfterEachResolution()
    *   MetricError,
    *   MinimumStepSize };
    */
-  std::string stopcondition;
-
-  switch (this->GetStopCondition())
-  {
-    case MaximumNumberOfIterations:
-      stopcondition = "Maximum number of iterations has been reached";
-      break;
-
-    case MetricError:
-      stopcondition = "Error in metric";
-      break;
-
-    case MinimumStepSize:
-      stopcondition = "The minimum step length has been reached";
-      break;
-
-    default:
-      stopcondition = "Unknown";
-      break;
-  }
+  const std::string stopcondition = [this] {
+    switch (this->GetStopCondition())
+    {
+      case MaximumNumberOfIterations:
+        return "Maximum number of iterations has been reached";
+      case MetricError:
+        return "Error in metric";
+      case MinimumStepSize:
+        return "The minimum step length has been reached";
+      default:
+        return "Unknown";
+    }
+  }();
 
   /** Print the stopping condition. */
   log::info(std::ostringstream{} << "Stopping condition: " << stopcondition << ".");

--- a/Components/Optimizers/AdaptiveStochasticLBFGS/elxAdaptiveStochasticLBFGS.hxx
+++ b/Components/Optimizers/AdaptiveStochasticLBFGS/elxAdaptiveStochasticLBFGS.hxx
@@ -375,34 +375,23 @@ AdaptiveStochasticLBFGS<TElastix>::AfterEachResolution()
    *   MetricError,
    *   MinimumStepSize };
    */
-  std::string stopcondition;
-
-  switch (this->GetStopCondition())
-  {
-    case MetricError:
-      stopcondition = "Error in metric";
-      break;
-
-    case MaximumNumberOfIterations:
-      stopcondition = "Maximum number of iterations has been reached";
-      break;
-
-    case InvalidDiagonalMatrix:
-      stopcondition = "The InvalidDiagonalMatrix";
-      break;
-
-    case GradientMagnitudeTolerance:
-      stopcondition = "The gradient magnitude has (nearly) vanished";
-      break;
-
-    case MinimumStepSize:
-      stopcondition = "The last step size was (nearly) zero";
-      break;
-
-    default:
-      stopcondition = "Unknown";
-      break;
-  }
+  const std::string stopcondition = [this] {
+    switch (this->GetStopCondition())
+    {
+      case MetricError:
+        return "Error in metric";
+      case MaximumNumberOfIterations:
+        return "Maximum number of iterations has been reached";
+      case InvalidDiagonalMatrix:
+        return "The InvalidDiagonalMatrix";
+      case GradientMagnitudeTolerance:
+        return "The gradient magnitude has (nearly) vanished";
+      case MinimumStepSize:
+        return "The last step size was (nearly) zero";
+      default:
+        return "Unknown";
+    }
+  }();
 
   /** Print the stopping condition. */
   log::info(std::ostringstream{} << "Stopping condition: " << stopcondition << ".");

--- a/Components/Optimizers/AdaptiveStochasticVarianceReducedGradient/elxAdaptiveStochasticVarianceReducedGradient.hxx
+++ b/Components/Optimizers/AdaptiveStochasticVarianceReducedGradient/elxAdaptiveStochasticVarianceReducedGradient.hxx
@@ -327,22 +327,17 @@ AdaptiveStochasticVarianceReducedGradient<TElastix>::AfterEachResolution()
    *   MetricError,
    *   MinimumStepSize };
    */
-  std::string stopcondition;
-
-  switch (this->GetStopCondition())
-  {
-    case MetricError:
-      stopcondition = "Error in metric";
-      break;
-
-    case MinimumStepSize:
-      stopcondition = "The minimum step length has been reached";
-      break;
-
-    default:
-      stopcondition = "Unknown";
-      break;
-  }
+  const std::string stopcondition = [this] {
+    switch (this->GetStopCondition())
+    {
+      case MetricError:
+        return "Error in metric";
+      case MinimumStepSize:
+        return "The minimum step length has been reached";
+      default:
+        return "Unknown";
+    }
+  }();
 
   /** Print the stopping condition. */
   log::info(std::ostringstream{} << "Stopping condition: " << stopcondition << ".");

--- a/Components/Optimizers/CMAEvolutionStrategy/elxCMAEvolutionStrategy.hxx
+++ b/Components/Optimizers/CMAEvolutionStrategy/elxCMAEvolutionStrategy.hxx
@@ -240,38 +240,25 @@ CMAEvolutionStrategy<TElastix>::AfterEachResolution()
     ZeroStepLength,
     Unknown };  */
 
-  std::string stopcondition;
-
-  switch (this->GetStopCondition())
-  {
-    case MetricError:
-      stopcondition = "Error in metric";
-      break;
-
-    case MaximumNumberOfIterations:
-      stopcondition = "Maximum number of iterations has been reached";
-      break;
-
-    case PositionToleranceMin:
-      stopcondition = "The minimum step length condition has been reached";
-      break;
-
-    case PositionToleranceMax:
-      stopcondition = "The maximum step length condition has been reached";
-      break;
-
-    case ValueTolerance:
-      stopcondition = "Almost no decrease in function value anymore";
-      break;
-
-    case ZeroStepLength:
-      stopcondition = "The step length is 0";
-      break;
-
-    default:
-      stopcondition = "Unknown";
-      break;
-  }
+  const std::string stopcondition = [this] {
+    switch (this->GetStopCondition())
+    {
+      case MetricError:
+        return "Error in metric";
+      case MaximumNumberOfIterations:
+        return "Maximum number of iterations has been reached";
+      case PositionToleranceMin:
+        return "The minimum step length condition has been reached";
+      case PositionToleranceMax:
+        return "The maximum step length condition has been reached";
+      case ValueTolerance:
+        return "Almost no decrease in function value anymore";
+      case ZeroStepLength:
+        return "The step length is 0";
+      default:
+        return "Unknown";
+    }
+  }();
 
   /** Print the stopping condition */
   log::info(std::ostringstream{} << "Stopping condition: " << stopcondition << ".");

--- a/Components/Optimizers/ConjugateGradient/elxConjugateGradient.hxx
+++ b/Components/Optimizers/ConjugateGradient/elxConjugateGradient.hxx
@@ -402,37 +402,26 @@ ConjugateGradient<TElastix>::AfterEachResolution()
   }
   else
   {
-    switch (this->GetStopCondition())
-    {
+    stopcondition = [this] {
+      switch (this->GetStopCondition())
+      {
 
-      case StopConditionType::MetricError:
-        stopcondition = "Error in metric";
-        break;
-
-      case StopConditionType::LineSearchError:
-        stopcondition = "Error in LineSearch";
-        break;
-
-      case StopConditionType::MaximumNumberOfIterations:
-        stopcondition = "Maximum number of iterations has been reached";
-        break;
-
-      case StopConditionType::GradientMagnitudeTolerance:
-        stopcondition = "The gradient magnitude has (nearly) vanished";
-        break;
-
-      case StopConditionType::ValueTolerance:
-        stopcondition = "Almost no decrease in function value anymore";
-        break;
-
-      case StopConditionType::InfiniteBeta:
-        stopcondition = "The beta factor became infinite";
-        break;
-
-      default:
-        stopcondition = "Unknown";
-        break;
-    }
+        case StopConditionType::MetricError:
+          return "Error in metric";
+        case StopConditionType::LineSearchError:
+          return "Error in LineSearch";
+        case StopConditionType::MaximumNumberOfIterations:
+          return "Maximum number of iterations has been reached";
+        case StopConditionType::GradientMagnitudeTolerance:
+          return "The gradient magnitude has (nearly) vanished";
+        case StopConditionType::ValueTolerance:
+          return "Almost no decrease in function value anymore";
+        case StopConditionType::InfiniteBeta:
+          return "The beta factor became infinite";
+        default:
+          return "Unknown";
+      }
+    }();
   } // end else
 
   /** Print the stopping condition */
@@ -509,51 +498,28 @@ ConjugateGradient<TElastix>::GetLineSearchStopCondition() const
     Unknown
   };
 
-  std::string stopcondition;
-
-  auto lineSearchStopCondition = static_cast<LineSearchStopConditionType>(this->m_LineOptimizer->GetStopCondition());
-
-  switch (lineSearchStopCondition)
+  switch (static_cast<LineSearchStopConditionType>(this->m_LineOptimizer->GetStopCondition()))
   {
 
     case LineSearchStopConditionType::StrongWolfeConditionsSatisfied:
-      stopcondition = "WolfeSatisfied";
-      break;
-
+      return "WolfeSatisfied";
     case LineSearchStopConditionType::MetricError:
-      stopcondition = "MetricError";
-      break;
-
+      return "MetricError";
     case LineSearchStopConditionType::MaximumNumberOfIterations:
-      stopcondition = "MaxNrIterations";
-      break;
-
+      return "MaxNrIterations";
     case LineSearchStopConditionType::StepTooSmall:
-      stopcondition = "StepTooSmall";
-      break;
-
+      return "StepTooSmall";
     case LineSearchStopConditionType::StepTooLarge:
-      stopcondition = "StepTooLarge";
-      break;
-
+      return "StepTooLarge";
     case LineSearchStopConditionType::IntervalTooSmall:
-      stopcondition = "IntervalTooSmall";
-      break;
-
+      return "IntervalTooSmall";
     case LineSearchStopConditionType::RoundingError:
-      stopcondition = "RoundingError";
-      break;
-
+      return "RoundingError";
     case LineSearchStopConditionType::AscentSearchDirection:
-      stopcondition = "AscentSearchDir";
-      break;
-
+      return "AscentSearchDir";
     default:
-      stopcondition = "Unknown";
-      break;
+      return "Unknown";
   }
-
-  return stopcondition;
 
 } // end GetLineSearchStopCondition
 

--- a/Components/Optimizers/ConjugateGradientFRPR/elxConjugateGradientFRPR.hxx
+++ b/Components/Optimizers/ConjugateGradientFRPR/elxConjugateGradientFRPR.hxx
@@ -203,26 +203,19 @@ ConjugateGradientFRPR<TElastix>::AfterEachResolution()
 
   /** \todo StopConditions are not yet implemented in the FRPROptimizer;
    * Uncomment the following code when they are implemented.
+  std::string stopcondition = [this] {
+    switch (this->GetStopCondition())
+    {
 
-  std::string stopcondition;
-
-  switch( this->GetStopCondition() )
-  {
-
-  case MaximumNumberOfIterations :
-    stopcondition = "Maximum number of iterations has been reached";
-    break;
-
-  case MetricError :
-    stopcondition = "Error in metric";
-    break;
-
-  default:
-    stopcondition = "Unknown";
-    break;
-
-  }
-*/
+      case MaximumNumberOfIterations:
+        return "Maximum number of iterations has been reached";
+      case MetricError:
+        return "Error in metric";
+      default:
+        return "Unknown";
+    }
+  }();
+   */
   /** Print the stopping condition */
   // elxout << "Stopping condition: " << stopcondition << "." << std::endl;
 

--- a/Components/Optimizers/FiniteDifferenceGradientDescent/elxFiniteDifferenceGradientDescent.hxx
+++ b/Components/Optimizers/FiniteDifferenceGradientDescent/elxFiniteDifferenceGradientDescent.hxx
@@ -160,23 +160,18 @@ FiniteDifferenceGradientDescent<TElastix>::AfterEachResolution()
   /**
    * enum   StopConditionType {  MaximumNumberOfIterations, MetricError }
    */
-  std::string stopcondition;
+  const std::string stopcondition = [this] {
+    switch (this->GetStopCondition())
+    {
 
-  switch (this->GetStopCondition())
-  {
-
-    case MaximumNumberOfIterations:
-      stopcondition = "Maximum number of iterations has been reached";
-      break;
-
-    case MetricError:
-      stopcondition = "Error in metric";
-      break;
-
-    default:
-      stopcondition = "Unknown";
-      break;
-  }
+      case MaximumNumberOfIterations:
+        return "Maximum number of iterations has been reached";
+      case MetricError:
+        return "Error in metric";
+      default:
+        return "Unknown";
+    }
+  }();
   /** Print the stopping condition */
 
   log::info(std::ostringstream{} << "Stopping condition: " << stopcondition << ".");

--- a/Components/Optimizers/FullSearch/elxFullSearchOptimizer.hxx
+++ b/Components/Optimizers/FullSearch/elxFullSearchOptimizer.hxx
@@ -221,22 +221,17 @@ FullSearch<TElastix>::AfterEachResolution()
   const Configuration & configuration = itk::Deref(Superclass2::GetConfiguration());
 
   // enum StopConditionType {FullRangeSearched,  MetricError };
-  std::string stopcondition;
-
-  switch (this->GetStopCondition())
-  {
-    case FullRangeSearched:
-      stopcondition = "The full range has been searched";
-      break;
-
-    case MetricError:
-      stopcondition = "Error in metric";
-      break;
-
-    default:
-      stopcondition = "Unknown";
-      break;
-  }
+  const std::string stopcondition = [this] {
+    switch (this->GetStopCondition())
+    {
+      case FullRangeSearched:
+        return "The full range has been searched";
+      case MetricError:
+        return "Error in metric";
+      default:
+        return "Unknown";
+    }
+  }();
 
   /** Print the stopping condition */
   log::info(std::ostringstream{} << "Stopping condition: " << stopcondition << ".");

--- a/Components/Optimizers/PreconditionedStochasticGradientDescent/elxPreconditionedStochasticGradientDescent.hxx
+++ b/Components/Optimizers/PreconditionedStochasticGradientDescent/elxPreconditionedStochasticGradientDescent.hxx
@@ -329,26 +329,19 @@ PreconditionedStochasticGradientDescent<TElastix>::AfterEachResolution()
    *   MetricError,
    *   MinimumStepSize };
    */
-  std::string stopcondition;
-
-  switch (this->GetStopCondition())
-  {
-    case MaximumNumberOfIterations:
-      stopcondition = "Maximum number of iterations has been reached";
-      break;
-
-    case MetricError:
-      stopcondition = "Error in metric";
-      break;
-
-    case MinimumStepSize:
-      stopcondition = "The minimum step length has been reached";
-      break;
-
-    default:
-      stopcondition = "Unknown";
-      break;
-  }
+  const std::string stopcondition = [this] {
+    switch (this->GetStopCondition())
+    {
+      case MaximumNumberOfIterations:
+        return "Maximum number of iterations has been reached";
+      case MetricError:
+        return "Error in metric";
+      case MinimumStepSize:
+        return "The minimum step length has been reached";
+      default:
+        return "Unknown";
+    }
+  }();
 
   /** Print the stopping condition. */
   log::info(std::ostringstream{} << "Stopping condition: " << stopcondition << ".");

--- a/Components/Optimizers/QuasiNewtonLBFGS/elxQuasiNewtonLBFGS.hxx
+++ b/Components/Optimizers/QuasiNewtonLBFGS/elxQuasiNewtonLBFGS.hxx
@@ -391,37 +391,26 @@ QuasiNewtonLBFGS<TElastix>::AfterEachResolution()
   }
   else
   {
-    switch (this->GetStopCondition())
-    {
+    stopcondition = [this] {
+      switch (this->GetStopCondition())
+      {
 
-      case StopConditionType::MetricError:
-        stopcondition = "Error in metric";
-        break;
-
-      case StopConditionType::LineSearchError:
-        stopcondition = "Error in LineSearch";
-        break;
-
-      case StopConditionType::MaximumNumberOfIterations:
-        stopcondition = "Maximum number of iterations has been reached";
-        break;
-
-      case StopConditionType::InvalidDiagonalMatrix:
-        stopcondition = "The diagonal matrix is invalid";
-        break;
-
-      case StopConditionType::GradientMagnitudeTolerance:
-        stopcondition = "The gradient magnitude has (nearly) vanished";
-        break;
-
-      case StopConditionType::ZeroStep:
-        stopcondition = "The last step size was (nearly) zero";
-        break;
-
-      default:
-        stopcondition = "Unknown";
-        break;
-    }
+        case StopConditionType::MetricError:
+          return "Error in metric";
+        case StopConditionType::LineSearchError:
+          return "Error in LineSearch";
+        case StopConditionType::MaximumNumberOfIterations:
+          return "Maximum number of iterations has been reached";
+        case StopConditionType::InvalidDiagonalMatrix:
+          return "The diagonal matrix is invalid";
+        case StopConditionType::GradientMagnitudeTolerance:
+          return "The gradient magnitude has (nearly) vanished";
+        case StopConditionType::ZeroStep:
+          return "The last step size was (nearly) zero";
+        default:
+          return "Unknown";
+      }
+    }();
   }
 
   /** Print the stopping condition */
@@ -497,51 +486,27 @@ QuasiNewtonLBFGS<TElastix>::GetLineSearchStopCondition() const
     Unknown
   };
 
-  std::string stopcondition;
-
-  auto lineSearchStopCondition = static_cast<LineSearchStopConditionType>(this->m_LineOptimizer->GetStopCondition());
-
-  switch (lineSearchStopCondition)
+  switch (static_cast<LineSearchStopConditionType>(this->m_LineOptimizer->GetStopCondition()))
   {
-
     case LineSearchStopConditionType::StrongWolfeConditionsSatisfied:
-      stopcondition = "WolfeSatisfied";
-      break;
-
+      return "WolfeSatisfied";
     case LineSearchStopConditionType::MetricError:
-      stopcondition = "MetricError";
-      break;
-
+      return "MetricError";
     case LineSearchStopConditionType::MaximumNumberOfIterations:
-      stopcondition = "MaxNrIterations";
-      break;
-
+      return "MaxNrIterations";
     case LineSearchStopConditionType::StepTooSmall:
-      stopcondition = "StepTooSmall";
-      break;
-
+      return "StepTooSmall";
     case LineSearchStopConditionType::StepTooLarge:
-      stopcondition = "StepTooLarge";
-      break;
-
+      return "StepTooLarge";
     case LineSearchStopConditionType::IntervalTooSmall:
-      stopcondition = "IntervalTooSmall";
-      break;
-
+      return "IntervalTooSmall";
     case LineSearchStopConditionType::RoundingError:
-      stopcondition = "RoundingError";
-      break;
-
+      return "RoundingError";
     case LineSearchStopConditionType::AscentSearchDirection:
-      stopcondition = "AscentSearchDir";
-      break;
-
+      return "AscentSearchDir";
     default:
-      stopcondition = "Unknown";
-      break;
+      return "Unknown";
   }
-
-  return stopcondition;
 
 } // end GetLineSearchStopCondition
 

--- a/Components/Optimizers/RSGDEachParameterApart/elxRSGDEachParameterApart.hxx
+++ b/Components/Optimizers/RSGDEachParameterApart/elxRSGDEachParameterApart.hxx
@@ -125,39 +125,26 @@ RSGDEachParameterApart<TElastix>::AfterEachResolution()
    * enum   StopConditionType {   GradientMagnitudeTolerance = 1, StepTooSmall,
    * ImageNotAvailable, SamplesNotAvailable, MaximumNumberOfIterations, MetricError
    */
-  std::string stopcondition;
+  const std::string stopcondition = [this] {
+    switch (this->GetStopCondition())
+    {
 
-  switch (this->GetStopCondition())
-  {
-
-    case GradientMagnitudeTolerance:
-      stopcondition = "Minimum gradient magnitude has been reached";
-      break;
-
-    case StepTooSmall:
-      stopcondition = "Minimum step size has been reached";
-      break;
-
-    case MaximumNumberOfIterations:
-      stopcondition = "Maximum number of iterations has been reached";
-      break;
-
-    case ImageNotAvailable:
-      stopcondition = "No image available";
-      break;
-
-    case SamplesNotAvailable:
-      stopcondition = "No samples available";
-      break;
-
-    case MetricError:
-      stopcondition = "Error in metric";
-      break;
-
-    default:
-      stopcondition = "Unknown";
-      break;
-  }
+      case GradientMagnitudeTolerance:
+        return "Minimum gradient magnitude has been reached";
+      case StepTooSmall:
+        return "Minimum step size has been reached";
+      case MaximumNumberOfIterations:
+        return "Maximum number of iterations has been reached";
+      case ImageNotAvailable:
+        return "No image available";
+      case SamplesNotAvailable:
+        return "No samples available";
+      case MetricError:
+        return "Error in metric";
+      default:
+        return "Unknown";
+    }
+  }();
   /** Print the stopping condition */
 
   log::info(std::ostringstream{} << "Stopping condition: " << stopcondition << ".");

--- a/Components/Optimizers/RegularStepGradientDescent/elxRegularStepGradientDescent.hxx
+++ b/Components/Optimizers/RegularStepGradientDescent/elxRegularStepGradientDescent.hxx
@@ -120,35 +120,24 @@ RegularStepGradientDescent<TElastix>::AfterEachResolution()
    * enum   StopConditionType {   GradientMagnitudeTolerance = 1, StepTooSmall,
    * ImageNotAvailable, CostFunctionError, MaximumNumberOfIterations
    */
-  std::string stopcondition;
+  const std::string stopcondition = [this] {
+    switch (this->GetStopCondition())
+    {
 
-  switch (this->GetStopCondition())
-  {
-
-    case StopConditionEnum::GradientMagnitudeTolerance:
-      stopcondition = "Minimum gradient magnitude has been reached";
-      break;
-
-    case StopConditionEnum::StepTooSmall:
-      stopcondition = "Minimum step size has been reached";
-      break;
-
-    case StopConditionEnum::MaximumNumberOfIterations:
-      stopcondition = "Maximum number of iterations has been reached";
-      break;
-
-    case StopConditionEnum::ImageNotAvailable:
-      stopcondition = "No image available";
-      break;
-
-    case StopConditionEnum::CostFunctionError:
-      stopcondition = "Error in cost function";
-      break;
-
-    default:
-      stopcondition = "Unknown";
-      break;
-  }
+      case StopConditionEnum::GradientMagnitudeTolerance:
+        return "Minimum gradient magnitude has been reached";
+      case StopConditionEnum::StepTooSmall:
+        return "Minimum step size has been reached";
+      case StopConditionEnum::MaximumNumberOfIterations:
+        return "Maximum number of iterations has been reached";
+      case StopConditionEnum::ImageNotAvailable:
+        return "No image available";
+      case StopConditionEnum::CostFunctionError:
+        return "Error in cost function";
+      default:
+        return "Unknown";
+    }
+  }();
   /** Print the stopping condition */
 
   log::info(std::ostringstream{} << "Stopping condition: " << stopcondition << ".");

--- a/Components/Optimizers/SimultaneousPerturbation/elxSimultaneousPerturbation.hxx
+++ b/Components/Optimizers/SimultaneousPerturbation/elxSimultaneousPerturbation.hxx
@@ -169,23 +169,18 @@ SimultaneousPerturbation<TElastix>::AfterEachResolution()
    * enum   StopConditionType {  MaximumNumberOfIterations, MetricError }
    * ignore the BelowTolerance-criterion.
    */
-  std::string stopcondition;
+  const std::string stopcondition = [this] {
+    switch (this->GetStopCondition())
+    {
 
-  switch (this->GetStopCondition())
-  {
-
-    case StopConditionSPSAOptimizerEnum::MaximumNumberOfIterations:
-      stopcondition = "Maximum number of iterations has been reached";
-      break;
-
-    case StopConditionSPSAOptimizerEnum::MetricError:
-      stopcondition = "Error in metric";
-      break;
-
-    default:
-      stopcondition = "Unknown";
-      break;
-  }
+      case StopConditionSPSAOptimizerEnum::MaximumNumberOfIterations:
+        return "Maximum number of iterations has been reached";
+      case StopConditionSPSAOptimizerEnum::MetricError:
+        return "Error in metric";
+      default:
+        return "Unknown";
+    }
+  }();
   /** Print the stopping condition */
 
   log::info(std::ostringstream{} << "Stopping condition: " << stopcondition << ".");

--- a/Components/Optimizers/StandardGradientDescent/elxStandardGradientDescent.hxx
+++ b/Components/Optimizers/StandardGradientDescent/elxStandardGradientDescent.hxx
@@ -144,22 +144,18 @@ StandardGradientDescent<TElastix>::AfterEachResolution()
   /**
    * enum   StopConditionType {  MaximumNumberOfIterations, MetricError }
    */
-  std::string stopcondition;
-  switch (this->GetStopCondition())
-  {
+  const std::string stopcondition = [this] {
+    switch (this->GetStopCondition())
+    {
 
-    case MaximumNumberOfIterations:
-      stopcondition = "Maximum number of iterations has been reached";
-      break;
-
-    case MetricError:
-      stopcondition = "Error in metric";
-      break;
-
-    default:
-      stopcondition = "Unknown";
-      break;
-  }
+      case MaximumNumberOfIterations:
+        return "Maximum number of iterations has been reached";
+      case MetricError:
+        return "Error in metric";
+      default:
+        return "Unknown";
+    }
+  }();
 
   /** Print the stopping condition */
   log::info(std::ostringstream{} << "Stopping condition: " << stopcondition << ".");


### PR DESCRIPTION
Replaced `break` statements in `switch` cases by `return` statements, directly returning the appropriate string, in Optimizers.

Using Notepad++, Replace in Files:

    Find what: ^  ([ ]+)stopcondition = "(.+)";\r\n  \1break;\r\n
    Replace with: $1return "$2";
    (*) Regular expression