### PR TITLE
Improve performance of Advanced, ParzenWindowHistogram, ParzenWindowMutualInformation ImageToImageMetric

### DIFF
--- a/Common/CostFunctions/itkAdvancedImageToImageMetric.hxx
+++ b/Common/CostFunctions/itkAdvancedImageToImageMetric.hxx
@@ -424,7 +424,7 @@ AdvancedImageToImageMetric<TFixedImage, TMovingImage>::EvaluateMovingImageValueA
       else if (m_ReducedBSplineInterpolator && !Superclass::m_ComputeGradient)
       {
         /** Compute moving image value and gradient using the B-spline kernel. */
-        movingImageValue = Superclass::m_Interpolator->EvaluateAtContinuousIndex(cindex);
+        movingImageValue = m_ReducedBSplineInterpolator->EvaluateAtContinuousIndex(cindex);
         *gradient = m_ReducedBSplineInterpolator->EvaluateDerivativeAtContinuousIndex(cindex);
         // m_ReducedBSplineInterpolator->EvaluateValueAndDerivativeAtContinuousIndex(
         //  cindex, movingImageValue, *gradient );
@@ -490,7 +490,11 @@ AdvancedImageToImageMetric<TFixedImage, TMovingImage>::EvaluateMovingImageValueA
     } // end if gradient
     else
     {
-      movingImageValue = Superclass::m_Interpolator->EvaluateAtContinuousIndex(cindex);
+      movingImageValue = m_BSplineInterpolator
+                           ? m_BSplineInterpolator->EvaluateAtContinuousIndex(cindex, optionalThreadId...)
+                         : m_BSplineInterpolatorFloat
+                           ? m_BSplineInterpolatorFloat->EvaluateAtContinuousIndex(cindex, optionalThreadId...)
+                           : Superclass::m_Interpolator->EvaluateAtContinuousIndex(cindex);
     }
   } // end if sampleOk
 

--- a/Common/CostFunctions/itkParzenWindowHistogramImageToImageMetric.h
+++ b/Common/CostFunctions/itkParzenWindowHistogramImageToImageMetric.h
@@ -413,7 +413,8 @@ private:
                                const RealType                     movingImageValue,
                                const DerivativeType *             imageJacobian,
                                const NonZeroJacobianIndicesType * nzji,
-                               JointPDFType *                     jointPDF) const;
+                               JointPDFType *                     jointPDF,
+                               PDFValueType * const               preallocatedParzenValues) const;
 
   /** Update the joint PDF and the incremental pdfs.
    * The input is a pixel pair (fixed, moving, moving mask) and

--- a/Common/CostFunctions/itkParzenWindowHistogramImageToImageMetric.hxx
+++ b/Common/CostFunctions/itkParzenWindowHistogramImageToImageMetric.hxx
@@ -469,7 +469,8 @@ ParzenWindowHistogramImageToImageMetric<TFixedImage, TMovingImage>::UpdateJointP
   const RealType                     movingImageValue,
   const DerivativeType *             imageJacobian,
   const NonZeroJacobianIndicesType * nzji,
-  JointPDFType *                     jointPDF) const
+  JointPDFType *                     jointPDF,
+  PDFValueType * const               preallocatedParzenValues) const
 {
   using PDFIteratorType = ImageScanlineIterator<JointPDFType>;
 
@@ -487,11 +488,8 @@ ParzenWindowHistogramImageToImageMetric<TFixedImage, TMovingImage>::UpdateJointP
   const auto numberOfFixedParzenValues = m_JointPDFWindow.GetSize()[1];
   const auto numberOfMovingParzenValues = m_JointPDFWindow.GetSize()[0];
 
-  // Create a buffer of Parzen values for both the fixed and the moving image.
-  const auto parzenValues = std::make_unique<PDFValueType[]>(numberOfFixedParzenValues + numberOfMovingParzenValues);
-
-  PDFValueType * const fixedParzenValues = parzenValues.get();
-  PDFValueType * const movingParzenValues = parzenValues.get() + numberOfFixedParzenValues;
+  PDFValueType * const fixedParzenValues = preallocatedParzenValues;
+  PDFValueType * const movingParzenValues = preallocatedParzenValues + numberOfFixedParzenValues;
 
   Self::EvaluateParzenValues(
     fixedImageParzenWindowTerm, fixedImageParzenWindowIndex, *m_FixedKernel, fixedParzenValues);
@@ -903,6 +901,12 @@ ParzenWindowHistogramImageToImageMetric<TFixedImage, TMovingImage>::ComputePDFsS
   /** Get a handle to the sample container. */
   ImageSampleContainerPointer sampleContainer = this->GetImageSampler()->GetOutput();
 
+  const auto & jointPDFWindowSize = m_JointPDFWindow.GetSize();
+
+  // Create a buffer of Parzen values for both the fixed and the moving image.
+  const auto preallocatedParzenValues =
+    make_unique_for_overwrite<PDFValueType[]>(jointPDFWindowSize[0] + jointPDFWindowSize[1]);
+
   /** Loop over sample container and compute contribution of each sample to pdfs. */
   for (const auto & fixedImageSample : *sampleContainer)
   {
@@ -936,7 +940,8 @@ ParzenWindowHistogramImageToImageMetric<TFixedImage, TMovingImage>::ComputePDFsS
       movingImageValue = this->GetMovingImageLimiter()->Evaluate(movingImageValue);
 
       /** Compute this sample's contribution to the joint distributions. */
-      this->UpdateJointPDFAndDerivatives(fixedImageValue, movingImageValue, nullptr, nullptr, m_JointPDF.GetPointer());
+      this->UpdateJointPDFAndDerivatives(
+        fixedImageValue, movingImageValue, nullptr, nullptr, m_JointPDF.GetPointer(), preallocatedParzenValues.get());
     }
 
   } // end iterating over fixed image spatial sample container for loop
@@ -1005,6 +1010,12 @@ ParzenWindowHistogramImageToImageMetric<TFixedImage, TMovingImage>::ThreadedComp
   JointPDFPointer & jointPDF = m_ParzenWindowHistogramGetValueAndDerivativePerThreadVariables[threadId].st_JointPDF;
   jointPDF->FillBuffer(PDFValueType{});
 
+  const auto & jointPDFWindowSize = m_JointPDFWindow.GetSize();
+
+  // Create a buffer of Parzen values for both the fixed and the moving image.
+  const auto preallocatedParzenValues =
+    make_unique_for_overwrite<PDFValueType[]>(jointPDFWindowSize[0] + jointPDFWindowSize[1]);
+
   /** Create variables to store intermediate results. circumvent false sharing */
   unsigned long numberOfPixelsCounted = 0;
 
@@ -1041,7 +1052,8 @@ ParzenWindowHistogramImageToImageMetric<TFixedImage, TMovingImage>::ThreadedComp
       movingImageValue = this->GetMovingImageLimiter()->Evaluate(movingImageValue);
 
       /** Compute this sample's contribution to the joint distributions. */
-      this->UpdateJointPDFAndDerivatives(fixedImageValue, movingImageValue, nullptr, nullptr, jointPDF.GetPointer());
+      this->UpdateJointPDFAndDerivatives(
+        fixedImageValue, movingImageValue, nullptr, nullptr, jointPDF.GetPointer(), preallocatedParzenValues.get());
     }
   } // end iterating over fixed image spatial sample container for loop
 
@@ -1153,6 +1165,12 @@ ParzenWindowHistogramImageToImageMetric<TFixedImage, TMovingImage>::ComputePDFsA
    */
   this->BeforeThreadedGetValueAndDerivative(parameters);
 
+  const auto & jointPDFWindowSize = m_JointPDFWindow.GetSize();
+
+  // Create a buffer of Parzen values for both the fixed and the moving image.
+  const auto preallocatedParzenValues =
+    make_unique_for_overwrite<PDFValueType[]>(jointPDFWindowSize[0] + jointPDFWindowSize[1]);
+
   /** Get a handle to the sample container. */
   ImageSampleContainerPointer sampleContainer = this->GetImageSampler()->GetOutput();
 
@@ -1197,8 +1215,12 @@ ParzenWindowHistogramImageToImageMetric<TFixedImage, TMovingImage>::ComputePDFsA
       this->EvaluateTransformJacobianInnerProduct(jacobian, movingImageDerivative, imageJacobian);
 
       /** Update the joint pdf and the joint pdf derivatives. */
-      this->UpdateJointPDFAndDerivatives(
-        fixedImageValue, movingImageValue, &imageJacobian, &nzji, m_JointPDF.GetPointer());
+      this->UpdateJointPDFAndDerivatives(fixedImageValue,
+                                         movingImageValue,
+                                         &imageJacobian,
+                                         &nzji,
+                                         m_JointPDF.GetPointer(),
+                                         preallocatedParzenValues.get());
 
     } // end if-block check sampleOk
   } // end iterating over fixed image spatial sample container for loop

--- a/Components/Metrics/AdvancedMattesMutualInformation/itkParzenWindowMutualInformationImageToImageMetric.h
+++ b/Components/Metrics/AdvancedMattesMutualInformation/itkParzenWindowMutualInformationImageToImageMetric.h
@@ -271,7 +271,8 @@ private:
                             const RealType                     movingImageValue,
                             const DerivativeType &             imageJacobian,
                             const NonZeroJacobianIndicesType & nzji,
-                            DerivativeType &                   derivative) const;
+                            DerivativeType &                   derivative,
+                            PDFValueType * const               parzenValues) const;
 
   /** Helper function to compute m_PRatioArray in case of low memory consumption. */
   void

--- a/Components/Metrics/AdvancedMattesMutualInformation/itkParzenWindowMutualInformationImageToImageMetric.hxx
+++ b/Components/Metrics/AdvancedMattesMutualInformation/itkParzenWindowMutualInformationImageToImageMetric.hxx
@@ -295,6 +295,11 @@ ParzenWindowMutualInformationImageToImageMetric<TFixedImage, TMovingImage>::Comp
     preconditioningDivisor = DerivativeType(this->GetNumberOfParameters(), 0.0);
   }
 
+  const auto & jointPDFWindowSize = Superclass::m_JointPDFWindow.GetSize();
+
+  // Create a buffer of Parzen values for both the fixed and the moving image.
+  const auto parzenValues = make_unique_for_overwrite<PDFValueType[]>(jointPDFWindowSize[0] + jointPDFWindowSize[1]);
+
   /** Get a handle to the sample container. */
   ImageSampleContainerPointer sampleContainer = this->GetImageSampler()->GetOutput();
 
@@ -354,7 +359,8 @@ ParzenWindowMutualInformationImageToImageMetric<TFixedImage, TMovingImage>::Comp
       }
 
       /** Compute this sample's contribution to the joint distributions. */
-      this->UpdateDerivativeLowMemory(fixedImageValue, movingImageValue, imageJacobian, nzji, derivative);
+      this->UpdateDerivativeLowMemory(
+        fixedImageValue, movingImageValue, imageJacobian, nzji, derivative, parzenValues.get());
 
     } // end sampleOk
   } // end loop over sample container
@@ -433,6 +439,11 @@ ParzenWindowMutualInformationImageToImageMetric<TFixedImage, TMovingImage>::Thre
     preconditioningDivisor = DerivativeType(this->GetNumberOfParameters(), 0.0);
   }
 
+  const auto & jointPDFWindowSize = Superclass::m_JointPDFWindow.GetSize();
+
+  // Create a buffer of Parzen values for both the fixed and the moving image.
+  const auto parzenValues = make_unique_for_overwrite<PDFValueType[]>(jointPDFWindowSize[0] + jointPDFWindowSize[1]);
+
   /** Loop over sample container and compute contribution of each sample to pdfs. */
   for (const auto & sample : this->Superclass::GetRangeOfSamples(threadId))
   {
@@ -499,7 +510,8 @@ ParzenWindowMutualInformationImageToImageMetric<TFixedImage, TMovingImage>::Thre
       }
 
       /** Compute this sample's contribution to the joint distributions. */
-      this->UpdateDerivativeLowMemory(fixedImageValue, movingImageValue, imageJacobian, nzji, derivative);
+      this->UpdateDerivativeLowMemory(
+        fixedImageValue, movingImageValue, imageJacobian, nzji, derivative, parzenValues.get());
 
     } // end sampleOk
   } // end loop over sample container
@@ -673,7 +685,8 @@ ParzenWindowMutualInformationImageToImageMetric<TFixedImage, TMovingImage>::Upda
   const RealType                     movingImageValue,
   const DerivativeType &             imageJacobian,
   const NonZeroJacobianIndicesType & nzji,
-  DerivativeType &                   derivative) const
+  DerivativeType &                   derivative,
+  PDFValueType * const               parzenValues) const
 {
   /** In this function we need to do (see eq. 24 of Thevenaz [3]):
    *      derivative -= constant * imageJacobian *
@@ -704,17 +717,13 @@ ParzenWindowMutualInformationImageToImageMetric<TFixedImage, TMovingImage>::Upda
   const auto numberOfFixedParzenValues = Superclass::m_JointPDFWindow.GetSize()[1];
   const auto numberOfDerivedMovingParzenValues = Superclass::m_JointPDFWindow.GetSize()[0];
 
-  // Create a buffer of Parzen values for both the fixed and the moving image.
-  const auto parzenValues =
-    std::make_unique<PDFValueType[]>(numberOfFixedParzenValues + numberOfDerivedMovingParzenValues);
-
   /** Compute the fixed Parzen values. */
-  PDFValueType * const fixedParzenValues = parzenValues.get();
+  PDFValueType * const fixedParzenValues = parzenValues;
   Superclass::EvaluateParzenValues(
     fixedImageParzenWindowTerm, fixedParzenWindowIndex, *Superclass::m_FixedKernel, fixedParzenValues);
 
   /** Compute the derivatives of the moving Parzen window. */
-  PDFValueType * const derivativeMovingParzenValues = parzenValues.get() + numberOfFixedParzenValues;
+  PDFValueType * const derivativeMovingParzenValues = parzenValues + numberOfFixedParzenValues;
   Superclass::EvaluateParzenValues(movingImageParzenWindowTerm,
                                    movingParzenWindowIndex,
                                    *Superclass::m_DerivativeMovingKernel,


### PR DESCRIPTION
- Preallocated the memory for Parzen PDF values outside of for-each-sample loops
- Used the most specific derived interpolator type in `AdvancedImageToImageMetric::EvaluateMovingImageValueAndDerivative`

The registration test case of the benchmark by Nicolas Chiaruttini  (@NicoKiaru)  at https://discourse.itk.org/t/8x-slower-registration-with-itk-elastix-python-api-vs-elastix-cli-minimal-reproducible-example/7736 appears to run more than 5 % faster with the CLI (elastix executable) on Window 11, at "my" [LKEB/LUMC](https://www.lkeb.nl/) pc (AMD Threadripper, 32-Cores, 4 GHz, 64 logical processors), when using the default number of work units for the metric (`ITK_MAX_THREADS`, which is 128 for the executable), so without specifying "-threads".
