### PR TITLE
Avoid lossy string-to-float conversion by `ParameterObject::PrintSelf`

### DIFF
--- a/Core/Main/elxParameterObject.cxx
+++ b/Core/Main/elxParameterObject.cxx
@@ -536,15 +536,15 @@ ParameterObject::PrintSelf(std::ostream & os, itk::Indent indent) const
         stream >> number;
         if (stream.fail())
         {
-          os << " \"" << value << "\"";
+          os << " \"" << value << '"';
         }
         else
         {
-          os << " " << number;
+          os << ' ' << number;
         }
       }
 
-      os << ")" << std::endl;
+      os << ')' << std::endl;
       ++parameterMapIterator;
     }
   }

--- a/Core/Main/elxParameterObject.cxx
+++ b/Core/Main/elxParameterObject.cxx
@@ -531,16 +531,13 @@ ParameterObject::PrintSelf(std::ostream & os, itk::Indent indent) const
 
       for (const std::string & value : parameterMapValueVector)
       {
-        std::istringstream stream(value);
-        float              number;
-        stream >> number;
-        if (stream.fail())
+        if (Conversion::IsNumber(value))
         {
-          os << " \"" << value << '"';
+          os << ' ' << value;
         }
         else
         {
-          os << ' ' << number;
+          os << " \"" << value << '"';
         }
       }
 


### PR DESCRIPTION
`ParameterObject::PrintSelf` introduced rounding errors when printing numeric parameter values. `1.23456789` was printed as `1.23457`, `9223372036854775807` was printed as `9.22337e+18`, etc. Numbers that were larger than 32-bit FLOAT_MAX were double-quoted (e.g., `"4e+38"`), indicating that they were not recognized as a number.

This was caused by trying to convert each parameter value to a 32-bit float, and then converting the float back to string (by insertion into an output stream).

This pull request avoids such a "round-trip". Instead, it simply prints the original string representations of the parameter values.

----

For the record, these rounding errors and unnecessary double-quotes appear when using ITKElastix (including [version 0.22.0](https://github.com/InsightSoftwareConsortium/ITKElastix/releases/tag/v0.22.0), 10 Mar 2025), as follows:

```py
parameter_object = itk.ParameterObject.New(
    parameter_map={"ParameterName": ("1.23456789", "9223372036854775807", "4e+38")}
)
print(parameter_object)
```

Output:
```
ParameterObject (0000023B7A0F3980)
  RTTI typeinfo:   class elastix::ParameterObject
  Reference Count: 1
  Modified Time: 2611
  Debug: Off
  Object Name: 
  Observers: 
    none
ParameterMap 0: 
  (ParameterName 1.23457 9.22337e+18 "4e+38")
```

