### PR TITLE
Replace `(long)` with `static_cast<int64_t>` in CalcRayIntercepts(), and also replace other uses of `long`

### DIFF
--- a/Common/CostFunctions/itkAdvancedImageToImageMetric.hxx
+++ b/Common/CostFunctions/itkAdvancedImageToImageMetric.hxx
@@ -443,7 +443,7 @@ AdvancedImageToImageMetric<TFixedImage, TMovingImage>::EvaluateMovingImageValueA
         MovingImageIndexType index;
         for (unsigned int j = 0; j < MovingImageDimension; ++j)
         {
-          index[j] = static_cast<long>(Math::Round<int64_t>(cindex[j]));
+          index[j] = Math::Round<int64_t>(cindex[j]);
         }
         (*gradient) = Superclass::m_GradientImage->GetPixel(index);
       }

--- a/Common/itkAdvancedRayCastInterpolateImageFunction.hxx
+++ b/Common/itkAdvancedRayCastInterpolateImageFunction.hxx
@@ -531,7 +531,7 @@ AdvancedRayCastInterpolateImageFunction<TInputImage, TCoordinate>::RayCastHelper
     denom = (m_BoundingPlane[j][0] * m_RayDirectionInMM[0] + m_BoundingPlane[j][1] * m_RayDirectionInMM[1] +
              m_BoundingPlane[j][2] * m_RayDirectionInMM[2]);
 
-    if ((long)(denom * 100) != 0)
+    if (static_cast<int64_t>(denom * 100) != 0)
     {
       d[j] =
         -(m_BoundingPlane[j][3] + m_BoundingPlane[j][0] * m_CurrentRayPositionInMM[0] +

--- a/Components/Metrics/AdvancedKappaStatistic/elxAdvancedKappaStatisticMetric.hxx
+++ b/Components/Metrics/AdvancedKappaStatistic/elxAdvancedKappaStatisticMetric.hxx
@@ -39,7 +39,7 @@ AdvancedKappaStatisticMetric<TElastix>::Initialize()
   this->Superclass1::Initialize();
   timer.Stop();
   log::info(std::ostringstream{} << "Initialization of AdvancedKappaStatistic metric took: "
-                                 << static_cast<long>(timer.GetMean() * 1000) << " ms.");
+                                 << static_cast<std::int64_t>(timer.GetMean() * 1000) << " ms.");
 
 } // end Initialize()
 

--- a/Components/Metrics/AdvancedMattesMutualInformation/elxAdvancedMattesMutualInformationMetric.hxx
+++ b/Components/Metrics/AdvancedMattesMutualInformation/elxAdvancedMattesMutualInformationMetric.hxx
@@ -58,7 +58,7 @@ AdvancedMattesMutualInformationMetric<TElastix>::Initialize()
   this->Superclass1::Initialize();
   timer.Stop();
   log::info(std::ostringstream{} << "Initialization of AdvancedMattesMutualInformation metric took: "
-                                 << static_cast<long>(timer.GetMean() * 1000) << " ms.");
+                                 << static_cast<std::int64_t>(timer.GetMean() * 1000) << " ms.");
 
 } // end Initialize()
 

--- a/Components/Metrics/AdvancedMeanSquares/elxAdvancedMeanSquaresMetric.hxx
+++ b/Components/Metrics/AdvancedMeanSquares/elxAdvancedMeanSquaresMetric.hxx
@@ -38,7 +38,7 @@ AdvancedMeanSquaresMetric<TElastix>::Initialize()
   this->Superclass1::Initialize();
   timer.Stop();
   log::info(std::ostringstream{} << "Initialization of AdvancedMeanSquares metric took: "
-                                 << static_cast<long>(timer.GetMean() * 1000) << " ms.");
+                                 << static_cast<std::int64_t>(timer.GetMean() * 1000) << " ms.");
 
 } // end Initialize()
 

--- a/Components/Metrics/AdvancedNormalizedCorrelation/elxAdvancedNormalizedCorrelationMetric.hxx
+++ b/Components/Metrics/AdvancedNormalizedCorrelation/elxAdvancedNormalizedCorrelationMetric.hxx
@@ -71,7 +71,7 @@ AdvancedNormalizedCorrelationMetric<TElastix>::Initialize()
   this->Superclass1::Initialize();
   timer.Stop();
   log::info(std::ostringstream{} << "Initialization of AdvancedNormalizedCorrelation metric took: "
-                                 << static_cast<long>(timer.GetMean() * 1000) << " ms.");
+                                 << static_cast<std::int64_t>(timer.GetMean() * 1000) << " ms.");
 
 } // end Initialize()
 

--- a/Components/Metrics/BendingEnergyPenalty/elxTransformBendingEnergyPenaltyTerm.hxx
+++ b/Components/Metrics/BendingEnergyPenalty/elxTransformBendingEnergyPenaltyTerm.hxx
@@ -37,7 +37,7 @@ TransformBendingEnergyPenalty<TElastix>::Initialize()
   this->Superclass1::Initialize();
   timer.Stop();
   log::info(std::ostringstream{} << "Initialization of TransformBendingEnergy metric took: "
-                                 << static_cast<long>(timer.GetMean() * 1000) << " ms.");
+                                 << static_cast<std::int64_t>(timer.GetMean() * 1000) << " ms.");
 
 } // end Initialize()
 

--- a/Components/Metrics/CorrespondingPointsEuclideanDistanceMetric/elxCorrespondingPointsEuclideanDistanceMetric.hxx
+++ b/Components/Metrics/CorrespondingPointsEuclideanDistanceMetric/elxCorrespondingPointsEuclideanDistanceMetric.hxx
@@ -40,7 +40,7 @@ CorrespondingPointsEuclideanDistanceMetric<TElastix>::Initialize()
   this->Superclass1::Initialize();
   timer.Stop();
   log::info(std::ostringstream{} << "Initialization of CorrespondingPointsEuclideanDistance metric took: "
-                                 << static_cast<long>(timer.GetMean() * 1000) << " ms.");
+                                 << static_cast<std::int64_t>(timer.GetMean() * 1000) << " ms.");
 
 } // end Initialize()
 

--- a/Components/Metrics/DisplacementMagnitudePenalty/elxDisplacementMagnitudePenalty.hxx
+++ b/Components/Metrics/DisplacementMagnitudePenalty/elxDisplacementMagnitudePenalty.hxx
@@ -37,7 +37,7 @@ DisplacementMagnitudePenalty<TElastix>::Initialize()
   this->Superclass1::Initialize();
   timer.Stop();
   log::info(std::ostringstream{} << "Initialization of DisplacementMagnitude metric took: "
-                                 << static_cast<long>(timer.GetMean() * 1000) << " ms.");
+                                 << static_cast<std::int64_t>(timer.GetMean() * 1000) << " ms.");
 
 } // end Initialize()
 

--- a/Components/Metrics/DistancePreservingRigidityPenalty/elxDistancePreservingRigidityPenaltyTerm.hxx
+++ b/Components/Metrics/DistancePreservingRigidityPenalty/elxDistancePreservingRigidityPenaltyTerm.hxx
@@ -129,7 +129,7 @@ DistancePreservingRigidityPenalty<TElastix>::Initialize()
   /** Stop and print the timer. */
   timer.Stop();
   log::info(std::ostringstream{} << "Initialization of DistancePreservingRigidityPenalty term took: "
-                                 << static_cast<long>(timer.GetMean() * 1000) << " ms.");
+                                 << static_cast<std::int64_t>(timer.GetMean() * 1000) << " ms.");
 
 } // end Initialize()
 

--- a/Components/Metrics/GradientDifference/elxGradientDifferenceMetric.hxx
+++ b/Components/Metrics/GradientDifference/elxGradientDifferenceMetric.hxx
@@ -37,7 +37,7 @@ GradientDifferenceMetric<TElastix>::Initialize()
   this->Superclass1::Initialize();
   timer.Stop();
   log::info(std::ostringstream{} << "Initialization of GradientDifference metric took: "
-                                 << static_cast<long>(timer.GetMean() * 1000) << " ms.");
+                                 << static_cast<std::int64_t>(timer.GetMean() * 1000) << " ms.");
 
 } // end Initialize()
 

--- a/Components/Metrics/KNNGraphAlphaMutualInformation/elxKNNGraphAlphaMutualInformationMetric.hxx
+++ b/Components/Metrics/KNNGraphAlphaMutualInformation/elxKNNGraphAlphaMutualInformationMetric.hxx
@@ -41,7 +41,7 @@ KNNGraphAlphaMutualInformationMetric<TElastix>::Initialize()
   this->Superclass1::Initialize();
   timer.Stop();
   log::info(std::ostringstream{} << "Initialization of KNNGraphAlphaMutualInformation metric took: "
-                                 << static_cast<long>(timer.GetMean() * 1000) << " ms.");
+                                 << static_cast<std::int64_t>(timer.GetMean() * 1000) << " ms.");
 
 } // end Initialize()
 

--- a/Components/Metrics/MissingStructurePenalty/elxMissingStructurePenalty.hxx
+++ b/Components/Metrics/MissingStructurePenalty/elxMissingStructurePenalty.hxx
@@ -48,7 +48,7 @@ MissingStructurePenalty<TElastix>::Initialize()
   this->Superclass1::Initialize();
   timer.Stop();
   log::info(std::ostringstream{} << "Initialization of MissingStructurePenalty metric took: "
-                                 << static_cast<long>(timer.GetMean() * 1000) << " ms.");
+                                 << static_cast<std::int64_t>(timer.GetMean() * 1000) << " ms.");
 } // end Initialize()
 
 

--- a/Components/Metrics/NormalizedGradientCorrelation/elxNormalizedGradientCorrelationMetric.hxx
+++ b/Components/Metrics/NormalizedGradientCorrelation/elxNormalizedGradientCorrelationMetric.hxx
@@ -37,7 +37,7 @@ NormalizedGradientCorrelationMetric<TElastix>::Initialize()
   this->Superclass1::Initialize();
   timer.Stop();
   log::info(std::ostringstream{} << "Initialization of NormalizedGradientCorrelation metric took: "
-                                 << static_cast<long>(timer.GetMean() * 1000) << " ms.");
+                                 << static_cast<std::int64_t>(timer.GetMean() * 1000) << " ms.");
 
 } // end Initialize()
 

--- a/Components/Metrics/NormalizedMutualInformation/elxNormalizedMutualInformationMetric.hxx
+++ b/Components/Metrics/NormalizedMutualInformation/elxNormalizedMutualInformationMetric.hxx
@@ -42,7 +42,7 @@ NormalizedMutualInformationMetric<TElastix>::Initialize()
   this->Superclass1::Initialize();
   timer.Stop();
   log::info(std::ostringstream{} << "Initialization of NormalizedMutualInformation metric took: "
-                                 << static_cast<long>(timer.GetMean() * 1000) << " ms.");
+                                 << static_cast<std::int64_t>(timer.GetMean() * 1000) << " ms.");
 
 } // end Initialize()
 

--- a/Components/Metrics/PCAMetric/elxPCAMetric.hxx
+++ b/Components/Metrics/PCAMetric/elxPCAMetric.hxx
@@ -49,7 +49,7 @@ PCAMetric<TElastix>::Initialize()
 
   timer.Stop();
   log::info(std::ostringstream{} << "Initialization of PCAMetric metric took: "
-                                 << static_cast<long>(timer.GetMean() * 1000) << " ms.");
+                                 << static_cast<std::int64_t>(timer.GetMean() * 1000) << " ms.");
 
 } // end Initialize()
 

--- a/Components/Metrics/PCAMetric2/elxPCAMetric2.hxx
+++ b/Components/Metrics/PCAMetric2/elxPCAMetric2.hxx
@@ -49,7 +49,7 @@ PCAMetric2<TElastix>::Initialize()
 
   timer.Stop();
   log::info(std::ostringstream{} << "Initialization of PCAMetric2 metric took: "
-                                 << static_cast<long>(timer.GetMean() * 1000) << " ms.");
+                                 << static_cast<std::int64_t>(timer.GetMean() * 1000) << " ms.");
 
 } // end Initialize()
 

--- a/Components/Metrics/PatternIntensity/elxPatternIntensityMetric.hxx
+++ b/Components/Metrics/PatternIntensity/elxPatternIntensityMetric.hxx
@@ -38,7 +38,7 @@ PatternIntensityMetric<TElastix>::Initialize()
   this->Superclass1::Initialize();
   timer.Stop();
   log::info(std::ostringstream{} << "Initialization of PatternIntensity metric took: "
-                                 << static_cast<long>(timer.GetMean() * 1000) << " ms.");
+                                 << static_cast<std::int64_t>(timer.GetMean() * 1000) << " ms.");
 
 } // end Initialize()
 

--- a/Components/Metrics/PolydataDummyPenalty/elxPolydataDummyPenalty.hxx
+++ b/Components/Metrics/PolydataDummyPenalty/elxPolydataDummyPenalty.hxx
@@ -47,7 +47,7 @@ PolydataDummyPenalty<TElastix>::Initialize()
   this->Superclass1::Initialize();
   timer.Stop();
   log::info(std::ostringstream{} << "Initialization of PolydataDummyPenalty metric took: "
-                                 << static_cast<long>(timer.GetMean() * 1000) << " ms.");
+                                 << static_cast<std::int64_t>(timer.GetMean() * 1000) << " ms.");
 
 } // end Initialize()
 

--- a/Components/Metrics/RigidityPenalty/elxTransformRigidityPenaltyTerm.hxx
+++ b/Components/Metrics/RigidityPenalty/elxTransformRigidityPenaltyTerm.hxx
@@ -155,7 +155,7 @@ TransformRigidityPenalty<TElastix>::Initialize()
   this->Superclass1::Initialize();
   timer.Stop();
   log::info(std::ostringstream{} << "Initialization of TransformRigidityPenalty metric took: "
-                                 << static_cast<long>(timer.GetMean() * 1000) << " ms.");
+                                 << static_cast<std::int64_t>(timer.GetMean() * 1000) << " ms.");
 
   /** Check stuff. */
   this->CheckUseAndCalculationBooleans();

--- a/Components/Metrics/StatisticalShapePenalty/elxStatisticalShapePenalty.hxx
+++ b/Components/Metrics/StatisticalShapePenalty/elxStatisticalShapePenalty.hxx
@@ -44,7 +44,7 @@ StatisticalShapePenalty<TElastix>::Initialize()
   this->Superclass1::Initialize();
   timer.Stop();
   log::info(std::ostringstream{} << "Initialization of StatisticalShape metric took: "
-                                 << static_cast<long>(timer.GetMean() * 1000) << " ms.");
+                                 << static_cast<std::int64_t>(timer.GetMean() * 1000) << " ms.");
 
 } // end Initialize()
 

--- a/Components/Metrics/SumOfPairwiseCorrelationsMetric/elxSumOfPairwiseCorrelationCoefficientsMetric.hxx
+++ b/Components/Metrics/SumOfPairwiseCorrelationsMetric/elxSumOfPairwiseCorrelationCoefficientsMetric.hxx
@@ -50,7 +50,7 @@ SumOfPairwiseCorrelationCoefficientsMetric<TElastix>::Initialize()
 
   timer.Stop();
   log::info(std::ostringstream{} << "Initialization of SumOfPairwiseCorrelationCoefficientsMetric metric took: "
-                                 << static_cast<long>(timer.GetMean() * 1000) << " ms.");
+                                 << static_cast<std::int64_t>(timer.GetMean() * 1000) << " ms.");
 
 } // end Initialize()
 

--- a/Components/Metrics/SumSquaredTissueVolumeDifferenceMetric/elxSumSquaredTissueVolumeDifferenceMetric.hxx
+++ b/Components/Metrics/SumSquaredTissueVolumeDifferenceMetric/elxSumSquaredTissueVolumeDifferenceMetric.hxx
@@ -38,7 +38,7 @@ SumSquaredTissueVolumeDifferenceMetric<TElastix>::Initialize()
   this->Superclass1::Initialize();
   timer.Stop();
   log::info(std::ostringstream{} << "Initialization of SumSquaredTissueVolumeDifference metric took: "
-                                 << static_cast<long>(timer.GetMean() * 1000) << " ms.");
+                                 << static_cast<std::int64_t>(timer.GetMean() * 1000) << " ms.");
 
 } // end Initialize()
 

--- a/Components/Metrics/VarianceOverLastDimension/elxVarianceOverLastDimensionMetric.hxx
+++ b/Components/Metrics/VarianceOverLastDimension/elxVarianceOverLastDimensionMetric.hxx
@@ -49,7 +49,7 @@ VarianceOverLastDimensionMetric<TElastix>::Initialize()
 
   timer.Stop();
   log::info(std::ostringstream{} << "Initialization of VarianceOverLastDimensionMetric metric took: "
-                                 << static_cast<long>(timer.GetMean() * 1000) << " ms.");
+                                 << static_cast<std::int64_t>(timer.GetMean() * 1000) << " ms.");
 
 } // end Initialize()
 

--- a/Components/Registrations/MultiMetricMultiResolutionRegistration/elxMultiMetricMultiResolutionRegistration.hxx
+++ b/Components/Registrations/MultiMetricMultiResolutionRegistration/elxMultiMetricMultiResolutionRegistration.hxx
@@ -437,8 +437,8 @@ MultiMetricMultiResolutionRegistration<TElastix>::UpdateFixedMasks(unsigned int 
 
   /** Stop timer and print the elapsed time. */
   timer.Stop();
-  log::info(std::ostringstream{} << "Setting the fixed masks took: " << static_cast<long>(timer.GetMean() * 1000)
-                                 << " ms.");
+  log::info(std::ostringstream{} << "Setting the fixed masks took: "
+                                 << static_cast<std::int64_t>(timer.GetMean() * 1000) << " ms.");
 
 } // end UpdateFixedMasks()
 
@@ -525,8 +525,8 @@ MultiMetricMultiResolutionRegistration<TElastix>::UpdateMovingMasks(unsigned int
 
   /** Stop timer and print the elapsed time. */
   timer.Stop();
-  log::info(std::ostringstream{} << "Setting the moving masks took: " << static_cast<long>(timer.GetMean() * 1000)
-                                 << " ms.");
+  log::info(std::ostringstream{} << "Setting the moving masks took: "
+                                 << static_cast<std::int64_t>(timer.GetMean() * 1000) << " ms.");
 
 } // end UpdateMovingMasks()
 

--- a/Components/Registrations/MultiResolutionRegistration/elxMultiResolutionRegistration.hxx
+++ b/Components/Registrations/MultiResolutionRegistration/elxMultiResolutionRegistration.hxx
@@ -199,8 +199,8 @@ MultiResolutionRegistration<TElastix>::UpdateMasks(unsigned int level)
 
   /** Stop timer and print the elapsed time. */
   timer.Stop();
-  log::info(std::ostringstream{} << "Setting the fixed masks took: " << static_cast<long>(timer.GetMean() * 1000)
-                                 << " ms.");
+  log::info(std::ostringstream{} << "Setting the fixed masks took: "
+                                 << static_cast<std::int64_t>(timer.GetMean() * 1000) << " ms.");
 
   /** Start timer, to time the whole moving mask configuration procedure. */
   timer.Reset();
@@ -217,8 +217,8 @@ MultiResolutionRegistration<TElastix>::UpdateMasks(unsigned int level)
 
   /** Stop timer and print the elapsed time. */
   timer.Stop();
-  log::info(std::ostringstream{} << "Setting the moving masks took: " << static_cast<long>(timer.GetMean() * 1000)
-                                 << " ms.");
+  log::info(std::ostringstream{} << "Setting the moving masks took: "
+                                 << static_cast<std::int64_t>(timer.GetMean() * 1000) << " ms.");
 
 } // end UpdateMasks()
 

--- a/Components/Registrations/MultiResolutionRegistrationWithFeatures/elxMultiResolutionRegistrationWithFeatures.hxx
+++ b/Components/Registrations/MultiResolutionRegistrationWithFeatures/elxMultiResolutionRegistrationWithFeatures.hxx
@@ -246,8 +246,8 @@ MultiResolutionRegistrationWithFeatures<TElastix>::UpdateFixedMasks(unsigned int
 
   /** Stop timer and print the elapsed time. */
   timer.Stop();
-  log::info(std::ostringstream{} << "Setting the fixed masks took: " << static_cast<long>(timer.GetMean() * 1000)
-                                 << " ms.");
+  log::info(std::ostringstream{} << "Setting the fixed masks took: "
+                                 << static_cast<std::int64_t>(timer.GetMean() * 1000) << " ms.");
 
 } // end UpdateFixedMasks()
 
@@ -285,8 +285,8 @@ MultiResolutionRegistrationWithFeatures<TElastix>::UpdateMovingMasks(unsigned in
 
   /** Stop timer and print the elapsed time. */
   timer.Stop();
-  log::info(std::ostringstream{} << "Setting the moving masks took: " << static_cast<long>(timer.GetMean() * 1000)
-                                 << " ms.");
+  log::info(std::ostringstream{} << "Setting the moving masks took: "
+                                 << static_cast<std::int64_t>(timer.GetMean() * 1000) << " ms.");
 
 } // end UpdateMovingMasks()
 

--- a/Core/Kernel/elxElastixTemplate.hxx
+++ b/Core/Kernel/elxElastixTemplate.hxx
@@ -192,7 +192,7 @@ ElastixTemplate<TFixedImage, TMovingImage>::Run()
   /** Print the time spent on reading images. */
   ElastixBase::m_Timer0.Stop();
   log::info(std::ostringstream{} << "Reading images took "
-                                 << static_cast<unsigned long>(ElastixBase::m_Timer0.GetMean() * 1000) << " ms.\n");
+                                 << static_cast<std::uint64_t>(ElastixBase::m_Timer0.GetMean() * 1000) << " ms.\n");
 
   /** Give all components the opportunity to do some initialization. */
   this->BeforeRegistration();
@@ -503,7 +503,7 @@ ElastixTemplate<TFixedImage, TMovingImage>::BeforeRegistration()
   /** Print time for initializing. */
   ElastixBase::m_Timer0.Stop();
   log::info(std::ostringstream{} << "Initialization of all components (before registration) took: "
-                                 << static_cast<unsigned long>(ElastixBase::m_Timer0.GetMean() * 1000) << " ms.");
+                                 << static_cast<std::uint64_t>(ElastixBase::m_Timer0.GetMean() * 1000) << " ms.");
 
   /** Start Timer0 here, to make it possible to measure the time needed for
    * preparation of the first resolution.
@@ -529,7 +529,7 @@ ElastixTemplate<TFixedImage, TMovingImage>::BeforeEachResolution()
   {
     ElastixBase::m_Timer0.Stop();
     log::info(std::ostringstream{} << "Preparation of the image pyramids took: "
-                                   << static_cast<unsigned long>(ElastixBase::m_Timer0.GetMean() * 1000) << " ms.");
+                                   << static_cast<std::uint64_t>(ElastixBase::m_Timer0.GetMean() * 1000) << " ms.");
     ElastixBase::m_Timer0.Reset();
     ElastixBase::m_Timer0.Start();
   }
@@ -558,7 +558,7 @@ ElastixTemplate<TFixedImage, TMovingImage>::BeforeEachResolution()
   /** Print the extra preparation time needed for this resolution. */
   ElastixBase::m_Timer0.Stop();
   log::info(std::ostringstream{} << "Elastix initialization of all components (for this resolution) took: "
-                                 << static_cast<unsigned long>(ElastixBase::m_Timer0.GetMean() * 1000) << " ms.");
+                                 << static_cast<std::uint64_t>(ElastixBase::m_Timer0.GetMean() * 1000) << " ms.");
 
   /** Start ResolutionTimer, which measures the total iteration time in this resolution. */
   ElastixBase::m_ResolutionTimer.Reset();
@@ -763,7 +763,7 @@ ElastixTemplate<TFixedImage, TMovingImage>::AfterRegistration()
   /** Print the time spent on things after the registration. */
   ElastixBase::m_Timer0.Stop();
   log::info(std::ostringstream{} << "Time spent on saving the results, applying the final transform etc.: "
-                                 << static_cast<unsigned long>(ElastixBase::m_Timer0.GetMean() * 1000) << " ms.");
+                                 << static_cast<std::uint64_t>(ElastixBase::m_Timer0.GetMean() * 1000) << " ms.");
 
 } // end AfterRegistration()
 

--- a/Core/Main/GTesting/itkTransformixFilterGTest.cxx
+++ b/Core/Main/GTesting/itkTransformixFilterGTest.cxx
@@ -1577,7 +1577,7 @@ GTEST_TEST(itkTransformixFilter, CheckMinimumMovingImageUsingAnyInternalPixelTyp
   };
 
   check(TypeHolder<char>{});
-  check(TypeHolder<unsigned long>{});
+  check(TypeHolder<unsigned int>{});
   check(TypeHolder<double>{});
 }
 
@@ -1619,7 +1619,7 @@ GTEST_TEST(itkTransformixFilter, CheckZeroFilledMovingImageWithRandomDomainUsing
   };
 
   check(TypeHolder<char>{});
-  check(TypeHolder<unsigned long>{});
+  check(TypeHolder<unsigned int>{});
   check(TypeHolder<double>{});
 }
 

--- a/Core/Main/elastix.cxx
+++ b/Core/Main/elastix.cxx
@@ -138,7 +138,7 @@ main(int argc, char ** argv)
     auto                    level = elx::log::level::info;
 
     /** Put command line parameters into parameterFileList. */
-    for (unsigned int i = 1; static_cast<long>(i) < (argc - 1); i += 2)
+    for (unsigned int i = 1; static_cast<std::int64_t>(i) < (argc - 1); i += 2)
     {
       std::string key(argv[i]);
       std::string value(argv[i + 1]);

--- a/Core/Main/transformix.cxx
+++ b/Core/Main/transformix.cxx
@@ -137,7 +137,7 @@ main(int argc, char ** argv)
     auto            level = elx::log::level::info;
 
     /** Put command line parameters into parameterFileList. */
-    for (unsigned int i = 1; static_cast<long>(i) < argc - 1; i += 2)
+    for (unsigned int i = 1; static_cast<std::int64_t>(i) < argc - 1; i += 2)
     {
       std::string key(argv[i]);
       std::string value(argv[i + 1]);

--- a/Core/elxProgressCommand.cxx
+++ b/Core/elxProgressCommand.cxx
@@ -185,7 +185,7 @@ ProgressCommand::PrintProgress(const float progress) const
 void
 ProgressCommand::UpdateAndPrintProgress(const unsigned long currentVoxelNumber) const
 {
-  const auto frac = static_cast<unsigned long>(m_NumberOfVoxels / m_NumberOfUpdates);
+  const auto frac = static_cast<std::uint64_t>(m_NumberOfVoxels / m_NumberOfUpdates);
   if (currentVoxelNumber % frac == 0)
   {
     this->PrintProgress(static_cast<float>(currentVoxelNumber) / static_cast<float>(m_NumberOfVoxels));

--- a/Testing/itkBSplineInterpolationDerivativeWeightFunctionTest.cxx
+++ b/Testing/itkBSplineInterpolationDerivativeWeightFunctionTest.cxx
@@ -21,6 +21,8 @@
 #include <ctime>
 #include <iomanip>
 
+#include <itkMath.h>
+
 //-------------------------------------------------------------------------------------
 
 int
@@ -166,8 +168,7 @@ main()
     return 1;
   }
 
-  if (DerivativeWeightFunctionType::NumberOfWeights !=
-      static_cast<unsigned long>(std::pow(static_cast<float>(SplineOrder + 1), 2.0f)))
+  if (DerivativeWeightFunctionType::NumberOfWeights != itk::Math::sqr(SplineOrder + 1))
   {
     std::cerr << "ERROR: wrong number of weights was computed." << std::endl;
     return 1;

--- a/Testing/itkBSplineInterpolationSODerivativeWeightFunctionTest.cxx
+++ b/Testing/itkBSplineInterpolationSODerivativeWeightFunctionTest.cxx
@@ -21,6 +21,8 @@
 #include <ctime>
 #include <iomanip>
 
+#include <itkMath.h>
+
 //-------------------------------------------------------------------------------------
 
 int
@@ -255,8 +257,7 @@ main()
     return 1;
   }
 
-  if (SODerivativeWeightFunctionType::NumberOfWeights !=
-      static_cast<unsigned long>(std::pow(static_cast<float>(SplineOrder + 1), 2.0f)))
+  if (SODerivativeWeightFunctionType::NumberOfWeights != itk::Math::sqr(SplineOrder + 1))
   {
     std::cerr << "ERROR: wrong number of weights was computed." << std::endl;
     return 1;

--- a/Testing/itkBSplineInterpolationWeightFunctionTest.cxx
+++ b/Testing/itkBSplineInterpolationWeightFunctionTest.cxx
@@ -21,6 +21,8 @@
 #include <ctime>
 #include <iomanip>
 
+#include <itkMath.h>
+
 //-------------------------------------------------------------------------------------
 // This test tests the itkBSplineInterpolationWeightFunction2 and compares
 // it with the ITK implementation. It should give equal results and comparable
@@ -249,8 +251,7 @@ main()
     return EXIT_FAILURE;
   }
 
-  if (WeightFunction2Type2D::NumberOfWeights !=
-      static_cast<unsigned long>(std::pow(static_cast<float>(SplineOrder + 1), 2.0f)))
+  if (WeightFunction2Type2D::NumberOfWeights != itk::Math::sqr(SplineOrder + 1))
   {
     std::cerr << "ERROR: wrong number of weights was computed." << std::endl;
     return EXIT_FAILURE;


### PR DESCRIPTION
- Follow-up to pull request #1316 commit 3246875d3a45723e216cb0716943d421cb3c02d0

Note: this pull request does not yet replace _all_ occurrences of `long` and `unsigned long`. Unfortunately.  `long` and `unsigned long` are problematic. They cause behavior differences between platforms.  On Windows, `long` and `unsigned long` are typically 32 bits, whereas on Linux, they are typically 64 bits long.