### PR TITLE
STYLE: Make StopRegistration() non-virtual

### DIFF
--- a/Common/itkMultiResolutionImageRegistrationMethod2.h
+++ b/Common/itkMultiResolutionImageRegistrationMethod2.h
@@ -160,7 +160,7 @@ public:
   using DataObjectPointer = typename DataObject::Pointer;
 
   /** Method to stop the registration. */
-  virtual void
+  void
   StopRegistration();
 
   /** Set/Get the Fixed image. */


### PR DESCRIPTION
Removed the `virtual`keyword from `MultiResolutionImageRegistrationMethod2::StopRegistration()`.

Corresponds with the documentation of `StopMultiMetricRegistration()`, which already says that `StopRegistration` is non-virtual: https://github.com/SuperElastix/elastix/blob/89250c656e6a4caf2fa6b3cd48f3d9c64fed356f/Components/Registrations/MultiMetricMultiResolutionRegistration/itkMultiMetricMultiResolutionImageRegistrationMethod.h#L126

ITK's `MultiResolutionImageRegistrationMethod::StopRegistration()` is also non-virtual: https://github.com/InsightSoftwareConsortium/ITK/blob/v5.4.4/Modules/Registration/Common/include/itkMultiResolutionImageRegistrationMethod.h#L138

Following C++ Core Guidelines, Jul 8, 2025: "Don’t make a function `virtual` without reason", https://isocpp.github.io/CppCoreGuidelines/CppCoreGuidelines#Rh-virtual