### PR TITLE
ENH: Add support for multiple metrics and regularization

### DIFF
--- a/Components/Registrations/MultiMetricMultiResolutionRegistration/itkCombinationImageToImageMetric.h
+++ b/Components/Registrations/MultiMetricMultiResolutionRegistration/itkCombinationImageToImageMetric.h
@@ -18,6 +18,7 @@
 #ifndef itkCombinationImageToImageMetric_h
 #define itkCombinationImageToImageMetric_h
 
+#include "itkTransformPenaltyTerm.h"
 #include "itkAdvancedImageToImageMetric.h"
 #include "itkSingleValuedPointSetToPointSetMetric.h"
 
@@ -131,6 +132,10 @@ public:
   using MovingImageRegionType = typename MovingImageType::RegionType;
   using MovingImageDerivativeScalesType = FixedArray<double, Self::MovingImageDimension>;
 
+  /** Typedef for transform penalty metrics. */
+  typedef TransformPenaltyTerm<TFixedImage>             TransformMetricType;
+  typedef typename TransformMetricType::Pointer         TransformMetricPointer;
+
   /** Typedef for the PointSetMetric. */
   using FixedPointSetType = PointSet<CoordinateRepresentationType,
                                      TFixedImage::ImageDimension,
@@ -163,6 +168,9 @@ public:
 
   /** Get the number of metrics to combine. */
   itkGetConstMacro(NumberOfMetrics, unsigned int);
+  itkGetConstMacro(NumberOfImageMetrics, unsigned int);
+  itkGetConstMacro(NumberOfTransformMetrics, unsigned int);
+  itkGetConstMacro(NumberOfPointSetMetrics, unsigned int);
 
   /** Set metric i. It may be a SingleValuedCostFunction, instead of
    * a ImageToImageMetric, but the first one should be an
@@ -453,6 +461,9 @@ protected:
 private:
   /** Store the metrics and the corresponding weights. */
   unsigned int                                 m_NumberOfMetrics{ 0 };
+  unsigned int                                 m_NumberOfImageMetrics{ 0 };
+  unsigned int                                 m_NumberOfTransformMetrics{ 0 };
+  unsigned int                                 m_NumberOfPointSetMetrics{ 0 };
   std::vector<SingleValuedCostFunctionPointer> m_Metrics{};
   std::vector<double>                          m_MetricWeights{};
   std::vector<double>                          m_MetricRelativeWeights{};

--- a/Components/Registrations/MultiMetricMultiResolutionRegistration/itkCombinationImageToImageMetric.hxx
+++ b/Components/Registrations/MultiMetricMultiResolutionRegistration/itkCombinationImageToImageMetric.hxx
@@ -160,6 +160,9 @@ CombinationImageToImageMetric<TFixedImage, TMovingImage>::PrintSelf(std::ostream
 
   /** Add debugging information. */
   os << "NumberOfMetrics: " << this->m_NumberOfMetrics << std::endl;
+  os << "NumberOfImageMetrics: " << this->m_NumberOfImageMetrics << std::endl;
+  os << "NumberOfTransformMetrics: " << this->m_NumberOfTransformMetrics << std::endl;
+  os << "NumberOfPointSetMetrics: " << this->m_NumberOfPointSetMetrics << std::endl;
   for (unsigned int i = 0; i < this->m_NumberOfMetrics; ++i)
   {
     os << "Metric " << i << ":\n";
@@ -275,11 +278,50 @@ CombinationImageToImageMetric<TFixedImage, TMovingImage>::SetMetric(SingleValued
     this->SetNumberOfMetrics(pos + 1);
   }
 
-  if (metric != this->m_Metrics[pos])
+  SingleValuedCostFunctionPointer oldMetricPtr = this->m_Metrics[pos];
+  if (metric == oldMetricPtr)
   {
-    this->m_Metrics[pos] = metric;
-    this->Modified();
+    return;
   }
+
+  PointSetMetricType * testPtr1 = dynamic_cast<PointSetMetricType *>(metric);
+  TransformMetricType * testPtr2 = dynamic_cast<TransformMetricType *>(metric);
+
+  // Increase newly defined numberOfMetric counters
+  if (testPtr1)
+  {
+    this->m_NumberOfPointSetMetrics++;
+  }
+  else if (testPtr2)
+  {
+    this->m_NumberOfTransformMetrics++;
+  }
+  else
+  {
+    this->m_NumberOfImageMetrics++;
+  }
+
+  // if the metric has already been set, decrease the correct counter
+  if (oldMetricPtr != nullptr)
+  {
+    PointSetMetricType * oldTestPtr1 = dynamic_cast<PointSetMetricType *>(oldMetricPtr.GetPointer());
+    TransformMetricType * oldTestPtr2 = dynamic_cast<TransformMetricType *>(oldMetricPtr.GetPointer());
+    if (oldTestPtr1)
+    {
+      this->m_NumberOfPointSetMetrics--;
+    }
+    else if (oldTestPtr2)
+    {
+      this->m_NumberOfTransformMetrics--;
+    }
+    else
+    {
+      this->m_NumberOfImageMetrics--;
+    }
+  }
+
+  this->m_Metrics[pos] = metric;
+  this->Modified();
 
 } // end SetMetric()
 

--- a/Components/Registrations/MultiMetricMultiResolutionRegistration/itkMultiMetricMultiResolutionImageRegistrationMethod.hxx
+++ b/Components/Registrations/MultiMetricMultiResolutionRegistration/itkMultiMetricMultiResolutionImageRegistrationMethod.hxx
@@ -565,44 +565,44 @@ MultiMetricMultiResolutionImageRegistrationMethod<TFixedImage, TMovingImage>::Ch
   }
 
   /** nrofmetrics >= nrofinterpolators >= nrofpyramids >= nofimages */
-  unsigned int nrOfMetrics = m_CombinationMetric->GetNumberOfMetrics();
-  if (this->GetNumberOfInterpolators() > nrOfMetrics)
+  unsigned int nrOfImageMetrics = this->GetCombinationMetric()->GetNumberOfImageMetrics();
+  if (this->GetNumberOfInterpolators() > nrOfImageMetrics)
   {
-    itkExceptionMacro("NumberOfInterpolators can not exceed the NumberOfMetrics in the CombinationMetric!");
+    itkExceptionMacro("NumberOfInterpolators can not exceed the nrOfImageMetrics in the CombinationMetric!");
   }
-  if (this->GetNumberOfFixedImagePyramids() > nrOfMetrics)
+  if (this->GetNumberOfFixedImagePyramids() > nrOfImageMetrics)
   {
-    itkExceptionMacro("NumberOfFixedImagePyramids can not exceed the NumberOfMetrics in the CombinationMetric!");
+    itkExceptionMacro("NumberOfFixedImagePyramids can not exceed the nrOfImageMetrics in the CombinationMetric!");
   }
-  if (this->GetNumberOfMovingImagePyramids() > nrOfMetrics)
+  if (this->GetNumberOfMovingImagePyramids() > nrOfImageMetrics)
   {
-    itkExceptionMacro("NumberOfMovingImagePyramids can not exceed the NumberOfMetrics in the CombinationMetric!");
+    itkExceptionMacro("NumberOfMovingImagePyramids can not exceed the nrOfImageMetrics in the CombinationMetric!");
   }
   if (this->GetNumberOfMovingImagePyramids() > this->GetNumberOfInterpolators())
   {
     itkExceptionMacro("NumberOfMovingImagePyramids can not exceed the NumberOfInterpolators!");
   }
 
-  /** For all components: ==nrofmetrics of ==1. */
-  if ((this->GetNumberOfInterpolators() != 1) && (this->GetNumberOfInterpolators() != nrOfMetrics))
+  /** For all components: ==nrOfImageMetrics of ==1. */
+  if ((this->GetNumberOfInterpolators() != 1) && (this->GetNumberOfInterpolators() != nrOfImageMetrics))
   {
-    itkExceptionMacro("The NumberOfInterpolators should equal 1 or equal the NumberOfMetrics");
+    itkExceptionMacro("The NumberOfInterpolators should equal 1 or equal the nrOfImageMetrics");
   }
-  if ((this->GetNumberOfFixedImagePyramids() != 1) && (this->GetNumberOfFixedImagePyramids() != nrOfMetrics))
+  if ((this->GetNumberOfFixedImagePyramids() != 1) && (this->GetNumberOfFixedImagePyramids() != nrOfImageMetrics))
   {
-    itkExceptionMacro("The NumberOfFixedImagePyramids should equal 1 or equal the NumberOfMetrics");
+    itkExceptionMacro("The NumberOfFixedImagePyramids should equal 1 or equal the nrOfImageMetrics");
   }
-  if ((this->GetNumberOfMovingImagePyramids() != 1) && (this->GetNumberOfMovingImagePyramids() != nrOfMetrics))
+  if ((this->GetNumberOfMovingImagePyramids() != 1) && (this->GetNumberOfMovingImagePyramids() != nrOfImageMetrics))
   {
-    itkExceptionMacro("The NumberOfMovingImagePyramids should equal 1 or equal the NumberOfMetrics");
+    itkExceptionMacro("The NumberOfMovingImagePyramids should equal 1 or equal the nrOfImageMetrics");
   }
-  if ((this->GetNumberOfFixedImages() != 1) && (this->GetNumberOfFixedImages() != nrOfMetrics))
+  if ((this->GetNumberOfFixedImages() != 1) && (this->GetNumberOfFixedImages() != nrOfImageMetrics))
   {
-    itkExceptionMacro("The NumberOfFixedImages should equal 1 or equal the NumberOfMetrics");
+    itkExceptionMacro("The NumberOfFixedImages should equal 1 or equal the nrOfImageMetrics");
   }
-  if ((this->GetNumberOfMovingImages() != 1) && (this->GetNumberOfMovingImages() != nrOfMetrics))
+  if ((this->GetNumberOfMovingImages() != 1) && (this->GetNumberOfMovingImages() != nrOfImageMetrics))
   {
-    itkExceptionMacro("The NumberOfMovingImages should equal 1 or equal the NumberOfMetrics");
+    itkExceptionMacro("The NumberOfMovingImages should equal 1 or equal the nrOfImageMetrics");
   }
 
 } // end CheckOnInitialize()


### PR DESCRIPTION
Hi, apparently it was not possible to do a multi-image registration with a transform metric like this:

```
(Metric "AdvancedMattesMutualInformation" "AdvancedMattesMutualInformation" "AdvancedMattesMutualInformation" "AdvancedMattesMutualInformation" "TransformBendingEnergyPenalty")
(Metric0Weight 1.0)
(Metric1Weight 1.0)
(Metric2Weight 1.0)
(Metric3Weight 1.0)
(Metric4Weight 10.0)

(NumberOfHistogramBins0 32)
(NumberOfHistogramBins1 32)
(NumberOfHistogramBins2 32)
(NumberOfHistogramBins3 32)
```

Now it is possible :)