### PR TITLE
COMP: Add missing `#include "itkCompositeTransform.h"`

### DIFF
--- a/Core/Main/itkElastixRegistrationMethod.h
+++ b/Core/Main/itkElastixRegistrationMethod.h
@@ -36,6 +36,8 @@
 #define itkElastixRegistrationMethod_h
 
 #include "itkImageSource.h"
+#include "itkCompositeTransform.h"
+
 #include "itkAdvancedCombinationTransform.h"
 #include "itkElastixLogLevel.h"
 


### PR DESCRIPTION
Fixes issue #1465, reported by Valentin Boussot (@vboussot).