### PR TITLE
BUG: Initialize GridScheduleComputer ImageDirection as identity matrix

### DIFF
--- a/Common/Transforms/itkGridScheduleComputer.hxx
+++ b/Common/Transforms/itkGridScheduleComputer.hxx
@@ -40,7 +40,7 @@ GridScheduleComputer<TTransformScalarType, VImageDimension>::GridScheduleCompute
 
   m_ImageOrigin.Fill(0.0);
   m_ImageSpacing.Fill(1.0);
-  m_ImageDirection.Fill(0.0);
+  m_ImageDirection.SetIdentity();
   m_FinalGridSpacing.Fill(0.0);
 
   this->SetDefaultSchedule(3);


### PR DESCRIPTION
`m_ImageDirection` was originally just zero-filled, in the default-constructor of `GridScheduleComputer`. By commit 18e1e8b0d16092fc353b14ccf64195fdcd9b0d70, Coert Metz, 28-06-2013. However `itk::Image` does not allow using a zero-filled direction. For example, the following code would cause an exception:

    ImageType::DirectionType direction;
    direction.Fill(0.0);
    image->SetDirection(direction);

The exception would says something like:

> itkImageBase.hxx:139: in 'void itk::ImageBase::SetDirection(const itk::Matrix &)':
> ITK ERROR: Image: Bad direction, determinant is 0. Refusing to change direction from 1 0 0 1 to 0 0 0 0

Obviously, `itk::Image` _does_ allow using an identity matrix instead.