### PR TITLE
WIP: PERF: Accumulate joint histograms in ThreadedComputePDFs

### DIFF
--- a/Common/CostFunctions/itkParzenWindowHistogramImageToImageMetric.h
+++ b/Common/CostFunctions/itkParzenWindowHistogramImageToImageMetric.h
@@ -20,6 +20,7 @@
 
 #include "itkAdvancedImageToImageMetric.h"
 #include "itkKernelFunctionBase2.h"
+#include <mutex>
 #include <vector>
 
 
@@ -504,6 +505,8 @@ private:
   bool          m_UseExplicitPDFDerivatives{ true };
   bool          m_UseFiniteDifferenceDerivative{ false };
   double        m_FiniteDifferencePerturbation{ 1.0 };
+
+  std::mutex m_Mutex{};
 };
 
 } // end namespace itk

--- a/Common/CostFunctions/itkParzenWindowHistogramImageToImageMetric.hxx
+++ b/Common/CostFunctions/itkParzenWindowHistogramImageToImageMetric.hxx
@@ -195,7 +195,7 @@ ParzenWindowHistogramImageToImageMetric<TFixedImage, TMovingImage>::InitializeHi
    */
   m_JointPDF = JointPDFType::New();
   m_JointPDF->SetRegions(JointPDFSizeType{ m_NumberOfMovingHistogramBins, m_NumberOfFixedHistogramBins });
-  m_JointPDF->Allocate();
+  m_JointPDF->AllocateInitialized();
 
   if (this->GetUseDerivative())
   {
@@ -1046,6 +1046,21 @@ ParzenWindowHistogramImageToImageMetric<TFixedImage, TMovingImage>::ThreadedComp
   m_ParzenWindowHistogramGetValueAndDerivativePerThreadVariables[threadId].st_NumberOfPixelsCounted =
     numberOfPixelsCounted;
 
+  {
+    const std::lock_guard<std::mutex> lockGuard(m_Mutex);
+
+    /** Accumulate joint histogram. */
+    const ImageBufferRange imageBufferRange(*m_JointPDF);
+
+    auto pdfValueIteratorOfThread = ImageBufferRange(*jointPDF).cbegin();
+
+    for (PDFValueType & pdfValue : imageBufferRange)
+    {
+      pdfValue += *pdfValueIteratorOfThread;
+      ++pdfValueIteratorOfThread;
+    }
+  }
+
 } // end ThreadedComputePDFs()
 
 
@@ -1075,21 +1090,6 @@ ParzenWindowHistogramImageToImageMetric<TFixedImage, TMovingImage>::AfterThreade
   /** Compute alpha. */
   m_Alpha = 1.0 / static_cast<double>(Superclass::m_NumberOfPixelsCounted);
 
-  /** Accumulate joint histogram. */
-  const ImageBufferRange imageBufferRange(*m_JointPDF);
-
-  std::fill(imageBufferRange.begin(), imageBufferRange.end(), PDFValueType{});
-
-  for (const auto & perThreadStruct : m_ParzenWindowHistogramGetValueAndDerivativePerThreadVariables)
-  {
-    auto pdfValueIteratorPerThread = ImageBufferRange(*perThreadStruct.st_JointPDF).cbegin();
-
-    for (PDFValueType & pdfValue : imageBufferRange)
-    {
-      pdfValue += *pdfValueIteratorPerThread;
-      ++pdfValueIteratorPerThread;
-    }
-  }
 } // end AfterThreadedComputePDFs()
 
 


### PR DESCRIPTION
Inspired by a suggestion from Bradley Lowekamp (@blowekamp), June 2, 2026, at https://discourse.itk.org/t/8x-slower-registration-with-itk-elastix-python-api-vs-elastix-cli-minimal-reproducible-example/7736/37

----
A major performance improvement (10% to 40%) of elastix.exe was observed on the benchmark data set from https://discourse.itk.org/t/8x-slower-registration-with-itk-elastix-python-api-vs-elastix-cli-minimal-reproducible-example (by @NicoKiaru). However, this PR might cause slightly different results, because it may change the order of additions of floating point numbers, during accumulation.

----

Update, July 15, 2026: I feel a bit uncertain now about the performance claims that I did above here. I would have to redo the benchmark, to double-check. @blowekamp FYI