### PR TITLE
COMP: Upgrade GitHub Actions to Python 3.9

### DIFF
--- a/.github/workflows/ElastixGitHubActions.yml
+++ b/.github/workflows/ElastixGitHubActions.yml
@@ -59,9 +59,10 @@ jobs:
         key: ${{ matrix.itk-git-tag }}-${{ matrix.os }}-${{ matrix.cmake-build-type }}
 
     - name: Set up Python
-      uses: actions/setup-python@v3
+      # Use the version of setup-python that has just dropped Python 3.8.
+      uses: actions/setup-python@v5.4.0
       with:
-        python-version: 3.8
+        python-version: 3.9
 
     - name: Install build dependencies
       run: |


### PR DESCRIPTION
Python 3.8 has reached end of life (according to https://devguide.python.org/versions).