### PR TITLE
ENH: Print a warning for each unused parameter of the ParameterMap

### DIFF
--- a/Core/Configuration/elxConfiguration.cxx
+++ b/Core/Configuration/elxConfiguration.cxx
@@ -114,6 +114,59 @@ Configuration::PrintParameterMap() const
                         << "\n=============== end of ParameterMap ===============\n");
 
 } // end PrintParameterMap()
+
+
+/**
+ * ************************ AccessParameter ***************************
+ */
+
+void
+Configuration::AccessParameter(const std::string & parameterName) const
+{
+  std::size_t i{};
+
+  for (const auto & pair : m_ParameterMapInterface->GetParameterMap())
+  {
+    if (pair.first == parameterName)
+    {
+      // Conceptually, m_ParameterAccessFlags[i] is mutable.
+      m_ParameterAccessFlags[i] = true;
+      return;
+    }
+    ++i;
+  }
+}
+
+
+/**
+ * ************************ AfterRegistration ***************************
+ */
+
+void
+Configuration::AfterRegistration()
+{
+  const auto &       parameterMap = m_ParameterMapInterface->GetParameterMap();
+  const bool * const parameterAccessFlags = m_ParameterAccessFlags.get();
+
+  if (const auto numberOfUnusedParameters =
+        std::count(parameterAccessFlags, parameterAccessFlags + parameterMap.size(), false);
+      numberOfUnusedParameters > 0)
+  {
+    log::warn("WARNING: " + std::to_string(numberOfUnusedParameters) + " unused parameter(s) found!");
+    std::size_t i{};
+
+    for (const auto & pair : parameterMap)
+    {
+      if (!parameterAccessFlags[i])
+      {
+        log::warn("  Unused parameter: " + pair.first);
+      }
+      ++i;
+    }
+  }
+}
+
+
 /**
  * ************************ BeforeAll ***************************
  */
@@ -218,6 +271,8 @@ Configuration::Initialize(const CommandLineArgumentMapType & _arg)
   m_ParameterMapInterface->SetParameterMap(
     AddDataFromExternalTransformFile(m_ParameterFileName, parameterFileParser->GetParameterMap()));
 
+  m_ParameterAccessFlags = std::make_unique<bool[]>(m_ParameterMapInterface->GetParameterMap().size());
+
   /** Silently check in the parameter file if error messages should be printed. */
   m_ParameterMapInterface->SetPrintErrorMessages(false);
   bool printErrorMessages = true;
@@ -253,6 +308,8 @@ Configuration::Initialize(const CommandLineArgumentMapType &                 _ar
   m_CommandLineArgumentMap = _arg;
 
   m_ParameterMapInterface->SetParameterMap(AddDataFromExternalTransformFile(m_ParameterFileName, inputMap));
+
+  m_ParameterAccessFlags = std::make_unique<bool[]>(m_ParameterMapInterface->GetParameterMap().size());
 
   /** Silently check in the parameter file if error messages should be printed. */
   m_ParameterMapInterface->SetPrintErrorMessages(false);

--- a/Core/Configuration/elxConfiguration.h
+++ b/Core/Configuration/elxConfiguration.h
@@ -145,6 +145,7 @@ public:
   std::size_t
   CountNumberOfParameterEntries(const std::string & parameterName) const
   {
+    AccessParameter(parameterName);
     return m_ParameterMapInterface->CountNumberOfParameterEntries(parameterName);
   }
 
@@ -157,6 +158,7 @@ public:
                 const unsigned int  entry_nr,
                 const bool          produceWarningMessage) const
   {
+    AccessParameter(parameterName);
     std::string warningMessage = "";
     bool        found = m_ParameterMapInterface->ReadParameter(
       parameterValue, parameterName, entry_nr, produceWarningMessage, warningMessage);
@@ -174,6 +176,7 @@ public:
   bool
   ReadParameter(T & parameterValue, const std::string & parameterName, const unsigned int entry_nr) const
   {
+    AccessParameter(parameterName);
     std::string warningMessage = "";
     bool        found = m_ParameterMapInterface->ReadParameter(parameterValue, parameterName, entry_nr, warningMessage);
     if (!warningMessage.empty())
@@ -195,6 +198,7 @@ public:
                 const int           default_entry_nr,
                 const bool          produceWarningMessage) const
   {
+    AccessParameter(parameterName);
     std::string warningMessage = "";
     bool        found = m_ParameterMapInterface->ReadParameter(
       parameterValue, parameterName, prefix, entry_nr, default_entry_nr, produceWarningMessage, warningMessage);
@@ -216,6 +220,7 @@ public:
                 const unsigned int  entry_nr,
                 const int           default_entry_nr) const
   {
+    AccessParameter(parameterName);
     std::string warningMessage = "";
     bool        found = m_ParameterMapInterface->ReadParameter(
       parameterValue, parameterName, prefix, entry_nr, default_entry_nr, warningMessage);
@@ -232,6 +237,7 @@ public:
   bool
   HasParameter(const std::string & parameterName) const
   {
+    AccessParameter(parameterName);
     return m_ParameterMapInterface->HasParameter(parameterName);
   }
 
@@ -240,6 +246,7 @@ public:
   std::vector<std::string>
   GetValuesOfParameter(const std::string & parameterName) const
   {
+    AccessParameter(parameterName);
     return m_ParameterMapInterface->GetValues(parameterName);
   }
 
@@ -253,6 +260,7 @@ public:
   std::unique_ptr<std::vector<T>>
   RetrieveValuesOfParameter(const std::string & parameterName) const
   {
+    AccessParameter(parameterName);
     return m_ParameterMapInterface->RetrieveValues<T>(parameterName);
   }
 
@@ -292,6 +300,7 @@ public:
                 const unsigned int  entry_nr_end,
                 const bool          produceWarningMessage) const
   {
+    AccessParameter(parameterName);
     std::string warningMessage = "";
     bool        found = m_ParameterMapInterface->ReadParameter(
       parameterValues, parameterName, entry_nr_start, entry_nr_end, produceWarningMessage, warningMessage);
@@ -320,9 +329,18 @@ protected:
   PrintParameterMap() const;
 
 private:
+  void
+  AccessParameter(const std::string & parameterName) const;
+
+  void
+  AfterRegistration() override;
+
   CommandLineArgumentMapType                m_CommandLineArgumentMap{};
   std::string                               m_ParameterFileName{};
   const itk::ParameterMapInterface::Pointer m_ParameterMapInterface{ itk::ParameterMapInterface::New() };
+
+  // Tells for each parameter whether it is accessed.
+  std::unique_ptr<bool[]> m_ParameterAccessFlags;
 
   bool         m_IsInitialized{ false };
   unsigned int m_ElastixLevel{ 0 };


### PR DESCRIPTION
Checks that all parameters in the ParameterMap are accessed.

----

Example output:

```
WARNING: 5 unused parameter(s) found!
  Unused parameter: AutomaticScalesEstimation
  Unused parameter: AutomaticTransformInitialization
  Unused parameter: AutomaticTransformInitializationMethod
  Unused parameter: Blablabla
  Unused parameter: ErodeMask
```

@mstaring @stefanklein This should ease finding mistakes in parameter maps that are edited by the user.