### PR TITLE
DOC: Fix and extend documentation parameters.2D.NC.translation.ASGD.txt

### DIFF
--- a/Testing/Data/parameters.2D.NC.translation.ASGD.txt
+++ b/Testing/Data/parameters.2D.NC.translation.ASGD.txt
@@ -1,5 +1,6 @@
 // This parameter file is used to register the images
-// 2D_square_object_at_(1,3) and 2D_square_object_at_(2,1).
+// 2D_2x2_square_object_at_(1,3) and 2D_2x2_square_object_at_(1,3):
+// elastix -p parameters.2D.NC.translation.ASGD.txt -f 2D_2x2_square_object_at_(1,3).mhd -m 2D_2x2_square_object_at_(1,3).mhd -out out
 
 (FixedInternalImagePixelType "float")
 (FixedImageDimension 2)


### PR DESCRIPTION
Suggested the following command-line call:

    elastix -p parameters.2D.NC.translation.ASGD.txt -f 2D_2x2_square_object_at_(1,3).mhd -m 2D_2x2_square_object_at_(1,3).mhd -out out