### PR TITLE
ENH: Replace ImpactWriteFeatureMaps with ImpactFeatureMapOutputDirectory and fix publish-elastix workflow bug

### DIFF
--- a/.github/workflows/publish-elastix.yml
+++ b/.github/workflows/publish-elastix.yml
@@ -139,9 +139,9 @@ jobs:
         shell: cmd
         run: |
           cd elastix-build
-          cmake -DCMAKE_C_COMPILER="${{ inputs.c-compiler }}" ^
-              -DCMAKE_CXX_COMPILER="${{ inputs.cxx-compiler }}" ^
-              -DCMAKE_BUILD_TYPE="${{ inputs.cmake-build-type }}" ^
+          cmake -DCMAKE_C_COMPILER="${{ matrix.c-compiler }}" ^
+              -DCMAKE_CXX_COMPILER="${{ matrix.cxx-compiler }}" ^
+              -DCMAKE_BUILD_TYPE="${{ matrix.cmake-build-type }}" ^
               -DITK_DIR=../ITK-build ^
               -DCMAKE_CUDA_FLAGS="-allow-unsupported-compiler -Xcompiler \"/D_ALLOW_COMPILER_AND_STL_VERSION_MISMATCH\"" ^
               -DTorch_DIR=../libtorch/libtorch/share/cmake/Torch ^
@@ -159,9 +159,9 @@ jobs:
         shell: bash
         run: |
           cd elastix-build
-          cmake -DCMAKE_C_COMPILER="${{ inputs.c-compiler }}" \
-              -DCMAKE_CXX_COMPILER="${{ inputs.cxx-compiler }}" \
-              -DCMAKE_BUILD_TYPE="${{ inputs.cmake-build-type }}" \
+          cmake -DCMAKE_C_COMPILER="${{ matrix.c-compiler }}" \
+              -DCMAKE_CXX_COMPILER="${{ matrix.cxx-compiler }}" \
+              -DCMAKE_BUILD_TYPE="${{ matrix.cmake-build-type }}" \
               -DITK_DIR=../ITK-build \
               -DTorch_DIR=../libtorch/libtorch/share/cmake/Torch \
               -DUSE_ALL_COMPONENTS=ON \

--- a/Components/Metrics/Impact/elxImpactMetric.h
+++ b/Components/Metrics/Impact/elxImpactMetric.h
@@ -52,7 +52,7 @@ namespace elastix
  * (ImpactGPU 0)
  * (ImpactUseMixedPrecision "true")
  * (ImpactFeaturesMapUpdateInterval -1)
- * (ImpactWriteFeatureMaps "false")
+ * (ImpactFeatureMapOutputDirectory "")
  * \endcode
  *
  * ### Parameter Descriptions
@@ -105,7 +105,8 @@ namespace elastix
  *   - Set to `-1` to compute once per resolution level.
  *   - Set to a positive integer to recompute every _N_ iterations.
  *
- * \param ImpactWriteFeatureMaps Enables saving both the input images and feature maps to disk (in Static mode).
+ * \param ImpactFeatureMapOutputDirectory Enables saving both the input images and feature maps to disk (in Static
+ * mode).
  *
  * ### Advanced Use: Multi-resolution and Multi-model Setup
  *
@@ -137,7 +138,7 @@ namespace elastix
  * (ImpactGPU 0 0)
  * (ImpactUseMixedPrecision "true" "true")
  * (ImpactFeaturesMapUpdateInterval -1 -1)
- * (ImpactWriteFeatureMaps "false" "false")
+ * (ImpactFeatureMapOutputDirectory "" "")
  * \endcode
  *
  * **Multi-model Setup**:

--- a/Components/Metrics/Impact/elxImpactMetric.hxx
+++ b/Components/Metrics/Impact/elxImpactMetric.hxx
@@ -437,9 +437,10 @@ ImpactMetric<TElastix>::BeforeEachResolution()
 
   if (mode == "Static")
   {
-    std::string writeFeatureMapsStr = "false";
-    configuration.ReadParameter(writeFeatureMapsStr, "ImpactWriteFeatureMaps", this->GetComponentLabel(), level, 0);
-    if (writeFeatureMapsStr != "false")
+    std::string writeFeatureMapsStr = "";
+    configuration.ReadParameter(
+      writeFeatureMapsStr, "ImpactFeatureMapOutputDirectory", this->GetComponentLabel(), level, 0);
+    if (!writeFeatureMapsStr.empty())
     {
       // If enabled, prepare output directory for feature map export (Static mode)
       if (!std::filesystem::exists(writeFeatureMapsStr))

--- a/Testing/Data/parameters.2D.IMPACT.bspline.ASGD.002.txt
+++ b/Testing/Data/parameters.2D.IMPACT.bspline.ASGD.002.txt
@@ -75,7 +75,7 @@
 (ImpactMode "Static")
 (ImpactGPU -1)
 (ImpactFeaturesMapUpdateInterval -1)
-(ImpactWriteFeatureMaps "./Features/")
+(ImpactFeatureMapOutputDirectory "./Features/")
 
 
 

--- a/Testing/Data/parameters.3D.IMPACT.bspline.ASGD.001.txt
+++ b/Testing/Data/parameters.3D.IMPACT.bspline.ASGD.001.txt
@@ -75,7 +75,7 @@
 (ImpactMode "Jacobian")
 (ImpactGPU -1)
 (ImpactFeaturesMapUpdateInterval -1)
-(ImpactWriteFeatureMaps "false")
+(ImpactFeatureMapOutputDirectory "")
 
 
 // ********** Several

--- a/Testing/Data/parameters.3D.IMPACT.bspline.ASGD.002.txt
+++ b/Testing/Data/parameters.3D.IMPACT.bspline.ASGD.002.txt
@@ -75,7 +75,7 @@
 (ImpactMode "Static")
 (ImpactGPU -1)
 (ImpactFeaturesMapUpdateInterval -1)
-(ImpactWriteFeatureMaps "false")
+(ImpactFeatureMapOutputDirectory "")
 
 
 // ********** Several


### PR DESCRIPTION
This PR replaces the deprecated ImpactWriteFeatureMaps parameter with ImpactFeatureMapOutputDirectory, following the suggestion by @N-Dekker (see https://github.com/vboussot/ImpactElastix/issues/6).

It also fixes an issue in the publish-elastix GitHub Actions workflow related to the generation of release artifacts.

In addition, for the 5.3.1 release, GPU support could be enabled by manually running the publish-elastix.yml workflow to build the ImpactMetricCuda library, and then adding the generated binaries (ImpactMetricCuda.so for Linux and ImpactMetricCuda.dll for Windows) to the existing release archives alongside the CPU library.

At runtime, when installing the component, elastix first attempts to load ImpactMetricCuda if a compatible GPU environment is detected. Otherwise, it automatically falls back to ImpactMetric, resulting in CPU-only execution.

Currently, the 5.3.1 release only ships the CPU library, meaning that even on systems with GPU support elastix immediately falls back to ImpactMetric, and GPU acceleration cannot be used.