### PR TITLE
ENH: Use target based includes

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -129,13 +129,12 @@ if(ELASTIX_USE_OPENCL)
   endif()
 
   # Include the OpenCL include directories to elastix
-  include_directories(${OPENCL_INCLUDE_DIRS})
+  # Note: OPENCL_INCLUDE_DIRS and -DELASTIX_USE_OPENCL are set as PUBLIC
+  # target properties on elxOpenCL (Common/OpenCL/CMakeLists.txt) and
+  # propagate transitively to all targets that link elxOpenCL.
 
   # Add some useful macro's
   include(elastixOpenCL)
-
-  # Add definition for the OpenCL
-  add_definitions(-DELASTIX_USE_OPENCL)
 endif()
 
 #---------------------------------------------------------------------
@@ -145,8 +144,6 @@ option(ELASTIX_USE_EIGEN "Use Eigen library." OFF)
 
 if(ELASTIX_USE_EIGEN)
   find_package(Eigen3 REQUIRED)
-  include_directories(${EIGEN3_INCLUDE_DIR})
-  add_definitions(-DELASTIX_USE_EIGEN)
 endif()
 
 #---------------------------------------------------------------------
@@ -235,6 +232,10 @@ endif()
 
 #---------------------------------------------------------------------
 # Include directories
+# Note: Target-based include directories are set in the individual
+# library CMakeLists.txt files using target_include_directories().
+# The variables below are kept for ElastixConfig.cmake generation
+# to support external projects that use the old-style include_directories().
 
 set(elxCommon_INCLUDE_DIRECTORIES
   ${elastix_SOURCE_DIR}/Common
@@ -284,15 +285,7 @@ set(elxINCLUDE_DIRECTORIES
   ${ELASTIX_USER_COMPONENT_DIRS}
 )
 
-include_directories(${elxINCLUDE_DIRECTORIES})
-
-# include the OpenCL directories
-# The key-word BEFORE is important here, because the elastix distribution
-# contains some files with the same name as in the ITK distribution.
-# Some bugs were fixed and features added. When these are contributed back
-# to the ITK the BEFORE keyword is not needed anymore.
 if(ELASTIX_USE_OPENCL)
-  include_directories(BEFORE ${elxCommon_OpenCL_INCLUDE_DIRECTORIES})
   list(APPEND elxINCLUDE_DIRECTORIES ${elxCommon_OpenCL_INCLUDE_DIRECTORIES})
 endif()
 

--- a/Common/CMakeLists.txt
+++ b/Common/CMakeLists.txt
@@ -217,3 +217,40 @@ endif()
 target_link_libraries(elxCommon
   ${ITK_LIBRARIES}
 )
+
+target_include_directories(elxCommon PUBLIC
+  $<BUILD_INTERFACE:${elastix_SOURCE_DIR}/Common>
+  $<BUILD_INTERFACE:${elastix_SOURCE_DIR}/Common/CostFunctions>
+  $<BUILD_INTERFACE:${elastix_SOURCE_DIR}/Common/ImageSamplers>
+  $<BUILD_INTERFACE:${elastix_SOURCE_DIR}/Common/LineSearchOptimizers>
+  $<BUILD_INTERFACE:${elastix_SOURCE_DIR}/Common/Transforms>
+  # Note: elxTransformIO.h (a public header in Common/Transforms) includes
+  # ExternalTransform/elxAdvancedTransformAdapter.h from Components/Transforms.
+  # This is a circular dependency but must be PUBLIC since downstream targets
+  # also include elxTransformIO.h.
+  $<BUILD_INTERFACE:${elastix_SOURCE_DIR}/Components/Transforms>
+  $<INSTALL_INTERFACE:${ELASTIX_INCLUDE_DIR}/Common>
+  $<INSTALL_INTERFACE:${ELASTIX_INCLUDE_DIR}/Common/CostFunctions>
+  $<INSTALL_INTERFACE:${ELASTIX_INCLUDE_DIR}/Common/ImageSamplers>
+  $<INSTALL_INTERFACE:${ELASTIX_INCLUDE_DIR}/Common/LineSearchOptimizers>
+  $<INSTALL_INTERFACE:${ELASTIX_INCLUDE_DIR}/Common/Transforms>
+  $<INSTALL_INTERFACE:${ELASTIX_INCLUDE_DIR}/Components/Transforms>
+)
+
+# Note: elxCommon sources have circular dependencies on Core and Components
+# headers (e.g. elxTransformFactoryRegistration.cxx includes Component transform
+# headers which in turn include Core headers, and elxTransformIO.h includes
+# ExternalTransform/elxAdvancedTransformAdapter.h from Components/Transforms).
+# These cannot be expressed as target_link_libraries without creating cycles,
+# so they are added as PRIVATE include directories.
+target_include_directories(elxCommon PRIVATE
+  ${elastix_SOURCE_DIR}/Core
+  ${elastix_SOURCE_DIR}/Core/Kernel
+  ${elastix_SOURCE_DIR}/Core/Install
+  ${elastix_SOURCE_DIR}/Core/ComponentBaseClasses
+  ${elastix_SOURCE_DIR}/Core/Configuration
+  ${elastix_SOURCE_DIR}/Core/Main
+  ${elastix_SOURCE_DIR}/Common/ParameterFileParser
+  ${elastix_SOURCE_DIR}/Common/MevisDicomTiff
+  ${elastix_BINARY_DIR}
+)

--- a/Common/GTesting/CMakeLists.txt
+++ b/Common/GTesting/CMakeLists.txt
@@ -50,4 +50,11 @@ else()
     )
 endif()
 
+target_include_directories(CommonGTest PRIVATE
+  ${elastix_SOURCE_DIR}/Components/Metrics
+  ${elastix_SOURCE_DIR}/Components/ResampleInterpolators
+  ${elastix_SOURCE_DIR}/Components/Resamplers
+  ${elastix_SOURCE_DIR}/Components/Transforms
+)
+
 add_test(NAME CommonGTest_test COMMAND CommonGTest)

--- a/Common/MevisDicomTiff/CMakeLists.txt
+++ b/Common/MevisDicomTiff/CMakeLists.txt
@@ -25,6 +25,9 @@ if(NOT ELASTIX_NO_INSTALL_DEVELOPMENT)
 endif()
 
 target_link_libraries(mevisdcmtiff ${ITK_LIBRARIES})
+target_include_directories(mevisdcmtiff PUBLIC
+  $<BUILD_INTERFACE:${CMAKE_CURRENT_SOURCE_DIR}>
+  $<INSTALL_INTERFACE:${ELASTIX_INCLUDE_DIR}/Common/MevisDicomTiff>)
 
 # Group in IDE's like Visual Studio
 set_property(TARGET mevisdcmtiff PROPERTY FOLDER "libraries")

--- a/Common/OpenCL/CMakeLists.txt
+++ b/Common/OpenCL/CMakeLists.txt
@@ -61,6 +61,27 @@ target_link_libraries(elxOpenCL
   ${OPENCL_LIBRARIES}
 )
 
+target_include_directories(elxOpenCL PUBLIC ${OPENCL_INCLUDE_DIRS})
+target_compile_definitions(elxOpenCL PUBLIC ELASTIX_USE_OPENCL)
+
+# The key-word BEFORE is important here, because the elastix distribution
+# contains some files with the same name as in the ITK distribution.
+# Some bugs were fixed and features added. When these are contributed back
+# to the ITK the BEFORE keyword is not needed anymore.
+target_include_directories(elxOpenCL BEFORE PUBLIC
+  $<BUILD_INTERFACE:${CMAKE_CURRENT_SOURCE_DIR}>
+  $<BUILD_INTERFACE:${CMAKE_CURRENT_SOURCE_DIR}/Factories>
+  $<BUILD_INTERFACE:${CMAKE_CURRENT_SOURCE_DIR}/ITKimprovements>
+  $<BUILD_INTERFACE:${CMAKE_CURRENT_SOURCE_DIR}/Filters>
+  $<BUILD_INTERFACE:${CMAKE_CURRENT_SOURCE_DIR}/Kernels>
+  $<BUILD_INTERFACE:${OPENCL_KERNELS_DEBUG_PATH}>
+  $<INSTALL_INTERFACE:${ELASTIX_INCLUDE_DIR}/Common/OpenCL>
+  $<INSTALL_INTERFACE:${ELASTIX_INCLUDE_DIR}/Common/OpenCL/Factories>
+  $<INSTALL_INTERFACE:${ELASTIX_INCLUDE_DIR}/Common/OpenCL/ITKimprovements>
+  $<INSTALL_INTERFACE:${ELASTIX_INCLUDE_DIR}/Common/OpenCL/Filters>
+  $<INSTALL_INTERFACE:${ELASTIX_INCLUDE_DIR}/Common/OpenCL/Kernels>
+)
+
 # Group in IDE's like Visual Studio
 set_property(TARGET elxOpenCL PROPERTY FOLDER "libraries")
 

--- a/Common/ParameterFileParser/CMakeLists.txt
+++ b/Common/ParameterFileParser/CMakeLists.txt
@@ -18,6 +18,18 @@ if(NOT ELASTIX_NO_INSTALL_DEVELOPMENT)
 endif()
 
 target_link_libraries(param ${ITK_LIBRARIES})
+target_include_directories(param PUBLIC
+  $<BUILD_INTERFACE:${CMAKE_CURRENT_SOURCE_DIR}>
+  $<INSTALL_INTERFACE:${ELASTIX_INCLUDE_DIR}/Common/ParameterFileParser>)
+# Note: param sources include elxConfiguration.h and elxConversion.h from Core.
+# This is a circular dependency (elxCore links param), so we add these as PRIVATE.
+target_include_directories(param PRIVATE
+  ${elastix_SOURCE_DIR}/Common
+  ${elastix_SOURCE_DIR}/Core/Configuration
+  ${elastix_SOURCE_DIR}/Core/Install
+  ${elastix_SOURCE_DIR}/Core/Kernel
+  ${elastix_BINARY_DIR}
+)
 
 # Group in IDE's like Visual Studio
 set_property(TARGET param PROPERTY FOLDER "libraries")

--- a/Components/CMakeLists.txt
+++ b/Components/CMakeLists.txt
@@ -6,27 +6,9 @@ project(elxComponents)
 #---------------------------------------------------------------------
 # Set the libraries to be linked.
 
-# Linux gave an error, if param was linked. This was only
-# when we still used .dll's. I'm not sure if it will still
-# give an error, but as long as linux does not complain
-# about the missing param, just leave it out.
-if(UNIX)
-  if(NOT APPLE)
-    set(elxLinkLibs
-      elxCommon
-      elxCore
-      ${ITK_LIBRARIES})
-  endif()
-endif()
-
-# Interestingly, visual c++ and MAC-GCC do need param
-if(WIN32 OR APPLE)
-  set(elxLinkLibs
-    param
-    elxCommon
-    elxCore
-    ${ITK_LIBRARIES})
-endif()
+set(elxLinkLibs
+  elxCore
+  ${ITK_LIBRARIES})
 
 #--------------------------------------------------------------------
 # Prepare elxInstallComponentFunctionDeclarations.h and
@@ -130,6 +112,7 @@ macro(ADD_ELXCOMPONENT name)
       add_library(${name} STATIC ${filelist})
     endif()
     target_link_libraries(${name} ${elxLinkLibs})
+    target_include_directories(${name} PRIVATE ${CMAKE_CURRENT_SOURCE_DIR})
     if(NOT ELASTIX_NO_INSTALL_DEVELOPMENT)
       install(TARGETS ${name}
         ARCHIVE DESTINATION ${ELASTIX_ARCHIVE_DIR}

--- a/Components/FixedImagePyramids/OpenCLFixedGenericPyramid/CMakeLists.txt
+++ b/Components/FixedImagePyramids/OpenCLFixedGenericPyramid/CMakeLists.txt
@@ -5,10 +5,12 @@ if(ELASTIX_USE_OPENCL)
     elxOpenCLFixedGenericPyramid.hxx
     elxOpenCLFixedGenericPyramid.cxx)
 
-  include_directories(
-  ../FixedGenericPyramid)
-
   if(USE_OpenCLFixedGenericPyramid)
+    target_include_directories(OpenCLFixedGenericPyramid PRIVATE
+      ${CMAKE_CURRENT_SOURCE_DIR}/../FixedGenericPyramid)
+    target_include_directories(OpenCLFixedGenericPyramid BEFORE PRIVATE
+      ${elxCommon_OpenCL_INCLUDE_DIRECTORIES}
+      ${OPENCL_KERNELS_DEBUG_PATH})
     target_link_libraries(OpenCLFixedGenericPyramid elxOpenCL)
   endif()
 else()

--- a/Components/Metrics/KNNGraphAlphaMutualInformation/KNN/ann_1.1/CMakeLists.txt
+++ b/Components/Metrics/KNNGraphAlphaMutualInformation/KNN/ann_1.1/CMakeLists.txt
@@ -15,12 +15,6 @@ configure_file(
   ${elastix_BINARY_DIR}/ANN/ANN.h
   @ONLY)
 
-# Include these directories to look for header files.
-include_directories(
-  ${ANN_SOURCE_DIR}/include
-  ${ANN_SOURCE_DIR}/src
-)
-
 # Sources of non-templated classes.
 set(ANN_SRCS
   src/ANN.cpp
@@ -41,6 +35,15 @@ set(ANN_SRCS
 
 # Create the ANNlib library
 add_library(ANNlib SHARED ${ANN_SRCS})
+
+# Include these directories to look for header files.
+target_include_directories(ANNlib
+  PUBLIC
+    $<BUILD_INTERFACE:${ANN_SOURCE_DIR}/include>
+    $<BUILD_INTERFACE:${elastix_BINARY_DIR}>
+  PRIVATE
+    ${ANN_SOURCE_DIR}/src
+)
 
 include(GenerateExportHeader)
 generate_export_header(ANNlib

--- a/Components/MovingImagePyramids/OpenCLMovingGenericPyramid/CMakeLists.txt
+++ b/Components/MovingImagePyramids/OpenCLMovingGenericPyramid/CMakeLists.txt
@@ -5,13 +5,16 @@ if(ELASTIX_USE_OPENCL)
     elxOpenCLMovingGenericPyramid.hxx
     elxOpenCLMovingGenericPyramid.cxx)
 
-  include_directories(../MovingGenericPyramid)
-
   if(USE_OpenCLMovingGenericPyramid)
+    target_include_directories(OpenCLMovingGenericPyramid PRIVATE
+      ${CMAKE_CURRENT_SOURCE_DIR}/../MovingGenericPyramid)
+    target_include_directories(OpenCLMovingGenericPyramid BEFORE PRIVATE
+      ${elxCommon_OpenCL_INCLUDE_DIRECTORIES}
+      ${OPENCL_KERNELS_DEBUG_PATH})
     target_link_libraries(OpenCLMovingGenericPyramid elxOpenCL)
   endif()
 else()
-  # If the user set USE_OpenCLFixedGenericPyramid ON, but ELASTIX_USE_OPENCL was OFF,
+  # If the user set USE_OpenCLMovingGenericPyramid ON, but ELASTIX_USE_OPENCL was OFF,
   # then issue a warning.
   if(USE_OpenCLMovingGenericPyramid)
     message(WARNING "You selected to compile OpenCLMovingGenericPyramid, "

--- a/Components/Optimizers/AdaptiveStochasticLBFGS/CMakeLists.txt
+++ b/Components/Optimizers/AdaptiveStochasticLBFGS/CMakeLists.txt
@@ -10,3 +10,8 @@ ADD_ELXCOMPONENT( AdaptiveStochasticLBFGS OFF # OFF by default after elastix 5.0
  ../StandardStochasticGradientDescent/itkStochasticGradientDescentOptimizer.h
  ../StandardStochasticGradientDescent/itkStochasticGradientDescentOptimizer.cxx
 )
+
+if(USE_AdaptiveStochasticLBFGS AND ELASTIX_USE_EIGEN)
+  target_include_directories(AdaptiveStochasticLBFGS PRIVATE ${EIGEN3_INCLUDE_DIR})
+  target_compile_definitions(AdaptiveStochasticLBFGS PRIVATE ELASTIX_USE_EIGEN)
+endif()

--- a/Components/Optimizers/AdaptiveStochasticVarianceReducedGradient/CMakeLists.txt
+++ b/Components/Optimizers/AdaptiveStochasticVarianceReducedGradient/CMakeLists.txt
@@ -8,3 +8,8 @@ ADD_ELXCOMPONENT( AdaptiveStochasticVarianceReducedGradient OFF # OFF by default
  itkStandardStochasticVarianceReducedGradientDescentOptimizer.cxx
  itkStochasticVarianceReducedGradientDescentOptimizer.cxx
 )
+
+if(USE_AdaptiveStochasticVarianceReducedGradient AND ELASTIX_USE_EIGEN)
+  target_include_directories(AdaptiveStochasticVarianceReducedGradient PRIVATE ${EIGEN3_INCLUDE_DIR})
+  target_compile_definitions(AdaptiveStochasticVarianceReducedGradient PRIVATE ELASTIX_USE_EIGEN)
+endif()

--- a/Components/Resamplers/OpenCLResampler/CMakeLists.txt
+++ b/Components/Resamplers/OpenCLResampler/CMakeLists.txt
@@ -6,6 +6,9 @@ if(ELASTIX_USE_OPENCL)
     elxOpenCLResampler.cxx)
 
   if(USE_OpenCLResampler)
+    target_include_directories(OpenCLResampler BEFORE PRIVATE
+      ${elxCommon_OpenCL_INCLUDE_DIRECTORIES}
+      ${OPENCL_KERNELS_DEBUG_PATH})
     target_link_libraries(OpenCLResampler elxOpenCL)
   endif()
 else()

--- a/Core/CMakeLists.txt
+++ b/Core/CMakeLists.txt
@@ -161,6 +161,23 @@ target_link_libraries(elxCore
 target_include_directories(elxCore PRIVATE
   ${ITK_CMAKE_DIR}/../Modules/ThirdParty/DoubleConversion/src/double-conversion)
 
+target_include_directories(elxCore PUBLIC
+  $<BUILD_INTERFACE:${elastix_SOURCE_DIR}/Core>
+  $<BUILD_INTERFACE:${elastix_SOURCE_DIR}/Core/Install>
+  $<BUILD_INTERFACE:${elastix_SOURCE_DIR}/Core/Kernel>
+  $<BUILD_INTERFACE:${elastix_SOURCE_DIR}/Core/ComponentBaseClasses>
+  $<BUILD_INTERFACE:${elastix_SOURCE_DIR}/Core/Configuration>
+  $<BUILD_INTERFACE:${elastix_SOURCE_DIR}/Core/Main>
+  $<BUILD_INTERFACE:${elastix_BINARY_DIR}>
+  $<INSTALL_INTERFACE:${ELASTIX_INCLUDE_DIR}/Core>
+  $<INSTALL_INTERFACE:${ELASTIX_INCLUDE_DIR}/Core/Install>
+  $<INSTALL_INTERFACE:${ELASTIX_INCLUDE_DIR}/Core/Kernel>
+  $<INSTALL_INTERFACE:${ELASTIX_INCLUDE_DIR}/Core/ComponentBaseClasses>
+  $<INSTALL_INTERFACE:${ELASTIX_INCLUDE_DIR}/Core/Configuration>
+  $<INSTALL_INTERFACE:${ELASTIX_INCLUDE_DIR}/Core/Main>
+  $<INSTALL_INTERFACE:${ELASTIX_INCLUDE_DIR}>
+)
+
 elastix_export_target(elxCommon)
 elastix_export_target(param)
 

--- a/Testing/CMakeLists.txt
+++ b/Testing/CMakeLists.txt
@@ -71,12 +71,13 @@ macro(elx_add_test_core executable_name source_name test_name group)
     # Link against other libraries.
     target_link_libraries(${executable_name}
       param               # some test use the CommandLineArgumentParser
+      elxCommon            # provides Common headers (Transforms, CostFunctions, etc.)
       ${mevisdcmtifflib}  # is empty if not selected in CMake
       ${ITK_LIBRARIES}
     )
 
     if(ELASTIX_USE_OPENCL)
-      include_directories(${CMAKE_CURRENT_SOURCE_DIR})
+      target_include_directories(${executable_name} PRIVATE ${CMAKE_CURRENT_SOURCE_DIR})
       target_link_libraries(${executable_name} elxOpenCL)
     endif()
 
@@ -513,6 +514,10 @@ elx_add_test(ThinPlateSplineTransformPerformanceTest "" "Common"
 elx_add_test(ThinPlateSplineTransformTest "" "Common"
   ${TestDataDir}/parameters_TPSTransformTest.txt)
 elx_add_test(AdvanceOneStepParallellizationTest "" "Common")
+if(ELASTIX_USE_EIGEN)
+  target_include_directories(itkAdvanceOneStepParallellizationTest PRIVATE ${EIGEN3_INCLUDE_DIR})
+  target_compile_definitions(itkAdvanceOneStepParallellizationTest PRIVATE ELASTIX_USE_EIGEN)
+endif()
 elx_add_test(AccumulateDerivativesParallellizationTest "" "Common")
 elx_add_test(BSplineTransformPointPerformanceTest "" "Common"
   ${TestDataDir}/parameters_AdvancedBSplineDeformableTransformTest.txt)


### PR DESCRIPTION
Replace directly level includes, with target based includes. This allows for setting include properties on targets which allows for propagation to users of the libraries. Additionally, private and public scope can be applied.