### PR TITLE
Use log level for image writing progress messages.

### DIFF
--- a/Core/ComponentBaseClasses/elxFixedImagePyramidBase.hxx
+++ b/Core/ComponentBaseClasses/elxFixedImagePyramidBase.hxx
@@ -177,7 +177,7 @@ FixedImagePyramidBase<TElastix>::WritePyramidImage(const std::string & filename,
   configuration.ReadParameter(doCompression, "CompressResultImage", 0, false);
 
   /** Do the writing. */
-  log::to_stdout("  Writing fixed pyramid image ...");
+  log::info("  Writing fixed pyramid image ...");
 #ifndef ELX_NO_FILESYSTEM_ACCESS
   try
   {

--- a/Core/ComponentBaseClasses/elxMovingImagePyramidBase.hxx
+++ b/Core/ComponentBaseClasses/elxMovingImagePyramidBase.hxx
@@ -178,7 +178,7 @@ MovingImagePyramidBase<TElastix>::WritePyramidImage(const std::string & filename
   configuration.ReadParameter(doCompression, "CompressResultImage", 0, false);
 
   /** Do the writing. */
-  log::to_stdout("  Writing moving pyramid image ...");
+  log::info("  Writing moving pyramid image ...");
 #ifndef ELX_NO_FILESYSTEM_ACCESS
   try
   {

--- a/Core/ComponentBaseClasses/elxResamplerBase.hxx
+++ b/Core/ComponentBaseClasses/elxResamplerBase.hxx
@@ -395,7 +395,7 @@ ResamplerBase<TElastix>::WriteResultImage(OutputImageType *   image,
   /** Do the writing. */
   if (showProgress)
   {
-    log::to_stdout("  Writing image ...");
+    log::info("  Writing image ...");
   }
 #ifndef ELX_NO_FILESYSTEM_ACCESS
   try


### PR DESCRIPTION
* Core/ComponentBaseClasses/elxResamplerBase.hxx (WriteResultImage): Use log::info instead of log::to_stdout.
* Core/ComponentBaseClasses/elxFixedImagePyramidBase.hxx (WritePyramidImage): Likewise.
* Core/ComponentBaseClasses/elxMovingImagePyramidBase.hxx (WritePyramidImage): Likewise.