### PR TITLE
ENH: Adjust MultiResolutionImageRegistrationMethod2 to support IMPACT

### DIFF
--- a/Common/itkMultiResolutionImageRegistrationMethod2.hxx
+++ b/Common/itkMultiResolutionImageRegistrationMethod2.hxx
@@ -105,6 +105,10 @@ MultiResolutionImageRegistrationMethod2<TFixedImage, TMovingImage>::Initialize()
     itkExceptionMacro("Interpolator is not present");
   }
 
+  // The transform parameters must be set before initializing the metric, in order to support the IMPACT metric in
+  // "Static" mode. The IMPACT metric is written by Valentin Boussot, pull request #1311.
+  m_Transform->SetParameters(m_InitialTransformParametersOfNextLevel);
+
   // Setup the metric
   m_Metric->SetMovingImage(m_MovingImagePyramid->GetOutput(m_CurrentLevel));
   m_Metric->SetFixedImage(m_FixedImagePyramid->GetOutput(m_CurrentLevel));

--- a/Components/Registrations/MultiMetricMultiResolutionRegistration/itkMultiMetricMultiResolutionImageRegistrationMethod.hxx
+++ b/Components/Registrations/MultiMetricMultiResolutionRegistration/itkMultiMetricMultiResolutionImageRegistrationMethod.hxx
@@ -21,6 +21,7 @@
 #include "itkMultiMetricMultiResolutionImageRegistrationMethod.h"
 
 #include "itkContinuousIndex.h"
+#include "itkDeref.h"
 #include <vnl/vnl_math.h>
 
 /** Macro that implements the set methods. */
@@ -151,8 +152,14 @@ MultiMetricMultiResolutionImageRegistrationMethod<TFixedImage, TMovingImage>::In
 {
   this->CheckOnInitialize();
 
+  TransformType & transform = Deref(this->GetModifiableTransform());
+
+  // The transform parameters must be set before initializing the metric, in order to support the IMPACT metric in
+  // "Static" mode. The IMPACT metric is written by Valentin Boussot, pull request #1311.
+  transform.SetParameters(this->GetInitialTransformParametersOfNextLevel());
+
   /** Setup the metric. */
-  this->GetCombinationMetric()->SetTransform(this->GetModifiableTransform());
+  this->GetCombinationMetric()->SetTransform(&transform);
 
   this->GetCombinationMetric()->SetFixedImage(this->GetFixedImagePyramid()->GetOutput(this->GetCurrentLevel()));
   for (unsigned int i = 0; i < this->GetNumberOfFixedImagePyramids(); ++i)


### PR DESCRIPTION
For the IMPACT metric (Valentin Boussot (@vboussot) pull request #1311), it appears necessary to set the transform parameters in `MultiResolutionImageRegistrationMethod2::Initialize()`. Doing so would address warnings, saying "B-spline coefficients have not been set". As was concluded from an elastix brainstorm/sprint with Marius Staring (@mstaring) and Stefan Klein (@stefanklein).