### PR TITLE
COMP: Migrate CI from macos-13 to macos-14-large

### DIFF
--- a/.github/workflows/ElastixGitHubActions.yml
+++ b/.github/workflows/ElastixGitHubActions.yml
@@ -13,7 +13,7 @@ jobs:
     strategy:
       max-parallel: 3
       matrix:
-        os: [ubuntu-22.04, windows-2022, macos-13]
+        os: [ubuntu-22.04, windows-2022, macos-14-large]
         include:
           - os: ubuntu-22.04
             c-compiler: "gcc"
@@ -29,7 +29,7 @@ jobs:
             cmake-build-type: "Release"
             ANNLib: "ANNlib-5.2.dll"
             vcvars64: "C:/Program Files/Microsoft Visual Studio/2022/Enterprise/VC/Auxiliary/Build/vcvars64.bat"
-          - os: macos-13
+          - os: macos-14-large
             c-compiler: "clang"
             cxx-compiler: "clang++"
             itk-git-tag: "v5.4.1"

--- a/Testing/CI/Azure/ci.yml
+++ b/Testing/CI/Azure/ci.yml
@@ -135,7 +135,7 @@ jobs:
 - job: macOS
   timeoutInMinutes: 0
   pool:
-    vmImage: 'macOS-13'
+    vmImage: 'macOS-14-large'
   strategy:
     matrix:
       ITKv5:


### PR DESCRIPTION
Aims to address:
"This is a scheduled macos-13 brownout. The macOS-13 based runner images are being deprecated."

Following
- issue https://github.com/actions/runner-images/issues/13046 "[macOS] The macOS 13 Ventura based runner images will begin deprecation on September 22nd and will be fully unsupported by December 4th for GitHub and ADO"
- https://github.blog/changelog/2025-09-19-github-actions-macos-13-runner-image-is-closing-down/#what-you-need-to-do "GitHub Actions: macOS 13 runner image is closing down"