### PR TITLE
ENH: use utf-8 via manifest on Windows

### DIFF
--- a/Core/CMakeLists.txt
+++ b/Core/CMakeLists.txt
@@ -201,6 +201,9 @@ if(ELASTIX_BUILD_EXECUTABLE)
     target_compile_definitions(elastix_exe PUBLIC ELX_NO_FILESYSTEM_ACCESS)
   endif()
   target_link_libraries(elastix_exe ${ELASTIX_TARGET_LINK_LIBRARIES})
+  if (MSVC)
+    target_sources(elastix_exe PRIVATE ${CMAKE_CURRENT_SOURCE_DIR}/utf8.manifest)
+  endif()
 endif()
 
 # The library type (STATIC or SHARED) is determined by the parameter
@@ -246,6 +249,9 @@ if(ELASTIX_BUILD_EXECUTABLE)
     target_compile_definitions(transformix_exe PUBLIC ELX_NO_FILESYSTEM_ACCESS)
   endif()
   target_link_libraries(transformix_exe ${ELASTIX_TARGET_LINK_LIBRARIES})
+  if (MSVC)
+    target_sources(transformix_exe PRIVATE ${CMAKE_CURRENT_SOURCE_DIR}/utf8.manifest)
+  endif()
 endif()
 
 # The library type (STATIC or SHARED) is determined by the parameter

--- a/Core/Main/elastix.cxx
+++ b/Core/Main/elastix.cxx
@@ -90,6 +90,10 @@ main(int argc, char ** argv)
     elastix::BaseComponent::InitializeElastixExecutable();
     assert(!elastix::BaseComponent::IsElastixLibrary());
 
+#ifdef _MSC_VER
+    SetConsoleOutputCP(CP_UTF8);
+#endif
+
     /** Check if "--help" or "--version" was asked for. */
     if (argc == 1)
     {

--- a/Core/Main/transformix.cxx
+++ b/Core/Main/transformix.cxx
@@ -85,6 +85,10 @@ main(int argc, char ** argv)
     elastix::BaseComponent::InitializeElastixExecutable();
     assert(!elastix::BaseComponent::IsElastixLibrary());
 
+#ifdef _MSC_VER
+    SetConsoleOutputCP(CP_UTF8);
+#endif
+
     /** Check if "-help" or "--version" was asked for.*/
     if (argc == 1)
     {

--- a/Core/utf8.manifest
+++ b/Core/utf8.manifest
@@ -1,0 +1,8 @@
+<?xml version="1.0" encoding="UTF-8" standalone="yes"?>
+<assembly manifestVersion="1.0" xmlns="urn:schemas-microsoft-com:asm.v1">
+  <application>
+    <windowsSettings>
+      <activeCodePage xmlns="http://schemas.microsoft.com/SMI/2019/WindowsSettings">UTF-8</activeCodePage>
+    </windowsSettings>
+  </application>
+</assembly>

--- a/Testing/CMakeLists.txt
+++ b/Testing/CMakeLists.txt
@@ -451,6 +451,34 @@ if(ELASTIX_BUILD_EXECUTABLE)
     -m "${TestDataDir}/2D_2x2_square_object_at_(2,1).mhd"
     -p "${TestDataDir}/parameters.2D.NC.translation.ASGD.txt"
     -out "${TestOutputDir}/OutputDirectoryPathContainingSpacesTest/path with spaces/name with spaces")
+
+  set(SPECIALCHARACTER_OUTPUTDIR "${TestOutputDir}/OutputDirectoryPathWithSpecialCharacters/speciäl/👌")
+  file(MAKE_DIRECTORY "${SPECIALCHARACTER_OUTPUTDIR}")
+  add_test(NAME SpecialCharactersOutputDirectoryPath
+    COMMAND ${EXECUTABLE_OUTPUT_PATH}/elastix
+    -f "${TestDataDir}/2D_2x2_square_object_at_(1,3).mhd"
+    -m "${TestDataDir}/2D_2x2_square_object_at_(2,1).mhd"
+    -p "${TestDataDir}/parameters.2D.NC.translation.ASGD.txt"
+    -out "${SPECIALCHARACTER_OUTPUTDIR}")
+
+  set(SPECIALCHARPARAMFILE_OUTPUTDIR "${TestOutputDir}/OutputDirectorySpecialCharParamFile")
+  file(MAKE_DIRECTORY "${SPECIALCHARPARAMFILE_OUTPUTDIR}")
+  add_test(NAME SpecialCharactersParameterFile
+    COMMAND ${EXECUTABLE_OUTPUT_PATH}/elastix
+    -f "${TestDataDir}/2D_2x2_square_object_at_(1,3).mhd"
+    -m "${TestDataDir}/2D_2x2_square_object_at_(2,1).mhd"
+    -p "${TestDataDir}/pärameters.2D.NC.translation.ASGD👍.txt"
+    -out "${SPECIALCHARPARAMFILE_OUTPUTDIR}")
+
+  set(SPECIALCHARINITIALTRANSFORM_OUTPUTDIR "${TestOutputDir}/OutputDirectorySpecialCharInitialTransform")
+  file(MAKE_DIRECTORY "${SPECIALCHARINITIALTRANSFORM_OUTPUTDIR}")
+  add_test(NAME SpecialCharactersInitialTransform
+    COMMAND ${EXECUTABLE_OUTPUT_PATH}/elastix
+    -f "${TestDataDir}/2D_2x2_square_object_at_(1,3).mhd"
+    -m "${TestDataDir}/2D_2x2_square_object_at_(2,1).mhd"
+    -p "${TestDataDir}/parameters.2D.NC.translation.ASGD.txt"
+    -t0 "${TestDataDir}/transförmparameters.2D.NC.txt"
+    -out "${SPECIALCHARINITIALTRANSFORM_OUTPUTDIR}")
 endif()
 
 # Add a test for inverting an affine transform

--- a/Testing/Data/pärameters.2D.NC.translation.ASGD👍.txt
+++ b/Testing/Data/pärameters.2D.NC.translation.ASGD👍.txt
@@ -1,0 +1,14 @@
+// This parameter file is used to register the images
+// 2D_2x2_square_object_at_(1,3) and 2D_2x2_square_object_at_(1,3):
+// elastix -p parameters.2D.NC.translation.ASGD.txt -f 2D_2x2_square_object_at_(1,3).mhd -m 2D_2x2_square_object_at_(1,3).mhd -out out
+
+(FixedInternalImagePixelType "float")
+(FixedImageDimension 2)
+(MovingInternalImagePixelType "float")
+(MovingImageDimension 2)
+
+(Metric "AdvancedNormalizedCorrelation")
+(Optimizer "AdaptiveStochasticGradientDescent")
+(Transform "TranslationTransform")
+(MaximumNumberOfIterations 2)
+(ImageSampler "Full")

--- a/Testing/Data/transförmparameters.2D.NC.txt
+++ b/Testing/Data/transförmparameters.2D.NC.txt
@@ -1,0 +1,3 @@
+(Transform "TranslationTransform")
+(NumberOfParameters 2)
+(TransformParameters 0.0 0.0)


### PR DESCRIPTION
Elastix was not able to correctly handle special characters in some folder/file name parameter input on Windows; Elastix would interpret those names incorrectly, resulting in errors.

Test cases:

- Failing (1): With parameter `-out C:\tmp\elöx\result-transform`:
```
ERROR: the output directory "C:\tmp\el÷x\result-transform\" does not exist.
You are responsible for creating it.
```
(The folder `C:\tmp\elöx\result-transform` did exist before the call)

- Failing (2): With parameter `-t0 C:\tmp\elx\input\initialTransförmParameter.txt`:
```
itk::ExceptionObject (000000CF80DBF190)
Location: "unknown"
File: C:\Source\elastix\src\Core\ComponentBaseClasses\elxTransformBase.hxx
Line: 202
Description: ITK ERROR: SimilarityTransformElastix(000001D8B0FBAAD8): ERROR: the file C:\tmp\elx\input\initialTransf÷rmParameter.txt does not exist!
Errors occurred!
```
(the file `C:\tmp\elx\input\initialTransförmParameter.txt` did exist before the call)

- Working (tested with https://github.com/SuperElastix/elastix/commit/796175c7538b0008d477813613320ae4d6ad7ec6) - special characters already correctly interpreted previously:
    - in the moving/fixed volume file name (e.g. `-m C:\tmp\elx\input\möving.mha` / `-f C:\tmp\elx\input\fäxed.mha`)
    - The content of the file given via `-t0` parameter  is already read as UTF-8, and a .h5 file referenced from within that file (`TransformFileName`) is already correctly loaded when containing special characters

This PR fixes the 2 failing test cases specified above. It adds an application manifest to switch the executable's locale to utf-8 (available since [Windows 10 1903](https://learn.microsoft.com/de-de/windows/apps/design/globalizing/use-utf8-code-page), so for every still supported Windows version); this is same as e.g. [applied in Slicer](https://discourse.slicer.org/t/slicer-switches-to-utf-8-everywhere/10374) . Also the console output is switched to utf-8.

**Note:** A similar workaround (but setting locale to utf-8 systemwide instead of for the application alone) was already proposed [in this issue way back in 2021](https://github.com/SuperElastix/elastix/issues/201#issuecomment-846560474) for fixing special character issues; the way this PR handles it does not require any action by the user and should just enable special characters working fine on any system >= 1903.
