### PR TITLE
ENH: Replace `unsigned long` with uint64_t for non-zero Jacobian indices

### DIFF
--- a/Common/Transforms/itkAdvancedTransform.h
+++ b/Common/Transforms/itkAdvancedTransform.h
@@ -130,7 +130,7 @@ public:
    * Using an itk::FixedArray instead of an std::vector gives a performance
    * gain for the SpatialHessianType.
    */
-  using NonZeroJacobianIndicesType = std::vector<unsigned long>;
+  using NonZeroJacobianIndicesType = std::vector<uint64_t>;
   using SpatialJacobianType = Matrix<ScalarType, OutputSpaceDimension, InputSpaceDimension>;
   using JacobianOfSpatialJacobianType = std::vector<SpatialJacobianType>;
   // \todo: think about the SpatialHessian type, should be a 3D native type

--- a/Common/Transforms/itkRecursiveBSplineTransform.hxx
+++ b/Common/Transforms/itkRecursiveBSplineTransform.hxx
@@ -566,8 +566,8 @@ RecursiveBSplineTransform<TScalar, NDimensions, VSplineOrder>::ComputeNonZeroJac
   }
 
   /** Call the recursive implementation. */
-  unsigned long   currentIndex = totalOffsetToSupportIndex;
-  unsigned long * nzjiPointer = &nonZeroJacobianIndices[0];
+  unsigned long currentIndex = totalOffsetToSupportIndex;
+  uint64_t *    nzjiPointer = &nonZeroJacobianIndices[0];
   ImplementationType::ComputeNonZeroJacobianIndices(nzjiPointer, parametersPerDim, currentIndex, gridOffsetTable);
 
 } // end ComputeNonZeroJacobianIndices()

--- a/Common/Transforms/itkRecursiveBSplineTransformImplementation.h
+++ b/Common/Transforms/itkRecursiveBSplineTransformImplementation.h
@@ -122,7 +122,7 @@ public:
 
   /** ComputeNonZeroJacobianIndices recursive implementation. */
   static void
-  ComputeNonZeroJacobianIndices(unsigned long *&              nzji,
+  ComputeNonZeroJacobianIndices(uint64_t *&                   nzji,
                                 const unsigned long           parametersPerDim,
                                 unsigned long                 currentIndex,
                                 const OffsetValueType * const gridOffsetTable)
@@ -409,7 +409,7 @@ public:
 
   /** ComputeNonZeroJacobianIndices recursive implementation. */
   static void
-  ComputeNonZeroJacobianIndices(unsigned long *&              nzji,
+  ComputeNonZeroJacobianIndices(uint64_t *&                   nzji,
                                 const unsigned long           parametersPerDim,
                                 const unsigned long           currentIndex,
                                 const OffsetValueType * const itkNotUsed(gridOffsetTable))


### PR DESCRIPTION
Aims to ease interaction with LibTorch (specifically when passing such indices as `data` parameter to `torch::from_blob`). `unsigned long` appears problematic, as it is typically 32-bit on Windows, while it's typically 64-bit on Linux.

Issue encountered during the development of the IMPACT Similarity Metric, pull request https://github.com/SuperElastix/elastix/pull/1311 by Valentin Boussot (@vboussot) et al.