### PR TITLE
STYLE: Improve const-correctness TransformImage interface (ABI change)

### DIFF
--- a/Core/Main/transformixlib.cxx
+++ b/Core/Main/transformixlib.cxx
@@ -79,11 +79,11 @@ TRANSFORMIX::GetResultImage()
  */
 
 int
-TRANSFORMIX::TransformImage(ImagePointer                    inputImage,
-                            std::vector<ParameterMapType> & parameterMaps,
-                            const std::string &             outputPath,
-                            bool                            performLogging,
-                            bool                            performCout)
+TRANSFORMIX::TransformImage(ImagePointer                          inputImage,
+                            const std::vector<ParameterMapType> & parameterMaps,
+                            const std::string &                   outputPath,
+                            bool                                  performLogging,
+                            bool                                  performCout)
 {
   /** Some typedef's.*/
   using TransformixMainType = elx::TransformixMain;
@@ -237,11 +237,11 @@ TRANSFORMIX::TransformImage(ImagePointer                    inputImage,
  */
 
 int
-TRANSFORMIX::TransformImage(ImagePointer       inputImage,
-                            ParameterMapType & parameterMap,
-                            std::string        outputPath,
-                            bool               performLogging,
-                            bool               performCout)
+TRANSFORMIX::TransformImage(ImagePointer             inputImage,
+                            const ParameterMapType & parameterMap,
+                            const std::string &      outputPath,
+                            bool                     performLogging,
+                            bool                     performCout)
 {
   // Transform single parameter map to a one-sized vector of parameter maps and call other
   // transform method.

--- a/Core/Main/transformixlib.h
+++ b/Core/Main/transformixlib.h
@@ -56,11 +56,11 @@ public:
    *   -2 = output folder does not exist
    */
   int
-  TransformImage(ImagePointer       inputImage,
-                 ParameterMapType & parameterMap,
-                 std::string        outputPath,
-                 bool               performLogging,
-                 bool               performCout);
+  TransformImage(ImagePointer             inputImage,
+                 const ParameterMapType & parameterMap,
+                 const std::string &      outputPath,
+                 bool                     performLogging,
+                 bool                     performCout);
 
   /** Return value: 0 is success in case not 0 an error occurred
    *    0 = success
@@ -68,11 +68,11 @@ public:
    *   -2 = output folder does not exist
    */
   int
-  TransformImage(ImagePointer                    inputImage,
-                 std::vector<ParameterMapType> & parameterMaps,
-                 const std::string &             outputPath,
-                 bool                            performLogging,
-                 bool                            performCout);
+  TransformImage(ImagePointer                          inputImage,
+                 const std::vector<ParameterMapType> & parameterMaps,
+                 const std::string &                   outputPath,
+                 bool                                  performLogging,
+                 bool                                  performCout);
 
   /** Getter for result image. */
   ConstImagePointer


### PR DESCRIPTION
Declared `parameterMap`, `parameterMaps` and `outputPath` parameters of `TRANSFORMIX::TransformImage` as `const` reference.

- Follow-up to pull request https://github.com/SuperElastix/elastix/pull/228 commit 1429e74e8d6acf779db56f7637a6d4bcb0da0d15 "STYLE: Improve const-correctness RegisterImages interface (ABI change)", Mar 2, 2020.