### PR TITLE
COMP: Do `cmake_minimum_required(VERSION 3.16.3)` in Dashboard files

### DIFF
--- a/Testing/Dashboard/elxCommonCDash.cmake
+++ b/Testing/Dashboard/elxCommonCDash.cmake
@@ -94,7 +94,7 @@
 #
 #==========================================================================*/
 
-cmake_minimum_required(VERSION 2.8 FATAL_ERROR)
+cmake_minimum_required(VERSION 3.16.3)
 
 set(dashboard_user_home "$ENV{HOME}")
 

--- a/Testing/Dashboard/elxDashboardCommon.cmake
+++ b/Testing/Dashboard/elxDashboardCommon.cmake
@@ -37,7 +37,7 @@
 # Note: this script is based on the vxl_common.cmake script.
 #
 
-cmake_minimum_required(VERSION 3.10.2)
+cmake_minimum_required(VERSION 3.16.3)
 
 set(CTEST_PROJECT_NAME elastix)
 


### PR DESCRIPTION
`cmake_minimum_required(VERSION 2.8 FATAL_ERROR)` appears to cause errors when trying to upgrade to CMake 4 (specifically, version 4.20), saying:

> elxCommonCDash.cmake:97 (cmake_minimum_required):
>  Compatibility with CMake < 3.5 has been removed from CMake.

So now, just use the same `cmake_minimum_required` in "Testing/Dashboard" as in the root CMakeLists of elastix.