### PR TITLE
ENH: Let ElastixBase print git revision info, also for library users

### DIFF
--- a/Core/Kernel/elxElastixBase.cxx
+++ b/Core/Kernel/elxElastixBase.cxx
@@ -18,6 +18,7 @@
 #include "elxElastixBase.h"
 #include <Core/elxVersionMacros.h>
 #include "elxConversion.h"
+#include <Core/elxGitRevisionInfo.h>
 #include <sstream>
 #include "itkMersenneTwisterRandomVariateGenerator.h"
 
@@ -177,7 +178,8 @@ ElastixBase::BeforeAllBase()
   int returndummy = 0;
 
   /** Check Command line options and print them to the logfile. */
-  log::info("ELASTIX version: " ELASTIX_VERSION_STRING "\nCommand line options from ElastixBase:");
+  log::info(std::string("ELASTIX version: " ELASTIX_VERSION_STRING "\nGit revision SHA: ") + gitRevisionSha +
+            "\nGit revision date: " + gitRevisionDate + "\nCommand line options from ElastixBase:");
 
   if (!BaseComponent::IsElastixLibrary())
   {


### PR DESCRIPTION
Previously, the git revision info (SHA and revision date) were only available to users of the executable (by `elastix.exe --extended-version`, as well as in the "elastix.log" file).