### PR TITLE
ENH: Add DEFAULT_ITK_GIT_TAG to .github yml files

### DIFF
--- a/.github/workflows/ElastixGitHubActions.yml
+++ b/.github/workflows/ElastixGitHubActions.yml
@@ -2,6 +2,9 @@ name: Elastix
 
 on: [push, pull_request]
 
+env:
+  DEFAULT_ITK_GIT_TAG "v5.4.6"
+
 jobs:
   build:
     runs-on: ${{ matrix.os }}
@@ -15,7 +18,7 @@ jobs:
             cxx-compiler: "g++"
             libtorch-cpu-url: "https://download.pytorch.org/libtorch/cpu/libtorch-shared-with-deps-2.8.0%2Bcpu.zip"
             cuda-version: "cpu"
-            itk-git-tag: "v5.4.6"
+            itk-git-tag: $DEFAULT_ITK_GIT_TAG
             cmake-build-type: "Release"
             libs:
               - elastix-build/bin/libelx-ANNlib.so
@@ -25,7 +28,7 @@ jobs:
             cxx-compiler: "cl.exe"
             libtorch-cpu-url: "https://download.pytorch.org/libtorch/cpu/libtorch-win-shared-with-deps-2.8.0%2Bcpu.zip"
             cuda-version: "cpu"
-            itk-git-tag: "v5.4.6"
+            itk-git-tag: $DEFAULT_ITK_GIT_TAG
             cmake-build-type: "Release"
             libs:
               - elastix-build/bin/elx-ANNlib.dll
@@ -36,7 +39,7 @@ jobs:
             cxx-compiler: "clang++"
             libtorch-cpu-url: "https://download.pytorch.org/libtorch/cpu/libtorch-macos-arm64-2.8.0.zip"
             cuda-version: "cpu"
-            itk-git-tag: "v5.4.6"
+            itk-git-tag: $DEFAULT_ITK_GIT_TAG
             cmake-build-type: "Release"
             libs:
               - elastix-build/bin/libelx-ANNlib.dylib

--- a/.github/workflows/publish-elastix.yml
+++ b/.github/workflows/publish-elastix.yml
@@ -3,6 +3,9 @@ name: ElastixPublish
 on:
   workflow_dispatch:
 
+env:
+  DEFAULT_ITK_GIT_TAG "v5.4.6"
+
 jobs:
   publish:
     runs-on: ${{ matrix.os }}
@@ -15,7 +18,7 @@ jobs:
             libtorch-cpu-url: "https://download.pytorch.org/libtorch/cpu/libtorch-shared-with-deps-2.8.0%2Bcpu.zip"
             libtorch-cuda-url: "https://download.pytorch.org/libtorch/cu128/libtorch-shared-with-deps-2.8.0%2Bcu128.zip"
             cuda_toolkit_version: '12.8.0'
-            itk-git-tag: "v5.4.6"
+            itk-git-tag: $DEFAULT_ITK_GIT_TAG
             c-compiler: "gcc"
             cxx-compiler: "g++"
             cmake-build-type: "Release"
@@ -25,7 +28,7 @@ jobs:
             libtorch-cpu-url: "https://download.pytorch.org/libtorch/cpu/libtorch-win-shared-with-deps-2.8.0%2Bcpu.zip"
             libtorch-cuda-url: "https://download.pytorch.org/libtorch/cu128/libtorch-win-shared-with-deps-2.8.0%2Bcu128.zip"
             cuda_toolkit_version: '12.8.0'
-            itk-git-tag: "v5.4.6"
+            itk-git-tag: $DEFAULT_ITK_GIT_TAG
             c-compiler: "cl.exe"
             cxx-compiler: "cl.exe"
             cmake-build-type: "Release"
@@ -36,7 +39,7 @@ jobs:
             c-compiler: "clang"
             cxx-compiler: "clang++"
             libtorch-cpu-url: "https://download.pytorch.org/libtorch/cpu/libtorch-macos-arm64-2.8.0.zip"
-            itk-git-tag: "v5.4.6"
+            itk-git-tag: $DEFAULT_ITK_GIT_TAG
             cmake-build-type: "Release"
             libs:
               - elastix-build/bin/libelx-ANNlib.dylib


### PR DESCRIPTION
Eases moving from one ITK version to another.