### PR TITLE
COMP: Upgrade GitHub Actions to Python 3.10

### DIFF
--- a/.github/workflows/ElastixGitHubActions.yml
+++ b/.github/workflows/ElastixGitHubActions.yml
@@ -82,7 +82,7 @@ jobs:
       - name: Set up Python
         uses: actions/setup-python@v5.4.0
         with:
-          python-version: 3.9
+          python-version: '3.10'
 
       - name: Install build dependencies
         run: |


### PR DESCRIPTION
Python 3.9 has reached end of life already on 2025-10-31 (according to https://devguide.python.org/versions).

Follow-up to pull request https://github.com/SuperElastix/elastix/pull/1320 commit 629be602608d0878da6edf717aebfaa4029576e6