### PR TITLE
BUG: Fix calculation CenterOfRotationPoint in EulerStackTransform

### DIFF
--- a/Components/Transforms/EulerStackTransform/elxEulerStackTransform.hxx
+++ b/Components/Transforms/EulerStackTransform/elxEulerStackTransform.hxx
@@ -234,7 +234,7 @@ EulerStackTransform<TElastix>::InitializeTransform()
 
     for (unsigned int k = 0; k < ReducedSpaceDimension; ++k)
     {
-      redDimCenterOfRotationPoint[k] = redDimCenterOfRotationPoint[k];
+      redDimCenterOfRotationPoint[k] = centerOfRotationPoint[k];
     }
 
     /** FIX: why may the cop not work when using direction cosines? */


### PR DESCRIPTION
When the user did not explicitly specify "CenterOfRotation" or "CenterOfRotationPoint", the elements of `redDimCenterOfRotationPoint` were accidentally just assigned to themselves, in `EulerStackTransform::InitializeTransform()`. Effectively their values would then remain `0.0`.

The bug appears already with the initial EulerStackTransform commit, 4dda84b59d1753597641bc3ec72b69541c1d97eb "Added EulerStackTransform to trunkpublic", 1 March 2017.

----

@mstaring @stefanklein @whuizinga Please check!