### PR TITLE
COMP: Use itk::Math::MatrixExponential instead of removed vnl_matrix_exp

### DIFF
--- a/Components/Transforms/AffineLogTransform/itkAffineLogTransform.hxx
+++ b/Components/Transforms/AffineLogTransform/itkAffineLogTransform.hxx
@@ -18,7 +18,12 @@
 #ifndef itkAffineLogTransform_hxx
 #define itkAffineLogTransform_hxx
 
-#include <vnl/vnl_matrix_exp.h>
+// itk::Math::MatrixExponential exists in ITK >= 6 (ITK#6454); ITK 5.4.x lacks it, so fall back to vnl_matrix_exp.
+#if __has_include("itkMatrixExponential.h")
+#  include "itkMatrixExponential.h"
+#else
+#  include <vnl/vnl_matrix_exp.h>
+#endif
 #include "itkMath.h"
 #include "itkAffineLogTransform.h"
 
@@ -83,7 +88,11 @@ AffineLogTransform<TScalarType, Dimension>::SetParameters(const ParametersType &
     }
   }
 
+#if __has_include("itkMatrixExponential.h")
+  exponentMatrix = itk::Math::MatrixExponential(this->m_MatrixLogDomain);
+#else
   exponentMatrix = vnl_matrix_exp(this->m_MatrixLogDomain.GetVnlMatrix());
+#endif
 
   this->PrecomputeJacobianOfSpatialJacobian();
 
@@ -233,7 +242,11 @@ AffineLogTransform<TScalarType, Dimension>::PrecomputeJacobianOfSpatialJacobian(
           A_bar(k, l) = dA(k, (l - d));
         }
       }
+#if __has_include("itkMatrixExponential.h")
+      B_bar = itk::Math::MatrixExponential(A_bar);
+#else
       B_bar = vnl_matrix_exp(A_bar);
+#endif
       for (unsigned int k = 0; k < d; ++k)
       {
         for (unsigned int l = d; l < 2 * d; ++l)


### PR DESCRIPTION
VXL removed `core/vnl/vnl_matrix_exp`, which `AffineLogTransform` included via `<vnl/vnl_matrix_exp.h>` (InsightSoftwareConsortium/ITK#6452). This migrates the two call sites to `itk::Math::MatrixExponential`, an ITK-supported Eigen-backed replacement.

> **Depends on** InsightSoftwareConsortium/ITK#6454 (adds `itk::Math::MatrixExponential` / `itkMatrixExponential.h`). Hold merge until an ITK containing it is required.

<details>
<summary>Change</summary>

```
-#include <vnl/vnl_matrix_exp.h>             →  #include "itkMatrixExponential.h"
-vnl_matrix_exp(... .GetVnlMatrix())         →  itk::Math::MatrixExponential(...)
-vnl_matrix_exp(A_bar)                        →  itk::Math::MatrixExponential(A_bar)
```

Call-site argument types (`vnl_matrix_fixed`, `vnl_matrix`) are unchanged; the new function provides matching overloads. Both `AffineLogTransform` and `AffineLogStackTransform` components rebuild clean against the new header.

</details>

<!--
provenance: claude-code 2026-06-16, ITK#6452
itk_dep: InsightSoftwareConsortium/ITK#6454
-->
