### PR TITLE
COMP: Add missing semicolons

### DIFF
--- a/Components/Transforms/AdvancedAffineTransform/elxAdvancedAffineTransform.hxx
+++ b/Components/Transforms/AdvancedAffineTransform/elxAdvancedAffineTransform.hxx
@@ -107,7 +107,7 @@ AdvancedAffineTransformElastix<TElastix>::ReadFromFile()
     if (itkFixedParameterValues == nullptr)
     {
       log::error("ERROR: No center of rotation is specified in the transform parameter file");
-      itkExceptionMacro("Transform parameter file is corrupt.")
+      itkExceptionMacro("Transform parameter file is corrupt.");
     }
   }
 

--- a/Components/Transforms/AffineDTITransform/elxAffineDTITransform.hxx
+++ b/Components/Transforms/AffineDTITransform/elxAffineDTITransform.hxx
@@ -78,7 +78,7 @@ AffineDTITransformElastix<TElastix>::ReadFromFile()
   if (!pointRead)
   {
     log::error("ERROR: No center of rotation is specified in the transform parameter file");
-    itkExceptionMacro("Transform parameter file is corrupt.")
+    itkExceptionMacro("Transform parameter file is corrupt.");
   }
 
   /** Set the center in this Transform. */

--- a/Components/Transforms/AffineLogStackTransform/elxAffineLogStackTransform.hxx
+++ b/Components/Transforms/AffineLogStackTransform/elxAffineLogStackTransform.hxx
@@ -119,7 +119,7 @@ AffineLogStackTransform<TElastix>::ReadFromFile()
     if (!pointRead)
     {
       log::error("ERROR: No center of rotation is specified in the transform parameter file");
-      itkExceptionMacro("Transform parameter file is corrupt.")
+      itkExceptionMacro("Transform parameter file is corrupt.");
     }
 
     this->InitializeAffineLogTransform();

--- a/Components/Transforms/BSplineStackTransform/elxBSplineStackTransform.hxx
+++ b/Components/Transforms/BSplineStackTransform/elxBSplineStackTransform.hxx
@@ -492,7 +492,7 @@ BSplineStackTransform<TElastix>::ReadFromFile()
     {
       itkExceptionMacro("NumberOfSubTransforms, StackOrigin, StackSpacing, GridSize, GridIndex, GridSpacing and "
                         "GridOrigin is required by "
-                        << this->GetNameOfClass() << ".")
+                        << this->GetNameOfClass() << ".");
     }
 
     /** Set it all. */

--- a/Components/Transforms/EulerStackTransform/elxEulerStackTransform.hxx
+++ b/Components/Transforms/EulerStackTransform/elxEulerStackTransform.hxx
@@ -117,7 +117,7 @@ EulerStackTransform<TElastix>::ReadFromFile()
     if (!pointRead && !indexRead)
     {
       log::error("ERROR: No center of rotation is specified in the transform parameter file");
-      itkExceptionMacro("Transform parameter file is corrupt.")
+      itkExceptionMacro("Transform parameter file is corrupt.");
     }
 
     this->InitializeEulerTransform();

--- a/Components/Transforms/EulerTransform/elxEulerTransform.hxx
+++ b/Components/Transforms/EulerTransform/elxEulerTransform.hxx
@@ -77,7 +77,7 @@ EulerTransformElastix<TElastix>::ReadFromFile()
     if (!pointRead)
     {
       log::error("ERROR: No center of rotation is specified in the transform parameter file");
-      itkExceptionMacro("Transform parameter file is corrupt.")
+      itkExceptionMacro("Transform parameter file is corrupt.");
     }
 
     /** Set the center in this Transform. */

--- a/Components/Transforms/SimilarityTransform/elxSimilarityTransform.hxx
+++ b/Components/Transforms/SimilarityTransform/elxSimilarityTransform.hxx
@@ -86,7 +86,7 @@ SimilarityTransformElastix<TElastix>::ReadFromFile()
     if (!pointRead && !indexRead)
     {
       log::error("ERROR: No center of rotation is specified in the transform parameter file.");
-      itkExceptionMacro("Transform parameter file is corrupt.")
+      itkExceptionMacro("Transform parameter file is corrupt.");
     }
 
     /** Set the center in this Transform. */

--- a/Core/Main/elxParameterObject.cxx
+++ b/Core/Main/elxParameterObject.cxx
@@ -229,7 +229,7 @@ ParameterObject::ReadParameterFiles(const ParameterFileNameVectorType & paramete
   {
     if (!itksys::SystemTools::FileExists(parameterFileName))
     {
-      itkExceptionMacro("Parameter file \"" << parameterFileName << "\" does not exist.")
+      itkExceptionMacro("Parameter file \"" << parameterFileName << "\" does not exist.");
     }
 
     this->AddParameterFile(parameterFileName);


### PR DESCRIPTION
Compilation against ITK v6.0a3 requires these semicolons after the itkExceptionMacro.