### PR TITLE
COMP: Add colon (`:`) to DEFAULT_ITK_GIT_TAG in GitHub Actions yml files

### DIFF
--- a/.github/workflows/ElastixGitHubActions.yml
+++ b/.github/workflows/ElastixGitHubActions.yml
@@ -3,7 +3,7 @@ name: Elastix
 on: [push, pull_request]
 
 env:
-  DEFAULT_ITK_GIT_TAG "v5.4.6"
+  DEFAULT_ITK_GIT_TAG: "v5.4.6"
 
 jobs:
   build:

--- a/.github/workflows/publish-elastix.yml
+++ b/.github/workflows/publish-elastix.yml
@@ -4,7 +4,7 @@ on:
   workflow_dispatch:
 
 env:
-  DEFAULT_ITK_GIT_TAG "v5.4.6"
+  DEFAULT_ITK_GIT_TAG: "v5.4.6"
 
 jobs:
   publish:


### PR DESCRIPTION
Aims to fix "check failures" from GitHub Actions, saying:

    Invalid workflow file
    Unexpected value 'DEFAULT_ITK_GIT_TAG "v5.4.6"'