### PR TITLE
Let `Configuration::Initialize(_arg, inputMap)` return void, clean-up `#include`'s

### DIFF
--- a/Core/Configuration/elxConfiguration.cxx
+++ b/Core/Configuration/elxConfiguration.cxx
@@ -237,7 +237,7 @@ Configuration::Initialize(const CommandLineArgumentMapType & _arg)
  * ********************** Initialize ****************************
  */
 
-int
+void
 Configuration::Initialize(const CommandLineArgumentMapType &                 _arg,
                           const itk::ParameterFileParser::ParameterMapType & inputMap)
 {
@@ -262,9 +262,6 @@ Configuration::Initialize(const CommandLineArgumentMapType &                 _ar
 
   /** Set the initialized flag. */
   m_IsInitialized = true;
-
-  /** Return a value.*/
-  return 0;
 
 } // end Initialize()
 

--- a/Core/Configuration/elxConfiguration.h
+++ b/Core/Configuration/elxConfiguration.h
@@ -18,13 +18,18 @@
 #ifndef elxConfiguration_h
 #define elxConfiguration_h
 
-#include "itkObject.h"
 #include "elxBaseComponent.h"
+#include "elxlog.h"
 
 #include "itkParameterFileParser.h"
 #include "itkParameterMapInterface.h"
+
+#include <itkObject.h>
+
+#include <memory> // For unique_ptr.
 #include <map>
-#include "elxlog.h"
+#include <string>
+#include <vector>
 
 namespace elastix
 {

--- a/Core/Configuration/elxConfiguration.h
+++ b/Core/Configuration/elxConfiguration.h
@@ -97,7 +97,7 @@ public:
   int
   Initialize(const CommandLineArgumentMapType & _arg);
 
-  int
+  void
   Initialize(const CommandLineArgumentMapType & _arg, const itk::ParameterFileParser::ParameterMapType & inputMap);
 
   /** True, if Initialize was successfully called. */

--- a/Core/Kernel/elxElastixMain.cxx
+++ b/Core/Kernel/elxElastixMain.cxx
@@ -217,11 +217,7 @@ ElastixMain::RunWithInitialTransformParameterMaps(const ArgumentMapType &       
                                                   const ParameterMapType &              inputMap,
                                                   const std::vector<ParameterMapType> & initialTransformParameterMaps)
 {
-  if (Deref(MainBase::GetConfiguration()).Initialize(argmap, inputMap) != 0)
-  {
-    log::error("ERROR: Something went wrong during initialization of the configuration object.");
-  }
-
+  Deref(MainBase::GetConfiguration()).Initialize(argmap, inputMap);
   const auto numberOfTransformParameterMaps = initialTransformParameterMaps.size();
   m_TransformConfigurations.clear();
   m_TransformConfigurations.resize(numberOfTransformParameterMaps);
@@ -232,13 +228,8 @@ ElastixMain::RunWithInitialTransformParameterMaps(const ArgumentMapType &       
      * command line parameters entered by the user.
      */
     const auto configuration = Configuration::New();
-    int        dummy = configuration->Initialize(argmap, initialTransformParameterMaps[i]);
+    configuration->Initialize(argmap, initialTransformParameterMaps[i]);
     m_TransformConfigurations[i] = configuration;
-    if (dummy)
-    {
-      log::error(std::ostringstream{} << "ERROR: Something went wrong during initialization of configuration object "
-                                      << i << ".");
-    }
   }
 
   return ElastixMain::Run();

--- a/Core/Kernel/elxMainBase.cxx
+++ b/Core/Kernel/elxMainBase.cxx
@@ -127,11 +127,7 @@ MainBase::Run(const ArgumentMapType & argmap, const ParameterMapType & inputMap)
   /** Initialize the configuration object with the
    * command line parameters entered by the user.
    */
-  if (m_Configuration->Initialize(argmap, inputMap) != 0)
-  {
-    log::error("ERROR: Something went wrong during initialization of the configuration object.");
-  }
-
+  m_Configuration->Initialize(argmap, inputMap);
   return this->Run();
 } // end Run()
 

--- a/Core/Kernel/elxTransformixMain.cxx
+++ b/Core/Kernel/elxTransformixMain.cxx
@@ -302,13 +302,8 @@ TransformixMain::EnterCommandLineArgumentsWithTransformParameterMaps(
      * command line parameters entered by the user.
      */
     const auto configuration = Configuration::New();
-    int        dummy = configuration->Initialize(argmap, transformParameterMaps[i]);
+    configuration->Initialize(argmap, transformParameterMaps[i]);
     m_TransformConfigurations[i] = configuration;
-    if (dummy)
-    {
-      log::error(std::ostringstream{} << "ERROR: Something went wrong during initialization of configuration object "
-                                      << i << ".");
-    }
 
     if ((i + 1) == numberOfTransformParameterMaps)
     {


### PR DESCRIPTION
Two small style improvements