### PR TITLE
Default default-constructors of Optimizers

### DIFF
--- a/Components/Optimizers/AdaGrad/elxAdaGrad.h
+++ b/Components/Optimizers/AdaGrad/elxAdaGrad.h
@@ -291,7 +291,7 @@ public:
   itkGetConstReferenceMacro(MaximumNumberOfSamplingAttempts, SizeValueType);
 
 protected:
-  AdaGrad();
+  AdaGrad() = default;
   ~AdaGrad() override = default;
 
   /** Protected typedefs */
@@ -350,23 +350,23 @@ protected:
   using BSplineTransformBasePointer = typename AdvancedBSplineDeformableTransformType::Pointer;
 
   /** Variable to store the automatically determined settings for each resolution. */
-  SettingsVectorType m_SettingsVector;
+  SettingsVectorType m_SettingsVector{};
 
   /** Some options for automatic parameter estimation. */
-  SizeValueType m_NumberOfGradientMeasurements;
-  SizeValueType m_NumberOfJacobianMeasurements;
-  SizeValueType m_NumberOfSamplesForNoiseCompensationFactor;
-  SizeValueType m_NumberOfSamplesForPrecondition;
-  SizeValueType m_NumberOfSpatialSamples;
+  SizeValueType m_NumberOfGradientMeasurements{ 0 };
+  SizeValueType m_NumberOfJacobianMeasurements{ 0 };
+  SizeValueType m_NumberOfSamplesForNoiseCompensationFactor{ 0 };
+  SizeValueType m_NumberOfSamplesForPrecondition{ 0 };
+  SizeValueType m_NumberOfSpatialSamples{ 5000 };
 
   /** The transform stored as AdvancedTransform */
-  AdvancedTransformPointer m_AdvancedTransform;
+  AdvancedTransformPointer m_AdvancedTransform{ nullptr };
 
-  double m_SigmoidScaleFactor;
-  double m_NoiseFactor;
-  double m_GlobalStepSize;
-  double m_RegularizationKappa;
-  double m_ConditionNumber;
+  double m_SigmoidScaleFactor{ 0.1 };
+  double m_NoiseFactor{ 1.0 };
+  double m_GlobalStepSize{ 0 };
+  double m_RegularizationKappa{ 0.8 };
+  double m_ConditionNumber{ 2.0 };
 
   /** Select different method to estimate some reasonable values for the parameters
    * SP_a, SP_alpha (=1), SigmoidMin, SigmoidMax (=1), and
@@ -400,23 +400,23 @@ protected:
 private:
   elxOverrideGetSelfMacro;
 
-  bool   m_AutomaticParameterEstimation;
-  double m_MaximumStepLength;
-  double m_MaximumStepLengthRatio;
+  bool   m_AutomaticParameterEstimation{ false };
+  double m_MaximumStepLength{ 1.0 };
+  double m_MaximumStepLengthRatio{ 1.0 };
 
   /** Private variables for the sampling attempts. */
-  SizeValueType m_MaximumNumberOfSamplingAttempts;
-  SizeValueType m_CurrentNumberOfSamplingAttempts;
-  SizeValueType m_PreviousErrorAtIteration;
-  bool          m_AutomaticParameterEstimationDone;
+  SizeValueType m_MaximumNumberOfSamplingAttempts{ 0 };
+  SizeValueType m_CurrentNumberOfSamplingAttempts{ 0 };
+  SizeValueType m_PreviousErrorAtIteration{ 0 };
+  bool          m_AutomaticParameterEstimationDone{ false };
 
   /** Private variables for band size estimation of covariance matrix. */
-  SizeValueType m_MaxBandCovSize;
-  SizeValueType m_NumberOfBandStructureSamples;
+  SizeValueType m_MaxBandCovSize{};
+  SizeValueType m_NumberOfBandStructureSamples{};
 
   /** The flag of using noise compensation. */
-  bool m_UseNoiseCompensation;
-  bool m_OriginalButSigmoidToDefault;
+  bool m_UseNoiseCompensation{ true };
+  bool m_OriginalButSigmoidToDefault{};
 };
 
 } // end namespace elastix

--- a/Components/Optimizers/AdaGrad/elxAdaGrad.hxx
+++ b/Components/Optimizers/AdaGrad/elxAdaGrad.hxx
@@ -35,40 +35,6 @@ namespace elastix
 {
 
 /**
- * ********************** Constructor ***********************
- */
-
-template <typename TElastix>
-AdaGrad<TElastix>::AdaGrad()
-{
-  this->m_MaximumNumberOfSamplingAttempts = 0;
-  this->m_CurrentNumberOfSamplingAttempts = 0;
-  this->m_PreviousErrorAtIteration = 0;
-  this->m_AutomaticParameterEstimationDone = false;
-
-  this->m_AutomaticParameterEstimation = false;
-  this->m_MaximumStepLength = 1.0;
-  this->m_MaximumStepLengthRatio = 1.0;
-  this->m_RegularizationKappa = 0.8;
-  this->m_ConditionNumber = 2.0;
-  this->m_NoiseFactor = 1.0;
-
-  this->m_NumberOfGradientMeasurements = 0;
-  this->m_NumberOfJacobianMeasurements = 0;
-  this->m_NumberOfSamplesForPrecondition = 0;
-  this->m_NumberOfSamplesForNoiseCompensationFactor = 0;
-  this->m_NumberOfSpatialSamples = 5000;
-  this->m_SigmoidScaleFactor = 0.1;
-  this->m_GlobalStepSize = 0;
-
-  this->m_AdvancedTransform = nullptr;
-
-  this->m_UseNoiseCompensation = true;
-
-} // Constructor
-
-
-/**
  * ***************** BeforeRegistration ***********************
  */
 

--- a/Components/Optimizers/AdaptiveStochasticGradientDescent/elxAdaptiveStochasticGradientDescent.h
+++ b/Components/Optimizers/AdaptiveStochasticGradientDescent/elxAdaptiveStochasticGradientDescent.h
@@ -329,7 +329,7 @@ protected:
   using AdvancedTransformPointer = typename AdvancedTransformType::Pointer;
   using NonZeroJacobianIndicesType = typename AdvancedTransformType::NonZeroJacobianIndicesType;
 
-  AdaptiveStochasticGradientDescent();
+  AdaptiveStochasticGradientDescent() = default;
   ~AdaptiveStochasticGradientDescent() override = default;
 
   /** Select different method to estimate some reasonable values for the parameters
@@ -378,35 +378,35 @@ private:
   elxOverrideGetSelfMacro;
 
   /** Variable to store the automatically determined settings for each resolution. */
-  SettingsVectorType m_SettingsVector;
+  SettingsVectorType m_SettingsVector{};
 
   /** Some options for automatic parameter estimation. */
-  SizeValueType m_NumberOfGradientMeasurements;
-  SizeValueType m_NumberOfJacobianMeasurements;
-  SizeValueType m_NumberOfSamplesForExactGradient;
+  SizeValueType m_NumberOfGradientMeasurements{ 0 };
+  SizeValueType m_NumberOfJacobianMeasurements{ 0 };
+  SizeValueType m_NumberOfSamplesForExactGradient{ 100000 };
 
   /** The transform stored as AdvancedTransform */
-  AdvancedTransformPointer m_AdvancedTransform;
+  AdvancedTransformPointer m_AdvancedTransform{ nullptr };
 
-  double m_SigmoidScaleFactor;
+  double m_SigmoidScaleFactor{ 0.1 };
 
-  bool   m_AutomaticParameterEstimation;
-  double m_MaximumStepLength;
-  double m_MaximumStepLengthRatio;
+  bool   m_AutomaticParameterEstimation{ false };
+  double m_MaximumStepLength{ 1.0 };
+  double m_MaximumStepLengthRatio{ 1.0 };
 
   /** Private variables for the sampling attempts. */
-  SizeValueType m_MaximumNumberOfSamplingAttempts;
-  SizeValueType m_CurrentNumberOfSamplingAttempts;
-  SizeValueType m_PreviousErrorAtIteration;
-  bool          m_AutomaticParameterEstimationDone;
+  SizeValueType m_MaximumNumberOfSamplingAttempts{ 0 };
+  SizeValueType m_CurrentNumberOfSamplingAttempts{ 0 };
+  SizeValueType m_PreviousErrorAtIteration{ 0 };
+  bool          m_AutomaticParameterEstimationDone{ false };
 
   /** Private variables for band size estimation of covariance matrix. */
-  SizeValueType m_MaxBandCovSize;
-  SizeValueType m_NumberOfBandStructureSamples;
+  SizeValueType m_MaxBandCovSize{};
+  SizeValueType m_NumberOfBandStructureSamples{};
 
   /** The flag of using noise compensation. */
-  bool m_UseNoiseCompensation;
-  bool m_OriginalButSigmoidToDefault;
+  bool m_UseNoiseCompensation{ true };
+  bool m_OriginalButSigmoidToDefault{ false };
 };
 
 } // end namespace elastix

--- a/Components/Optimizers/AdaptiveStochasticGradientDescent/elxAdaptiveStochasticGradientDescent.hxx
+++ b/Components/Optimizers/AdaptiveStochasticGradientDescent/elxAdaptiveStochasticGradientDescent.hxx
@@ -34,35 +34,6 @@ namespace elastix
 {
 
 /**
- * ********************** Constructor ***********************
- */
-
-template <typename TElastix>
-AdaptiveStochasticGradientDescent<TElastix>::AdaptiveStochasticGradientDescent()
-{
-  this->m_MaximumNumberOfSamplingAttempts = 0;
-  this->m_CurrentNumberOfSamplingAttempts = 0;
-  this->m_PreviousErrorAtIteration = 0;
-  this->m_AutomaticParameterEstimationDone = false;
-
-  this->m_AutomaticParameterEstimation = false;
-  this->m_MaximumStepLength = 1.0;
-  this->m_MaximumStepLengthRatio = 1.0;
-
-  this->m_NumberOfGradientMeasurements = 0;
-  this->m_NumberOfJacobianMeasurements = 0;
-  this->m_NumberOfSamplesForExactGradient = 100000;
-  this->m_SigmoidScaleFactor = 0.1;
-
-  this->m_AdvancedTransform = nullptr;
-
-  this->m_UseNoiseCompensation = true;
-  this->m_OriginalButSigmoidToDefault = false;
-
-} // Constructor
-
-
-/**
  * ***************** BeforeRegistration ***********************
  */
 

--- a/Components/Optimizers/ConjugateGradientFRPR/elxConjugateGradientFRPR.h
+++ b/Components/Optimizers/ConjugateGradientFRPR/elxConjugateGradientFRPR.h
@@ -143,17 +143,17 @@ public:
   itkGetConstReferenceMacro(CurrentSearchDirectionMagnitude, double);
 
 protected:
-  ConjugateGradientFRPR();
+  ConjugateGradientFRPR() = default;
   ~ConjugateGradientFRPR() override = default;
 
   /** To store the latest computed derivative's magnitude */
-  double m_CurrentDerivativeMagnitude;
+  double m_CurrentDerivativeMagnitude{ 0.0 };
 
   /** Variable to store the line search direction magnitude */
-  double m_CurrentSearchDirectionMagnitude;
+  double m_CurrentSearchDirectionMagnitude{ 0.0 };
 
   /** the current gain */
-  double m_CurrentStepLength;
+  double m_CurrentStepLength{ 0.0 };
 
   /** Set if the optimizer is currently bracketing the minimum, or is
    * optimizing along a line */
@@ -214,8 +214,8 @@ protected:
 private:
   elxOverrideGetSelfMacro;
 
-  bool m_LineOptimizing;
-  bool m_LineBracketing;
+  bool m_LineOptimizing{ false };
+  bool m_LineBracketing{ false };
 
   const char *
   DeterminePhase() const;

--- a/Components/Optimizers/ConjugateGradientFRPR/elxConjugateGradientFRPR.hxx
+++ b/Components/Optimizers/ConjugateGradientFRPR/elxConjugateGradientFRPR.hxx
@@ -29,22 +29,6 @@ namespace elastix
 {
 
 /**
- * ********************* Constructor ****************************
- */
-
-template <typename TElastix>
-ConjugateGradientFRPR<TElastix>::ConjugateGradientFRPR()
-{
-  this->m_LineBracketing = false;
-  this->m_LineOptimizing = false;
-  this->m_CurrentStepLength = 0.0;
-  this->m_CurrentSearchDirectionMagnitude = 0.0;
-  this->m_CurrentDerivativeMagnitude = 0.0;
-
-} // end Constructor
-
-
-/**
  * ***************** DeterminePhase *****************************
  *
  * This method gives only sensible output if it is called

--- a/Components/Optimizers/FiniteDifferenceGradientDescent/elxFiniteDifferenceGradientDescent.h
+++ b/Components/Optimizers/FiniteDifferenceGradientDescent/elxFiniteDifferenceGradientDescent.h
@@ -138,10 +138,10 @@ public:
   StartOptimization() override;
 
 protected:
-  FiniteDifferenceGradientDescent();
+  FiniteDifferenceGradientDescent() = default;
   ~FiniteDifferenceGradientDescent() override = default;
 
-  bool m_ShowMetricValues;
+  bool m_ShowMetricValues{ false };
 
 private:
   elxOverrideGetSelfMacro;

--- a/Components/Optimizers/FiniteDifferenceGradientDescent/elxFiniteDifferenceGradientDescent.hxx
+++ b/Components/Optimizers/FiniteDifferenceGradientDescent/elxFiniteDifferenceGradientDescent.hxx
@@ -29,17 +29,6 @@ namespace elastix
 {
 
 /**
- * ********************* Constructor ****************************
- */
-
-template <typename TElastix>
-FiniteDifferenceGradientDescent<TElastix>::FiniteDifferenceGradientDescent()
-{
-  this->m_ShowMetricValues = false;
-} // end Constructor
-
-
-/**
  * ***************** BeforeRegistration ***********************
  */
 

--- a/Components/Optimizers/FullSearch/elxFullSearchOptimizer.h
+++ b/Components/Optimizers/FullSearch/elxFullSearchOptimizer.h
@@ -130,15 +130,15 @@ public:
   itkGetModifiableObjectMacro(OptimizationSurface, NDImageType);
 
 protected:
-  FullSearch();
+  FullSearch() = default;
   ~FullSearch() override = default;
 
 private:
   elxOverrideGetSelfMacro;
 
-  NDImagePointer m_OptimizationSurface;
+  NDImagePointer m_OptimizationSurface{ nullptr };
 
-  DimensionNameMapType m_SearchSpaceDimensionNames;
+  DimensionNameMapType m_SearchSpaceDimensionNames{};
 
   /** Checks if an error generated while reading the search space
    * ranges from the parameter file is a real error. Prints some

--- a/Components/Optimizers/FullSearch/elxFullSearchOptimizer.hxx
+++ b/Components/Optimizers/FullSearch/elxFullSearchOptimizer.hxx
@@ -29,18 +29,6 @@ namespace elastix
 {
 
 /**
- * ********************* Constructor ****************************
- */
-
-template <typename TElastix>
-FullSearch<TElastix>::FullSearch()
-{
-  this->m_OptimizationSurface = nullptr;
-
-} // end Constructor
-
-
-/**
  * ***************** BeforeRegistration ***********************
  */
 

--- a/Components/Optimizers/PreconditionedStochasticGradientDescent/elxPreconditionedStochasticGradientDescent.h
+++ b/Components/Optimizers/PreconditionedStochasticGradientDescent/elxPreconditionedStochasticGradientDescent.h
@@ -279,7 +279,7 @@ public:
   itkGetConstReferenceMacro(MaximumNumberOfSamplingAttempts, SizeValueType);
 
 protected:
-  PreconditionedStochasticGradientDescent();
+  PreconditionedStochasticGradientDescent() = default;
   ~PreconditionedStochasticGradientDescent() override = default;
 
   /** Protected typedefs */
@@ -369,41 +369,41 @@ private:
   elxOverrideGetSelfMacro;
 
   /** Variable to store the automatically determined settings for each resolution. */
-  SettingsVectorType m_SettingsVector;
+  SettingsVectorType m_SettingsVector{};
 
   /** Some options for automatic parameter estimation. */
-  SizeValueType m_NumberOfGradientMeasurements;
-  SizeValueType m_NumberOfJacobianMeasurements;
-  SizeValueType m_NumberOfSamplesForNoiseCompensationFactor;
-  SizeValueType m_NumberOfSamplesForPrecondition;
-  SizeValueType m_NumberOfSpatialSamples;
+  SizeValueType m_NumberOfGradientMeasurements{ 0 };
+  SizeValueType m_NumberOfJacobianMeasurements{ 0 };
+  SizeValueType m_NumberOfSamplesForNoiseCompensationFactor{ 0 };
+  SizeValueType m_NumberOfSamplesForPrecondition{ 0 };
+  SizeValueType m_NumberOfSpatialSamples{ 5000 };
 
   /** The transform stored as AdvancedTransform */
-  AdvancedTransformPointer m_AdvancedTransform;
+  AdvancedTransformPointer m_AdvancedTransform{ nullptr };
 
-  double m_SigmoidScaleFactor;
-  double m_NoiseFactor;
-  double m_GlobalStepSize;
-  double m_RegularizationKappa;
-  double m_ConditionNumber;
+  double m_SigmoidScaleFactor{ 0.1 };
+  double m_NoiseFactor{ 1.0 };
+  double m_GlobalStepSize{ 0 };
+  double m_RegularizationKappa{ 0.8 };
+  double m_ConditionNumber{ 2.0 };
 
-  bool   m_AutomaticParameterEstimation;
-  double m_MaximumStepLength;
-  double m_MaximumStepLengthRatio;
+  bool   m_AutomaticParameterEstimation{ false };
+  double m_MaximumStepLength{ 1.0 };
+  double m_MaximumStepLengthRatio{ 1.0 };
 
   /** Private variables for the sampling attempts. */
-  SizeValueType m_MaximumNumberOfSamplingAttempts;
-  SizeValueType m_CurrentNumberOfSamplingAttempts;
-  SizeValueType m_PreviousErrorAtIteration;
-  bool          m_AutomaticParameterEstimationDone;
+  SizeValueType m_MaximumNumberOfSamplingAttempts{ 0 };
+  SizeValueType m_CurrentNumberOfSamplingAttempts{ 0 };
+  SizeValueType m_PreviousErrorAtIteration{ 0 };
+  bool          m_AutomaticParameterEstimationDone{ false };
 
   /** Private variables for band size estimation of covariance matrix. */
-  SizeValueType m_MaxBandCovSize;
-  SizeValueType m_NumberOfBandStructureSamples;
+  SizeValueType m_MaxBandCovSize{};
+  SizeValueType m_NumberOfBandStructureSamples{};
 
   /** The flag of using noise compensation. */
-  bool m_UseNoiseCompensation;
-  bool m_OriginalButSigmoidToDefault;
+  bool m_UseNoiseCompensation{ true };
+  bool m_OriginalButSigmoidToDefault{};
 };
 
 } // end namespace elastix

--- a/Components/Optimizers/PreconditionedStochasticGradientDescent/elxPreconditionedStochasticGradientDescent.hxx
+++ b/Components/Optimizers/PreconditionedStochasticGradientDescent/elxPreconditionedStochasticGradientDescent.hxx
@@ -35,40 +35,6 @@ namespace elastix
 {
 
 /**
- * ********************** Constructor ***********************
- */
-
-template <typename TElastix>
-PreconditionedStochasticGradientDescent<TElastix>::PreconditionedStochasticGradientDescent()
-{
-  this->m_MaximumNumberOfSamplingAttempts = 0;
-  this->m_CurrentNumberOfSamplingAttempts = 0;
-  this->m_PreviousErrorAtIteration = 0;
-  this->m_AutomaticParameterEstimationDone = false;
-
-  this->m_AutomaticParameterEstimation = false;
-  this->m_MaximumStepLength = 1.0;
-  this->m_MaximumStepLengthRatio = 1.0;
-  this->m_RegularizationKappa = 0.8;
-  this->m_ConditionNumber = 2.0;
-  this->m_NoiseFactor = 1.0;
-
-  this->m_NumberOfGradientMeasurements = 0;
-  this->m_NumberOfJacobianMeasurements = 0;
-  this->m_NumberOfSamplesForPrecondition = 0;
-  this->m_NumberOfSamplesForNoiseCompensationFactor = 0;
-  this->m_NumberOfSpatialSamples = 5000;
-  this->m_SigmoidScaleFactor = 0.1;
-  this->m_GlobalStepSize = 0;
-
-  this->m_AdvancedTransform = nullptr;
-
-  this->m_UseNoiseCompensation = true;
-
-} // Constructor
-
-
-/**
  * ***************** BeforeRegistration ***********************
  */
 

--- a/Components/Optimizers/SimultaneousPerturbation/elxSimultaneousPerturbation.h
+++ b/Components/Optimizers/SimultaneousPerturbation/elxSimultaneousPerturbation.h
@@ -142,10 +142,10 @@ public:
   SetInitialPosition(const ParametersType & param) override;
 
 protected:
-  SimultaneousPerturbation();
+  SimultaneousPerturbation() = default;
   ~SimultaneousPerturbation() override = default;
 
-  bool m_ShowMetricValues;
+  bool m_ShowMetricValues{ false };
 
 private:
   elxOverrideGetSelfMacro;

--- a/Components/Optimizers/SimultaneousPerturbation/elxSimultaneousPerturbation.hxx
+++ b/Components/Optimizers/SimultaneousPerturbation/elxSimultaneousPerturbation.hxx
@@ -29,17 +29,6 @@ namespace elastix
 {
 
 /**
- * ********************* Constructor ****************************
- */
-
-template <typename TElastix>
-SimultaneousPerturbation<TElastix>::SimultaneousPerturbation()
-{
-  this->m_ShowMetricValues = false;
-} // end Constructor
-
-
-/**
  * ***************** BeforeRegistration ***********************
  */
 

--- a/Components/Optimizers/StandardGradientDescent/elxStandardGradientDescent.h
+++ b/Components/Optimizers/StandardGradientDescent/elxStandardGradientDescent.h
@@ -147,16 +147,16 @@ public:
   itkGetConstReferenceMacro(MaximumNumberOfSamplingAttempts, unsigned long);
 
 protected:
-  StandardGradientDescent();
+  StandardGradientDescent() = default;
   ~StandardGradientDescent() override = default;
 
 private:
   elxOverrideGetSelfMacro;
 
   /** Private variables for the sampling attempts. */
-  unsigned long m_MaximumNumberOfSamplingAttempts;
-  unsigned long m_CurrentNumberOfSamplingAttempts;
-  unsigned long m_PreviousErrorAtIteration;
+  unsigned long m_MaximumNumberOfSamplingAttempts{ 0 };
+  unsigned long m_CurrentNumberOfSamplingAttempts{ 0 };
+  unsigned long m_PreviousErrorAtIteration{ 0 };
 };
 
 } // end namespace elastix

--- a/Components/Optimizers/StandardGradientDescent/elxStandardGradientDescent.hxx
+++ b/Components/Optimizers/StandardGradientDescent/elxStandardGradientDescent.hxx
@@ -27,20 +27,6 @@ namespace elastix
 {
 
 /**
- * ***************** Constructor ***********************
- */
-
-template <typename TElastix>
-StandardGradientDescent<TElastix>::StandardGradientDescent()
-{
-  this->m_MaximumNumberOfSamplingAttempts = 0;
-  this->m_CurrentNumberOfSamplingAttempts = 0;
-  this->m_PreviousErrorAtIteration = 0;
-
-} // end Constructor()
-
-
-/**
  * ***************** BeforeRegistration ***********************
  */
 


### PR DESCRIPTION
Defaulted (`= default`) the default-constructors of most of the elastix classes in "Components\Optimizers". Initialized their data members directly at their declaration, by default member initializers, as is recommended in modern C++ code.

Excluded AdaptiveStochasticLBFGS, because its default-constructor also adjusts data of one of its (indirect) base classes: `itk::StochasticGradientDescentOptimizer::m_LBFGSMemory`. Exluded AdaptiveStochasticVarianceReducedGradient, because  its default-constructor also adjusts `itk::StochasticVarianceReducedGradientDescentOptimizer::m_NumberOfInnerIterations`.

Excluded ConjugateGradient and QuasiNewtonLBFGS, because their default-constructors do more than just initializing their members with constant values.  (They also call AddObserver and SetCallbackFunction)