### PR TITLE
BUG: Fix const-correctness of `elx::ParameterObject::GetParameter`

### DIFF
--- a/Core/Main/elxParameterObject.cxx
+++ b/Core/Main/elxParameterObject.cxx
@@ -164,9 +164,11 @@ ParameterObject::SetParameter(const ParameterKeyType & key, const ParameterValue
  */
 
 const ParameterObject::ParameterValueVectorType &
-ParameterObject::GetParameter(const unsigned int index, const ParameterKeyType & key)
+ParameterObject::GetParameter(const unsigned int index, const ParameterKeyType & key) const
 {
-  return m_ParameterMaps[index][key];
+  const auto & parameterMap = m_ParameterMaps[index];
+  const auto   found = parameterMap.find(key);
+  return (found == parameterMap.cend()) ? m_EmptyValueVector : found->second;
 }
 
 

--- a/Core/Main/elxParameterObject.h
+++ b/Core/Main/elxParameterObject.h
@@ -96,7 +96,7 @@ public:
   void
   SetParameter(const ParameterKeyType & key, const ParameterValueVectorType & value);
   const ParameterValueVectorType &
-  GetParameter(const unsigned int index, const ParameterKeyType & key);
+  GetParameter(const unsigned int index, const ParameterKeyType & key) const;
   bool
   HasParameter(const unsigned int index, const ParameterKeyType & key) const;
   bool
@@ -156,6 +156,9 @@ protected:
 
 private:
   ParameterMapVectorType m_ParameterMaps;
+
+  // Dummy empty return value returned when the key passed to GetParameter is not there.
+  const ParameterValueVectorType m_EmptyValueVector{};
 };
 
 } // namespace elastix


### PR DESCRIPTION
Let `parameterObject->GetParameter(index, key)` return an empty vector of values when the specified key is not there, without modifying the specified parameter map.

- Fixes https://github.com/SuperElastix/elastix/issues/1398

----

@mstaring @stefanklein @thewtex `parameterObject->GetParameter(index, key)` silently returns an empty vector of values when the key does not exist. (It already did so with commit 0ce6c24a2b74c0132f1a53848321f1c7a92162ea, June 2018, when the function was introduced.) Do we want to keep it like that?

We could instead let it throw an exception, in that case. It would prevent users from having typo's in their key names. But that might _possibly_ break some legacy user code 🤷 