### PR TITLE
STYLE: Remove `m_JacobianImage` from BSpline transforms

### DIFF
--- a/Common/Transforms/itkAdvancedBSplineDeformableTransformBase.h
+++ b/Common/Transforms/itkAdvancedBSplineDeformableTransformBase.h
@@ -395,8 +395,6 @@ protected:
   using JacobianPixelType = typename JacobianType::ValueType;
   using JacobianImageType = Image<JacobianPixelType, Self::SpaceDimension>;
 
-  typename JacobianImageType::Pointer m_JacobianImage[NDimensions]{};
-
   /** Array holding images wrapped from the flat parameters. */
   ImagePointer m_WrappedImage[NDimensions]{};
 

--- a/Common/Transforms/itkAdvancedBSplineDeformableTransformBase.hxx
+++ b/Common/Transforms/itkAdvancedBSplineDeformableTransformBase.hxx
@@ -48,16 +48,6 @@ AdvancedBSplineDeformableTransformBase<TScalarType, NDimensions>::AdvancedBSplin
     m_CoefficientImages[j] = nullptr;
   }
 
-  // Initialize Jacobian images
-  //   for ( unsigned int j = 0; j < SpaceDimension; j++ )
-  //     {
-  //     m_JacobianImage[j] = ImageType::New();
-  //     m_JacobianImage[j]->SetRegions( m_GridRegion );
-  //     m_JacobianImage[j]->SetOrigin( m_GridOrigin.GetDataPointer() );
-  //     m_JacobianImage[j]->SetSpacing( m_GridSpacing.GetDataPointer() );
-  //     m_JacobianImage[j]->SetDirection( m_GridDirection );
-  //     }
-
   /** Fixed Parameters store the following information:
    *     Grid Size
    *     Grid Origin

--- a/Components/Transforms/MultiBSplineTransformWithNormal/itkMultiBSplineDeformableTransformWithNormal.h
+++ b/Components/Transforms/MultiBSplineTransformWithNormal/itkMultiBSplineDeformableTransformWithNormal.h
@@ -462,15 +462,6 @@ protected:
   /** Keep a pointer to the input parameters. */
   const ParametersType * m_InputParametersPointer{};
 
-  /** Jacobian as SpaceDimension number of images. */
-  /*
-  using JacobianPixelType = typename JacobianType::ValueType;
-  using JacobianImageType = Image< JacobianPixelType,
-    itkGetStaticConstMacro( SpaceDimension ) >;
-
-  typename JacobianImageType::Pointer m_JacobianImage[ NDimensions ]{};
-  */
-
   /** Keep track of last support region used in computing the Jacobian
    * for fast resetting of Jacobian to zero.
    */


### PR DESCRIPTION
It was only used in commented-out code.