### PR TITLE
Remove NormalizeJointPDFDerivatives and LaunchComputePDFsThreaderCallback from ParzenWindowHistogramImageToImageMetric

### DIFF
--- a/Common/CostFunctions/itkParzenWindowHistogramImageToImageMetric.h
+++ b/Common/CostFunctions/itkParzenWindowHistogramImageToImageMetric.h
@@ -405,10 +405,6 @@ private:
   static ITK_THREAD_RETURN_FUNCTION_CALL_CONVENTION
   ComputePDFsThreaderCallback(void * arg);
 
-  /** Helper function to launch the threads. */
-  void
-  LaunchComputePDFsThreaderCallback() const;
-
   /** Update the joint PDF with a pixel pair; on demand also updates the
    * pdf derivatives (if the Jacobian pointers are nonzero).
    */

--- a/Common/CostFunctions/itkParzenWindowHistogramImageToImageMetric.h
+++ b/Common/CostFunctions/itkParzenWindowHistogramImageToImageMetric.h
@@ -450,10 +450,6 @@ private:
                             const DerivativeType &             imageJacobian,
                             const NonZeroJacobianIndicesType & nzji) const;
 
-  /** Multiply the pdf derivatives entries by the given normalization factor. */
-  void
-  NormalizeJointPDFDerivatives(JointPDFDerivativesType * pdf, const double factor) const;
-
   /** Compute PDFs; Loops over the fixed image samples and constructs
    * the m_JointPDF and m_Alpha
    * The JointPDF and Alpha are related as follows:

--- a/Common/CostFunctions/itkParzenWindowHistogramImageToImageMetric.hxx
+++ b/Common/CostFunctions/itkParzenWindowHistogramImageToImageMetric.hxx
@@ -631,32 +631,6 @@ ParzenWindowHistogramImageToImageMetric<TFixedImage, TMovingImage>::NormalizeJoi
 
 
 /**
- * *********************** NormalizeJointPDFDerivatives ***********************
- */
-
-template <typename TFixedImage, typename TMovingImage>
-void
-ParzenWindowHistogramImageToImageMetric<TFixedImage, TMovingImage>::NormalizeJointPDFDerivatives(
-  JointPDFDerivativesType * pdf,
-  const double              factor) const
-{
-  using JointPDFDerivativesIteratorType = ImageScanlineIterator<JointPDFDerivativesType>;
-  JointPDFDerivativesIteratorType it(pdf, pdf->GetBufferedRegion());
-  const PDFValueType              castfac = static_cast<PDFValueType>(factor);
-  while (!it.IsAtEnd())
-  {
-    while (!it.IsAtEndOfLine())
-    {
-      it.Value() *= castfac;
-      ++it;
-    }
-    it.NextLine();
-  }
-
-} // end NormalizeJointPDFDerivatives()
-
-
-/**
  * ************************ ComputeMarginalPDF ***********************
  */
 

--- a/Common/CostFunctions/itkParzenWindowHistogramImageToImageMetric.hxx
+++ b/Common/CostFunctions/itkParzenWindowHistogramImageToImageMetric.hxx
@@ -996,8 +996,10 @@ ParzenWindowHistogramImageToImageMetric<TFixedImage, TMovingImage>::ComputePDFs(
    */
   this->BeforeThreadedGetValueAndDerivative(parameters);
 
-  /** Launch multi-threading JointPDF computation. */
-  this->LaunchComputePDFsThreaderCallback();
+  // Set up threader and launch multi-threaded JointPDF computation:
+  this->m_Threader->SetSingleMethodAndExecute(
+    this->ComputePDFsThreaderCallback,
+    const_cast<void *>(static_cast<const void *>(&this->m_ParzenWindowHistogramThreaderParameters)));
 
   /** Gather the results from all threads. */
   this->AfterThreadedComputePDFs();
@@ -1165,22 +1167,6 @@ ParzenWindowHistogramImageToImageMetric<TFixedImage, TMovingImage>::ComputePDFsT
   return ITK_THREAD_RETURN_DEFAULT_VALUE;
 
 } // end ComputePDFsThreaderCallback()
-
-
-/**
- * *********************** LaunchComputePDFsThreaderCallback***************
- */
-
-template <typename TFixedImage, typename TMovingImage>
-void
-ParzenWindowHistogramImageToImageMetric<TFixedImage, TMovingImage>::LaunchComputePDFsThreaderCallback() const
-{
-  /** Setup threader and launch. */
-  this->m_Threader->SetSingleMethodAndExecute(
-    this->ComputePDFsThreaderCallback,
-    const_cast<void *>(static_cast<const void *>(&this->m_ParzenWindowHistogramThreaderParameters)));
-
-} // end LaunchComputePDFsThreaderCallback()
 
 
 /**


### PR DESCRIPTION
These two private member functions appear no longer necessary.