### PR TITLE
STYLE: Add PUBLIC to target_link_libraries and elastix_link_itk calls

### DIFF
--- a/Common/GTesting/CMakeLists.txt
+++ b/Common/GTesting/CMakeLists.txt
@@ -37,14 +37,14 @@ target_compile_definitions(CommonGTest PRIVATE
 )
 
 if (ITK_VERSION VERSION_LESS_EQUAL 5.4.6)
-  target_link_libraries(CommonGTest
+  target_link_libraries(CommonGTest PUBLIC
     GTest::GTest
     GTest::Main
     ${ELASTIX_ITK_EXECUTABLE_LIBRARIES}
     elastix_lib
   )
 else()
-  target_link_libraries(CommonGTest
+  target_link_libraries(CommonGTest PUBLIC
     GTest::gtest
     GTest::gtest_main
     ${ELASTIX_ITK_EXECUTABLE_LIBRARIES}
@@ -54,7 +54,7 @@ endif()
 
 if(USE_ImpactMetric)
   find_package(Torch REQUIRED)
-  target_link_libraries(CommonGTest "${TORCH_LIBRARIES}")
+  target_link_libraries(CommonGTest PUBLIC "${TORCH_LIBRARIES}")
 endif()
 
 target_include_directories(CommonGTest PRIVATE

--- a/Common/MevisDicomTiff/CMakeLists.txt
+++ b/Common/MevisDicomTiff/CMakeLists.txt
@@ -24,7 +24,7 @@ if(NOT ELASTIX_NO_INSTALL_DEVELOPMENT)
     COMPONENT Development)
 endif()
 
-elastix_link_itk(mevisdcmtiff MODULES
+elastix_link_itk(mevisdcmtiff PUBLIC MODULES
   ITKCommon
   ITKGDCM
   ITKIOImageBase

--- a/Common/OpenCL/CMakeLists.txt
+++ b/Common/OpenCL/CMakeLists.txt
@@ -56,7 +56,7 @@ set(OpenCL_Files
 add_library(elxOpenCL STATIC ${OpenCL_Files})
 
 # Link it against the necessary libraries.
-elastix_link_itk(elxOpenCL MODULES
+elastix_link_itk(elxOpenCL PUBLIC MODULES
   ITKCommon
   ITKGPUCommon
   ITKTransform
@@ -64,7 +64,7 @@ elastix_link_itk(elxOpenCL MODULES
   ITKSmoothing
   ITKImageFunction
 )
-target_link_libraries(elxOpenCL ${OPENCL_LIBRARIES})
+target_link_libraries(elxOpenCL PUBLIC ${OPENCL_LIBRARIES})
 
 target_include_directories(elxOpenCL PUBLIC ${OPENCL_INCLUDE_DIRS})
 target_compile_definitions(elxOpenCL PUBLIC ELASTIX_USE_OPENCL)

--- a/Common/ParameterFileParser/CMakeLists.txt
+++ b/Common/ParameterFileParser/CMakeLists.txt
@@ -17,7 +17,7 @@ if(NOT ELASTIX_NO_INSTALL_DEVELOPMENT)
     COMPONENT Development)
 endif()
 
-elastix_link_itk(param MODULES
+elastix_link_itk(param PUBLIC MODULES
   ITKCommon
 )
 target_include_directories(param PUBLIC

--- a/Components/CMakeLists.txt
+++ b/Components/CMakeLists.txt
@@ -123,7 +123,7 @@ macro(ADD_ELXCOMPONENT name)
     else()
       add_library(${name} STATIC ${filelist})
     endif()
-    target_link_libraries(${name} ${elxLinkLibs})
+    target_link_libraries(${name} PUBLIC ${elxLinkLibs})
     target_include_directories(${name} PRIVATE ${CMAKE_CURRENT_SOURCE_DIR})
     if(NOT ELASTIX_NO_INSTALL_DEVELOPMENT)
       install(TARGETS ${name}

--- a/Components/FixedImagePyramids/OpenCLFixedGenericPyramid/CMakeLists.txt
+++ b/Components/FixedImagePyramids/OpenCLFixedGenericPyramid/CMakeLists.txt
@@ -11,7 +11,7 @@ if(ELASTIX_USE_OPENCL)
     target_include_directories(OpenCLFixedGenericPyramid BEFORE PRIVATE
       ${elxCommon_OpenCL_INCLUDE_DIRECTORIES}
       ${OPENCL_KERNELS_DEBUG_PATH})
-    target_link_libraries(OpenCLFixedGenericPyramid elxOpenCL)
+    target_link_libraries(OpenCLFixedGenericPyramid PUBLIC elxOpenCL)
   endif()
 else()
   # If the user set USE_OpenCLFixedGenericPyramid ON, but ELASTIX_USE_OPENCL was OFF,

--- a/Components/Metrics/Impact/CMakeLists.txt
+++ b/Components/Metrics/Impact/CMakeLists.txt
@@ -14,5 +14,5 @@ ADD_ELXCOMPONENT(ImpactMetric OFF PLUGIN
 
 if(USE_ImpactMetric)
     find_package(Torch REQUIRED)
-    target_link_libraries(ImpactMetric ${TORCH_LIBRARIES})
+    target_link_libraries(ImpactMetric PUBLIC ${TORCH_LIBRARIES})
 endif()

--- a/Components/Metrics/KNNGraphAlphaMutualInformation/CMakeLists.txt
+++ b/Components/Metrics/KNNGraphAlphaMutualInformation/CMakeLists.txt
@@ -14,7 +14,7 @@ if(USE_KNNGraphAlphaMutualInformationMetric)
   add_subdirectory(KNN)
   target_include_directories(KNNGraphAlphaMutualInformationMetric
     PRIVATE ${CMAKE_CURRENT_SOURCE_DIR}/KNN)
-  target_link_libraries(KNNGraphAlphaMutualInformationMetric KNNlib ANNlib)
+  target_link_libraries(KNNGraphAlphaMutualInformationMetric PUBLIC KNNlib ANNlib)
   elastix_export_target(KNNlib)
   elastix_export_target(ANNlib)
 endif()

--- a/Components/Metrics/KNNGraphAlphaMutualInformation/KNN/CMakeLists.txt
+++ b/Components/Metrics/KNNGraphAlphaMutualInformation/KNN/CMakeLists.txt
@@ -36,12 +36,12 @@ add_subdirectory(ann_1.1)
 add_library(KNNlib STATIC ${KNN_Files})
 
 # Link it against the necessary libraries.
-elastix_link_itk(KNNlib MODULES
+elastix_link_itk(KNNlib PUBLIC MODULES
   ITKCommon
   ITKStatistics
   ITKSpatialObjects
 )
-target_link_libraries(KNNlib ANNlib)
+target_link_libraries(KNNlib PUBLIC ANNlib)
 
 # Group in IDE's like Visual Studio
 set_property(TARGET KNNlib PROPERTY FOLDER "libraries")

--- a/Components/MovingImagePyramids/OpenCLMovingGenericPyramid/CMakeLists.txt
+++ b/Components/MovingImagePyramids/OpenCLMovingGenericPyramid/CMakeLists.txt
@@ -11,7 +11,7 @@ if(ELASTIX_USE_OPENCL)
     target_include_directories(OpenCLMovingGenericPyramid BEFORE PRIVATE
       ${elxCommon_OpenCL_INCLUDE_DIRECTORIES}
       ${OPENCL_KERNELS_DEBUG_PATH})
-    target_link_libraries(OpenCLMovingGenericPyramid elxOpenCL)
+    target_link_libraries(OpenCLMovingGenericPyramid PUBLIC elxOpenCL)
   endif()
 else()
   # If the user set USE_OpenCLMovingGenericPyramid ON, but ELASTIX_USE_OPENCL was OFF,

--- a/Components/Resamplers/OpenCLResampler/CMakeLists.txt
+++ b/Components/Resamplers/OpenCLResampler/CMakeLists.txt
@@ -9,7 +9,7 @@ if(ELASTIX_USE_OPENCL)
     target_include_directories(OpenCLResampler BEFORE PRIVATE
       ${elxCommon_OpenCL_INCLUDE_DIRECTORIES}
       ${OPENCL_KERNELS_DEBUG_PATH})
-    target_link_libraries(OpenCLResampler elxOpenCL)
+    target_link_libraries(OpenCLResampler PUBLIC elxOpenCL)
   endif()
 else()
   # If the user set USE_OpenCLResampler ON, but ELASTIX_USE_OPENCL was OFF,

--- a/Core/CMakeLists.txt
+++ b/Core/CMakeLists.txt
@@ -149,7 +149,7 @@ elastix_export_target(elxCore)
 #---------------------------------------------------------------------
 # Link against other libraries.
 
-target_link_libraries(elxCore
+target_link_libraries(elxCore PUBLIC
   elxCommon
   param # Needed for elxConfiguration
   #  ${ITK_LIBRARIES}
@@ -224,7 +224,7 @@ if(ELASTIX_BUILD_EXECUTABLE)
   if (WASI OR EMSCRIPTEN)
     target_compile_definitions(elastix_exe PUBLIC ELX_NO_FILESYSTEM_ACCESS)
   endif()
-  target_link_libraries(elastix_exe ${ELASTIX_TARGET_LINK_LIBRARIES})
+  target_link_libraries(elastix_exe PUBLIC ${ELASTIX_TARGET_LINK_LIBRARIES})
   if (MSVC)
     target_sources(elastix_exe PRIVATE ${CMAKE_CURRENT_SOURCE_DIR}/utf8.manifest)
   endif()
@@ -250,7 +250,7 @@ target_compile_definitions(elastix_lib PRIVATE ELX_CMAKE_VERSION="${CMAKE_VERSIO
 if (WASI OR EMSCRIPTEN)
   target_compile_definitions(elastix_lib PUBLIC ELX_NO_FILESYSTEM_ACCESS)
 endif()
-target_link_libraries(elastix_lib ${ELASTIX_TARGET_LINK_LIBRARIES})
+target_link_libraries(elastix_lib PUBLIC ${ELASTIX_TARGET_LINK_LIBRARIES})
 
 #---------------------------------------------------------------------
 # Create the transformix executable.
@@ -272,7 +272,7 @@ if(ELASTIX_BUILD_EXECUTABLE)
   if (WASI OR EMSCRIPTEN)
     target_compile_definitions(transformix_exe PUBLIC ELX_NO_FILESYSTEM_ACCESS)
   endif()
-  target_link_libraries(transformix_exe ${ELASTIX_TARGET_LINK_LIBRARIES})
+  target_link_libraries(transformix_exe PUBLIC ${ELASTIX_TARGET_LINK_LIBRARIES})
   if (MSVC)
     target_sources(transformix_exe PRIVATE ${CMAKE_CURRENT_SOURCE_DIR}/utf8.manifest)
   endif()
@@ -294,7 +294,7 @@ add_library(transformix_lib
   ${InstallFilesForExecutables}
 )
 set_target_properties(transformix_lib PROPERTIES OUTPUT_NAME transformix)
-target_link_libraries(transformix_lib ${ELASTIX_TARGET_LINK_LIBRARIES})
+target_link_libraries(transformix_lib PUBLIC ${ELASTIX_TARGET_LINK_LIBRARIES})
 target_compile_definitions(transformix_lib PRIVATE ELX_CMAKE_VERSION="${CMAKE_VERSION}")
 if (WASI OR EMSCRIPTEN)
   target_compile_definitions(transformix_lib PUBLIC ELX_NO_FILESYSTEM_ACCESS)

--- a/Core/Main/GTesting/CMakeLists.txt
+++ b/Core/Main/GTesting/CMakeLists.txt
@@ -13,7 +13,7 @@ target_compile_definitions(ElastixLibGTest PRIVATE
 )
 
 if (ITK_VERSION VERSION_LESS_EQUAL 5.4.6)
-  target_link_libraries(ElastixLibGTest
+  target_link_libraries(ElastixLibGTest PUBLIC
     GTest::GTest
     GTest::Main
     elastix_lib
@@ -21,7 +21,7 @@ if (ITK_VERSION VERSION_LESS_EQUAL 5.4.6)
     ${ELASTIX_ITK_EXECUTABLE_LIBRARIES}
   )
 else()
-  target_link_libraries(ElastixLibGTest
+  target_link_libraries(ElastixLibGTest PUBLIC
     GTest::gtest
     GTest::gtest_main
     elastix_lib
@@ -34,7 +34,7 @@ endif()
 target_compile_definitions(ElastixLibGTest PRIVATE ELX_CMAKE_SOURCE_DIR="${CMAKE_SOURCE_DIR}" ELX_CMAKE_CURRENT_BINARY_DIR="${CMAKE_CURRENT_BINARY_DIR}")
 
 if(ELASTIX_USE_OPENCL)
-  target_link_libraries(ElastixLibGTest elxOpenCL)
+  target_link_libraries(ElastixLibGTest PUBLIC elxOpenCL)
 endif()
 
 add_test(NAME ElastixLibGTest_test COMMAND ElastixLibGTest)

--- a/Testing/CMakeLists.txt
+++ b/Testing/CMakeLists.txt
@@ -69,7 +69,7 @@ macro(elx_add_test_core executable_name source_name test_name group)
     )
 
     # Link against other libraries.
-    target_link_libraries(${executable_name}
+    target_link_libraries(${executable_name} PUBLIC
       param               # some test use the CommandLineArgumentParser
       elxCommon            # provides Common headers (Transforms, CostFunctions, etc.)
       ${mevisdcmtifflib}  # is empty if not selected in CMake
@@ -79,7 +79,7 @@ macro(elx_add_test_core executable_name source_name test_name group)
 
     if(ELASTIX_USE_OPENCL)
       target_include_directories(${executable_name} PRIVATE ${CMAKE_CURRENT_SOURCE_DIR})
-      target_link_libraries(${executable_name} elxOpenCL)
+      target_link_libraries(${executable_name} PUBLIC elxOpenCL)
     endif()
 
     # Group in IDE's like Visual Studio
@@ -421,22 +421,22 @@ endmacro()
 
 # Create elxComputeOverlap
 add_executable(elxComputeOverlap elxComputeOverlap.cxx itkCommandLineArgumentParser.cxx)
-target_link_libraries(elxComputeOverlap ${ELASTIX_ITK_ALL_LIBRARIES})
+target_link_libraries(elxComputeOverlap PUBLIC ${ELASTIX_ITK_ALL_LIBRARIES})
 set_property(TARGET elxComputeOverlap PROPERTY FOLDER "tests/Executable")
 
 # Create elxImageCompare
 add_executable(elxImageCompare elxImageCompare.cxx itkCommandLineArgumentParser.cxx)
-target_link_libraries(elxImageCompare ${ELASTIX_ITK_ALL_LIBRARIES})
+target_link_libraries(elxImageCompare PUBLIC ${ELASTIX_ITK_ALL_LIBRARIES})
 set_property(TARGET elxImageCompare PROPERTY FOLDER "tests/Executable")
 
 # Create elxTransformParametersCompare
 add_executable(elxTransformParametersCompare elxTransformParametersCompare.cxx itkCommandLineArgumentParser.cxx)
-target_link_libraries(elxTransformParametersCompare elxCore param ${ELASTIX_ITK_EXECUTABLE_LIBRARIES})
+target_link_libraries(elxTransformParametersCompare PUBLIC elxCore param ${ELASTIX_ITK_EXECUTABLE_LIBRARIES})
 set_property(TARGET elxTransformParametersCompare PROPERTY FOLDER "tests/Executable")
 
 # Create elxInvertTransform
 add_executable(elxInvertTransform elxInvertTransform.cxx itkCommandLineArgumentParser.cxx)
-target_link_libraries(elxInvertTransform elxCore param ${ELASTIX_ITK_EXECUTABLE_LIBRARIES})
+target_link_libraries(elxInvertTransform PUBLIC elxCore param ${ELASTIX_ITK_EXECUTABLE_LIBRARIES})
 set_property(TARGET elxInvertTransform PROPERTY FOLDER "tests/Executable")
 
 #---------------------------------------------------------------------
@@ -1031,7 +1031,7 @@ elx_add_test(TransformixFilterTest "" "Transformix"
   ${TestDataDir}/3DCT_lung_baseline_small.mha
   ${TestDataDir}/transformparameters.3DCT_lung.affine.txt
   ${TestOutputDir}/TransformixFilterTest.mha)
-target_link_libraries(itkTransformixFilterTest elastix_lib transformix_lib)
+target_link_libraries(itkTransformixFilterTest PUBLIC elastix_lib transformix_lib)
 
 
 if(USE_ImpactMetric)

--- a/dox/externalproject/CMakeLists.txt
+++ b/dox/externalproject/CMakeLists.txt
@@ -32,12 +32,12 @@ if(ITK_VERSION_MAJOR GREATER_EQUAL 6)
   # ITK 6+: elastix_lib carries all ITK module dependencies and include paths
   # transitively via its INTERFACE_LINK_LIBRARIES. No explicit ${ITK_INCLUDE_DIRS}
   # or ${ITK_LIBRARIES} needed.
-  target_link_libraries(elastix_translation_example
+  target_link_libraries(elastix_translation_example PUBLIC
     PRIVATE elastix_lib)
 else()
   target_include_directories(elastix_translation_example
     PRIVATE ${ELASTIX_INCLUDE_DIRS} ${ITK_INCLUDE_DIRS})
-  target_link_libraries(elastix_translation_example
+  target_link_libraries(elastix_translation_example PUBLIC
     PRIVATE ${ITK_LIBRARIES} elastix_lib)
 endif()
 
@@ -47,12 +47,12 @@ add_executable(elastix_impact_metric_example ElastixImpactMetricExample.cxx)
 set_property(TARGET elastix_impact_metric_example PROPERTY CXX_STANDARD 17)
 
 if(ITK_VERSION_MAJOR GREATER_EQUAL 6)
-  target_link_libraries(elastix_impact_metric_example
+  target_link_libraries(elastix_impact_metric_example PUBLIC
     PRIVATE elastix_lib)
 else()
   target_include_directories(elastix_impact_metric_example
     PRIVATE ${ELASTIX_INCLUDE_DIRS} ${ITK_INCLUDE_DIRS})
-  target_link_libraries(elastix_impact_metric_example
+  target_link_libraries(elastix_impact_metric_example PUBLIC
     PRIVATE ${ITK_LIBRARIES} elastix_lib)
 endif()
 


### PR DESCRIPTION
Using Notepad++, Replace in Files, doing

  Find what: `(target_link_libraries\([^ \r\n]+) `
  Replace with: `\1 PUBLIC `
  Find what: `(target_link_libraries\([^ \r\n]+)$`
  Replace with: `\1 PUBLIC`
  Find what: `(elastix_link_itk\([^ \r\n]+) MODULES`
  Replace with: `\1 PUBLIC MODULES`
  Filters: `CMakeLists*.txt`
  (*) Regular expression

It appears clearer, and more modern, to explicitly specify the scope (by adding the `PUBLIC` keyword).

Doing so would prevent a CMake error when having multiple target_link_libraries calls on the same target, saying:

    The plain signature for target_link_libraries has already been used with
    the target "...".  All uses of target_link_libraries with a target must
    be either all-keyword or all-plain.

As experienced with CMake 4.3.2

- Follow-up to pull request #1457
----

@blowekamp Please check! Do you agree that the `PUBLIC` keyword is preferred over leaving the scope unspecified (implicitly transitive)?