### PR TITLE
ENH: Fixed width types ("int8", "float64", etc) for ResultImagePixelType

### DIFF
--- a/Common/itkImageFileCastWriter.hxx
+++ b/Common/itkImageFileCastWriter.hxx
@@ -89,7 +89,7 @@ ImageFileCastWriter<TInputImage>::GenerateData()
   /** Extract the data as a raw buffer pointer and possibly convert.
    * Converting is only possible if the number of components equals 1 */
   if (m_OutputComponentType != ImageIOBase::GetComponentTypeAsString(imageIO.GetComponentType()) &&
-      numberOfComponents == 1)
+      m_OutputComponentType != elx::PixelTypeToString<ScalarType>() && numberOfComponents == 1)
   {
     const void * const convertedDataBuffer = [this, &input] {
       /** convert the scalar image to a scalar image with another componenttype
@@ -134,9 +134,24 @@ ImageFileCastWriter<TInputImage>::GenerateData()
       {
         return this->ConvertScalarImage<double>(input);
       }
+      return ConvertScalarImageAsSpecifiedByFixedWidthPixelType<std::int8_t,
+                                                                std::uint8_t,
+                                                                std::int16_t,
+                                                                std::uint16_t,
+                                                                std::int32_t,
+                                                                std::uint32_t,
+                                                                std::int64_t,
+                                                                std::uint64_t,
+                                                                float,
+                                                                double>(input);
+    }();
+
+    if (convertedDataBuffer == nullptr)
+    {
+
       itkExceptionMacro("Unable to convert the input image. An unknown or unsupported component type was specified: "
                         << std::quoted(m_OutputComponentType) << ".");
-    }();
+    }
 
     /** Do the writing */
     imageIO.Write(convertedDataBuffer);

--- a/Core/ComponentBaseClasses/elxResamplerBase.hxx
+++ b/Core/ComponentBaseClasses/elxResamplerBase.hxx
@@ -526,11 +526,26 @@ ResamplerBase<TElastix>::CreateItkResultImage()
       return CastImage<double>(infoChangerOutputImage);
     }
 
-    itkExceptionMacro("Unable to cast result image: ResultImagePixelType must be one of \"char\", \"unsigned "
-                      "char\", \"short\", \"ushort\", \"unsigned short\", \"int\", \"unsigned int\", \"long\", "
-                      "\"unsigned long\", \"float\" or \"double\" but was \""
-                      << resultImagePixelType << "\".");
+    return CastImageAsSpecifiedByFixedWidthPixelType<std::int8_t,
+                                                     std::uint8_t,
+                                                     std::int16_t,
+                                                     std::uint16_t,
+                                                     std::int32_t,
+                                                     std::uint32_t,
+                                                     std::int64_t,
+                                                     std::uint64_t,
+                                                     float,
+                                                     double>(resultImagePixelType, infoChangerOutputImage);
   }();
+
+  if (resultImage == nullptr)
+  {
+    itkExceptionMacro("Unable to cast result image: ResultImagePixelType must be one of \"char\", \"unsigned char\", "
+                      "\"short\", \"ushort\", \"unsigned short\", \"int\", \"unsigned int\", \"long\", \"unsigned "
+                      "long\", \"float\", \"double\", or a fixed width type (\"intN\", \"uintN\", or \"floatN\" for a "
+                      "type of 'N' bits), but was \""
+                      << resultImagePixelType << "\".");
+  }
 
   // put image in container
   this->m_Elastix->SetResultImage(resultImage);

--- a/Core/Main/GTesting/itkElastixRegistrationMethodGTest.cxx
+++ b/Core/Main/GTesting/itkElastixRegistrationMethodGTest.cxx
@@ -2439,6 +2439,8 @@ GTEST_TEST(itkElastixRegistrationMethod, CheckMinimumMovingImageUsingAnyInternal
 
   check(TypeHolder<char>{});
   check(TypeHolder<short>{});
+  check(TypeHolder<std::int64_t>{});
+  check(TypeHolder<std::uint64_t>{});
   check(TypeHolder<float>{});
   check(TypeHolder<double>{});
 }

--- a/Core/Main/GTesting/itkTransformixFilterGTest.cxx
+++ b/Core/Main/GTesting/itkTransformixFilterGTest.cxx
@@ -1578,6 +1578,8 @@ GTEST_TEST(itkTransformixFilter, CheckMinimumMovingImageUsingAnyInternalPixelTyp
 
   check(TypeHolder<char>{});
   check(TypeHolder<unsigned int>{});
+  check(TypeHolder<std::int64_t>{});
+  check(TypeHolder<std::uint64_t>{});
   check(TypeHolder<double>{});
 }
 

--- a/Core/Main/elxPixelTypeToString.h
+++ b/Core/Main/elxPixelTypeToString.h
@@ -18,85 +18,57 @@
 #ifndef elxPixelType_h
 #define elxPixelType_h
 
+#include <climits> // For CHAR_BIT.
+#include <cstdint> // For int8_t, uint64_t, etc.
+#include <string>
+#include <type_traits> // For is_floating_point_v and is_unsigned_v.
+
 namespace elastix
 {
-// Helper function (template) for writing pixel types as strings to parameter files
-// `PixelTypeToString()` is only supported for the template specializations below here.
-template <typename>
-constexpr const char *
-PixelTypeToString() = delete;
-
-
-template <>
-constexpr const char *
-PixelTypeToString<char>()
+// Converts the pixel type specified by its template argument to a string, which can be used as parameter value of the
+// elastix/transformix parameter ResultImagePixelType. Uses a "fixed width" format, returning a string of the form
+// "intN", "uintN", or "floatN", with N being the number of bits of the specified type.
+template <typename TPixel>
+std::string
+PixelTypeToFixedWidthString()
 {
-  return "char";
+  // Check that `TPixel` can be represented losslessly as fixed-width type:
+  static_assert(std::get<TPixel>(std::tuple<std::int8_t,
+                                            std::uint8_t,
+                                            std::int16_t,
+                                            std::uint16_t,
+                                            std::int32_t,
+                                            std::uint32_t,
+                                            std::int64_t,
+                                            std::uint64_t,
+                                            float,
+                                            double>()) == 0);
+
+  return (std::is_floating_point_v<TPixel> ? "float"
+          : std::is_unsigned_v<TPixel>     ? "uint"
+                                           : "int") +
+         std::to_string(sizeof(TPixel) * CHAR_BIT);
 }
 
-template <>
-constexpr const char *
-PixelTypeToString<unsigned char>()
-{
-  return "unsigned char";
-}
 
-template <>
-constexpr const char *
-PixelTypeToString<short>()
+// Converts the pixel type specified by its template argument to a string, which can be used as parameter value of the
+// elastix/transformix parameter ResultImagePixelType.
+template <typename TPixel>
+std::string
+PixelTypeToString()
 {
-  return "short";
-}
-
-template <>
-constexpr const char *
-PixelTypeToString<unsigned short>()
-{
-  return "unsigned short";
-}
-
-template <>
-constexpr const char *
-PixelTypeToString<int>()
-{
-  return "int";
-}
-
-template <>
-constexpr const char *
-PixelTypeToString<unsigned int>()
-{
-  return "unsigned int";
-}
-
-template <>
-constexpr const char *
-PixelTypeToString<long>()
-{
-  return "long";
-}
-
-template <>
-constexpr const char *
-PixelTypeToString<unsigned long>()
-{
-  return "unsigned long";
-}
-
-template <>
-constexpr const char *
-PixelTypeToString<float>()
-{
-  return "float";
-}
-
-template <>
-constexpr const char *
-PixelTypeToString<double>()
-{
-  return "double";
+  if constexpr (std::is_same_v<TPixel, char> && !std::is_same_v<char, std::int8_t> &&
+                !std::is_same_v<char, std::uint8_t>)
+  {
+    // `char` appears different from both `int8_t` and `uint8_t`, so it must have its own string representation.
+    return "char";
+  }
+  else
+  {
+    return PixelTypeToFixedWidthString<TPixel>();
+  }
 }
 
 } // namespace elastix
 
-#endif // elxPixelType_h
+#endif


### PR DESCRIPTION
Supported any of the following values for the elastix/transformix parameter `ResultImagePixelType`:

  "int8", "uint8", "int16", "uint16", "int32", "uint32", "int64", "uint64", "float32", "float64".

The number of bits of such a fixed width type is guaranteed to be the same on all supported platforms.

Note that this commit adds support for 64-bit integer types on Windows (which was not supported on Windows before, because its "long" is only 32 bits).