### PR TITLE
STYLE: Remove reserve calls from MultiResolutionImageRegistrationMethods

### DIFF
--- a/Common/itkMultiResolutionImageRegistrationMethod2.hxx
+++ b/Common/itkMultiResolutionImageRegistrationMethod2.hxx
@@ -209,7 +209,6 @@ MultiResolutionImageRegistrationMethod2<TFixedImage, TMovingImage>::PreparePyram
     inputEnd[dim] += (inputSize[dim] - 1);
   }
 
-  m_FixedImageRegionPyramid.reserve(m_NumberOfLevels);
   m_FixedImageRegionPyramid.resize(m_NumberOfLevels);
 
   // Compute the FixedImageRegion corresponding to each level of the

--- a/Components/Registrations/MultiMetricMultiResolutionRegistration/itkMultiMetricMultiResolutionImageRegistrationMethod.hxx
+++ b/Components/Registrations/MultiMetricMultiResolutionRegistration/itkMultiMetricMultiResolutionImageRegistrationMethod.hxx
@@ -252,7 +252,6 @@ MultiMetricMultiResolutionImageRegistrationMethod<TFixedImage, TMovingImage>::Pr
         inputEnd[dim] += (inputSize[dim] - 1);
       }
 
-      m_FixedImageRegionPyramids[i].reserve(this->GetNumberOfLevels());
       m_FixedImageRegionPyramids[i].resize(this->GetNumberOfLevels());
 
       // Compute the FixedImageRegion corresponding to each level of the

--- a/Components/Registrations/MultiResolutionRegistrationWithFeatures/itkMultiInputMultiResolutionImageRegistrationMethodBase.hxx
+++ b/Components/Registrations/MultiResolutionRegistrationWithFeatures/itkMultiInputMultiResolutionImageRegistrationMethodBase.hxx
@@ -373,7 +373,6 @@ MultiInputMultiResolutionImageRegistrationMethodBase<TFixedImage, TMovingImage>:
         inputEnd[dim] += (inputSize[dim] - 1);
       }
 
-      this->m_FixedImageRegionPyramids[i].reserve(this->GetNumberOfLevels());
       this->m_FixedImageRegionPyramids[i].resize(this->GetNumberOfLevels());
 
       // Compute the FixedImageRegion corresponding to each level of the


### PR DESCRIPTION
Following ITK pull request https://github.com/InsightSoftwareConsortium/ITK/pull/5595 commit https://github.com/InsightSoftwareConsortium/ITK/commit/93ff353cad413553de131af85d2018976b7f0c3b "STYLE: Remove `reserve` call from MultiResolutionImageRegistrationMethod"