### PR TITLE
STYLE: Remove `this->` on data ParzenWindowHistogramImageToImageMetric

### DIFF
--- a/Common/CostFunctions/itkParzenWindowHistogramImageToImageMetric.hxx
+++ b/Common/CostFunctions/itkParzenWindowHistogramImageToImageMetric.hxx
@@ -42,7 +42,7 @@ ParzenWindowHistogramImageToImageMetric<TFixedImage, TMovingImage>::ParzenWindow
   this->SetUseMovingImageLimiter(true);
 
   /** Initialize the m_ParzenWindowHistogramThreaderParameters */
-  this->m_ParzenWindowHistogramThreaderParameters.m_Metric = this;
+  m_ParzenWindowHistogramThreaderParameters.m_Metric = this;
 
 } // end Constructor
 
@@ -59,10 +59,10 @@ ParzenWindowHistogramImageToImageMetric<TFixedImage, TMovingImage>::PrintSelf(st
   Superclass::PrintSelf(os, indent);
 
   /** Add debugging information. */
-  os << indent << "NumberOfFixedHistogramBins: " << this->m_NumberOfFixedHistogramBins << std::endl;
-  os << indent << "NumberOfMovingHistogramBins: " << this->m_NumberOfMovingHistogramBins << std::endl;
-  os << indent << "FixedKernelBSplineOrder: " << this->m_FixedKernelBSplineOrder << std::endl;
-  os << indent << "MovingKernelBSplineOrder: " << this->m_MovingKernelBSplineOrder << std::endl;
+  os << indent << "NumberOfFixedHistogramBins: " << m_NumberOfFixedHistogramBins << std::endl;
+  os << indent << "NumberOfMovingHistogramBins: " << m_NumberOfMovingHistogramBins << std::endl;
+  os << indent << "FixedKernelBSplineOrder: " << m_FixedKernelBSplineOrder << std::endl;
+  os << indent << "MovingKernelBSplineOrder: " << m_MovingKernelBSplineOrder << std::endl;
 
   /*double m_MovingImageNormalizedMin;
   double m_FixedImageNormalizedMin;
@@ -102,13 +102,13 @@ ParzenWindowHistogramImageToImageMetric<TFixedImage, TMovingImage>::Initialize()
    */
   if (this->GetUseDerivative() && this->GetUseFiniteDifferenceDerivative())
   {
-    this->m_PerturbedAlphaRight.SetSize(this->GetNumberOfParameters());
-    this->m_PerturbedAlphaLeft.SetSize(this->GetNumberOfParameters());
+    m_PerturbedAlphaRight.SetSize(this->GetNumberOfParameters());
+    m_PerturbedAlphaLeft.SetSize(this->GetNumberOfParameters());
   }
   else
   {
-    this->m_PerturbedAlphaRight.SetSize(0);
-    this->m_PerturbedAlphaLeft.SetSize(0);
+    m_PerturbedAlphaRight.SetSize(0);
+    m_PerturbedAlphaLeft.SetSize(0);
   }
 
 } // end Initialize()
@@ -138,56 +138,54 @@ ParzenWindowHistogramImageToImageMetric<TFixedImage, TMovingImage>::InitializeHi
    */
   // int fixedPadding = 2;  // this will pad by 2 bins
   // int movingPadding = 2;  // this will pad by 2 bins
-  int fixedPadding = this->m_FixedKernelBSplineOrder / 2; // should be enough
-  int movingPadding = this->m_MovingKernelBSplineOrder / 2;
+  int fixedPadding = m_FixedKernelBSplineOrder / 2; // should be enough
+  int movingPadding = m_MovingKernelBSplineOrder / 2;
 
   /** The ratio times the expected bin size will be added twice to the image range. */
   const double smallNumberRatio = 0.001;
   const double smallNumberFixed = smallNumberRatio *
                                   (Superclass::m_FixedImageMaxLimit - Superclass::m_FixedImageMinLimit) /
-                                  static_cast<double>(this->m_NumberOfFixedHistogramBins - 2 * fixedPadding - 1);
+                                  static_cast<double>(m_NumberOfFixedHistogramBins - 2 * fixedPadding - 1);
   const double smallNumberMoving = smallNumberRatio *
                                    (Superclass::m_MovingImageMaxLimit - Superclass::m_MovingImageMinLimit) /
-                                   static_cast<double>(this->m_NumberOfFixedHistogramBins - 2 * movingPadding - 1);
+                                   static_cast<double>(m_NumberOfFixedHistogramBins - 2 * movingPadding - 1);
 
   /** Compute binsizes. */
-  const auto fixedHistogramWidth = static_cast<double>(
-    static_cast<OffsetValueType>(this->m_NumberOfFixedHistogramBins) // requires cast to signed type!
-    - 2.0 * fixedPadding - 1.0);
-  this->m_FixedImageBinSize =
-    (Superclass::m_FixedImageMaxLimit - Superclass::m_FixedImageMinLimit + 2.0 * smallNumberFixed) /
-    fixedHistogramWidth;
-  this->m_FixedImageBinSize = std::max(this->m_FixedImageBinSize, 1e-10);
-  this->m_FixedImageBinSize = std::min(this->m_FixedImageBinSize, 1e+10);
-  this->m_FixedImageNormalizedMin = (Superclass::m_FixedImageMinLimit - smallNumberFixed) / this->m_FixedImageBinSize -
-                                    static_cast<double>(fixedPadding);
+  const auto fixedHistogramWidth =
+    static_cast<double>(static_cast<OffsetValueType>(m_NumberOfFixedHistogramBins) // requires cast to signed type!
+                        - 2.0 * fixedPadding - 1.0);
+  m_FixedImageBinSize = (Superclass::m_FixedImageMaxLimit - Superclass::m_FixedImageMinLimit + 2.0 * smallNumberFixed) /
+                        fixedHistogramWidth;
+  m_FixedImageBinSize = std::max(m_FixedImageBinSize, 1e-10);
+  m_FixedImageBinSize = std::min(m_FixedImageBinSize, 1e+10);
+  m_FixedImageNormalizedMin =
+    (Superclass::m_FixedImageMinLimit - smallNumberFixed) / m_FixedImageBinSize - static_cast<double>(fixedPadding);
 
-  const auto movingHistogramWidth = static_cast<double>(
-    static_cast<OffsetValueType>(this->m_NumberOfMovingHistogramBins) // requires cast to signed type!
-    - 2.0 * movingPadding - 1.0);
-  this->m_MovingImageBinSize =
+  const auto movingHistogramWidth =
+    static_cast<double>(static_cast<OffsetValueType>(m_NumberOfMovingHistogramBins) // requires cast to signed type!
+                        - 2.0 * movingPadding - 1.0);
+  m_MovingImageBinSize =
     (Superclass::m_MovingImageMaxLimit - Superclass::m_MovingImageMinLimit + 2.0 * smallNumberMoving) /
     movingHistogramWidth;
-  this->m_MovingImageBinSize = std::max(this->m_MovingImageBinSize, 1e-10);
-  this->m_MovingImageBinSize = std::min(this->m_MovingImageBinSize, 1e+10);
-  this->m_MovingImageNormalizedMin =
-    (Superclass::m_MovingImageMinLimit - smallNumberMoving) / this->m_MovingImageBinSize -
-    static_cast<double>(movingPadding);
+  m_MovingImageBinSize = std::max(m_MovingImageBinSize, 1e-10);
+  m_MovingImageBinSize = std::min(m_MovingImageBinSize, 1e+10);
+  m_MovingImageNormalizedMin =
+    (Superclass::m_MovingImageMinLimit - smallNumberMoving) / m_MovingImageBinSize - static_cast<double>(movingPadding);
 
   /** Allocate memory for the marginal PDF. */
-  this->m_FixedImageMarginalPDF.SetSize(this->m_NumberOfFixedHistogramBins);
-  this->m_MovingImageMarginalPDF.SetSize(this->m_NumberOfMovingHistogramBins);
+  m_FixedImageMarginalPDF.SetSize(m_NumberOfFixedHistogramBins);
+  m_MovingImageMarginalPDF.SetSize(m_NumberOfMovingHistogramBins);
 
   /** Allocate memory for the joint PDF and joint PDF derivatives. */
 
   /** First set these ones to zero */
-  this->m_FixedIncrementalMarginalPDFRight = nullptr;
-  this->m_MovingIncrementalMarginalPDFRight = nullptr;
-  this->m_FixedIncrementalMarginalPDFLeft = nullptr;
-  this->m_MovingIncrementalMarginalPDFLeft = nullptr;
+  m_FixedIncrementalMarginalPDFRight = nullptr;
+  m_MovingIncrementalMarginalPDFRight = nullptr;
+  m_FixedIncrementalMarginalPDFLeft = nullptr;
+  m_MovingIncrementalMarginalPDFLeft = nullptr;
 
   /** For the joint PDF define a region starting from {0,0}
-   * with size {this->m_NumberOfMovingHistogramBins, this->m_NumberOfFixedHistogramBins}
+   * with size {m_NumberOfMovingHistogramBins, m_NumberOfFixedHistogramBins}
    * The dimension represents moving image Parzen window index
    * and fixed image Parzen window index, respectively.
    * The moving Parzen index is chosen as the first dimension,
@@ -195,9 +193,9 @@ ParzenWindowHistogramImageToImageMetric<TFixedImage, TMovingImage>::InitializeHi
    * than the fixed B-spline kernel order and it is faster to iterate along
    * the first dimension.
    */
-  this->m_JointPDF = JointPDFType::New();
-  this->m_JointPDF->SetRegions(JointPDFSizeType{ m_NumberOfMovingHistogramBins, m_NumberOfFixedHistogramBins });
-  this->m_JointPDF->Allocate();
+  m_JointPDF = JointPDFType::New();
+  m_JointPDF->SetRegions(JointPDFSizeType{ m_NumberOfMovingHistogramBins, m_NumberOfFixedHistogramBins });
+  m_JointPDF->Allocate();
 
   if (this->GetUseDerivative())
   {
@@ -216,14 +214,14 @@ ParzenWindowHistogramImageToImageMetric<TFixedImage, TMovingImage>::InitializeHi
 
     if (this->GetUseFiniteDifferenceDerivative())
     {
-      this->m_JointPDFDerivatives = nullptr;
+      m_JointPDFDerivatives = nullptr;
 
-      this->m_IncrementalJointPDFRight = JointPDFDerivativesType::New();
-      this->m_IncrementalJointPDFLeft = JointPDFDerivativesType::New();
-      this->m_IncrementalJointPDFRight->SetRegions(jointPDFDerivativesSize);
-      this->m_IncrementalJointPDFLeft->SetRegions(jointPDFDerivativesSize);
-      this->m_IncrementalJointPDFRight->Allocate();
-      this->m_IncrementalJointPDFLeft->Allocate();
+      m_IncrementalJointPDFRight = JointPDFDerivativesType::New();
+      m_IncrementalJointPDFLeft = JointPDFDerivativesType::New();
+      m_IncrementalJointPDFRight->SetRegions(jointPDFDerivativesSize);
+      m_IncrementalJointPDFLeft->SetRegions(jointPDFDerivativesSize);
+      m_IncrementalJointPDFRight->Allocate();
+      m_IncrementalJointPDFLeft->Allocate();
 
       /** Also initialize the incremental marginal pdfs. */
       const IncrementalMarginalPDFSizeType fixedIMPDFSize{ this->GetNumberOfParameters(),
@@ -231,50 +229,50 @@ ParzenWindowHistogramImageToImageMetric<TFixedImage, TMovingImage>::InitializeHi
       const IncrementalMarginalPDFSizeType movingIMPDFSize{ this->GetNumberOfParameters(),
                                                             m_NumberOfMovingHistogramBins };
 
-      this->m_FixedIncrementalMarginalPDFRight = IncrementalMarginalPDFType::New();
-      this->m_MovingIncrementalMarginalPDFRight = IncrementalMarginalPDFType::New();
-      this->m_FixedIncrementalMarginalPDFLeft = IncrementalMarginalPDFType::New();
-      this->m_MovingIncrementalMarginalPDFLeft = IncrementalMarginalPDFType::New();
+      m_FixedIncrementalMarginalPDFRight = IncrementalMarginalPDFType::New();
+      m_MovingIncrementalMarginalPDFRight = IncrementalMarginalPDFType::New();
+      m_FixedIncrementalMarginalPDFLeft = IncrementalMarginalPDFType::New();
+      m_MovingIncrementalMarginalPDFLeft = IncrementalMarginalPDFType::New();
 
-      this->m_FixedIncrementalMarginalPDFRight->SetRegions(fixedIMPDFSize);
-      this->m_MovingIncrementalMarginalPDFRight->SetRegions(movingIMPDFSize);
-      this->m_FixedIncrementalMarginalPDFLeft->SetRegions(fixedIMPDFSize);
-      this->m_MovingIncrementalMarginalPDFLeft->SetRegions(movingIMPDFSize);
+      m_FixedIncrementalMarginalPDFRight->SetRegions(fixedIMPDFSize);
+      m_MovingIncrementalMarginalPDFRight->SetRegions(movingIMPDFSize);
+      m_FixedIncrementalMarginalPDFLeft->SetRegions(fixedIMPDFSize);
+      m_MovingIncrementalMarginalPDFLeft->SetRegions(movingIMPDFSize);
 
-      this->m_FixedIncrementalMarginalPDFRight->Allocate();
-      this->m_MovingIncrementalMarginalPDFRight->Allocate();
-      this->m_FixedIncrementalMarginalPDFLeft->Allocate();
-      this->m_MovingIncrementalMarginalPDFLeft->Allocate();
+      m_FixedIncrementalMarginalPDFRight->Allocate();
+      m_MovingIncrementalMarginalPDFRight->Allocate();
+      m_FixedIncrementalMarginalPDFLeft->Allocate();
+      m_MovingIncrementalMarginalPDFLeft->Allocate();
     } // end if this->GetUseFiniteDifferenceDerivative()
     else
     {
-      if (this->m_UseExplicitPDFDerivatives)
+      if (m_UseExplicitPDFDerivatives)
       {
-        this->m_IncrementalJointPDFRight = nullptr;
-        this->m_IncrementalJointPDFLeft = nullptr;
+        m_IncrementalJointPDFRight = nullptr;
+        m_IncrementalJointPDFLeft = nullptr;
 
-        this->m_JointPDFDerivatives = JointPDFDerivativesType::New();
-        this->m_JointPDFDerivatives->SetRegions(jointPDFDerivativesSize);
-        this->m_JointPDFDerivatives->Allocate();
+        m_JointPDFDerivatives = JointPDFDerivativesType::New();
+        m_JointPDFDerivatives->SetRegions(jointPDFDerivativesSize);
+        m_JointPDFDerivatives->Allocate();
       }
       else
       {
         /** De-allocate large amount of memory for the m_JointPDFDerivatives. */
         // \todo Should not be allocated in the first place
-        if (!this->m_JointPDFDerivatives.IsNull())
+        if (!m_JointPDFDerivatives.IsNull())
         {
-          this->m_JointPDFDerivatives->SetRegions(JointPDFDerivativesSizeType{});
-          this->m_JointPDFDerivatives->Allocate();
-          this->m_JointPDFDerivatives->GetPixelContainer()->Squeeze();
+          m_JointPDFDerivatives->SetRegions(JointPDFDerivativesSizeType{});
+          m_JointPDFDerivatives->Allocate();
+          m_JointPDFDerivatives->GetPixelContainer()->Squeeze();
         }
       }
     }
   }
   else
   {
-    this->m_JointPDFDerivatives = nullptr;
-    this->m_IncrementalJointPDFRight = nullptr;
-    this->m_IncrementalJointPDFLeft = nullptr;
+    m_JointPDFDerivatives = nullptr;
+    m_IncrementalJointPDFRight = nullptr;
+    m_IncrementalJointPDFLeft = nullptr;
   }
 
 } // end InitializeHistograms()
@@ -288,51 +286,49 @@ template <typename TFixedImage, typename TMovingImage>
 void
 ParzenWindowHistogramImageToImageMetric<TFixedImage, TMovingImage>::InitializeKernels()
 {
-  switch (this->m_FixedKernelBSplineOrder)
+  switch (m_FixedKernelBSplineOrder)
   {
     case 0:
-      this->m_FixedKernel = BSplineKernelFunction2<0>::New();
+      m_FixedKernel = BSplineKernelFunction2<0>::New();
       break;
     case 1:
-      this->m_FixedKernel = BSplineKernelFunction2<1>::New();
+      m_FixedKernel = BSplineKernelFunction2<1>::New();
       break;
     case 2:
-      this->m_FixedKernel = BSplineKernelFunction2<2>::New();
+      m_FixedKernel = BSplineKernelFunction2<2>::New();
       break;
     case 3:
-      this->m_FixedKernel = BSplineKernelFunction2<3>::New();
+      m_FixedKernel = BSplineKernelFunction2<3>::New();
       break;
     default:
-      itkExceptionMacro(
-        "The following FixedKernelBSplineOrder is not implemented: " << this->m_FixedKernelBSplineOrder);
+      itkExceptionMacro("The following FixedKernelBSplineOrder is not implemented: " << m_FixedKernelBSplineOrder);
   } // end switch FixedKernelBSplineOrder
 
-  switch (this->m_MovingKernelBSplineOrder)
+  switch (m_MovingKernelBSplineOrder)
   {
     case 0:
-      this->m_MovingKernel = BSplineKernelFunction2<0>::New();
+      m_MovingKernel = BSplineKernelFunction2<0>::New();
       /** The derivative of a zero order B-spline makes no sense. Using the
        * derivative of a first order gives a kind of finite difference idea
        * Anyway, if you plan to call GetValueAndDerivative you should use
        * a higher B-spline order.
        */
-      this->m_DerivativeMovingKernel = BSplineDerivativeKernelFunction2<1>::New();
+      m_DerivativeMovingKernel = BSplineDerivativeKernelFunction2<1>::New();
       break;
     case 1:
-      this->m_MovingKernel = BSplineKernelFunction2<1>::New();
-      this->m_DerivativeMovingKernel = BSplineDerivativeKernelFunction2<1>::New();
+      m_MovingKernel = BSplineKernelFunction2<1>::New();
+      m_DerivativeMovingKernel = BSplineDerivativeKernelFunction2<1>::New();
       break;
     case 2:
-      this->m_MovingKernel = BSplineKernelFunction2<2>::New();
-      this->m_DerivativeMovingKernel = BSplineDerivativeKernelFunction2<2>::New();
+      m_MovingKernel = BSplineKernelFunction2<2>::New();
+      m_DerivativeMovingKernel = BSplineDerivativeKernelFunction2<2>::New();
       break;
     case 3:
-      this->m_MovingKernel = BSplineKernelFunction2<3>::New();
-      this->m_DerivativeMovingKernel = BSplineDerivativeKernelFunction2<3>::New();
+      m_MovingKernel = BSplineKernelFunction2<3>::New();
+      m_DerivativeMovingKernel = BSplineDerivativeKernelFunction2<3>::New();
       break;
     default:
-      itkExceptionMacro(
-        "The following MovingKernelBSplineOrder is not implemented: " << this->m_MovingKernelBSplineOrder);
+      itkExceptionMacro("The following MovingKernelBSplineOrder is not implemented: " << m_MovingKernelBSplineOrder);
   } // end switch MovingKernelBSplineOrder
 
   /** The region of support of the Parzen window determines which bins
@@ -344,17 +340,17 @@ ParzenWindowHistogramImageToImageMetric<TFixedImage, TMovingImage>::InitializeKe
 
   /** Set the size of the Parzen window. */
   JointPDFSizeType parzenWindowSize;
-  parzenWindowSize[0] = this->m_MovingKernelBSplineOrder + 1;
-  parzenWindowSize[1] = this->m_FixedKernelBSplineOrder + 1;
-  this->m_JointPDFWindow.SetSize(parzenWindowSize);
+  parzenWindowSize[0] = m_MovingKernelBSplineOrder + 1;
+  parzenWindowSize[1] = m_FixedKernelBSplineOrder + 1;
+  m_JointPDFWindow.SetSize(parzenWindowSize);
 
   /** The ParzenIndex is the lowest bin number that is affected by a
    * pixel and computed as:
    * ParzenIndex = std::floor( ParzenTerm + ParzenTermToIndexOffset )
    * where ParzenTermToIndexOffset = 1/2, 0, -1/2, or -1.
    */
-  this->m_FixedParzenTermToIndexOffset = 0.5 - static_cast<double>(this->m_FixedKernelBSplineOrder) / 2.0;
-  this->m_MovingParzenTermToIndexOffset = 0.5 - static_cast<double>(this->m_MovingKernelBSplineOrder) / 2.0;
+  m_FixedParzenTermToIndexOffset = 0.5 - static_cast<double>(m_FixedKernelBSplineOrder) / 2.0;
+  m_MovingParzenTermToIndexOffset = 0.5 - static_cast<double>(m_MovingKernelBSplineOrder) / 2.0;
 
 } // end InitializeKernels()
 
@@ -478,16 +474,14 @@ ParzenWindowHistogramImageToImageMetric<TFixedImage, TMovingImage>::UpdateJointP
   using PDFIteratorType = ImageScanlineIterator<JointPDFType>;
 
   /** Determine Parzen window arguments (see eq. 6 of Mattes paper [2]). */
-  const double fixedImageParzenWindowTerm =
-    fixedImageValue / this->m_FixedImageBinSize - this->m_FixedImageNormalizedMin;
-  const double movingImageParzenWindowTerm =
-    movingImageValue / this->m_MovingImageBinSize - this->m_MovingImageNormalizedMin;
+  const double fixedImageParzenWindowTerm = fixedImageValue / m_FixedImageBinSize - m_FixedImageNormalizedMin;
+  const double movingImageParzenWindowTerm = movingImageValue / m_MovingImageBinSize - m_MovingImageNormalizedMin;
 
   /** The lowest bin numbers affected by this pixel: */
   const auto fixedImageParzenWindowIndex =
-    static_cast<OffsetValueType>(std::floor(fixedImageParzenWindowTerm + this->m_FixedParzenTermToIndexOffset));
+    static_cast<OffsetValueType>(std::floor(fixedImageParzenWindowTerm + m_FixedParzenTermToIndexOffset));
   const auto movingImageParzenWindowIndex =
-    static_cast<OffsetValueType>(std::floor(movingImageParzenWindowTerm + this->m_MovingParzenTermToIndexOffset));
+    static_cast<OffsetValueType>(std::floor(movingImageParzenWindowTerm + m_MovingParzenTermToIndexOffset));
 
   /** The Parzen values. */
   const auto numberOfFixedParzenValues = m_JointPDFWindow.GetSize()[1];
@@ -512,7 +506,7 @@ ParzenWindowHistogramImageToImageMetric<TFixedImage, TMovingImage>::UpdateJointP
   /** For thread-safety, make a local copy of the support region,
    * and use that one. Because each thread will modify it.
    */
-  JointPDFRegionType jointPDFWindow = this->m_JointPDFWindow;
+  JointPDFRegionType jointPDFWindow = m_JointPDFWindow;
   jointPDFWindow.SetIndex(pdfWindowIndex);
   PDFIteratorType it(jointPDF, jointPDFWindow);
 
@@ -539,7 +533,7 @@ ParzenWindowHistogramImageToImageMetric<TFixedImage, TMovingImage>::UpdateJointP
                                *m_DerivativeMovingKernel,
                                derivativeMovingParzenValues.data_block());
 
-    const auto et = static_cast<double>(this->m_MovingImageBinSize);
+    const auto et = static_cast<double>(m_MovingImageBinSize);
 
     /** Loop over the Parzen window region and increment the values
      * Also update the pdf derivatives.
@@ -574,9 +568,9 @@ ParzenWindowHistogramImageToImageMetric<TFixedImage, TMovingImage>::UpdateJointP
   const NonZeroJacobianIndicesType & nzji) const
 {
   /** Get the pointer to the element with index [0, pdfIndex[0], pdfIndex[1]]. */
-  PDFDerivativeValueType * derivPtr = this->m_JointPDFDerivatives->GetBufferPointer() +
-                                      (pdfIndex[0] * this->m_JointPDFDerivatives->GetOffsetTable()[1]) +
-                                      (pdfIndex[1] * this->m_JointPDFDerivatives->GetOffsetTable()[2]);
+  PDFDerivativeValueType * derivPtr = m_JointPDFDerivatives->GetBufferPointer() +
+                                      (pdfIndex[0] * m_JointPDFDerivatives->GetOffsetTable()[1]) +
+                                      (pdfIndex[1] * m_JointPDFDerivatives->GetOffsetTable()[2]);
 
   const auto numberOfParameters = this->GetNumberOfParameters();
 
@@ -643,7 +637,7 @@ ParzenWindowHistogramImageToImageMetric<TFixedImage, TMovingImage>::ComputeMargi
 {
   using JointPDFLinearIterator = ImageLinearIteratorWithIndex<JointPDFType>;
   // \todo: bug? shouldn't this be over the function argument jointPDF ?
-  JointPDFLinearIterator linearIter(this->m_JointPDF, this->m_JointPDF->GetBufferedRegion());
+  JointPDFLinearIterator linearIter(m_JointPDF, m_JointPDF->GetBufferedRegion());
   linearIter.SetDirection(direction);
   linearIter.GoToBegin();
   unsigned int marginalIndex = 0;
@@ -687,9 +681,9 @@ ParzenWindowHistogramImageToImageMetric<TFixedImage, TMovingImage>::ComputeIncre
   const auto numberOfParameters = this->GetNumberOfParameters();
 
   /** Loop over the incremental pdf and update the incremental marginal pdfs. */
-  for (unsigned int f = 0; f < this->m_NumberOfFixedHistogramBins; ++f)
+  for (unsigned int f = 0; f < m_NumberOfFixedHistogramBins; ++f)
   {
-    for (unsigned int m = 0; m < this->m_NumberOfMovingHistogramBins; ++m)
+    for (unsigned int m = 0; m < m_NumberOfMovingHistogramBins; ++m)
     {
       for (unsigned int p = 0; p < numberOfParameters; ++p)
       {
@@ -726,30 +720,28 @@ ParzenWindowHistogramImageToImageMetric<TFixedImage, TMovingImage>::UpdateJointP
   const NonZeroJacobianIndicesType & nzji) const
 {
   /** Pointers to the first pixels in the incremental joint pdfs. */
-  PDFDerivativeValueType * incRightBasePtr = this->m_IncrementalJointPDFRight->GetBufferPointer();
-  PDFDerivativeValueType * incLeftBasePtr = this->m_IncrementalJointPDFLeft->GetBufferPointer();
+  PDFDerivativeValueType * incRightBasePtr = m_IncrementalJointPDFRight->GetBufferPointer();
+  PDFDerivativeValueType * incLeftBasePtr = m_IncrementalJointPDFLeft->GetBufferPointer();
 
   /** The Parzen value containers. */
-  ParzenValueContainerType fixedParzenValues(this->m_JointPDFWindow.GetSize()[1]);
-  ParzenValueContainerType movingParzenValues(this->m_JointPDFWindow.GetSize()[0]);
+  ParzenValueContainerType fixedParzenValues(m_JointPDFWindow.GetSize()[1]);
+  ParzenValueContainerType movingParzenValues(m_JointPDFWindow.GetSize()[0]);
 
   /** Determine fixed image Parzen window arguments (see eq. 6 of Mattes paper [2]). */
-  const double fixedImageParzenWindowTerm =
-    fixedImageValue / this->m_FixedImageBinSize - this->m_FixedImageNormalizedMin;
+  const double fixedImageParzenWindowTerm = fixedImageValue / m_FixedImageBinSize - m_FixedImageNormalizedMin;
 
   /** The lowest bin numbers affected by this pixel: */
   const auto fixedImageParzenWindowIndex =
-    static_cast<OffsetValueType>(std::floor(fixedImageParzenWindowTerm + this->m_FixedParzenTermToIndexOffset));
+    static_cast<OffsetValueType>(std::floor(fixedImageParzenWindowTerm + m_FixedParzenTermToIndexOffset));
   Self::EvaluateParzenValues(
     fixedImageParzenWindowTerm, fixedImageParzenWindowIndex, *m_FixedKernel, fixedParzenValues.data_block());
 
   if (movingMaskValue > 1e-10)
   {
     /** Determine moving image Parzen window arguments (see eq. 6 of Mattes paper [2]). */
-    const double movingImageParzenWindowTerm =
-      movingImageValue / this->m_MovingImageBinSize - this->m_MovingImageNormalizedMin;
-    const auto movingImageParzenWindowIndex =
-      static_cast<OffsetValueType>(std::floor(movingImageParzenWindowTerm + this->m_MovingParzenTermToIndexOffset));
+    const double movingImageParzenWindowTerm = movingImageValue / m_MovingImageBinSize - m_MovingImageNormalizedMin;
+    const auto   movingImageParzenWindowIndex =
+      static_cast<OffsetValueType>(std::floor(movingImageParzenWindowTerm + m_MovingParzenTermToIndexOffset));
     Self::EvaluateParzenValues(
       movingImageParzenWindowTerm, movingImageParzenWindowIndex, *m_MovingKernel, movingParzenValues.data_block());
 
@@ -770,10 +762,10 @@ ParzenWindowHistogramImageToImageMetric<TFixedImage, TMovingImage>::UpdateJointP
       for (unsigned int m = 0; m < movingParzenValues.GetSize(); ++m)
       {
         const auto fv_mask_mv = static_cast<PDFValueType>(fv_mask * movingParzenValues[m]);
-        this->m_JointPDF->GetPixel(pdfIndex) += fv_mask_mv;
+        m_JointPDF->GetPixel(pdfIndex) += fv_mask_mv;
 
-        auto offset = static_cast<unsigned long>(pdfIndex[0] * this->m_IncrementalJointPDFRight->GetOffsetTable()[1] +
-                                                 pdfIndex[1] * this->m_IncrementalJointPDFRight->GetOffsetTable()[2]);
+        auto offset = static_cast<unsigned long>(pdfIndex[0] * m_IncrementalJointPDFRight->GetOffsetTable()[1] +
+                                                 pdfIndex[1] * m_IncrementalJointPDFRight->GetOffsetTable()[2]);
 
         /** Get the pointer to the element with index [0, pdfIndex[0], pdfIndex[1]]. */
         PDFDerivativeValueType * incRightPtr = incRightBasePtr + offset;
@@ -819,9 +811,9 @@ ParzenWindowHistogramImageToImageMetric<TFixedImage, TMovingImage>::UpdateJointP
     {
       /** Compute Parzen stuff; note: we reuse the movingParzenValues container. */
       const double movr = movingImageValuesRight[i];
-      const double movParzenWindowTermRight = movr / this->m_MovingImageBinSize - this->m_MovingImageNormalizedMin;
+      const double movParzenWindowTermRight = movr / m_MovingImageBinSize - m_MovingImageNormalizedMin;
       const auto   movParzenWindowIndexRight =
-        static_cast<OffsetValueType>(std::floor(movParzenWindowTermRight + this->m_MovingParzenTermToIndexOffset));
+        static_cast<OffsetValueType>(std::floor(movParzenWindowTermRight + m_MovingParzenTermToIndexOffset));
       Self::EvaluateParzenValues(
         movParzenWindowTermRight, movParzenWindowIndexRight, *m_MovingKernel, movingParzenValues.data_block());
 
@@ -837,7 +829,7 @@ ParzenWindowHistogramImageToImageMetric<TFixedImage, TMovingImage>::UpdateJointP
         for (unsigned int m = 0; m < movingParzenValues.GetSize(); ++m)
         {
           const auto fv_mask_mv = static_cast<PDFValueType>(fv_mask * movingParzenValues[m]);
-          this->m_IncrementalJointPDFRight->GetPixel(rindex) += fv_mask_mv;
+          m_IncrementalJointPDFRight->GetPixel(rindex) += fv_mask_mv;
           ++(rindex[1]);
         } // end for m
 
@@ -851,9 +843,9 @@ ParzenWindowHistogramImageToImageMetric<TFixedImage, TMovingImage>::UpdateJointP
     {
       /** Compute Parzen stuff; note: we reuse the movingParzenValues container. */
       const double movl = movingImageValuesLeft[i];
-      const double movParzenWindowTermLeft = movl / this->m_MovingImageBinSize - this->m_MovingImageNormalizedMin;
+      const double movParzenWindowTermLeft = movl / m_MovingImageBinSize - m_MovingImageNormalizedMin;
       const auto   movParzenWindowIndexLeft =
-        static_cast<OffsetValueType>(std::floor(movParzenWindowTermLeft + this->m_MovingParzenTermToIndexOffset));
+        static_cast<OffsetValueType>(std::floor(movParzenWindowTermLeft + m_MovingParzenTermToIndexOffset));
       Self::EvaluateParzenValues(
         movParzenWindowTermLeft, movParzenWindowIndexLeft, *m_MovingKernel, movingParzenValues.data_block());
 
@@ -869,7 +861,7 @@ ParzenWindowHistogramImageToImageMetric<TFixedImage, TMovingImage>::UpdateJointP
         for (unsigned int m = 0; m < movingParzenValues.GetSize(); ++m)
         {
           const auto fv_mask_mv = static_cast<PDFValueType>(fv_mask * movingParzenValues[m]);
-          this->m_IncrementalJointPDFLeft->GetPixel(lindex) += fv_mask_mv;
+          m_IncrementalJointPDFLeft->GetPixel(lindex) += fv_mask_mv;
           ++(lindex[1]);
         } // end for m
 
@@ -880,8 +872,8 @@ ParzenWindowHistogramImageToImageMetric<TFixedImage, TMovingImage>::UpdateJointP
     } // end if maskl
 
     /** Update the perturbed alphas. */
-    this->m_PerturbedAlphaRight[mu] += (maskr - movingMaskValue);
-    this->m_PerturbedAlphaLeft[mu] += (maskl - movingMaskValue);
+    m_PerturbedAlphaRight[mu] += (maskr - movingMaskValue);
+    m_PerturbedAlphaLeft[mu] += (maskl - movingMaskValue);
   } // end for i
 
 } // end UpdateJointPDFAndIncrementalPDFs()
@@ -897,9 +889,9 @@ ParzenWindowHistogramImageToImageMetric<TFixedImage, TMovingImage>::ComputePDFsS
   const ParametersType & parameters) const
 {
   /** Initialize some variables. */
-  this->m_JointPDF->FillBuffer(0.0);
+  m_JointPDF->FillBuffer(0.0);
   Superclass::m_NumberOfPixelsCounted = 0;
-  this->m_Alpha = 0.0;
+  m_Alpha = 0.0;
 
   /** Call non-thread-safe stuff, such as:
    *   this->SetTransformParameters( parameters );
@@ -952,8 +944,7 @@ ParzenWindowHistogramImageToImageMetric<TFixedImage, TMovingImage>::ComputePDFsS
       movingImageValue = this->GetMovingImageLimiter()->Evaluate(movingImageValue);
 
       /** Compute this sample's contribution to the joint distributions. */
-      this->UpdateJointPDFAndDerivatives(
-        fixedImageValue, movingImageValue, nullptr, nullptr, this->m_JointPDF.GetPointer());
+      this->UpdateJointPDFAndDerivatives(fixedImageValue, movingImageValue, nullptr, nullptr, m_JointPDF.GetPointer());
     }
 
   } // end iterating over fixed image spatial sample container for loop
@@ -962,7 +953,7 @@ ParzenWindowHistogramImageToImageMetric<TFixedImage, TMovingImage>::ComputePDFsS
   this->CheckNumberOfSamples();
 
   /** Compute alpha. */
-  this->m_Alpha = 1.0 / static_cast<double>(Superclass::m_NumberOfPixelsCounted);
+  m_Alpha = 1.0 / static_cast<double>(Superclass::m_NumberOfPixelsCounted);
 
 } // end ComputePDFsSingleThreaded()
 
@@ -999,7 +990,7 @@ ParzenWindowHistogramImageToImageMetric<TFixedImage, TMovingImage>::ComputePDFs(
   // Set up threader and launch multi-threaded JointPDF computation:
   this->m_Threader->SetSingleMethodAndExecute(
     this->ComputePDFsThreaderCallback,
-    const_cast<void *>(static_cast<const void *>(&this->m_ParzenWindowHistogramThreaderParameters)));
+    const_cast<void *>(static_cast<const void *>(&m_ParzenWindowHistogramThreaderParameters)));
 
   /** Gather the results from all threads. */
   this->AfterThreadedComputePDFs();
@@ -1019,8 +1010,7 @@ ParzenWindowHistogramImageToImageMetric<TFixedImage, TMovingImage>::ThreadedComp
    * The initialization is performed here, so that it is done multi-threadedly
    * instead of sequentially in InitializeThreadingParameters().
    */
-  JointPDFPointer & jointPDF =
-    this->m_ParzenWindowHistogramGetValueAndDerivativePerThreadVariables[threadId].st_JointPDF;
+  JointPDFPointer & jointPDF = m_ParzenWindowHistogramGetValueAndDerivativePerThreadVariables[threadId].st_JointPDF;
   jointPDF->FillBuffer(PDFValueType{});
 
   /** Get a handle to the sample container. */
@@ -1080,7 +1070,7 @@ ParzenWindowHistogramImageToImageMetric<TFixedImage, TMovingImage>::ThreadedComp
   } // end iterating over fixed image spatial sample container for loop
 
   /** Only update these variables at the end to prevent unnecessary "false sharing". */
-  this->m_ParzenWindowHistogramGetValueAndDerivativePerThreadVariables[threadId].st_NumberOfPixelsCounted =
+  m_ParzenWindowHistogramGetValueAndDerivativePerThreadVariables[threadId].st_NumberOfPixelsCounted =
     numberOfPixelsCounted;
 
 } // end ThreadedComputePDFs()
@@ -1098,11 +1088,11 @@ ParzenWindowHistogramImageToImageMetric<TFixedImage, TMovingImage>::AfterThreade
 
   /** Accumulate the number of pixels. */
   Superclass::m_NumberOfPixelsCounted =
-    this->m_ParzenWindowHistogramGetValueAndDerivativePerThreadVariables[0].st_NumberOfPixelsCounted;
+    m_ParzenWindowHistogramGetValueAndDerivativePerThreadVariables[0].st_NumberOfPixelsCounted;
   for (ThreadIdType i = 1; i < numberOfThreads; ++i)
   {
     Superclass::m_NumberOfPixelsCounted +=
-      this->m_ParzenWindowHistogramGetValueAndDerivativePerThreadVariables[i].st_NumberOfPixelsCounted;
+      m_ParzenWindowHistogramGetValueAndDerivativePerThreadVariables[i].st_NumberOfPixelsCounted;
   }
 
   /** Check if enough samples were valid. */
@@ -1110,17 +1100,17 @@ ParzenWindowHistogramImageToImageMetric<TFixedImage, TMovingImage>::AfterThreade
   this->CheckNumberOfSamples();
 
   /** Compute alpha. */
-  this->m_Alpha = 1.0 / static_cast<double>(Superclass::m_NumberOfPixelsCounted);
+  m_Alpha = 1.0 / static_cast<double>(Superclass::m_NumberOfPixelsCounted);
 
   /** Accumulate joint histogram. */
   // could be multi-threaded too, by each thread updating only a part of the JointPDF.
   using JointPDFIteratorType = ImageScanlineIterator<JointPDFType>;
-  JointPDFIteratorType              it(this->m_JointPDF, this->m_JointPDF->GetBufferedRegion());
+  JointPDFIteratorType              it(m_JointPDF, m_JointPDF->GetBufferedRegion());
   std::vector<JointPDFIteratorType> itT(numberOfThreads);
   for (ThreadIdType i = 0; i < numberOfThreads; ++i)
   {
-    itT[i] = JointPDFIteratorType(this->m_ParzenWindowHistogramGetValueAndDerivativePerThreadVariables[i].st_JointPDF,
-                                  this->m_JointPDF->GetBufferedRegion());
+    itT[i] = JointPDFIteratorType(m_ParzenWindowHistogramGetValueAndDerivativePerThreadVariables[i].st_JointPDF,
+                                  m_JointPDF->GetBufferedRegion());
   }
 
   PDFValueType sum;
@@ -1179,9 +1169,9 @@ ParzenWindowHistogramImageToImageMetric<TFixedImage, TMovingImage>::ComputePDFsA
   const ParametersType & parameters) const
 {
   /** Initialize some variables. */
-  this->m_JointPDF->FillBuffer(0.0);
-  this->m_JointPDFDerivatives->FillBuffer(0.0);
-  this->m_Alpha = 0.0;
+  m_JointPDF->FillBuffer(0.0);
+  m_JointPDFDerivatives->FillBuffer(0.0);
+  m_Alpha = 0.0;
   Superclass::m_NumberOfPixelsCounted = 0;
 
   /** Array that stores dM(x)/dmu, and the sparse jacobian+indices. */
@@ -1249,7 +1239,7 @@ ParzenWindowHistogramImageToImageMetric<TFixedImage, TMovingImage>::ComputePDFsA
 
       /** Update the joint pdf and the joint pdf derivatives. */
       this->UpdateJointPDFAndDerivatives(
-        fixedImageValue, movingImageValue, &imageJacobian, &nzji, this->m_JointPDF.GetPointer());
+        fixedImageValue, movingImageValue, &imageJacobian, &nzji, m_JointPDF.GetPointer());
 
     } // end if-block check sampleOk
   } // end iterating over fixed image spatial sample container for loop
@@ -1258,10 +1248,10 @@ ParzenWindowHistogramImageToImageMetric<TFixedImage, TMovingImage>::ComputePDFsA
   this->CheckNumberOfSamples();
 
   /** Compute alpha. */
-  this->m_Alpha = 0.0;
+  m_Alpha = 0.0;
   if (Superclass::m_NumberOfPixelsCounted > 0)
   {
-    this->m_Alpha = 1.0 / static_cast<double>(Superclass::m_NumberOfPixelsCounted);
+    m_Alpha = 1.0 / static_cast<double>(Superclass::m_NumberOfPixelsCounted);
   }
 
 } // end ComputePDFsAndPDFDerivatives()
@@ -1277,12 +1267,12 @@ ParzenWindowHistogramImageToImageMetric<TFixedImage, TMovingImage>::ComputePDFsA
   const ParametersType & parameters) const
 {
   /** Initialize some variables. */
-  this->m_JointPDF->FillBuffer(0.0);
-  this->m_IncrementalJointPDFRight->FillBuffer(0.0);
-  this->m_IncrementalJointPDFLeft->FillBuffer(0.0);
-  this->m_Alpha = 0.0;
-  this->m_PerturbedAlphaRight.Fill(0.0);
-  this->m_PerturbedAlphaLeft.Fill(0.0);
+  m_JointPDF->FillBuffer(0.0);
+  m_IncrementalJointPDFRight->FillBuffer(0.0);
+  m_IncrementalJointPDFLeft->FillBuffer(0.0);
+  m_Alpha = 0.0;
+  m_PerturbedAlphaRight.Fill(0.0);
+  m_PerturbedAlphaLeft.Fill(0.0);
 
   Superclass::m_NumberOfPixelsCounted = 0;
   double       sumOfMovingMaskValues = 0.0;
@@ -1454,33 +1444,33 @@ ParzenWindowHistogramImageToImageMetric<TFixedImage, TMovingImage>::ComputePDFsA
   this->CheckNumberOfSamples();
 
   /** Compute alpha and its perturbed versions. */
-  this->m_Alpha = 0.0;
+  m_Alpha = 0.0;
   if (sumOfMovingMaskValues > 1e-14)
   {
-    this->m_Alpha = 1.0 / sumOfMovingMaskValues;
+    m_Alpha = 1.0 / sumOfMovingMaskValues;
   }
 
   const auto numberOfParameters = this->GetNumberOfParameters();
 
   for (unsigned int i = 0; i < numberOfParameters; ++i)
   {
-    this->m_PerturbedAlphaRight[i] += sumOfMovingMaskValues;
-    this->m_PerturbedAlphaLeft[i] += sumOfMovingMaskValues;
-    if (this->m_PerturbedAlphaRight[i] > 1e-10)
+    m_PerturbedAlphaRight[i] += sumOfMovingMaskValues;
+    m_PerturbedAlphaLeft[i] += sumOfMovingMaskValues;
+    if (m_PerturbedAlphaRight[i] > 1e-10)
     {
-      this->m_PerturbedAlphaRight[i] = 1.0 / this->m_PerturbedAlphaRight[i];
+      m_PerturbedAlphaRight[i] = 1.0 / m_PerturbedAlphaRight[i];
     }
     else
     {
-      this->m_PerturbedAlphaRight[i] = 0.0;
+      m_PerturbedAlphaRight[i] = 0.0;
     }
-    if (this->m_PerturbedAlphaLeft[i] > 1e-10)
+    if (m_PerturbedAlphaLeft[i] > 1e-10)
     {
-      this->m_PerturbedAlphaLeft[i] = 1.0 / this->m_PerturbedAlphaLeft[i];
+      m_PerturbedAlphaLeft[i] = 1.0 / m_PerturbedAlphaLeft[i];
     }
     else
     {
-      this->m_PerturbedAlphaLeft[i] = 0.0;
+      m_PerturbedAlphaLeft[i] = 0.0;
     }
   }
 


### PR DESCRIPTION
- Follow-up to pull request #1373 commit 441614091d6bfe66dc6a655f87ef7c6893262e1d "STYLE: Remove `this->` when MultiMetric Method accesses its own data"