### PR TITLE
COMP: Restore new GTest targets for ITK > v5.4.5

### DIFF
--- a/Common/GTesting/CMakeLists.txt
+++ b/Common/GTesting/CMakeLists.txt
@@ -35,19 +35,25 @@ target_compile_definitions(CommonGTest PRIVATE
   ELX_CMAKE_CURRENT_BINARY_DIR="${CMAKE_CURRENT_BINARY_DIR}"
 )
 
-if(USE_ImpactMetric)
-  find_package(Torch REQUIRED)
+if (ITK_VERSION VERSION_LESS_EQUAL 5.4.5)
   target_link_libraries(CommonGTest
-   GTest::GTest GTest::Main
+    GTest::GTest
+    GTest::Main
     ${ITK_LIBRARIES}
     elastix_lib
-    "${TORCH_LIBRARIES}")
+  )
 else()
   target_link_libraries(CommonGTest
-    GTest::GTest GTest::Main
+    GTest::gtest
+    GTest::gtest_main
     ${ITK_LIBRARIES}
     elastix_lib
-    )
+  )
+endif()
+
+if(USE_ImpactMetric)
+  find_package(Torch REQUIRED)
+  target_link_libraries(CommonGTest "${TORCH_LIBRARIES}")
 endif()
 
 target_include_directories(CommonGTest PRIVATE


### PR DESCRIPTION
Restored support for new GTest target names, that was already introduced with pull request https://github.com/SuperElastix/elastix/pull/1408 commit b2701168a9f2f1300cf9403cd20af5918a3b3d74 "COMP: Use GTest::gtest and GTest::gtest_main targets for ITK > v5.4.5"

It was accidentally removed with pull request https://github.com/SuperElastix/elastix/pull/1396 commit d3fd241565e4dac79a806b8529239f030bce9c8d "ENH: Enable IMPACT as a lazy-loaded plugin (CPU/CUDA)"

---
@vboussot Please have a look! I _think_ we accidentally removed that piece of CMake code, right?