### PR TITLE
PERF: Use FixedArray for table in BSplineInterpolationWeightFunctionBase

### DIFF
--- a/Common/Transforms/itkBSplineInterpolationWeightFunctionBase.h
+++ b/Common/Transforms/itkBSplineInterpolationWeightFunctionBase.h
@@ -20,8 +20,7 @@
 
 #include "itkFunctionBase.h"
 #include "itkContinuousIndex.h"
-#include "itkArray.h"
-#include "itkArray2D.h"
+#include "itkIndexRange.h"
 #include "itkMath.h"
 #include "itkMatrix.h"
 #include "itkBSplineKernelFunction2.h"
@@ -103,7 +102,7 @@ public:
   static constexpr SizeType SupportSize{ SizeType::Filled(VSplineOrder + 1) };
 
 protected:
-  BSplineInterpolationWeightFunctionBase();
+  BSplineInterpolationWeightFunctionBase() = default;
   ~BSplineInterpolationWeightFunctionBase() override = default;
 
   /** Interpolation kernel types. */
@@ -131,16 +130,16 @@ protected:
   void
   PrintSelf(std::ostream & os, Indent indent) const override;
 
-  /** Member variables. */
-  vnl_matrix<unsigned long> m_OffsetToIndexTable{};
-
 private:
-  /** Function to initialize the offset table.
-   * The offset table is a convenience table, just to
-   * keep track where is what.
-   */
-  void
-  InitializeOffsetToIndexTable();
+  /** Lookup table type. */
+  using TableType = FixedArray<IndexType, NumberOfWeights>;
+
+  /** Table mapping linear offset to indices. */
+  const TableType m_OffsetToIndexTable{ [] {
+    TableType     table;
+    std::copy_n(ZeroBasedIndexRange<SpaceDimension>(SupportSize).cbegin(), NumberOfWeights, table.begin());
+    return table;
+  }() };
 };
 
 } // end namespace itk

--- a/Common/Transforms/itkBSplineInterpolationWeightFunctionBase.hxx
+++ b/Common/Transforms/itkBSplineInterpolationWeightFunctionBase.hxx
@@ -19,61 +19,9 @@
 #define itkBSplineInterpolationWeightFunctionBase_hxx
 
 #include "itkBSplineInterpolationWeightFunctionBase.h"
-#include "itkImage.h"
-#include "itkMatrix.h"
-#include "itkImageRegionConstIteratorWithIndex.h"
 
 namespace itk
 {
-
-/**
- * ****************** Constructor *******************************
- */
-
-template <typename TCoordinate, unsigned int VSpaceDimension, unsigned int VSplineOrder>
-BSplineInterpolationWeightFunctionBase<TCoordinate, VSpaceDimension, VSplineOrder>::
-  BSplineInterpolationWeightFunctionBase()
-{
-  /** Initialize members. */
-  this->InitializeOffsetToIndexTable();
-
-} // end Constructor
-
-
-/**
- * ******************* InitializeOffsetToIndexTable *******************
- */
-
-template <typename TCoordinate, unsigned int VSpaceDimension, unsigned int VSplineOrder>
-void
-BSplineInterpolationWeightFunctionBase<TCoordinate, VSpaceDimension, VSplineOrder>::InitializeOffsetToIndexTable()
-{
-  /** Create a temporary image. */
-  using CharImageType = Image<char, SpaceDimension>;
-  auto tempImage = CharImageType::New();
-  tempImage->SetRegions(SupportSize);
-  tempImage->Allocate();
-
-  /** Create an iterator over the image. */
-  ImageRegionConstIteratorWithIndex<CharImageType> it(tempImage, tempImage->GetBufferedRegion());
-
-  /** Fill the OffsetToIndexTable. */
-  this->m_OffsetToIndexTable.set_size(NumberOfWeights, SpaceDimension);
-  unsigned long counter = 0;
-  while (!it.IsAtEnd())
-  {
-    IndexType ind = it.GetIndex();
-    for (unsigned int i = 0; i < SpaceDimension; ++i)
-    {
-      this->m_OffsetToIndexTable[counter][i] = ind[i];
-    }
-
-    ++counter;
-    ++it;
-  }
-
-} // end InitializeOffsetToIndexTable()
-
 
 /**
  * ******************* PrintSelf *******************
@@ -153,8 +101,8 @@ BSplineInterpolationWeightFunctionBase<TCoordinate, VSpaceDimension, VSplineOrde
   /** Compute the vector of weights. */
   for (unsigned int k = 0; k < NumberOfWeights; ++k)
   {
-    double                tmp1 = 1.0;
-    const unsigned long * tmp2 = this->m_OffsetToIndexTable[k];
+    double     tmp1 = 1.0;
+    const auto tmp2 = m_OffsetToIndexTable[k];
     for (unsigned int j = 0; j < SpaceDimension; ++j)
     {
       tmp1 *= weights1D[j][tmp2[j]];


### PR DESCRIPTION
Following ITK pull request https://github.com/InsightSoftwareConsortium/ITK/pull/2721 commit https://github.com/InsightSoftwareConsortium/ITK/commit/974540982b2926ee6dc4f3933c07962ff74ac9a6 "PERF: Use FixedArray for table within BSplineInterpolationWeightFunction"