### PR TITLE
ENH: Add ConvertCompositionToItkTransform to ElastixRegistrationMethod

### DIFF
--- a/Core/Main/GTesting/itkElastixRegistrationMethodGTest.cxx
+++ b/Core/Main/GTesting/itkElastixRegistrationMethodGTest.cxx
@@ -2040,6 +2040,47 @@ GTEST_TEST(itkElastixRegistrationMethod, ConvertToItkTransform)
   }
 }
 
+
+GTEST_TEST(itkElastixRegistrationMethod, ConvertCompositionToItkTransform)
+{
+  static constexpr auto ImageDimension = 2U;
+  using ImageType = itk::Image<float, ImageDimension>;
+  const auto image =
+    CreateImageFilledWithSequenceOfNaturalNumbers<ImageType::PixelType>(itk::Size<ImageDimension>{ 5, 6 });
+
+  elx::DefaultConstruct<ElastixRegistrationMethodType<ImageType>> registration{};
+
+  registration.SetFixedImage(image);
+  registration.SetMovingImage(image);
+
+  for (const bool useInitialTransform : { false, true })
+  {
+    registration.SetInitialTransformParameterFileName(
+      useInitialTransform ? (GetDataDirectoryPath() + "/Translation(1,-2)/TransformParameters.txt") : "");
+
+    const std::string nameOfLastTransform = "BSplineTransform";
+    registration.SetParameterObject(CreateParameterObject({ // Parameters in alphabetic order:
+                                                            { "AutomaticTransformInitialization", "false" },
+                                                            { "ImageSampler", "Full" },
+                                                            { "MaximumNumberOfIterations", "0" },
+                                                            { "Metric", "AdvancedNormalizedCorrelation" },
+                                                            { "Optimizer", "AdaptiveStochasticGradientDescent" },
+                                                            { "Transform", nameOfLastTransform } }));
+    registration.Update();
+
+    const unsigned int expectedNumberOfTransforms{ useInitialTransform ? 2U : 1U };
+
+    // TODO Check result
+    const auto result = ElastixRegistrationMethodType<ImageType>::ConvertCompositionToItkTransform(
+      itk::Deref(registration.GetCombinationTransform()));
+
+    ASSERT_NE(result, nullptr);
+    EXPECT_EQ(result->GetReferenceCount(), 1);
+    EXPECT_EQ(result->GetNumberOfTransforms(), expectedNumberOfTransforms);
+  }
+}
+
+
 GTEST_TEST(itkElastixRegistrationMethod, WriteCompositeTransform)
 {
   static constexpr auto ImageDimension = 2U;

--- a/Core/Main/itkElastixRegistrationMethod.h
+++ b/Core/Main/itkElastixRegistrationMethod.h
@@ -329,6 +329,12 @@ public:
   static SmartPointer<TransformType>
   ConvertToItkTransform(const TransformType &);
 
+  /** Converts the specified elastix combination transform object to the corresponding ITK CompositeTransform object.
+   * Returns null if there is no corresponding ITK Transform type, or if the combination is not a composition (as may be
+   * specified by the "HowToCombineTransforms" parameter). */
+  static SmartPointer<CompositeTransform<double, ImageDimension>>
+  ConvertCompositionToItkTransform(const TransformType &);
+
 protected:
   ElastixRegistrationMethod();
 

--- a/Core/Main/itkElastixRegistrationMethod.hxx
+++ b/Core/Main/itkElastixRegistrationMethod.hxx
@@ -1052,6 +1052,24 @@ ElastixRegistrationMethod<TFixedImage, TMovingImage>::ConvertToItkTransform(cons
   itkGenericExceptionMacro("Failed to convert transform object " << elxTransform);
 }
 
+
+template <typename TFixedImage, typename TMovingImage>
+auto
+ElastixRegistrationMethod<TFixedImage, TMovingImage>::ConvertCompositionToItkTransform(
+  const TransformType & elxTransform) -> SmartPointer<CompositeTransform<double, ImageDimension>>
+{
+  if (const auto * const combinationTransform =
+        dynamic_cast<const AdvancedCombinationTransform<double, FixedImageDimension> *>(&elxTransform))
+  {
+    if (const auto itkTransform = elx::TransformIO::ConvertToCompositionOfItkTransforms(*combinationTransform))
+    {
+      return itkTransform;
+    }
+    itkGenericExceptionMacro("Failed to convert transform object " << elxTransform);
+  }
+  itkGenericExceptionMacro("The argument must be a combination transform object. Argument: " << elxTransform);
+}
+
 } // namespace itk
 
 #endif


### PR DESCRIPTION
The existing `ConvertToItkTransform` appears inconvenient for composition transforms, as it may cause end-users to "downcast" the return value to `itk::CompositeTransform`.