### PR TITLE
STYLE: Remove unused variables from InitializeTransform stack transforms

### DIFF
--- a/Components/Transforms/AffineLogStackTransform/elxAffineLogStackTransform.hxx
+++ b/Components/Transforms/AffineLogStackTransform/elxAffineLogStackTransform.hxx
@@ -174,12 +174,10 @@ AffineLogStackTransform<TElastix>::InitializeTransform()
    * which is the rotationPoint, expressed in index-values.
    */
 
-  ContinuousIndexType                 centerOfRotationIndex{};
-  InputPointType                      centerOfRotationPoint{};
-  ReducedDimensionContinuousIndexType RDcenterOfRotationIndex{};
-  ReducedDimensionInputPointType      RDcenterOfRotationPoint{};
-  InputPointType                      TransformedCenterOfRotation{};
-  ReducedDimensionInputPointType      RDTransformedCenterOfRotation{};
+  ContinuousIndexType            centerOfRotationIndex{};
+  ReducedDimensionInputPointType RDcenterOfRotationPoint{};
+  InputPointType                 TransformedCenterOfRotation{};
+  ReducedDimensionInputPointType RDTransformedCenterOfRotation{};
 
   bool     centerGivenAsIndex = true;
   bool     centerGivenAsPoint = true;

--- a/Components/Transforms/EulerStackTransform/elxEulerStackTransform.hxx
+++ b/Components/Transforms/EulerStackTransform/elxEulerStackTransform.hxx
@@ -190,10 +190,9 @@ EulerStackTransform<TElastix>::InitializeTransform()
    * which is the rotationPoint, expressed in index-values.
    */
 
-  ContinuousIndexType                 centerOfRotationIndex{};
-  InputPointType                      centerOfRotationPoint{};
-  ReducedDimensionContinuousIndexType redDimCenterOfRotationIndex{};
-  ReducedDimensionInputPointType      redDimCenterOfRotationPoint{};
+  ContinuousIndexType            centerOfRotationIndex{};
+  InputPointType                 centerOfRotationPoint{};
+  ReducedDimensionInputPointType redDimCenterOfRotationPoint{};
 
   bool     centerGivenAsIndex = true;
   bool     centerGivenAsPoint = true;


### PR DESCRIPTION
`centerOfRotationPoint` was not used in AffineLogStackTransform. `RDcenterOfRotationIndex` and `redDimCenterOfRotationIndex` were not used anywhere in elastix.

The unused variables `centerOfRotationPoint` and `RDcenterOfRotationIndex` appear introduced with commit 2607ad674891168a96d1214823b62fefe280718a "Added AffineLogTransform and AffineLogStackTransform", 14 Apr 2016.

The unused `redDimCenterOfRotationIndex` variable appears introduced with commit 4dda84b59d1753597641bc3ec72b69541c1d97eb, "Added EulerStackTransform to trunkpublic", 1 Mar 2017.

@stefanklein Is it OK to you if I just merge this as a code clean-up?