### PR TITLE
ENH: MultiResolutionGaussianSmoothingPyramidImageFilter support 3D slice

### DIFF
--- a/Common/itkMultiResolutionGaussianSmoothingPyramidImageFilter.h
+++ b/Common/itkMultiResolutionGaussianSmoothingPyramidImageFilter.h
@@ -107,6 +107,10 @@ namespace itk
  * To generate each output image, Gaussian smoothing is first performed
  * using a series of RecursiveGaussianImageFilter with standard deviation
  * (shrink factor / 2)*imagespacing.
+ *
+ * When either a shrink factor is set to zero for a particular dimension, or when the dimension itself is `1`, or both,
+ * no smoothing is performed along that dimension.
+ *
  * The smoothed images are NOT downsampled, in contrast to the superclass's
  * behaviour.
  *

--- a/Common/itkMultiResolutionGaussianSmoothingPyramidImageFilter.hxx
+++ b/Common/itkMultiResolutionGaussianSmoothingPyramidImageFilter.hxx
@@ -127,6 +127,8 @@ MultiResolutionGaussianSmoothingPyramidImageFilter<TInputImage, TOutputImage>::G
   double       stdev[ImageDimension];
   SpacingType  spacing = inputPtr->GetSpacing();
 
+  const itk::Size<ImageDimension> imageSize = inputPtr->GetRequestedRegion().GetSize();
+
   for (ilevel = 0; ilevel < this->m_NumberOfLevels; ++ilevel)
   {
 
@@ -159,7 +161,7 @@ MultiResolutionGaussianSmoothingPyramidImageFilter<TInputImage, TOutputImage>::G
       smootherArray[idim]->Modified();
 
       // Update smoother pointer array for this dimension
-      if (factors[idim] == 0.0)
+      if (factors[idim] == 0.0 || imageSize[idim] == 1)
       {
         // Bypass the filter for this dimension
         if (idim > 0)


### PR DESCRIPTION
When a 3D image has a thickness of 1 (pixel) along one of the dimensions (`imageSize[i] == 1`), just avoided Gaussian smoothing along that dimension.

This commit prevents exceptions that said, "ITK ERROR: RecursiveGaussianImageFilter(...): The number of pixels along direction 2 is less than 4...".

Related to Christian Tischer - [Elastix questions related to 2D => 3D registration](https://forum.image.sc/t/elastix-questions-related-to-2d-3d-registration/117821) 