### PR TITLE
ENH: Do not append elastix version numbers to filenames of helper libs

### DIFF
--- a/.github/workflows/ElastixGitHubActions.yml
+++ b/.github/workflows/ElastixGitHubActions.yml
@@ -22,8 +22,8 @@ jobs:
               - libtorch/libtorch/lib/libgomp-98b21ff3.so.1
               - libtorch/libtorch/lib/libtorch.so
               - libtorch/libtorch/lib/libtorch_cpu.so
-              - elastix-build/bin/libANNlib-5.2.so
-              - elastix-build/bin/libANNlib-5.2.so.1
+              - elastix-build/bin/libelxANNlib.so
+              - elastix-build/bin/libelxANNlib.so.1
           - os: windows-2022
             c-compiler: "cl.exe"
             cxx-compiler: "cl.exe"
@@ -35,7 +35,7 @@ jobs:
               - libtorch/libtorch/lib/c10.dll
               - libtorch/libtorch/lib/torch_cpu.dll
               - libtorch/libtorch/lib/torch.dll
-              - elastix-build/bin/ANNlib-5.2.dll
+              - elastix-build/bin/elxANNlib.dll
             vcvars64: "C:/Program Files/Microsoft Visual Studio/2022/Enterprise/VC/Auxiliary/Build/vcvars64.bat"
           - os: macos-14
             c-compiler: "clang"
@@ -48,8 +48,8 @@ jobs:
               - libtorch/libtorch/lib/libtorch.dylib
               - libtorch/libtorch/lib/libc10.dylib
               - libtorch/libtorch/lib/libtorch_cpu.dylib
-              - elastix-build/bin/libANNlib-5.2.1.dylib
-              - elastix-build/bin/libANNlib-5.2.dylib
+              - elastix-build/bin/libelxANNlib.1.dylib
+              - elastix-build/bin/libelxANNlib.dylib
     steps:
       - name: Clone elastix
         uses: actions/checkout@v3

--- a/.github/workflows/ElastixPublish.yml
+++ b/.github/workflows/ElastixPublish.yml
@@ -21,8 +21,8 @@ jobs:
             cxx-compiler: "g++"
             cmake-build-type: "Release"
             libs:
-              - elastix-build/bin/libANNlib-5.2.so
-              - elastix-build/bin/libANNlib-5.2.so.1
+              - elastix-build/bin/libelxANNlib.so
+              - elastix-build/bin/libelxANNlib.so.1
           - cuda-version: cu126
             os: ubuntu-22.04
             cuda_toolkit_version: '12.6.1'
@@ -32,8 +32,8 @@ jobs:
             cxx-compiler: "g++"
             cmake-build-type: "Release"
             libs:
-              - elastix-build/bin/libANNlib-5.2.so
-              - elastix-build/bin/libANNlib-5.2.so.1
+              - elastix-build/bin/libelxANNlib.so
+              - elastix-build/bin/libelxANNlib.so.1
           - cuda-version: cu128
             os: ubuntu-22.04
             cuda_toolkit_version: '12.8.1'
@@ -43,8 +43,8 @@ jobs:
             cxx-compiler: "g++"
             cmake-build-type: "Release"
             libs:
-              - elastix-build/bin/libANNlib-5.2.so
-              - elastix-build/bin/libANNlib-5.2.so.1
+              - elastix-build/bin/libelxANNlib.so
+              - elastix-build/bin/libelxANNlib.so.1
     steps:
       - name: Clone elastix
         uses: actions/checkout@v3

--- a/CMake/elastixExportTarget.cmake
+++ b/CMake/elastixExportTarget.cmake
@@ -20,8 +20,13 @@ function(elastix_export_target tgt)
       set_property(TARGET ${tgt} PROPERTY
         OUTPUT_NAME transformix-${ELASTIX_VERSION_MAJOR}.${ELASTIX_VERSION_MINOR})
     else()
-      set_property(TARGET ${tgt} PROPERTY
-        OUTPUT_NAME ${tgt}-${ELASTIX_VERSION_MAJOR}.${ELASTIX_VERSION_MINOR})
+      if("${tgt}" MATCHES "elx.*")
+        set_property(TARGET ${tgt} PROPERTY
+          OUTPUT_NAME ${tgt})
+      else()
+        set_property(TARGET ${tgt} PROPERTY
+          OUTPUT_NAME elx${tgt})
+      endif()
     endif()
 
     if(type STREQUAL "STATIC_LIBRARY")


### PR DESCRIPTION
Instead, just added an "elx" prefix to those file names.

Eases maintaining elastix releases, as it takes away the need to rename the ANNlib files with each release.

The "elx" prefix is added, just to prevent possible naming conflicts with other software.
