### PR TITLE
ENH: Replace `macos-13` with `macos-14` (amd64) in *.yml

### DIFF
--- a/.github/workflows/ElastixGitHubActions.yml
+++ b/.github/workflows/ElastixGitHubActions.yml
@@ -13,7 +13,7 @@ jobs:
     strategy:
       max-parallel: 3
       matrix:
-        os: [ubuntu-22.04, windows-2022, macos-13]
+        os: [ubuntu-22.04, windows-2022, macos-14]
         include:
           - os: ubuntu-22.04
             c-compiler: "gcc"
@@ -29,7 +29,7 @@ jobs:
             cmake-build-type: "Release"
             ANNLib: "ANNlib-5.2.dll"
             vcvars64: "C:/Program Files/Microsoft Visual Studio/2022/Enterprise/VC/Auxiliary/Build/vcvars64.bat"
-          - os: macos-13
+          - os: macos-14
             c-compiler: "clang"
             cxx-compiler: "clang++"
             itk-git-tag: "v5.4.1"

--- a/Testing/CI/Azure/ci.yml
+++ b/Testing/CI/Azure/ci.yml
@@ -135,7 +135,7 @@ jobs:
 - job: macOS
   timeoutInMinutes: 0
   pool:
-    vmImage: 'macOS-13'
+    vmImage: 'macOS-14'
   strategy:
     matrix:
       ITKv5:


### PR DESCRIPTION
- Partially addressed issue https://github.com/SuperElastix/elastix/issues/1318 "Proposal: CI testing for ARM macOS systems, deprecate Intel macOS support", proposed by Matt McCormick
- Related to ITK issue https://github.com/InsightSoftwareConsortium/ITK/issues/5326 "Proposal to Deprecate macOS Intel Support in ITK 6 (Retain in ITK 5)"

YAML Label `macos-14` (for GitHub Actions) corresponds with macOS-14-arm64, according to: https://github.com/actions/runner-images/blob/0e37973a015a27a4a410a4ae37c0aa99bdd63ea8/README.md#available-images

However, YAML VM Image Label `macOS-14` (for Azure Pipeline) still appears to refer to an Intel machine. See also https://learn.microsoft.com/en-us/azure/devops/pipelines/agents/hosted?view=azure-devops&tabs=yaml