### PR TITLE
ENH: Replace `log::to_stdout` with `log::info_to_stdout`

### DIFF
--- a/Core/ComponentBaseClasses/elxFixedImagePyramidBase.hxx
+++ b/Core/ComponentBaseClasses/elxFixedImagePyramidBase.hxx
@@ -177,7 +177,7 @@ FixedImagePyramidBase<TElastix>::WritePyramidImage(const std::string & filename,
   configuration.ReadParameter(doCompression, "CompressResultImage", 0, false);
 
   /** Do the writing. */
-  log::to_stdout("  Writing fixed pyramid image ...");
+  log::info_to_stdout("  Writing fixed pyramid image ...");
 #ifndef ELX_NO_FILESYSTEM_ACCESS
   try
   {

--- a/Core/ComponentBaseClasses/elxMovingImagePyramidBase.hxx
+++ b/Core/ComponentBaseClasses/elxMovingImagePyramidBase.hxx
@@ -178,7 +178,7 @@ MovingImagePyramidBase<TElastix>::WritePyramidImage(const std::string & filename
   configuration.ReadParameter(doCompression, "CompressResultImage", 0, false);
 
   /** Do the writing. */
-  log::to_stdout("  Writing moving pyramid image ...");
+  log::info_to_stdout("  Writing moving pyramid image ...");
 #ifndef ELX_NO_FILESYSTEM_ACCESS
   try
   {

--- a/Core/ComponentBaseClasses/elxResamplerBase.hxx
+++ b/Core/ComponentBaseClasses/elxResamplerBase.hxx
@@ -395,7 +395,7 @@ ResamplerBase<TElastix>::WriteResultImage(OutputImageType *   image,
   /** Do the writing. */
   if (showProgress)
   {
-    log::to_stdout("  Writing image ...");
+    log::info_to_stdout("  Writing image ...");
   }
 #ifndef ELX_NO_FILESYSTEM_ACCESS
   try

--- a/Core/Kernel/elxlog.cxx
+++ b/Core/Kernel/elxlog.cxx
@@ -96,6 +96,12 @@ public:
   }
 
   auto
+  is_logging_to_stdout() const
+  {
+    return m_data.is_logging_to_stdout;
+  }
+
+  auto
   is_logging_to_any_output() const
   {
     return m_data.is_logging_to_file || m_data.is_logging_to_stdout;
@@ -270,15 +276,14 @@ log::info_to_log_file(const std::ostream & stream)
 }
 
 void
-log::to_stdout(const std::string & message)
+log::info_to_stdout(const std::string & message)
 {
-  get_logger().to_stdout(message);
-}
+  auto & logger = get_logger();
 
-void
-log::to_stdout(const std::ostream & stream)
-{
-  get_logger().to_stdout(get_string_from_stream(stream));
+  if (logger.is_logging_to_stdout() && (logger.get_log_level() == level::info))
+  {
+    logger.to_stdout(message);
+  }
 }
 
 } // end namespace elastix

--- a/Core/Kernel/elxlog.h
+++ b/Core/Kernel/elxlog.h
@@ -93,12 +93,10 @@ public:
   ///@}
 
   ///@{
-  /** Passes the message only to stdout, not to the log file. */
+  /** Passes the message only to stdout, not to the log file. Only when log level is `info`, and `do_log_to_stdout` is
+   * enabled */
   static void
-  to_stdout(const std::string & message);
-
-  static void
-  to_stdout(const std::ostream & stream);
+  info_to_stdout(const std::string & message);
   ///@}
 };
 


### PR DESCRIPTION
`log::info_to_stdout(message)` respects the log level: it only prints the message when the log level is `info`.

- Inspired by pull request https://github.com/SuperElastix/elastix/pull/1448, @jakeforster, May 31, 2026.