### PR TITLE
Remove parameters from `CheckNumberOfSamples`, let `AdvancedImageToImageMetric` directly access its own data

### DIFF
--- a/Common/CostFunctions/itkAdvancedImageToImageMetric.h
+++ b/Common/CostFunctions/itkAdvancedImageToImageMetric.h
@@ -483,7 +483,7 @@ protected:
   /** Check if enough samples have been found to compute a reliable
    * estimate of the value/derivative; throws an exception if not. */
   void
-  CheckNumberOfSamples(unsigned long wanted, unsigned long found) const;
+  CheckNumberOfSamples(unsigned long wanted) const;
 
   /** Methods for image derivative evaluation support **********/
 

--- a/Common/CostFunctions/itkAdvancedImageToImageMetric.h
+++ b/Common/CostFunctions/itkAdvancedImageToImageMetric.h
@@ -483,7 +483,7 @@ protected:
   /** Check if enough samples have been found to compute a reliable
    * estimate of the value/derivative; throws an exception if not. */
   void
-  CheckNumberOfSamples(unsigned long wanted) const;
+  CheckNumberOfSamples() const;
 
   /** Methods for image derivative evaluation support **********/
 

--- a/Common/CostFunctions/itkAdvancedImageToImageMetric.hxx
+++ b/Common/CostFunctions/itkAdvancedImageToImageMetric.hxx
@@ -143,9 +143,9 @@ void
 AdvancedImageToImageMetric<TFixedImage, TMovingImage>::InitializeLimiters()
 {
   /** Set up fixed limiter. */
-  if (this->GetUseFixedImageLimiter())
+  if (m_UseFixedImageLimiter)
   {
-    if (this->GetFixedImageLimiter() == nullptr)
+    if (m_FixedImageLimiter == nullptr)
     {
       itkExceptionMacro("No fixed image limiter has been set!");
     }
@@ -172,9 +172,9 @@ AdvancedImageToImageMetric<TFixedImage, TMovingImage>::InitializeLimiters()
   }
 
   /** Set up moving limiter. */
-  if (this->GetUseMovingImageLimiter())
+  if (m_UseMovingImageLimiter)
   {
-    if (this->GetMovingImageLimiter() == nullptr)
+    if (m_MovingImageLimiter == nullptr)
     {
       itkExceptionMacro("No moving image limiter has been set!");
     }
@@ -211,7 +211,7 @@ template <typename TFixedImage, typename TMovingImage>
 void
 AdvancedImageToImageMetric<TFixedImage, TMovingImage>::InitializeImageSampler()
 {
-  if (this->GetUseImageSampler())
+  if (m_UseImageSampler)
   {
     /** Check if the ImageSampler is set. */
     if (!m_ImageSampler)
@@ -610,7 +610,7 @@ AdvancedImageToImageMetric<TFixedImage, TMovingImage>::BeforeThreadedGetValueAnd
     this->SetTransformParameters(parameters);
     if (m_UseImageSampler)
     {
-      this->GetImageSampler()->Update();
+      m_ImageSampler->Update();
     }
   }
 
@@ -753,7 +753,7 @@ AdvancedImageToImageMetric<TFixedImage, TMovingImage>::CheckNumberOfSamples(unsi
                                                                             unsigned long found) const
 {
   Superclass::m_NumberOfPixelsCounted = found;
-  if (found < wanted * this->GetRequiredRatioOfValidSamples())
+  if (found < wanted * m_RequiredRatioOfValidSamples)
   {
     itkExceptionMacro("Too many samples map outside moving image buffer: " << found << " / " << wanted << '\n');
   }

--- a/Common/CostFunctions/itkAdvancedImageToImageMetric.hxx
+++ b/Common/CostFunctions/itkAdvancedImageToImageMetric.hxx
@@ -749,11 +749,9 @@ AdvancedImageToImageMetric<TFixedImage, TMovingImage>::AccumulateDerivativesThre
 
 template <typename TFixedImage, typename TMovingImage>
 void
-AdvancedImageToImageMetric<TFixedImage, TMovingImage>::CheckNumberOfSamples(unsigned long wanted,
-                                                                            unsigned long found) const
+AdvancedImageToImageMetric<TFixedImage, TMovingImage>::CheckNumberOfSamples(unsigned long wanted) const
 {
-  Superclass::m_NumberOfPixelsCounted = found;
-  if (found < wanted * m_RequiredRatioOfValidSamples)
+  if (const SizeValueType found{ Superclass::m_NumberOfPixelsCounted }; found < wanted * m_RequiredRatioOfValidSamples)
   {
     itkExceptionMacro("Too many samples map outside moving image buffer: " << found << " / " << wanted << '\n');
   }

--- a/Common/CostFunctions/itkAdvancedImageToImageMetric.hxx
+++ b/Common/CostFunctions/itkAdvancedImageToImageMetric.hxx
@@ -23,6 +23,7 @@
 
 #include "itkAdvancedRayCastInterpolateImageFunction.h"
 #include "itkComputeImageExtremaFilter.h"
+#include <itkDeref.h>
 
 #include <algorithm> // For min.
 #include <cassert>
@@ -749,11 +750,16 @@ AdvancedImageToImageMetric<TFixedImage, TMovingImage>::AccumulateDerivativesThre
 
 template <typename TFixedImage, typename TMovingImage>
 void
-AdvancedImageToImageMetric<TFixedImage, TMovingImage>::CheckNumberOfSamples(unsigned long wanted) const
+AdvancedImageToImageMetric<TFixedImage, TMovingImage>::CheckNumberOfSamples() const
 {
-  if (const SizeValueType found{ Superclass::m_NumberOfPixelsCounted }; found < wanted * m_RequiredRatioOfValidSamples)
+  const auto & samples = Deref(Deref(m_ImageSampler.get()).GetOutput());
+  const auto   numberOfSamples = samples.size();
+
+  if (const SizeValueType found{ Superclass::m_NumberOfPixelsCounted };
+      found < m_RequiredRatioOfValidSamples * numberOfSamples)
   {
-    itkExceptionMacro("Too many samples map outside moving image buffer: " << found << " / " << wanted << '\n');
+    itkExceptionMacro("Too many samples map outside moving image buffer: " << found << " / " << numberOfSamples
+                                                                           << '\n');
   }
 
 } // end CheckNumberOfSamples()

--- a/Common/CostFunctions/itkParzenWindowHistogramImageToImageMetric.hxx
+++ b/Common/CostFunctions/itkParzenWindowHistogramImageToImageMetric.hxx
@@ -985,7 +985,7 @@ ParzenWindowHistogramImageToImageMetric<TFixedImage, TMovingImage>::ComputePDFsS
   } // end iterating over fixed image spatial sample container for loop
 
   /** Check if enough samples were valid. */
-  this->CheckNumberOfSamples(sampleContainer->Size(), Superclass::m_NumberOfPixelsCounted);
+  this->CheckNumberOfSamples(sampleContainer->Size());
 
   /** Compute alpha. */
   this->m_Alpha = 1.0 / static_cast<double>(Superclass::m_NumberOfPixelsCounted);
@@ -1131,7 +1131,7 @@ ParzenWindowHistogramImageToImageMetric<TFixedImage, TMovingImage>::AfterThreade
 
   /** Check if enough samples were valid. */
   ImageSampleContainerPointer sampleContainer = this->GetImageSampler()->GetOutput();
-  this->CheckNumberOfSamples(sampleContainer->Size(), Superclass::m_NumberOfPixelsCounted);
+  this->CheckNumberOfSamples(sampleContainer->Size());
 
   /** Compute alpha. */
   this->m_Alpha = 1.0 / static_cast<double>(Superclass::m_NumberOfPixelsCounted);
@@ -1295,7 +1295,7 @@ ParzenWindowHistogramImageToImageMetric<TFixedImage, TMovingImage>::ComputePDFsA
   } // end iterating over fixed image spatial sample container for loop
 
   /** Check if enough samples were valid. */
-  this->CheckNumberOfSamples(sampleContainer->Size(), Superclass::m_NumberOfPixelsCounted);
+  this->CheckNumberOfSamples(sampleContainer->Size());
 
   /** Compute alpha. */
   this->m_Alpha = 0.0;
@@ -1491,7 +1491,7 @@ ParzenWindowHistogramImageToImageMetric<TFixedImage, TMovingImage>::ComputePDFsA
   } // end iterating over fixed image spatial sample container for loop
 
   /** Check if enough samples were valid. */
-  this->CheckNumberOfSamples(sampleContainer->Size(), Superclass::m_NumberOfPixelsCounted);
+  this->CheckNumberOfSamples(sampleContainer->Size());
 
   /** Compute alpha and its perturbed versions. */
   this->m_Alpha = 0.0;

--- a/Common/CostFunctions/itkParzenWindowHistogramImageToImageMetric.hxx
+++ b/Common/CostFunctions/itkParzenWindowHistogramImageToImageMetric.hxx
@@ -985,7 +985,7 @@ ParzenWindowHistogramImageToImageMetric<TFixedImage, TMovingImage>::ComputePDFsS
   } // end iterating over fixed image spatial sample container for loop
 
   /** Check if enough samples were valid. */
-  this->CheckNumberOfSamples(sampleContainer->Size());
+  this->CheckNumberOfSamples();
 
   /** Compute alpha. */
   this->m_Alpha = 1.0 / static_cast<double>(Superclass::m_NumberOfPixelsCounted);
@@ -1131,7 +1131,7 @@ ParzenWindowHistogramImageToImageMetric<TFixedImage, TMovingImage>::AfterThreade
 
   /** Check if enough samples were valid. */
   ImageSampleContainerPointer sampleContainer = this->GetImageSampler()->GetOutput();
-  this->CheckNumberOfSamples(sampleContainer->Size());
+  this->CheckNumberOfSamples();
 
   /** Compute alpha. */
   this->m_Alpha = 1.0 / static_cast<double>(Superclass::m_NumberOfPixelsCounted);
@@ -1295,7 +1295,7 @@ ParzenWindowHistogramImageToImageMetric<TFixedImage, TMovingImage>::ComputePDFsA
   } // end iterating over fixed image spatial sample container for loop
 
   /** Check if enough samples were valid. */
-  this->CheckNumberOfSamples(sampleContainer->Size());
+  this->CheckNumberOfSamples();
 
   /** Compute alpha. */
   this->m_Alpha = 0.0;
@@ -1491,7 +1491,7 @@ ParzenWindowHistogramImageToImageMetric<TFixedImage, TMovingImage>::ComputePDFsA
   } // end iterating over fixed image spatial sample container for loop
 
   /** Check if enough samples were valid. */
-  this->CheckNumberOfSamples(sampleContainer->Size());
+  this->CheckNumberOfSamples();
 
   /** Compute alpha and its perturbed versions. */
   this->m_Alpha = 0.0;

--- a/Components/Metrics/AdvancedKappaStatistic/itkAdvancedKappaStatisticImageToImageMetric.hxx
+++ b/Components/Metrics/AdvancedKappaStatistic/itkAdvancedKappaStatisticImageToImageMetric.hxx
@@ -201,7 +201,7 @@ AdvancedKappaStatisticImageToImageMetric<TFixedImage, TMovingImage>::GetValue(co
   } // end for loop over the image sample container
 
   /** Check if enough samples were valid. */
-  this->CheckNumberOfSamples(sampleContainer->Size(), Superclass::m_NumberOfPixelsCounted);
+  this->CheckNumberOfSamples(sampleContainer->Size());
 
   /** Compute the final metric value. */
   std::size_t areaSum = fixedForegroundArea + movingForegroundArea;
@@ -348,7 +348,7 @@ AdvancedKappaStatisticImageToImageMetric<TFixedImage, TMovingImage>::GetValueAnd
   } // end for loop over the image sample container
 
   /** Check if enough samples were valid. */
-  this->CheckNumberOfSamples(sampleContainer->Size(), Superclass::m_NumberOfPixelsCounted);
+  this->CheckNumberOfSamples(sampleContainer->Size());
 
   /** Compute the final metric value. */
   std::size_t areaSum = fixedForegroundArea + movingForegroundArea;
@@ -562,7 +562,7 @@ AdvancedKappaStatisticImageToImageMetric<TFixedImage, TMovingImage>::AfterThread
 
   /** Check if enough samples were valid. */
   ImageSampleContainerPointer sampleContainer = this->GetImageSampler()->GetOutput();
-  this->CheckNumberOfSamples(sampleContainer->Size(), Superclass::m_NumberOfPixelsCounted);
+  this->CheckNumberOfSamples(sampleContainer->Size());
 
   /** Accumulate values. */
   MeasureType areaSum{};

--- a/Components/Metrics/AdvancedKappaStatistic/itkAdvancedKappaStatisticImageToImageMetric.hxx
+++ b/Components/Metrics/AdvancedKappaStatistic/itkAdvancedKappaStatisticImageToImageMetric.hxx
@@ -201,7 +201,7 @@ AdvancedKappaStatisticImageToImageMetric<TFixedImage, TMovingImage>::GetValue(co
   } // end for loop over the image sample container
 
   /** Check if enough samples were valid. */
-  this->CheckNumberOfSamples(sampleContainer->Size());
+  this->CheckNumberOfSamples();
 
   /** Compute the final metric value. */
   std::size_t areaSum = fixedForegroundArea + movingForegroundArea;
@@ -348,7 +348,7 @@ AdvancedKappaStatisticImageToImageMetric<TFixedImage, TMovingImage>::GetValueAnd
   } // end for loop over the image sample container
 
   /** Check if enough samples were valid. */
-  this->CheckNumberOfSamples(sampleContainer->Size());
+  this->CheckNumberOfSamples();
 
   /** Compute the final metric value. */
   std::size_t areaSum = fixedForegroundArea + movingForegroundArea;
@@ -562,7 +562,7 @@ AdvancedKappaStatisticImageToImageMetric<TFixedImage, TMovingImage>::AfterThread
 
   /** Check if enough samples were valid. */
   ImageSampleContainerPointer sampleContainer = this->GetImageSampler()->GetOutput();
-  this->CheckNumberOfSamples(sampleContainer->Size());
+  this->CheckNumberOfSamples();
 
   /** Accumulate values. */
   MeasureType areaSum{};

--- a/Components/Metrics/AdvancedMeanSquares/itkAdvancedMeanSquaresImageToImageMetric.hxx
+++ b/Components/Metrics/AdvancedMeanSquares/itkAdvancedMeanSquaresImageToImageMetric.hxx
@@ -186,7 +186,7 @@ AdvancedMeanSquaresImageToImageMetric<TFixedImage, TMovingImage>::GetValueSingle
   } // end for loop over the image sample container
 
   /** Check if enough samples were valid. */
-  this->CheckNumberOfSamples(sampleContainer->Size());
+  this->CheckNumberOfSamples();
 
   /** Update measure value. */
   double normal_sum = 0.0;
@@ -335,7 +335,7 @@ AdvancedMeanSquaresImageToImageMetric<TFixedImage, TMovingImage>::AfterThreadedG
 
   /** Check if enough samples were valid. */
   ImageSampleContainerPointer sampleContainer = this->GetImageSampler()->GetOutput();
-  this->CheckNumberOfSamples(sampleContainer->Size());
+  this->CheckNumberOfSamples();
 
   /** The normalization factor. */
   DerivativeValueType normal_sum =
@@ -468,7 +468,7 @@ AdvancedMeanSquaresImageToImageMetric<TFixedImage, TMovingImage>::GetValueAndDer
   } // end for loop over the image sample container
 
   /** Check if enough samples were valid. */
-  this->CheckNumberOfSamples(sampleContainer->Size());
+  this->CheckNumberOfSamples();
 
   /** Compute the measure value and derivative. */
   double normal_sum = 0.0;
@@ -647,7 +647,7 @@ AdvancedMeanSquaresImageToImageMetric<TFixedImage, TMovingImage>::AfterThreadedG
 
   /** Check if enough samples were valid. */
   ImageSampleContainerPointer sampleContainer = this->GetImageSampler()->GetOutput();
-  this->CheckNumberOfSamples(sampleContainer->Size());
+  this->CheckNumberOfSamples();
 
   /** The normalization factor. */
   DerivativeValueType normal_sum =

--- a/Components/Metrics/AdvancedMeanSquares/itkAdvancedMeanSquaresImageToImageMetric.hxx
+++ b/Components/Metrics/AdvancedMeanSquares/itkAdvancedMeanSquaresImageToImageMetric.hxx
@@ -186,7 +186,7 @@ AdvancedMeanSquaresImageToImageMetric<TFixedImage, TMovingImage>::GetValueSingle
   } // end for loop over the image sample container
 
   /** Check if enough samples were valid. */
-  this->CheckNumberOfSamples(sampleContainer->Size(), Superclass::m_NumberOfPixelsCounted);
+  this->CheckNumberOfSamples(sampleContainer->Size());
 
   /** Update measure value. */
   double normal_sum = 0.0;
@@ -335,7 +335,7 @@ AdvancedMeanSquaresImageToImageMetric<TFixedImage, TMovingImage>::AfterThreadedG
 
   /** Check if enough samples were valid. */
   ImageSampleContainerPointer sampleContainer = this->GetImageSampler()->GetOutput();
-  this->CheckNumberOfSamples(sampleContainer->Size(), Superclass::m_NumberOfPixelsCounted);
+  this->CheckNumberOfSamples(sampleContainer->Size());
 
   /** The normalization factor. */
   DerivativeValueType normal_sum =
@@ -468,7 +468,7 @@ AdvancedMeanSquaresImageToImageMetric<TFixedImage, TMovingImage>::GetValueAndDer
   } // end for loop over the image sample container
 
   /** Check if enough samples were valid. */
-  this->CheckNumberOfSamples(sampleContainer->Size(), Superclass::m_NumberOfPixelsCounted);
+  this->CheckNumberOfSamples(sampleContainer->Size());
 
   /** Compute the measure value and derivative. */
   double normal_sum = 0.0;
@@ -647,7 +647,7 @@ AdvancedMeanSquaresImageToImageMetric<TFixedImage, TMovingImage>::AfterThreadedG
 
   /** Check if enough samples were valid. */
   ImageSampleContainerPointer sampleContainer = this->GetImageSampler()->GetOutput();
-  this->CheckNumberOfSamples(sampleContainer->Size(), Superclass::m_NumberOfPixelsCounted);
+  this->CheckNumberOfSamples(sampleContainer->Size());
 
   /** The normalization factor. */
   DerivativeValueType normal_sum =

--- a/Components/Metrics/AdvancedNormalizedCorrelation/itkAdvancedNormalizedCorrelationImageToImageMetric.hxx
+++ b/Components/Metrics/AdvancedNormalizedCorrelation/itkAdvancedNormalizedCorrelationImageToImageMetric.hxx
@@ -214,7 +214,7 @@ AdvancedNormalizedCorrelationImageToImageMetric<TFixedImage, TMovingImage>::GetV
   } // end for loop over the image sample container
 
   /** Check if enough samples were valid. */
-  this->CheckNumberOfSamples(sampleContainer->Size(), Superclass::m_NumberOfPixelsCounted);
+  this->CheckNumberOfSamples(sampleContainer->Size());
 
   /** If NumberOfPixelsCounted > 0, then subtract things from sff, smm and sfm. */
   const auto N = static_cast<RealType>(Superclass::m_NumberOfPixelsCounted);
@@ -368,7 +368,7 @@ AdvancedNormalizedCorrelationImageToImageMetric<TFixedImage, TMovingImage>::GetV
   } // end for loop over the image sample container
 
   /** Check if enough samples were valid. */
-  this->CheckNumberOfSamples(sampleContainer->Size(), Superclass::m_NumberOfPixelsCounted);
+  this->CheckNumberOfSamples(sampleContainer->Size());
 
   const auto numberOfParameters = this->GetNumberOfParameters();
 
@@ -590,7 +590,7 @@ AdvancedNormalizedCorrelationImageToImageMetric<TFixedImage, TMovingImage>::Afte
 
   /** Check if enough samples were valid. */
   ImageSampleContainerPointer sampleContainer = this->GetImageSampler()->GetOutput();
-  this->CheckNumberOfSamples(sampleContainer->Size(), Superclass::m_NumberOfPixelsCounted);
+  this->CheckNumberOfSamples(sampleContainer->Size());
 
   /** Accumulate values. */
   AccumulateType sff = this->m_CorrelationGetValueAndDerivativePerThreadVariables[0].st_Sff;

--- a/Components/Metrics/AdvancedNormalizedCorrelation/itkAdvancedNormalizedCorrelationImageToImageMetric.hxx
+++ b/Components/Metrics/AdvancedNormalizedCorrelation/itkAdvancedNormalizedCorrelationImageToImageMetric.hxx
@@ -214,7 +214,7 @@ AdvancedNormalizedCorrelationImageToImageMetric<TFixedImage, TMovingImage>::GetV
   } // end for loop over the image sample container
 
   /** Check if enough samples were valid. */
-  this->CheckNumberOfSamples(sampleContainer->Size());
+  this->CheckNumberOfSamples();
 
   /** If NumberOfPixelsCounted > 0, then subtract things from sff, smm and sfm. */
   const auto N = static_cast<RealType>(Superclass::m_NumberOfPixelsCounted);
@@ -368,7 +368,7 @@ AdvancedNormalizedCorrelationImageToImageMetric<TFixedImage, TMovingImage>::GetV
   } // end for loop over the image sample container
 
   /** Check if enough samples were valid. */
-  this->CheckNumberOfSamples(sampleContainer->Size());
+  this->CheckNumberOfSamples();
 
   const auto numberOfParameters = this->GetNumberOfParameters();
 
@@ -590,7 +590,7 @@ AdvancedNormalizedCorrelationImageToImageMetric<TFixedImage, TMovingImage>::Afte
 
   /** Check if enough samples were valid. */
   ImageSampleContainerPointer sampleContainer = this->GetImageSampler()->GetOutput();
-  this->CheckNumberOfSamples(sampleContainer->Size());
+  this->CheckNumberOfSamples();
 
   /** Accumulate values. */
   AccumulateType sff = this->m_CorrelationGetValueAndDerivativePerThreadVariables[0].st_Sff;

--- a/Components/Metrics/BendingEnergyPenalty/itkTransformBendingEnergyPenaltyTerm.hxx
+++ b/Components/Metrics/BendingEnergyPenalty/itkTransformBendingEnergyPenaltyTerm.hxx
@@ -108,7 +108,7 @@ TransformBendingEnergyPenaltyTerm<TFixedImage, TScalarType>::GetValue(const Para
   } // end for loop over the image sample container
 
   /** Check if enough samples were valid. */
-  this->CheckNumberOfSamples(sampleContainer->Size(), Superclass::m_NumberOfPixelsCounted);
+  this->CheckNumberOfSamples(sampleContainer->Size());
 
   /** Update measure value. */
   measure /= static_cast<RealType>(Superclass::m_NumberOfPixelsCounted);
@@ -309,7 +309,7 @@ TransformBendingEnergyPenaltyTerm<TFixedImage, TScalarType>::GetValueAndDerivati
   } // end for loop over the image sample container
 
   /** Check if enough samples were valid. */
-  this->CheckNumberOfSamples(sampleContainer->Size(), Superclass::m_NumberOfPixelsCounted);
+  this->CheckNumberOfSamples(sampleContainer->Size());
 
   /** Update measure value. */
   measure /= static_cast<RealType>(Superclass::m_NumberOfPixelsCounted);
@@ -551,7 +551,7 @@ TransformBendingEnergyPenaltyTerm<TFixedImage, TScalarType>::AfterThreadedGetVal
 
   /** Check if enough samples were valid. */
   ImageSampleContainerPointer sampleContainer = this->GetImageSampler()->GetOutput();
-  this->CheckNumberOfSamples(sampleContainer->Size(), Superclass::m_NumberOfPixelsCounted);
+  this->CheckNumberOfSamples(sampleContainer->Size());
 
   /** Accumulate and normalize values. */
   value = MeasureType{};

--- a/Components/Metrics/BendingEnergyPenalty/itkTransformBendingEnergyPenaltyTerm.hxx
+++ b/Components/Metrics/BendingEnergyPenalty/itkTransformBendingEnergyPenaltyTerm.hxx
@@ -108,7 +108,7 @@ TransformBendingEnergyPenaltyTerm<TFixedImage, TScalarType>::GetValue(const Para
   } // end for loop over the image sample container
 
   /** Check if enough samples were valid. */
-  this->CheckNumberOfSamples(sampleContainer->Size());
+  this->CheckNumberOfSamples();
 
   /** Update measure value. */
   measure /= static_cast<RealType>(Superclass::m_NumberOfPixelsCounted);
@@ -309,7 +309,7 @@ TransformBendingEnergyPenaltyTerm<TFixedImage, TScalarType>::GetValueAndDerivati
   } // end for loop over the image sample container
 
   /** Check if enough samples were valid. */
-  this->CheckNumberOfSamples(sampleContainer->Size());
+  this->CheckNumberOfSamples();
 
   /** Update measure value. */
   measure /= static_cast<RealType>(Superclass::m_NumberOfPixelsCounted);
@@ -551,7 +551,7 @@ TransformBendingEnergyPenaltyTerm<TFixedImage, TScalarType>::AfterThreadedGetVal
 
   /** Check if enough samples were valid. */
   ImageSampleContainerPointer sampleContainer = this->GetImageSampler()->GetOutput();
-  this->CheckNumberOfSamples(sampleContainer->Size());
+  this->CheckNumberOfSamples();
 
   /** Accumulate and normalize values. */
   value = MeasureType{};

--- a/Components/Metrics/DisplacementMagnitudePenalty/itkDisplacementMagnitudePenaltyTerm.hxx
+++ b/Components/Metrics/DisplacementMagnitudePenalty/itkDisplacementMagnitudePenaltyTerm.hxx
@@ -104,7 +104,7 @@ DisplacementMagnitudePenaltyTerm<TFixedImage, TScalarType>::GetValue(const Param
   } // end for loop over the image sample container
 
   /** Check if enough samples were valid. */
-  this->CheckNumberOfSamples(sampleContainer->Size(), Superclass::m_NumberOfPixelsCounted);
+  this->CheckNumberOfSamples(sampleContainer->Size());
 
   /** Update measure value. Avoid division by zero. */
   measure /= std::max(NumericTraits<RealType>::One, static_cast<RealType>(Superclass::m_NumberOfPixelsCounted));
@@ -213,7 +213,7 @@ DisplacementMagnitudePenaltyTerm<TFixedImage, TScalarType>::GetValueAndDerivativ
   } // end for loop over the image sample container
 
   /** Check if enough samples were valid. */
-  this->CheckNumberOfSamples(sampleContainer->Size(), Superclass::m_NumberOfPixelsCounted);
+  this->CheckNumberOfSamples(sampleContainer->Size());
 
   /** Update measure value and derivative. The factor 2 in the derivative
    * originates from the square in ||T(x)-x||^2 */

--- a/Components/Metrics/DisplacementMagnitudePenalty/itkDisplacementMagnitudePenaltyTerm.hxx
+++ b/Components/Metrics/DisplacementMagnitudePenalty/itkDisplacementMagnitudePenaltyTerm.hxx
@@ -104,7 +104,7 @@ DisplacementMagnitudePenaltyTerm<TFixedImage, TScalarType>::GetValue(const Param
   } // end for loop over the image sample container
 
   /** Check if enough samples were valid. */
-  this->CheckNumberOfSamples(sampleContainer->Size());
+  this->CheckNumberOfSamples();
 
   /** Update measure value. Avoid division by zero. */
   measure /= std::max(NumericTraits<RealType>::One, static_cast<RealType>(Superclass::m_NumberOfPixelsCounted));
@@ -213,7 +213,7 @@ DisplacementMagnitudePenaltyTerm<TFixedImage, TScalarType>::GetValueAndDerivativ
   } // end for loop over the image sample container
 
   /** Check if enough samples were valid. */
-  this->CheckNumberOfSamples(sampleContainer->Size());
+  this->CheckNumberOfSamples();
 
   /** Update measure value and derivative. The factor 2 in the derivative
    * originates from the square in ||T(x)-x||^2 */

--- a/Components/Metrics/KNNGraphAlphaMutualInformation/itkKNNGraphAlphaMutualInformationImageToImageMetric.hxx
+++ b/Components/Metrics/KNNGraphAlphaMutualInformation/itkKNNGraphAlphaMutualInformationImageToImageMetric.hxx
@@ -307,7 +307,7 @@ KNNGraphAlphaMutualInformationImageToImageMetric<TFixedImage, TMovingImage>::Get
 
   /** Check if enough samples were valid. */
   unsigned long size = this->GetImageSampler()->GetOutput()->Size();
-  this->CheckNumberOfSamples(size, Superclass::m_NumberOfPixelsCounted);
+  this->CheckNumberOfSamples(size);
 
   /**
    * *************** Generate the three trees ******************
@@ -531,7 +531,7 @@ KNNGraphAlphaMutualInformationImageToImageMetric<TFixedImage, TMovingImage>::Get
 
   /** Check if enough samples were valid. */
   unsigned long size = this->GetImageSampler()->GetOutput()->Size();
-  this->CheckNumberOfSamples(size, Superclass::m_NumberOfPixelsCounted);
+  this->CheckNumberOfSamples(size);
 
   /**
    * *************** Generate the three trees ******************

--- a/Components/Metrics/KNNGraphAlphaMutualInformation/itkKNNGraphAlphaMutualInformationImageToImageMetric.hxx
+++ b/Components/Metrics/KNNGraphAlphaMutualInformation/itkKNNGraphAlphaMutualInformationImageToImageMetric.hxx
@@ -306,8 +306,7 @@ KNNGraphAlphaMutualInformationImageToImageMetric<TFixedImage, TMovingImage>::Get
                                                          dummySpatialDerivativesContainer);
 
   /** Check if enough samples were valid. */
-  unsigned long size = this->GetImageSampler()->GetOutput()->Size();
-  this->CheckNumberOfSamples(size);
+  this->CheckNumberOfSamples();
 
   /**
    * *************** Generate the three trees ******************
@@ -530,8 +529,7 @@ KNNGraphAlphaMutualInformationImageToImageMetric<TFixedImage, TMovingImage>::Get
                                                          spatialDerivativesContainer);
 
   /** Check if enough samples were valid. */
-  unsigned long size = this->GetImageSampler()->GetOutput()->Size();
-  this->CheckNumberOfSamples(size);
+  this->CheckNumberOfSamples();
 
   /**
    * *************** Generate the three trees ******************

--- a/Components/Metrics/PCAMetric/itkPCAMetric.hxx
+++ b/Components/Metrics/PCAMetric/itkPCAMetric.hxx
@@ -219,7 +219,7 @@ PCAMetric<TFixedImage, TMovingImage>::GetValue(const ParametersType & parameters
   } /** end first loop over image sample container */
 
   /** Check if enough samples were valid. */
-  this->CheckNumberOfSamples(numberOfSamples, Superclass::m_NumberOfPixelsCounted);
+  this->CheckNumberOfSamples(numberOfSamples);
   MatrixType A(datablock.extract(Superclass::m_NumberOfPixelsCounted, m_G));
 
   MatrixType Amm(Superclass::m_NumberOfPixelsCounted, m_G, vnl_matrix_null);
@@ -390,7 +390,7 @@ PCAMetric<TFixedImage, TMovingImage>::GetValueAndDerivativeSingleThreaded(const 
   } /** end first loop over image sample container */
 
   /** Check if enough samples were valid. */
-  this->CheckNumberOfSamples(sampleContainer->Size(), Superclass::m_NumberOfPixelsCounted);
+  this->CheckNumberOfSamples(sampleContainer->Size());
 
   MatrixType A(datablock.extract(Superclass::m_NumberOfPixelsCounted, m_G));
 
@@ -741,7 +741,7 @@ PCAMetric<TFixedImage, TMovingImage>::AfterThreadedGetSamples(MeasureType & valu
 
   /** Check if enough samples were valid. */
   ImageSampleContainerPointer sampleContainer = this->GetImageSampler()->GetOutput();
-  this->CheckNumberOfSamples(sampleContainer->Size(), Superclass::m_NumberOfPixelsCounted);
+  this->CheckNumberOfSamples(sampleContainer->Size());
 
   MatrixType   A(Superclass::m_NumberOfPixelsCounted, m_G);
   unsigned int row_start = 0;

--- a/Components/Metrics/PCAMetric/itkPCAMetric.hxx
+++ b/Components/Metrics/PCAMetric/itkPCAMetric.hxx
@@ -219,7 +219,7 @@ PCAMetric<TFixedImage, TMovingImage>::GetValue(const ParametersType & parameters
   } /** end first loop over image sample container */
 
   /** Check if enough samples were valid. */
-  this->CheckNumberOfSamples(numberOfSamples);
+  this->CheckNumberOfSamples();
   MatrixType A(datablock.extract(Superclass::m_NumberOfPixelsCounted, m_G));
 
   MatrixType Amm(Superclass::m_NumberOfPixelsCounted, m_G, vnl_matrix_null);
@@ -390,7 +390,7 @@ PCAMetric<TFixedImage, TMovingImage>::GetValueAndDerivativeSingleThreaded(const 
   } /** end first loop over image sample container */
 
   /** Check if enough samples were valid. */
-  this->CheckNumberOfSamples(sampleContainer->Size());
+  this->CheckNumberOfSamples();
 
   MatrixType A(datablock.extract(Superclass::m_NumberOfPixelsCounted, m_G));
 
@@ -741,7 +741,7 @@ PCAMetric<TFixedImage, TMovingImage>::AfterThreadedGetSamples(MeasureType & valu
 
   /** Check if enough samples were valid. */
   ImageSampleContainerPointer sampleContainer = this->GetImageSampler()->GetOutput();
-  this->CheckNumberOfSamples(sampleContainer->Size());
+  this->CheckNumberOfSamples();
 
   MatrixType   A(Superclass::m_NumberOfPixelsCounted, m_G);
   unsigned int row_start = 0;

--- a/Components/Metrics/PCAMetric2/itkPCAMetric2.hxx
+++ b/Components/Metrics/PCAMetric2/itkPCAMetric2.hxx
@@ -220,7 +220,7 @@ PCAMetric2<TFixedImage, TMovingImage>::GetValue(const ParametersType & parameter
   } /** end first loop over image sample container */
 
   /** Check if enough samples were valid. */
-  this->CheckNumberOfSamples(numberOfSamples, Superclass::m_NumberOfPixelsCounted);
+  this->CheckNumberOfSamples(numberOfSamples);
   const unsigned int N = Superclass::m_NumberOfPixelsCounted;
   MatrixType         A(datablock.extract(N, lastDimSize));
 
@@ -402,7 +402,7 @@ PCAMetric2<TFixedImage, TMovingImage>::GetValueAndDerivative(const ParametersTyp
   }
 
   /** Check if enough samples were valid. */
-  this->CheckNumberOfSamples(sampleContainer->Size(), Superclass::m_NumberOfPixelsCounted);
+  this->CheckNumberOfSamples(sampleContainer->Size());
   unsigned int N = Superclass::m_NumberOfPixelsCounted;
 
   MatrixType A(datablock.extract(N, lastDimSize));

--- a/Components/Metrics/PCAMetric2/itkPCAMetric2.hxx
+++ b/Components/Metrics/PCAMetric2/itkPCAMetric2.hxx
@@ -220,7 +220,7 @@ PCAMetric2<TFixedImage, TMovingImage>::GetValue(const ParametersType & parameter
   } /** end first loop over image sample container */
 
   /** Check if enough samples were valid. */
-  this->CheckNumberOfSamples(numberOfSamples);
+  this->CheckNumberOfSamples();
   const unsigned int N = Superclass::m_NumberOfPixelsCounted;
   MatrixType         A(datablock.extract(N, lastDimSize));
 
@@ -402,7 +402,7 @@ PCAMetric2<TFixedImage, TMovingImage>::GetValueAndDerivative(const ParametersTyp
   }
 
   /** Check if enough samples were valid. */
-  this->CheckNumberOfSamples(sampleContainer->Size());
+  this->CheckNumberOfSamples();
   unsigned int N = Superclass::m_NumberOfPixelsCounted;
 
   MatrixType A(datablock.extract(N, lastDimSize));

--- a/Components/Metrics/SumOfPairwiseCorrelationsMetric/itkSumOfPairwiseCorrelationCoefficientsMetric.hxx
+++ b/Components/Metrics/SumOfPairwiseCorrelationsMetric/itkSumOfPairwiseCorrelationCoefficientsMetric.hxx
@@ -203,7 +203,7 @@ SumOfPairwiseCorrelationCoefficientsMetric<TFixedImage, TMovingImage>::GetValue(
   } /** end first loop over image sample container */
 
   /** Check if enough samples were valid. */
-  this->CheckNumberOfSamples(NumberOfSamples, Superclass::m_NumberOfPixelsCounted);
+  this->CheckNumberOfSamples(NumberOfSamples);
   unsigned int N = Superclass::m_NumberOfPixelsCounted;
 
   MatrixType A(datablock.extract(N, G));
@@ -368,7 +368,7 @@ SumOfPairwiseCorrelationCoefficientsMetric<TFixedImage, TMovingImage>::GetValueA
   } /** end first loop over image sample container */
 
   /** Check if enough samples were valid. */
-  this->CheckNumberOfSamples(sampleContainer->Size(), Superclass::m_NumberOfPixelsCounted);
+  this->CheckNumberOfSamples(sampleContainer->Size());
   unsigned int N = Superclass::m_NumberOfPixelsCounted;
 
   MatrixType A(datablock.extract(N, G));

--- a/Components/Metrics/SumOfPairwiseCorrelationsMetric/itkSumOfPairwiseCorrelationCoefficientsMetric.hxx
+++ b/Components/Metrics/SumOfPairwiseCorrelationsMetric/itkSumOfPairwiseCorrelationCoefficientsMetric.hxx
@@ -203,7 +203,7 @@ SumOfPairwiseCorrelationCoefficientsMetric<TFixedImage, TMovingImage>::GetValue(
   } /** end first loop over image sample container */
 
   /** Check if enough samples were valid. */
-  this->CheckNumberOfSamples(NumberOfSamples);
+  this->CheckNumberOfSamples();
   unsigned int N = Superclass::m_NumberOfPixelsCounted;
 
   MatrixType A(datablock.extract(N, G));
@@ -368,7 +368,7 @@ SumOfPairwiseCorrelationCoefficientsMetric<TFixedImage, TMovingImage>::GetValueA
   } /** end first loop over image sample container */
 
   /** Check if enough samples were valid. */
-  this->CheckNumberOfSamples(sampleContainer->Size());
+  this->CheckNumberOfSamples();
   unsigned int N = Superclass::m_NumberOfPixelsCounted;
 
   MatrixType A(datablock.extract(N, G));

--- a/Components/Metrics/SumSquaredTissueVolumeDifferenceMetric/itkSumSquaredTissueVolumeDifferenceImageToImageMetric.hxx
+++ b/Components/Metrics/SumSquaredTissueVolumeDifferenceMetric/itkSumSquaredTissueVolumeDifferenceImageToImageMetric.hxx
@@ -124,7 +124,7 @@ SumSquaredTissueVolumeDifferenceImageToImageMetric<TFixedImage, TMovingImage>::G
   } // end for loop over the image sample container
 
   /** Check if enough samples were valid. */
-  this->CheckNumberOfSamples(sampleContainer->Size());
+  this->CheckNumberOfSamples();
 
   /** Update measure value. */
   double sum = 0.0;
@@ -286,7 +286,7 @@ SumSquaredTissueVolumeDifferenceImageToImageMetric<TFixedImage, TMovingImage>::A
 
   /** Check if enough samples were valid. */
   ImageSampleContainerPointer sampleContainer = this->GetImageSampler()->GetOutput();
-  this->CheckNumberOfSamples(sampleContainer->Size());
+  this->CheckNumberOfSamples();
 
   /** Accumulate values. */
   value = MeasureType{};
@@ -430,7 +430,7 @@ SumSquaredTissueVolumeDifferenceImageToImageMetric<TFixedImage, TMovingImage>::G
   } // end for loop over the image sample container
 
   /** Check if enough samples were valid. */
-  this->CheckNumberOfSamples(sampleContainer->Size());
+  this->CheckNumberOfSamples();
 
   /** Compute the measure value and derivative. */
   double sum = 0.0;
@@ -618,7 +618,7 @@ SumSquaredTissueVolumeDifferenceImageToImageMetric<TFixedImage, TMovingImage>::A
 
   /** Check if enough samples were valid. */
   ImageSampleContainerPointer sampleContainer = this->GetImageSampler()->GetOutput();
-  this->CheckNumberOfSamples(sampleContainer->Size());
+  this->CheckNumberOfSamples();
 
   /** Accumulate values. */
   value = MeasureType{};

--- a/Components/Metrics/SumSquaredTissueVolumeDifferenceMetric/itkSumSquaredTissueVolumeDifferenceImageToImageMetric.hxx
+++ b/Components/Metrics/SumSquaredTissueVolumeDifferenceMetric/itkSumSquaredTissueVolumeDifferenceImageToImageMetric.hxx
@@ -124,7 +124,7 @@ SumSquaredTissueVolumeDifferenceImageToImageMetric<TFixedImage, TMovingImage>::G
   } // end for loop over the image sample container
 
   /** Check if enough samples were valid. */
-  this->CheckNumberOfSamples(sampleContainer->Size(), Superclass::m_NumberOfPixelsCounted);
+  this->CheckNumberOfSamples(sampleContainer->Size());
 
   /** Update measure value. */
   double sum = 0.0;
@@ -286,7 +286,7 @@ SumSquaredTissueVolumeDifferenceImageToImageMetric<TFixedImage, TMovingImage>::A
 
   /** Check if enough samples were valid. */
   ImageSampleContainerPointer sampleContainer = this->GetImageSampler()->GetOutput();
-  this->CheckNumberOfSamples(sampleContainer->Size(), Superclass::m_NumberOfPixelsCounted);
+  this->CheckNumberOfSamples(sampleContainer->Size());
 
   /** Accumulate values. */
   value = MeasureType{};
@@ -430,7 +430,7 @@ SumSquaredTissueVolumeDifferenceImageToImageMetric<TFixedImage, TMovingImage>::G
   } // end for loop over the image sample container
 
   /** Check if enough samples were valid. */
-  this->CheckNumberOfSamples(sampleContainer->Size(), Superclass::m_NumberOfPixelsCounted);
+  this->CheckNumberOfSamples(sampleContainer->Size());
 
   /** Compute the measure value and derivative. */
   double sum = 0.0;
@@ -618,7 +618,7 @@ SumSquaredTissueVolumeDifferenceImageToImageMetric<TFixedImage, TMovingImage>::A
 
   /** Check if enough samples were valid. */
   ImageSampleContainerPointer sampleContainer = this->GetImageSampler()->GetOutput();
-  this->CheckNumberOfSamples(sampleContainer->Size(), Superclass::m_NumberOfPixelsCounted);
+  this->CheckNumberOfSamples(sampleContainer->Size());
 
   /** Accumulate values. */
   value = MeasureType{};

--- a/Components/Metrics/VarianceOverLastDimension/itkVarianceOverLastDimensionImageMetric.hxx
+++ b/Components/Metrics/VarianceOverLastDimension/itkVarianceOverLastDimensionImageMetric.hxx
@@ -289,7 +289,7 @@ VarianceOverLastDimensionImageMetric<TFixedImage, TMovingImage>::GetValue(const 
   } // end for loop over the image sample container
 
   /** Check if enough samples were valid. */
-  this->CheckNumberOfSamples(sampleContainer->Size(), Superclass::m_NumberOfPixelsCounted);
+  this->CheckNumberOfSamples(sampleContainer->Size());
 
   /** Compute average over variances. */
   measure /= static_cast<float>(Superclass::m_NumberOfPixelsCounted);
@@ -487,7 +487,7 @@ VarianceOverLastDimensionImageMetric<TFixedImage, TMovingImage>::GetValueAndDeri
   } // end for loop over the image sample container
 
   /** Check if enough samples were valid. */
-  this->CheckNumberOfSamples(sampleContainer->Size(), Superclass::m_NumberOfPixelsCounted);
+  this->CheckNumberOfSamples(sampleContainer->Size());
 
   /** Compute average over variances and normalize with initial variance. */
   measure /= static_cast<float>(Superclass::m_NumberOfPixelsCounted * m_InitialVariance);

--- a/Components/Metrics/VarianceOverLastDimension/itkVarianceOverLastDimensionImageMetric.hxx
+++ b/Components/Metrics/VarianceOverLastDimension/itkVarianceOverLastDimensionImageMetric.hxx
@@ -289,7 +289,7 @@ VarianceOverLastDimensionImageMetric<TFixedImage, TMovingImage>::GetValue(const 
   } // end for loop over the image sample container
 
   /** Check if enough samples were valid. */
-  this->CheckNumberOfSamples(sampleContainer->Size());
+  this->CheckNumberOfSamples();
 
   /** Compute average over variances. */
   measure /= static_cast<float>(Superclass::m_NumberOfPixelsCounted);
@@ -487,7 +487,7 @@ VarianceOverLastDimensionImageMetric<TFixedImage, TMovingImage>::GetValueAndDeri
   } // end for loop over the image sample container
 
   /** Check if enough samples were valid. */
-  this->CheckNumberOfSamples(sampleContainer->Size());
+  this->CheckNumberOfSamples();
 
   /** Compute average over variances and normalize with initial variance. */
   measure /= static_cast<float>(Superclass::m_NumberOfPixelsCounted * m_InitialVariance);


### PR DESCRIPTION
The `found` parameter always had the value `Superclass::m_NumberOfPixelsCounted`, so it might as well be removed.

---

@mstaring Looking at the initial commit, it appears that `CheckNumberOfSamples` always had a `found` parameter that should be equal to `m_NumberOfPixelsCounted`. Or the other way around, `m_NumberOfPixelsCounted` should be equal to `found`:  https://github.com/SuperElastix/elastix/blob/f6d2f4b5f63b54b88f407ff84e4dc3ca48b73ecf/src/Common/CostFunctions/itkAdvancedImageToImageMetric.hxx#L730-L740

In practice they _are_ always equal, because `m_NumberOfPixelsCounted` is always passed as the argument for this parameter. For example, https://github.com/SuperElastix/elastix/blob/0dd663acc9e34e9c627d3bf61d246634854f36cc/src/Components/Metrics/AdvancedNormalizedCorrelation/itkAdvancedNormalizedCorrelationImageToImageMetric.txx#L209-L210

So that's why I think the parameter is unnecessary!
