### PR TITLE
ENH: Use the latest ITK patch release (v5.4.5) on GitHub Actions

### DIFF
--- a/.github/workflows/ElastixGitHubActions.yml
+++ b/.github/workflows/ElastixGitHubActions.yml
@@ -15,7 +15,7 @@ jobs:
             cxx-compiler: "g++"
             libtorch-cpu-url: "https://download.pytorch.org/libtorch/cpu/libtorch-shared-with-deps-2.8.0%2Bcpu.zip"
             cuda-version: "cpu"
-            itk-git-tag: "v5.4.1"
+            itk-git-tag: "v5.4.5"
             cmake-build-type: "Release"
             libs:
               - libtorch/libtorch/lib/libc10.so
@@ -29,7 +29,7 @@ jobs:
             cxx-compiler: "cl.exe"
             libtorch-cpu-url: "https://download.pytorch.org/libtorch/cpu/libtorch-win-shared-with-deps-2.8.0%2Bcpu.zip"
             cuda-version: "cpu"
-            itk-git-tag: "v5.4.1"
+            itk-git-tag: "v5.4.5"
             cmake-build-type: "Release"
             libs:
               - libtorch/libtorch/lib/c10.dll
@@ -42,7 +42,7 @@ jobs:
             cxx-compiler: "clang++"
             libtorch-cpu-url: "https://download.pytorch.org/libtorch/cpu/libtorch-macos-arm64-2.8.0.zip"
             cuda-version: "cpu"
-            itk-git-tag: "v5.4.1"
+            itk-git-tag: "v5.4.5"
             cmake-build-type: "Release"
             libs:
               - libtorch/libtorch/lib/libtorch.dylib

--- a/.github/workflows/ElastixPublish.yml
+++ b/.github/workflows/ElastixPublish.yml
@@ -16,7 +16,7 @@ jobs:
             os: ubuntu-22.04
             cuda_toolkit_version: '11.8.0'
             libtorch-cuda-url: https://download.pytorch.org/libtorch/cu118/libtorch-cxx11-abi-shared-with-deps-2.7.0%2Bcu118.zip
-            itk-git-tag: "v5.4.1"
+            itk-git-tag: "v5.4.5"
             c-compiler: "gcc"
             cxx-compiler: "g++"
             cmake-build-type: "Release"
@@ -27,7 +27,7 @@ jobs:
             os: ubuntu-22.04
             cuda_toolkit_version: '12.6.1'
             libtorch-cuda-url: https://download.pytorch.org/libtorch/cu126/libtorch-cxx11-abi-shared-with-deps-2.7.0%2Bcu126.zip
-            itk-git-tag: "v5.4.1"
+            itk-git-tag: "v5.4.5"
             c-compiler: "gcc"
             cxx-compiler: "g++"
             cmake-build-type: "Release"
@@ -38,7 +38,7 @@ jobs:
             os: ubuntu-22.04
             cuda_toolkit_version: '12.8.1'
             libtorch-cuda-url: https://download.pytorch.org/libtorch/cu128/libtorch-cxx11-abi-shared-with-deps-2.7.0%2Bcu128.zip
-            itk-git-tag: "v5.4.1"
+            itk-git-tag: "v5.4.5"
             c-compiler: "gcc"
             cxx-compiler: "g++"
             cmake-build-type: "Release"


### PR DESCRIPTION
Preparing a new elastix release.

It appears better to get the latest bug fixes from ITK 5.4, before the release.
Details: https://github.com/InsightSoftwareConsortium/ITK/compare/v5.4.1...v5.4.5

----

@vboussot I'm sorry this may again cause a merge confict of your PRs (specificaly, #1394 and #1396). It just replaces "v5.4.1" with "v5.4.5"in two yml files in ".github/workflows"