### PR TITLE
COMP: Upgrade Azure Pipelines CI from ubuntu-20.04 to ubuntu-22.04

### DIFF
--- a/Testing/CI/Azure/ci.yml
+++ b/Testing/CI/Azure/ci.yml
@@ -82,7 +82,7 @@ jobs:
 - job: Ubuntu
   timeoutInMinutes: 0
   pool:
-    vmImage: 'ubuntu-20.04'
+    vmImage: 'ubuntu-22.04'
   strategy:
     matrix:
       ITKv5:


### PR DESCRIPTION
Addressed the error message at https://dev.azure.com/kaspermarstal/Elastix/_build/results?buildId=5639&view=results saying:

> ##[error]This is a scheduled Ubuntu 20.04 brownout. Ubuntu 20.04 LTS runner will be removed on 2025-04-15. For more details, see https://github.com/actions/runner-images/issues/11101