### PR TITLE
Replace `VectorDataContainer::Size()` calls with `std::vector::size()`, use `size_t` 

### DIFF
--- a/Common/CostFunctions/itkParzenWindowHistogramImageToImageMetric.hxx
+++ b/Common/CostFunctions/itkParzenWindowHistogramImageToImageMetric.hxx
@@ -1049,7 +1049,7 @@ ParzenWindowHistogramImageToImageMetric<TFixedImage, TMovingImage>::ThreadedComp
 
   /** Get a handle to the sample container. */
   ImageSampleContainerPointer sampleContainer = this->GetImageSampler()->GetOutput();
-  const unsigned long         sampleContainerSize = sampleContainer->Size();
+  const size_t                sampleContainerSize{ sampleContainer->size() };
 
   /** Get the samples for this thread. */
   const auto nrOfSamplesPerThreads = static_cast<unsigned long>(

--- a/Common/ImageSamplers/itkImageRandomSamplerSparseMask.hxx
+++ b/Common/ImageSamplers/itkImageRandomSamplerSparseMask.hxx
@@ -73,7 +73,7 @@ ImageRandomSamplerSparseMask<TInputImage>::GenerateData()
 
   /** Get a handle to the full sampler output. */
   const ImageSampleContainerType & allValidSamples = Deref(this->m_InternalFullSampler->GetOutput());
-  unsigned long                    numberOfValidSamples = allValidSamples.Size();
+  size_t                           numberOfValidSamples{ allValidSamples.size() };
 
   Statistics::MersenneTwisterRandomVariateGenerator & randomVariateGenerator = Superclass::GetRandomVariateGenerator();
 

--- a/Common/ImageSamplers/itkVectorDataContainer.h
+++ b/Common/ImageSamplers/itkVectorDataContainer.h
@@ -293,7 +293,7 @@ public:
   /**
    * Get the number of elements currently stored in the vector.
    */
-  unsigned long
+  SizeValueType
   Size() const;
 
   /**

--- a/Common/ImageSamplers/itkVectorDataContainer.hxx
+++ b/Common/ImageSamplers/itkVectorDataContainer.hxx
@@ -262,10 +262,10 @@ VectorDataContainer<TElement>::End() -> Iterator
  * Get the number of elements currently stored in the vector.
  */
 template <typename TElement>
-unsigned long
+SizeValueType
 VectorDataContainer<TElement>::Size() const
 {
-  return static_cast<unsigned long>(this->VectorType::size());
+  return SizeValueType{ this->VectorType::size() };
 }
 
 

--- a/Common/Transforms/itkAdvancedImageMomentsCalculator.hxx
+++ b/Common/Transforms/itkAdvancedImageMomentsCalculator.hxx
@@ -574,15 +574,13 @@ AdvancedImageMomentsCalculator<TInputImage>::SampleImage(ImageSampleContainerPoi
    * Note that the actually obtained number of samples may be lower, due to masks.
    * This is taken into account at the end of this function.
    */
-  SizeValueType nrofsamples = this->m_NumberOfSamplesForCenteredTransformInitialization;
-  sampler->SetNumberOfSamples(nrofsamples);
+  sampler->SetNumberOfSamples(m_NumberOfSamplesForCenteredTransformInitialization);
 
   /** Get samples and check the actually obtained number of samples. */
   sampler->Update();
   sampleContainer = sampler->GetOutput();
-  nrofsamples = sampleContainer->Size();
 
-  if (nrofsamples == 0)
+  if (sampleContainer->empty())
   {
     itkExceptionMacro("No valid voxels (0/" << this->m_NumberOfSamplesForCenteredTransformInitialization
                                             << ") found to estimate the AutomaticTransformInitialization parameters.");

--- a/Common/Transforms/itkAdvancedImageMomentsCalculator.hxx
+++ b/Common/Transforms/itkAdvancedImageMomentsCalculator.hxx
@@ -268,8 +268,8 @@ AdvancedImageMomentsCalculator<TImage>::ThreadedCompute(ThreadIdType threadId)
   unsigned long numberOfPixelsCounted = 0;
 
   /** Get sample container size, number of threads, and output space dimension. */
-  const SizeValueType sampleContainerSize = this->m_SampleContainer->Size();
-  const ThreadIdType  numberOfThreads = this->m_Threader->GetNumberOfWorkUnits();
+  const size_t       sampleContainerSize{ this->m_SampleContainer->size() };
+  const ThreadIdType numberOfThreads = this->m_Threader->GetNumberOfWorkUnits();
 
   /** Get the samples for this thread. */
   const auto nrOfSamplesPerThreads = static_cast<unsigned long>(

--- a/Components/Metrics/AdvancedKappaStatistic/itkAdvancedKappaStatisticImageToImageMetric.hxx
+++ b/Components/Metrics/AdvancedKappaStatistic/itkAdvancedKappaStatisticImageToImageMetric.hxx
@@ -451,7 +451,7 @@ AdvancedKappaStatisticImageToImageMetric<TFixedImage, TMovingImage>::ThreadedGet
 
   /** Get a handle to the sample container. */
   ImageSampleContainerPointer sampleContainer = this->GetImageSampler()->GetOutput();
-  const unsigned long         sampleContainerSize = sampleContainer->Size();
+  const size_t                sampleContainerSize{ sampleContainer->size() };
 
   /** Get the samples for this thread. */
   const auto nrOfSamplesPerThreads = static_cast<unsigned long>(

--- a/Components/Metrics/AdvancedMattesMutualInformation/itkParzenWindowMutualInformationImageToImageMetric.hxx
+++ b/Components/Metrics/AdvancedMattesMutualInformation/itkParzenWindowMutualInformationImageToImageMetric.hxx
@@ -435,7 +435,7 @@ ParzenWindowMutualInformationImageToImageMetric<TFixedImage, TMovingImage>::Thre
 
   /** Get a handle to the sample container. */
   ImageSampleContainerPointer sampleContainer = this->GetImageSampler()->GetOutput();
-  const unsigned long         sampleContainerSize = sampleContainer->Size();
+  const size_t                sampleContainerSize{ sampleContainer->size() };
 
   /** Get the samples for this thread. */
   const auto nrOfSamplesPerThreads = static_cast<unsigned long>(

--- a/Components/Metrics/AdvancedMeanSquares/itkAdvancedMeanSquaresImageToImageMetric.hxx
+++ b/Components/Metrics/AdvancedMeanSquares/itkAdvancedMeanSquaresImageToImageMetric.hxx
@@ -253,7 +253,7 @@ AdvancedMeanSquaresImageToImageMetric<TFixedImage, TMovingImage>::ThreadedGetVal
 {
   /** Get a handle to the sample container. */
   ImageSampleContainerPointer sampleContainer = this->GetImageSampler()->GetOutput();
-  const unsigned long         sampleContainerSize = sampleContainer->Size();
+  const size_t                sampleContainerSize{ sampleContainer->size() };
 
   /** Get the samples for this thread. */
   const auto nrOfSamplesPerThreads = static_cast<unsigned long>(
@@ -549,7 +549,7 @@ AdvancedMeanSquaresImageToImageMetric<TFixedImage, TMovingImage>::ThreadedGetVal
 
   /** Get a handle to the sample container. */
   ImageSampleContainerPointer sampleContainer = this->GetImageSampler()->GetOutput();
-  const unsigned long         sampleContainerSize = sampleContainer->Size();
+  const size_t                sampleContainerSize{ sampleContainer->size() };
 
   /** Get the samples for this thread. */
   const auto nrOfSamplesPerThreads = static_cast<unsigned long>(

--- a/Components/Metrics/AdvancedNormalizedCorrelation/itkAdvancedNormalizedCorrelationImageToImageMetric.hxx
+++ b/Components/Metrics/AdvancedNormalizedCorrelation/itkAdvancedNormalizedCorrelationImageToImageMetric.hxx
@@ -476,7 +476,7 @@ AdvancedNormalizedCorrelationImageToImageMetric<TFixedImage, TMovingImage>::Thre
 
   /** Get a handle to the sample container. */
   ImageSampleContainerPointer sampleContainer = this->GetImageSampler()->GetOutput();
-  const unsigned long         sampleContainerSize = sampleContainer->Size();
+  const size_t                sampleContainerSize{ sampleContainer->size() };
 
   /** Get the samples for this thread. */
   const auto nrOfSamplesPerThreads = static_cast<unsigned long>(

--- a/Components/Metrics/BendingEnergyPenalty/itkTransformBendingEnergyPenaltyTerm.hxx
+++ b/Components/Metrics/BendingEnergyPenalty/itkTransformBendingEnergyPenaltyTerm.hxx
@@ -399,7 +399,7 @@ TransformBendingEnergyPenaltyTerm<TFixedImage, TScalarType>::ThreadedGetValueAnd
 
   /** Get a handle to the sample container. */
   ImageSampleContainerPointer sampleContainer = this->GetImageSampler()->GetOutput();
-  const unsigned long         sampleContainerSize = sampleContainer->Size();
+  const size_t                sampleContainerSize{ sampleContainer->size() };
 
   /** Get the samples for this thread. */
   const auto nrOfSamplesPerThreads = static_cast<unsigned long>(

--- a/Components/Metrics/KNNGraphAlphaMutualInformation/itkKNNGraphAlphaMutualInformationImageToImageMetric.hxx
+++ b/Components/Metrics/KNNGraphAlphaMutualInformation/itkKNNGraphAlphaMutualInformationImageToImageMetric.hxx
@@ -734,7 +734,7 @@ KNNGraphAlphaMutualInformationImageToImageMetric<TFixedImage, TMovingImage>::
 
   /** Get a handle to the sample container. */
   ImageSampleContainerPointer sampleContainer = this->GetImageSampler()->GetOutput();
-  const unsigned long         nrOfRequestedSamples = sampleContainer->Size();
+  const size_t                nrOfRequestedSamples{ sampleContainer->size() };
 
   /** Get the size of the feature vectors. */
   const unsigned int fixedSize = this->GetNumberOfFixedImages();

--- a/Components/Metrics/PCAMetric/itkPCAMetric.hxx
+++ b/Components/Metrics/PCAMetric/itkPCAMetric.hxx
@@ -162,8 +162,8 @@ PCAMetric<TFixedImage, TMovingImage>::GetValue(const ParametersType & parameters
   ImageSampleContainerPointer sampleContainer = this->GetImageSampler()->GetOutput();
 
   /** The rows of the ImageSampleMatrix contain the samples of the images of the stack */
-  const unsigned int numberOfSamples = sampleContainer->Size();
-  MatrixType         datablock(numberOfSamples, m_G, vnl_matrix_null);
+  const size_t numberOfSamples{ sampleContainer->size() };
+  MatrixType   datablock(numberOfSamples, m_G, vnl_matrix_null);
 
   /** Initialize dummy loop variable */
   unsigned int pixelIndex = 0;
@@ -332,8 +332,8 @@ PCAMetric<TFixedImage, TMovingImage>::GetValueAndDerivativeSingleThreaded(const 
   std::vector<FixedImagePointType> SamplesOK;
 
   /** The rows of the ImageSampleMatrix contain the samples of the images of the stack */
-  const unsigned int numberOfSamples = sampleContainer->Size();
-  MatrixType         datablock(numberOfSamples, m_G, vnl_matrix_null);
+  const size_t numberOfSamples{ sampleContainer->size() };
+  MatrixType   datablock(numberOfSamples, m_G, vnl_matrix_null);
 
   /** Initialize dummy loop variables */
   unsigned int pixelIndex = 0;
@@ -646,7 +646,7 @@ PCAMetric<TFixedImage, TMovingImage>::ThreadedGetSamples(ThreadIdType threadId)
 {
   /** Get a handle to the sample container. */
   ImageSampleContainerPointer sampleContainer = this->GetImageSampler()->GetOutput();
-  const unsigned long         sampleContainerSize = sampleContainer->Size();
+  const size_t                sampleContainerSize{ sampleContainer->size() };
 
   /** Get the samples for this thread. */
   const auto nrOfSamplesPerThreads = static_cast<unsigned long>(

--- a/Components/Metrics/PCAMetric2/itkPCAMetric2.hxx
+++ b/Components/Metrics/PCAMetric2/itkPCAMetric2.hxx
@@ -163,8 +163,8 @@ PCAMetric2<TFixedImage, TMovingImage>::GetValue(const ParametersType & parameter
   using MatrixType = vnl_matrix<RealType>;
 
   /** The rows of the ImageSampleMatrix contain the samples of the images of the stack */
-  const unsigned int numberOfSamples = sampleContainer->Size();
-  MatrixType         datablock(numberOfSamples, lastDimSize, vnl_matrix_null);
+  const size_t numberOfSamples{ sampleContainer->size() };
+  MatrixType   datablock(numberOfSamples, lastDimSize, vnl_matrix_null);
 
   /** Initialize dummy loop variable */
   unsigned int pixelIndex = 0;
@@ -346,8 +346,8 @@ PCAMetric2<TFixedImage, TMovingImage>::GetValueAndDerivative(const ParametersTyp
   std::vector<FixedImagePointType> SamplesOK;
 
   /** The rows of the ImageSampleMatrix contain the samples of the images of the stack */
-  const unsigned int numberOfSamples = sampleContainer->Size();
-  MatrixType         datablock(numberOfSamples, lastDimSize, vnl_matrix_null);
+  const size_t numberOfSamples{ sampleContainer->size() };
+  MatrixType   datablock(numberOfSamples, lastDimSize, vnl_matrix_null);
 
   /** Initialize dummy loop variables */
   unsigned int pixelIndex = 0;

--- a/Components/Metrics/SumOfPairwiseCorrelationsMetric/itkSumOfPairwiseCorrelationCoefficientsMetric.hxx
+++ b/Components/Metrics/SumOfPairwiseCorrelationsMetric/itkSumOfPairwiseCorrelationCoefficientsMetric.hxx
@@ -146,8 +146,8 @@ SumOfPairwiseCorrelationCoefficientsMetric<TFixedImage, TMovingImage>::GetValue(
   using MatrixType = vnl_matrix<RealType>;
 
   /** The rows of the ImageSampleMatrix contain the samples of the images of the stack */
-  unsigned int NumberOfSamples = sampleContainer->Size();
-  MatrixType   datablock(NumberOfSamples, G, vnl_matrix_null);
+  size_t     NumberOfSamples{ sampleContainer->size() };
+  MatrixType datablock(NumberOfSamples, G, vnl_matrix_null);
 
   /** Initialize dummy loop variable */
   unsigned int pixelIndex = 0;
@@ -309,8 +309,8 @@ SumOfPairwiseCorrelationCoefficientsMetric<TFixedImage, TMovingImage>::GetValueA
   std::vector<FixedImagePointType> SamplesOK;
 
   /** The rows of the ImageSampleMatrix contain the samples of the images of the stack */
-  unsigned int NumberOfSamples = sampleContainer->Size();
-  MatrixType   datablock(NumberOfSamples, G, vnl_matrix_null);
+  size_t     NumberOfSamples{ sampleContainer->size() };
+  MatrixType datablock(NumberOfSamples, G, vnl_matrix_null);
 
   /** Initialize dummy loop variables */
   unsigned int pixelIndex = 0;

--- a/Components/Metrics/SumSquaredTissueVolumeDifferenceMetric/itkSumSquaredTissueVolumeDifferenceImageToImageMetric.hxx
+++ b/Components/Metrics/SumSquaredTissueVolumeDifferenceMetric/itkSumSquaredTissueVolumeDifferenceImageToImageMetric.hxx
@@ -200,7 +200,7 @@ SumSquaredTissueVolumeDifferenceImageToImageMetric<TFixedImage, TMovingImage>::T
 
   /** Get a handle to the sample container. */
   ImageSampleContainerPointer sampleContainer = this->GetImageSampler()->GetOutput();
-  const unsigned long         sampleContainerSize = sampleContainer->Size();
+  const size_t                sampleContainerSize{ sampleContainer->size() };
 
   /** Get the samples for this thread. */
   const auto nSamplesPerThread = static_cast<unsigned long>(
@@ -508,7 +508,7 @@ SumSquaredTissueVolumeDifferenceImageToImageMetric<TFixedImage, TMovingImage>::T
 
   /** Get a handle to the sample container. */
   ImageSampleContainerPointer sampleContainer = this->GetImageSampler()->GetOutput();
-  const unsigned long         sampleContainerSize = sampleContainer->Size();
+  const size_t                sampleContainerSize{ sampleContainer->size() };
 
   /** Get the samples for this thread. */
   const auto nSamplesPerThread = static_cast<unsigned long>(

--- a/Core/ComponentBaseClasses/elxTransformBase.hxx
+++ b/Core/ComponentBaseClasses/elxTransformBase.hxx
@@ -1405,13 +1405,12 @@ TransformBase<TElastix>::AutomaticScalesEstimation(ScalesType & scales) const
   sampler->SetInputImageRegion(this->GetRegistration()->GetAsITKBaseType()->GetFixedImageRegion());
 
   /** Compute the grid spacing. */
-  unsigned long nrofsamples = 10000;
-  sampler->SetNumberOfSamples(nrofsamples);
+  sampler->SetNumberOfSamples(10000);
 
   /** Get samples and check the actually obtained number of samples. */
   sampler->Update();
   ImageSampleContainerPointer sampleContainer = sampler->GetOutput();
-  nrofsamples = sampleContainer->Size();
+  const std::size_t           nrofsamples{ sampleContainer->size() };
   if (nrofsamples == 0)
   {
     /** \todo: should we demand a minimum number (~100) of voxels? */
@@ -1492,13 +1491,12 @@ TransformBase<TElastix>::AutomaticScalesEstimationStackTransform(const unsigned 
   sampler->SetInputImageRegion(desiredRegion);
 
   /** Compute the grid spacing. */
-  unsigned long nrofsamples = 10000;
-  sampler->SetNumberOfSamples(nrofsamples);
+  sampler->SetNumberOfSamples(10000);
 
   /** Get samples and check the actually obtained number of samples. */
   sampler->Update();
   ImageSampleContainerPointer sampleContainer = sampler->GetOutput();
-  nrofsamples = sampleContainer->Size();
+  const std::size_t           nrofsamples{ sampleContainer->size() };
   if (nrofsamples == 0)
   {
     /** \todo: should we demand a minimum number (~100) of voxels? */


### PR DESCRIPTION
Reduced the use of `unsigned long`, which is platform dependent (either 32-bit or 64-bit).