### PR TITLE
STYLE: Remove unnecessary parentheses from `(*variable)`

### DIFF
--- a/Common/CostFunctions/itkAdvancedImageToImageMetric.hxx
+++ b/Common/CostFunctions/itkAdvancedImageToImageMetric.hxx
@@ -425,7 +425,7 @@ AdvancedImageToImageMetric<TFixedImage, TMovingImage>::EvaluateMovingImageValueA
       {
         /** Compute moving image value and gradient using the B-spline kernel. */
         movingImageValue = Superclass::m_Interpolator->EvaluateAtContinuousIndex(cindex);
-        (*gradient) = m_ReducedBSplineInterpolator->EvaluateDerivativeAtContinuousIndex(cindex);
+        *gradient = m_ReducedBSplineInterpolator->EvaluateDerivativeAtContinuousIndex(cindex);
         // m_ReducedBSplineInterpolator->EvaluateValueAndDerivativeAtContinuousIndex(
         //  cindex, movingImageValue, *gradient );
       }
@@ -445,7 +445,7 @@ AdvancedImageToImageMetric<TFixedImage, TMovingImage>::EvaluateMovingImageValueA
         {
           index[j] = Math::Round<int64_t>(cindex[j]);
         }
-        (*gradient) = Superclass::m_GradientImage->GetPixel(index);
+        *gradient = Superclass::m_GradientImage->GetPixel(index);
       }
 
       /** The moving image gradient is multiplied with its scales, when requested. */

--- a/Common/CostFunctions/itkParzenWindowHistogramImageToImageMetric.hxx
+++ b/Common/CostFunctions/itkParzenWindowHistogramImageToImageMetric.hxx
@@ -586,7 +586,7 @@ ParzenWindowHistogramImageToImageMetric<TFixedImage, TMovingImage>::UpdateJointP
     typename DerivativeType::const_iterator imjac = imageJacobian.begin();
     for (unsigned int mu = 0; mu < numberOfParameters; ++mu)
     {
-      *(derivPtr) -= static_cast<PDFDerivativeValueType>((*imjac) * factor);
+      *(derivPtr) -= static_cast<PDFDerivativeValueType>(*imjac * factor);
       ++derivPtr;
       ++imjac;
     }

--- a/Common/OpenCL/Kernels/GPUBSplineTransform.cl
+++ b/Common/OpenCL/Kernels/GPUBSplineTransform.cl
@@ -85,8 +85,8 @@ bool inside_valid_region_1d( float * cindex, const uint spline_order,
 
   // x
   float max_limit = coefficients_image_size_x - max_helper;
-  float cind = (*cindex); float diff = cind - max_limit;
-  if( diff > 0.0f && diff < eps ){ (*cindex) -= eps; }
+  float cind = *cindex; float diff = cind - max_limit;
+  if( diff > 0.0f && diff < eps ){ *cindex -= eps; }
   else if( cind >= max_limit ) return false;
   else if( cind <  min_limit ) return false;
 

--- a/Common/Transforms/itkAdvancedBSplineDeformableTransform.hxx
+++ b/Common/Transforms/itkAdvancedBSplineDeformableTransform.hxx
@@ -404,7 +404,7 @@ AdvancedBSplineDeformableTransform<TScalarType, NDimensions, VSplineOrder>::GetS
     {
       while (!itCoef.IsAtEndOfLine())
       {
-        (*itCoeffsLinear) = itCoef.Value();
+        *itCoeffsLinear = itCoef.Value();
         ++itCoeffsLinear;
         ++itCoef;
       }
@@ -437,7 +437,7 @@ AdvancedBSplineDeformableTransform<TScalarType, NDimensions, VSplineOrder>::GetS
       /** Compute the sum for this dimension. */
       for (unsigned int mu = 0; mu < NumberOfWeights; ++mu)
       {
-        sj(dim, i) += (*itCoeffs) * (*itWeights);
+        sj(dim, i) += *itCoeffs * *itWeights;
         ++itWeights;
         ++itCoeffs;
       } // end for mu
@@ -503,7 +503,7 @@ AdvancedBSplineDeformableTransform<TScalarType, NDimensions, VSplineOrder>::GetS
     {
       while (!itCoef.IsAtEndOfLine())
       {
-        (*itCoeffsLinear) = itCoef.Value();
+        *itCoeffsLinear = itCoef.Value();
         ++itCoeffsLinear;
         ++itCoef;
       }
@@ -537,7 +537,7 @@ AdvancedBSplineDeformableTransform<TScalarType, NDimensions, VSplineOrder>::GetS
 
         for (unsigned int mu = 0; mu < NumberOfWeights; ++mu)
         {
-          sum += (*itCoeffs) * (*itWeights);
+          sum += *itCoeffs * *itWeights;
           ++itWeights;
           ++itCoeffs;
         }
@@ -709,7 +709,7 @@ AdvancedBSplineDeformableTransform<TScalarType, NDimensions, VSplineOrder>::GetJ
     {
       while (!itCoef.IsAtEndOfLine())
       {
-        (*itCoeffsLinear) = itCoef.Value();
+        *itCoeffsLinear = itCoef.Value();
         ++itCoeffsLinear;
         ++itCoef;
       }
@@ -751,7 +751,7 @@ AdvancedBSplineDeformableTransform<TScalarType, NDimensions, VSplineOrder>::GetJ
       /** Compute the sum for this dimension. */
       for (unsigned int mu = 0; mu < NumberOfWeights; ++mu)
       {
-        sj(dim, i) += (*itCoeffs) * (*itWeights);
+        sj(dim, i) += *itCoeffs * *itWeights;
         ++itWeights;
         ++itCoeffs;
       }
@@ -968,7 +968,7 @@ AdvancedBSplineDeformableTransform<TScalarType, NDimensions, VSplineOrder>::GetJ
     {
       while (!itCoef.IsAtEndOfLine())
       {
-        (*itCoeffsLinear) = itCoef.Value();
+        *itCoeffsLinear = itCoef.Value();
         ++itCoeffsLinear;
         ++itCoef;
       }
@@ -1014,7 +1014,7 @@ AdvancedBSplineDeformableTransform<TScalarType, NDimensions, VSplineOrder>::GetJ
           double sum = 0.0;
           for (unsigned int mu = 0; mu < NumberOfWeights; ++mu)
           {
-            sum += (*itCoeffs) * (*itWeights);
+            sum += *itCoeffs * *itWeights;
             ++itWeights;
             ++itCoeffs;
           }

--- a/Common/Transforms/itkAdvancedBSplineDeformableTransformBase.hxx
+++ b/Common/Transforms/itkAdvancedBSplineDeformableTransformBase.hxx
@@ -418,7 +418,7 @@ AdvancedBSplineDeformableTransformBase<TScalarType, NDimensions>::GetParameters(
                       "SetCoefficientImages() has been called causing the NULL pointer.");
   }
 
-  return (*m_InputParametersPointer);
+  return *m_InputParametersPointer;
 }
 
 // Get the parameters

--- a/Common/Transforms/itkAdvancedTransform.h
+++ b/Common/Transforms/itkAdvancedTransform.h
@@ -324,7 +324,7 @@ EvaluateInnerProduct(const vnl_matrix<TScalarType> &                        inpu
   {
     for (auto & outputVectorElement : outputVector)
     {
-      outputVectorElement += (*inputMatrixIterator) * inputVectorElement;
+      outputVectorElement += *inputMatrixIterator * inputVectorElement;
       ++inputMatrixIterator;
     }
   }

--- a/Common/Transforms/itkCyclicBSplineDeformableTransform.hxx
+++ b/Common/Transforms/itkCyclicBSplineDeformableTransform.hxx
@@ -340,7 +340,7 @@ CyclicBSplineDeformableTransform<TScalarType, NDimensions, VSplineOrder>::GetSpa
 
         while (!itCoef.IsAtEnd())
         {
-          sum += itCoef.Value() * (*itWeights);
+          sum += itCoef.Value() * *itWeights;
           ++itWeights;
           ++itCoef;
         }

--- a/Components/Metrics/AdvancedKappaStatistic/itkAdvancedKappaStatisticImageToImageMetric.hxx
+++ b/Components/Metrics/AdvancedKappaStatistic/itkAdvancedKappaStatisticImageToImageMetric.hxx
@@ -740,9 +740,9 @@ AdvancedKappaStatisticImageToImageMetric<TFixedImage, TMovingImage>::UpdateValue
     {
       if (usableFixedSample)
       {
-        (*sum1it) += 2.0 * (*imjacit);
+        *sum1it += 2.0 * *imjacit;
       }
-      (*sum2it) += (*imjacit);
+      *sum2it += *imjacit;
 
       /** Increase iterators. */
       ++imjacit;

--- a/Components/Metrics/AdvancedMattesMutualInformation/itkParzenWindowMutualInformationImageToImageMetric.hxx
+++ b/Components/Metrics/AdvancedMattesMutualInformation/itkParzenWindowMutualInformationImageToImageMetric.hxx
@@ -207,7 +207,7 @@ ParzenWindowMutualInformationImageToImageMetric<TFixedImage, TMovingImage>::GetV
         while (derivit != derivend)
         {
           /**  Ref: eq 23 of Thevenaz & Unser paper [3]. */
-          (*derivit) -= jointPDFDerivativesit.Get() * pRatioAlpha;
+          *derivit -= jointPDFDerivativesit.Get() * pRatioAlpha;
           ++derivit;
           ++jointPDFDerivativesit;
         } // end while-loop over parameters
@@ -346,7 +346,7 @@ ParzenWindowMutualInformationImageToImageMetric<TFixedImage, TMovingImage>::Comp
         {
           while (imjacit != imageJacobian.end())
           {
-            (*imjacit) *= (*jacprecit);
+            *imjacit *= *jacprecit;
             ++imjacit;
             ++jacprecit;
           }
@@ -371,7 +371,7 @@ ParzenWindowMutualInformationImageToImageMetric<TFixedImage, TMovingImage>::Comp
     const double normalizationFactor = preconditioningDivisor.mean();
     while (derivit != derivative.end())
     {
-      (*derivit) *= normalizationFactor / ((*divisit) + 1e-14);
+      *derivit *= normalizationFactor / (*divisit + 1e-14);
       ++derivit;
       ++divisit;
     }
@@ -507,7 +507,7 @@ ParzenWindowMutualInformationImageToImageMetric<TFixedImage, TMovingImage>::Thre
         {
           while (imjacit != imageJacobian.end())
           {
-            (*imjacit) *= (*jacprecit);
+            *imjacit *= *jacprecit;
             ++imjacit;
             ++jacprecit;
           }
@@ -532,7 +532,7 @@ ParzenWindowMutualInformationImageToImageMetric<TFixedImage, TMovingImage>::Thre
     const double normalizationFactor = preconditioningDivisor.mean();
     while (derivit != derivative.end())
     {
-      (*derivit) *= normalizationFactor / ((*divisit) + 1e-14);
+      *derivit *= normalizationFactor / (*divisit + 1e-14);
       ++derivit;
       ++divisit;
     }
@@ -914,7 +914,7 @@ ParzenWindowMutualInformationImageToImageMetric<TFixedImage, TMovingImage>::GetV
         }
 
         /** Update the derivative component. */
-        (*derivit) += contrib;
+        *derivit += contrib;
 
         /** Move the iterators to the next parameter. */
         ++derivit;
@@ -956,7 +956,7 @@ ParzenWindowMutualInformationImageToImageMetric<TFixedImage, TMovingImage>::GetV
   derivit = derivative.begin();
   while (derivit != derivend)
   {
-    (*derivit) *= delta2;
+    *derivit *= delta2;
     ++derivit;
   }
 
@@ -990,7 +990,7 @@ ParzenWindowMutualInformationImageToImageMetric<TFixedImage, TMovingImage>::Comp
       double                             sum = 0.0;
       for (unsigned int mu = 0; mu < M; ++mu)
       {
-        sum += (*jacit1) * (*jacit2);
+        sum += *jacit1 * *jacit2;
         ++jacit1;
         ++jacit2;
       }
@@ -1025,7 +1025,7 @@ ParzenWindowMutualInformationImageToImageMetric<TFixedImage, TMovingImage>::Comp
       const double m = fac * jacjact(drow, dcol);
       for (unsigned int mu = 0; mu < M; ++mu)
       {
-        *precondit += m * (*jacit1) * (*jacit2);
+        *precondit += m * *jacit1 * *jacit2;
         ++precondit;
         ++jacit1;
         ++jacit2;

--- a/Components/Metrics/AdvancedMeanSquares/itkAdvancedMeanSquaresImageToImageMetric.hxx
+++ b/Components/Metrics/AdvancedMeanSquares/itkAdvancedMeanSquaresImageToImageMetric.hxx
@@ -705,7 +705,7 @@ AdvancedMeanSquaresImageToImageMetric<TFixedImage, TMovingImage>::UpdateValueAnd
     typename DerivativeType::iterator       derivit = deriv.begin();
     for (unsigned int mu = 0; mu < numberOfParameters; ++mu)
     {
-      (*derivit) += diff_2 * (*imjacit);
+      *derivit += diff_2 * *imjacit;
       ++imjacit;
       ++derivit;
     }

--- a/Components/Metrics/AdvancedNormalizedCorrelation/itkAdvancedNormalizedCorrelationImageToImageMetric.hxx
+++ b/Components/Metrics/AdvancedNormalizedCorrelation/itkAdvancedNormalizedCorrelationImageToImageMetric.hxx
@@ -110,9 +110,9 @@ AdvancedNormalizedCorrelationImageToImageMetric<TFixedImage, TMovingImage>::Upda
 
     for (unsigned int mu = 0; mu < numberOfParameters; ++mu)
     {
-      (*derivativeFit) += fixedImageValue * (*imjacit);
-      (*derivativeMit) += movingImageValue * (*imjacit);
-      (*differentialit) += (*imjacit);
+      *derivativeFit += fixedImageValue * *imjacit;
+      *derivativeMit += movingImageValue * *imjacit;
+      *differentialit += *imjacit;
       ++imjacit;
       ++derivativeFit;
       ++derivativeMit;

--- a/Components/Metrics/BendingEnergyPenalty/itkTransformBendingEnergyPenaltyTerm.hxx
+++ b/Components/Metrics/BendingEnergyPenalty/itkTransformBendingEnergyPenaltyTerm.hxx
@@ -254,7 +254,7 @@ TransformBendingEnergyPenaltyTerm<TFixedImage, TScalarType>::GetValueAndDerivati
             typename InternalMatrixType::const_iterator itAend = A[k].end();
             while (itA != itAend)
             {
-              matrixProduct += (*itA) * (*itB);
+              matrixProduct += *itA * *itB;
               ++itA;
               ++itB;
             }
@@ -294,7 +294,7 @@ TransformBendingEnergyPenaltyTerm<TFixedImage, TScalarType>::GetValueAndDerivati
             typename InternalMatrixType::const_iterator itAend = A[k].end();
             while (itA != itAend)
             {
-              matrixElementProduct += (*itA) * (*itB);
+              matrixElementProduct += *itA * *itB;
               ++itA;
               ++itB;
             }
@@ -476,7 +476,7 @@ TransformBendingEnergyPenaltyTerm<TFixedImage, TScalarType>::ThreadedGetValueAnd
             typename InternalMatrixType::const_iterator itAend = A[k].end();
             while (itA != itAend)
             {
-              matrixElementProduct += (*itA) * (*itB);
+              matrixElementProduct += *itA * *itB;
               ++itA;
               ++itB;
             }
@@ -510,7 +510,7 @@ TransformBendingEnergyPenaltyTerm<TFixedImage, TScalarType>::ThreadedGetValueAnd
             typename InternalMatrixType::const_iterator itAend = A[k].end();
             while (itA != itAend)
             {
-              matrixElementProduct += (*itA) * (*itB);
+              matrixElementProduct += *itA * *itB;
               ++itA;
               ++itB;
             }

--- a/Components/Metrics/NormalizedMutualInformation/itkParzenWindowNormalizedMutualInformationImageToImageMetric.hxx
+++ b/Components/Metrics/NormalizedMutualInformation/itkParzenWindowNormalizedMutualInformationImageToImageMetric.hxx
@@ -65,13 +65,13 @@ ParzenWindowNormalizedMutualInformationImageToImageMetric<TFixedImage, TMovingIm
   /** do it! */
   while (PDFit != PDFend)
   {
-    if ((*PDFit) > 1e-16)
+    if (*PDFit > 1e-16)
     {
-      (*PDFit) = std::log(*PDFit);
+      *PDFit = std::log(*PDFit);
     }
     else
     {
-      (*PDFit) = 0.0;
+      *PDFit = 0.0;
     }
     ++PDFit;
   }
@@ -258,7 +258,7 @@ ParzenWindowNormalizedMutualInformationImageToImageMetric<TFixedImage, TMovingIm
         derivit = derivative.begin();
         while (derivit != derivend)
         {
-          (*derivit) -= jointPDFDerivativesConstit.Get() * pRatioAlpha;
+          *derivit -= jointPDFDerivativesConstit.Get() * pRatioAlpha;
           ++derivit;
           ++jointPDFDerivativesConstit;
         } // end while-loop over parameters

--- a/Components/Metrics/StatisticalShapePenalty/itkStatisticalShapePointPenalty.hxx
+++ b/Components/Metrics/StatisticalShapePenalty/itkStatisticalShapePointPenalty.hxx
@@ -187,7 +187,7 @@ StatisticalShapePointPenalty<TFixedPointSet, TMovingPointSet>::Initialize()
       typename VnlVectorType::iterator lambdaIt = pcaCovariance.lambdas().begin();
       typename VnlVectorType::iterator lambdaEnd = pcaCovariance.lambdas().end();
       unsigned int                     nonZeroLength = 0;
-      for (; lambdaIt != lambdaEnd && (*lambdaIt) > 1e-14; ++lambdaIt, ++nonZeroLength)
+      for (; lambdaIt != lambdaEnd && *lambdaIt > 1e-14; ++lambdaIt, ++nonZeroLength)
       {
       }
       if (this->m_EigenValues != nullptr)
@@ -276,7 +276,7 @@ StatisticalShapePointPenalty<TFixedPointSet, TMovingPointSet>::Initialize()
         typename VnlVectorType::iterator lambdaIt = pcaCovariance.lambdas().begin();
         typename VnlVectorType::iterator lambdaEnd = pcaCovariance.lambdas().end();
         unsigned int                     nonZeroLength = 0;
-        for (; lambdaIt != lambdaEnd && (*lambdaIt) > 1e-14; ++lambdaIt, ++nonZeroLength)
+        for (; lambdaIt != lambdaEnd && *lambdaIt > 1e-14; ++lambdaIt, ++nonZeroLength)
         {
         }
 
@@ -509,7 +509,7 @@ StatisticalShapePointPenalty<TFixedPointSet, TMovingPointSet>::GetValueAndDeriva
     {
       if (*proposalDerivativeIt != nullptr)
       {
-        delete (*proposalDerivativeIt);
+        delete *proposalDerivativeIt;
       }
     }
   }
@@ -771,7 +771,7 @@ StatisticalShapePointPenalty<TFixedPointSet, TMovingPointSet>::CalculateValue(Me
     }
     case 1: // decomposed covariance (uniform regularization)
     {
-      centerrotated = differenceVector * (*m_EigenVectors);                /** diff^T * V */
+      centerrotated = differenceVector * *m_EigenVectors;                  /** diff^T * V */
       eigrot = element_quotient(centerrotated, *m_EigenValuesRegularized); /** diff^T * V * Lambda^-1 */
       if (this->m_ShrinkageIntensity != 0)
       {
@@ -882,7 +882,7 @@ StatisticalShapePointPenalty<TFixedPointSet, TMovingPointSet>::CalculateDerivati
           for (unsigned int propDerivElementIndex = 0; propDerivElementIndex < shapeLength;
                ++propDerivElementIndex, ++propDerivElementIt)
           {
-            (*propDerivElementIt) /= this->m_BaseStd;
+            *propDerivElementIt /= this->m_BaseStd;
           }
           (**proposalDerivativeIt)[shapeLength] /= this->m_CentroidXStd;
           (**proposalDerivativeIt)[shapeLength + 1] /= this->m_CentroidYStd;
@@ -910,7 +910,7 @@ StatisticalShapePointPenalty<TFixedPointSet, TMovingPointSet>::CalculateDerivati
         {
         }
 
-          delete (*proposalDerivativeIt);
+          delete *proposalDerivativeIt;
           // nzjacs++;
       }
     }

--- a/Components/Metrics/SumSquaredTissueVolumeDifferenceMetric/itkSumSquaredTissueVolumeDifferenceImageToImageMetric.hxx
+++ b/Components/Metrics/SumSquaredTissueVolumeDifferenceMetric/itkSumSquaredTissueVolumeDifferenceImageToImageMetric.hxx
@@ -663,7 +663,7 @@ SumSquaredTissueVolumeDifferenceImageToImageMetric<TFixedImage, TMovingImage>::E
 
     for (auto & imageJacobianElement : imageJacobian)
     {
-      imageJacobianElement += (*jac) * imDeriv;
+      imageJacobianElement += *jac * imDeriv;
       ++jac;
     }
   }
@@ -706,9 +706,9 @@ SumSquaredTissueVolumeDifferenceImageToImageMetric<TFixedImage, TMovingImage>::U
     typename DerivativeType::iterator       derivit = deriv.begin();
     for (unsigned int mu = 0; mu < numberOfParameters; ++mu)
     {
-      (*derivit) +=
+      *derivit +=
         diff_2 * spatialJacobianDeterminant *
-        ((*jsjdit) * (movingImageValue - this->m_AirValue) / (this->m_TissueValue - this->m_AirValue) + (*imjacit));
+        (*jsjdit * (movingImageValue - this->m_AirValue) / (this->m_TissueValue - this->m_AirValue) + *imjacit);
       ++imjacit;
       ++jsjdit;
       ++derivit;
@@ -758,7 +758,7 @@ SumSquaredTissueVolumeDifferenceImageToImageMetric<TFixedImage, TMovingImage>::
     {
       for (unsigned int idx = 0; idx < FixedImageDimension; ++idx)
       {
-        (*jsjdit) += inverseSpatialJacobian(diag, idx) * (*jsjit)(idx, diag);
+        *jsjdit += inverseSpatialJacobian(diag, idx) * (*jsjit)(idx, diag);
       }
     }
     ++jsjdit;


### PR DESCRIPTION
Using regular expressions, replacing ` \(\*(\w+)\);` with ` *$1;`, and `([ \(])\(\*(\w+)\)([ \)])` with `$1*$2$3`.