### PR TITLE
COMP: Remove const overload of `operator[]` from OpenCLVector

### DIFF
--- a/Common/OpenCL/ITKimprovements/itkOpenCLVector.h
+++ b/Common/OpenCL/ITKimprovements/itkOpenCLVector.h
@@ -104,12 +104,6 @@ public:
   T &
   operator[](const std::size_t index);
 
-  /** Returns a const reference to the element at \a index in this
-   * OpenCL vector. The vector will be copied to host memory
-   * if necessary. */
-  const T &
-  operator[](const std::size_t index) const;
-
   /** Reads the \a count elements starting \a offset in this vector
    * into \a data.
    * \sa Write() */

--- a/Common/OpenCL/ITKimprovements/itkOpenCLVector.hxx
+++ b/Common/OpenCL/ITKimprovements/itkOpenCLVector.hxx
@@ -93,20 +93,6 @@ OpenCLVector<T>::operator[](const std::size_t index)
 
 //------------------------------------------------------------------------------
 template <typename T>
-const T &
-OpenCLVector<T>::operator[](const std::size_t index) const
-{
-  itkAssertOrThrowMacro((index < this->m_Size), "OpenCLVector<T>::operator[" << index << "] index out of range");
-  if (!this->m_Mapped)
-  {
-    const_cast<OpenCLVector<T> *>(this)->map();
-  }
-  return (reinterpret_cast<T *>(this->m_Mapped))[index];
-}
-
-
-//------------------------------------------------------------------------------
-template <typename T>
 void
 OpenCLVector<T>::Write(const T * data, const std::size_t count, const std::size_t offset /*= 0 */)
 {


### PR DESCRIPTION
`OpenCLVector::operator[]` does potentially alter the internal state of the object, so it's more const-correct to just provide a non-const overload of this operator.

Moreover, this overload caused compile errors from Xcode (16.4) / Clang (17.0.0), as Aidyn Ubingazhibov (@AidynAIMedical) reported at issue https://github.com/SuperElastix/elastix/issues/1250:

> no member named 'map' in 'OpenCLVector<T>'; did you mean 'Map'?

This suggests that this particular overload was never used anyway.