### PR TITLE
STYLE: Make ParameterMapInterface default-constructible

### DIFF
--- a/Common/GTesting/elxConversionGTest.cxx
+++ b/Common/GTesting/elxConversionGTest.cxx
@@ -97,16 +97,16 @@ Expect_successful_round_trip_of_parameter_value(const TParameterValue & paramete
   const std::string                                  parameterName("Key");
   const itk::ParameterMapInterface::ParameterMapType parameterMap{ { parameterName,
                                                                      { Conversion::ToString(parameterValue) } } };
-  const auto                                         parameterMapInterface = CheckNew<itk::ParameterMapInterface>();
+  itk::ParameterMapInterface                         parameterMapInterface{};
 
-  parameterMapInterface->SetParameterMap(parameterMap);
+  parameterMapInterface.SetParameterMap(parameterMap);
 
   TParameterValue actualParameterValue{};
 
   std::string errorMessage;
   try
   {
-    EXPECT_TRUE(parameterMapInterface->ReadParameter(actualParameterValue, parameterName, 0, errorMessage));
+    EXPECT_TRUE(parameterMapInterface.ReadParameter(actualParameterValue, parameterName, 0, errorMessage));
   }
   catch (const itk::ExceptionObject & exceptionObject)
   {
@@ -203,13 +203,13 @@ Expect_parameter_with_decimal_point_and_trailing_zeros_can_be_read_as_integer()
       const std::string parameterName("Key");
       const std::string parameterStringValue = std::to_string(integer) + '.' + std::string(numberOfTrailingZeros, '0');
 
-      const auto parameterMapInterface = CheckNew<itk::ParameterMapInterface>();
-      parameterMapInterface->SetParameterMap({ { parameterName, { parameterStringValue } } });
+      itk::ParameterMapInterface parameterMapInterface{};
+      parameterMapInterface.SetParameterMap({ { parameterName, { parameterStringValue } } });
 
       TInteger actualParameterValue{};
 
       std::string errorMessage;
-      EXPECT_TRUE(parameterMapInterface->ReadParameter(actualParameterValue, parameterName, 0, errorMessage));
+      EXPECT_TRUE(parameterMapInterface.ReadParameter(actualParameterValue, parameterName, 0, errorMessage));
       EXPECT_EQ(errorMessage, std::string{});
       EXPECT_EQ(actualParameterValue, integer);
     }
@@ -230,13 +230,13 @@ Expect_parameter_with_decimal_point_and_non_zero_trailing_chars_can_not_be_read_
       const std::string parameterName("Key");
       const std::string parameterStringValue = std::to_string(integer) + '.' + trail;
 
-      const auto parameterMapInterface = CheckNew<itk::ParameterMapInterface>();
-      parameterMapInterface->SetParameterMap({ { parameterName, { parameterStringValue } } });
+      itk::ParameterMapInterface parameterMapInterface{};
+      parameterMapInterface.SetParameterMap({ { parameterName, { parameterStringValue } } });
 
       TInteger actualParameterValue{};
 
       std::string errorMessage;
-      EXPECT_THROW(parameterMapInterface->ReadParameter(actualParameterValue, parameterName, 0, errorMessage),
+      EXPECT_THROW(parameterMapInterface.ReadParameter(actualParameterValue, parameterName, 0, errorMessage),
                    itk::ExceptionObject);
     }
   }
@@ -254,7 +254,7 @@ Expect_negative_parameter_value_can_not_be_read_as_unsigned()
     const std::string parameterName("Key");
     const std::string parameterStringValue = std::to_string(integer);
 
-    elx::DefaultConstruct<itk::ParameterMapInterface> parameterMapInterface;
+    itk::ParameterMapInterface parameterMapInterface{};
     parameterMapInterface.SetParameterMap({ { parameterName, { parameterStringValue } } });
 
     std::make_unsigned_t<TSignedInteger> actualParameterValue{};

--- a/Common/GTesting/itkParameterMapInterfaceTest.cxx
+++ b/Common/GTesting/itkParameterMapInterfaceTest.cxx
@@ -30,29 +30,29 @@ using itk::ParameterMapInterface;
 
 GTEST_TEST(ParameterMapInterface, RetrieveValuesReturnsNullWhenParameterMapIsEmpty)
 {
-  const auto parameterMapInterface = ParameterMapInterface::New();
-  EXPECT_EQ(parameterMapInterface->RetrieveValues<bool>("parameterName"), nullptr);
-  EXPECT_EQ(parameterMapInterface->RetrieveValues<double>("parameterName"), nullptr);
+  const ParameterMapInterface parameterMapInterface{};
+  EXPECT_EQ(parameterMapInterface.RetrieveValues<bool>("parameterName"), nullptr);
+  EXPECT_EQ(parameterMapInterface.RetrieveValues<double>("parameterName"), nullptr);
 }
 
 
 GTEST_TEST(ParameterMapInterface, RetrieveValuesReturnsNullWhenParameterNameIsMissing)
 {
-  const auto parameterMapInterface = ParameterMapInterface::New();
-  parameterMapInterface->SetParameterMap({ { "ParameterName", { "0", "1" } } });
+  ParameterMapInterface parameterMapInterface{};
+  parameterMapInterface.SetParameterMap({ { "ParameterName", { "0", "1" } } });
 
-  EXPECT_EQ(parameterMapInterface->RetrieveValues<bool>("MissingParameterName"), nullptr);
-  EXPECT_EQ(parameterMapInterface->RetrieveValues<double>("MissingParameterName"), nullptr);
+  EXPECT_EQ(parameterMapInterface.RetrieveValues<bool>("MissingParameterName"), nullptr);
+  EXPECT_EQ(parameterMapInterface.RetrieveValues<double>("MissingParameterName"), nullptr);
 }
 
 
 GTEST_TEST(ParameterMapInterface, RetrieveValuesSupportsZeroValues)
 {
-  const auto        parameterMapInterface = ParameterMapInterface::New();
-  const std::string parameterName("Key");
-  parameterMapInterface->SetParameterMap({ { parameterName, {} } });
+  ParameterMapInterface parameterMapInterface{};
+  const std::string     parameterName("Key");
+  parameterMapInterface.SetParameterMap({ { parameterName, {} } });
 
-  const auto retrievedValues = parameterMapInterface->RetrieveValues<double>(parameterName);
+  const auto retrievedValues = parameterMapInterface.RetrieveValues<double>(parameterName);
   ASSERT_NE(retrievedValues, nullptr);
   EXPECT_EQ(*retrievedValues, std::vector<double>{});
 }
@@ -60,22 +60,22 @@ GTEST_TEST(ParameterMapInterface, RetrieveValuesSupportsZeroValues)
 
 GTEST_TEST(ParameterMapInterface, RetrieveValuesSupportsSingleValue)
 {
-  const auto        parameterMapInterface = ParameterMapInterface::New();
-  const std::string parameterName("Key");
+  ParameterMapInterface parameterMapInterface{};
+  const std::string     parameterName("Key");
 
   for (const double testValue : { -1.0, 0.0, 1.0 })
   {
-    parameterMapInterface->SetParameterMap({ { parameterName, { itk::NumberToString<double>{}(testValue) } } });
+    parameterMapInterface.SetParameterMap({ { parameterName, { itk::NumberToString<double>{}(testValue) } } });
 
-    const auto retrievedValues = parameterMapInterface->RetrieveValues<double>(parameterName);
+    const auto retrievedValues = parameterMapInterface.RetrieveValues<double>(parameterName);
     ASSERT_NE(retrievedValues, nullptr);
     EXPECT_EQ(*retrievedValues, std::vector<double>{ testValue });
   }
   for (const bool testValue : { false, true })
   {
-    parameterMapInterface->SetParameterMap({ { parameterName, { testValue ? "true" : "false" } } });
+    parameterMapInterface.SetParameterMap({ { parameterName, { testValue ? "true" : "false" } } });
 
-    const auto retrievedValues = parameterMapInterface->RetrieveValues<bool>(parameterName);
+    const auto retrievedValues = parameterMapInterface.RetrieveValues<bool>(parameterName);
     ASSERT_NE(retrievedValues, nullptr);
     EXPECT_EQ(*retrievedValues, std::vector<bool>{ testValue });
   }
@@ -84,18 +84,18 @@ GTEST_TEST(ParameterMapInterface, RetrieveValuesSupportsSingleValue)
 
 GTEST_TEST(ParameterMapInterface, RetrieveValuesSupportsMultipleValues)
 {
-  const auto        parameterMapInterface = ParameterMapInterface::New();
-  const std::string parameterName("Key");
+  ParameterMapInterface parameterMapInterface{};
+  const std::string     parameterName("Key");
   using NumberToString = itk::NumberToString<double>;
 
   for (const double testValue1 : { 0.0, 1.0 })
   {
     for (const double testValue2 : { 0.0, 1.0 })
     {
-      parameterMapInterface->SetParameterMap(
+      parameterMapInterface.SetParameterMap(
         { { parameterName, { NumberToString{}(testValue1), NumberToString{}(testValue2) } } });
 
-      const auto retrievedValues = parameterMapInterface->RetrieveValues<double>(parameterName);
+      const auto retrievedValues = parameterMapInterface.RetrieveValues<double>(parameterName);
       ASSERT_NE(retrievedValues, nullptr);
       const std::vector<double> expectedValues{ testValue1, testValue2 };
       EXPECT_EQ(*retrievedValues, expectedValues);
@@ -106,35 +106,35 @@ GTEST_TEST(ParameterMapInterface, RetrieveValuesSupportsMultipleValues)
 
 GTEST_TEST(ParameterMapInterface, RetrieveValuesThrowsExceptionWhenConversionFails)
 {
-  const auto        parameterMapInterface = ParameterMapInterface::New();
-  const std::string parameterName("Key");
+  ParameterMapInterface parameterMapInterface{};
+  const std::string     parameterName("Key");
 
-  parameterMapInterface->SetParameterMap({ { parameterName, { "not-a-valid-bool-or-double-value" } } });
-  EXPECT_THROW(parameterMapInterface->RetrieveValues<bool>(parameterName), itk::ExceptionObject);
-  EXPECT_THROW(parameterMapInterface->RetrieveValues<double>(parameterName), itk::ExceptionObject);
+  parameterMapInterface.SetParameterMap({ { parameterName, { "not-a-valid-bool-or-double-value" } } });
+  EXPECT_THROW(parameterMapInterface.RetrieveValues<bool>(parameterName), itk::ExceptionObject);
+  EXPECT_THROW(parameterMapInterface.RetrieveValues<double>(parameterName), itk::ExceptionObject);
 
   // A typical input error where floating point value 1.25 might have been intended:
-  parameterMapInterface->SetParameterMap({ { parameterName, { "1,25" } } });
-  EXPECT_THROW(parameterMapInterface->RetrieveValues<double>(parameterName), itk::ExceptionObject);
+  parameterMapInterface.SetParameterMap({ { parameterName, { "1,25" } } });
+  EXPECT_THROW(parameterMapInterface.RetrieveValues<double>(parameterName), itk::ExceptionObject);
 
   // Either 2375 (using comma as thousands separator) or 2.375 might have been intended:
-  parameterMapInterface->SetParameterMap({ { parameterName, { "2,375" } } });
-  EXPECT_THROW(parameterMapInterface->RetrieveValues<double>(parameterName), itk::ExceptionObject);
+  parameterMapInterface.SetParameterMap({ { parameterName, { "2,375" } } });
+  EXPECT_THROW(parameterMapInterface.RetrieveValues<double>(parameterName), itk::ExceptionObject);
 }
 
 
 GTEST_TEST(ParameterMapInterface, HasParameter)
 {
-  const auto        parameterMapInterface = ParameterMapInterface::New();
-  const std::string parameterName("Key");
+  ParameterMapInterface parameterMapInterface{};
+  const std::string     parameterName("Key");
 
-  EXPECT_FALSE(parameterMapInterface->HasParameter(parameterName));
+  EXPECT_FALSE(parameterMapInterface.HasParameter(parameterName));
 
-  parameterMapInterface->SetParameterMap({ { parameterName, {} } });
-  EXPECT_TRUE(parameterMapInterface->HasParameter(parameterName));
+  parameterMapInterface.SetParameterMap({ { parameterName, {} } });
+  EXPECT_TRUE(parameterMapInterface.HasParameter(parameterName));
 
-  parameterMapInterface->SetParameterMap({ { parameterName, { "a", "b", "c" } } });
-  EXPECT_TRUE(parameterMapInterface->HasParameter(parameterName));
+  parameterMapInterface.SetParameterMap({ { parameterName, { "a", "b", "c" } } });
+  EXPECT_TRUE(parameterMapInterface.HasParameter(parameterName));
 
-  EXPECT_FALSE(parameterMapInterface->HasParameter("This-is-not-a-key-from-this-map-" + parameterName));
+  EXPECT_FALSE(parameterMapInterface.HasParameter("This-is-not-a-key-from-this-map-" + parameterName));
 }

--- a/Common/ParameterFileParser/itkParameterMapInterface.cxx
+++ b/Common/ParameterFileParser/itkParameterMapInterface.cxx
@@ -98,10 +98,10 @@ ParameterMapInterface::ReadParameter(bool &              parameterValue,
   if (!elastix::Conversion::StringToValue(parameterValueString, parameterValue))
   {
     /** Trying to read a string other than "true" or "false" as a boolean. */
-    itkExceptionMacro("ERROR: Entry number "
-                      << entry_nr << " for the parameter \"" << parameterName
-                      << "\" should be a boolean, i.e. either \"true\" or \"false\", but it reads \""
-                      << parameterValueString << "\".");
+    itkGenericExceptionMacro("ERROR: Entry number "
+                             << entry_nr << " for the parameter \"" << parameterName
+                             << "\" should be a boolean, i.e. either \"true\" or \"false\", but it reads \""
+                             << parameterValueString << "\".");
   }
 
   return dummy;
@@ -145,17 +145,17 @@ ParameterMapInterface::ReadParameter(std::vector<std::string> & parameterValues,
   if (entry_nr_start > entry_nr_end)
   {
     /** Programming error: just throw an exception. */
-    itkExceptionMacro("WARNING: The entry number start ("
-                      << entry_nr_start << ") should be smaller than entry number end (" << entry_nr_end
-                      << "). It was requested for parameter \"" << parameterName << "\".\n");
+    itkGenericExceptionMacro("WARNING: The entry number start ("
+                             << entry_nr_start << ") should be smaller than entry number end (" << entry_nr_end
+                             << "). It was requested for parameter \"" << parameterName << "\".\n");
   }
 
   /** Check if it exists at the requested entry numbers. */
   if (entry_nr_end >= numberOfEntries)
   {
-    itkExceptionMacro("WARNING: The parameter \"" << parameterName << "\" does not exist at entry number "
-                                                  << entry_nr_end
-                                                  << ".\nThe default empty string \"\" is used instead.\n");
+    itkGenericExceptionMacro("WARNING: The parameter \"" << parameterName << "\" does not exist at entry number "
+                                                         << entry_nr_end
+                                                         << ".\nThe default empty string \"\" is used instead.\n");
   }
 
   /** Get the vector of parameters. */

--- a/Common/ParameterFileParser/itkParameterMapInterface.h
+++ b/Common/ParameterFileParser/itkParameterMapInterface.h
@@ -21,7 +21,6 @@
 
 #include "elxConversion.h"
 
-#include "itkObject.h"
 #include "itkObjectFactory.h"
 #include "itkMacro.h"
 #include "itkNumericTraits.h"
@@ -58,14 +57,14 @@ namespace itk
  *
  * This class can be used in the following way:\n
  *
- * itk::ParameterMapInterface::Pointer p_interface = itk::ParameterMapInterface::New();
- * p_interface->SetParameterMap( parser->GetParameterMap() );
- * p_interface->PrintErrorMessages( true );
+ * itk::ParameterMapInterface p_interface{};
+ * p_interface.SetParameterMap( parser->GetParameterMap() );
+ * p_interface.PrintErrorMessages( true );
  * unsigned long parameterValue = 3;
  * unsigned int index = 2;
  * bool printWarning = true;
  * std::string warningMessage = "";
- * bool success = p_interface->ReadParameter( parameterValue,
+ * bool success = p_interface.ReadParameter( parameterValue,
  *   "ParameterName", index, printWarning, warningMessage );
  *
  *
@@ -75,26 +74,23 @@ namespace itk
  * \sa itk::ParameterFileParser
  */
 
-class ParameterMapInterface : public Object
+class ParameterMapInterface
 {
 public:
   ITK_DISALLOW_COPY_AND_MOVE(ParameterMapInterface);
 
   /** Standard ITK typedefs. */
   using Self = ParameterMapInterface;
-  using Superclass = Object;
-  using Pointer = SmartPointer<Self>;
-  using ConstPointer = SmartPointer<const Self>;
-
-  /** Method for creation through the object factory. */
-  itkNewMacro(Self);
-
-  /** Run-time type information (and related methods). */
-  itkOverrideGetNameOfClassMacro(ParameterMapInterface);
 
   /** Typedefs. */
   using ParameterValuesType = ParameterFileParser::ParameterValuesType;
   using ParameterMapType = ParameterFileParser::ParameterMapType;
+
+  /** Default-constructor. */
+  ParameterMapInterface();
+
+  /** Destructor. */
+  ~ParameterMapInterface();
 
   /** Set the parameter map. */
   void
@@ -112,8 +108,17 @@ public:
    */
   // \todo: we could think of a warning level. (maybe you want warnings, but
   // not when for example a parameter is not found at entry entry_nr but at entry 0 instead
-  itkSetMacro(PrintErrorMessages, bool);
-  itkGetConstMacro(PrintErrorMessages, bool);
+  void
+  SetPrintErrorMessages(const bool arg)
+  {
+    m_PrintErrorMessages = arg;
+  }
+
+  bool
+  GetPrintErrorMessages() const
+  {
+    return m_PrintErrorMessages;
+  }
 
   /** Tells whether this parameter map has the parameter with the given name. */
   bool
@@ -191,10 +196,10 @@ public:
     /** Check if the cast was successful. */
     if (!castSuccesful)
     {
-      itkExceptionMacro("ERROR: Casting entry number "
-                        << entry_nr << " for the parameter \"" << parameterName << "\" failed!\n"
-                        << "  You tried to cast \"" << vec[entry_nr] << "\" from std::string to "
-                        << typeid(parameterValue).name() << '\n');
+      itkGenericExceptionMacro("ERROR: Casting entry number "
+                               << entry_nr << " for the parameter \"" << parameterName << "\" failed!\n"
+                               << "  You tried to cast \"" << vec[entry_nr] << "\" from std::string to "
+                               << typeid(parameterValue).name() << '\n');
     }
 
     return true;
@@ -322,17 +327,17 @@ public:
     if (entry_nr_start > entry_nr_end)
     {
       /** Programming error: just throw an exception. */
-      itkExceptionMacro("WARNING: The entry number start ("
-                        << entry_nr_start << ") should be smaller than entry number end (" << entry_nr_end
-                        << "). It was requested for parameter \"" << parameterName << "\".\n");
+      itkGenericExceptionMacro("WARNING: The entry number start ("
+                               << entry_nr_start << ") should be smaller than entry number end (" << entry_nr_end
+                               << "). It was requested for parameter \"" << parameterName << "\".\n");
     }
 
     /** Check if it exists at the requested entry numbers. */
     if (entry_nr_end >= numberOfEntries)
     {
-      itkExceptionMacro("WARNING: The parameter \"" << parameterName << "\" does not exist at entry number "
-                                                    << entry_nr_end << ".\nThe default value \"" << T{}
-                                                    << "\" is used instead.");
+      itkGenericExceptionMacro("WARNING: The parameter \"" << parameterName << "\" does not exist at entry number "
+                                                           << entry_nr_end << ".\nThe default value \"" << T{}
+                                                           << "\" is used instead.");
     }
 
     /** Get the vector of parameters. */
@@ -355,10 +360,10 @@ public:
       /** Check if the cast was successful. */
       if (!castSuccesful)
       {
-        itkExceptionMacro("ERROR: Casting entry number "
-                          << i << " for the parameter \"" << parameterName << "\" failed!\n"
-                          << "  You tried to cast \"" << vec[i] << "\" from std::string to "
-                          << typeid(parameterValues[0]).name() << '\n');
+        itkGenericExceptionMacro("ERROR: Casting entry number "
+                                 << i << " for the parameter \"" << parameterName << "\" failed!\n"
+                                 << "  You tried to cast \"" << vec[i] << "\" from std::string to "
+                                 << typeid(parameterValues[0]).name() << '\n');
       }
     }
 
@@ -411,18 +416,14 @@ public:
       else
       {
         const auto entry_nr = &str - found->second.data();
-        itkExceptionMacro("Failed to cast parameter \"" << parameterName << "\" entry number " << entry_nr
-                                                        << " value \"" << str << "\" to type \"" << typeid(T).name()
-                                                        << "\"!");
+        itkGenericExceptionMacro("Failed to cast parameter \"" << parameterName << "\" entry number " << entry_nr
+                                                               << " value \"" << str << "\" to type \""
+                                                               << typeid(T).name() << "\"!");
       }
     }
     return std::make_unique<std::vector<T>>(std::move(result));
   }
 
-
-protected:
-  ParameterMapInterface();
-  ~ParameterMapInterface() override;
 
 private:
   /** Member variable to store the parameters. */

--- a/Core/Configuration/elxConfiguration.cxx
+++ b/Core/Configuration/elxConfiguration.cxx
@@ -109,7 +109,7 @@ Configuration::PrintParameterMap() const
   // Separate clearly in log-file, before and after writing the parameter map.
   log::info_to_log_file(std::ostringstream{}
                         << "\n=============== start of ParameterMap ===============\n"
-                        << Conversion::ParameterMapToString(m_ParameterMapInterface->GetParameterMap(),
+                        << Conversion::ParameterMapToString(m_ParameterMapInterface.GetParameterMap(),
                                                             ParameterMapStringFormat::LegacyTxt)
                         << "\n=============== end of ParameterMap ===============\n");
 
@@ -125,7 +125,7 @@ Configuration::AccessParameter(const std::string & parameterName) const
 {
   std::size_t i{};
 
-  for (const auto & pair : m_ParameterMapInterface->GetParameterMap())
+  for (const auto & pair : m_ParameterMapInterface.GetParameterMap())
   {
     if (pair.first == parameterName)
     {
@@ -145,7 +145,7 @@ Configuration::AccessParameter(const std::string & parameterName) const
 void
 Configuration::AfterRegistration()
 {
-  const auto &       parameterMap = m_ParameterMapInterface->GetParameterMap();
+  const auto &       parameterMap = m_ParameterMapInterface.GetParameterMap();
   const bool * const parameterAccessFlags = m_ParameterAccessFlags.get();
 
   if (const auto numberOfUnusedParameters =
@@ -268,16 +268,16 @@ Configuration::Initialize(const CommandLineArgumentMapType & _arg)
   }
 
   /** Connect the parameter file reader to the interface. */
-  m_ParameterMapInterface->SetParameterMap(
+  m_ParameterMapInterface.SetParameterMap(
     AddDataFromExternalTransformFile(m_ParameterFileName, parameterFileParser->GetParameterMap()));
 
-  m_ParameterAccessFlags = std::make_unique<bool[]>(m_ParameterMapInterface->GetParameterMap().size());
+  m_ParameterAccessFlags = std::make_unique<bool[]>(m_ParameterMapInterface.GetParameterMap().size());
 
   /** Silently check in the parameter file if error messages should be printed. */
-  m_ParameterMapInterface->SetPrintErrorMessages(false);
+  m_ParameterMapInterface.SetPrintErrorMessages(false);
   bool printErrorMessages = true;
   this->ReadParameter(printErrorMessages, "PrintErrorMessages", 0, false);
-  m_ParameterMapInterface->SetPrintErrorMessages(printErrorMessages);
+  m_ParameterMapInterface.SetPrintErrorMessages(printErrorMessages);
 
   /** Set the initialized flag. */
   m_IsInitialized = true;
@@ -307,15 +307,15 @@ Configuration::Initialize(const CommandLineArgumentMapType &                 _ar
   /** Store the command line arguments. */
   m_CommandLineArgumentMap = _arg;
 
-  m_ParameterMapInterface->SetParameterMap(AddDataFromExternalTransformFile(m_ParameterFileName, inputMap));
+  m_ParameterMapInterface.SetParameterMap(AddDataFromExternalTransformFile(m_ParameterFileName, inputMap));
 
-  m_ParameterAccessFlags = std::make_unique<bool[]>(m_ParameterMapInterface->GetParameterMap().size());
+  m_ParameterAccessFlags = std::make_unique<bool[]>(m_ParameterMapInterface.GetParameterMap().size());
 
   /** Silently check in the parameter file if error messages should be printed. */
-  m_ParameterMapInterface->SetPrintErrorMessages(false);
+  m_ParameterMapInterface.SetPrintErrorMessages(false);
   bool printErrorMessages = true;
   this->ReadParameter(printErrorMessages, "PrintErrorMessages", 0, false);
-  m_ParameterMapInterface->SetPrintErrorMessages(printErrorMessages);
+  m_ParameterMapInterface.SetPrintErrorMessages(printErrorMessages);
 
   /** Set the initialized flag. */
   m_IsInitialized = true;

--- a/Core/Configuration/elxConfiguration.h
+++ b/Core/Configuration/elxConfiguration.h
@@ -118,7 +118,7 @@ public:
   bool
   GetPrintErrorMessages() const
   {
-    return m_ParameterMapInterface->GetPrintErrorMessages();
+    return m_ParameterMapInterface.GetPrintErrorMessages();
   }
 
 
@@ -146,7 +146,7 @@ public:
   CountNumberOfParameterEntries(const std::string & parameterName) const
   {
     AccessParameter(parameterName);
-    return m_ParameterMapInterface->CountNumberOfParameterEntries(parameterName);
+    return m_ParameterMapInterface.CountNumberOfParameterEntries(parameterName);
   }
 
 
@@ -160,7 +160,7 @@ public:
   {
     AccessParameter(parameterName);
     std::string warningMessage = "";
-    bool        found = m_ParameterMapInterface->ReadParameter(
+    bool        found = m_ParameterMapInterface.ReadParameter(
       parameterValue, parameterName, entry_nr, produceWarningMessage, warningMessage);
     if (!warningMessage.empty())
     {
@@ -178,7 +178,7 @@ public:
   {
     AccessParameter(parameterName);
     std::string warningMessage = "";
-    bool        found = m_ParameterMapInterface->ReadParameter(parameterValue, parameterName, entry_nr, warningMessage);
+    bool        found = m_ParameterMapInterface.ReadParameter(parameterValue, parameterName, entry_nr, warningMessage);
     if (!warningMessage.empty())
     {
       log::warn(warningMessage);
@@ -200,7 +200,7 @@ public:
   {
     AccessParameter(parameterName);
     std::string warningMessage = "";
-    bool        found = m_ParameterMapInterface->ReadParameter(
+    bool        found = m_ParameterMapInterface.ReadParameter(
       parameterValue, parameterName, prefix, entry_nr, default_entry_nr, produceWarningMessage, warningMessage);
     if (!warningMessage.empty())
     {
@@ -222,7 +222,7 @@ public:
   {
     AccessParameter(parameterName);
     std::string warningMessage = "";
-    bool        found = m_ParameterMapInterface->ReadParameter(
+    bool        found = m_ParameterMapInterface.ReadParameter(
       parameterValue, parameterName, prefix, entry_nr, default_entry_nr, warningMessage);
     if (!warningMessage.empty())
     {
@@ -238,7 +238,7 @@ public:
   HasParameter(const std::string & parameterName) const
   {
     AccessParameter(parameterName);
-    return m_ParameterMapInterface->HasParameter(parameterName);
+    return m_ParameterMapInterface.HasParameter(parameterName);
   }
 
 
@@ -247,7 +247,7 @@ public:
   GetValuesOfParameter(const std::string & parameterName) const
   {
     AccessParameter(parameterName);
-    return m_ParameterMapInterface->GetValues(parameterName);
+    return m_ParameterMapInterface.GetValues(parameterName);
   }
 
 
@@ -261,7 +261,7 @@ public:
   RetrieveValuesOfParameter(const std::string & parameterName) const
   {
     AccessParameter(parameterName);
-    return m_ParameterMapInterface->RetrieveValues<T>(parameterName);
+    return m_ParameterMapInterface.RetrieveValues<T>(parameterName);
   }
 
   /** Retrieves the value of the specified parameter (from the parameter file). Returns the specified default parameter
@@ -302,7 +302,7 @@ public:
   {
     AccessParameter(parameterName);
     std::string warningMessage = "";
-    bool        found = m_ParameterMapInterface->ReadParameter(
+    bool        found = m_ParameterMapInterface.ReadParameter(
       parameterValues, parameterName, entry_nr_start, entry_nr_end, produceWarningMessage, warningMessage);
     if (!warningMessage.empty())
     {
@@ -335,9 +335,9 @@ private:
   void
   AfterRegistration() override;
 
-  CommandLineArgumentMapType                m_CommandLineArgumentMap{};
-  std::string                               m_ParameterFileName{};
-  const itk::ParameterMapInterface::Pointer m_ParameterMapInterface{ itk::ParameterMapInterface::New() };
+  CommandLineArgumentMapType m_CommandLineArgumentMap{};
+  std::string                m_ParameterFileName{};
+  itk::ParameterMapInterface m_ParameterMapInterface{};
 
   // Tells for each parameter whether it is accessed.
   std::unique_ptr<bool[]> m_ParameterAccessFlags;

--- a/Testing/elxInvertTransform.cxx
+++ b/Testing/elxInvertTransform.cxx
@@ -95,13 +95,13 @@ main(int argc, char * argv[])
   // typedef BaseTransformType::OutputPointType               OutputPointType;
 
   /** Interface to the original transform parameters file. */
-  auto config = itk::ParameterMapInterface::New();
-  config->SetParameterMap(itk::ParameterFileParser::ReadParameterMap(inputTransformParametersName));
+  itk::ParameterMapInterface config{};
+  config.SetParameterMap(itk::ParameterFileParser::ReadParameterMap(inputTransformParametersName));
 
   /** Check no initial transform. */
   std::string initialTransform = "";
-  config->ReadParameter(initialTransform, "InitialTransformParameterFileName", 0, dummyErrorMessage) ||
-    config->ReadParameter(initialTransform, "InitialTransformParametersFileName", 0, dummyErrorMessage);
+  config.ReadParameter(initialTransform, "InitialTransformParameterFileName", 0, dummyErrorMessage) ||
+    config.ReadParameter(initialTransform, "InitialTransformParametersFileName", 0, dummyErrorMessage);
 
   if (initialTransform != "NoInitialTransform")
   {
@@ -113,7 +113,7 @@ main(int argc, char * argv[])
 
   /** Check dimension. */
   unsigned int dimF = 0;
-  config->ReadParameter(dimF, "FixedImageDimension", 0, dummyErrorMessage);
+  config.ReadParameter(dimF, "FixedImageDimension", 0, dummyErrorMessage);
   if (dimF != Dimension)
   {
     std::cerr << "ERROR: the program elxInvertTransform was compiled for images of dimension " << Dimension << ",\n"
@@ -155,11 +155,11 @@ main(int argc, char * argv[])
 
   /** Get the number of TransformParameters. */
   unsigned int numberOfParameters = 0;
-  config->ReadParameter(numberOfParameters, "NumberOfParameters", 0, dummyErrorMessage);
+  config.ReadParameter(numberOfParameters, "NumberOfParameters", 0, dummyErrorMessage);
 
   /** Read the TransformParameters as a vector. */
   std::vector<ScalarType> vecPar(numberOfParameters, ScalarType{});
-  config->ReadParameter(vecPar, "TransformParameters", 0, numberOfParameters - 1, true, dummyErrorMessage);
+  config.ReadParameter(vecPar, "TransformParameters", 0, numberOfParameters - 1, true, dummyErrorMessage);
 
   /** Convert to ParametersType. */
   const ParametersType transformParameters(vecPar.data(), numberOfParameters);
@@ -168,7 +168,7 @@ main(int argc, char * argv[])
   CenterType centerOfRotation;
   for (unsigned int i = 0; i < Dimension; ++i)
   {
-    config->ReadParameter(centerOfRotation[i], "CenterOfRotationPoint", i, dummyErrorMessage);
+    config.ReadParameter(centerOfRotation[i], "CenterOfRotationPoint", i, dummyErrorMessage);
   }
 
   /** Set up the transform. */
@@ -176,7 +176,7 @@ main(int argc, char * argv[])
   CenterType     centerOfRotationInv;
 
   std::string transformType = "";
-  config->ReadParameter(transformType, "Transform", 0, dummyErrorMessage);
+  config.ReadParameter(transformType, "Transform", 0, dummyErrorMessage);
 
   try
   {
@@ -223,20 +223,20 @@ main(int argc, char * argv[])
 
   /** Get some information from the input transform parameters file that needs to be copied. */
   std::string combinationMethod = "Compose";
-  config->ReadParameter(combinationMethod, "HowToCombineTransforms", 0, dummyErrorMessage);
+  config.ReadParameter(combinationMethod, "HowToCombineTransforms", 0, dummyErrorMessage);
 
   unsigned int FixDim = Dimension;
-  config->ReadParameter(FixDim, "FixedImageDimension", 0, dummyErrorMessage);
+  config.ReadParameter(FixDim, "FixedImageDimension", 0, dummyErrorMessage);
   unsigned int MovDim = Dimension;
-  config->ReadParameter(MovDim, "MovingImageDimension", 0, dummyErrorMessage);
+  config.ReadParameter(MovDim, "MovingImageDimension", 0, dummyErrorMessage);
 
   std::string fixpix = "float";
-  config->ReadParameter(fixpix, "FixedInternalImagePixelType", 0, dummyErrorMessage);
+  config.ReadParameter(fixpix, "FixedInternalImagePixelType", 0, dummyErrorMessage);
   std::string movpix = "float";
-  config->ReadParameter(movpix, "MovingInternalImagePixelType", 0, dummyErrorMessage);
+  config.ReadParameter(movpix, "MovingInternalImagePixelType", 0, dummyErrorMessage);
 
   std::string useDirectionCosines = "true";
-  config->ReadParameter(useDirectionCosines, "UseDirectionCosines", 0, dummyErrorMessage);
+  config.ReadParameter(useDirectionCosines, "UseDirectionCosines", 0, dummyErrorMessage);
 
   /** Open a file for writing. */
   std::ofstream outputTPFile(outputTransformParametersName);
@@ -336,28 +336,28 @@ main(int argc, char * argv[])
 
   /** Read from input transform parameter file. */
   std::string computeZYX = "true";
-  config->ReadParameter(computeZYX, "ComputeZYX", 0, dummyErrorMessage);
+  config.ReadParameter(computeZYX, "ComputeZYX", 0, dummyErrorMessage);
 
   std::string resampleInterpolator = "FinalBSplineInterpolator";
-  config->ReadParameter(resampleInterpolator, "ResampleInterpolator", 0, dummyErrorMessage);
+  config.ReadParameter(resampleInterpolator, "ResampleInterpolator", 0, dummyErrorMessage);
 
   unsigned int interpolationOrder = 3;
-  config->ReadParameter(interpolationOrder, "FinalBSplineInterpolationOrder", 0, dummyErrorMessage);
+  config.ReadParameter(interpolationOrder, "FinalBSplineInterpolationOrder", 0, dummyErrorMessage);
 
   std::string resampler = "DefaultResampler";
-  config->ReadParameter(resampler, "DefaultResampler", 0, dummyErrorMessage);
+  config.ReadParameter(resampler, "DefaultResampler", 0, dummyErrorMessage);
 
   float defaultPixelValue = 0.0;
-  config->ReadParameter(defaultPixelValue, "DefaultPixelValue", 0, dummyErrorMessage);
+  config.ReadParameter(defaultPixelValue, "DefaultPixelValue", 0, dummyErrorMessage);
 
   std::string resultImageFormat = "mhd";
-  config->ReadParameter(resultImageFormat, "ResultImageFormat", 0, dummyErrorMessage);
+  config.ReadParameter(resultImageFormat, "ResultImageFormat", 0, dummyErrorMessage);
 
   std::string resultImagePixelType = "short";
-  config->ReadParameter(resultImagePixelType, "ResultImagePixelType", 0, dummyErrorMessage);
+  config.ReadParameter(resultImagePixelType, "ResultImagePixelType", 0, dummyErrorMessage);
 
   std::string compressResultImage = "false";
-  config->ReadParameter(compressResultImage, "CompressResultImage", 0, dummyErrorMessage);
+  config.ReadParameter(compressResultImage, "CompressResultImage", 0, dummyErrorMessage);
 
   /** Write to file. */
   outputTPFile << "\n// " << transformType << " specific\n";

--- a/Testing/elxTransformParametersCompare.cxx
+++ b/Testing/elxTransformParametersCompare.cxx
@@ -120,8 +120,8 @@ main(int argc, char ** argv)
   using ScalarType = double;
   std::string dummyErrorMessage = "";
 
-  auto parameterFileParser = ParserType::New();
-  auto config = InterfaceType::New();
+  auto                       parameterFileParser = ParserType::New();
+  itk::ParameterMapInterface config{};
 
   /** Read test parameters. */
   parameterFileParser->SetParameterFileName(testFileName);
@@ -135,12 +135,12 @@ main(int argc, char ** argv)
     return EXIT_FAILURE;
   }
 
-  config->SetParameterMap(parameterFileParser->GetParameterMap());
+  config.SetParameterMap(parameterFileParser->GetParameterMap());
 
   unsigned int numberOfParametersTest = 0;
-  config->ReadParameter(numberOfParametersTest, "NumberOfParameters", 0, dummyErrorMessage);
+  config.ReadParameter(numberOfParametersTest, "NumberOfParameters", 0, dummyErrorMessage);
   std::vector<ScalarType> parametersTest(numberOfParametersTest, ScalarType{});
-  config->ReadParameter(parametersTest, "TransformParameters", 0, numberOfParametersTest - 1, true, dummyErrorMessage);
+  config.ReadParameter(parametersTest, "TransformParameters", 0, numberOfParametersTest - 1, true, dummyErrorMessage);
 
   /** Read baseline parameters. */
   parameterFileParser->SetParameterFileName(baselineFileName);
@@ -153,13 +153,13 @@ main(int argc, char ** argv)
     std::cerr << "Error during reading baseline transform parameters: " << err << std::endl;
     return EXIT_FAILURE;
   }
-  config->SetParameterMap(parameterFileParser->GetParameterMap());
+  config.SetParameterMap(parameterFileParser->GetParameterMap());
 
   unsigned int numberOfParametersBaseline = 0;
-  config->ReadParameter(numberOfParametersBaseline, "NumberOfParameters", 0, dummyErrorMessage);
+  config.ReadParameter(numberOfParametersBaseline, "NumberOfParameters", 0, dummyErrorMessage);
 
   std::vector<ScalarType> parametersBaseline(numberOfParametersBaseline, ScalarType{});
-  config->ReadParameter(
+  config.ReadParameter(
     parametersBaseline, "TransformParameters", 0, numberOfParametersBaseline - 1, true, dummyErrorMessage);
 
   /** The sizes of the baseline and test parameters must match. */
@@ -184,7 +184,7 @@ main(int argc, char ** argv)
    * Only the B-spline transform has mask support.
    */
   std::string transformName = "";
-  config->ReadParameter(transformName, "Transform", 0, true, dummyErrorMessage);
+  config.ReadParameter(transformName, "Transform", 0, true, dummyErrorMessage);
   if (transformName != "BSplineTransform")
   {
     /** Now compare the two parameter vectors. */
@@ -203,7 +203,7 @@ main(int argc, char ** argv)
 
     /** Get the true dimension. */
     unsigned int dimension = 2;
-    config->ReadParameter(dimension, "FixedImageDimension", 0, true, dummyErrorMessage);
+    config.ReadParameter(dimension, "FixedImageDimension", 0, true, dummyErrorMessage);
 
     /** Get coefficient image information. */
     auto       gridSize = SizeType::Filled(1);
@@ -213,13 +213,13 @@ main(int argc, char ** argv)
     auto       gridDirection = DirectionType::GetIdentity();
     for (unsigned int i = 0; i < dimension; ++i)
     {
-      config->ReadParameter(gridSize[i], "GridSize", i, true, dummyErrorMessage);
-      config->ReadParameter(gridIndex[i], "GridIndex", i, true, dummyErrorMessage);
-      config->ReadParameter(gridSpacing[i], "GridSpacing", i, true, dummyErrorMessage);
-      config->ReadParameter(gridOrigin[i], "GridOrigin", i, true, dummyErrorMessage);
+      config.ReadParameter(gridSize[i], "GridSize", i, true, dummyErrorMessage);
+      config.ReadParameter(gridIndex[i], "GridIndex", i, true, dummyErrorMessage);
+      config.ReadParameter(gridSpacing[i], "GridSpacing", i, true, dummyErrorMessage);
+      config.ReadParameter(gridOrigin[i], "GridOrigin", i, true, dummyErrorMessage);
       for (unsigned int j = 0; j < dimension; ++j)
       {
-        config->ReadParameter(gridDirection(j, i), "GridDirection", i * dimension + j, true, dummyErrorMessage);
+        config.ReadParameter(gridDirection(j, i), "GridDirection", i * dimension + j, true, dummyErrorMessage);
       }
     }
 


### PR DESCRIPTION
It appears unnecessary for ParameterMapInterface to inherit from `itk::Object`.