### PR TITLE
Improve "-threads" command-line argument retrieval, remove "-argv0"

### DIFF
--- a/Core/ComponentBaseClasses/elxMetricBase.hxx
+++ b/Core/ComponentBaseClasses/elxMetricBase.hxx
@@ -19,6 +19,7 @@
 #define elxMetricBase_hxx
 
 #include "elxMetricBase.h"
+#include "elxConversion.h"
 
 namespace elastix
 {
@@ -155,11 +156,17 @@ MetricBase<TElastix>::BeforeEachResolutionBase()
     thisAsAdvanced->SetUseMultiThread(useMultiThreading);
     if (useMultiThreading)
     {
-      std::string tmp = configuration.GetCommandLineArgument("-threads");
-      if (!tmp.empty())
+      if (const std::string commandLineArgument = configuration.GetCommandLineArgument("-threads");
+          !commandLineArgument.empty())
       {
-        const unsigned int nrOfThreads = atoi(tmp.c_str());
-        thisAsAdvanced->SetNumberOfWorkUnits(nrOfThreads);
+        if (itk::ThreadIdType numberOfThreads{}; Conversion::StringToValue(commandLineArgument, numberOfThreads))
+        {
+          thisAsAdvanced->SetNumberOfWorkUnits(numberOfThreads);
+        }
+        else
+        {
+          assert(!"This command-line argument should be checked already, by MainBase::SetMaximumNumberOfThreads()!");
+        }
       }
     }
 

--- a/Core/Kernel/elxMainBase.cxx
+++ b/Core/Kernel/elxMainBase.cxx
@@ -28,6 +28,7 @@
 
 #include "elxMainBase.h"
 #include "elxComponentLoader.h"
+#include "elxConversion.h"
 
 #include "elxMacro.h"
 #include "itkMultiThreaderBase.h"
@@ -38,6 +39,7 @@
 #endif
 
 #include <cstdlib>
+#include <limits>
 #include <sstream>
 
 namespace elastix
@@ -409,19 +411,28 @@ MainBase::SetProcessPriority() const
 void
 MainBase::SetMaximumNumberOfThreads() const
 {
-  /** Get the number of threads from the command line. */
-  std::string maximumNumberOfThreadsString = m_Configuration->GetCommandLineArgument("-threads");
+  // Get the number of threads from the command line. If supplied, set the maximum number of threads.
+  const auto commandLineKey = "-threads";
 
-  /** If supplied, set the maximum number of threads. */
-  if (!maximumNumberOfThreadsString.empty())
+  if (const std::string commandLineArgument = m_Configuration->GetCommandLineArgument(commandLineKey);
+      !commandLineArgument.empty())
   {
-    const int maximumNumberOfThreads = atoi(maximumNumberOfThreadsString.c_str());
-    itk::MultiThreaderBase::SetGlobalMaximumNumberOfThreads(maximumNumberOfThreads);
+    if (itk::ThreadIdType numberOfThreads{}; Conversion::StringToValue(commandLineArgument, numberOfThreads))
+    {
+      itk::MultiThreaderBase::SetGlobalMaximumNumberOfThreads(numberOfThreads);
 
-    // The following statement (getting and setting GlobalDefaultNumberOfThreads) may look redundant, but it's not
-    // (using ITK 5.4.0)! The Set function ensures that GlobalDefaultNumberOfThreads <= GlobalMaximumNumberOfThreads.
-    // (GlobalDefaultNumberOfThreads is important, as ITK uses this number when constructing the ThreadPool.)
-    itk::MultiThreaderBase::SetGlobalDefaultNumberOfThreads(itk::MultiThreaderBase::GetGlobalDefaultNumberOfThreads());
+      // The following statement (getting and setting GlobalDefaultNumberOfThreads) may look redundant, but it's not
+      // (using ITK 5.4.0)! The Set function ensures that GlobalDefaultNumberOfThreads <= GlobalMaximumNumberOfThreads.
+      // (GlobalDefaultNumberOfThreads is important, as ITK uses this number when constructing the ThreadPool.)
+      itk::MultiThreaderBase::SetGlobalDefaultNumberOfThreads(
+        itk::MultiThreaderBase::GetGlobalDefaultNumberOfThreads());
+    }
+    else
+    {
+      itkExceptionMacro("\"" << commandLineKey << "\" command-line argument \"" << commandLineArgument
+                             << "\" must be a positive " << std::numeric_limits<itk::ThreadIdType>::digits
+                             << "-bits number.");
+    }
   }
 } // end SetMaximumNumberOfThreads()
 

--- a/Core/Main/elastix.cxx
+++ b/Core/Main/elastix.cxx
@@ -201,9 +201,6 @@ main(int argc, char ** argv)
       } // end else (so, if key does not equal "-p")
     } // end for loop
 
-    /** The argv0 argument, required for finding the component.dll/so's. */
-    argMap.insert(ArgumentMapEntryType("-argv0", argv[0]));
-
     int returndummy{};
 
     /** Check if at least once the option "-p" is given. */

--- a/Core/Main/elastixlib.cxx
+++ b/Core/Main/elastixlib.cxx
@@ -162,10 +162,7 @@ ELASTIX::RegisterImages(ImagePointer                          fixedImage,
   /** Save this information. */
   const auto outFolder = value;
 
-  const ArgumentMapType argMap{ /** The argv0 argument, required for finding the component.dll/so's. */
-                                ArgumentMapEntryType("-argv0", "elastix"),
-                                ArgumentMapEntryType("-out", outFolder)
-  };
+  const ArgumentMapType argMap{ ArgumentMapEntryType("-out", outFolder) };
 
   /** Check if the output directory exists. */
   if (performLogging && !itksys::SystemTools::FileIsDirectory(outFolder))

--- a/Core/Main/transformix.cxx
+++ b/Core/Main/transformix.cxx
@@ -187,9 +187,6 @@ main(int argc, char ** argv)
 
     } // end for loop
 
-    /** The argv0 argument, required for finding the component.dll/so's. */
-    argMap.insert(ArgumentMapEntryType("-argv0", argv[0]));
-
     /** Check that the option "-tp" is given. */
     if (argMap.count("-tp") == 0)
     {

--- a/Core/Main/transformixlib.cxx
+++ b/Core/Main/transformixlib.cxx
@@ -169,9 +169,6 @@ TRANSFORMIX::TransformImage(ImagePointer                          inputImage,
     }
   }
 
-  /** The argv0 argument, required for finding the component.dll/so's. */
-  argMap.insert(ArgumentMapEntryType("-argv0", "transformix"));
-
   /** Setup the log system. */
   const elx::log::guard logGuard{};
   int                   returndummy2 = elx::log::setup(logFileName, performLogging, performCout) ? 0 : 1;


### PR DESCRIPTION
Added error checking to the "-threads" command-line argument

Removed the internal "-argv0" from the command-line argument map, as it is no longer used:

- `ComponentLoader::LoadComponents` stopped using `argv0` with commit https://github.com/SuperElastix/elastix/commit/c09357417b0feb33d86812035c255e26473dfd38, "SK: Some huge changes", Stefan Klein, Feb 12, 2008.
- The `argv0` parameter was removed from `ComponentLoader::LoadComponents` with commit https://github.com/SuperElastix/elastix/commit/e72d2b690d0a0d869ec89cb9bd444a450d21bf88 "COMP: Fix  Clang dangling-gsl warning in LoadComponents...", by me, 10-11-2020