### PR TITLE
Make default upsampling factor of GridScheduleComputer fixed (`2.0`)

### DIFF
--- a/Common/GTesting/CMakeLists.txt
+++ b/Common/GTesting/CMakeLists.txt
@@ -12,6 +12,7 @@ add_executable(CommonGTest
   itkAdvancedMeanSquaresImageToImageMetricGTest.cxx
   itkComputeImageExtremaFilterGTest.cxx
   itkCorrespondingPointsEuclideanDistancePointMetricGTest.cxx
+  itkGridScheduleComputerGTest.cxx
   itkImageFileCastWriterGTest.cxx
   itkImageFullSamplerGTest.cxx
   itkImageGridSamplerGTest.cxx

--- a/Common/GTesting/itkGridScheduleComputerGTest.cxx
+++ b/Common/GTesting/itkGridScheduleComputerGTest.cxx
@@ -1,0 +1,51 @@
+/*=========================================================================
+ *
+ *  Copyright UMC Utrecht and contributors
+ *
+ *  Licensed under the Apache License, Version 2.0 (the "License");
+ *  you may not use this file except in compliance with the License.
+ *  You may obtain a copy of the License at
+ *
+ *        http://www.apache.org/licenses/LICENSE-2.0.txt
+ *
+ *  Unless required by applicable law or agreed to in writing, software
+ *  distributed under the License is distributed on an "AS IS" BASIS,
+ *  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *  See the License for the specific language governing permissions and
+ *  limitations under the License.
+ *
+ *=========================================================================*/
+
+// First include the header file to be tested:
+#include "itkGridScheduleComputer.h"
+#include "elxDefaultConstruct.h"
+#include <gtest/gtest.h>
+
+
+// Checks that the default schedule has consecutive powers of two, in reverse order, for example, for 3D and four
+// levels: (GridSpacingSchedule 8 8 8 4 4 4 2 2 2 1 1 1)
+GTEST_TEST(GridScheduleComputer, SetDefaultSchedule)
+{
+  static constexpr auto imageDimension = 3U;
+
+  using GridScheduleComputerType = itk::GridScheduleComputer<double, imageDimension>;
+  elx::DefaultConstruct<GridScheduleComputerType> gridScheduleComputer{};
+
+  // In ElastixModelZoo, "NumberOfResolutions" (= number of levels) always appears below 10, so that should be
+  // sufficient for this test.
+  for (unsigned int numberOfLevels{}; numberOfLevels < 10; ++numberOfLevels)
+  {
+    gridScheduleComputer.SetDefaultSchedule(numberOfLevels);
+    GridScheduleComputerType::VectorGridSpacingFactorType schedule{};
+    gridScheduleComputer.GetSchedule(schedule);
+    EXPECT_EQ(schedule.size(), numberOfLevels);
+
+    for (unsigned int level = 0; level < numberOfLevels; ++level)
+    {
+      for (const double actualScheduleValue : schedule.at(level))
+      {
+        EXPECT_DOUBLE_EQ(actualScheduleValue, std::pow(2.0, numberOfLevels - level - 1));
+      }
+    }
+  }
+}

--- a/Common/Transforms/itkGridScheduleComputer.h
+++ b/Common/Transforms/itkGridScheduleComputer.h
@@ -116,7 +116,7 @@ public:
 
   /** Set a default grid spacing schedule. */
   void
-  SetDefaultSchedule(unsigned int levels, double upsamplingFactor);
+  SetDefaultSchedule(unsigned int levels);
 
   /** Set a grid spacing schedule. */
   virtual void
@@ -179,12 +179,6 @@ private:
   unsigned int  m_BSplineOrder{};
   unsigned int  m_NumberOfLevels{};
   SpacingType   m_FinalGridSpacing{};
-
-  /** Clamp the upsampling factor. */
-  itkSetClampMacro(UpsamplingFactor, float, 1.0, NumericTraits<float>::max());
-
-  /** Declare member variables, needed internally. */
-  float m_UpsamplingFactor{};
 };
 
 } // end namespace itk

--- a/Common/Transforms/itkGridScheduleComputer.h
+++ b/Common/Transforms/itkGridScheduleComputer.h
@@ -115,7 +115,7 @@ public:
   itkGetConstMacro(FinalGridSpacing, SpacingType);
 
   /** Set a default grid spacing schedule. */
-  virtual void
+  void
   SetDefaultSchedule(unsigned int levels, double upsamplingFactor);
 
   /** Set a grid spacing schedule. */

--- a/Common/Transforms/itkGridScheduleComputer.hxx
+++ b/Common/Transforms/itkGridScheduleComputer.hxx
@@ -37,14 +37,13 @@ GridScheduleComputer<TTransformScalarType, VImageDimension>::GridScheduleCompute
 {
   m_BSplineOrder = 3;
   m_InitialTransform = nullptr;
-  m_UpsamplingFactor = 2.0;
 
   m_ImageOrigin.Fill(0.0);
   m_ImageSpacing.Fill(1.0);
   m_ImageDirection.Fill(0.0);
   m_FinalGridSpacing.Fill(0.0);
 
-  this->SetDefaultSchedule(3, 2.0);
+  this->SetDefaultSchedule(3);
 
 } // end Constructor()
 
@@ -55,24 +54,24 @@ GridScheduleComputer<TTransformScalarType, VImageDimension>::GridScheduleCompute
 
 template <typename TTransformScalarType, unsigned int VImageDimension>
 void
-GridScheduleComputer<TTransformScalarType, VImageDimension>::SetDefaultSchedule(unsigned int levels,
-                                                                                double       upsamplingFactor)
+GridScheduleComputer<TTransformScalarType, VImageDimension>::SetDefaultSchedule(unsigned int levels)
 {
   /** Set member variables. */
   m_NumberOfLevels = levels;
-  this->SetUpsamplingFactor(upsamplingFactor);
 
   /** Initialize the schedule. */
   auto factors = MakeFilled<GridSpacingFactorType>(1.0);
   m_GridSpacingFactors.clear();
   m_GridSpacingFactors.resize(levels, factors);
 
+  static constexpr float upsamplingFactor{ 2.0 };
+
   /** Setup a default schedule. */
-  float factor = m_UpsamplingFactor;
+  float factor = upsamplingFactor;
   for (int i = levels - 2; i > -1; --i)
   {
     m_GridSpacingFactors[i] *= factor;
-    factor *= m_UpsamplingFactor;
+    factor *= upsamplingFactor;
   }
 
 } // end SetDefaultSchedule()
@@ -388,8 +387,6 @@ GridScheduleComputer<TTransformScalarType, VImageDimension>::PrintSelf(std::ostr
   {
     os << indent.GetNextIndent() << m_GridRegions[i] << std::endl;
   }
-
-  os << indent << "UpsamplingFactor: " << m_UpsamplingFactor << std::endl;
 
 } // end PrintSelf()
 

--- a/Components/Transforms/AdvancedBSplineTransform/elxAdvancedBSplineTransform.hxx
+++ b/Components/Transforms/AdvancedBSplineTransform/elxAdvancedBSplineTransform.hxx
@@ -241,7 +241,7 @@ AdvancedBSplineTransform<TElastix>::PreComputeGridInformation()
   }
 
   /** Set up a default grid spacing schedule. */
-  this->m_GridScheduleComputer->SetDefaultSchedule(nrOfResolutions, 2.0);
+  this->m_GridScheduleComputer->SetDefaultSchedule(nrOfResolutions);
   GridScheduleType gridSchedule;
   this->m_GridScheduleComputer->GetSchedule(gridSchedule);
 

--- a/Components/Transforms/BSplineStackTransform/elxBSplineStackTransform.hxx
+++ b/Components/Transforms/BSplineStackTransform/elxBSplineStackTransform.hxx
@@ -283,7 +283,7 @@ BSplineStackTransform<TElastix>::PreComputeGridInformation()
   }
 
   /** Set up a default grid spacing schedule. */
-  m_GridScheduleComputer->SetDefaultSchedule(nrOfResolutions, 2.0);
+  m_GridScheduleComputer->SetDefaultSchedule(nrOfResolutions);
   GridScheduleType gridSchedule;
   m_GridScheduleComputer->GetSchedule(gridSchedule);
 

--- a/Components/Transforms/MultiBSplineTransformWithNormal/elxMultiBSplineTransformWithNormal.hxx
+++ b/Components/Transforms/MultiBSplineTransformWithNormal/elxMultiBSplineTransformWithNormal.hxx
@@ -267,7 +267,7 @@ MultiBSplineTransformWithNormal<TElastix>::PreComputeGridInformation()
   }
 
   /** Set up a default grid spacing schedule. */
-  this->m_GridScheduleComputer->SetDefaultSchedule(nrOfResolutions, 2.0);
+  this->m_GridScheduleComputer->SetDefaultSchedule(nrOfResolutions);
   GridScheduleType gridSchedule;
   this->m_GridScheduleComputer->GetSchedule(gridSchedule);
 

--- a/Components/Transforms/RecursiveBSplineTransform/elxRecursiveBSplineTransform.hxx
+++ b/Components/Transforms/RecursiveBSplineTransform/elxRecursiveBSplineTransform.hxx
@@ -242,7 +242,7 @@ RecursiveBSplineTransform<TElastix>::PreComputeGridInformation()
   }
 
   /** Set up a default grid spacing schedule. */
-  this->m_GridScheduleComputer->SetDefaultSchedule(nrOfResolutions, 2.0);
+  this->m_GridScheduleComputer->SetDefaultSchedule(nrOfResolutions);
   GridScheduleType gridSchedule;
   this->m_GridScheduleComputer->GetSchedule(gridSchedule);
 


### PR DESCRIPTION
`GridScheduleComputer::SetDefaultSchedule` always had an upsampling factor of `2.0`, so it is not necessary to have it as a parameter or a data member (`m_UpsamplingFactor`) anymore.