### PR TITLE
STYLE: Drop support ParameterObject::GetDefaultParameterMap("nonrigid")

### DIFF
--- a/Core/Main/GTesting/ParameterObjectGTest.cxx
+++ b/Core/Main/GTesting/ParameterObjectGTest.cxx
@@ -222,3 +222,10 @@ GTEST_TEST(ParameterObject, HasParameterWithoutIndex)
   EXPECT_FALSE(parameterObject.HasParameter("OnlyInMap2"));
   EXPECT_FALSE(parameterObject.HasParameter("NonExistentParameter"));
 }
+
+
+//  Tests that ParameterObject::GetDefaultParameterMap("nonrigid") throws an exception.
+GTEST_TEST(ParameterObject, GetDefaultParameterMapThrowsExceptionOnTransformNameNonrigid)
+{
+  EXPECT_THROW(elx::ParameterObject::GetDefaultParameterMap("nonrigid"), itk::ExceptionObject);
+}

--- a/Core/Main/elxParameterObject.cxx
+++ b/Core/Main/elxParameterObject.cxx
@@ -25,6 +25,7 @@
 #include <fstream>
 #include <iostream>
 #include <cmath>
+#include <iomanip> // For quoted.
 
 namespace elastix
 {
@@ -438,6 +439,14 @@ ParameterObject::GetDefaultParameterMap(const std::string & transformName,
                                         const unsigned int  numberOfResolutions,
                                         const double        finalGridSpacingInPhysicalUnits)
 {
+  if (transformName == "nonrigid")
+  {
+    itkGenericExceptionMacro("The transform name "
+                             << std::quoted(transformName)
+                             << " is no longer supported, after elastix version 5.2.0. It was originally equivalent to "
+                                "\"bspline\" (which is the preferred transform name).");
+  }
+
   // Parameters that depend on size and number of resolutions
   ParameterMapType parameterMap{};
 
@@ -493,7 +502,7 @@ ParameterObject::GetDefaultParameterMap(const std::string & transformName,
     parameterMap["MaximumNumberOfIterations"] = ParameterValueVectorType(1, "256");
     parameterMap["AutomaticScalesEstimation"] = ParameterValueVectorType(1, "true");
   }
-  else if (transformName == "bspline" || transformName == "nonrigid") // <-- nonrigid for backwards compatibility
+  else if (transformName == "bspline")
   {
     parameterMap["Registration"] = ParameterValueVectorType(1, "MultiMetricMultiResolutionRegistration");
     parameterMap["Transform"] = ParameterValueVectorType(1, "BSplineTransform");
@@ -525,8 +534,7 @@ ParameterObject::GetDefaultParameterMap(const std::string & transformName,
   }
 
   // B-spline transform settings
-  if (transformName == "bspline" || transformName == "nonrigid" ||
-      transformName == "groupwise") // <-- nonrigid for backwards compatibility
+  if (transformName == "bspline" || transformName == "groupwise")
   {
     ParameterValueVectorType gridSpacingSchedule{};
     for (double resolution = 0; resolution < numberOfResolutions; ++resolution)


### PR DESCRIPTION
Let users just use the transform name "bspline" (which was already preferred anyway).

Follow-up to commit 5d725fd33d585fe3be68d5619cacc1ee00510bf7, "STYLE: Rename nonrigid default parameter map to the more precise name of bspline", Kasper Marstal, 15 Feb 2016.

----

@mstaring @stefanklein Just for your information! (I think dropping the name "nonrigid" isn't controversial anymore, as Kasper already introduced the preferred name "bspline" more than 9 years ago.)