### PR TITLE
STYLE: Reduce scope of jacobian in ThreadedComputeDerivativeLowMemory

### DIFF
--- a/Components/Metrics/AdvancedMattesMutualInformation/itkParzenWindowMutualInformationImageToImageMetric.hxx
+++ b/Components/Metrics/AdvancedMattesMutualInformation/itkParzenWindowMutualInformationImageToImageMetric.hxx
@@ -479,9 +479,9 @@ ParzenWindowMutualInformationImageToImageMetric<TFixedImage, TMovingImage>::Thre
 #endif
 
       /** If desired, apply the technique introduced by Tustison. */
-      TransformJacobianType jacobian;
       if (this->GetUseJacobianPreconditioning())
       {
+        TransformJacobianType jacobian;
         this->EvaluateTransformJacobian(fixedPoint, jacobian, nzji);
 
         this->ComputeJacobianPreconditioner(jacobian, nzji, jacobianPreconditioner, preconditioningDivisor);


### PR DESCRIPTION
Following C++ Core Guidelines, Jul 8, 2025, "Keep scopes small", https://isocpp.github.io/CppCoreGuidelines/CppCoreGuidelines#res-scope

Possibly slightly related to issue https://github.com/SuperElastix/elastix/issues/1443 "Suspicious `for`-`while`-loops in ParzenWindowMutualInformationImageToImageMetric"