### PR TITLE
Remove unnecessary private `m_NumberOfPixelsCounted` data members

### DIFF
--- a/Common/Transforms/itkAdvancedImageMomentsCalculator.h
+++ b/Common/Transforms/itkAdvancedImageMomentsCalculator.h
@@ -313,7 +313,6 @@ private:
 
   mutable std::vector<AlignedComputePerThreadStruct> m_ComputePerThreadVariables{};
   bool                                               m_UseMultiThread{};
-  SizeValueType                                      m_NumberOfPixelsCounted{};
 
   SizeValueType               m_NumberOfSamplesForCenteredTransformInitialization{};
   InputPixelType              m_LowerThresholdForCenterGravity{};

--- a/Common/itkComputeDisplacementDistribution.h
+++ b/Common/itkComputeDisplacementDistribution.h
@@ -203,7 +203,6 @@ private:
 
   mutable std::vector<AlignedComputePerThreadStruct> m_ComputePerThreadVariables{};
 
-  SizeValueType                m_NumberOfPixelsCounted{};
   bool                         m_UseMultiThread{ true };
   std::vector<ImageSampleType> m_Samples{};
 };

--- a/Common/itkComputeDisplacementDistribution.hxx
+++ b/Common/itkComputeDisplacementDistribution.hxx
@@ -410,9 +410,9 @@ ComputeDisplacementDistribution<TFixedImage, TTransform>::AfterThreadedCompute(d
 {
   /** Reset all variables. */
   maxJJ = 0.0;
-  double displacement = 0.0;
-  double displacementSquared = 0.0;
-  m_NumberOfPixelsCounted = 0.0;
+  double        displacement = 0.0;
+  double        displacementSquared = 0.0;
+  SizeValueType numberOfPixelsCounted = 0;
 
   /** Accumulate thread results. */
   for (const auto & computePerThreadStruct : m_ComputePerThreadVariables)
@@ -420,14 +420,14 @@ ComputeDisplacementDistribution<TFixedImage, TTransform>::AfterThreadedCompute(d
     maxJJ = std::max(maxJJ, computePerThreadStruct.st_MaxJJ);
     displacement += computePerThreadStruct.st_Displacement;
     displacementSquared += computePerThreadStruct.st_DisplacementSquared;
-    m_NumberOfPixelsCounted += computePerThreadStruct.st_NumberOfPixelsCounted;
+    numberOfPixelsCounted += computePerThreadStruct.st_NumberOfPixelsCounted;
   }
   // Reset all variables for the next resolution.
   std::fill_n(m_ComputePerThreadVariables.begin(), m_ComputePerThreadVariables.size(), AlignedComputePerThreadStruct());
 
   /** Compute the sigma of the distribution of the displacements. */
-  const double meanDisplacement = displacement / m_NumberOfPixelsCounted;
-  const double sigma = displacementSquared / m_NumberOfPixelsCounted - vnl_math::sqr(meanDisplacement);
+  const double meanDisplacement = displacement / numberOfPixelsCounted;
+  const double sigma = displacementSquared / numberOfPixelsCounted - vnl_math::sqr(meanDisplacement);
 
   jacg = meanDisplacement + 2.0 * std::sqrt(sigma);
 


### PR DESCRIPTION
`ComputeDisplacementDistribution::m_NumberOfPixelsCounted` was only used in its `AfterThreadedCompute` member function, so it could be replaced by a local variable.

`AdvancedImageMomentsCalculator::m_NumberOfPixelsCounted` was always just zero, and it was never used.